### PR TITLE
[expo] bump react-native-reanimated to 4.1.1

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2685,7 +2685,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNReanimated (4.1.0):
+  - RNReanimated (4.1.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2707,10 +2707,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNReanimated/reanimated (= 4.1.0)
+    - RNReanimated/reanimated (= 4.1.1)
     - RNWorklets
     - Yoga
-  - RNReanimated/reanimated (4.1.0):
+  - RNReanimated/reanimated (4.1.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2732,10 +2732,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNReanimated/reanimated/apple (= 4.1.0)
+    - RNReanimated/reanimated/apple (= 4.1.1)
     - RNWorklets
     - Yoga
-  - RNReanimated/reanimated/apple (4.1.0):
+  - RNReanimated/reanimated/apple (4.1.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3716,7 +3716,7 @@ SPEC CHECKSUMS:
   RNCPicker: f97c908b7774248c1093ec3831ca70d338627bf7
   RNDateTimePicker: 6fdd63f5d1e0f21faf4cc8674957c52958a7efae
   RNGestureHandler: 6a488ce85c88e82d8610db1108daf04e9b2d5162
-  RNReanimated: ec8886a7ff1bc514c5757c0a18d9c4a65ea00364
+  RNReanimated: e30c3cfe4fc124a818e541d9ec8bb8a3bcbc6bd3
   RNScreens: dd61bc3a3e6f6901ad833efa411917d44827cf51
   RNSVG: 2825ee146e0f6a16221e852299943e4cceef4528
   RNWorklets: 56b7e8755716f5995a4a775bebf3a6ea4e2f7f64

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -71,7 +71,7 @@
     "react-native-gesture-handler": "~2.28.0",
     "react-native-keyboard-controller": "^1.18.5",
     "react-native-pager-view": "6.9.1",
-    "react-native-reanimated": "4.1.0",
+    "react-native-reanimated": "4.1.1",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.16.0",
     "react-native-svg": "15.12.1",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3294,7 +3294,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNReanimated (4.1.0):
+  - RNReanimated (4.1.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -3321,11 +3321,11 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated (= 4.1.0)
+    - RNReanimated/reanimated (= 4.1.1)
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNReanimated/reanimated (4.1.0):
+  - RNReanimated/reanimated (4.1.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -3352,11 +3352,11 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated/apple (= 4.1.0)
+    - RNReanimated/reanimated/apple (= 4.1.1)
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNReanimated/reanimated/apple (4.1.0):
+  - RNReanimated/reanimated/apple (4.1.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -4448,7 +4448,7 @@ SPEC CHECKSUMS:
   RNCPicker: 6da395ee9db8d67a38c6102d4128b5a0b9ec0e21
   RNDateTimePicker: c4a42c6a77d474f05162d61a4ab4253d13008277
   RNGestureHandler: 4f7cc97a71d4fe0fcba38c94acdd969f5f17c91c
-  RNReanimated: 0cb057fceda450a0eb6dff9b7dc10bdd9f59b24f
+  RNReanimated: 9e6d0d40b991302208d906a5da29e758ce344998
   RNScreens: 74985ca8e102294a60cec7513fa84c936fa0b20b
   RNSVG: 8d87cff016edf1b6ca409ed39804101836d75e90
   RNWorklets: a4a057191f470b49f5d30f7995dd5408f40214f6

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -78,7 +78,7 @@
     "react-native-maps": "1.20.1",
     "react-native-pager-view": "6.9.1",
     "react-native-paper": "^5.12.5",
-    "react-native-reanimated": "4.1.0",
+    "react-native-reanimated": "4.1.1",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.16.0",
     "react-native-svg": "15.12.1",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -148,7 +148,7 @@
     "react-native-pager-view": "6.9.1",
     "react-native-paper": "^5.12.5",
     "react-native-worklets": "0.5.1",
-    "react-native-reanimated": "4.1.0",
+    "react-native-reanimated": "4.1.1",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.16.0",
     "react-native-svg": "15.12.1",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -101,7 +101,7 @@
   "react-native-maps": "1.20.1",
   "react-native-pager-view": "6.9.1",
   "react-native-worklets": "0.5.1",
-  "react-native-reanimated": "~4.1.0",
+  "react-native-reanimated": "~4.1.1",
   "react-native-screens": "~4.16.0",
   "react-native-safe-area-context": "~5.6.0",
   "react-native-svg": "15.12.1",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -33,7 +33,7 @@
     "react-native": "0.81.4",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-worklets": "0.5.1",
-    "react-native-reanimated": "~4.1.0",
+    "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-web": "~0.21.0"

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -25,7 +25,7 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.4",
     "react-native-worklets": "0.5.1",
-    "react-native-reanimated": "~4.1.0",
+    "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-web": "~0.21.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13778,10 +13778,10 @@ react-native-paper@^5.12.5:
     color "^3.1.2"
     use-latest-callback "^0.1.5"
 
-react-native-reanimated@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-4.1.0.tgz#dd0a2495b14fa344d7f482131ecae79110fa59cd"
-  integrity sha512-L8FqZn8VjZyBaCUMYFyx1Y+T+ZTbblaudpxReOXJ66RnOf52g6UM4Pa/IjwLD1XAw1FUxLRQrtpdjbkEc74FiQ==
+react-native-reanimated@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-4.1.1.tgz#01f16d3184570be4bf8d5db14edfe494d3694d1e"
+  integrity sha512-QWe8EJJFOQW92b/sl551u3uPeLT5TUx2eAXkga8Kcj2w+Qs/Yh6fsz5sN8iyNO6zcoSNFqYQLICD6dvBIFGzbg==
   dependencies:
     react-native-is-edge-to-edge "^1.2.1"
     semver "7.7.2"


### PR DESCRIPTION
# Why

Bumped `react-native-reanimated`: 4.1.0 -> 4.1.1

This version has some nice fixes, among them is the fix for the android size increase:

https://github.com/software-mansion/react-native-reanimated/releases/tag/4.1.1

Also a fix for this one: https://github.com/expo/expo/issues/39582

# Test Plan

✅ BareExpo - iOS
✅ BareExpo - Android

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).