### PR TITLE
[3/n] Upgrade React Native to 0.82.x  

### DIFF
--- a/apps/bare-expo/macos/Podfile.lock
+++ b/apps/bare-expo/macos/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
-  - EASClient (1.0.5):
+  - EASClient (1.0.7):
     - ExpoModulesCore
-  - EXConstants (18.0.6):
+  - EXConstants (18.0.9):
     - ExpoModulesCore
-  - EXManifests (1.0.6):
+  - EXManifests (1.0.8):
     - ExpoModulesCore
-  - Expo (54.0.0-preview.12):
+  - Expo (54.0.8):
     - DoubleConversion
     - ExpoModulesCore
     - glog
@@ -34,23 +34,23 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - ExpoAsset (12.0.6):
+  - ExpoAsset (12.0.8):
     - ExpoModulesCore
-  - ExpoCrypto (15.0.5):
+  - ExpoCrypto (15.0.7):
     - ExpoModulesCore
-  - ExpoFileSystem (19.0.7):
+  - ExpoFileSystem (19.0.14):
     - ExpoModulesCore
-  - ExpoFont (14.0.6):
+  - ExpoFont (14.0.8):
     - ExpoModulesCore
-  - ExpoKeepAwake (15.0.5):
+  - ExpoKeepAwake (15.0.7):
     - ExpoModulesCore
-  - ExpoLinking (8.0.6):
+  - ExpoLinking (8.0.8):
     - ExpoModulesCore
-  - ExpoLocalAuthentication (17.0.5):
+  - ExpoLocalAuthentication (17.0.7):
     - ExpoModulesCore
-  - ExpoMeshGradient (0.4.5):
+  - ExpoMeshGradient (0.4.7):
     - ExpoModulesCore
-  - ExpoModulesCore (3.0.10):
+  - ExpoModulesCore (3.0.16):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -75,12 +75,12 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - ExpoSQLite (16.0.6):
+  - ExpoSQLite (16.0.8):
     - ExpoModulesCore
-  - ExpoWebBrowser (15.0.5):
+  - ExpoWebBrowser (15.0.7):
     - ExpoModulesCore
   - EXStructuredHeaders (5.0.0)
-  - EXUpdates (29.0.7):
+  - EXUpdates (29.0.10):
     - DoubleConversion
     - EASClient
     - EXManifests
@@ -2287,23 +2287,23 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 7d49a506d1ac47358fea28558d184dd6431170ca
   DoubleConversion: 10f51d3e1238973c033faac2d84c0ea114942f53
-  EASClient: 7484d2e32e19f8ad1afb7f35d9466957baddf9b8
-  EXConstants: a0a43b3a237bc0f054d355b34152942f4e3cf8e2
-  EXManifests: cb359a63f88e471a0f666b7d88694f6e594a594e
-  Expo: 51be89b47c856134d3756914c4aa28fa71db3364
-  ExpoAsset: 230d905936188048e059bdf67dcffaf2d6fbddee
-  ExpoCrypto: 6d5884a1dc6a8e8058fdf43569d25d629c8f10ea
-  ExpoFileSystem: 09e642f44b742405e9736d0795578d428055db9a
-  ExpoFont: b6c3912330b03b9c029f091ae3e86e3f27fe465e
-  ExpoKeepAwake: 6e88b6103dca5e643d1a9d3dcfeedad80b87dffe
-  ExpoLinking: 5af535c9d56c0a8678a75073917003875cf55aef
-  ExpoLocalAuthentication: 7ee11968a997093cf764b903fa9227db88ad687a
-  ExpoMeshGradient: 4658b4d4595f10159f969c9e34953a75d1f9666c
-  ExpoModulesCore: febbe93c470ea2bdc087fb49e8843853412f4103
-  ExpoSQLite: 1b3814901c5c8f0f1b536637c624c8d4666fe328
-  ExpoWebBrowser: cefae8f80fd6d452942d740ff29fd2f151b02cae
+  EASClient: de38c20c1dd9af7ff435afdc8b2c9b7c20d46767
+  EXConstants: 59d46d25b89f88cc38291a56dbce4d550758f72d
+  EXManifests: 7469efed75d694ce3c43a6da9c6f3886f66d3c26
+  Expo: bf4d616332c9ad2c4af6698d3611eb16fe814207
+  ExpoAsset: 4375a46b45b12bbfcf6efac8c8a33aebdb8ba12b
+  ExpoCrypto: 4c50a152f5939e16a2ca10be77b002a3a391c4d3
+  ExpoFileSystem: adffad7d1f57f768ca7a5e3bf450312fb9ebd27a
+  ExpoFont: d3e56c7cc03d9fd113b90a5513ad32b4bf46b0ff
+  ExpoKeepAwake: 3f5e3ac53627849174f3603271df8e08f174ed4a
+  ExpoLinking: f5c171877e118e792cb9a77e5ade0b080d899b14
+  ExpoLocalAuthentication: 8f11d958b956fa372c0a49975f54ed1dc617ae1d
+  ExpoMeshGradient: 763087d3b1e6e9a0974e9700ea24cb598816d93c
+  ExpoModulesCore: 1f58292be04d71465231222ce53d894e15aebbbe
+  ExpoSQLite: f9d1202877e12bfa78a58309a3977ee4ea0b1314
+  ExpoWebBrowser: 4f0dc52a559027cc0fba6920adc19a7604e2733d
   EXStructuredHeaders: c951e77f2d936f88637421e9588c976da5827368
-  EXUpdates: 7aa186e9550742dda3f4106972962caeca1df120
+  EXUpdates: 50eb85c508f37965b8464e8708a99baf1c82beab
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   fast_float: 44983b3bddb2d2ed3021a98be86f60ec8abc9ffd
   FBLazyVector: 71133f116ceb23bd2d81af6df1a7ae5496c9f322
@@ -2379,7 +2379,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 7cf0e76983fc9f5e599b7969e4efcc47d540ef40
   ReactCommon: a2877349c13ee61be275db2c80ff3cc3eb02010e
   RNCAsyncStorage: 2cf7d05f5b1bc38680b6c83971e535a6ae9c5bc7
-  RNSVG: b0261be8e66f5ee23e2ec92b2027bf9e89e88a28
+  RNSVG: 363f6a7dc3d63870befaf64bfe78da20a4906b9d
   SocketRocket: 03f7111df1a343b162bf5b06ead333be808e1e0a
   Yoga: 45ce05cb11db042ba2e5e51a2dfaf0ff63d269f9
 

--- a/apps/bare-expo/scripts/fixtures/macos/patches/react-native+0.82.0-rc.4.patch
+++ b/apps/bare-expo/scripts/fixtures/macos/patches/react-native+0.82.0-rc.4.patch
@@ -11,14 +11,14 @@ index 4241e5e..3939434 100644
 +  ) => mixed;
 +  +cancelIdleCallback: (handle: mixed) => void;
  }
- 
+
  export default (TurboModuleRegistry.getEnforcing<Spec>(
 diff --git a/node_modules/react-native/src/private/webapis/intersectionobserver/specs/NativeIntersectionObserver.js b/node_modules/react-native/src/private/webapis/intersectionobserver/specs/NativeIntersectionObserver.js
-index af1cac0..57eb05d 100644
+index f5e3609..9c207d2 100644
 --- a/node_modules/react-native/src/private/webapis/intersectionobserver/specs/NativeIntersectionObserver.js
 +++ b/node_modules/react-native/src/private/webapis/intersectionobserver/specs/NativeIntersectionObserver.js
-@@ -40,10 +40,10 @@ export interface Spec extends TurboModule {
-   +unobserve: (intersectionObserverId: number, targetShadowNode: mixed) => void;
+@@ -36,10 +36,10 @@ export opaque type NativeIntersectionObserverToken = mixed;
+ export interface Spec extends TurboModule {
    +observeV2?: (
      options: NativeIntersectionObserverObserveOptions,
 -  ) => NativeIntersectionObserverToken;
@@ -31,28 +31,28 @@ index af1cac0..57eb05d 100644
    +connect: (notifyIntersectionObserversCallback: () => void) => void;
    +disconnect: () => void;
 diff --git a/node_modules/react-native/src/private/webapis/performance/specs/NativePerformance.js b/node_modules/react-native/src/private/webapis/performance/specs/NativePerformance.js
-index 1871405..bf130e5 100644
+index e191d0a..603ae59 100644
 --- a/node_modules/react-native/src/private/webapis/performance/specs/NativePerformance.js
 +++ b/node_modules/react-native/src/private/webapis/performance/specs/NativePerformance.js
-@@ -82,16 +82,16 @@ export interface Spec extends TurboModule {
- 
-   +createObserver?: (
+@@ -80,16 +80,16 @@ export interface Spec extends TurboModule {
+
+   +createObserver: (
      callback: NativeBatchedObserverCallback,
 -  ) => OpaqueNativeObserverHandle;
--  +getDroppedEntriesCount?: (observer: OpaqueNativeObserverHandle) => number;
+-  +getDroppedEntriesCount: (observer: OpaqueNativeObserverHandle) => number;
 +  ) => mixed;
-+  +getDroppedEntriesCount?: (observer: mixed) => number;
- 
-   +observe?: (
++  +getDroppedEntriesCount: (observer: mixed) => number;
+
+   +observe: (
 -    observer: OpaqueNativeObserverHandle,
 +    observer: mixed,
      options: PerformanceObserverInit,
    ) => void;
--  +disconnect?: (observer: OpaqueNativeObserverHandle) => void;
-+  +disconnect?: (observer: mixed) => void;
-   +takeRecords?: (
+-  +disconnect: (observer: OpaqueNativeObserverHandle) => void;
++  +disconnect: (observer: mixed) => void;
+   +takeRecords: (
 -    observer: OpaqueNativeObserverHandle,
 +    observer: mixed,
      sort: boolean,
    ) => $ReadOnlyArray<RawPerformanceEntry>;
- 
+

--- a/apps/expo-go/android/expoview/build.gradle
+++ b/apps/expo-go/android/expoview/build.gradle
@@ -119,15 +119,10 @@ class GenerateDynamicMacrosPlugin implements Plugin<Project> {
         commandLine "./expotools", "android-generate-dynamic-macros", "--configuration", configuration
       }
     }
-    target.tasks.matching { it.name.startsWith('pre') && it.name.endsWith('Build') }.all {
-      it.dependsOn("generateDynamicMacros")
-    }
 
-    // target.plugins.withId("com.android.application") {
-    //   target.tasks.named("preBuild").configure {
-    //     dependsOn("generateDynamicMacros")
-    //   }
-    // }
+    target.tasks.named("preBuild").configure {
+      dependsOn("generateDynamicMacros")
+    }
   }
 }
 

--- a/apps/expo-go/android/expoview/build.gradle
+++ b/apps/expo-go/android/expoview/build.gradle
@@ -106,12 +106,12 @@ import org.apache.tools.ant.taskdefs.condition.Os
 class GenerateDynamicMacrosPlugin implements Plugin<Project> {
   @Override
   void apply(org.gradle.api.Project target) {
-    target.exec {
+    target.tasks.create("generateDynamicMacros", Exec) {
       def configuration = target.gradle.startParameter.taskNames.any {
         it.toLowerCase().contains("release")
       } ? "release" : "debug"
 
-      workingDir '../../../../bin'
+      workingDir project.file('../../../../bin')
 
       if (Os.isFamily(Os.FAMILY_WINDOWS)) {
         commandLine 'cmd.exe', '/c', "expotools android-generate-dynamic-macros --configuration ${configuration}"
@@ -119,6 +119,15 @@ class GenerateDynamicMacrosPlugin implements Plugin<Project> {
         commandLine "./expotools", "android-generate-dynamic-macros", "--configuration", configuration
       }
     }
+    target.tasks.matching { it.name.startsWith('pre') && it.name.endsWith('Build') }.all {
+      it.dependsOn("generateDynamicMacros")
+    }
+
+    // target.plugins.withId("com.android.application") {
+    //   target.tasks.named("preBuild").configure {
+    //     dependsOn("generateDynamicMacros")
+    //   }
+    // }
   }
 }
 

--- a/apps/expo-go/android/settings.gradle
+++ b/apps/expo-go/android/settings.gradle
@@ -33,6 +33,9 @@ includeBuild(new File(rootDir, "../../../react-native-lab/react-native/packages/
 
 include ':expoview'
 include ':tools'
+
+include(":packages")
+project(":packages").projectDir = file("$rootDir/../../../react-native-lab/react-native/packages") // Gradle 9 require us to include this
 include ':packages:react-native:ReactAndroid'
 project(':packages:react-native:ReactAndroid').projectDir = new File(rootDir, '../../../react-native-lab/react-native/packages/react-native/ReactAndroid')
 dependencyResolutionManagement {

--- a/apps/expo-go/android/tools/build.gradle
+++ b/apps/expo-go/android/tools/build.gradle
@@ -8,6 +8,6 @@ dependencies {
 }
 
 task execute(type: JavaExec) {
-  main = 'host.exp.exponent.tools.ReactAndroidCodeTransformer'
+  mainClass = 'host.exp.exponent.tools.ReactAndroidCodeTransformer'
   classpath = sourceSets.main.runtimeClasspath
 }

--- a/apps/expo-go/android/tools/src/main/java/host/exp/exponent/tools/ReactAndroidKotlinTransformer.java
+++ b/apps/expo-go/android/tools/src/main/java/host/exp/exponent/tools/ReactAndroidKotlinTransformer.java
@@ -273,6 +273,7 @@ public class ReactAndroidKotlinTransformer {
         public String transform(String content) {
             content = makePublic(content, "class BridgelessDevSupportManager");
             content = content.replaceAll("constructor", "public constructor");
+            content = content.replaceAll("fun tracingState():", "public fun tracingState():");
             return content;
         }
     }

--- a/packages/expo-av/android/build.gradle
+++ b/packages/expo-av/android/build.gradle
@@ -64,7 +64,7 @@ android {
         "**/libjscexecutor.so",
         "**/libfbjni.so",
         "**/libfolly_json.so",
-        "**/libhermes.so",
+        "**/libhermesvm.so",
         "**/libjsi.so",
     ]
   }

--- a/packages/expo-av/android/build.gradle
+++ b/packages/expo-av/android/build.gradle
@@ -90,6 +90,8 @@ dependencies {
 
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.1'
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.5.1"
+  // Gradle 9+ requires explicit dependency on the launcher
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.3'
 
   testImplementation 'io.mockk:mockk:1.12.3'
 }

--- a/packages/expo-modules-core/android/CMakeLists.txt
+++ b/packages/expo-modules-core/android/CMakeLists.txt
@@ -74,7 +74,7 @@ target_compile_options(CommonSettings INTERFACE
 if(${UNIT_TEST})
   if(${USE_HERMES})
     find_package(hermes-engine REQUIRED CONFIG)
-    set(JSEXECUTOR_LIB hermes-engine::libhermes)
+    set(JSEXECUTOR_LIB hermes-engine::hermesvm)
   else()
     set(JSEXECUTOR_LIB ReactAndroid::jscexecutor)
   endif()

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -121,7 +121,7 @@ android {
       "**/libfolly_json.so",
       "**/libfolly_runtime.so",
       "**/libglog.so",
-      "**/libhermes.so",
+      "**/libhermesvm.so",
       "**/libjscexecutor.so",
       "**/libjsi.so",
       "**/libreactnative.so",
@@ -273,7 +273,7 @@ def generatePCHTask = tasks.register("generatePCH") {
         def tokens = tokenizer.tokenList
 
         def workingDirFile = new File(commandObj.directory)
-  
+
         providers.exec {
           workingDir(providers.provider { workingDirFile }.get())
           commandLine(tokens)


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/expo/pull/39960

# How

- Fix Expo Go AGP 9 compatibility
- Fix unit tests
- Update ReactAndroidKotlinTransformer.java to handle the new `tracingState()` func
- Update BareExpo react-native patch to work with react-native-macos 0.79


# Test Plan

CI should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
