### PR TITLE
[contacts][ios]  Fix issue with missing namePrefix on iOS 

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed issue with missing `namePrefix` on iOS ([#39974](https://github.com/expo/expo/pull/39974) by [@hryhoriiK97](https://github.com/hryhoriiK97))
+
 ### 💡 Others
 
 - Added contact image uri validation. ([#39658](https://github.com/expo/expo/pull/39658) by [@hryhoriiK97](https://github.com/hryhoriiK97))

--- a/packages/expo-contacts/ios/Serialization.swift
+++ b/packages/expo-contacts/ios/Serialization.swift
@@ -241,6 +241,7 @@ func serializeContact(person: CNContact, keys: [String]?, directory: URL?) throw
   }
 
   if keysToFetch.contains(CNContactNamePrefixKey) && fieldHasValue(field: person.namePrefix) {
+    contact[ContactsKey.namePrefix] = person.namePrefix
   }
   if keysToFetch.contains(CNContactNameSuffixKey) && fieldHasValue(field: person.nameSuffix) {
     contact[ContactsKey.nameSuffix] = person.nameSuffix


### PR DESCRIPTION
# Why
Fixes: #39911

Due to the issue mentioned above, the namePrefix is missing on iOS. After checking the Serialization.swift file, I found that namePrefix was not passed to the contact.

<img width="793" height="46" alt="Zrzut ekranu 2025-09-24 o 22 25 16" src="https://github.com/user-attachments/assets/51158e4c-1f9b-4762-a4df-73456c5f1cca" />

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
