### PR TITLE
[dev-menu] Remove unused dev dependencies

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Remove unused dev dependencies ([#39987](https://github.com/expo/expo/pull/39987) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### ⚠️ Notices
 
 - Added support for React Native 0.82.x. ([#39678](https://github.com/expo/expo/pull/39678) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -36,18 +36,13 @@
     "expo-dev-menu-interface": "2.0.0"
   },
   "devDependencies": {
-    "@apollo/client": "^3.4.10",
     "@babel/preset-typescript": "^7.7.4",
     "@testing-library/react-native": "^13.2.0",
     "babel-plugin-module-resolver": "^5.0.0",
     "babel-preset-expo": "~54.0.1",
-    "expo-dev-client-components": "3.0.7",
     "expo-module-scripts": "^5.0.7",
-    "fuse.js": "^6.4.6",
     "react": "19.1.1",
-    "react-native": "0.82.0-rc.4",
-    "url": "^0.11.0",
-    "use-subscription": "^1.8.0"
+    "react-native": "0.82.0-rc.4"
   },
   "peerDependencies": {
     "expo": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16418,14 +16418,7 @@ use-sidecar@^1.1.3:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
 
-use-subscription@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.8.0.tgz#f118938c29d263c2bce12fc5585d3fe694d4dbce"
-  integrity sha512-LISuG0/TmmoDoCRmV5XAqYkd3UCBNM0ML3gGBndze65WITcsExCD3DTvXXTLyNcOC0heFQZzluW88bN/oC1DQQ==
-  dependencies:
-    use-sync-external-store "^1.2.0"
-
-use-sync-external-store@^1.2.0, use-sync-external-store@^1.5.0:
+use-sync-external-store@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz#55122e2a3edd2a6c106174c27485e0fd59bcfca0"
   integrity sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==


### PR DESCRIPTION
# Why

While working on brownfield, I noticed some additional unused dependencies in dev-menu that we no longer need now that we've migrated to a fully native UI

# How

Remove unused dev dependencies from dev-menu

# Test Plan

Run BareExpo 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
