### PR TITLE
[config-plugins][babel-preset] fix tests

### DIFF
--- a/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
+++ b/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
@@ -241,6 +241,14 @@ require File.join(File.dirname(\`node --print "require.resolve('react-native/pac
 require 'json'
 podfile_properties = JSON.parse(File.read(File.join(__dir__, 'Podfile.properties.json'))) rescue {}
 
+def ccache_enabled?(podfile_properties)
+  # Environment variable takes precedence
+  return ENV['USE_CCACHE'] == '1' if ENV['USE_CCACHE']
+  
+  # Fall back to Podfile properties
+  podfile_properties['apple.ccacheEnabled'] == 'true'
+end
+
 ENV['RCT_NEW_ARCH_ENABLED'] ||= '0' if podfile_properties['newArchEnabled'] == 'false'
 ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] ||= podfile_properties['EX_DEV_CLIENT_NETWORK_INSPECTOR']
 ENV['RCT_USE_RN_DEP'] ||= '1' if podfile_properties['ios.buildReactNativeFromSource'] != 'true' && podfile_properties['newArchEnabled'] != 'false'
@@ -286,7 +294,7 @@ target 'HelloWorld' do
       installer,
       config[:reactNativePath],
       :mac_catalyst_enabled => false,
-      :ccache_enabled => podfile_properties['apple.ccacheEnabled'] == 'true',
+      :ccache_enabled => ccache_enabled?(podfile_properties),
     )
   end
 end

--- a/packages/babel-preset-expo/src/__tests__/hermes-bytecode.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/hermes-bytecode.test.ts
@@ -220,8 +220,11 @@ const LANGUAGE_SAMPLES: {
         throw 0;
       } catch {
       }`,
-    getCompiledCode() {
-      return `try{throw 0;}catch{}`;
+    getCompiledCode({ platform }) {
+      if (platform === 'web') {
+        return `try{throw 0;}catch{}`;
+      }
+      return `try{throw 0;}catch(_unused){}`;
     },
   },
   {
@@ -266,16 +269,22 @@ const LANGUAGE_SAMPLES: {
   {
     name: 'optional-chaining',
     code: `var m = {}?.x;`,
-    getCompiledCode() {
-      return `var m={}?.x;`;
+    getCompiledCode({ platform }) {
+      if (platform === 'web') {
+        return `var m={}?.x;`;
+      }
+      return `var _ref;var m=(_ref={})==null?void 0:_ref.x;`;
     },
   },
   {
     name: 'nullish-coalescing-operator',
     code: `var obj2 = {};
     var foo = obj2.foo ?? "default";`,
-    getCompiledCode() {
-      return `var obj2={};var foo=obj2.foo??"default";`;
+    getCompiledCode({ platform }) {
+      if (platform === 'web') {
+        return `var obj2={};var foo=obj2.foo??"default";`;
+      }
+      return `var _obj2$foo;var obj2={};var foo=(_obj2$foo=obj2.foo)!=null?_obj2$foo:"default";`;
     },
   },
   {
@@ -337,7 +346,7 @@ const LANGUAGE_SAMPLES: {
       if (platform === 'web') {
         return `var _interopRequireDefault=require("@babel/runtime/helpers/interopRequireDefault");var _classPrivateFieldLooseBase2=_interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseBase"));var _classPrivateFieldLooseKey2=_interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseKey"));var _C;var _x=(0,_classPrivateFieldLooseKey2.default)("x");class C{}_C=C;Object.defineProperty(C,_x,{writable:true,value:42});(()=>{try{_C.y=doSomethingWith((0,_classPrivateFieldLooseBase2.default)(_C,_x)[_x]);}catch{_C.y="unknown";}})();`;
       }
-      return `var _interopRequireDefault=require("@babel/runtime/helpers/interopRequireDefault").default;var _createClass2=_interopRequireDefault(require("@babel/runtime/helpers/createClass"));var _classCallCheck2=_interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));var _classPrivateFieldLooseBase2=_interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseBase"));var _classPrivateFieldLooseKey2=_interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseKey"));var _C;var _x=(0,_classPrivateFieldLooseKey2.default)("x");var C=(0,_createClass2.default)(function C(){(0,_classCallCheck2.default)(this,C);});_C=C;Object.defineProperty(C,_x,{writable:true,value:42});(()=>{try{_C.y=doSomethingWith((0,_classPrivateFieldLooseBase2.default)(_C,_x)[_x]);}catch{_C.y="unknown";}})();`;
+      return `var _interopRequireDefault=require("@babel/runtime/helpers/interopRequireDefault").default;var _createClass2=_interopRequireDefault(require("@babel/runtime/helpers/createClass"));var _classCallCheck2=_interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));var _classPrivateFieldLooseBase2=_interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseBase"));var _classPrivateFieldLooseKey2=_interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseKey"));var _C;var _x=(0,_classPrivateFieldLooseKey2.default)("x");var C=(0,_createClass2.default)(function C(){(0,_classCallCheck2.default)(this,C);});_C=C;Object.defineProperty(C,_x,{writable:true,value:42});(()=>{try{_C.y=doSomethingWith((0,_classPrivateFieldLooseBase2.default)(_C,_x)[_x]);}catch(_unused){_C.y="unknown";}})();`;
     },
     hermesError: /private properties are not supported/,
   },


### PR DESCRIPTION
# Why

fix test errors: https://github.com/expo/expo/runs/51240288563

# How

- [config-plugins] update template snapshot from template changes
- [babel-preset] update test coming from ~babel-plugin-syntax-hermes-parser~ @react-native/babel-preset bump. specifically https://github.com/facebook/react-native/pull/52651

# Test Plan

ci passed

# Checklist

- [n/a] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
