### PR TITLE
[gha] bump sdk branch for template sync workflow

### DIFF
--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -3,7 +3,7 @@ name: Sync App Template Repository
 on:
   workflow_dispatch: {}
   push:
-    branches: [sdk-53]
+    branches: [sdk-54]
     paths:
       - .github/workflows/sync-template.yml
       - templates/expo-template-default/**


### PR DESCRIPTION
# Why

We want to sync template repo with the SDK 54 branch 

# Test Plan
We should see the template https://github.com/expo/expo-template-default sync to the latest version once this is bumped

