### PR TITLE
[dev-launcher][dev-menu][iOS] Color adjustments for dev client on Apple TV

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🐛 Bug fixes
 
 - [expo-dev-launcher] Fix manual URL entry: decode percent-encoded URLs, enable return key submit, and support dark mode text. ([#39840](https://github.com/expo/expo/pull/39840) by [@blazejkustra](https://github.com/blazejkustra))
+- [iOS] Adjust tvOS colors. ([#40006](https://github.com/expo/expo/pull/40006) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
@@ -132,6 +132,7 @@ struct DevServersView: View {
       } label: {
         Text("info".uppercased())
           #if os(tvOS)
+          .foregroundColor(.primary)
           .font(.system(size: 24))
           #else
           .font(.system(size: 12))

--- a/packages/expo-dev-launcher/ios/SwiftUI/HomeTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/HomeTabView.swift
@@ -51,6 +51,9 @@ struct HomeTabView: View {
         .padding()
       }
     }
+    #if os(tvOS)
+    .background()
+    #endif
     .overlay(
       DevServerInfoModal(showingInfoDialog: $showingInfoDialog)
     )

--- a/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
@@ -56,6 +56,9 @@ struct SettingsTabView: View {
       .padding()
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
+    #if os(tvOS)
+    .background()
+    #endif
     .navigationBarHidden(true)
   }
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesTabView.swift
@@ -20,6 +20,9 @@ struct UpdatesTabView: View {
         }
       }
     }
+    #if os(tvOS)
+    .background()
+    #endif
   }
 }
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Adjust tvOS colors. ([#40006](https://github.com/expo/expo/pull/40006) by [@douglowder](https://github.com/douglowder))
+
 ### 💡 Others
 
 - Remove unused dev dependencies ([#39987](https://github.com/expo/expo/pull/39987) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo-dev-menu/ios/SwiftUI/HeaderView.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/HeaderView.swift
@@ -30,7 +30,11 @@ struct HeaderView: View {
       } label: {
         ZStack {
           Circle()
+          #if os(tvOS)
+            .fill(Color.expoSystemGray4.opacity(0.2))
+          #else
             .fill(Color.expoSystemGray6)
+          #endif
             .frame(width: 36, height: 36)
 
           Image(systemName: "xmark")


### PR DESCRIPTION
# Why

On tvOS, some UI elements in the dev launcher were almost invisible, especially when the device is set to have the dark UI theme.

# How

- Add `.background()` calls to the dev launcher screens
- Fix the "close" button colors for tvOS on the dev menu

# Test Plan

- Tested in an Expo SDK 54 TV app
- CI should pass

