### PR TITLE
[modules-core][iOS] Introduce ExpoAppDelegateSubscriberManager class

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - [Android] Adds support for `ArrayBuffer`. ([#39943](https://github.com/expo/expo/pull/39943) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Introduce ExpoAppDelegateSubscriberManager class ([#40008](https://github.com/expo/expo/pull/40008) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriberManager.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriberManager.swift
@@ -1,0 +1,501 @@
+import Dispatch
+import Foundation
+
+public class ExpoAppDelegateSubscriberManager: NSObject {
+#if os(iOS) || os(tvOS)
+
+  @objc
+  public static func application(
+    _ application: UIApplication,
+    willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    let parsedSubscribers = ExpoAppDelegateSubscriberRepository.subscribers.filter {
+      $0.responds(to: #selector(application(_:willFinishLaunchingWithOptions:)))
+    }
+
+    // If we can't find a subscriber that implements `willFinishLaunchingWithOptions`, we will delegate the decision if we can handel the passed URL to
+    // the `didFinishLaunchingWithOptions` method by returning `true` here.
+    //  You can read more about how iOS handles deep links here: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application#discussion
+    if parsedSubscribers.isEmpty {
+      return true
+    }
+
+    return parsedSubscribers.reduce(false) { result, subscriber in
+      return subscriber.application?(application, willFinishLaunchingWithOptions: launchOptions) ?? false || result
+    }
+  }
+
+  @objc
+  public static func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    ExpoAppDelegateSubscriberRepository.subscribers.forEach { subscriber in
+      // Subscriber result is ignored as it doesn't matter if any subscriber handled the incoming URL – we always return `true` anyway.
+      _ = subscriber.application?(application, didFinishLaunchingWithOptions: launchOptions)
+    }
+
+    return true
+  }
+
+#elseif os(macOS)
+  @objc
+  public static func applicationWillFinishLaunching(_ notification: Notification) {
+    let parsedSubscribers = ExpoAppDelegateSubscriberRepository.subscribers.filter {
+      $0.responds(to: #selector(applicationWillFinishLaunching(_:)))
+    }
+
+    parsedSubscribers.forEach { subscriber in
+      subscriber.applicationWillFinishLaunching?(notification)
+    }
+  }
+
+  @objc
+  public static func applicationDidFinishLaunching(_ notification: Notification) {
+    ExpoAppDelegateSubscriberRepository
+      .subscribers
+      .forEach { subscriber in
+        // Subscriber result is ignored as it doesn't matter if any subscriber handled the incoming URL – we always return `true` anyway.
+        _ = subscriber.applicationDidFinishLaunching?(notification)
+      }
+  }
+
+  // TODO: - Configuring and Discarding Scenes
+#endif
+
+  // MARK: - Responding to App Life-Cycle Events
+
+#if os(iOS) || os(tvOS)
+
+  @objc
+  public static func applicationDidBecomeActive(_ application: UIApplication) {
+    ExpoAppDelegateSubscriberRepository
+      .subscribers
+      .forEach { $0.applicationDidBecomeActive?(application) }
+  }
+
+  @objc
+  public static func applicationWillResignActive(_ application: UIApplication) {
+    ExpoAppDelegateSubscriberRepository
+      .subscribers
+      .forEach { $0.applicationWillResignActive?(application) }
+  }
+
+  @objc
+  public static func applicationDidEnterBackground(_ application: UIApplication) {
+    ExpoAppDelegateSubscriberRepository
+      .subscribers
+      .forEach { $0.applicationDidEnterBackground?(application) }
+  }
+
+  @objc
+  public static func applicationWillEnterForeground(_ application: UIApplication) {
+    ExpoAppDelegateSubscriberRepository
+      .subscribers
+      .forEach { $0.applicationWillEnterForeground?(application) }
+  }
+
+  @objc
+  public static func applicationWillTerminate(_ application: UIApplication) {
+    ExpoAppDelegateSubscriberRepository
+      .subscribers
+      .forEach { $0.applicationWillTerminate?(application) }
+  }
+
+#elseif os(macOS)
+  @objc
+  public static func applicationDidBecomeActive(_ notification: Notification) {
+    ExpoAppDelegateSubscriberRepository
+      .subscribers
+      .forEach { $0.applicationDidBecomeActive?(notification) }
+  }
+
+  @objc
+  public static func applicationWillResignActive(_ notification: Notification) {
+    ExpoAppDelegateSubscriberRepository
+      .subscribers
+      .forEach { $0.applicationWillResignActive?(notification) }
+  }
+
+  @objc
+  public static func applicationDidHide(_ notification: Notification) {
+    ExpoAppDelegateSubscriberRepository
+      .subscribers
+      .forEach { $0.applicationDidHide?(notification) }
+  }
+
+  @objc
+  public static func applicationWillUnhide(_ notification: Notification) {
+    ExpoAppDelegateSubscriberRepository
+      .subscribers
+      .forEach { $0.applicationWillUnhide?(notification) }
+  }
+
+  @objc
+  public static func applicationWillTerminate(_ notification: Notification) {
+    ExpoAppDelegateSubscriberRepository
+      .subscribers
+      .forEach { $0.applicationWillTerminate?(notification) }
+  }
+#endif
+
+  // TODO: - Responding to Environment Changes
+
+  // TODO: - Managing App State Restoration
+
+  // MARK: - Downloading Data in the Background
+
+#if os(iOS) || os(tvOS)
+  @objc
+  public static func application(
+    _ application: UIApplication,
+    handleEventsForBackgroundURLSession identifier: String,
+    completionHandler: @escaping () -> Void
+  ) {
+    let selector = #selector(application(_:handleEventsForBackgroundURLSession:completionHandler:))
+    let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
+    var subscribersLeft = subs.count
+    let dispatchQueue = DispatchQueue(label: "expo.application.handleBackgroundEvents")
+
+    let handler = {
+      dispatchQueue.sync {
+        subscribersLeft -= 1
+
+        if subscribersLeft == 0 {
+          completionHandler()
+        }
+      }
+    }
+
+    if subs.isEmpty {
+      completionHandler()
+    } else {
+      subs.forEach {
+        $0.application?(application, handleEventsForBackgroundURLSession: identifier, completionHandler: handler)
+      }
+    }
+  }
+
+#endif
+
+  // MARK: - Handling Remote Notification Registration
+
+  @objc
+  public static func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+    ExpoAppDelegateSubscriberRepository
+      .subscribers
+      .forEach { $0.application?(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken) }
+  }
+
+  @objc
+  public static func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+    ExpoAppDelegateSubscriberRepository
+      .subscribers
+      .forEach { $0.application?(application, didFailToRegisterForRemoteNotificationsWithError: error) }
+  }
+
+#if os(iOS) || os(tvOS)
+  @objc
+  public static func application(
+    _ application: UIApplication,
+    didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+    fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+  ) {
+    let selector = #selector(application(_:didReceiveRemoteNotification:fetchCompletionHandler:))
+    let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
+    var subscribersLeft = subs.count
+    let dispatchQueue = DispatchQueue(label: "expo.application.remoteNotification", qos: .userInteractive)
+    var failedCount = 0
+    var newDataCount = 0
+
+    let handler = { (result: UIBackgroundFetchResult) in
+      dispatchQueue.sync {
+        if result == .failed {
+          failedCount += 1
+        } else if result == .newData {
+          newDataCount += 1
+        }
+
+        subscribersLeft -= 1
+
+        if subscribersLeft == 0 {
+          if newDataCount > 0 {
+            completionHandler(.newData)
+          } else if failedCount > 0 {
+            completionHandler(.failed)
+          } else {
+            completionHandler(.noData)
+          }
+        }
+      }
+    }
+
+    if subs.isEmpty {
+      completionHandler(.noData)
+    } else {
+      subs.forEach { subscriber in
+        subscriber.application?(application, didReceiveRemoteNotification: userInfo, fetchCompletionHandler: handler)
+      }
+    }
+  }
+
+#elseif os(macOS)
+  @objc
+  public static func application(
+    _ application: NSApplication,
+    didReceiveRemoteNotification userInfo: [String: Any]
+  ) {
+    let selector = #selector(application(_:didReceiveRemoteNotification:))
+    let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
+
+    subs.forEach { subscriber in
+      subscriber.application?(application, didReceiveRemoteNotification: userInfo)
+    }
+  }
+#endif
+
+  // MARK: - Continuing User Activity and Handling Quick Actions
+
+  @objc
+  public static func application(_ application: UIApplication, willContinueUserActivityWithType userActivityType: String) -> Bool {
+    return ExpoAppDelegateSubscriberRepository
+      .subscribers
+      .reduce(false) { result, subscriber in
+        return subscriber.application?(application, willContinueUserActivityWithType: userActivityType) ?? false || result
+      }
+  }
+
+#if os(iOS) || os(tvOS)
+  @objc
+  public static func application(
+    _ application: UIApplication,
+    continue userActivity: NSUserActivity,
+    restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
+  ) -> Bool {
+    let selector = #selector(application(_:continue:restorationHandler:))
+    let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
+    var subscribersLeft = subs.count
+    let dispatchQueue = DispatchQueue(label: "expo.application.continueUserActivity", qos: .userInteractive)
+    var allRestorableObjects = [UIUserActivityRestoring]()
+
+    let handler = { (restorableObjects: [UIUserActivityRestoring]?) in
+      dispatchQueue.sync {
+        if let restorableObjects = restorableObjects {
+          allRestorableObjects.append(contentsOf: restorableObjects)
+        }
+
+        subscribersLeft -= 1
+
+        if subscribersLeft == 0 {
+          restorationHandler(allRestorableObjects)
+        }
+      }
+    }
+
+    return subs.reduce(false) { result, subscriber in
+      return subscriber.application?(application, continue: userActivity, restorationHandler: handler) ?? false || result
+    }
+  }
+#elseif os(macOS)
+  @objc
+  public static func application(
+    _ application: NSApplication,
+    continue userActivity: NSUserActivity,
+    restorationHandler: @escaping ([any NSUserActivityRestoring]) -> Void
+  ) -> Bool {
+    let selector = #selector(application(_:continue:restorationHandler:))
+    let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
+    var subscribersLeft = subs.count
+    let dispatchQueue = DispatchQueue(label: "expo.application.continueUserActivity", qos: .userInteractive)
+    var allRestorableObjects = [NSUserActivityRestoring]()
+
+    let handler = { (restorableObjects: [NSUserActivityRestoring]?) in
+      dispatchQueue.sync {
+        if let restorableObjects = restorableObjects {
+          allRestorableObjects.append(contentsOf: restorableObjects)
+        }
+
+        subscribersLeft -= 1
+
+        if subscribersLeft == 0 {
+          restorationHandler(allRestorableObjects)
+        }
+      }
+    }
+
+    return subs.reduce(false) { result, subscriber in
+      return subscriber.application?(application, continue: userActivity, restorationHandler: handler) ?? false || result
+    }
+  }
+#endif
+
+  @objc
+  public static func application(_ application: UIApplication, didUpdate userActivity: NSUserActivity) {
+    return ExpoAppDelegateSubscriberRepository
+      .subscribers
+      .forEach { $0.application?(application, didUpdate: userActivity) }
+  }
+
+  @objc
+  public static func application(_ application: UIApplication, didFailToContinueUserActivityWithType userActivityType: String, error: Error) {
+    return ExpoAppDelegateSubscriberRepository
+      .subscribers
+      .forEach {
+        $0.application?(application, didFailToContinueUserActivityWithType: userActivityType, error: error)
+      }
+  }
+
+#if os(iOS)
+  @objc
+  public static func application(
+    _ application: UIApplication,
+    performActionFor shortcutItem: UIApplicationShortcutItem,
+    completionHandler: @escaping (Bool) -> Void
+  ) {
+    let selector = #selector(application(_:performActionFor:completionHandler:))
+    let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
+    var subscribersLeft = subs.count
+    var result: Bool = false
+    let dispatchQueue = DispatchQueue(label: "expo.application.performAction", qos: .userInteractive)
+
+    let handler = { (succeeded: Bool) in
+      dispatchQueue.sync {
+        result = result || succeeded
+        subscribersLeft -= 1
+
+        if subscribersLeft == 0 {
+          completionHandler(result)
+        }
+      }
+    }
+
+    if subs.isEmpty {
+      completionHandler(result)
+    } else {
+      subs.forEach { subscriber in
+        subscriber.application?(application, performActionFor: shortcutItem, completionHandler: handler)
+      }
+    }
+  }
+#endif
+
+  // MARK: - Background Fetch
+
+#if os(iOS) || os(tvOS)
+  @objc
+  public static func application(
+    _ application: UIApplication,
+    performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+  ) {
+    let selector = #selector(application(_:performFetchWithCompletionHandler:))
+    let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
+    var subscribersLeft = subs.count
+    let dispatchQueue = DispatchQueue(label: "expo.application.performFetch", qos: .userInteractive)
+    var failedCount = 0
+    var newDataCount = 0
+
+    let handler = { (result: UIBackgroundFetchResult) in
+      dispatchQueue.sync {
+        if result == .failed {
+          failedCount += 1
+        } else if result == .newData {
+          newDataCount += 1
+        }
+
+        subscribersLeft -= 1
+
+        if subscribersLeft == 0 {
+          if newDataCount > 0 {
+            completionHandler(.newData)
+          } else if failedCount > 0 {
+            completionHandler(.failed)
+          } else {
+            completionHandler(.noData)
+          }
+        }
+      }
+    }
+
+    if subs.isEmpty {
+      completionHandler(.noData)
+    } else {
+      subs.forEach { subscriber in
+        subscriber.application?(application, performFetchWithCompletionHandler: handler)
+      }
+    }
+  }
+
+#endif
+
+  // MARK: - Opening a URL-Specified Resource
+#if os(iOS) || os(tvOS)
+
+  @objc
+  public static func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+    return ExpoAppDelegateSubscriberRepository.subscribers.reduce(false) { result, subscriber in
+      return subscriber.application?(app, open: url, options: options) ?? false || result
+    }
+  }
+#elseif os(macOS)
+  @objc
+  public static func application(_ app: NSApplication, open urls: [URL]) {
+    ExpoAppDelegateSubscriberRepository.subscribers.forEach { subscriber in
+      subscriber.application?(app, open: urls)
+    }
+  }
+#endif
+
+#if os(iOS)
+
+  /**
+   * Sets allowed orientations for the application. It will use the values from `Info.plist`as the orientation mask unless a subscriber requested
+   * a different orientation.
+   */
+  @objc
+  public static func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+    let deviceOrientationMask = allowedOrientations(for: UIDevice.current.userInterfaceIdiom)
+    let universalOrientationMask = allowedOrientations(for: .unspecified)
+    let infoPlistOrientations = deviceOrientationMask.isEmpty ? universalOrientationMask : deviceOrientationMask
+
+    let parsedSubscribers = ExpoAppDelegateSubscriberRepository.subscribers.filter {
+      $0.responds(to: #selector(application(_:supportedInterfaceOrientationsFor:)))
+    }
+
+    // We want to create an intersection of all orientations set by subscribers.
+    let subscribersMask: UIInterfaceOrientationMask = parsedSubscribers.reduce(.all) { result, subscriber in
+      guard let requestedOrientation = subscriber.application?(application, supportedInterfaceOrientationsFor: window) else {
+        return result
+      }
+      return requestedOrientation.intersection(result)
+    }
+    return parsedSubscribers.isEmpty ? infoPlistOrientations : subscribersMask
+  }
+#endif
+}
+
+#if os(iOS)
+private func allowedOrientations(for userInterfaceIdiom: UIUserInterfaceIdiom) -> UIInterfaceOrientationMask {
+  // For now only iPad-specific orientations are supported
+  let deviceString = userInterfaceIdiom == .pad ? "~pad" : ""
+  var mask: UIInterfaceOrientationMask = []
+  guard let orientations = Bundle.main.infoDictionary?["UISupportedInterfaceOrientations\(deviceString)"] as? [String] else {
+    return mask
+  }
+
+  for orientation in orientations {
+    switch orientation {
+    case "UIInterfaceOrientationPortrait":
+      mask.insert(.portrait)
+    case "UIInterfaceOrientationLandscapeLeft":
+      mask.insert(.landscapeLeft)
+    case "UIInterfaceOrientationLandscapeRight":
+      mask.insert(.landscapeRight)
+    case "UIInterfaceOrientationPortraitUpsideDown":
+      mask.insert(.portraitUpsideDown)
+    default:
+      break
+    }
+  }
+  return mask
+}
+#endif // os(iOS)

--- a/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
@@ -18,52 +18,23 @@ open class ExpoAppDelegate: NSObject, UIApplicationDelegate {
     _ application: UIApplication,
     willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
-    let parsedSubscribers = ExpoAppDelegateSubscriberRepository.subscribers.filter {
-      $0.responds(to: #selector(application(_:willFinishLaunchingWithOptions:)))
-    }
-
-    // If we can't find a subscriber that implements `willFinishLaunchingWithOptions`, we will delegate the decision if we can handel the passed URL to
-    // the `didFinishLaunchingWithOptions` method by returning `true` here.
-    //  You can read more about how iOS handles deep links here: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application#discussion
-    if parsedSubscribers.isEmpty {
-      return true
-    }
-
-    return parsedSubscribers.reduce(false) { result, subscriber in
-      return subscriber.application?(application, willFinishLaunchingWithOptions: launchOptions) ?? false || result
-    }
+    return ExpoAppDelegateSubscriberManager.application(application, willFinishLaunchingWithOptions: launchOptions)
   }
 
   open func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
-    ExpoAppDelegateSubscriberRepository.subscribers.forEach { subscriber in
-      // Subscriber result is ignored as it doesn't matter if any subscriber handled the incoming URL – we always return `true` anyway.
-      _ = subscriber.application?(application, didFinishLaunchingWithOptions: launchOptions)
-    }
-
-    return true
+    return ExpoAppDelegateSubscriberManager.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 
 #elseif os(macOS)
   open func applicationWillFinishLaunching(_ notification: Notification) {
-    let parsedSubscribers = ExpoAppDelegateSubscriberRepository.subscribers.filter {
-      $0.responds(to: #selector(applicationWillFinishLaunching(_:)))
-    }
-
-    parsedSubscribers.forEach { subscriber in
-      subscriber.applicationWillFinishLaunching?(notification)
-    }
+    ExpoAppDelegateSubscriberManager.applicationWillFinishLaunching(notification)
   }
 
   open func applicationDidFinishLaunching(_ notification: Notification) {
-    ExpoAppDelegateSubscriberRepository
-      .subscribers
-      .forEach { subscriber in
-        // Subscriber result is ignored as it doesn't matter if any subscriber handled the incoming URL – we always return `true` anyway.
-        _ = subscriber.applicationDidFinishLaunching?(notification)
-      }
+    ExpoAppDelegateSubscriberManager.applicationDidFinishLaunching(notification)
   }
 
   // TODO: - Configuring and Discarding Scenes
@@ -75,69 +46,49 @@ open class ExpoAppDelegate: NSObject, UIApplicationDelegate {
 
   @objc
   open func applicationDidBecomeActive(_ application: UIApplication) {
-    ExpoAppDelegateSubscriberRepository
-      .subscribers
-      .forEach { $0.applicationDidBecomeActive?(application) }
+    ExpoAppDelegateSubscriberManager.applicationDidBecomeActive(application)
   }
 
   @objc
   open func applicationWillResignActive(_ application: UIApplication) {
-    ExpoAppDelegateSubscriberRepository
-      .subscribers
-      .forEach { $0.applicationWillResignActive?(application) }
+    ExpoAppDelegateSubscriberManager.applicationWillResignActive(application)
   }
 
   @objc
   open func applicationDidEnterBackground(_ application: UIApplication) {
-    ExpoAppDelegateSubscriberRepository
-      .subscribers
-      .forEach { $0.applicationDidEnterBackground?(application) }
+    ExpoAppDelegateSubscriberManager.applicationDidEnterBackground(application)
   }
 
   open func applicationWillEnterForeground(_ application: UIApplication) {
-    ExpoAppDelegateSubscriberRepository
-      .subscribers
-      .forEach { $0.applicationWillEnterForeground?(application) }
+    ExpoAppDelegateSubscriberManager.applicationWillEnterForeground(application)
   }
 
   open func applicationWillTerminate(_ application: UIApplication) {
-    ExpoAppDelegateSubscriberRepository
-      .subscribers
-      .forEach { $0.applicationWillTerminate?(application) }
+    ExpoAppDelegateSubscriberManager.applicationWillTerminate(application)
   }
 
 #elseif os(macOS)
   @objc
   open func applicationDidBecomeActive(_ notification: Notification) {
-    ExpoAppDelegateSubscriberRepository
-      .subscribers
-      .forEach { $0.applicationDidBecomeActive?(notification) }
+    ExpoAppDelegateSubscriberManager.applicationDidBecomeActive(notification)
   }
 
   @objc
   open func applicationWillResignActive(_ notification: Notification) {
-    ExpoAppDelegateSubscriberRepository
-      .subscribers
-      .forEach { $0.applicationWillResignActive?(notification) }
+    ExpoAppDelegateSubscriberManager.applicationWillResignActive(notification)
   }
 
   @objc
   open func applicationDidHide(_ notification: Notification) {
-    ExpoAppDelegateSubscriberRepository
-      .subscribers
-      .forEach { $0.applicationDidHide?(notification) }
+    ExpoAppDelegateSubscriberManager.applicationDidHide(notification)
   }
 
   open func applicationWillUnhide(_ notification: Notification) {
-    ExpoAppDelegateSubscriberRepository
-      .subscribers
-      .forEach { $0.applicationWillUnhide?(notification) }
+    ExpoAppDelegateSubscriberManager.applicationWillUnhide(notification)
   }
 
   open func applicationWillTerminate(_ notification: Notification) {
-    ExpoAppDelegateSubscriberRepository
-      .subscribers
-      .forEach { $0.applicationWillTerminate?(notification) }
+    ExpoAppDelegateSubscriberManager.applicationWillTerminate(notification)
   }
 #endif
 
@@ -153,28 +104,7 @@ open class ExpoAppDelegate: NSObject, UIApplicationDelegate {
     handleEventsForBackgroundURLSession identifier: String,
     completionHandler: @escaping () -> Void
   ) {
-    let selector = #selector(application(_:handleEventsForBackgroundURLSession:completionHandler:))
-    let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
-    var subscribersLeft = subs.count
-    let dispatchQueue = DispatchQueue(label: "expo.application.handleBackgroundEvents")
-
-    let handler = {
-      dispatchQueue.sync {
-        subscribersLeft -= 1
-
-        if subscribersLeft == 0 {
-          completionHandler()
-        }
-      }
-    }
-
-    if subs.isEmpty {
-      completionHandler()
-    } else {
-      subs.forEach {
-        $0.application?(application, handleEventsForBackgroundURLSession: identifier, completionHandler: handler)
-      }
-    }
+    ExpoAppDelegateSubscriberManager.application(application, handleEventsForBackgroundURLSession: identifier, completionHandler: completionHandler)
   }
 
 #endif
@@ -182,15 +112,11 @@ open class ExpoAppDelegate: NSObject, UIApplicationDelegate {
   // MARK: - Handling Remote Notification Registration
 
   open func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-    ExpoAppDelegateSubscriberRepository
-      .subscribers
-      .forEach { $0.application?(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken) }
+    ExpoAppDelegateSubscriberManager.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
   }
 
   open func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
-    ExpoAppDelegateSubscriberRepository
-      .subscribers
-      .forEach { $0.application?(application, didFailToRegisterForRemoteNotificationsWithError: error) }
+    ExpoAppDelegateSubscriberManager.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
   }
 
 #if os(iOS) || os(tvOS)
@@ -199,42 +125,7 @@ open class ExpoAppDelegate: NSObject, UIApplicationDelegate {
     didReceiveRemoteNotification userInfo: [AnyHashable: Any],
     fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
   ) {
-    let selector = #selector(application(_:didReceiveRemoteNotification:fetchCompletionHandler:))
-    let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
-    var subscribersLeft = subs.count
-    let dispatchQueue = DispatchQueue(label: "expo.application.remoteNotification", qos: .userInteractive)
-    var failedCount = 0
-    var newDataCount = 0
-
-    let handler = { (result: UIBackgroundFetchResult) in
-      dispatchQueue.sync {
-        if result == .failed {
-          failedCount += 1
-        } else if result == .newData {
-          newDataCount += 1
-        }
-
-        subscribersLeft -= 1
-
-        if subscribersLeft == 0 {
-          if newDataCount > 0 {
-            completionHandler(.newData)
-          } else if failedCount > 0 {
-            completionHandler(.failed)
-          } else {
-            completionHandler(.noData)
-          }
-        }
-      }
-    }
-
-    if subs.isEmpty {
-      completionHandler(.noData)
-    } else {
-      subs.forEach { subscriber in
-        subscriber.application?(application, didReceiveRemoteNotification: userInfo, fetchCompletionHandler: handler)
-      }
-    }
+    ExpoAppDelegateSubscriberManager.application(application, didReceiveRemoteNotification: userInfo, fetchCompletionHandler: completionHandler)
   }
 
 #elseif os(macOS)
@@ -242,23 +133,14 @@ open class ExpoAppDelegate: NSObject, UIApplicationDelegate {
     _ application: NSApplication,
     didReceiveRemoteNotification userInfo: [String: Any]
   ) {
-    let selector = #selector(application(_:didReceiveRemoteNotification:))
-    let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
-
-    subs.forEach { subscriber in
-      subscriber.application?(application, didReceiveRemoteNotification: userInfo)
-    }
+    ExpoAppDelegateSubscriberManager.application(application, didReceiveRemoteNotification: userInfo)
   }
 #endif
 
   // MARK: - Continuing User Activity and Handling Quick Actions
 
   open func application(_ application: UIApplication, willContinueUserActivityWithType userActivityType: String) -> Bool {
-    return ExpoAppDelegateSubscriberRepository
-      .subscribers
-      .reduce(false) { result, subscriber in
-        return subscriber.application?(application, willContinueUserActivityWithType: userActivityType) ?? false || result
-      }
+    return ExpoAppDelegateSubscriberManager.application(application, willContinueUserActivityWithType: userActivityType)
   }
 
 #if os(iOS) || os(tvOS)
@@ -267,29 +149,7 @@ open class ExpoAppDelegate: NSObject, UIApplicationDelegate {
     continue userActivity: NSUserActivity,
     restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
   ) -> Bool {
-    let selector = #selector(application(_:continue:restorationHandler:))
-    let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
-    var subscribersLeft = subs.count
-    let dispatchQueue = DispatchQueue(label: "expo.application.continueUserActivity", qos: .userInteractive)
-    var allRestorableObjects = [UIUserActivityRestoring]()
-
-    let handler = { (restorableObjects: [UIUserActivityRestoring]?) in
-      dispatchQueue.sync {
-        if let restorableObjects = restorableObjects {
-          allRestorableObjects.append(contentsOf: restorableObjects)
-        }
-
-        subscribersLeft -= 1
-
-        if subscribersLeft == 0 {
-          restorationHandler(allRestorableObjects)
-        }
-      }
-    }
-
-    return subs.reduce(false) { result, subscriber in
-      return subscriber.application?(application, continue: userActivity, restorationHandler: handler) ?? false || result
-    }
+    return ExpoAppDelegateSubscriberManager.application(application, continue: userActivity, restorationHandler: restorationHandler)
   }
 #elseif os(macOS)
   open func application(
@@ -297,44 +157,16 @@ open class ExpoAppDelegate: NSObject, UIApplicationDelegate {
     continue userActivity: NSUserActivity,
     restorationHandler: @escaping ([any NSUserActivityRestoring]) -> Void
   ) -> Bool {
-    let selector = #selector(application(_:continue:restorationHandler:))
-    let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
-    var subscribersLeft = subs.count
-    let dispatchQueue = DispatchQueue(label: "expo.application.continueUserActivity", qos: .userInteractive)
-    var allRestorableObjects = [NSUserActivityRestoring]()
-
-    let handler = { (restorableObjects: [NSUserActivityRestoring]?) in
-      dispatchQueue.sync {
-        if let restorableObjects = restorableObjects {
-          allRestorableObjects.append(contentsOf: restorableObjects)
-        }
-
-        subscribersLeft -= 1
-
-        if subscribersLeft == 0 {
-          restorationHandler(allRestorableObjects)
-        }
-      }
-    }
-
-    return subs.reduce(false) { result, subscriber in
-      return subscriber.application?(application, continue: userActivity, restorationHandler: handler) ?? false || result
-    }
+    return ExpoAppDelegateSubscriberManager.application(application, continue: userActivity, restorationHandler: restorationHandler)
   }
 #endif
 
   open func application(_ application: UIApplication, didUpdate userActivity: NSUserActivity) {
-    return ExpoAppDelegateSubscriberRepository
-      .subscribers
-      .forEach { $0.application?(application, didUpdate: userActivity) }
+    return ExpoAppDelegateSubscriberManager.application(application, didUpdate: userActivity)
   }
 
   open func application(_ application: UIApplication, didFailToContinueUserActivityWithType userActivityType: String, error: Error) {
-    return ExpoAppDelegateSubscriberRepository
-      .subscribers
-      .forEach {
-        $0.application?(application, didFailToContinueUserActivityWithType: userActivityType, error: error)
-      }
+    return ExpoAppDelegateSubscriberManager.application(application, didFailToContinueUserActivityWithType: userActivityType, error: error)
   }
 
 #if os(iOS)
@@ -343,30 +175,7 @@ open class ExpoAppDelegate: NSObject, UIApplicationDelegate {
     performActionFor shortcutItem: UIApplicationShortcutItem,
     completionHandler: @escaping (Bool) -> Void
   ) {
-    let selector = #selector(application(_:performActionFor:completionHandler:))
-    let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
-    var subscribersLeft = subs.count
-    var result: Bool = false
-    let dispatchQueue = DispatchQueue(label: "expo.application.performAction", qos: .userInteractive)
-
-    let handler = { (succeeded: Bool) in
-      dispatchQueue.sync {
-        result = result || succeeded
-        subscribersLeft -= 1
-
-        if subscribersLeft == 0 {
-          completionHandler(result)
-        }
-      }
-    }
-
-    if subs.isEmpty {
-      completionHandler(result)
-    } else {
-      subs.forEach { subscriber in
-        subscriber.application?(application, performActionFor: shortcutItem, completionHandler: handler)
-      }
-    }
+    ExpoAppDelegateSubscriberManager.application(application, performActionFor: shortcutItem, completionHandler: completionHandler)
   }
 #endif
 
@@ -377,42 +186,7 @@ open class ExpoAppDelegate: NSObject, UIApplicationDelegate {
     _ application: UIApplication,
     performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
   ) {
-    let selector = #selector(application(_:performFetchWithCompletionHandler:))
-    let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
-    var subscribersLeft = subs.count
-    let dispatchQueue = DispatchQueue(label: "expo.application.performFetch", qos: .userInteractive)
-    var failedCount = 0
-    var newDataCount = 0
-
-    let handler = { (result: UIBackgroundFetchResult) in
-      dispatchQueue.sync {
-        if result == .failed {
-          failedCount += 1
-        } else if result == .newData {
-          newDataCount += 1
-        }
-
-        subscribersLeft -= 1
-
-        if subscribersLeft == 0 {
-          if newDataCount > 0 {
-            completionHandler(.newData)
-          } else if failedCount > 0 {
-            completionHandler(.failed)
-          } else {
-            completionHandler(.noData)
-          }
-        }
-      }
-    }
-
-    if subs.isEmpty {
-      completionHandler(.noData)
-    } else {
-      subs.forEach { subscriber in
-        subscriber.application?(application, performFetchWithCompletionHandler: handler)
-      }
-    }
+    ExpoAppDelegateSubscriberManager.application(application, performFetchWithCompletionHandler: completionHandler)
   }
 
   // TODO: - Interacting With WatchKit
@@ -424,15 +198,11 @@ open class ExpoAppDelegate: NSObject, UIApplicationDelegate {
 #if os(iOS) || os(tvOS)
 
   open func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-    return ExpoAppDelegateSubscriberRepository.subscribers.reduce(false) { result, subscriber in
-      return subscriber.application?(app, open: url, options: options) ?? false || result
-    }
+    return ExpoAppDelegateSubscriberManager.application(app, open: url, options: options)
   }
 #elseif os(macOS)
   open func application(_ app: NSApplication, open urls: [URL]) {
-    ExpoAppDelegateSubscriberRepository.subscribers.forEach { subscriber in
-      subscriber.application?(app, open: urls)
-    }
+    ExpoAppDelegateSubscriberManager.application(app, open: urls)
   }
 #endif
   // TODO: - Disallowing Specified App Extension Types
@@ -449,49 +219,7 @@ open class ExpoAppDelegate: NSObject, UIApplicationDelegate {
    * a different orientation.
    */
   open func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
-    let deviceOrientationMask = allowedOrientations(for: UIDevice.current.userInterfaceIdiom)
-    let universalOrientationMask = allowedOrientations(for: .unspecified)
-    let infoPlistOrientations = deviceOrientationMask.isEmpty ? universalOrientationMask : deviceOrientationMask
-
-    let parsedSubscribers = ExpoAppDelegateSubscriberRepository.subscribers.filter {
-      $0.responds(to: #selector(application(_:supportedInterfaceOrientationsFor:)))
-    }
-
-    // We want to create an intersection of all orientations set by subscribers.
-    let subscribersMask: UIInterfaceOrientationMask = parsedSubscribers.reduce(.all) { result, subscriber in
-      guard let requestedOrientation = subscriber.application?(application, supportedInterfaceOrientationsFor: window) else {
-        return result
-      }
-      return requestedOrientation.intersection(result)
-    }
-    return parsedSubscribers.isEmpty ? infoPlistOrientations : subscribersMask
+    return ExpoAppDelegateSubscriberManager.application(application, supportedInterfaceOrientationsFor: window)
   }
 #endif
 }
-
-#if os(iOS)
-private func allowedOrientations(for userInterfaceIdiom: UIUserInterfaceIdiom) -> UIInterfaceOrientationMask {
-  // For now only iPad-specific orientations are supported
-  let deviceString = userInterfaceIdiom == .pad ? "~pad" : ""
-  var mask: UIInterfaceOrientationMask = []
-  guard let orientations = Bundle.main.infoDictionary?["UISupportedInterfaceOrientations\(deviceString)"] as? [String] else {
-    return mask
-  }
-
-  for orientation in orientations {
-    switch orientation {
-    case "UIInterfaceOrientationPortrait":
-      mask.insert(.portrait)
-    case "UIInterfaceOrientationLandscapeLeft":
-      mask.insert(.landscapeLeft)
-    case "UIInterfaceOrientationLandscapeRight":
-      mask.insert(.landscapeRight)
-    case "UIInterfaceOrientationPortraitUpsideDown":
-      mask.insert(.portraitUpsideDown)
-    default:
-      break
-    }
-  }
-  return mask
-}
-#endif // os(iOS)


### PR DESCRIPTION
# Why

In order to simplify integrating iOS lifecycle events in brownfield apps without requiring the inheritance of ExpoAppDelegate, this PR aims to wrap all ExpoAppDelegate functions related to subscribers into a single static class

# How

Wrap life cycle logic in a static class named  ExpoAppDelegateSubscriberManager

# Test Plan

Run BareExpo on iOS and macOS

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
