### PR TITLE
[test-suite] fix e2e crash

### DIFF
--- a/apps/test-suite/screens/TestScreen.js
+++ b/apps/test-suite/screens/TestScreen.js
@@ -29,8 +29,8 @@ export default class TestScreen extends React.Component {
   _scrollViewRef = null;
 
   componentDidMount() {
-    const selectionQuery = this.props.route.params?.tests ?? [];
-    const selectedTestNames = selectionQuery.split(' ');
+    const selectionQuery = this.props.route.params?.tests ?? '';
+    const selectedTestNames = selectionQuery.split(/[,\s]/);
 
     // We get test modules here to make sure that React Native will reload this component when tests were changed.
     const selectedModules = getTestModules().filter((m) => selectedTestNames.includes(m.name));


### PR DESCRIPTION
# Why

fixes ci error: https://github.com/expo/expo/actions/runs/18008057865/job/51259983905

```
2025-09-25 17:52:02.214474+0000 0xba0b     Error       0x0                  10933  0    BareExpo: (React) [com.facebook.react.log:native] Unhandled JS Exception: TypeError: undefined is not a function

This error is located at:
    at TestScreen (/Users/runner/Library/Developer/Xcode/DerivedData/BareExpo-cilowpuzarpyfthblhhxnutaihyt/Build/Products/Release-iphonesimulator/main.jsbundle:293876:35)
    at StaticContainer (/Users/runner/Library/Developer/Xcode/DerivedData/BareExpo-cilowpuzarpyfthblhhxnutaihyt/Build/Products/Release-iphonesimulator/main.jsbundle:78035:17)
    at EnsureSingleNavigator (/Users/runner/Library/Developer/Xcode/DerivedData/BareExpo-cilowpuzarpyfthblhhxnutaihyt/Build/Products/Release-iphonesimulator/main.jsbundle:73323:24)
    at SceneView (/Users/runner/Library/Developer/Xcode/DerivedData/BareExpo-cilowpuzarpyfthblhhxnutaihyt/Build/Products/Release-iphonesimulator/main.jsbundle:77840:22)
    at RNSScreenContentWrapper (<anonymous>)
    at ScreenContentWrapper (<anonymous>)
    at DebugContainer (<anonymous>)
    at RNSScreen (<anonymous>)
    at Animated(Anonymous) (/Users/runner/Library/Developer/Xcode/DerivedDa<…>
```

# How

- we open app `bareexpo://test-suite/run` at beginning for e2e
https://github.com/expo/expo/blob/555e5cd2334f2341ec92f87f1585e4c14257bc20/apps/bare-expo/scripts/lib/e2e-common.ts#L43
- the issue was there for a while. see https://github.com/expo/expo/actions/runs/18000614308/job/51218120482. it's not a problem because we have retries and suppress the problem

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
