### PR TITLE
[contacts][ios] Fix bug with phoneticFirstName and phoneticMiddleNam

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fixed issue with missing `namePrefix` on iOS ([#39974](https://github.com/expo/expo/pull/39974) by [@hryhoriiK97](https://github.com/hryhoriiK97))
+- [iOS] Fixed phonetic name fields being assigned to wrong keys ([#40013](https://github.com/expo/expo/pull/40013) by [@hryhoriiK97](https://github.com/hryhoriiK97))
 
 ### 💡 Others
 

--- a/packages/expo-contacts/ios/Serialization.swift
+++ b/packages/expo-contacts/ios/Serialization.swift
@@ -247,10 +247,10 @@ func serializeContact(person: CNContact, keys: [String]?, directory: URL?) throw
     contact[ContactsKey.nameSuffix] = person.nameSuffix
   }
   if keysToFetch.contains(CNContactPhoneticGivenNameKey) && fieldHasValue(field: person.phoneticGivenName) {
-    contact[ContactsKey.note] = person.phoneticGivenName
+    contact[ContactsKey.phoneticFirstName] = person.phoneticGivenName
   }
   if keysToFetch.contains(CNContactPhoneticMiddleNameKey) && fieldHasValue(field: person.phoneticMiddleName) {
-    contact[ContactsKey.note] = person.phoneticMiddleName
+    contact[ContactsKey.phoneticMiddleName] = person.phoneticMiddleName
   }
   if keysToFetch.contains(CNContactPhoneticFamilyNameKey) && fieldHasValue(field: person.phoneticFamilyName) {
     contact[ContactsKey.phoneticLastName] = person.phoneticFamilyName


### PR DESCRIPTION
# Why
Phonetic name fields were assigned to wrong keys - phoneticFirstName and phoneticMiddleName were being assigned to the note field instead of their correct keys

# How
Fixed the iOS serialization logic in Serialization.swift mapping to the right keys.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
