### PR TITLE
[autolinking][Android] Fix passing exclude options

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix passing exclude options
+
 ### 💡 Others
 
 - [iOS] Added support for passing pod targets that should be statically linked and not built as frameworks. ([#39742](https://github.com/expo/expo/pull/39742) by [@chrfalch](https://github.com/chrfalch))

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix passing exclude options
+- [Android] Fix passing exclude options. ([#40014](https://github.com/expo/expo/pull/40014) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/main/kotlin/expo/modules/plugin/AutolinkigCommandBuilder.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/main/kotlin/expo/modules/plugin/AutolinkigCommandBuilder.kt
@@ -22,7 +22,7 @@ class AutolinkingCommandBuilder {
 
   private var autolinkingCommand = emptyList<String>()
   private var useJson = emptyList<String>()
-  private val optionsMap = mutableMapOf<String, String>()
+  private val optionsMap = mutableSetOf<Pair<String, String>>()
   private var searchPaths = emptyList<String>()
 
   /**
@@ -36,14 +36,14 @@ class AutolinkingCommandBuilder {
    * Add an option to the command.
    */
   fun option(key: String, value: String) = apply {
-    optionsMap[key] = value
+    optionsMap.add(key to value)
   }
 
   /**
    * Add a list of values as an option to the command.
    */
   fun option(key: String, value: List<String>) = apply {
-    optionsMap[key] = value.joinToString(" ")
+    value.forEach { optionsMap.add(key to it) }
   }
 
   /**
@@ -61,7 +61,6 @@ class AutolinkingCommandBuilder {
   }
 
   fun useAutolinkingOptions(autolinkingOptions: AutolinkingOptions) = apply {
-    autolinkingOptions.ignorePaths?.let { option(IGNORE_PATHS_KEY, it) }
     autolinkingOptions.exclude?.let { option(EXCLUDE_KEY, it) }
     autolinkingOptions.searchPaths?.let { searchPaths(it) }
   }
@@ -77,7 +76,6 @@ class AutolinkingCommandBuilder {
   }
 
   companion object {
-    const val IGNORE_PATHS_KEY = "ignore-paths"
     const val EXCLUDE_KEY = "exclude"
   }
 }

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/main/kotlin/expo/modules/plugin/ExpoGradleExtension.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/main/kotlin/expo/modules/plugin/ExpoGradleExtension.kt
@@ -8,7 +8,6 @@ import java.security.MessageDigest
 @Serializable
 data class AutolinkingOptions(
   val searchPaths: List<String>? = null,
-  val ignorePaths: List<String>? = null,
   val exclude: List<String>? = null
 ) {
   fun toJson(): String {

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingSettingsExtension.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingSettingsExtension.kt
@@ -41,11 +41,6 @@ open class ExpoAutolinkingSettingsExtension(
   var searchPaths: List<String>? = null
 
   /**
-   * Paths to ignore when looking up for modules.
-   */
-  var ignorePaths: List<String>? = null
-
-  /**
    * Package names to exclude when looking up for modules.
    */
   var exclude: List<String>? = null
@@ -82,7 +77,6 @@ open class ExpoAutolinkingSettingsExtension(
       settings,
       projectRoot,
       searchPaths,
-      ignorePaths,
       exclude
     ).useExpoModules()
   }

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/SettingsManager.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/SettingsManager.kt
@@ -28,12 +28,10 @@ class SettingsManager(
   val settings: Settings,
   val projectRoot: File,
   searchPaths: List<String>? = null,
-  ignorePaths: List<String>? = null,
   exclude: List<String>? = null
 ) {
   private val autolinkingOptions = AutolinkingOptions(
     searchPaths,
-    ignorePaths,
     exclude
   )
 


### PR DESCRIPTION
# Why

Exclude is not working correctly.

# How

Pass every item as a separate --exclude option.

## Before 
```sh
--exclude "expo-module-template expo-module-template-local react-native-reanimated expo-dev-menu-interface" ...
```
## After 
```sh
--exclude expo-module-template --exclude expo-module-template-local --exclude react-native-reanimated --exclude expo-dev-menu-interface ...
```

# Test Plan

CI should be green ✅

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
