### PR TITLE
[docs] Add Ask AI on latest pages under Reference

### DIFF
--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -57,12 +57,15 @@ export default function DocumentationPage({
   const sidebarScrollPosition = process?.browser ? window.__sidebarScroll : 0;
   const currentPath = router?.asPath ?? '';
   const isLatestSdkPage = currentPath.startsWith('/versions/latest/sdk/');
+  const isLatestConfigPage = currentPath.startsWith('/versions/latest/config/');
+  const isAskAIEligiblePage = isLatestSdkPage || isLatestConfigPage;
+  const askAIButtonVariant = isLatestConfigPage ? 'config' : 'default';
 
   useEffect(() => {
-    if (!isLatestSdkPage && isAskAIVisible) {
+    if (!isAskAIEligiblePage && isAskAIVisible) {
       setAskAIVisible(false);
     }
-  }, [isLatestSdkPage, isAskAIVisible]);
+  }, [isAskAIEligiblePage, isAskAIVisible]);
 
   const handleAskAIChatClose = () => {
     setAskAIVisible(false);
@@ -71,7 +74,7 @@ export default function DocumentationPage({
     setAskAIVisible(false);
   };
   const handleAskAIToggle = () => {
-    if (!isLatestSdkPage) {
+    if (!isAskAIEligiblePage) {
       return;
     }
 
@@ -197,9 +200,10 @@ export default function DocumentationPage({
               packageName={packageName}
               iconUrl={iconUrl}
               platforms={platforms}
-              showAskAIButton={isLatestSdkPage}
+              showAskAIButton={isAskAIEligiblePage}
               onAskAIClick={handleAskAIToggle}
               isAskAIVisible={isAskAIVisible}
+              askAIButtonVariant={askAIButtonVariant}
             />
           )}
           {title && <Separator />}
@@ -214,7 +218,7 @@ export default function DocumentationPage({
           modificationDate={modificationDate}
         />
       </DocumentationNestedScrollLayout>
-      {isLatestSdkPage && (
+      {isAskAIEligiblePage && (
         <AskPageAIOverlay
           onClose={handleAskAIChatClose}
           onMinimize={handleAskAIMinimize}

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -67,6 +67,9 @@ export default function DocumentationPage({
   const handleAskAIChatClose = () => {
     setAskAIVisible(false);
   };
+  const handleAskAIMinimize = () => {
+    setAskAIVisible(false);
+  };
   const handleAskAIToggle = () => {
     if (!isLatestSdkPage) {
       return;
@@ -211,7 +214,14 @@ export default function DocumentationPage({
           modificationDate={modificationDate}
         />
       </DocumentationNestedScrollLayout>
-      {isAskAIVisible && <AskPageAIOverlay onClose={handleAskAIChatClose} pageTitle={title} />}
+      {isLatestSdkPage && (
+        <AskPageAIOverlay
+          onClose={handleAskAIChatClose}
+          onMinimize={handleAskAIMinimize}
+          pageTitle={title}
+          isVisible={isAskAIVisible}
+        />
+      )}
     </>
   );
 }

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -247,6 +247,7 @@ export default function DocumentationPage({
           onClose={handleAskAIChatClose}
           onMinimize={handleAskAIMinimize}
           pageTitle={title}
+          isExpoSdkPage={isLatestSdkPage}
           isVisible={isAskAIVisible}
         />
       )}

--- a/docs/jest.config.js
+++ b/docs/jest.config.js
@@ -12,6 +12,8 @@ const jestConfig = {
     // note(simek): force Jest to use non ESM bundle
     '^@radix-ui/react-select$': '<rootDir>/node_modules/@radix-ui/react-select/dist/index.js',
     '^framer-motion$': '<rootDir>/node_modules/framer-motion/dist/cjs/index.js',
+    '^@fingerprintjs/fingerprintjs-pro-react$':
+      '<rootDir>/node_modules/@fingerprintjs/fingerprintjs-pro-react/dist/fp-pro-react.cjs.js',
   },
   transform: {},
   extensionsToTreatAsEsm: ['.ts', '.tsx'],

--- a/docs/package.json
+++ b/docs/package.json
@@ -31,6 +31,7 @@
     "@expo/styleguide-base": "^2.0.3",
     "@expo/styleguide-icons": "^2.2.3",
     "@expo/styleguide-search-ui": "^3.2.1",
+    "@kapaai/react-sdk": "^0.5.1",
     "@mdx-js/loader": "^3.1.0",
     "@mdx-js/mdx": "^3.1.0",
     "@mdx-js/react": "^3.1.0",

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -1,4 +1,5 @@
 import { ThemeProvider } from '@expo/styleguide';
+import { KapaProvider } from '@kapaai/react-sdk';
 import { MDXProvider } from '@mdx-js/react';
 import * as Sentry from '@sentry/react';
 import { MotionConfig } from 'framer-motion';
@@ -20,6 +21,7 @@ import '@expo/styleguide-search-ui/dist/expo-search-ui.css';
 import 'tippy.js/dist/tippy.css';
 
 const isDev = process.env.NODE_ENV === 'development';
+const KAPA_INTEGRATION_ID = '2063233f-1e70-45e8-b1b5-a872c9887afc';
 
 export const regularFont = Inter({
   display: 'swap',
@@ -86,7 +88,9 @@ export default function App({ Component, pageProps }: AppProps) {
               <CodeBlockSettingsProvider>
                 <MDXProvider components={rootMarkdownComponents}>
                   <Tooltip.Provider>
-                    <Component {...pageProps} />
+                    <KapaProvider integrationId={KAPA_INTEGRATION_ID} callbacks={{}}>
+                      <Component {...pageProps} />
+                    </KapaProvider>
                   </Tooltip.Provider>
                 </MDXProvider>
               </CodeBlockSettingsProvider>

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -1,8 +1,9 @@
-import { Button, mergeClasses, DocsLogo } from '@expo/styleguide';
+import { Button, DocsLogo, mergeClasses } from '@expo/styleguide';
 import { Stars03DuotoneIcon } from '@expo/styleguide-icons/duotone/Stars03DuotoneIcon';
 import { Send03Icon } from '@expo/styleguide-icons/outline/Send03Icon';
 import { XIcon } from '@expo/styleguide-icons/outline/XIcon';
-import { type FormEvent } from 'react';
+import { useChat } from '@kapaai/react-sdk';
+import { type FormEvent, useEffect, useMemo, useRef, useState } from 'react';
 
 import { FOOTNOTE, RawH5 } from '../Text';
 
@@ -11,11 +12,61 @@ type AskPageAIChatProps = {
   pageTitle?: string;
 };
 
+type ConversationKey = string | null;
+
 export function AskPageAIChat({ onClose, pageTitle }: AskPageAIChatProps) {
+  const {
+    conversation,
+    submitQuery,
+    isGeneratingAnswer,
+    isPreparingAnswer,
+    error,
+    resetConversation,
+    stopGeneration,
+  } = useChat();
+
   const contextLabel = pageTitle?.trim() ? pageTitle : 'This page';
+  const [question, setQuestion] = useState('');
+  const previousTitleRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (previousTitleRef.current !== pageTitle) {
+      previousTitleRef.current = pageTitle;
+      resetConversation();
+      setQuestion('');
+    }
+  }, [pageTitle, resetConversation]);
+
+  const isBusy = isPreparingAnswer || isGeneratingAnswer;
+  const buildPrompt = useMemo(() => {
+    const origin = typeof window !== 'undefined' ? window.location.href : '';
+    return (text: string) =>
+      [
+        'You are ExpoDocsExpert, an assistant who answers questions strictly using the supplied Expo SDK documentation context.',
+        `The user is reading the Expo docs page titled "${contextLabel}" at ${origin || 'the latest Expo SDK docs'}.`,
+        'Only rely on the provided context. If the answer is missing, respond exactly with: "I couldn\'t find that in this page."',
+        'Prefer concise explanations, reference relevant APIs or headings, and format instructions as short steps or bullet lists when helpful.',
+        'Mention the Expo SDK version when relevant (this context represents the "latest" docs).',
+        '',
+        `User question: ${text}`,
+      ].join('\n');
+  }, [contextLabel]);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    const trimmed = question.trim();
+    if (!trimmed) {
+      return;
+    }
+    submitQuery(buildPrompt(trimmed));
+    setQuestion('');
+  };
+
+  const handleClose = () => {
+    if (isGeneratingAnswer) {
+      stopGeneration();
+    }
+    onClose();
   };
 
   return (
@@ -35,12 +86,65 @@ export function AskPageAIChat({ onClose, pageTitle }: AskPageAIChatProps) {
           theme="quaternary"
           size="xs"
           className="px-2"
-          onClick={onClose}>
+          onClick={handleClose}>
           <XIcon className="icon-xs text-icon-secondary" />
         </Button>
       </div>
-      <div className="mt-auto px-4 pb-5 pt-4">
-        <div className="mb-3 inline-flex items-center gap-2 rounded-md border border-default bg-subtle px-3 py-2 shadow-xs">
+
+      <div className="flex-1 overflow-y-auto px-4 py-6">
+        {conversation.length > 0 ? (
+          <div className="space-y-5">
+            {conversation.map((qa, index) => {
+              const isLast = index === conversation.length - 1;
+              const key = (qa.id as ConversationKey) ?? `${qa.question}-${index}`;
+
+              return (
+                <div key={key} className="space-y-2">
+                  <div className="rounded-md border border-default bg-default px-3 py-2 shadow-xs">
+                    <FOOTNOTE className="font-medium text-default">You</FOOTNOTE>
+                    <FOOTNOTE theme="secondary" className="mt-1">
+                      {qa.question}
+                    </FOOTNOTE>
+                  </div>
+                  <div className="rounded-md border border-default bg-subtle px-3 py-2 shadow-xs">
+                    <FOOTNOTE className="font-medium text-default">AI Assistant</FOOTNOTE>
+                    <FOOTNOTE theme="secondary" className="mt-1">
+                      {qa.answer || (isLast && isBusy ? 'Thinking…' : '')}
+                    </FOOTNOTE>
+                  </div>
+                  {qa.sources?.length ? (
+                    <FOOTNOTE theme="secondary" className="ml-1 text-xs">
+                      Sources:{' '}
+                      {qa.sources.map((source, sourceIdx) => (
+                        <span key={source.source_url}>
+                          <a
+                            className="text-link"
+                            href={source.source_url}
+                            target="_blank"
+                            rel="noreferrer">
+                            {source.title || `Source ${sourceIdx + 1}`}
+                          </a>
+                          {sourceIdx < qa.sources.length - 1 ? ', ' : ''}
+                        </span>
+                      ))}
+                    </FOOTNOTE>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <FOOTNOTE theme="secondary">Ask a question about {contextLabel}.</FOOTNOTE>
+        )}
+        {error && (
+          <FOOTNOTE theme="danger" className="mt-4">
+            {error}
+          </FOOTNOTE>
+        )}
+      </div>
+
+      <div className="mt-auto border-t border-default px-4 pb-5 pt-4">
+        <div className="mb-3 inline-flex items-center gap-2 text-secondary">
           <DocsLogo className="icon-sm text-icon-secondary" />
           <FOOTNOTE theme="secondary">{contextLabel}</FOOTNOTE>
         </div>
@@ -52,13 +156,18 @@ export function AskPageAIChat({ onClose, pageTitle }: AskPageAIChatProps) {
             aria-label="Ask AI about this page"
             className="flex-1 resize-none bg-transparent text-default outline-none"
             rows={1}
+            value={question}
+            onChange={event => {
+              setQuestion(event.target.value);
+            }}
+            disabled={isBusy && conversation.length === 0}
           />
           <Button
             type="submit"
             theme="quaternary"
             size="sm"
             className="flex size-9 items-center justify-center rounded-full !p-0"
-            disabled>
+            disabled={isBusy || question.trim().length === 0}>
             <Send03Icon className="icon-sm text-icon-default" />
           </Button>
         </form>

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -225,7 +225,7 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
   return (
     <div className="flex h-full flex-col overflow-hidden bg-default">
       <div className="flex items-center justify-between border-b border-default bg-palette-black px-4 py-3 text-palette-white">
-        <div className="flex items-center">
+        <div className="flex items-center gap-2">
           <span
             className={mergeClasses(
               'inline-flex size-8 items-center justify-center rounded-full bg-palette-white shadow-xs'

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -244,7 +244,7 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
             className="px-2 !text-palette-white hover:!text-palette-white focus:!text-palette-white"
             style={{
               ...closeButtonThemeOverrides,
-              ...(feedbackTarget?.reaction === 'upvote' ? activeFeedbackBackground : null),
+              ...(feedbackTarget?.reaction === 'upvote' ? activeFeedbackBackground : {}),
             }}
             aria-pressed={feedbackTarget?.reaction === 'upvote'}
             disabled={!feedbackTarget?.isFeedbackSubmissionEnabled}
@@ -261,7 +261,7 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
             className="px-2 !text-palette-white hover:!text-palette-white focus:!text-palette-white"
             style={{
               ...closeButtonThemeOverrides,
-              ...(feedbackTarget?.reaction === 'downvote' ? activeFeedbackBackground : null),
+              ...(feedbackTarget?.reaction === 'downvote' ? activeFeedbackBackground : {}),
             }}
             aria-pressed={feedbackTarget?.reaction === 'downvote'}
             disabled={!feedbackTarget?.isFeedbackSubmissionEnabled}

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -538,7 +538,7 @@ export function AskPageAIChat({
           aria-label="Ask AI form">
           <textarea
             aria-label="Ask AI about this page"
-            className="min-h-[72px] flex-1 resize-none rounded-md border border-transparent bg-subtle p-2 text-sm leading-relaxed outline-none"
+            className="min-h-[72px] flex-1 resize-none rounded-md border border-transparent bg-subtle p-2 text-sm leading-relaxed outline-none focus:!shadow-none focus:!outline-none focus:ring-0 focus-visible:!shadow-none focus-visible:!outline-none focus-visible:ring-0"
             rows={3}
             value={question}
             onChange={event => {

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -35,6 +35,7 @@ type AskPageAIChatProps = {
   pageTitle?: string;
   onToggleExpand?: () => void;
   isExpanded?: boolean;
+  isExpoSdkPage?: boolean;
 };
 
 type ConversationKey = string | null;
@@ -45,6 +46,7 @@ export function AskPageAIChat({
   pageTitle,
   onToggleExpand,
   isExpanded = false,
+  isExpoSdkPage = false,
 }: AskPageAIChatProps) {
   const {
     conversation,
@@ -58,6 +60,17 @@ export function AskPageAIChat({
   } = useChat();
 
   const contextLabel = pageTitle?.trim() ? pageTitle : 'This page';
+  const displayContextLabel = useMemo(() => {
+    const label = contextLabel.trim();
+    if (!isExpoSdkPage) {
+      return label;
+    }
+    const lower = label.toLowerCase();
+    if (lower === 'expo' || lower.startsWith('expo ')) {
+      return label;
+    }
+    return `Expo ${label}`;
+  }, [contextLabel, isExpoSdkPage]);
   const [question, setQuestion] = useState('');
   const [askedQuestions, setAskedQuestions] = useState<string[]>([]);
 
@@ -442,7 +455,7 @@ export function AskPageAIChat({
           </div>
         </div>
         <FOOTNOTE className="text-palette-white">
-          Ask a question about <span className="font-semibold">{contextLabel}</span>.
+          Ask a question about <span className="font-semibold">{displayContextLabel}</span>.
         </FOOTNOTE>
       </div>
 

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -102,6 +102,7 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
         `The user is reading the Expo docs page titled "${contextLabel}" at ${origin || 'the latest Expo SDK docs'}.`,
         'Only rely on the provided context. If the answer is missing, respond exactly with: "I couldn\'t find that on this page."',
         'Prefer concise explanations, reference relevant APIs or headings, and format instructions as short steps or bullet lists when helpful.',
+        'Whenever you share code or configuration examples, return complete, ready-to-run snippets with all required imports and setup so the user can copy and paste them into their app without additional context.',
         'Mention the Expo SDK version when relevant (this context represents the "latest" docs).',
         '',
         `User question: ${text}`,

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -1,0 +1,68 @@
+import { Button, mergeClasses, DocsLogo } from '@expo/styleguide';
+import { Stars03DuotoneIcon } from '@expo/styleguide-icons/duotone/Stars03DuotoneIcon';
+import { Send03Icon } from '@expo/styleguide-icons/outline/Send03Icon';
+import { XIcon } from '@expo/styleguide-icons/outline/XIcon';
+import { type FormEvent } from 'react';
+
+import { FOOTNOTE, RawH5 } from '../Text';
+
+type AskPageAIChatProps = {
+  onClose: () => void;
+  pageTitle?: string;
+};
+
+export function AskPageAIChat({ onClose, pageTitle }: AskPageAIChatProps) {
+  const contextLabel = pageTitle?.trim() ? pageTitle : 'This page';
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+  };
+
+  return (
+    <div className="flex h-full flex-col bg-default">
+      <div className="flex items-center justify-between border-b border-default px-4 py-3">
+        <div className="flex items-center gap-2">
+          <span
+            className={mergeClasses(
+              'inline-flex size-8 items-center justify-center rounded-full bg-element shadow-xs'
+            )}>
+            <Stars03DuotoneIcon className="icon-sm text-icon-default" />
+          </span>
+          <RawH5 className="!my-0">AI Assistant</RawH5>
+        </div>
+        <Button
+          aria-label="Close Ask AI assistant"
+          theme="quaternary"
+          size="xs"
+          className="px-2"
+          onClick={onClose}>
+          <XIcon className="icon-xs text-icon-secondary" />
+        </Button>
+      </div>
+      <div className="mt-auto px-4 pb-5 pt-4">
+        <div className="mb-3 inline-flex items-center gap-2 rounded-md border border-default bg-subtle px-3 py-2 shadow-xs">
+          <DocsLogo className="icon-sm text-icon-secondary" />
+          <FOOTNOTE theme="secondary">{contextLabel}</FOOTNOTE>
+        </div>
+        <form
+          className="flex items-center gap-3 rounded-full border border-default bg-default px-4 py-2 shadow-xs"
+          onSubmit={handleSubmit}
+          aria-label="Ask AI form">
+          <textarea
+            aria-label="Ask AI about this page"
+            className="flex-1 resize-none bg-transparent text-default outline-none"
+            rows={1}
+          />
+          <Button
+            type="submit"
+            theme="quaternary"
+            size="sm"
+            className="flex size-9 items-center justify-center rounded-full !p-0"
+            disabled>
+            <Send03Icon className="icon-sm text-icon-default" />
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -515,7 +515,15 @@ export function AskPageAIChat({
               );
             })}
           </div>
-        ) : null}
+        ) : (
+          <div className="rounded-md border border-default bg-subtle px-3 py-2 shadow-xs">
+            <FOOTNOTE className="font-medium text-default">AI Assistant</FOOTNOTE>
+            <div className="mt-1 space-y-3 text-xs text-secondary">
+              I'm an SDK AI assistant — ask me a question about the{' '}
+              <span className="font-medium text-default">{displayContextLabel}</span> page.
+            </div>
+          </div>
+        )}
         {error && (
           <FOOTNOTE theme="danger" className="mt-4">
             {error}

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -98,11 +98,12 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
     const origin = typeof window !== 'undefined' ? window.location.href : '';
     return (text: string) =>
       [
-        'You are ExpoDocsExpert, an assistant who answers questions strictly using the supplied Expo SDK documentation context.',
+        'You are ExpoDocsExpert, an assistant that must answer strictly using the supplied Expo SDK documentation context.',
         `The user is reading the Expo docs page titled "${contextLabel}" at ${origin || 'the latest Expo SDK docs'}.`,
-        'Only rely on the provided context from this page. Do not use external knowledge, other Expo docs pages, or prior answers.',
-        'Before responding, verify that every part of the answer is explicitly supported by the supplied context.',
-        'If the answer is missing or not fully supported, respond exactly with: "I couldn\'t find that on this page."',
+        'You only have access to the content from this page. You do not have access to other pages, past answers, or external knowledge.',
+        'Before responding, confirm that every sentence in your answer is directly supported by the provided context.',
+        'If you cannot confirm this support, respond exactly with: "I couldn\'t find that on this page." Do not explain or apologize.',
+        'If the question is unrelated to the provided context, respond exactly with: "I couldn\'t find that on this page."',
         'Prefer concise explanations, reference relevant APIs or headings, and format instructions as short steps or bullet lists when helpful.',
         'Whenever you share code or configuration examples, return complete, ready-to-run snippets with all required imports and setup so the user can copy and paste them into their app without additional context.',
         'Mention the Expo SDK version when relevant (this context represents the "latest" docs).',

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -222,7 +222,7 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
 
       return (
         <div className="relative">
-          <PreComponent {...preProps} />
+          <PreComponent {...preProps} className={mergeClasses('px-3 py-2', preProps.className)} />
           <Button
             type="button"
             theme="quaternary"
@@ -245,61 +245,69 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
       h1: props => (
         <Heading1Component
           {...props}
-          className={mergeClasses('text-xs font-semibold text-default', props.className)}
+          className={mergeClasses('!text-[14px] font-semibold text-default', props.className)}
         />
       ),
       h2: props => (
         <Heading2Component
           {...props}
-          className={mergeClasses('text-xs font-semibold text-default', props.className)}
+          className={mergeClasses('!text-[14px] font-semibold text-default', props.className)}
         />
       ),
       h3: props => (
         <Heading3Component
           {...props}
-          className={mergeClasses('text-[11px] font-semibold text-default', props.className)}
+          className={mergeClasses('!text-[12px] font-semibold text-default', props.className)}
         />
       ),
       h4: props => (
         <Heading4Component
           {...props}
-          className={mergeClasses('text-[11px] font-semibold text-default', props.className)}
+          className={mergeClasses('!text-[12px] font-semibold text-default', props.className)}
         />
       ),
       h5: props => (
         <Heading5Component
           {...props}
-          className={mergeClasses('text-[10px] font-semibold text-default', props.className)}
+          className={mergeClasses('!text-[9px] font-semibold text-default', props.className)}
         />
       ),
-      p: props => (
+      p: ({ className, style, ...rest }) => (
         <ParagraphComponent
-          {...props}
-          className={mergeClasses('text-[11px] leading-[1.65] text-secondary', props.className)}
+          {...rest}
+          style={{ fontSize: '14px', lineHeight: '1.50', ...(style ?? {}) }}
+          className={mergeClasses(
+            '!mb-2 text-secondary',
+            className,
+            '!text-[10px] !leading-[1.55]'
+          )}
         />
       ),
-      ol: props => (
+      ol: ({ className, style, ...rest }) => (
         <OrderedListComponent
-          {...props}
-          className={mergeClasses('text-[10px] leading-[1.6] text-secondary', props.className)}
+          {...rest}
+          style={{ fontSize: '14px', lineHeight: '1.5', ...(style ?? {}) }}
+          className={mergeClasses('text-secondary', className, '!text-[10px] leading-normal')}
         />
       ),
-      ul: props => (
+      ul: ({ className, style, ...rest }) => (
         <UnorderedListComponent
-          {...props}
-          className={mergeClasses('text-[10px] leading-[1.6] text-secondary', props.className)}
+          {...rest}
+          style={{ fontSize: '14px', lineHeight: '1.5', ...(style ?? {}) }}
+          className={mergeClasses('text-secondary', className, '!text-[10px] leading-normal')}
         />
       ),
-      li: props => (
+      li: ({ className, style, ...rest }) => (
         <ListItemComponent
-          {...props}
-          className={mergeClasses('text-[10px] leading-[1.55] text-secondary', props.className)}
+          {...rest}
+          style={{ fontSize: '14px', lineHeight: '1.45', ...(style ?? {}) }}
+          className={mergeClasses('text-secondary', className, '!text-[10px] !leading-[1.45]')}
         />
       ),
       sup: ({ children, className, ...supProps }: any) => (
         <span
           {...supProps}
-          className={mergeClasses('align-baseline text-[10px] text-secondary', className)}>
+          className={mergeClasses('align-baseline !text-[10px] text-secondary', className)}>
           [{children}]
         </span>
       ),
@@ -417,6 +425,7 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
               const key = (qa.id as ConversationKey) ?? `${qa.question}-${index}`;
               const displayQuestion =
                 askedQuestions[index] ?? extractUserQuestion(qa.question, qa.question);
+              const normalizedAnswer = qa.answer?.replace(/<br\s*\/?>(\n)?/gi, '\n');
 
               return (
                 <div key={key} className="space-y-2">
@@ -428,9 +437,9 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
                   <div className="rounded-md border border-default bg-subtle px-3 py-2 shadow-xs">
                     <FOOTNOTE className="font-medium text-default">AI Assistant</FOOTNOTE>
                     <div className="mt-1 space-y-3 text-xs text-secondary">
-                      {qa.answer ? (
+                      {normalizedAnswer ? (
                         <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
-                          {qa.answer}
+                          {normalizedAnswer}
                         </ReactMarkdown>
                       ) : (
                         <FOOTNOTE theme="secondary">

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -7,6 +7,7 @@ import { XIcon } from '@expo/styleguide-icons/outline/XIcon';
 import { useChat } from '@kapaai/react-sdk';
 import {
   Children,
+  type CSSProperties,
   type FormEvent,
   type MouseEvent,
   useCallback,
@@ -18,7 +19,7 @@ import {
 import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
-import { FOOTNOTE, RawH5 } from '../Text';
+import { FOOTNOTE } from '../Text';
 
 type AskPageAIChatProps = {
   onClose: () => void;
@@ -60,6 +61,15 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
   }, [conversation.length, askedQuestions.length]);
 
   const isBusy = isPreparingAnswer || isGeneratingAnswer;
+  const closeButtonThemeOverrides = useMemo(
+    () =>
+      ({
+        '--expo-theme-button-quaternary-hover': 'rgba(255,255,255,0.12)',
+        '--expo-theme-button-quaternary-text': '#ffffff',
+        '--expo-theme-button-quaternary-icon': '#ffffff',
+      }) as CSSProperties,
+    []
+  );
   const buildPrompt = useMemo(() => {
     const origin = typeof window !== 'undefined' ? window.location.href : '';
     return (text: string) =>
@@ -107,7 +117,6 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
       code({
         inline,
         children,
-        className,
       }: {
         inline?: boolean;
         children?: React.ReactNode;
@@ -127,9 +136,7 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
 
           if (shouldRenderInline) {
             return (
-              <code className="rounded bg-subtle px-1.5 py-0.5 text-xs text-default">
-                {display}
-              </code>
+              <code className="rounded bg-subtle px-1 py-0.5 text-xs text-default">{display}</code>
             );
           }
 
@@ -138,7 +145,7 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
 
         if (!hasLineBreak && tokenCount <= 1) {
           return (
-            <code className="rounded bg-subtle px-1.5 py-0.5 text-xs text-default">
+            <code className="rounded bg-subtle px-1 py-0.5 text-xs text-default">
               {clean.trim()}
             </code>
           );
@@ -168,23 +175,24 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
 
   return (
     <div className="flex h-full flex-col overflow-hidden bg-default">
-      <div className="flex items-center justify-between border-b border-default px-4 py-3">
+      <div className="flex items-center justify-between border-b border-default bg-palette-black px-4 py-3 text-palette-white">
         <div className="flex items-center gap-2">
           <span
             className={mergeClasses(
-              'inline-flex size-8 items-center justify-center rounded-full bg-element shadow-xs'
+              'inline-flex size-8 items-center justify-center rounded-full bg-palette-white shadow-xs'
             )}>
-            <Stars03DuotoneIcon className="icon-sm text-icon-default" />
+            <Stars03DuotoneIcon className="icon-sm" />
           </span>
-          <RawH5 className="!my-0">AI Assistant</RawH5>
+          <span className="text-sm font-medium leading-tight text-palette-white">AI Assistant</span>
         </div>
         <Button
           aria-label="Close Ask AI assistant"
           theme="quaternary"
           size="xs"
-          className="px-2"
+          className="px-2 !text-palette-white hover:!text-palette-white focus:!text-palette-white"
+          style={closeButtonThemeOverrides}
           onClick={handleClose}>
-          <XIcon className="icon-xs text-icon-secondary" />
+          <XIcon className="icon-sm text-palette-white" />
         </Button>
       </div>
 
@@ -212,7 +220,7 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
                         </ReactMarkdown>
                       ) : (
                         <FOOTNOTE theme="secondary">
-                          {isLast && isBusy ? 'Thinking...' : ''}
+                          {isLast && isBusy ? 'Preparing answer...' : ''}
                         </FOOTNOTE>
                       )}
                     </div>
@@ -254,7 +262,7 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
 
       <div className="mt-auto border-t border-default px-5 pb-6 pt-4">
         <form
-          className="flex items-end gap-1 rounded-md border border-default bg-default px-2 py-1.5"
+          className="flex items-center gap-1 rounded-md border border-default bg-default px-2 py-1.5"
           onSubmit={handleSubmit}
           aria-label="Ask AI form">
           <textarea

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -2,6 +2,8 @@ import { Button, mergeClasses } from '@expo/styleguide';
 import { Stars03DuotoneIcon } from '@expo/styleguide-icons/duotone/Stars03DuotoneIcon';
 import { CheckIcon } from '@expo/styleguide-icons/outline/CheckIcon';
 import { ClipboardIcon } from '@expo/styleguide-icons/outline/ClipboardIcon';
+import { Maximize02Icon } from '@expo/styleguide-icons/outline/Maximize02Icon';
+import { Minimize02Icon } from '@expo/styleguide-icons/outline/Minimize02Icon';
 import { RefreshCcw02Icon } from '@expo/styleguide-icons/outline/RefreshCcw02Icon';
 import { Send03Icon } from '@expo/styleguide-icons/outline/Send03Icon';
 import { ThumbsDownIcon } from '@expo/styleguide-icons/outline/ThumbsDownIcon';
@@ -31,11 +33,19 @@ type AskPageAIChatProps = {
   onClose: () => void;
   onMinimize?: () => void;
   pageTitle?: string;
+  onToggleExpand?: () => void;
+  isExpanded?: boolean;
 };
 
 type ConversationKey = string | null;
 
-export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatProps) {
+export function AskPageAIChat({
+  onClose,
+  onMinimize,
+  pageTitle,
+  onToggleExpand,
+  isExpanded = false,
+}: AskPageAIChatProps) {
   const {
     conversation,
     submitQuery,
@@ -269,13 +279,13 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
       h5: props => (
         <Heading5Component
           {...props}
-          className={mergeClasses('!text-[9px] font-semibold text-default', props.className)}
+          className={mergeClasses('!text-[10px] font-semibold text-default', props.className)}
         />
       ),
       p: ({ className, style, ...rest }) => (
         <ParagraphComponent
           {...rest}
-          style={{ fontSize: '14px', lineHeight: '1.50', ...(style ?? {}) }}
+          style={{ ...(style ?? {}), fontSize: '14px', lineHeight: '1.5' }}
           className={mergeClasses(
             '!mb-2 text-secondary',
             className,
@@ -286,21 +296,21 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
       ol: ({ className, style, ...rest }) => (
         <OrderedListComponent
           {...rest}
-          style={{ fontSize: '14px', lineHeight: '1.5', ...(style ?? {}) }}
+          style={{ ...(style ?? {}), fontSize: '14px', lineHeight: '1.5' }}
           className={mergeClasses('text-secondary', className, '!text-[10px] leading-normal')}
         />
       ),
       ul: ({ className, style, ...rest }) => (
         <UnorderedListComponent
           {...rest}
-          style={{ fontSize: '14px', lineHeight: '1.5', ...(style ?? {}) }}
+          style={{ ...(style ?? {}), fontSize: '14px', lineHeight: '1.5' }}
           className={mergeClasses('text-secondary', className, '!text-[10px] leading-normal')}
         />
       ),
       li: ({ className, style, ...rest }) => (
         <ListItemComponent
           {...rest}
-          style={{ fontSize: '14px', lineHeight: '1.45', ...(style ?? {}) }}
+          style={{ ...(style ?? {}), fontSize: '14px', lineHeight: '1.45' }}
           className={mergeClasses('text-secondary', className, '!text-[10px] !leading-[1.45]')}
         />
       ),
@@ -391,6 +401,25 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
               }}>
               <ThumbsDownIcon className="icon-xs text-palette-white" />
             </Button>
+            {onToggleExpand ? (
+              <Button
+                type="button"
+                aria-label={
+                  isExpanded ? 'Restore Ask AI assistant size' : 'Expand Ask AI assistant'
+                }
+                theme="quaternary"
+                size="xs"
+                className="px-2 !text-palette-white hover:!text-palette-white focus:!text-palette-white"
+                style={closeButtonThemeOverrides}
+                aria-pressed={isExpanded}
+                onClick={onToggleExpand}>
+                {isExpanded ? (
+                  <Minimize02Icon className="icon-xs text-palette-white" />
+                ) : (
+                  <Maximize02Icon className="icon-xs text-palette-white" />
+                )}
+              </Button>
+            ) : null}
             <Button
               type="button"
               aria-label="Reset conversation"

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -16,7 +16,6 @@ import {
   useCallback,
   useEffect,
   useMemo,
-  useRef,
   useState,
 } from 'react';
 import ReactMarkdown, { type Components } from 'react-markdown';
@@ -47,16 +46,6 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
   const contextLabel = pageTitle?.trim() ? pageTitle : 'This page';
   const [question, setQuestion] = useState('');
   const [askedQuestions, setAskedQuestions] = useState<string[]>([]);
-  const previousTitleRef = useRef<string | undefined>(undefined);
-
-  useEffect(() => {
-    if (previousTitleRef.current !== pageTitle) {
-      previousTitleRef.current = pageTitle;
-      resetConversation();
-      setQuestion('');
-      setAskedQuestions([]);
-    }
-  }, [pageTitle, resetConversation]);
 
   useEffect(() => {
     if (conversation.length === 0 && askedQuestions.length > 0) {
@@ -134,9 +123,9 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
     if (isBusy && conversation.length > 0) {
       stopGeneration();
     }
-    resetConversation();
     setQuestion('');
     setAskedQuestions([]);
+    resetConversation();
   }, [conversation.length, isBusy, resetConversation, stopGeneration]);
 
   const handleFeedback = useCallback(

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -175,7 +175,9 @@ export function AskPageAIChat({
   const markersByIndex = useMemo(() => {
     const map: Record<number, { id: string; label: string }[]> = {};
     for (const m of contextMarkers) {
-      if (!map[m.at]) map[m.at] = [];
+      if (!map[m.at]) {
+        map[m.at] = [];
+      }
       map[m.at].push({ id: m.id, label: m.label });
     }
     return map;

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -100,7 +100,9 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
       [
         'You are ExpoDocsExpert, an assistant who answers questions strictly using the supplied Expo SDK documentation context.',
         `The user is reading the Expo docs page titled "${contextLabel}" at ${origin || 'the latest Expo SDK docs'}.`,
-        'Only rely on the provided context. If the answer is missing, respond exactly with: "I couldn\'t find that on this page."',
+        'Only rely on the provided context from this page. Do not use external knowledge, other Expo docs pages, or prior answers.',
+        'Before responding, verify that every part of the answer is explicitly supported by the supplied context.',
+        'If the answer is missing or not fully supported, respond exactly with: "I couldn\'t find that on this page."',
         'Prefer concise explanations, reference relevant APIs or headings, and format instructions as short steps or bullet lists when helpful.',
         'Whenever you share code or configuration examples, return complete, ready-to-run snippets with all required imports and setup so the user can copy and paste them into their app without additional context.',
         'Mention the Expo SDK version when relevant (this context represents the "latest" docs).',

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -109,6 +109,12 @@ export function AskPageAIChat({
   // Show a brief notice when the page context changes while the chat is open
   const [contextNotice, setContextNotice] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const scrollToBottom = useCallback(() => {
+    const el = scrollRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, []);
   const prevDisplayContextRef = useRef<string>(displayContextLabel);
   const prevBasePathRef = useRef<string | null>(null);
   const [pendingContextNotice, setPendingContextNotice] = useState(false);
@@ -160,13 +166,21 @@ export function AskPageAIChat({
   useEffect(() => {
     if (contextNotice) {
       window.requestAnimationFrame(() => {
-        const el = scrollRef.current;
-        if (el) {
-          el.scrollTop = el.scrollHeight;
-        }
+        scrollToBottom();
       });
     }
-  }, [contextNotice]);
+  }, [contextNotice, scrollToBottom]);
+
+  // Auto-scroll when a new message is added
+  const lastEntry = conversation[conversation.length - 1];
+  const lastEntryKey = `${conversation.length}-${lastEntry?.id ?? 'noid'}-${
+    lastEntry?.answer?.length ?? 0
+  }`;
+  useEffect(() => {
+    window.requestAnimationFrame(() => {
+      scrollToBottom();
+    });
+  }, [lastEntryKey, scrollToBottom]);
 
   const isBusy = isPreparingAnswer || isGeneratingAnswer;
   const closeButtonThemeOverrides = useMemo(

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -196,7 +196,7 @@ export function AskPageAIChat({ onClose, pageTitle }: AskPageAIChatProps) {
           aria-label="Ask AI form">
           <textarea
             aria-label="Ask AI about this page"
-            className="min-h-[72px] flex-1 resize-none rounded-md border border-transparent bg-subtle px-1 py-2 text-sm leading-relaxed text-default outline-none"
+            className="min-h-[72px] flex-1 resize-none rounded-md border border-transparent bg-subtle px-4 py-2 text-sm leading-relaxed text-default outline-none"
             rows={3}
             value={question}
             onChange={event => {

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -254,12 +254,12 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
 
       <div className="mt-auto border-t border-default px-5 pb-6 pt-4">
         <form
-          className="flex items-end gap-3 rounded-md border border-default bg-default px-5 py-3 shadow-xs"
+          className="flex items-end gap-1 rounded-md border border-default bg-default px-2 py-1.5"
           onSubmit={handleSubmit}
           aria-label="Ask AI form">
           <textarea
             aria-label="Ask AI about this page"
-            className="min-h-[72px] flex-1 resize-none rounded-md border border-transparent bg-subtle px-4 py-2 text-sm leading-relaxed text-default outline-none"
+            className="min-h-[72px] flex-1 resize-none rounded-md border border-transparent bg-subtle p-2 text-sm leading-relaxed outline-none"
             rows={3}
             value={question}
             onChange={event => {
@@ -277,7 +277,7 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
             type="submit"
             theme="quaternary"
             size="sm"
-            className="flex size-8 items-center justify-center rounded-full !p-0"
+            className="flex size-6 items-center justify-center rounded-full !p-0"
             disabled={isBusy || question.trim().length === 0}>
             <Send03Icon className="icon-xs text-icon-default" />
           </Button>

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -52,7 +52,7 @@ export function AskPageAIChat({ onClose, pageTitle }: AskPageAIChatProps) {
       [
         'You are ExpoDocsExpert, an assistant who answers questions strictly using the supplied Expo SDK documentation context.',
         `The user is reading the Expo docs page titled "${contextLabel}" at ${origin || 'the latest Expo SDK docs'}.`,
-        'Only rely on the provided context. If the answer is missing, respond exactly with: "I couldn\'t find that in this page."',
+        'Only rely on the provided context. If the answer is missing, respond exactly with: "I couldn\'t find that on this page."',
         'Prefer concise explanations, reference relevant APIs or headings, and format instructions as short steps or bullet lists when helpful.',
         'Mention the Expo SDK version when relevant (this context represents the "latest" docs).',
         '',
@@ -154,12 +154,12 @@ export function AskPageAIChat({ onClose, pageTitle }: AskPageAIChatProps) {
 
       <div className="mt-auto border-t border-default px-4 pb-5 pt-4">
         <form
-          className="flex items-center gap-3 rounded-full border border-default bg-default px-4 py-2 shadow-xs"
+          className="flex items-center gap-3 rounded-full border border-default bg-default px-5 py-2 shadow-xs"
           onSubmit={handleSubmit}
           aria-label="Ask AI form">
           <textarea
             aria-label="Ask AI about this page"
-            className="flex-1 resize-none bg-transparent text-default outline-none"
+            className="min-h-[38px] flex-1 resize-none bg-transparent text-sm text-default outline-none"
             rows={1}
             value={question}
             onChange={event => {

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -1,11 +1,11 @@
 import { Button, mergeClasses } from '@expo/styleguide';
-import { Stars03DuotoneIcon } from '@expo/styleguide-icons/duotone/Stars03DuotoneIcon';
 import { CheckIcon } from '@expo/styleguide-icons/outline/CheckIcon';
 import { ClipboardIcon } from '@expo/styleguide-icons/outline/ClipboardIcon';
 import { Maximize02Icon } from '@expo/styleguide-icons/outline/Maximize02Icon';
 import { Minimize02Icon } from '@expo/styleguide-icons/outline/Minimize02Icon';
 import { RefreshCcw02Icon } from '@expo/styleguide-icons/outline/RefreshCcw02Icon';
 import { Send03Icon } from '@expo/styleguide-icons/outline/Send03Icon';
+import { Star06Icon } from '@expo/styleguide-icons/outline/Star06Icon';
 import { ThumbsDownIcon } from '@expo/styleguide-icons/outline/ThumbsDownIcon';
 import { ThumbsUpIcon } from '@expo/styleguide-icons/outline/ThumbsUpIcon';
 import { XIcon } from '@expo/styleguide-icons/outline/XIcon';
@@ -373,7 +373,7 @@ export function AskPageAIChat({
                 'inline-flex size-8 items-center justify-center rounded-full bg-palette-white shadow-xs'
               )}
               style={headerAccentBackground}>
-              <Stars03DuotoneIcon className="icon-sm text-palette-white" />
+              <Star06Icon className="icon-sm text-palette-white" />
             </span>
             <span className="text-sm font-medium leading-tight text-palette-white">
               Expo AI Assistant

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -100,7 +100,7 @@ export function AskPageAIChat({ onClose, pageTitle }: AskPageAIChatProps) {
         </Button>
       </div>
 
-      <div className="flex-1 overflow-y-auto px-4 py-6">
+      <div className="flex-1 overflow-y-auto px-5 py-6">
         {conversation.length > 0 ? (
           <div className="space-y-5">
             {conversation.map((qa, index) => {
@@ -152,15 +152,15 @@ export function AskPageAIChat({ onClose, pageTitle }: AskPageAIChatProps) {
         )}
       </div>
 
-      <div className="mt-auto border-t border-default px-4 pb-5 pt-4">
+      <div className="mt-auto border-t border-default px-5 pb-6 pt-4">
         <form
-          className="flex items-center gap-3 rounded-full border border-default bg-default px-5 py-2 shadow-xs"
+          className="flex items-end gap-3 rounded-md border border-default bg-default px-5 py-3 shadow-xs"
           onSubmit={handleSubmit}
           aria-label="Ask AI form">
           <textarea
             aria-label="Ask AI about this page"
-            className="min-h-[38px] flex-1 resize-none bg-transparent text-sm text-default outline-none"
-            rows={1}
+            className="min-h-[72px] flex-1 resize-none rounded-md border border-transparent bg-subtle px-1 py-2 text-sm leading-relaxed text-default outline-none"
+            rows={3}
             value={question}
             onChange={event => {
               setQuestion(event.target.value);
@@ -177,9 +177,9 @@ export function AskPageAIChat({ onClose, pageTitle }: AskPageAIChatProps) {
             type="submit"
             theme="quaternary"
             size="sm"
-            className="flex size-9 items-center justify-center rounded-full !p-0"
+            className="flex size-8 items-center justify-center rounded-full !p-0"
             disabled={isBusy || question.trim().length === 0}>
-            <Send03Icon className="icon-sm text-icon-default" />
+            <Send03Icon className="icon-xs text-icon-default" />
           </Button>
         </form>
       </div>

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -4,14 +4,7 @@ import { Copy04Icon } from '@expo/styleguide-icons/outline/Copy04Icon';
 import { Send03Icon } from '@expo/styleguide-icons/outline/Send03Icon';
 import { XIcon } from '@expo/styleguide-icons/outline/XIcon';
 import { useChat } from '@kapaai/react-sdk';
-import {
-  Children,
-  type FormEvent,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { Children, type FormEvent, useEffect, useMemo, useRef, useState } from 'react';
 import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
@@ -90,7 +83,15 @@ export function AskPageAIChat({ onClose, pageTitle }: AskPageAIChatProps) {
 
   const markdownComponents = useMemo(() => {
     return {
-      code({ inline, children, className }: { inline?: boolean; children?: React.ReactNode; className?: string }) {
+      code({
+        inline,
+        children,
+        className,
+      }: {
+        inline?: boolean;
+        children?: React.ReactNode;
+        className?: string;
+      }) {
         const childArray = Children.toArray(children);
         const raw = childArray.map(node => (typeof node === 'string' ? node : '')).join('');
         const clean = raw.replace(/\n$/, '');
@@ -103,7 +104,7 @@ export function AskPageAIChat({ onClose, pageTitle }: AskPageAIChatProps) {
           );
         }
 
-        return <MarkdownCodeBlock code={clean} language={className} />;
+        return <MarkdownCodeBlock code={clean} />;
       },
     } as Components;
   }, []);
@@ -149,9 +150,7 @@ export function AskPageAIChat({ onClose, pageTitle }: AskPageAIChatProps) {
                     <FOOTNOTE className="font-medium text-default">AI Assistant</FOOTNOTE>
                     <div className="prose prose-sm mt-1 text-secondary dark:prose-invert prose-a:text-link">
                       {qa.answer ? (
-                        <ReactMarkdown
-                          remarkPlugins={[remarkGfm]}
-                          components={markdownComponents}>
+                        <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
                           {qa.answer}
                         </ReactMarkdown>
                       ) : (
@@ -229,13 +228,18 @@ function MarkdownCodeBlock({ code }: { code: string }) {
   const [copied, setCopied] = useState(false);
 
   useEffect(() => {
-    if (copied) {
-      const timer = setTimeout(() => setCopied(false), 2000);
-      return () => clearTimeout(timer);
+    if (!copied) {
+      return undefined;
     }
+    const timer = setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+    return () => {
+      clearTimeout(timer);
+    };
   }, [copied]);
 
-  const handleCopy = async () => {
+  const handleCopyAsync = async () => {
     try {
       await navigator.clipboard.writeText(code);
       setCopied(true);
@@ -248,9 +252,9 @@ function MarkdownCodeBlock({ code }: { code: string }) {
     <div className="relative overflow-hidden rounded-md border border-default bg-subtle">
       <button
         type="button"
-        className="absolute right-3 top-3 inline-flex items-center gap-1 rounded-full bg-default/80 px-2 py-1 text-3xs font-medium text-secondary shadow-sm hover:bg-default"
-        onClick={handleCopy}>
-        <Copy04Icon className="icon-xxs" />
+        className="bg-default/80 absolute right-3 top-3 inline-flex items-center gap-1 rounded-full px-2 py-1 text-3xs font-medium text-secondary shadow-sm hover:bg-default"
+        onClick={handleCopyAsync}>
+        <Copy04Icon className="icon-xs" />
         {copied ? 'Copied' : 'Copy'}
       </button>
       <pre className="overflow-x-auto whitespace-pre px-4 pb-4 pt-9 text-xs leading-relaxed text-default">

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -608,8 +608,8 @@ export function AskPageAIChat({
               <div className="flex justify-center">
                 <FOOTNOTE
                   theme="secondary"
-                  className="rounded inline-block border border-default bg-subtle px-2 py-1">
-                  Switched to <span className="font-medium text-default">{contextNotice}</span>.
+                  className="inline-block rounded-md border border-default bg-subtle px-2 py-1">
+                  Switched to <span className="font-medium text-default">{contextNotice}</span>
                 </FOOTNOTE>
               </div>
             ) : null}

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -225,74 +225,79 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
 
   return (
     <div className="flex h-full flex-col overflow-hidden bg-default">
-      <div className="flex items-center justify-between border-b border-default bg-palette-black px-4 py-3 text-palette-white">
-        <div className="flex items-center gap-2">
-          <span
-            className={mergeClasses(
-              'inline-flex size-8 items-center justify-center rounded-full bg-palette-white shadow-xs'
-            )}
-            style={headerAccentBackground}>
-            <Stars03DuotoneIcon className="icon-sm text-palette-white" />
-          </span>
-          <span className="text-sm font-medium leading-tight text-palette-white">
-            Expo AI Assistant
-          </span>
+      <div className="flex flex-col gap-3 border-b border-default bg-palette-black px-4 py-3 text-palette-white">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span
+              className={mergeClasses(
+                'inline-flex size-8 items-center justify-center rounded-full bg-palette-white shadow-xs'
+              )}
+              style={headerAccentBackground}>
+              <Stars03DuotoneIcon className="icon-sm text-palette-white" />
+            </span>
+            <span className="text-sm font-medium leading-tight text-palette-white">
+              Expo AI Assistant
+            </span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Button
+              type="button"
+              aria-label="Provide positive feedback"
+              theme="quaternary"
+              size="xs"
+              className="px-2 !text-palette-white hover:!text-palette-white focus:!text-palette-white"
+              style={{
+                ...closeButtonThemeOverrides,
+                ...(feedbackTarget?.reaction === 'upvote' ? activeFeedbackBackground : {}),
+              }}
+              aria-pressed={feedbackTarget?.reaction === 'upvote'}
+              disabled={!feedbackTarget?.isFeedbackSubmissionEnabled}
+              onClick={() => {
+                handleFeedback('upvote');
+              }}>
+              <ThumbsUpIcon className="icon-xs text-palette-white" />
+            </Button>
+            <Button
+              type="button"
+              aria-label="Provide negative feedback"
+              theme="quaternary"
+              size="xs"
+              className="px-2 !text-palette-white hover:!text-palette-white focus:!text-palette-white"
+              style={{
+                ...closeButtonThemeOverrides,
+                ...(feedbackTarget?.reaction === 'downvote' ? activeFeedbackBackground : {}),
+              }}
+              aria-pressed={feedbackTarget?.reaction === 'downvote'}
+              disabled={!feedbackTarget?.isFeedbackSubmissionEnabled}
+              onClick={() => {
+                handleFeedback('downvote');
+              }}>
+              <ThumbsDownIcon className="icon-xs text-palette-white" />
+            </Button>
+            <Button
+              type="button"
+              aria-label="Reset conversation"
+              theme="quaternary"
+              size="xs"
+              className="px-2 !text-palette-white hover:!text-palette-white focus:!text-palette-white"
+              style={closeButtonThemeOverrides}
+              onClick={handleConversationReset}>
+              <RefreshCcw02Icon className="icon-xs text-palette-white" />
+            </Button>
+            <Button
+              aria-label="Close Ask AI assistant"
+              theme="quaternary"
+              size="xs"
+              className="px-2 !text-palette-white hover:!text-palette-white focus:!text-palette-white"
+              style={closeButtonThemeOverrides}
+              onClick={handleClose}>
+              <XIcon className="icon-xs text-palette-white" />
+            </Button>
+          </div>
         </div>
-        <div className="flex items-center gap-1">
-          <Button
-            type="button"
-            aria-label="Provide positive feedback"
-            theme="quaternary"
-            size="xs"
-            className="px-2 !text-palette-white hover:!text-palette-white focus:!text-palette-white"
-            style={{
-              ...closeButtonThemeOverrides,
-              ...(feedbackTarget?.reaction === 'upvote' ? activeFeedbackBackground : {}),
-            }}
-            aria-pressed={feedbackTarget?.reaction === 'upvote'}
-            disabled={!feedbackTarget?.isFeedbackSubmissionEnabled}
-            onClick={() => {
-              handleFeedback('upvote');
-            }}>
-            <ThumbsUpIcon className="icon-xs text-palette-white" />
-          </Button>
-          <Button
-            type="button"
-            aria-label="Provide negative feedback"
-            theme="quaternary"
-            size="xs"
-            className="px-2 !text-palette-white hover:!text-palette-white focus:!text-palette-white"
-            style={{
-              ...closeButtonThemeOverrides,
-              ...(feedbackTarget?.reaction === 'downvote' ? activeFeedbackBackground : {}),
-            }}
-            aria-pressed={feedbackTarget?.reaction === 'downvote'}
-            disabled={!feedbackTarget?.isFeedbackSubmissionEnabled}
-            onClick={() => {
-              handleFeedback('downvote');
-            }}>
-            <ThumbsDownIcon className="icon-xs text-palette-white" />
-          </Button>
-          <Button
-            type="button"
-            aria-label="Reset conversation"
-            theme="quaternary"
-            size="xs"
-            className="px-2 !text-palette-white hover:!text-palette-white focus:!text-palette-white"
-            style={closeButtonThemeOverrides}
-            onClick={handleConversationReset}>
-            <RefreshCcw02Icon className="icon-xs text-palette-white" />
-          </Button>
-          <Button
-            aria-label="Close Ask AI assistant"
-            theme="quaternary"
-            size="xs"
-            className="px-2 !text-palette-white hover:!text-palette-white focus:!text-palette-white"
-            style={closeButtonThemeOverrides}
-            onClick={handleClose}>
-            <XIcon className="icon-sm text-palette-white" />
-          </Button>
-        </div>
+        <FOOTNOTE className="text-palette-white">
+          Ask a question about <span className="font-semibold">{contextLabel}</span>.
+        </FOOTNOTE>
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto px-5 py-6">
@@ -349,9 +354,7 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
               );
             })}
           </div>
-        ) : (
-          <FOOTNOTE theme="secondary">Ask a question about {contextLabel}.</FOOTNOTE>
-        )}
+        ) : null}
         {error && (
           <FOOTNOTE theme="danger" className="mt-4">
             {error}

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -185,6 +185,11 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
     const OrderedListComponent = (docsMarkdownComponents.ol as ComponentType<any>) ?? 'ol';
     const UnorderedListComponent = (docsMarkdownComponents.ul as ComponentType<any>) ?? 'ul';
     const ListItemComponent = (docsMarkdownComponents.li as ComponentType<any>) ?? 'li';
+    const Heading1Component = (docsMarkdownComponents.h1 as ComponentType<any>) ?? 'h1';
+    const Heading2Component = (docsMarkdownComponents.h2 as ComponentType<any>) ?? 'h2';
+    const Heading3Component = (docsMarkdownComponents.h3 as ComponentType<any>) ?? 'h3';
+    const Heading4Component = (docsMarkdownComponents.h4 as ComponentType<any>) ?? 'h4';
+    const Heading5Component = (docsMarkdownComponents.h5 as ComponentType<any>) ?? 'h5';
     const PreComponent = (docsMarkdownComponents.pre as ComponentType<any>) ?? 'pre';
 
     const ChatPre: ComponentType<any> = preProps => {
@@ -237,34 +242,64 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
 
     return {
       ...docsMarkdownComponents,
+      h1: props => (
+        <Heading1Component
+          {...props}
+          className={mergeClasses('text-xs font-semibold text-default', props.className)}
+        />
+      ),
+      h2: props => (
+        <Heading2Component
+          {...props}
+          className={mergeClasses('text-xs font-semibold text-default', props.className)}
+        />
+      ),
+      h3: props => (
+        <Heading3Component
+          {...props}
+          className={mergeClasses('text-[11px] font-semibold text-default', props.className)}
+        />
+      ),
+      h4: props => (
+        <Heading4Component
+          {...props}
+          className={mergeClasses('text-[11px] font-semibold text-default', props.className)}
+        />
+      ),
+      h5: props => (
+        <Heading5Component
+          {...props}
+          className={mergeClasses('text-[10px] font-semibold text-default', props.className)}
+        />
+      ),
       p: props => (
         <ParagraphComponent
           {...props}
-          className={mergeClasses('text-xs leading-[1.65] text-secondary', props.className)}
+          className={mergeClasses('text-[11px] leading-[1.65] text-secondary', props.className)}
         />
       ),
       ol: props => (
         <OrderedListComponent
           {...props}
-          className={mergeClasses('text-xs leading-[1.65] text-secondary', props.className)}
+          className={mergeClasses('text-[10px] leading-[1.6] text-secondary', props.className)}
         />
       ),
       ul: props => (
         <UnorderedListComponent
           {...props}
-          className={mergeClasses('text-xs leading-[1.65] text-secondary', props.className)}
+          className={mergeClasses('text-[10px] leading-[1.6] text-secondary', props.className)}
         />
       ),
       li: props => (
         <ListItemComponent
           {...props}
-          className={mergeClasses('text-xs leading-[1.65] text-secondary', props.className)}
+          className={mergeClasses('text-[10px] leading-[1.55] text-secondary', props.className)}
         />
       ),
       sup: ({ children, className, ...supProps }: any) => (
         <span
           {...supProps}
-          className={mergeClasses('align-baseline text-xs text-secondary', className)}>
+          className={mergeClasses('align-baseline text-[10px] text-secondary', className)}>
           [{children}]
         </span>
       ),
@@ -392,7 +427,7 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
                   </div>
                   <div className="rounded-md border border-default bg-subtle px-3 py-2 shadow-xs">
                     <FOOTNOTE className="font-medium text-default">AI Assistant</FOOTNOTE>
-                    <div className="prose prose-sm mt-1 text-secondary dark:prose-invert prose-a:text-link prose-pre:!bg-transparent">
+                    <div className="mt-1 space-y-3 text-xs text-secondary">
                       {qa.answer ? (
                         <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
                           {qa.answer}

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -1,6 +1,7 @@
 import { Button, mergeClasses } from '@expo/styleguide';
 import { Stars03DuotoneIcon } from '@expo/styleguide-icons/duotone/Stars03DuotoneIcon';
-import { Copy04Icon } from '@expo/styleguide-icons/outline/Copy04Icon';
+import { CheckIcon } from '@expo/styleguide-icons/outline/CheckIcon';
+import { ClipboardIcon } from '@expo/styleguide-icons/outline/ClipboardIcon';
 import { Send03Icon } from '@expo/styleguide-icons/outline/Send03Icon';
 import { XIcon } from '@expo/styleguide-icons/outline/XIcon';
 import { useChat } from '@kapaai/react-sdk';
@@ -96,10 +97,29 @@ export function AskPageAIChat({ onClose, pageTitle }: AskPageAIChatProps) {
         const raw = childArray.map(node => (typeof node === 'string' ? node : '')).join('');
         const clean = raw.replace(/\n$/, '');
 
+        const tokenCount = clean.trim().split(/\s+/).length;
+        const hasLineBreak = clean.includes('\n');
+
         if (inline) {
+          const trimmed = clean.replace(/^`+/, '').replace(/`+$/, '');
+          const display = trimmed.length > 0 ? trimmed : clean;
+          const shouldRenderInline = display.trim().split(/\s+/).length <= 1;
+
+          if (shouldRenderInline) {
+            return (
+              <code className="rounded bg-subtle px-1.5 py-0.5 text-xs text-default">
+                {display}
+              </code>
+            );
+          }
+
+          return <MarkdownCodeBlock code={display.trim()} compact />;
+        }
+
+        if (!hasLineBreak && tokenCount <= 1) {
           return (
             <code className="rounded bg-subtle px-1.5 py-0.5 text-xs text-default">
-              {childArray}
+              {clean.trim()}
             </code>
           );
         }
@@ -110,7 +130,7 @@ export function AskPageAIChat({ onClose, pageTitle }: AskPageAIChatProps) {
   }, []);
 
   return (
-    <div className="flex h-full flex-col bg-default">
+    <div className="flex h-full flex-col overflow-hidden bg-default">
       <div className="flex items-center justify-between border-b border-default px-4 py-3">
         <div className="flex items-center gap-2">
           <span
@@ -131,7 +151,7 @@ export function AskPageAIChat({ onClose, pageTitle }: AskPageAIChatProps) {
         </Button>
       </div>
 
-      <div className="flex-1 overflow-y-auto px-5 py-6">
+      <div className="min-h-0 flex-1 overflow-y-auto px-5 py-6">
         {conversation.length > 0 ? (
           <div className="space-y-5">
             {conversation.map((qa, index) => {
@@ -141,10 +161,10 @@ export function AskPageAIChat({ onClose, pageTitle }: AskPageAIChatProps) {
 
               return (
                 <div key={key} className="space-y-2">
-                  <div className="flex items-start justify-end pr-1">
-                    <span className="bg-link/10 inline-flex rounded-full px-3 py-1 text-link">
+                  <div className="flex justify-end pr-1">
+                    <div className="ml-auto max-w-[85%] rounded-md border border-default bg-subtle px-3 py-1.5 text-right text-sm leading-snug text-secondary shadow-xs">
                       {displayQuestion}
-                    </span>
+                    </div>
                   </div>
                   <div className="rounded-md border border-default bg-subtle px-3 py-2 shadow-xs">
                     <FOOTNOTE className="font-medium text-default">AI Assistant</FOOTNOTE>
@@ -224,7 +244,7 @@ export function AskPageAIChat({ onClose, pageTitle }: AskPageAIChatProps) {
   );
 }
 
-function MarkdownCodeBlock({ code }: { code: string }) {
+function MarkdownCodeBlock({ code, compact = false }: { code: string; compact?: boolean }) {
   const [copied, setCopied] = useState(false);
 
   useEffect(() => {
@@ -252,12 +272,20 @@ function MarkdownCodeBlock({ code }: { code: string }) {
     <div className="relative overflow-hidden rounded-md border border-default bg-subtle">
       <button
         type="button"
-        className="bg-default/90 absolute right-2 top-2 inline-flex size-7 items-center justify-center rounded-full text-secondary shadow-sm hover:bg-default"
+        className="bg-default/90 absolute right-2 top-2 inline-flex size-7 items-center justify-center rounded-full text-secondary shadow-sm transition hover:bg-default"
         onClick={handleCopyAsync}>
         <span className="sr-only">Copy code</span>
-        <Copy04Icon className="icon-xs" aria-hidden />
+        {copied ? (
+          <CheckIcon className="icon-xs text-success" aria-hidden />
+        ) : (
+          <ClipboardIcon className="icon-xs text-icon-secondary" aria-hidden />
+        )}
       </button>
-      <pre className="overflow-x-auto whitespace-pre bg-transparent p-4 text-xs leading-relaxed text-default">
+      <pre
+        className={mergeClasses(
+          'overflow-x-auto whitespace-pre bg-transparent text-xs leading-relaxed text-default',
+          compact ? 'px-3 py-1' : 'px-3 py-1.5'
+        )}>
         <code className="block whitespace-pre text-default">{code}</code>
       </pre>
     </div>

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -141,15 +141,15 @@ export function AskPageAIChat({
         `The user is reading the Expo docs page titled "${contextLabel}" at ${origin || 'the latest Expo SDK docs'}.`,
         'You only have access to the content from this page. You do not have access to other pages, past answers, or external knowledge.',
         'Before responding, confirm that every sentence in your answer is directly supported by the provided context.',
-        'If you cannot confirm this support, respond exactly with: "I couldn\'t find that on this page." Do not explain or apologize.',
-        'If the question is unrelated to the provided context, respond exactly with: "I couldn\'t find that on this page."',
+        `If you cannot confirm this support, respond exactly with: "I can only answer questions about the current ${displayContextLabel} documentation." Do not explain or apologize.`,
+        `If the question is unrelated to the provided context, respond exactly with: "I can only answer questions about the current ${displayContextLabel} documentation."`,
         'Prefer concise explanations, reference relevant APIs or headings, and format instructions as short steps or bullet lists when helpful.',
         'Whenever you share code or configuration examples, return complete, ready-to-run snippets with all required imports and setup so the user can copy and paste them into their app without additional context.',
         'Mention the Expo SDK version when relevant (this context represents the "latest" docs).',
         '',
         `User question: ${text}`,
       ].join('\n');
-  }, [contextLabel]);
+  }, [contextLabel, displayContextLabel]);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -148,7 +148,7 @@ export function AskPageAIChat({ onClose, pageTitle }: AskPageAIChatProps) {
                   </div>
                   <div className="rounded-md border border-default bg-subtle px-3 py-2 shadow-xs">
                     <FOOTNOTE className="font-medium text-default">AI Assistant</FOOTNOTE>
-                    <div className="prose prose-sm mt-1 text-secondary dark:prose-invert prose-a:text-link">
+                    <div className="prose prose-sm mt-1 text-secondary dark:prose-invert prose-a:text-link prose-pre:!bg-transparent">
                       {qa.answer ? (
                         <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
                           {qa.answer}
@@ -252,13 +252,13 @@ function MarkdownCodeBlock({ code }: { code: string }) {
     <div className="relative overflow-hidden rounded-md border border-default bg-subtle">
       <button
         type="button"
-        className="bg-default/80 absolute right-3 top-3 inline-flex items-center gap-1 rounded-full px-2 py-1 text-3xs font-medium text-secondary shadow-sm hover:bg-default"
+        className="bg-default/90 absolute right-2 top-2 inline-flex size-7 items-center justify-center rounded-full text-secondary shadow-sm hover:bg-default"
         onClick={handleCopyAsync}>
-        <Copy04Icon className="icon-xs" />
-        {copied ? 'Copied' : 'Copy'}
+        <span className="sr-only">Copy code</span>
+        <Copy04Icon className="icon-xs" aria-hidden />
       </button>
-      <pre className="overflow-x-auto whitespace-pre px-4 pb-4 pt-9 text-xs leading-relaxed text-default">
-        <code>{code}</code>
+      <pre className="overflow-x-auto whitespace-pre bg-transparent p-4 text-xs leading-relaxed text-default">
+        <code className="block whitespace-pre text-default">{code}</code>
       </pre>
     </div>
   );

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -166,6 +166,12 @@ export function AskPageAIChat({ onClose, pageTitle }: AskPageAIChatProps) {
               setQuestion(event.target.value);
             }}
             disabled={isBusy && conversation.length === 0}
+            onKeyDown={event => {
+              if (event.key === 'Enter' && !event.shiftKey) {
+                event.preventDefault();
+                event.currentTarget.form?.requestSubmit();
+              }
+            }}
           />
           <Button
             type="submit"

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -286,7 +286,7 @@ export function AskPageAIChat({ onClose, onMinimize, pageTitle }: AskPageAIChatP
             className="px-2 !text-palette-white hover:!text-palette-white focus:!text-palette-white"
             style={closeButtonThemeOverrides}
             onClick={handleClose}>
-            <XIcon className="icon-xs text-palette-white" />
+            <XIcon className="icon-sm text-palette-white" />
           </Button>
         </div>
       </div>

--- a/docs/ui/components/AskPageAI/AskPageAIOverlay.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIOverlay.tsx
@@ -8,6 +8,7 @@ type AskPageAIOverlayProps = {
   onClose: () => void;
   onMinimize: () => void;
   pageTitle?: string;
+  isExpoSdkPage?: boolean;
   isVisible: boolean;
 };
 
@@ -15,6 +16,7 @@ export function AskPageAIOverlay({
   onClose,
   onMinimize,
   pageTitle,
+  isExpoSdkPage,
   isVisible,
 }: AskPageAIOverlayProps) {
   const [isMounted, setMounted] = useState(false);
@@ -52,6 +54,7 @@ export function AskPageAIOverlay({
             onClose={onClose}
             onMinimize={onMinimize}
             pageTitle={pageTitle}
+            isExpoSdkPage={isExpoSdkPage}
             isExpanded={isExpanded}
             onToggleExpand={() => {
               setExpanded(prev => !prev);

--- a/docs/ui/components/AskPageAI/AskPageAIOverlay.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIOverlay.tsx
@@ -18,10 +18,17 @@ export function AskPageAIOverlay({
   isVisible,
 }: AskPageAIOverlayProps) {
   const [isMounted, setMounted] = useState(false);
+  const [isExpanded, setExpanded] = useState(false);
 
   useEffect(() => {
     setMounted(true);
   }, []);
+
+  useEffect(() => {
+    if (!isVisible) {
+      setExpanded(false);
+    }
+  }, [isVisible]);
 
   if (!isMounted) {
     return null;
@@ -31,7 +38,8 @@ export function AskPageAIOverlay({
     <div className="pointer-events-none fixed inset-0 z-[70]">
       <div
         className={mergeClasses(
-          'max-sm:left-4 sm:bottom-8 sm:right-8 fixed bottom-4 right-4 flex h-full max-h-[min(85vh,600px)] w-[min(420px,calc(100vw-24px))] flex-col overflow-hidden rounded-2xl border border-default bg-default transition-all duration-150 ease-out',
+          'max-sm:left-4 sm:bottom-8 sm:right-8 fixed bottom-4 right-4 flex h-full w-[min(420px,calc(100vw-24px))] flex-col overflow-hidden rounded-2xl border border-default bg-default transition-all duration-150 ease-out',
+          isExpanded ? 'h-[min(97vh,860px)] max-h-[min(97vh,860px)]' : 'max-h-[min(85vh,600px)]',
           isVisible
             ? 'pointer-events-auto translate-y-0 opacity-100 shadow-xl'
             : 'pointer-events-none translate-y-3 opacity-0 shadow-none'
@@ -39,7 +47,17 @@ export function AskPageAIOverlay({
         role="dialog"
         aria-modal="false"
         aria-hidden={!isVisible}>
-        <AskPageAIChat onClose={onClose} onMinimize={onMinimize} pageTitle={pageTitle} />
+        {isVisible && (
+          <AskPageAIChat
+            onClose={onClose}
+            onMinimize={onMinimize}
+            pageTitle={pageTitle}
+            isExpanded={isExpanded}
+            onToggleExpand={() => {
+              setExpanded(prev => !prev);
+            }}
+          />
+        )}
       </div>
     </div>,
     document.body

--- a/docs/ui/components/AskPageAI/AskPageAIOverlay.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIOverlay.tsx
@@ -1,3 +1,4 @@
+import { mergeClasses } from '@expo/styleguide';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
@@ -5,10 +6,17 @@ import { AskPageAIChat } from './AskPageAIChat';
 
 type AskPageAIOverlayProps = {
   onClose: () => void;
+  onMinimize: () => void;
   pageTitle?: string;
+  isVisible: boolean;
 };
 
-export function AskPageAIOverlay({ onClose, pageTitle }: AskPageAIOverlayProps) {
+export function AskPageAIOverlay({
+  onClose,
+  onMinimize,
+  pageTitle,
+  isVisible,
+}: AskPageAIOverlayProps) {
   const [isMounted, setMounted] = useState(false);
 
   useEffect(() => {
@@ -22,10 +30,16 @@ export function AskPageAIOverlay({ onClose, pageTitle }: AskPageAIOverlayProps) 
   return createPortal(
     <div className="pointer-events-none fixed inset-0 z-[70]">
       <div
-        className="max-sm:left-4 sm:bottom-8 sm:right-8 pointer-events-auto fixed bottom-4 right-4 flex h-full max-h-[min(85vh,600px)] w-[min(420px,calc(100vw-24px))] flex-col overflow-hidden rounded-2xl border border-default bg-default shadow-xl"
+        className={mergeClasses(
+          'max-sm:left-4 sm:bottom-8 sm:right-8 fixed bottom-4 right-4 flex h-full max-h-[min(85vh,600px)] w-[min(420px,calc(100vw-24px))] flex-col overflow-hidden rounded-2xl border border-default bg-default transition-all duration-150 ease-out',
+          isVisible
+            ? 'pointer-events-auto translate-y-0 opacity-100 shadow-xl'
+            : 'pointer-events-none translate-y-3 opacity-0 shadow-none'
+        )}
         role="dialog"
-        aria-modal="false">
-        <AskPageAIChat onClose={onClose} pageTitle={pageTitle} />
+        aria-modal="false"
+        aria-hidden={!isVisible}>
+        <AskPageAIChat onClose={onClose} onMinimize={onMinimize} pageTitle={pageTitle} />
       </div>
     </div>,
     document.body

--- a/docs/ui/components/AskPageAI/AskPageAIOverlay.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIOverlay.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import { AskPageAIChat } from './AskPageAIChat';
+
+type AskPageAIOverlayProps = {
+  onClose: () => void;
+  pageTitle?: string;
+};
+
+export function AskPageAIOverlay({ onClose, pageTitle }: AskPageAIOverlayProps) {
+  const [isMounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!isMounted) {
+    return null;
+  }
+
+  return createPortal(
+    <div className="pointer-events-none fixed inset-0 z-[70]">
+      <div
+        className="max-sm:left-4 sm:bottom-8 sm:right-8 pointer-events-auto fixed bottom-4 right-4 flex max-h-[min(85vh,600px)] w-[min(420px,calc(100vw-24px))] flex-col overflow-hidden rounded-2xl border border-default bg-default shadow-xl"
+        role="dialog"
+        aria-modal="false">
+        <AskPageAIChat onClose={onClose} pageTitle={pageTitle} />
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/docs/ui/components/AskPageAI/AskPageAIOverlay.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIOverlay.tsx
@@ -22,7 +22,7 @@ export function AskPageAIOverlay({ onClose, pageTitle }: AskPageAIOverlayProps) 
   return createPortal(
     <div className="pointer-events-none fixed inset-0 z-[70]">
       <div
-        className="max-sm:left-4 sm:bottom-8 sm:right-8 pointer-events-auto fixed bottom-4 right-4 flex max-h-[min(85vh,600px)] w-[min(420px,calc(100vw-24px))] flex-col overflow-hidden rounded-2xl border border-default bg-default shadow-xl"
+        className="max-sm:left-4 sm:bottom-8 sm:right-8 pointer-events-auto fixed bottom-4 right-4 flex h-full max-h-[min(85vh,600px)] w-[min(420px,calc(100vw-24px))] flex-col overflow-hidden rounded-2xl border border-default bg-default shadow-xl"
         role="dialog"
         aria-modal="false">
         <AskPageAIChat onClose={onClose} pageTitle={pageTitle} />

--- a/docs/ui/components/AskPageAI/AskPageAITrigger.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAITrigger.tsx
@@ -17,7 +17,7 @@ export function AskPageAITrigger({ onClick, isActive = false }: AskPageAITrigger
           type="button"
           theme="quaternary"
           className={mergeClasses(
-            'min-h-[48px] min-w-[60px] justify-center px-2 max-xl-gutters:min-h-[unset] border border-palette-purple7 hover:border-palette-purple8 focus:border-palette-purple8',
+            'min-h-[48px] min-w-[60px] justify-center border border-palette-purple7 px-2 hover:border-palette-purple8 focus:border-palette-purple8 max-xl-gutters:min-h-[unset]',
             isActive && 'border border-default bg-element'
           )}
           onClick={onClick}
@@ -50,7 +50,7 @@ export function AskPageAIConfigTrigger({ onClick, isActive = false }: AskPageAIT
           type="button"
           theme="quaternary"
           className={mergeClasses(
-            'min-h-[36px] justify-center px-2.5 border border-palette-purple7 hover:border-palette-purple8 focus:border-palette-purple8',
+            'min-h-[36px] justify-center border border-palette-purple7 px-2.5 hover:border-palette-purple8 focus:border-palette-purple8',
             isActive && 'border border-default bg-element'
           )}
           onClick={onClick}

--- a/docs/ui/components/AskPageAI/AskPageAITrigger.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAITrigger.tsx
@@ -1,5 +1,5 @@
 import { Button, mergeClasses } from '@expo/styleguide';
-import { Stars03DuotoneIcon } from '@expo/styleguide-icons/duotone/Stars03DuotoneIcon';
+import { Star06Icon } from '@expo/styleguide-icons/outline/Star06Icon';
 
 import { FOOTNOTE } from '../Text';
 import * as Tooltip from '../Tooltip';
@@ -17,7 +17,7 @@ export function AskPageAITrigger({ onClick, isActive = false }: AskPageAITrigger
           type="button"
           theme="quaternary"
           className={mergeClasses(
-            'min-h-[48px] min-w-[60px] justify-center px-2 max-xl-gutters:min-h-[unset]',
+            'min-h-[48px] min-w-[60px] justify-center px-2 max-xl-gutters:min-h-[unset] border border-palette-purple7 hover:border-palette-purple8 focus:border-palette-purple8',
             isActive && 'border border-default bg-element'
           )}
           onClick={onClick}
@@ -28,7 +28,7 @@ export function AskPageAITrigger({ onClick, isActive = false }: AskPageAITrigger
               'flex flex-col items-center',
               'max-xl-gutters:flex-row max-xl-gutters:gap-1.5'
             )}>
-            <Stars03DuotoneIcon className="mt-0.5 text-icon-secondary" />
+            <Star06Icon className="mt-0.5 text-palette-purple11" />
             <FOOTNOTE crawlable={false} theme="secondary">
               Ask AI
             </FOOTNOTE>
@@ -50,14 +50,14 @@ export function AskPageAIConfigTrigger({ onClick, isActive = false }: AskPageAIT
           type="button"
           theme="quaternary"
           className={mergeClasses(
-            'min-h-[36px] justify-center px-2.5',
+            'min-h-[36px] justify-center px-2.5 border border-palette-purple7 hover:border-palette-purple8 focus:border-palette-purple8',
             isActive && 'border border-default bg-element'
           )}
           onClick={onClick}
           aria-pressed={isActive}
           aria-label="Ask about this configuration page with AI">
           <div className="flex items-center gap-2">
-            <Stars03DuotoneIcon className="icon-sm text-icon-secondary" />
+            <Star06Icon className="icon-sm text-palette-purple11" />
             <FOOTNOTE crawlable={false} theme="secondary">
               Ask AI
             </FOOTNOTE>

--- a/docs/ui/components/AskPageAI/AskPageAITrigger.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAITrigger.tsx
@@ -17,8 +17,7 @@ export function AskPageAITrigger({ onClick, isActive = false }: AskPageAITrigger
           type="button"
           theme="quaternary"
           className={mergeClasses(
-            'min-h-[48px] min-w-[60px] justify-center border border-palette-purple7 px-2 hover:border-palette-purple8 focus:border-palette-purple8 max-xl-gutters:min-h-[unset]',
-            isActive && 'border border-default bg-element'
+            'min-h-[48px] min-w-[60px] justify-center px-2 max-xl-gutters:min-h-[unset]'
           )}
           onClick={onClick}
           aria-pressed={isActive}
@@ -29,7 +28,7 @@ export function AskPageAITrigger({ onClick, isActive = false }: AskPageAITrigger
               'max-xl-gutters:flex-row max-xl-gutters:gap-1.5'
             )}>
             <Star06Icon className="mt-0.5 text-palette-purple11" />
-            <FOOTNOTE crawlable={false} theme="secondary">
+            <FOOTNOTE crawlable={false} className="text-palette-purple11">
               Ask AI
             </FOOTNOTE>
           </div>
@@ -49,16 +48,13 @@ export function AskPageAIConfigTrigger({ onClick, isActive = false }: AskPageAIT
         <Button
           type="button"
           theme="quaternary"
-          className={mergeClasses(
-            'min-h-[36px] justify-center border border-palette-purple7 px-2.5 hover:border-palette-purple8 focus:border-palette-purple8',
-            isActive && 'border border-default bg-element'
-          )}
+          className={mergeClasses('min-h-[36px] justify-center px-2.5')}
           onClick={onClick}
           aria-pressed={isActive}
           aria-label="Ask about this configuration page with AI">
           <div className="flex items-center gap-2">
             <Star06Icon className="icon-sm text-palette-purple11" />
-            <FOOTNOTE crawlable={false} theme="secondary">
+            <FOOTNOTE crawlable={false} className="text-palette-purple11">
               Ask AI
             </FOOTNOTE>
           </div>

--- a/docs/ui/components/AskPageAI/AskPageAITrigger.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAITrigger.tsx
@@ -36,7 +36,7 @@ export function AskPageAITrigger({ onClick, isActive = false }: AskPageAITrigger
         </Button>
       </Tooltip.Trigger>
       <Tooltip.Content sideOffset={8} className="max-w-[300px] text-center">
-        <FOOTNOTE>Open the contextual AI assistant for this SDK page.</FOOTNOTE>
+        <FOOTNOTE>Open the contextual AI assistant for this SDK page</FOOTNOTE>
       </Tooltip.Content>
     </Tooltip.Root>
   );

--- a/docs/ui/components/AskPageAI/AskPageAITrigger.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAITrigger.tsx
@@ -50,16 +50,18 @@ export function AskPageAIConfigTrigger({ onClick, isActive = false }: AskPageAIT
           type="button"
           theme="quaternary"
           className={mergeClasses(
-            'min-h-[36px] justify-center gap-2 px-2.5',
+            'min-h-[36px] justify-center px-2.5',
             isActive && 'border border-default bg-element'
           )}
           onClick={onClick}
           aria-pressed={isActive}
           aria-label="Ask about this configuration page with AI">
-          <Stars03DuotoneIcon className="icon-sm text-icon-secondary" />
-          <FOOTNOTE crawlable={false} theme="secondary">
-            Ask AI
-          </FOOTNOTE>
+          <div className="flex items-center gap-2">
+            <Stars03DuotoneIcon className="icon-sm text-icon-secondary" />
+            <FOOTNOTE crawlable={false} theme="secondary">
+              Ask AI
+            </FOOTNOTE>
+          </div>
         </Button>
       </Tooltip.Trigger>
       <Tooltip.Content sideOffset={8} className="max-w-[300px] text-center">

--- a/docs/ui/components/AskPageAI/AskPageAITrigger.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAITrigger.tsx
@@ -41,3 +41,30 @@ export function AskPageAITrigger({ onClick, isActive = false }: AskPageAITrigger
     </Tooltip.Root>
   );
 }
+
+export function AskPageAIConfigTrigger({ onClick, isActive = false }: AskPageAITriggerProps) {
+  return (
+    <Tooltip.Root delayDuration={500}>
+      <Tooltip.Trigger asChild>
+        <Button
+          type="button"
+          theme="quaternary"
+          className={mergeClasses(
+            'min-h-[36px] justify-center gap-2 px-2.5',
+            isActive && 'border border-default bg-element'
+          )}
+          onClick={onClick}
+          aria-pressed={isActive}
+          aria-label="Ask about this configuration page with AI">
+          <Stars03DuotoneIcon className="icon-sm text-icon-secondary" />
+          <FOOTNOTE crawlable={false} theme="secondary">
+            Ask AI
+          </FOOTNOTE>
+        </Button>
+      </Tooltip.Trigger>
+      <Tooltip.Content sideOffset={8} className="max-w-[300px] text-center">
+        <FOOTNOTE>Open the contextual AI assistant for this configuration reference</FOOTNOTE>
+      </Tooltip.Content>
+    </Tooltip.Root>
+  );
+}

--- a/docs/ui/components/AskPageAI/AskPageAITrigger.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAITrigger.tsx
@@ -1,0 +1,43 @@
+import { Button, mergeClasses } from '@expo/styleguide';
+import { Stars03DuotoneIcon } from '@expo/styleguide-icons/duotone/Stars03DuotoneIcon';
+
+import { FOOTNOTE } from '../Text';
+import * as Tooltip from '../Tooltip';
+
+type AskPageAITriggerProps = {
+  onClick: () => void;
+  isActive?: boolean;
+};
+
+export function AskPageAITrigger({ onClick, isActive = false }: AskPageAITriggerProps) {
+  return (
+    <Tooltip.Root delayDuration={500}>
+      <Tooltip.Trigger asChild>
+        <Button
+          type="button"
+          theme="quaternary"
+          className={mergeClasses(
+            'min-h-[48px] min-w-[60px] justify-center px-2 max-xl-gutters:min-h-[unset]',
+            isActive && 'border border-default bg-element'
+          )}
+          onClick={onClick}
+          aria-pressed={isActive}
+          aria-label="Ask about this page with AI">
+          <div
+            className={mergeClasses(
+              'flex flex-col items-center',
+              'max-xl-gutters:flex-row max-xl-gutters:gap-1.5'
+            )}>
+            <Stars03DuotoneIcon className="mt-0.5 text-icon-secondary" />
+            <FOOTNOTE crawlable={false} theme="secondary">
+              Ask AI
+            </FOOTNOTE>
+          </div>
+        </Button>
+      </Tooltip.Trigger>
+      <Tooltip.Content sideOffset={8} className="max-w-[300px] text-center">
+        <FOOTNOTE>Open the contextual AI assistant for this SDK page.</FOOTNOTE>
+      </Tooltip.Content>
+    </Tooltip.Root>
+  );
+}

--- a/docs/ui/components/AskPageAI/index.ts
+++ b/docs/ui/components/AskPageAI/index.ts
@@ -1,3 +1,3 @@
-export { AskPageAITrigger } from './AskPageAITrigger';
+export { AskPageAITrigger, AskPageAIConfigTrigger } from './AskPageAITrigger';
 export { AskPageAIChat } from './AskPageAIChat';
 export { AskPageAIOverlay } from './AskPageAIOverlay';

--- a/docs/ui/components/AskPageAI/index.ts
+++ b/docs/ui/components/AskPageAI/index.ts
@@ -1,0 +1,2 @@
+export { AskPageAITrigger } from './AskPageAITrigger';
+export { AskPageAIChat } from './AskPageAIChat';

--- a/docs/ui/components/AskPageAI/index.ts
+++ b/docs/ui/components/AskPageAI/index.ts
@@ -1,2 +1,3 @@
 export { AskPageAITrigger } from './AskPageAITrigger';
 export { AskPageAIChat } from './AskPageAIChat';
+export { AskPageAIOverlay } from './AskPageAIOverlay';

--- a/docs/ui/components/PageHeader/PageHeader.tsx
+++ b/docs/ui/components/PageHeader/PageHeader.tsx
@@ -67,13 +67,12 @@ export function PageHeader({
           <PageTitleButtons packageName={packageName} sourceCodeUrl={sourceCodeUrl} />
           {(showMarkdownActions || (showAskAIButton && onAskAIClick)) && (
             <span className="flex items-center gap-1">
+              {showAskAIButton && onAskAIClick && askAIButtonVariant === 'config' && (
+                <AskPageAIConfigTrigger onClick={onAskAIClick} isActive={isAskAIVisible} />
+              )}
               {showMarkdownActions && <MarkdownActionsDropdown />}
-              {showAskAIButton && onAskAIClick && (
-                askAIButtonVariant === 'config' ? (
-                  <AskPageAIConfigTrigger onClick={onAskAIClick} isActive={isAskAIVisible} />
-                ) : (
-                  <AskPageAITrigger onClick={onAskAIClick} isActive={isAskAIVisible} />
-                )
+              {showAskAIButton && onAskAIClick && askAIButtonVariant !== 'config' && (
+                <AskPageAITrigger onClick={onAskAIClick} isActive={isAskAIVisible} />
               )}
             </span>
           )}
@@ -88,13 +87,12 @@ export function PageHeader({
         <PageTitleButtons packageName={packageName} sourceCodeUrl={sourceCodeUrl} />
         {(showMarkdownActions || (showAskAIButton && onAskAIClick)) && (
           <span className="ml-1 flex items-center gap-1">
+            {showAskAIButton && onAskAIClick && askAIButtonVariant === 'config' && (
+              <AskPageAIConfigTrigger onClick={onAskAIClick} isActive={isAskAIVisible} />
+            )}
             {showMarkdownActions && <MarkdownActionsDropdown />}
-            {showAskAIButton && onAskAIClick && (
-              askAIButtonVariant === 'config' ? (
-                <AskPageAIConfigTrigger onClick={onAskAIClick} isActive={isAskAIVisible} />
-              ) : (
-                <AskPageAITrigger onClick={onAskAIClick} isActive={isAskAIVisible} />
-              )
+            {showAskAIButton && onAskAIClick && askAIButtonVariant !== 'config' && (
+              <AskPageAITrigger onClick={onAskAIClick} isActive={isAskAIVisible} />
             )}
           </span>
         )}

--- a/docs/ui/components/PageHeader/PageHeader.tsx
+++ b/docs/ui/components/PageHeader/PageHeader.tsx
@@ -6,7 +6,7 @@ import { MarkdownActionsDropdown } from '~/ui/components/MarkdownActions/Markdow
 import { hasDynamicData, shouldShowMarkdownActions } from '~/ui/components/MarkdownActions/paths';
 import { H1, P } from '~/ui/components/Text';
 
-import { AskPageAITrigger } from '../AskPageAI';
+import { AskPageAIConfigTrigger, AskPageAITrigger } from '../AskPageAI';
 import { PagePackageVersion } from './PagePackageVersion';
 import { PagePlatformTags } from './PagePlatformTags';
 import { PageTitleButtons } from './PageTitleButtons';
@@ -21,6 +21,7 @@ type Props = {
   showAskAIButton?: boolean;
   onAskAIClick?: () => void;
   isAskAIVisible?: boolean;
+  askAIButtonVariant?: 'default' | 'config';
 } & WithTestRequire;
 
 export function PageHeader({
@@ -34,6 +35,7 @@ export function PageHeader({
   showAskAIButton = false,
   onAskAIClick,
   isAskAIVisible = false,
+  askAIButtonVariant = 'default',
 }: Props) {
   const router = useRouter();
   const currentPath = router?.asPath ?? router?.pathname ?? '';
@@ -67,7 +69,11 @@ export function PageHeader({
             <span className="flex items-center gap-1">
               {showMarkdownActions && <MarkdownActionsDropdown />}
               {showAskAIButton && onAskAIClick && (
-                <AskPageAITrigger onClick={onAskAIClick} isActive={isAskAIVisible} />
+                askAIButtonVariant === 'config' ? (
+                  <AskPageAIConfigTrigger onClick={onAskAIClick} isActive={isAskAIVisible} />
+                ) : (
+                  <AskPageAITrigger onClick={onAskAIClick} isActive={isAskAIVisible} />
+                )
               )}
             </span>
           )}
@@ -84,7 +90,11 @@ export function PageHeader({
           <span className="ml-1 flex items-center gap-1">
             {showMarkdownActions && <MarkdownActionsDropdown />}
             {showAskAIButton && onAskAIClick && (
-              <AskPageAITrigger onClick={onAskAIClick} isActive={isAskAIVisible} />
+              askAIButtonVariant === 'config' ? (
+                <AskPageAIConfigTrigger onClick={onAskAIClick} isActive={isAskAIVisible} />
+              ) : (
+                <AskPageAITrigger onClick={onAskAIClick} isActive={isAskAIVisible} />
+              )
             )}
           </span>
         )}

--- a/docs/ui/components/PageHeader/PageHeader.tsx
+++ b/docs/ui/components/PageHeader/PageHeader.tsx
@@ -2,9 +2,11 @@ import { mergeClasses } from '@expo/styleguide';
 import { useRouter } from 'next/compat/router';
 
 import { WithTestRequire } from '~/types/common';
+import { MarkdownActionsDropdown } from '~/ui/components/MarkdownActions/MarkdownActionsDropdown';
 import { hasDynamicData, shouldShowMarkdownActions } from '~/ui/components/MarkdownActions/paths';
 import { H1, P } from '~/ui/components/Text';
 
+import { AskPageAITrigger } from '../AskPageAI';
 import { PagePackageVersion } from './PagePackageVersion';
 import { PagePlatformTags } from './PagePlatformTags';
 import { PageTitleButtons } from './PageTitleButtons';
@@ -16,6 +18,9 @@ type Props = {
   sourceCodeUrl?: string;
   iconUrl?: string;
   platforms?: string[];
+  showAskAIButton?: boolean;
+  onAskAIClick?: () => void;
+  isAskAIVisible?: boolean;
 } & WithTestRequire;
 
 export function PageHeader({
@@ -26,6 +31,9 @@ export function PageHeader({
   sourceCodeUrl,
   platforms,
   testRequire,
+  showAskAIButton = false,
+  onAskAIClick,
+  isAskAIVisible = false,
 }: Props) {
   const router = useRouter();
   const currentPath = router?.asPath ?? router?.pathname ?? '';
@@ -53,12 +61,16 @@ export function PageHeader({
           {packageName && packageName.startsWith('expo-') && 'Expo '}
           {title}
         </H1>
-        <span className="-mt-0.5 flex gap-1 max-xl-gutters:hidden">
-          <PageTitleButtons
-            packageName={packageName}
-            sourceCodeUrl={sourceCodeUrl}
-            showMarkdownActions={showMarkdownActions}
-          />
+        <span className="-mt-0.5 flex items-center gap-1 max-xl-gutters:hidden">
+          <PageTitleButtons packageName={packageName} sourceCodeUrl={sourceCodeUrl} />
+          {(showMarkdownActions || (showAskAIButton && onAskAIClick)) && (
+            <span className="flex items-center gap-1">
+              {showMarkdownActions && <MarkdownActionsDropdown />}
+              {showAskAIButton && onAskAIClick && (
+                <AskPageAITrigger onClick={onAskAIClick} isActive={isAskAIVisible} />
+              )}
+            </span>
+          )}
         </span>
       </div>
       {description && (
@@ -66,12 +78,16 @@ export function PageHeader({
           {description}
         </P>
       )}
-      <span className="mb-1 mt-3 hidden gap-1 max-xl-gutters:flex">
-        <PageTitleButtons
-          packageName={packageName}
-          sourceCodeUrl={sourceCodeUrl}
-          showMarkdownActions={showMarkdownActions}
-        />
+      <span className="mb-1 mt-3 hidden items-center gap-1 max-xl-gutters:flex">
+        <PageTitleButtons packageName={packageName} sourceCodeUrl={sourceCodeUrl} />
+        {(showMarkdownActions || (showAskAIButton && onAskAIClick)) && (
+          <span className="ml-1 flex items-center gap-1">
+            {showMarkdownActions && <MarkdownActionsDropdown />}
+            {showAskAIButton && onAskAIClick && (
+              <AskPageAITrigger onClick={onAskAIClick} isActive={isAskAIVisible} />
+            )}
+          </span>
+        )}
       </span>
       <div
         className={mergeClasses(

--- a/docs/ui/components/PageHeader/PageTitleButtons.tsx
+++ b/docs/ui/components/PageHeader/PageTitleButtons.tsx
@@ -6,8 +6,6 @@ import { Tag03Icon } from '@expo/styleguide-icons/outline/Tag03Icon';
 import { useRouter } from 'next/compat/router';
 
 import { githubUrl } from '~/ui/components/Footer/utils';
-import { MarkdownActionsDropdown } from '~/ui/components/MarkdownActions/MarkdownActionsDropdown';
-import { shouldShowMarkdownActions } from '~/ui/components/MarkdownActions/paths';
 import { FOOTNOTE } from '~/ui/components/Text';
 
 import { SdkPackageButton } from './SdkPackageButton';
@@ -15,19 +13,11 @@ import { SdkPackageButton } from './SdkPackageButton';
 type Props = {
   packageName?: string;
   sourceCodeUrl?: string;
-  showMarkdownActions?: boolean;
 };
 
-export function PageTitleButtons({ packageName, sourceCodeUrl, showMarkdownActions }: Props) {
+export function PageTitleButtons({ packageName, sourceCodeUrl }: Props) {
   const router = useRouter();
   const showEditButton = !sourceCodeUrl && !packageName && router?.pathname;
-  const currentPath = router?.asPath ?? router?.pathname;
-  const markdownActionsEnabled =
-    showMarkdownActions ??
-    shouldShowMarkdownActions({
-      packageName,
-      path: currentPath,
-    });
 
   return (
     <>
@@ -46,30 +36,35 @@ export function PageTitleButtons({ packageName, sourceCodeUrl, showMarkdownActio
           </div>
         </Button>
       )}
-      {markdownActionsEnabled && <MarkdownActionsDropdown />}
-      {sourceCodeUrl && (
-        <SdkPackageButton
-          label="GitHub"
-          Icon={GithubIcon}
-          href={sourceCodeUrl}
-          tooltip="View source code on GitHub"
-        />
-      )}
-      {sourceCodeUrl?.startsWith('https://github.com/expo/expo') && (
-        <SdkPackageButton
-          label="Changelog"
-          Icon={Tag03Icon}
-          href={`${sourceCodeUrl}/CHANGELOG.md`}
-          tooltip="View package changelog on GitHub"
-        />
-      )}
-      {packageName && (
-        <SdkPackageButton
-          label="npm"
-          Icon={BuildIcon}
-          href={`https://www.npmjs.com/package/${packageName}`}
-          tooltip="View package in npm registry"
-        />
+      {(sourceCodeUrl ||
+        sourceCodeUrl?.startsWith('https://github.com/expo/expo') ||
+        packageName) && (
+        <span className="flex items-center gap-1">
+          {sourceCodeUrl && (
+            <SdkPackageButton
+              label="GitHub"
+              Icon={GithubIcon}
+              href={sourceCodeUrl}
+              tooltip="View source code on GitHub"
+            />
+          )}
+          {sourceCodeUrl?.startsWith('https://github.com/expo/expo') && (
+            <SdkPackageButton
+              label="Changelog"
+              Icon={Tag03Icon}
+              href={`${sourceCodeUrl}/CHANGELOG.md`}
+              tooltip="View package changelog on GitHub"
+            />
+          )}
+          {packageName && (
+            <SdkPackageButton
+              label="npm"
+              Icon={BuildIcon}
+              href={`https://www.npmjs.com/package/${packageName}`}
+              tooltip="View package in npm registry"
+            />
+          )}
+        </span>
       )}
     </>
   );

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -7130,6 +7130,7 @@ __metadata:
     "@expo/styleguide-base": "npm:^2.0.3"
     "@expo/styleguide-icons": "npm:^2.2.3"
     "@expo/styleguide-search-ui": "npm:^3.2.1"
+    "@kapaai/react-sdk": "npm:^0.5.1"
     "@mdx-js/loader": "npm:^3.1.0"
     "@mdx-js/mdx": "npm:^3.1.0"
     "@mdx-js/react": "npm:^3.1.0"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-16795

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add Ask AI on the latest pages under Reference that opens up a modal-style chat interface on the bottom right corner. It uses a custom prompt.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- See preview.
- **Recommended**: Test locally by running the docs app.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
