### PR TITLE
[notifications] add a warning for getDevicePushTokenAsync on iOS simulators

### DIFF
--- a/apps/notification-tester/scripts/prebuild-android.sh
+++ b/apps/notification-tester/scripts/prebuild-android.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RELEASE=1 MICROFOAM_GOOGLE_SERVICES_JSON=~/google-services-microfoam-vonovak.json EXPO_NO_GIT_STATUS=1 EXPO_DEBUG=1 npx expo prebuild --clean -p android --template expo-template-bare-minimum@sdk-54
+RELEASE=1 MICROFOAM_GOOGLE_SERVICES_JSON=~/google-services-microfoam-vonovak.json EXPO_NO_GIT_STATUS=1 EXPO_DEBUG=1 npx expo prebuild --clean -p android --template expo-template-bare-minimum@canary
 
 
 echo 'include(":expo-modules-test-core")' >> ./android/settings.gradle

--- a/apps/notification-tester/scripts/prebuild-ios.sh
+++ b/apps/notification-tester/scripts/prebuild-ios.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-EXPO_NO_GIT_STATUS=1 EXPO_DEBUG=1 npx expo prebuild --clean -p ios --template expo-template-bare-minimum@sdk-54
+EXPO_NO_GIT_STATUS=1 EXPO_DEBUG=1 npx expo prebuild --clean -p ios --template expo-template-bare-minimum@canary && xed ios

--- a/apps/notification-tester/src/registerForNotifications.ts
+++ b/apps/notification-tester/src/registerForNotifications.ts
@@ -1,18 +1,11 @@
 import Constants from 'expo-constants';
-import { isDevice } from 'expo-device';
 import {
   getExpoPushTokenAsync,
   getPermissionsAsync,
   requestPermissionsAsync,
 } from 'expo-notifications';
-import { Platform } from 'react-native';
 
 export async function registerForPushNotificationsAsync() {
-  if (Platform.OS === 'ios' && !isDevice) {
-    console.error('Must use physical device for Push Notifications');
-    return;
-  }
-
   const { status: existingStatus } = await getPermissionsAsync();
   let finalStatus = existingStatus;
   if (existingStatus !== 'granted') {

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 💡 Others
 
+- add a warning for getDevicePushTokenAsync on iOS simulators ([#40028](https://github.com/expo/expo/pull/40028) by [@vonovak](https://github.com/vonovak))
 - validate sound resource names with `assertValidAndroidAssetName` from `expo/config-plugins` ([#39883](https://github.com/expo/expo/pull/39883) by [@vonovak](https://github.com/vonovak))
 
 ## 0.32.11 — 2025-09-11

--- a/packages/expo-notifications/ios/EXNotifications/PushToken/PushTokenModule.swift
+++ b/packages/expo-notifications/ios/EXNotifications/PushToken/PushTokenModule.swift
@@ -30,6 +30,12 @@ To obtain the push token, await the result of the newer call.
 """
         existingPromise.reject("E_PROMISE_REPLACED", message)
       }
+
+      #if targetEnvironment(simulator)
+      if let appContext = appContext {
+        appContext.jsLogger.warn("expo-notifications: obtaining a push token may not work on iOS simulators due to an iOS issue. To obtain a push token, use a real device. Read more: https://developer.apple.com/forums/thread/795433")
+      }
+      #endif
       promiseNotYetResolved = promise
       UIApplication.shared.registerForRemoteNotifications()
     }
@@ -52,3 +58,4 @@ To obtain the push token, await the result of the newer call.
     promiseNotYetResolved = nil
   }
 }
+


### PR DESCRIPTION
# Why

Obtaining push tokens on ios simulators doesn't currently work (it worked before) - this is an iOS issue, not Expo issue. 

This means the promise from `getDevicePushTokenAsync` never resolves, leaving users confused as in https://github.com/expo/expo/issues/37516


# How

- Added a warning message in the iOS push token module to inform users about potential issues with obtaining push tokens on iOS simulators, with a link to Apple's developer forum for more information

# Test Plan

notification tester:

```
WARN  🟡 expo-notifications: obtaining a push token may not work on iOS simulators due to an iOS issue. To obtain a push token, use a real device. Read more: https://developer.apple.com/forums/thread/795433
```

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).