### PR TITLE
Change base64 method to return a Promise

### DIFF
--- a/packages/expo-file-system/src/ExpoFileSystem.types.ts
+++ b/packages/expo-file-system/src/ExpoFileSystem.types.ts
@@ -188,7 +188,7 @@ export declare class File {
    * Retrieves content of the file as base64.
    * @returns A promise that resolves with the contents of the file as a base64 string.
    */
-  base64(): string;
+  base64(): Promise<string>;
 
   /**
    * Retrieves content of the file as base64.


### PR DESCRIPTION
Fix File.base64 method type

# Why

Method type is not matching documentation (implementation).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)

