### PR TITLE
[docs]Mention Rust Expo Server SDK alongside Node SDK for push notifications

### DIFF
--- a/docs/pages/push-notifications/sending-notifications.mdx
+++ b/docs/pages/push-notifications/sending-notifications.mdx
@@ -122,7 +122,7 @@ The request body must be JSON. It may either be a single [message object](#messa
 ]
 ```
 
-The Expo Push Service also optionally accepts gzip-compressed request bodies. This can greatly reduce the amount of upload bandwidth needed to send large numbers of notifications. The [Node Expo Server SDK](https://github.com/expo/expo-server-sdk-node) automatically gzips requests for you and automatically throttles your requests to smooth out the load, so we highly recommend it.
+The Expo Push Service also optionally accepts gzip-compressed request bodies. This can greatly reduce the amount of upload bandwidth needed to send large numbers of notifications. The [Node Expo Server SDK](https://github.com/expo/expo-server-sdk-node) and [Rust Expo Server SDK](https://github.com/katayama8000/expo-push-notification-client-rust) automatically gzips requests for you and automatically throttles your requests to smooth out the load, so we highly recommend it.
 
 ### Push tickets
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
To enhance the developer experience for Rust users, I am adding a mention of the Rust Expo Server SDK to the official documentation. This allows Rust developers to easily find and utilize a highly recommended, feature-complete library for sending Expo Push Notifications.

I am a maintainer of https://github.com/katayama8000/expo-push-notification-client-rust.

Check the code https://github.com/katayama8000/expo-push-notification-client-rust/blob/f912361e7b6b0bb43457ee6247ece2df2f09c81f/src/expo_client.rs#L198.

# How

<!--
How did you build this feature or fix this bug and why?
-->
I just added simple text.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
