### PR TITLE
[docs] Process `FileTree`  components in markdown output for LLMs

### DIFF
--- a/docs/scripts/generate-llms/utils.js
+++ b/docs/scripts/generate-llms/utils.js
@@ -171,7 +171,7 @@ export function cleanContent(content) {
       .replace(/<\/PaddedAPIBox>/g, '')
       .replace(/<CodeBlocksTable[^>]*>/g, '')
       .replace(/<\/CodeBlocksTable>/g, '')
-      .replace(/<FileTree\s+files={(\[[\s\S]*?\])}\s*\/>/g, (_match, filesLiteral) => {
+      .replace(/<FileTree\s+files={(\[[\S\s]*?])}\s*\/>/g, (_match, filesLiteral) => {
         const files = parseFileTreeFilesLiteral(filesLiteral);
         if (!files || files.length === 0) {
           return '';

--- a/docs/scripts/generate-llms/utils.js
+++ b/docs/scripts/generate-llms/utils.js
@@ -171,7 +171,18 @@ export function cleanContent(content) {
       .replace(/<\/PaddedAPIBox>/g, '')
       .replace(/<CodeBlocksTable[^>]*>/g, '')
       .replace(/<\/CodeBlocksTable>/g, '')
-      .replace(/<FileTree[\S\s]*?\/>/g, '')
+      .replace(/<FileTree\s+files={(\[[\s\S]*?\])}\s*\/>/g, (_match, filesLiteral) => {
+        const files = parseFileTreeFilesLiteral(filesLiteral);
+        if (!files || files.length === 0) {
+          return '';
+        }
+        const structure = buildFileTreeStructure(files);
+        const lines = renderFileTreeAscii(structure);
+        if (lines.length === 0) {
+          return '';
+        }
+        return ['```', ...lines, '```'].join('\n');
+      })
       .replace(
         /<ContentSpotlight(?:\s+(?:src|file|alt|controls|caption|className|loop|containerClassName)(?:="[^"]*"|={`[^`]*`})?)*\s*\/>/g,
         ''
@@ -216,6 +227,74 @@ export function cleanContent(content) {
   });
 
   return processed.join('').replace(/^\s*[\n\r]/gm, '');
+}
+
+function parseFileTreeFilesLiteral(literal) {
+  try {
+    // eslint-disable-next-line no-new-func
+    return new Function(`return (${literal})`)();
+  } catch (error) {
+    console.warn('Unable to parse FileTree files literal:', error);
+    return [];
+  }
+}
+
+function buildFileTreeStructure(files = []) {
+  const root = [];
+
+  function modifyPath(path, note) {
+    const segments = path.split('/');
+    let currentLevel = root;
+
+    segments.forEach((segment, index) => {
+      let existing = currentLevel.find(node => node.name === segment);
+      if (!existing) {
+        existing = { name: segment, note: undefined, children: [] };
+        currentLevel.push(existing);
+      }
+
+      if (note && index === segments.length - 1) {
+        existing.note = note;
+      }
+
+      currentLevel = existing.children;
+    });
+  }
+
+  files.forEach(entry => {
+    if (Array.isArray(entry)) {
+      modifyPath(entry[0], entry[1]);
+    } else if (typeof entry === 'string') {
+      modifyPath(entry);
+    }
+  });
+
+  return root;
+}
+
+function renderFileTreeAscii(structure) {
+  const lines = [];
+
+  function renderNodes(nodes, prefix) {
+    nodes.forEach((node, index) => {
+      const isLast = index === nodes.length - 1;
+      const connector = `${prefix}${isLast ? '└── ' : '├── '}`;
+      const isDirectory = node.children.length > 0;
+      const name = isDirectory ? `${node.name}/` : node.name;
+      const note = node.note ? `  # ${node.note}` : '';
+
+      lines.push(`${connector}${name}${note}`);
+
+      if (isDirectory) {
+        const childPrefix = `${prefix}${isLast ? '    ' : '│   '}`;
+        renderNodes(node.children, childPrefix);
+      }
+    });
+  }
+
+  renderNodes(structure, '');
+
+  return lines.map(line => line.replace(/^(├── |└── )/, ''));
 }
 
 function generateItemMarkdown(item) {

--- a/docs/ui/components/MarkdownActions/processMarkdown.ts
+++ b/docs/ui/components/MarkdownActions/processMarkdown.ts
@@ -241,7 +241,7 @@ function replaceBoxLinks(content: string) {
   return result;
 }
 
-const FILE_TREE_PATTERN = /<FileTree\s+files={(\[[\s\S]*?\])}\s*\/>/g;
+const FILE_TREE_PATTERN = /<FileTree\s+files={(\[[\S\s]*?])}\s*\/>/g;
 
 function replaceFileTrees(content: string) {
   return content.replace(FILE_TREE_PATTERN, (_match, filesLiteral) => {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-17536

# How

<!--
How did you build this feature or fix this bug and why?
-->

Process `FileTree`  components in markdown output for LLMs in copy markdown button and in llms.txt files. 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

<img width="1632" height="1178" alt="CleanShot 2025-09-27 at 21 59 07@2x" src="https://github.com/user-attachments/assets/9fee2b1d-10f8-4f82-86f3-544309a99b17" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
