### PR TITLE
[docs] Fix Vale warnings

### DIFF
--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -49,7 +49,7 @@ Firebase JS SDK does not support all services for mobile apps. Some of these ser
 
 ### Install and initialize Firebase JS SDK
 
-> **warning** Expo SDK 53 and above only support `firebase@^12.0.0`. Versions prior to this version cause ES module resolution errors.
+> **warning** Expo SDK 53 and above only support `firebase@^12.0.0`. Versions before this version cause ES module resolution errors.
 
 <Step label="1">
 #### Install the SDK


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

<img width="1602" height="310" alt="CleanShot 2025-09-27 at 22 12 23@2x" src="https://github.com/user-attachments/assets/0aa847d1-63c9-49c0-8f86-cb9e4b2f4831" />

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn run lint-prose` in docs repo and there shouldn't be any warnings.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
