### PR TITLE
fix(cli): Only skip dependency validation for `EXPO_NO_DEPENDENCY_VALIDATION=1`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - fix launching apps on Android emulators where `hw.keyboard = no` ([#34677](https://github.com/expo/expo/pull/34677) by [@DimitarNestorov](https://github.com/DimitarNestorov))
+- only skip dependency validation for `EXPO_NO_DEPENDENCY_VALIDATION=1` ([#40043](https://github.com/expo/expo/pull/40043) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/e2e/__tests__/install-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/install-test.ts
@@ -201,7 +201,7 @@ it('runs `npx expo install expo@<version> --fix`', async () => {
   });
 });
 
-it('does not validate for `EXPO_NO_DEPENDENCY_VALIDATION=1 npx expo install --check`', async () => {
+it('validates when with `EXPO_NO_DEPENDENCY_VALIDATION=1 npx expo install --check`', async () => {
   const env = { EXPO_NO_DEPENDENCY_VALIDATION: '1' };
   const projectRoot = await setupTestProjectWithOptionsAsync(
     'install-check-no-validation',
@@ -223,28 +223,9 @@ it('does not validate for `EXPO_NO_DEPENDENCY_VALIDATION=1 npx expo install --ch
   expect(pkg.read().dependencies).toMatchObject({ 'expo-image': '1.0.0' });
 
   // Ensure `expo install --check` does not throw when validation is disabled
-  await expect(
-    executeExpoAsync(projectRoot, ['install', '--check'], { env })
-  ).resolves.toMatchObject({
-    stdout: expect.stringContaining('Dependencies are up to date'),
-  });
-
-  // Ensure `expo install --check <package>` does not throw when validation is disabled
-  await expect(
-    executeExpoAsync(projectRoot, ['install', 'expo-image', '--check'], {
-      env: { ...env, EXPO_DEBUG: '1' },
-    })
-  ).resolves.toMatchObject({
-    // Ensure no dependency issues are found
-    stdout: expect.stringContaining('Dependencies are up to date'),
-    // Ensure a debug warning is printed
-    stderr: expect.stringContaining(
-      'Dependency validation is disabled through EXPO_NO_DEPENDENCY_VALIDATION=1'
-    ),
-  });
-
-  // Ensure `--check` did not fix the version
-  expect(pkg.read().dependencies).toMatchObject({ 'expo-image': '1.0.0' });
+  await expect(() => {
+    return executeExpoAsync(projectRoot, ['install', '--check'], { env, verbose: false });
+  }).rejects.toThrow(/Found outdated dependencies/);
 });
 
 describe('expo-router integration', () => {

--- a/packages/@expo/cli/src/start/doctor/dependencies/getVersionedPackages.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/getVersionedPackages.ts
@@ -54,11 +54,6 @@ export async function getCombinedKnownVersionsAsync({
     Log.warn('Dependency validation might be unreliable when using canary SDK versions');
   }
 
-  if (env.EXPO_NO_DEPENDENCY_VALIDATION) {
-    debug('Dependency validation is disabled through EXPO_NO_DEPENDENCY_VALIDATION=1');
-    return {};
-  }
-
   const bundledNativeModules = sdkVersion
     ? await getVersionedNativeModulesAsync(projectRoot, sdkVersion, { skipRemoteVersions })
     : {};

--- a/packages/@expo/cli/src/start/doctor/dependencies/validateDependenciesVersions.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/validateDependenciesVersions.ts
@@ -41,6 +41,9 @@ export async function validateDependenciesVersionsAsync(
   if (env.EXPO_OFFLINE) {
     Log.warn('Skipping dependency validation in offline mode');
     return null;
+  } else if (env.EXPO_NO_DEPENDENCY_VALIDATION) {
+    debug('Dependency validation is disabled through EXPO_NO_DEPENDENCY_VALIDATION=1');
+    return null;
   }
 
   const incorrectDeps = await getVersionedDependenciesAsync(projectRoot, exp, pkg, packagesToCheck);


### PR DESCRIPTION
# Why

`EXPO_NO_DEPENDENCY_VALIDATION=1` (which defaults to enabled for webcontainers) is currently placed as a check into `getCombinedKnownVersionsAsync`. This prevents `install --check|--fix` from actually working, although we should ignore this flag when this command is explicitly called.

# How

- Move the check to `validateDependenciesVersionsAsync` instead. The `startAsync` path was already guarded and is unaffected

This fixes `expo install --check|--fix` when `EXPO_NO_DEPENDENCY_VALIDATION=1` is set.

# Test Plan

- Manually tested by flipping `EXPO_NO_DEPENDENCY_VALIDATION=1` and running `expo install --check`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
