### PR TITLE
[go][Android] Fix failing spotless CI job

### DIFF
--- a/apps/expo-go/android/build.gradle
+++ b/apps/expo-go/android/build.gradle
@@ -98,6 +98,7 @@ def ktlintTarget = '**/*.kt'
 
 subprojects { project ->
   if (project.name == "ReactAndroid") { return; }
+  if (project.name == "packages") { return; }
   if (project.name.startsWith("vendored_")) { return; }
   if (project.name.startsWith("react-native")) { return; }
   if (project.projectDir.toString().contains("/node_modules/")) { return; }


### PR DESCRIPTION
# Why

Fixes the failing spotless CI job

# How

When the fork of RN is added to a project, it's also added under the `packages` namespace. Our spotless configuration shouldn't touch those subprojects.

# Test Plan

- run `./gradlew spotlessCheck` ✅ 