### PR TITLE
[ios][image-picker] Fix iCloud video download on iOS 26

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix issue on iOS 26 where videos stored in iCloud were not downloaded when picked.
+  
 ### 💡 Others
 
 ## 17.0.8 — 2025-09-11

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix issue on iOS 26 where videos stored in iCloud were not downloaded when picked.
+- [iOS] Fix issue on iOS 26 where videos stored in iCloud were not downloaded when picked. ([#40047](https://github.com/expo/expo/pull/40047) by [@DvzZDev](https://github.com/DvzZDev))
   
 ### 💡 Others
 


### PR DESCRIPTION
# Why

On iOS 26, videos that are stored in iCloud and not yet downloaded fail when picked using `expo-image-picker`. This PR fixes that issue by ensuring that iCloud assets are properly downloaded before being used.  

Fixes #39937

# How

Added `PHAssetResourceRequestOptions().isNetworkAccessAllowed = true` for both images and videos in `MediaHandler.swift`. Updated video handling to always attempt to copy the original resource via `PHAssetResourceManager`, bypassing slower methods like `loadFileRepresentation` and ensuring the full-size asset is available locally.

# Test Plan

Tested on iOS (simulator and physical device) by picking:
- Videos stored locally
- Videos stored in iCloud

All assets downloaded successfully and returned correct paths. Verified no crashes or errors occur when `allowsEditing` is enabled.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
