### PR TITLE
[ncl][5/n] BlurView audit - Add new test screens

### DIFF
--- a/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
@@ -8,6 +8,7 @@ import { optionalRequire } from './routeBuilder';
 import { TabBackground } from '../components/TabBackground';
 import TabIcon from '../components/TabIcon';
 import { Layout } from '../constants';
+import { BlurScreens } from '../screens/BlurView/BlurViewScreen';
 import { CameraScreens } from '../screens/Camera/CameraScreen';
 import { componentScreensToListElements } from '../screens/ComponentListScreen';
 import ExpoComponents from '../screens/ExpoComponentsScreen';
@@ -52,6 +53,7 @@ const ScreensList: ScreenConfig[] = [
       return optionalRequire(() => require('../screens/BlurView/BlurViewScreen'));
     },
     name: 'BlurView',
+    route: 'blur',
   },
   {
     getComponent() {
@@ -303,6 +305,7 @@ const ScreensList: ScreenConfig[] = [
 export const Screens: ScreenConfig[] = [
   ...ScreensList,
 
+  ...BlurScreens,
   ...GLScreens,
   ...CameraScreens,
   ...ImageScreens,

--- a/apps/native-component-list/src/screens/BlurView/BlurViewAnimatedScreen.tsx
+++ b/apps/native-component-list/src/screens/BlurView/BlurViewAnimatedScreen.tsx
@@ -1,0 +1,64 @@
+import SegmentedControl from '@react-native-segmented-control/segmented-control';
+import { ExperimentalBlurMethod } from 'expo-blur';
+import React from 'react';
+import { StyleSheet, ScrollView, Text, Platform } from 'react-native';
+
+import BlurViewWithControls from './BlurViewWithControls';
+
+const blurStyles = [
+  'light',
+  'dark',
+  'default',
+  'extraLight',
+  'regular',
+  'prominent',
+  'systemUltraThinMaterial',
+  'systemThinMaterial',
+  'systemMaterial',
+  'systemThickMaterial',
+  'systemChromeMaterial',
+  'systemUltraThinMaterialLight',
+  'systemThinMaterialLight',
+  'systemMaterialLight',
+  'systemThickMaterialLight',
+  'systemChromeMaterialLight',
+  'systemUltraThinMaterialDark',
+  'systemThinMaterialDark',
+  'systemMaterialDark',
+  'systemThickMaterialDark',
+  'systemChromeMaterialDark',
+] as const;
+
+const blurMethods: ExperimentalBlurMethod[] = ['none', 'dimezisBlurView'];
+
+export default function BlurViewScreen() {
+  const [blurMethod, setBlurMethod] = React.useState<ExperimentalBlurMethod>('none');
+  return (
+    <ScrollView style={styles.container}>
+      {Platform.OS === 'android' && (
+        <>
+          <Text style={styles.text}>Blur method:</Text>
+          <SegmentedControl
+            values={blurMethods}
+            selectedIndex={blurMethods.indexOf(blurMethod)}
+            onChange={(event) => {
+              setBlurMethod(event.nativeEvent.value as ExperimentalBlurMethod);
+            }}
+          />
+        </>
+      )}
+      {blurStyles.map((tint) => (
+        <BlurViewWithControls key={tint} tint={tint} blurMethod={blurMethod} />
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  text: {
+    marginLeft: 10,
+  },
+});

--- a/apps/native-component-list/src/screens/BlurView/BlurViewCompatScreen.tsx
+++ b/apps/native-component-list/src/screens/BlurView/BlurViewCompatScreen.tsx
@@ -1,0 +1,50 @@
+import { BlurView } from 'expo-blur';
+import { Image } from 'expo-image';
+import { View, StyleSheet, Text } from 'react-native';
+
+export default function BlurViewCompatScreen() {
+  const backgroundImage = require('../../../assets/images/example1.jpg');
+
+  return (
+    <View style={styles.container}>
+      <Image source={backgroundImage} contentFit="cover" style={styles.image} />
+      <BlurView style={styles.blurView} blurMethod="dimezisBlurView" intensity={100}>
+        <Text style={styles.text}>
+          On iOS and Web the content behind this container should be blurred, but on Android the
+          container background should only be semi-transparent without aby blur, because the
+          BlurTarget was not set.
+        </Text>
+      </BlurView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignSelf: 'stretch',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: 300,
+  },
+  image: {
+    flex: 1,
+    alignSelf: 'stretch',
+  },
+  blurView: {
+    position: 'absolute',
+    width: 300,
+    aspectRatio: 1,
+    borderRadius: 48,
+    borderWidth: 1,
+    borderColor: 'white',
+    alignContent: 'center',
+    justifyContent: 'center',
+    padding: 30,
+    overflow: 'hidden',
+  },
+  text: {
+    textAlign: 'justify',
+    color: 'white',
+  },
+});

--- a/apps/native-component-list/src/screens/BlurView/BlurViewScreen.tsx
+++ b/apps/native-component-list/src/screens/BlurView/BlurViewScreen.tsx
@@ -1,63 +1,40 @@
-import SegmentedControl from '@react-native-segmented-control/segmented-control';
-import { ExperimentalBlurMethod } from 'expo-blur';
-import React from 'react';
-import { StyleSheet, ScrollView, Text, Platform } from 'react-native';
+import { optionalRequire } from '../../navigation/routeBuilder';
+import ComponentListScreen, { ListElement } from '../ComponentListScreen';
 
-import BlurViewWithControls from './BlurViewWithControls';
-
-const blurStyles = [
-  'light',
-  'dark',
-  'default',
-  'extraLight',
-  'regular',
-  'prominent',
-  'systemUltraThinMaterial',
-  'systemThinMaterial',
-  'systemMaterial',
-  'systemThickMaterial',
-  'systemChromeMaterial',
-  'systemUltraThinMaterialLight',
-  'systemThinMaterialLight',
-  'systemMaterialLight',
-  'systemThickMaterialLight',
-  'systemChromeMaterialLight',
-  'systemUltraThinMaterialDark',
-  'systemThinMaterialDark',
-  'systemMaterialDark',
-  'systemThickMaterialDark',
-  'systemChromeMaterialDark',
-] as const;
-const blurMethods: ExperimentalBlurMethod[] = ['none', 'dimezisBlurView'];
+export const BlurScreens = [
+  {
+    name: 'Animated BlurView',
+    route: 'blur/animated',
+    options: {},
+    getComponent() {
+      return optionalRequire(() => require('./BlurViewAnimatedScreen'));
+    },
+  },
+  {
+    name: 'BlurView Navbar Screen',
+    route: 'blur/navbar',
+    options: {},
+    getComponent() {
+      return optionalRequire(() => require('./BlurViewScrollScreen'));
+    },
+  },
+  {
+    name: 'BlurView Compat',
+    route: 'blur/compat',
+    options: {},
+    getComponent() {
+      return optionalRequire(() => require('./BlurViewCompatScreen'));
+    },
+  },
+];
 
 export default function BlurViewScreen() {
-  const [blurMethod, setBlurMethod] = React.useState<ExperimentalBlurMethod>('none');
-  return (
-    <ScrollView style={styles.container}>
-      {Platform.OS === 'android' && (
-        <>
-          <Text style={styles.text}>Blur method:</Text>
-          <SegmentedControl
-            values={blurMethods}
-            selectedIndex={blurMethods.indexOf(blurMethod)}
-            onChange={(event) => {
-              setBlurMethod(event.nativeEvent.value as ExperimentalBlurMethod);
-            }}
-          />
-        </>
-      )}
-      {blurStyles.map((tint) => (
-        <BlurViewWithControls key={tint} tint={tint} blurMethod={blurMethod} />
-      ))}
-    </ScrollView>
-  );
+  const apis: ListElement[] = BlurScreens.map((screen) => {
+    return {
+      name: screen.name,
+      isAvailable: true,
+      route: `/components/${screen.route}`,
+    };
+  });
+  return <ComponentListScreen apis={apis} sort={false} />;
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  text: {
-    marginLeft: 10,
-  },
-});

--- a/apps/native-component-list/src/screens/BlurView/BlurViewScrollScreen.tsx
+++ b/apps/native-component-list/src/screens/BlurView/BlurViewScrollScreen.tsx
@@ -1,0 +1,82 @@
+import FontAwesome from '@expo/vector-icons/FontAwesome';
+import { BlurTargetView, BlurView } from 'expo-blur';
+import { Image } from 'expo-image';
+import { useRef } from 'react';
+import { View, FlatList, StyleSheet, TouchableOpacity } from 'react-native';
+
+function TouchableIcon({ name }: { name: 'home' | 'heart' | 'gear' }) {
+  return (
+    <TouchableOpacity>
+      <FontAwesome name={name} size={48} color="rgba(255, 255, 255, 0.85)" />
+    </TouchableOpacity>
+  );
+}
+
+export default function BlurScrollScreen() {
+  const images = [
+    require('../../../assets/images/example1.jpg'),
+    require('../../../assets/images/example2.jpg'),
+    require('../../../assets/images/example3.jpg'),
+    require('../../../assets/images/chapeau.png'),
+  ];
+  const blurTargetRef = useRef<View | null>(null);
+
+  return (
+    <View style={styles.container}>
+      <BlurTargetView ref={blurTargetRef} style={styles.blurTarget}>
+        <FlatList
+          data={Array(100).fill(images).flat()}
+          renderItem={({ item }) => {
+            return (
+              <View>
+                <Image source={item} style={styles.image} contentFit="cover" />
+              </View>
+            );
+          }}
+          keyExtractor={(_, index) => {
+            return `${index}`;
+          }}
+        />
+      </BlurTargetView>
+      <View style={styles.overlayContainer}>
+        <BlurView
+          style={styles.overlay}
+          blurTarget={blurTargetRef}
+          blurMethod="dimezisBlurView"
+          intensity={40}>
+          <TouchableIcon name="home" />
+          <TouchableIcon name="heart" />
+          <TouchableIcon name="gear" />
+        </BlurView>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, maxWidth: 800, alignSelf: 'center', width: '100%' },
+  overlayContainer: {
+    position: 'absolute',
+    width: '100%',
+    height: 100,
+    bottom: 20,
+  },
+  overlay: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    marginHorizontal: 10,
+    alignItems: 'center',
+    borderRadius: 100,
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: 'white',
+  },
+  blurTarget: {
+    flex: 1,
+  },
+  image: {
+    width: '100%',
+    height: 300,
+  },
+});

--- a/apps/native-component-list/src/screens/BlurView/BlurViewScrollScreen.tsx
+++ b/apps/native-component-list/src/screens/BlurView/BlurViewScrollScreen.tsx
@@ -54,7 +54,12 @@ export default function BlurScrollScreen() {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, maxWidth: 800, alignSelf: 'center', width: '100%' },
+  container: {
+    flex: 1,
+    maxWidth: 800,
+    alignSelf: 'center',
+    width: '100%',
+  },
   overlayContainer: {
     position: 'absolute',
     width: '100%',


### PR DESCRIPTION
# Why

Adds two new test screens to expo-blur library.

# How

- Kept the OG animated screeen
- Added a more navbar example for performance testing without the overhead of animating 20 components at the same time.
- Added a BlurView Compat example - tests if the blur behaves correctly when no BlurTarget was defined

# Test Plan

Tested in BareExpo on Android and iOS
