### PR TITLE
[docs] add mcp guide

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -132,6 +132,7 @@ exceptions:
   - '.*Legend-State.*'
   - '.*Link component.*'
   - '.*Linking.*'
+  - '.*MCP*'
   - '.*macOS.*'
   - '.*manifest\.json.*'
   - '.*metro\.config\.js.*'

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -356,6 +356,7 @@ export const general = [
         makePage('guides/local-first.mdx'),
         makePage('guides/keyboard-handling.mdx'),
         makePage('guides/expo-ui-swift-ui.mdx'),
+        makePage('guides/mcp.mdx'),
       ]),
       makeSection('Integrations', [
         makePage('guides/using-analytics.mdx'),

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -356,7 +356,6 @@ export const general = [
         makePage('guides/local-first.mdx'),
         makePage('guides/keyboard-handling.mdx'),
         makePage('guides/expo-ui-swift-ui.mdx'),
-        makePage('guides/mcp.mdx'),
       ]),
       makeSection('Integrations', [
         makePage('guides/using-analytics.mdx'),
@@ -406,6 +405,7 @@ export const eas = [
       expanded: true,
     }
   ),
+  makeSection('AI', [makePage('eas/ai/mcp.mdx')]),
   makeSection('EAS Workflows', [
     makePage('eas/workflows/get-started.mdx'),
     makePage('eas/workflows/pre-packaged-jobs.mdx'),
@@ -776,6 +776,7 @@ function makePage(file) {
     isNew: data.isNew ?? undefined,
     isAlpha: data.isAlpha ?? undefined,
     isBeta: data.isBeta ?? undefined,
+    isPreview: data.isPreview ?? undefined,
     isDeprecated: data.isDeprecated ?? undefined,
     inExpoGo: data.inExpoGo ?? undefined,
     hasVideoLink: data.hasVideoLink ?? undefined,

--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -12,7 +12,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-> **important** Expo MCP Server is currently in **preview** and is only available for EAS paid plan subscribers.
+> **important** Expo MCP Server is currently in **preview** and is only available for [EAS paid plan subscribers](https://expo.dev/pricing).
 
 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is a standard protocol that allows AI models to integrate with external data sources, providing enhanced context for more precise responses. It enables AI tools to understand your development environment more deeply, allowing them to provide better assistance with your codebase.
 
@@ -143,7 +143,7 @@ These capabilities enable more sophisticated workflows like automated testing, v
 
 ## Available MCP capabilities
 
-> **info** The MCP capabilities are subject to change from the `expo-mcp` package updates or MCP server changes. The follow list is just a reference and may not be up to date.
+> **info** The MCP capabilities are subject to change from the `expo-mcp` package updates or MCP server changes. The following list is a reference and may not be up to date.
 
 ### Tools
 

--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -149,6 +149,8 @@ These capabilities enable more sophisticated workflows like automated testing, v
 
 | Tool                                   | Description                                                          | Example Prompt                                      | Availability                           |
 | -------------------------------------- | -------------------------------------------------------------------- | --------------------------------------------------- | -------------------------------------- |
+| `learn`                                | Learn Expo how-to for a specific topic                               | "learn how to use expo-router"                      | Server                                 |
+| `search_documentation`                 | Search from Expo documentation using natural language                | "search documentation for CNG"                      | Server                                 |
 | `add_library`                          | Install Expo packages with `npx expo install` and show documentation | "add sqlite and basic CRUD to the app"              | Server                                 |
 | `generate_claude_md`                   | Generate **CLAUDE.md** configuration files                           | "generate a CLAUDE.md for the project"              | Server (Claude Code only)              |
 | `generate_agents_md`                   | Generate **AGENTS.md** files                                         | "generate an AGENTS.md file for the project"        | Server                                 |

--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -2,6 +2,7 @@
 title: Using MCP with Expo
 sidebar_title: MCP
 description: A guide on integrating Model Context Protocol with Expo projects to enhance AI model capabilities.
+isPreview: true
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';

--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -86,7 +86,9 @@ After installing the MCP server, you'll need to authenticate using one of two me
 
 #### Access token (recommended)
 
-Generate an access token from your Expo account settings and use it during the OAuth flow.
+Generate a **Personal access token** from your Expo account and use it during the OAuth flow.
+
+To generate an access token, open your EAS dashboard, navigate to **Credentials** > **Access tokens** > **Personal access tokens**, and then click **Create token**.
 
 #### Credentials
 

--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -121,7 +121,7 @@ For the full MCP experience with advanced features like taking screenshots from 
 
 </Step>
 
-## Server capabilities vs client capabilities
+## Server capabilities vs local capabilities
 
 The Expo MCP server provides two types of capabilities depending on your setup:
 
@@ -129,15 +129,15 @@ The Expo MCP server provides two types of capabilities depending on your setup:
 
 Server capabilities are available with just the remote MCP server connection, without needing to set up a local development server. The **generate_agents_md** tool is an example of a server capability.
 
-### Client capabilities
+### Local capabilities
 
-Client capabilities require a local Expo development server to be running and provide advanced features that interact with your local development environment:
+Local capabilities require a local Expo development server to be running and provide advanced features that interact with your local development environment:
 
 - **Automation tools**: Take screenshots, tap views, find elements by testID
 - **Development tools**: Open React Native DevTools
 - **Project analysis**: Generate `expo-router` sitemap
 
-These capabilities enable more sophisticated workflows like automated testing, visual verification, and deeper project introspection.
+These capabilities enable more sophisticated workflows like automated testing, visual verification, and deeper project introspection. To use local capabilities, you will need to follow the [Set up local capabilities](#set-up-local-capabilities-recommended) section above.
 
 ## Available MCP capabilities
 

--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using MCP with Expo
+title: Using Model Context Protocol (MCP) with Expo
 sidebar_title: MCP
 description: A guide on integrating Model Context Protocol with Expo projects to enhance AI model capabilities.
 isPreview: true
@@ -12,9 +12,9 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-> **info** Expo MCP Server is currently in **preview** and is only available for EAS paid subscribers at the time of writing.
+> **important** Expo MCP Server is currently in **preview** and is only available for EAS paid plan subscribers.
 
-[Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is a standard protocol that allows AI models to integrate with external data sources, providing enhanced context for more precise responses. MCP enables AI tools to understand your development environment more deeply, allowing them to provide better assistance with your codebase.
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is a standard protocol that allows AI models to integrate with external data sources, providing enhanced context for more precise responses. It enables AI tools to understand your development environment more deeply, allowing them to provide better assistance with your codebase.
 
 The Expo MCP server is a remote MCP server hosted at [mcp.expo.dev](https://mcp.expo.dev) that integrates with popular AI tools such as Claude Code, Cursor, VS Code, and others, enabling them to interact directly with your Expo projects.
 
@@ -22,7 +22,7 @@ The Expo MCP server is a remote MCP server hosted at [mcp.expo.dev](https://mcp.
 
 Before using the Expo MCP server, ensure you have:
 
-- An expo.dev account (MCP server access is currently feature-gated for EAS paid subscribers)
+- An expo.dev account (MCP server access is currently available for EAS paid plan subscribers only)
 - An Expo project with Expo SDK 54 and the latest `expo` package version
 - AI tools with remote MCP server support (Claude Code, Cursor, VS Code and so on)
 
@@ -98,7 +98,7 @@ Use your Expo account username and password. In this case, the server will gener
 
 ### Set up local capabilities (Recommended)
 
-> **info** Local capabilities are only available in **SDK 54 and above**.
+> **info** Local capabilities are only available in **SDK 54 and later**.
 
 For the full MCP experience with advanced features like taking screenshots from your iOS Simulator, opening DevTools, and automation capabilities, set up a local Expo development server:
 
@@ -132,7 +132,7 @@ Client capabilities require a local Expo development server to be running and pr
 
 - **Automation tools**: Take screenshots, tap views, find elements by testID
 - **Development tools**: Open React Native DevTools
-- **Project analysis**: Generate expo-router sitemap
+- **Project analysis**: Generate `expo-router` sitemap
 
 These capabilities enable more sophisticated workflows like automated testing, visual verification, and deeper project introspection.
 
@@ -145,7 +145,7 @@ These capabilities enable more sophisticated workflows like automated testing, v
 | `add_library`                          | Install Expo packages with `npx expo install` and show documentation | "add sqlite and basic CRUD to the app"              | Server                       |
 | `generate_claude_md`                   | Generate **CLAUDE.md** configuration files                           | "generate a CLAUDE.md for the project"              | Server (Claude Code only)    |
 | `generate_agents_md`                   | Generate **AGENTS.md** files                                         | "generate an AGENTS.md file for the project"        | Server                       |
-| `expo_router_sitemap`                  | Execute and display expo-router-sitemap output                       | "check the expo-router-sitemap output"              | Local (requires expo-router) |
+| `expo_router_sitemap`                  | Execute and display expo-router-sitemap output                       | "check the expo-router-sitemap output"              | Local (requires `expo-router` library) |
 | `open_devtools`                        | Open React Native DevTools                                           | "open devtools"                                     | Local                        |
 | `automation_tap`                       | Tap at specific screen coordinates                                   | "tap the screen at x=12, y=22"                      | Local                        |
 | `automation_take_screenshot`           | Take full device screenshots                                         | "take a screenshot and verify the blue circle view" | Local                        |
@@ -159,7 +159,7 @@ If your AI tool supports [MCP prompts](https://modelcontextprotocol.io/specifica
 
 | Tool                  | Description                                    | Availability                 |
 | --------------------- | ---------------------------------------------- | ---------------------------- |
-| `expo_router_sitemap` | Execute and display expo-router-sitemap output | Local (requires expo-router) |
+| `expo_router_sitemap` | Execute and display expo-router-sitemap output | Local (requires `expo-router` library) |
 | `onboarding`          | Display **AGENTS.md** content to the AI        | Server                       |
 
 ## Limitations

--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -145,27 +145,27 @@ These capabilities enable more sophisticated workflows like automated testing, v
 
 ### Tools
 
-| Tool                                   | Description                                                          | Example Prompt                                      | Availability                 |
-| -------------------------------------- | -------------------------------------------------------------------- | --------------------------------------------------- | ---------------------------- |
-| `add_library`                          | Install Expo packages with `npx expo install` and show documentation | "add sqlite and basic CRUD to the app"              | Server                       |
-| `generate_claude_md`                   | Generate **CLAUDE.md** configuration files                           | "generate a CLAUDE.md for the project"              | Server (Claude Code only)    |
-| `generate_agents_md`                   | Generate **AGENTS.md** files                                         | "generate an AGENTS.md file for the project"        | Server                       |
+| Tool                                   | Description                                                          | Example Prompt                                      | Availability                           |
+| -------------------------------------- | -------------------------------------------------------------------- | --------------------------------------------------- | -------------------------------------- |
+| `add_library`                          | Install Expo packages with `npx expo install` and show documentation | "add sqlite and basic CRUD to the app"              | Server                                 |
+| `generate_claude_md`                   | Generate **CLAUDE.md** configuration files                           | "generate a CLAUDE.md for the project"              | Server (Claude Code only)              |
+| `generate_agents_md`                   | Generate **AGENTS.md** files                                         | "generate an AGENTS.md file for the project"        | Server                                 |
 | `expo_router_sitemap`                  | Execute and display expo-router-sitemap output                       | "check the expo-router-sitemap output"              | Local (requires `expo-router` library) |
-| `open_devtools`                        | Open React Native DevTools                                           | "open devtools"                                     | Local                        |
-| `automation_tap`                       | Tap at specific screen coordinates                                   | "tap the screen at x=12, y=22"                      | Local                        |
-| `automation_take_screenshot`           | Take full device screenshots                                         | "take a screenshot and verify the blue circle view" | Local                        |
-| `automation_find_view_by_testid`       | Find and analyze views by testID                                     | "dump properties for testID 'button-123'"           | Local                        |
-| `automation_tap_by_testid`             | Tap views by testID                                                  | "click the view with testID 'button-123'"           | Local                        |
-| `automation_take_screenshot_by_testid` | Screenshot specific views by testID                                  | "screenshot the view with testID 'button-123'"      | Local                        |
+| `open_devtools`                        | Open React Native DevTools                                           | "open devtools"                                     | Local                                  |
+| `automation_tap`                       | Tap at specific screen coordinates                                   | "tap the screen at x=12, y=22"                      | Local                                  |
+| `automation_take_screenshot`           | Take full device screenshots                                         | "take a screenshot and verify the blue circle view" | Local                                  |
+| `automation_find_view_by_testid`       | Find and analyze views by testID                                     | "dump properties for testID 'button-123'"           | Local                                  |
+| `automation_tap_by_testid`             | Tap views by testID                                                  | "click the view with testID 'button-123'"           | Local                                  |
+| `automation_take_screenshot_by_testid` | Screenshot specific views by testID                                  | "screenshot the view with testID 'button-123'"      | Local                                  |
 
 ### Prompts
 
 If your AI tool supports [MCP prompts](https://modelcontextprotocol.io/specification/2025-06-18/server/prompts), you may see additional menu options, such as [slash commands in Claude Code](https://docs.claude.com/en/docs/claude-code/mcp#use-mcp-prompts-as-slash-commands):
 
-| Tool                  | Description                                    | Availability                 |
-| --------------------- | ---------------------------------------------- | ---------------------------- |
+| Tool                  | Description                                    | Availability                           |
+| --------------------- | ---------------------------------------------- | -------------------------------------- |
 | `expo_router_sitemap` | Execute and display expo-router-sitemap output | Local (requires `expo-router` library) |
-| `onboarding`          | Display **AGENTS.md** content to the AI        | Server                       |
+| `onboarding`          | Display **AGENTS.md** content to the AI        | Server                                 |
 
 ## Limitations
 

--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -109,6 +109,9 @@ For the full MCP experience with advanced features like taking screenshots from 
     '# Install expo-mcp package',
     '$ npx expo install expo-mcp --dev',
     '',
+    '# Ensure you are logged in from CLI with the same account as the one used to authenticate with MCP server',
+    '$ npx expo whoami || npx expo login',
+    '',
     '# Start dev server with MCP capabilities',
     '$ EXPO_UNSTABLE_MCP_SERVER=1 npx expo start',
   ]}

--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -141,6 +141,8 @@ These capabilities enable more sophisticated workflows like automated testing, v
 
 ## Available MCP capabilities
 
+> **info** The MCP capabilities are subject to change from the `expo-mcp` package updates or MCP server changes. The follow list is just a reference and may not be up to date.
+
 ### Tools
 
 | Tool                                   | Description                                                          | Example Prompt                                      | Availability                 |

--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -50,7 +50,7 @@ After installation, run `/mcp` in your Claude Code session to authenticate.
 
 Click the following link to install the MCP server for Cursor:
 
-<a href="https://cursor.com/install-mcp?name=expo-mcp&config=eyJ1cmwiOiJodHRwczovL21jcC5leHBvLmRldi9tY3AifQ%3D%3D">
+<a href="cursor://anysphere.cursor-deeplink/mcp/install?name=expo-mcp&config=eyJ1cmwiOiJodHRwczovL21jcC5leHBvLmRldi9tY3AifQ%3D%3D">
   <img
     src="https://cursor.com/deeplink/mcp-install-light.svg"
     alt="Install MCP Server"

--- a/docs/pages/guides/mcp.mdx
+++ b/docs/pages/guides/mcp.mdx
@@ -15,7 +15,7 @@ import { Step } from '~/ui/components/Step';
 
 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is a standard protocol that allows AI models to integrate with external data sources, providing enhanced context for more precise responses. MCP enables AI tools to understand your development environment more deeply, allowing them to provide better assistance with your codebase.
 
-The Expo MCP server is a remote MCP server hosted at [mcp.expo.dev](https://mcp.expo.dev) that integrates with popular AI tools such as Claude Code, Cursor, VSCode, and others, enabling them to interact directly with your Expo projects.
+The Expo MCP server is a remote MCP server hosted at [mcp.expo.dev](https://mcp.expo.dev) that integrates with popular AI tools such as Claude Code, Cursor, VS Code, and others, enabling them to interact directly with your Expo projects.
 
 ## Prerequisites
 
@@ -23,9 +23,9 @@ Before using the Expo MCP server, ensure you have:
 
 - An expo.dev account (MCP server access is currently feature-gated for EAS paid subscribers)
 - An Expo project with Expo SDK 54 and the latest `expo` package version
-- AI tools with remote MCP server support (Claude Code, Cursor, VSCode, etc.)
+- AI tools with remote MCP server support (Claude Code, Cursor, VS Code and so on)
 
-## Installation and Setup
+## Installation and setup
 
 <Step label="1">
 
@@ -64,7 +64,7 @@ Click the following link to install the MCP server for Cursor:
 
 </Collapsible>
 
-<Collapsible summary="VSCode setup">
+<Collapsible summary="VS Code setup">
 
 1. Open Command Palette (<kbd>Cmd ⌘</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>)
 2. Run **MCP: Add Server**
@@ -83,7 +83,7 @@ Click the following link to install the MCP server for Cursor:
 
 After installing the MCP server, you'll need to authenticate using one of two methods:
 
-#### Access Token (Recommended)
+#### Access token (recommended)
 
 Generate an access token from your Expo account settings and use it during the OAuth flow.
 
@@ -99,7 +99,7 @@ Use your Expo account username and password. In this case, the server will gener
 
 > **info** Local capabilities are only available in **SDK 54 and above**.
 
-For the full MCP experience with advanced features like taking screenshots from your iOS simulator, opening dev tools, and automation capabilities, set up a local Expo development server:
+For the full MCP experience with advanced features like taking screenshots from your iOS Simulator, opening DevTools, and automation capabilities, set up a local Expo development server:
 
 <Terminal
   cmd={[

--- a/docs/pages/guides/mcp.mdx
+++ b/docs/pages/guides/mcp.mdx
@@ -117,15 +117,15 @@ For the full MCP experience with advanced features like taking screenshots from 
 
 </Step>
 
-## Server Capabilities vs Client Capabilities
+## Server capabilities vs client capabilities
 
 The Expo MCP server provides two types of capabilities depending on your setup:
 
-### Server Capabilities
+### Server capabilities
 
 Server capabilities are available with just the remote MCP server connection, without needing to set up a local development server. The **generate_agents_md** tool is an example of a server capability.
 
-### Client Capabilities
+### Client capabilities
 
 Client capabilities require a local Expo development server to be running and provide advanced features that interact with your local development environment:
 
@@ -135,7 +135,7 @@ Client capabilities require a local Expo development server to be running and pr
 
 These capabilities enable more sophisticated workflows like automated testing, visual verification, and deeper project introspection.
 
-## Available MCP Capabilities
+## Available MCP capabilities
 
 ### Tools
 

--- a/docs/pages/guides/mcp.mdx
+++ b/docs/pages/guides/mcp.mdx
@@ -1,0 +1,179 @@
+---
+title: Using MCP with Expo
+sidebar_title: MCP
+description: A guide on integrating Model Context Protocol with Expo projects to enhance AI model capabilities.
+---
+
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { Collapsible } from '~/ui/components/Collapsible';
+import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
+
+> **info** Expo MCP Server is currently in **preview** and is only available for EAS paid subscribers at the time of writing.
+
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is a standard protocol that allows AI models to integrate with external data sources, providing enhanced context for more precise responses. MCP enables AI tools to understand your development environment more deeply, allowing them to provide better assistance with your codebase.
+
+The Expo MCP server is a remote MCP server hosted at [mcp.expo.dev](https://mcp.expo.dev) that integrates with popular AI tools such as Claude Code, Cursor, VSCode, and others, enabling them to interact directly with your Expo projects.
+
+## Prerequisites
+
+Before using the Expo MCP server, ensure you have:
+
+- An expo.dev account (MCP server access is currently feature-gated for EAS paid subscribers)
+- An Expo project with Expo SDK 54 and the latest `expo` package version
+- AI tools with remote MCP server support (Claude Code, Cursor, VSCode, etc.)
+
+## Installation and Setup
+
+<Step label="1">
+
+### Install the Expo MCP server
+
+The Expo MCP server supports integration with various AI tools. Use the general settings below or expand your specific tool for detailed instructions:
+
+- **Server type**: Streamable HTTP
+- **URL**: `https://mcp.expo.dev/mcp`
+- **Authentication**: OAuth
+
+<Collapsible summary="Claude Code setup">
+
+<Terminal cmd={['$ claude mcp add --transport http expo-mcp https://mcp.expo.dev/mcp']} />
+
+After installation, run `/mcp` in your Claude Code session to authenticate.
+
+</Collapsible>
+
+<Collapsible summary="Cursor setup">
+
+Click the following link to install the MCP server for Cursor:
+
+<a href="https://cursor.com/install-mcp?name=expo-mcp&config=eyJ1cmwiOiJodHRwczovL21jcC5leHBvLmRldi9tY3AifQ%3D%3D">
+  <img
+    src="https://cursor.com/deeplink/mcp-install-light.svg"
+    alt="Install MCP Server"
+    className="hidden max-w-48 dark:block"
+  />
+  <img
+    src="https://cursor.com/deeplink/mcp-install-dark.svg"
+    alt="Install MCP Server"
+    className="block max-w-48 dark:hidden"
+  />
+</a>
+
+</Collapsible>
+
+<Collapsible summary="VSCode setup">
+
+1. Open Command Palette (<kbd>Cmd ⌘</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>)
+2. Run **MCP: Add Server**
+3. Select **HTTP**
+4. Enter the server details:
+   - **URL**: `https://mcp.expo.dev/mcp`
+   - **Name**: expo-mcp
+
+</Collapsible>
+
+</Step>
+
+<Step label="2">
+
+### Authenticate with Expo
+
+After installing the MCP server, you'll need to authenticate using one of two methods:
+
+#### Access Token (Recommended)
+
+Generate an access token from your Expo account settings and use it during the OAuth flow.
+
+#### Credentials
+
+Use your Expo account username and password. In this case, the server will generate an access token automatically.
+
+</Step>
+
+<Step label="3">
+
+### Set up local capabilities (Recommended)
+
+> **info** Local capabilities are only available in **SDK 54 and above**.
+
+For the full MCP experience with advanced features like taking screenshots from your iOS simulator, opening dev tools, and automation capabilities, set up a local Expo development server:
+
+<Terminal
+  cmd={[
+    '$ cd /path/to/your-project',
+    '',
+    '# Install expo-mcp package',
+    '$ npx expo install expo-mcp --dev',
+    '',
+    '# Start dev server with MCP capabilities',
+    '$ EXPO_UNSTABLE_MCP_SERVER=1 npx expo start',
+  ]}
+/>
+
+> **important** Whenever you start or stop the development server, you need to **reconnect or restart** your MCP server connection in your AI tool to ensure the AI tool gets refreshed capabilities.
+
+</Step>
+
+## Server Capabilities vs Client Capabilities
+
+The Expo MCP server provides two types of capabilities depending on your setup:
+
+### Server Capabilities
+
+Server capabilities are available with just the remote MCP server connection, without needing to set up a local development server. The **generate_agents_md** tool is an example of a server capability.
+
+### Client Capabilities
+
+Client capabilities require a local Expo development server to be running and provide advanced features that interact with your local development environment:
+
+- **Automation tools**: Take screenshots, tap views, find elements by testID
+- **Development tools**: Open React Native DevTools
+- **Project analysis**: Generate expo-router sitemap
+
+These capabilities enable more sophisticated workflows like automated testing, visual verification, and deeper project introspection.
+
+## Available MCP Capabilities
+
+### Tools
+
+| Tool                                   | Description                                                          | Example Prompt                                      | Availability                 |
+| -------------------------------------- | -------------------------------------------------------------------- | --------------------------------------------------- | ---------------------------- |
+| `add_library`                          | Install Expo packages with `npx expo install` and show documentation | "add sqlite and basic CRUD to the app"              | Server                       |
+| `generate_claude_md`                   | Generate **CLAUDE.md** configuration files                           | "generate a CLAUDE.md for the project"              | Server (Claude Code only)    |
+| `generate_agents_md`                   | Generate **AGENTS.md** files                                         | "generate an AGENTS.md file for the project"        | Server                       |
+| `expo_router_sitemap`                  | Execute and display expo-router-sitemap output                       | "check the expo-router-sitemap output"              | Local (requires expo-router) |
+| `open_devtools`                        | Open React Native DevTools                                           | "open devtools"                                     | Local                        |
+| `automation_tap`                       | Tap at specific screen coordinates                                   | "tap the screen at x=12, y=22"                      | Local                        |
+| `automation_take_screenshot`           | Take full device screenshots                                         | "take a screenshot and verify the blue circle view" | Local                        |
+| `automation_find_view_by_testid`       | Find and analyze views by testID                                     | "dump properties for testID 'button-123'"           | Local                        |
+| `automation_tap_by_testid`             | Tap views by testID                                                  | "click the view with testID 'button-123'"           | Local                        |
+| `automation_take_screenshot_by_testid` | Screenshot specific views by testID                                  | "screenshot the view with testID 'button-123'"      | Local                        |
+
+### Prompts
+
+If your AI tool supports [MCP prompts](https://modelcontextprotocol.io/specification/2025-06-18/server/prompts), you may see additional menu options, such as [slash commands in Claude Code](https://docs.claude.com/en/docs/claude-code/mcp#use-mcp-prompts-as-slash-commands):
+
+| Tool                  | Description                                    | Availability                 |
+| --------------------- | ---------------------------------------------- | ---------------------------- |
+| `expo_router_sitemap` | Execute and display expo-router-sitemap output | Local (requires expo-router) |
+| `onboarding`          | Display **AGENTS.md** content to the AI        | Server                       |
+
+## Limitations
+
+The current implementation has the following limitations:
+
+- Only supports a **single development server** connection at a time
+- iOS support for local capabilities is limited to simulators only (physical devices not yet supported)
+- iOS support for local capabilities is only available on macOS hosts.
+
+## Additional resources
+
+<BoxLink
+  title="Model Context Protocol Documentation"
+  Icon={BookOpen02Icon}
+  description="Learn more about the MCP specification and protocol details."
+  href="https://modelcontextprotocol.io/"
+/>

--- a/docs/types/common.ts
+++ b/docs/types/common.ts
@@ -47,6 +47,7 @@ export type NavigationRoute = {
   isNew?: boolean;
   isAlpha?: boolean;
   isBeta?: boolean;
+  isPreview?: boolean;
   isDeprecated?: boolean;
   inExpoGo?: boolean;
   hasVideoLink?: boolean;

--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -17,6 +17,7 @@ import { PaletteIcon } from '@expo/styleguide-icons/outline/PaletteIcon';
 import { Phone01Icon } from '@expo/styleguide-icons/outline/Phone01Icon';
 import { PlaySquareIcon } from '@expo/styleguide-icons/outline/PlaySquareIcon';
 import { Rocket01Icon } from '@expo/styleguide-icons/outline/Rocket01Icon';
+import { Star06Icon } from '@expo/styleguide-icons/outline/Star06Icon';
 import { TerminalBrowserIcon } from '@expo/styleguide-icons/outline/TerminalBrowserIcon';
 import { useRouter } from 'next/compat/router';
 
@@ -226,6 +227,8 @@ function shouldSkipTitle(info: NavigationRoute, parentGroup?: NavigationRoute) {
 
 function getIconElement(iconName?: string) {
   switch (iconName) {
+    case 'AI':
+      return Star06Icon;
     case 'Develop':
       return TerminalBrowserIcon;
     case 'Review':

--- a/docs/ui/components/Sidebar/SidebarLink.tsx
+++ b/docs/ui/components/Sidebar/SidebarLink.tsx
@@ -119,7 +119,10 @@ export const SidebarLink = ({ info, className, children }: SidebarLinkProps) => 
       {info.isPreview && (
         <div
           className={mergeClasses(
-            '-mt-px ml-2 inline-flex h-[17px] items-center rounded-full bg-element px-[10px] text-[10px] font-normal leading-none text-secondary'
+            '-mt-px ml-2 inline-flex h-[17px] items-center rounded-full border border-palette-purple10 px-[5px] text-[10px] font-semibold leading-none text-palette-white',
+            isSelected
+              ? 'bg-palette-purple10 text-palette-white dark:text-palette-black'
+              : 'border-palette-purple10 bg-none text-palette-purple11 dark:border-palette-purple9 dark:text-palette-purple10'
           )}>
           PREVIEW
         </div>

--- a/docs/ui/components/Sidebar/SidebarLink.tsx
+++ b/docs/ui/components/Sidebar/SidebarLink.tsx
@@ -116,6 +116,14 @@ export const SidebarLink = ({ info, className, children }: SidebarLinkProps) => 
           BETA
         </div>
       )}
+      {info.isPreview && (
+        <div
+          className={mergeClasses(
+            '-mt-px ml-2 inline-flex h-[17px] items-center rounded-full bg-element px-[10px] text-[10px] font-normal leading-none text-secondary'
+          )}>
+          PREVIEW
+        </div>
+      )}
       {isExternal && (
         <ArrowUpRightIcon className="icon-sm ml-auto text-icon-secondary group-hover:text-icon-info" />
       )}


### PR DESCRIPTION
# Why

close ENG-17391

# How

add mcp setup guide and available functionalities

# Test Plan

doc preview at /eas/ai/mcp/

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
