### PR TITLE
fix(expo-router): Fix `expo-router/server` exports (deprecated)

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -11,7 +11,7 @@
 - fix VectorIcon types ([#39747](https://github.com/expo/expo/pull/39747) by [@Ubax](https://github.com/Ubax))
 - [iOS] fix icons in context menu not being removed with `undefined` ([#39845](https://github.com/expo/expo/pull/39845) by [@hassankhan](https://github.com/hassankhan))
 - [iOS] fix optional context menu props not being unset with `undefined` ([#39853](https://github.com/expo/expo/pull/39853) by [@hassankhan](https://github.com/hassankhan))
-
+- Fix `expo-router/server` exports ([#40071](https://github.com/expo/expo/pull/40071) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/expo-router/server.d.ts
+++ b/packages/expo-router/server.d.ts
@@ -1,9 +1,20 @@
-import { type ExpoRequest, type ExpoResponse } from '@expo/server';
-export { type MiddlewareFunction } from '@expo/server';
+export type { MiddlewareFunction } from '@expo/server';
+
+/**
+ * @deprecated Use Fetch API `Request` instead.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request)
+ */
+export type ExpoRequest = Request;
+
+/**
+ * @deprecated Use Fetch API `Response` instead.
+ *
+ * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response)
+ */
+export type ExpoResponse = Response;
 
 export type RequestHandler = (
   request: Request,
   params: Record<string, string>
 ) => Response | Promise<Response>;
-
-export { ExpoRequest, ExpoResponse };

--- a/packages/expo-router/server.js
+++ b/packages/expo-router/server.js
@@ -1,3 +1,1 @@
-// These should be installed on the global by the server runtime to ensure faster bundling and smaller bundles.
-module.exports.ExpoRequest = global.ExpoRequest;
-module.exports.ExpoResponse = global.ExpoResponse;
+// Use `@expo/server` directly instead


### PR DESCRIPTION
# Why

This was deprecated and forgotten about. We should empty it out

# How

- Inline deprecated `ExpoRequest` / `ExpoResponse` types
- Empty out `server.js`

# Test Plan

- n/a

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
