### PR TITLE
[video][android] Fix service premission being always present in the manifest

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `FOREGROUND_SERVICE_MEDIA_PLAYBACK` being always present in the manifest. ([#40074](https://github.com/expo/expo/pull/40074) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 - [Android] Remove @UnstableReactNativeAPI annotations. ([#39921](https://github.com/expo/expo/pull/39921) by [@jakex7](https://github.com/jakex7))

--- a/packages/expo-video/android/src/main/AndroidManifest.xml
+++ b/packages/expo-video/android/src/main/AndroidManifest.xml
@@ -1,7 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.INTERNET" />
-  <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 
   <application>
     <activity android:name=".FullscreenPlayerActivity"


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/39988

The foreground service permission should've been removed from the expo-video manifest in https://github.com/expo/expo/pull/38980, which moved that functionality into the config plugin, but it wasn't, which means that people, who don't need that permission still have in the app manifest.

# How

Remove the permission from the manifest, the config plugin already handles it.

# Test Plan

Tested in a new project to see if the permission is getting added when necessary.

