### PR TITLE
[media-library][next] Refactor android permissions

### DIFF
--- a/apps/native-component-list/src/screens/MediaLibrary@Next/GranularPermissionsScreen.tsx
+++ b/apps/native-component-list/src/screens/MediaLibrary@Next/GranularPermissionsScreen.tsx
@@ -1,0 +1,146 @@
+import { Image } from 'expo-image';
+import { Query, Asset, requestPermissionsAsync } from 'expo-media-library/next';
+import { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  Dimensions,
+  Pressable,
+  ActivityIndicator,
+} from 'react-native';
+
+const numColumns = 3;
+const screenWidth = Dimensions.get('window').width;
+const imageSize = screenWidth / numColumns - 12;
+
+const GranularPermissionsScreen = () => {
+  const [assets, setAssets] = useState<Asset[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchAssets = async () => {
+    try {
+      setLoading(true);
+      const assets = await new Query().exe();
+      setAssets(assets);
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchAssets();
+  }, []);
+
+  const requestPermissionAndFetch = async (type: 'photo' | 'video') => {
+    try {
+      await requestPermissionsAsync(false, [type]);
+      fetchAssets();
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const renderItem = ({ item }: { item: Asset }) => (
+    <View style={styles.assetCard}>
+      <Image source={{ uri: item.id }} style={styles.assetImage} />
+    </View>
+  );
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.buttonGroup}>
+        <Pressable
+          style={styles.permissionButton}
+          onPress={() => requestPermissionAndFetch('photo')}>
+          <Text style={styles.permissionButtonText}>Request Image Permission</Text>
+        </Pressable>
+        <Pressable
+          style={styles.permissionButton}
+          onPress={() => requestPermissionAndFetch('video')}>
+          <Text style={styles.permissionButtonText}>Request Video Permission</Text>
+        </Pressable>
+      </View>
+
+      {loading ? (
+        <ActivityIndicator size="large" color="#007AFF" style={{ marginTop: 50 }} />
+      ) : assets.length === 0 ? (
+        <Text style={styles.statusText}>The gallery is empty</Text>
+      ) : (
+        <FlatList
+          data={assets}
+          renderItem={renderItem}
+          keyExtractor={(item) => item.id}
+          numColumns={numColumns}
+          contentContainerStyle={styles.grid}
+        />
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f5f5',
+  },
+  buttonGroup: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    marginTop: 20,
+    marginBottom: 10,
+  },
+  permissionButton: {
+    backgroundColor: '#007AFF',
+    paddingVertical: 12,
+    paddingHorizontal: 18,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 3.84,
+    elevation: 5,
+  },
+  permissionButtonText: {
+    color: '#fff',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  statusText: {
+    fontSize: 16,
+    color: '#666',
+    marginTop: 40,
+    textAlign: 'center',
+  },
+  grid: {
+    paddingHorizontal: 6,
+    paddingBottom: 20,
+  },
+  assetCard: {
+    flex: 1,
+    margin: 6,
+    borderRadius: 12,
+    overflow: 'hidden',
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+    elevation: 3,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 3,
+  },
+  assetImage: {
+    width: imageSize,
+    height: imageSize,
+    borderRadius: 10,
+    backgroundColor: '#eee',
+  },
+});
+
+export default GranularPermissionsScreen;

--- a/apps/native-component-list/src/screens/MediaLibrary@Next/MediaLibraryScreens.tsx
+++ b/apps/native-component-list/src/screens/MediaLibrary@Next/MediaLibraryScreens.tsx
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 import { optionalRequire } from '../../navigation/routeBuilder';
 import ComponentListScreen, { ListElement } from '../ComponentListScreen';
 
@@ -24,6 +26,16 @@ export const MediaLibraryScreens = [
     },
   },
 ];
+
+if (Platform.OS === 'android' && Platform.Version >= 33) {
+  MediaLibraryScreens.push({
+    name: 'Granular Permissions',
+    route: 'medialibrary@next/granular-permissions',
+    getComponent() {
+      return optionalRequire(() => require('./GranularPermissionsScreen'));
+    },
+  });
+}
 
 export default function MediaLibraryScreen() {
   const apis: ListElement[] = MediaLibraryScreens.map((screen) => {

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### 💡 Others
 
+- [next][android] Refactor permissions ([#40076](https://github.com/expo/expo/pull/40076) by [@Wenszel](https://github.com/Wenszel))
 - [next] Add test screens ([#39951](https://github.com/expo/expo/pull/39951) by [@Wenszel](https://github.com/Wenszel))
 - [next] Add documentation ([#39754](https://github.com/expo/expo/pull/39754) by [@Wenszel](https://github.com/Wenszel))
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/exceptions/PermissionExceptions.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/exceptions/PermissionExceptions.kt
@@ -2,5 +2,4 @@ package expo.modules.medialibrary.next.exceptions
 
 import expo.modules.kotlin.exception.CodedException
 
-class PermissionException(message: String) :
-  CodedException(message)
+class PermissionException(message: String, cause: Throwable? = null) : CodedException(message, cause)

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/extensions/ContextExtensions.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/extensions/ContextExtensions.kt
@@ -1,0 +1,16 @@
+package expo.modules.medialibrary.next.extensions
+
+import android.content.Context
+import android.media.MediaScannerConnection
+import android.net.Uri
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+suspend fun Context.scanFile(
+  path: String,
+  mimeType: String? = null
+): Pair<String, Uri?> = suspendCoroutine { continuation ->
+  MediaScannerConnection.scanFile(this, arrayOf(path), arrayOf(mimeType)) { path, uri ->
+    continuation.resume(Pair(path, uri))
+  }
+}

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/extensions/resolver/QueryOne.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/extensions/resolver/QueryOne.kt
@@ -16,7 +16,7 @@ suspend fun <T> ContentResolver.queryOne(
   sortOrder: String? = null
 ): T? = withContext(Dispatchers.IO) {
   val projection = arrayOf(column)
-  query(contentUri, projection, selection, selectionArgs, sortOrder)?.use { cursor ->
+  safeQuery(contentUri, projection, selection, selectionArgs, sortOrder)?.use { cursor ->
     ensureActive()
     val index = cursor.getColumnIndexOrThrow(column)
     return@withContext if (cursor.moveToFirst()) {
@@ -25,5 +25,4 @@ suspend fun <T> ContentResolver.queryOne(
       null
     }
   }
-  return@withContext null
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/extensions/resolver/SafeQuery.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/extensions/resolver/SafeQuery.kt
@@ -1,0 +1,20 @@
+package expo.modules.medialibrary.next.extensions.resolver
+
+import android.content.ContentResolver
+import android.database.Cursor
+import android.net.Uri
+import expo.modules.medialibrary.next.exceptions.PermissionException
+
+fun ContentResolver.safeQuery(
+  uri: Uri,
+  projection: Array<String>,
+  selection: String? = null,
+  selectionArgs: Array<String>? = null,
+  sortOrder: String? = null
+): Cursor? {
+  return try {
+    query(uri, projection, selection, selectionArgs, sortOrder)
+  } catch (_: SecurityException) {
+    throw PermissionException("Missing required system permissions")
+  }
+}

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/extensions/resolver/SafeQuery.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/extensions/resolver/SafeQuery.kt
@@ -14,7 +14,7 @@ fun ContentResolver.safeQuery(
 ): Cursor? {
   return try {
     query(uri, projection, selection, selectionArgs, sortOrder)
-  } catch (_: SecurityException) {
-    throw PermissionException("Missing required system permissions")
+  } catch (e: SecurityException) {
+    throw PermissionException("Missing required system permissions", e)
   }
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/album/factories/AlbumModernFactory.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/album/factories/AlbumModernFactory.kt
@@ -14,6 +14,7 @@ import expo.modules.medialibrary.next.objects.asset.Asset
 import expo.modules.medialibrary.next.objects.asset.deleters.AssetDeleter
 import expo.modules.medialibrary.next.objects.wrappers.MimeType
 import expo.modules.medialibrary.next.objects.asset.factories.AssetFactory
+import expo.modules.medialibrary.next.permissions.MediaStorePermissionsDelegate
 import java.io.IOException
 import java.lang.ref.WeakReference
 
@@ -21,6 +22,7 @@ import java.lang.ref.WeakReference
 class AlbumModernFactory(
   private val assetFactory: AssetFactory,
   private val assetDeleter: AssetDeleter,
+  private val mediaStorePermissionsDelegate: MediaStorePermissionsDelegate,
   context: Context
 ) : AlbumFactory {
   private val contextRef = WeakReference(context)
@@ -61,6 +63,7 @@ class AlbumModernFactory(
 
   private suspend fun processAssetsLocation(assets: List<Asset>, relativePath: RelativePath, deleteOriginalAssets: Boolean) {
     if (deleteOriginalAssets) {
+      mediaStorePermissionsDelegate.requestMediaLibraryWritePermission(assets.map { it.contentUri })
       assets.map { it.move(relativePath) }
     } else {
       assets.map { it.copy(relativePath) }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/delegates/AssetLegacyDelegate.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/delegates/AssetLegacyDelegate.kt
@@ -8,7 +8,6 @@ import android.os.Bundle
 import androidx.annotation.DeprecatedSinceApi
 import androidx.core.net.toUri
 import androidx.exifinterface.media.ExifInterface
-import expo.modules.medialibrary.MediaLibraryUtils
 import expo.modules.medialibrary.next.exceptions.AssetCouldNotBeCreated
 import expo.modules.medialibrary.next.exceptions.AssetPropertyNotFoundException
 import expo.modules.medialibrary.next.exceptions.ContentResolverNotObtainedException
@@ -23,12 +22,14 @@ import expo.modules.medialibrary.next.extensions.resolver.queryAssetWidth
 import expo.modules.medialibrary.next.extensions.resolver.queryAssetCreationTime
 import expo.modules.medialibrary.next.extensions.safeCopy
 import expo.modules.medialibrary.next.extensions.safeMove
+import expo.modules.medialibrary.next.extensions.scanFile
 import expo.modules.medialibrary.next.objects.wrappers.RelativePath
 import expo.modules.medialibrary.next.objects.asset.Asset
 import expo.modules.medialibrary.next.objects.asset.EXIF_TAGS
 import expo.modules.medialibrary.next.objects.asset.deleters.AssetDeleter
 import expo.modules.medialibrary.next.objects.wrappers.MediaType
 import expo.modules.medialibrary.next.objects.wrappers.MimeType
+import expo.modules.medialibrary.next.permissions.SystemPermissionsDelegate
 import expo.modules.medialibrary.next.records.Location
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
@@ -44,6 +45,7 @@ import kotlin.time.toDuration
 class AssetLegacyDelegate(
   contentUri: Uri,
   val assetDeleter: AssetDeleter,
+  val systemPermissionsDelegate: SystemPermissionsDelegate,
   context: Context
 ) : AssetDelegate {
   private val contextRef = WeakReference(context)
@@ -121,14 +123,17 @@ class AssetLegacyDelegate(
       ?: MimeType.from(getUri())
   }
 
-  override suspend fun getLocation(): Location? =
-    contentResolver.openInputStream(contentUri)?.use { stream ->
+  override suspend fun getLocation(): Location? {
+    systemPermissionsDelegate.requireReadPermissions()
+    return contentResolver.openInputStream(contentUri)?.use { stream ->
       ExifInterface(stream)
         .latLong
         ?.let { (lat, long) -> Location(lat, long) }
     }
+  }
 
   override suspend fun getExif(): Bundle = withContext(Dispatchers.IO) {
+    systemPermissionsDelegate.requireReadPermissions()
     if (getMediaType() != MediaType.IMAGE) {
       return@withContext Bundle()
     }
@@ -163,11 +168,12 @@ class AssetLegacyDelegate(
   }
 
   override suspend fun move(relativePath: RelativePath) = withContext(Dispatchers.IO) {
+    systemPermissionsDelegate.requireWritePermissions()
     val path = contentResolver.queryAssetPath(contentUri)
       ?: throw AssetPropertyNotFoundException("Asset path")
     val newFile = File(path).safeMove(File(relativePath.toFilePath()))
     contentResolver.deleteBy(path)
-    val (_, uri) = MediaLibraryUtils.scanFile(contextRef.getOrThrow(), arrayOf(newFile.path), null)
+    val (_, uri) = contextRef.getOrThrow().scanFile(newFile.path, null)
     this@AssetLegacyDelegate.contentUri = uri
       ?: throw AssetCouldNotBeCreated("Could not create a new asset while moving the old one")
   }
@@ -176,11 +182,11 @@ class AssetLegacyDelegate(
     val path = contentResolver.queryAssetPath(contentUri)
       ?: throw AssetPropertyNotFoundException("Asset path")
     val newFile = File(path).safeCopy(File(relativePath.toFilePath()))
-    val (_, uri) = MediaLibraryUtils.scanFile(contextRef.getOrThrow(), arrayOf(newFile.path), null)
+    val (_, uri) = contextRef.getOrThrow().scanFile(newFile.path, null)
     if (uri == null) {
       throw AssetCouldNotBeCreated("Could not create a new asset while copying the old one")
     }
-    val newAssetDelegate = AssetLegacyDelegate(contentUri, assetDeleter, contextRef.getOrThrow())
+    val newAssetDelegate = AssetLegacyDelegate(contentUri, assetDeleter, systemPermissionsDelegate, contextRef.getOrThrow())
     return@withContext Asset(newAssetDelegate)
   }
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/deleters/AssetLegacyDeleter.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/deleters/AssetLegacyDeleter.kt
@@ -9,6 +9,7 @@ import expo.modules.medialibrary.next.exceptions.AssetPropertyNotFoundException
 import expo.modules.medialibrary.next.exceptions.ContentResolverNotObtainedException
 import expo.modules.medialibrary.next.extensions.getOrThrow
 import expo.modules.medialibrary.next.extensions.resolver.queryAssetPath
+import expo.modules.medialibrary.next.permissions.SystemPermissionsDelegate
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -16,8 +17,11 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.lang.ref.WeakReference
 
-@DeprecatedSinceApi(Build.VERSION_CODES.Q)
-class AssetLegacyDeleter(context: Context) : AssetDeleter {
+@DeprecatedSinceApi(Build.VERSION_CODES.R)
+class AssetLegacyDeleter(
+  val systemPermissionsDelegate: SystemPermissionsDelegate,
+  context: Context
+) : AssetDeleter {
   private val contextRef = WeakReference(context)
 
   private val contentResolver
@@ -26,6 +30,7 @@ class AssetLegacyDeleter(context: Context) : AssetDeleter {
       .contentResolver ?: throw ContentResolverNotObtainedException()
 
   override suspend fun delete(contentUri: Uri): Unit = withContext(Dispatchers.IO) {
+    systemPermissionsDelegate.requireWritePermissions()
     val path = contentResolver.queryAssetPath(contentUri)
       ?: throw AssetPropertyNotFoundException("Uri")
     if (!File(path).delete()) {

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/factories/AssetLegacyFactory.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/factories/AssetLegacyFactory.kt
@@ -1,11 +1,11 @@
 package expo.modules.medialibrary.next.objects.asset.factories
 
 import android.content.Context
+import android.media.MediaScannerConnection
 import android.net.Uri
 import android.os.Build
 import androidx.annotation.DeprecatedSinceApi
 import androidx.core.net.toFile
-import expo.modules.medialibrary.MediaLibraryUtils
 import expo.modules.medialibrary.next.exceptions.AssetCouldNotBeCreated
 import expo.modules.medialibrary.next.exceptions.ContentResolverNotObtainedException
 import expo.modules.medialibrary.next.extensions.getOrThrow
@@ -16,15 +16,19 @@ import expo.modules.medialibrary.next.objects.asset.delegates.AssetDelegate
 import expo.modules.medialibrary.next.objects.asset.delegates.AssetLegacyDelegate
 import expo.modules.medialibrary.next.objects.asset.deleters.AssetDeleter
 import expo.modules.medialibrary.next.objects.wrappers.MimeType
+import expo.modules.medialibrary.next.permissions.SystemPermissionsDelegate
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.lang.ref.WeakReference
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 @DeprecatedSinceApi(Build.VERSION_CODES.R)
 class AssetLegacyFactory(
   val assetDeleter: AssetDeleter,
+  val systemPermissionsDelegate: SystemPermissionsDelegate,
   context: Context
 ) : AssetFactory {
   private val contextRef = WeakReference(context)
@@ -35,7 +39,7 @@ class AssetLegacyFactory(
       .contentResolver ?: throw ContentResolverNotObtainedException()
 
   private fun createAssetDelegate(contentUri: Uri): AssetDelegate {
-    return AssetLegacyDelegate(contentUri, assetDeleter, contextRef.getOrThrow())
+    return AssetLegacyDelegate(contentUri, assetDeleter, systemPermissionsDelegate, contextRef.getOrThrow())
   }
 
   override fun create(contentUri: Uri): Asset {
@@ -44,24 +48,35 @@ class AssetLegacyFactory(
   }
 
   override suspend fun create(filePath: Uri, relativePath: RelativePath?): Asset = withContext(Dispatchers.IO) {
-    val mimeType = contentResolver.getType(filePath)?.let { MimeType(it) }
-      ?: MimeType.from(filePath)
-    val destinationDirectory = if (relativePath != null) {
-      File(relativePath.toFilePath())
-    } else {
-      mimeType.externalStorageAssetDirectory()
-    }
-    destinationDirectory.mkdirs()
-
-    val destFile = filePath
+    systemPermissionsDelegate.requireWritePermissions()
+    val destinationDirectory = createDestinationDirectory(filePath, relativePath)
+    val destinationFile = filePath
       .toFile()
       .safeCopy(destinationDirectory)
-    val (_, uri) = MediaLibraryUtils.scanFile(contextRef.getOrThrow(), arrayOf(destFile.toString()), null)
-    coroutineContext.ensureActive()
-
+    val (_, uri) = scanFile(contextRef.getOrThrow(), arrayOf(destinationFile.toString()), null)
+    ensureActive()
     if (uri == null) {
       throw AssetCouldNotBeCreated("Failed to create asset: could not add asset to MediaStore")
     }
     return@withContext create(uri)
   }
+
+  private fun createDestinationDirectory(filePath: Uri, relativePath: RelativePath?): File {
+    val destinationDirectory = if (relativePath != null) {
+      File(relativePath.toFilePath())
+    } else {
+      val mimeType = contentResolver.getType(filePath)?.let { MimeType(it) }
+        ?: MimeType.from(filePath)
+      mimeType.externalStorageAssetDirectory()
+    }
+    destinationDirectory.mkdirs()
+    return destinationDirectory
+  }
+
+  private suspend fun scanFile(context: Context, paths: Array<String>, mimeTypes: Array<String>?) =
+    suspendCoroutine { complete ->
+      MediaScannerConnection.scanFile(context, paths, mimeTypes) { path: String, uri: Uri? ->
+        complete.resume(Pair(path, uri))
+      }
+    }
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/factories/AssetModernFactory.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/factories/AssetModernFactory.kt
@@ -15,6 +15,7 @@ import expo.modules.medialibrary.next.objects.asset.delegates.AssetDelegate
 import expo.modules.medialibrary.next.objects.asset.delegates.AssetModernDelegate
 import expo.modules.medialibrary.next.objects.asset.deleters.AssetDeleter
 import expo.modules.medialibrary.next.objects.wrappers.MimeType
+import expo.modules.medialibrary.next.permissions.MediaStorePermissionsDelegate
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
@@ -23,6 +24,7 @@ import java.lang.ref.WeakReference
 @RequiresApi(Build.VERSION_CODES.R)
 class AssetModernFactory(
   val assetDeleter: AssetDeleter,
+  val mediaStorePermissionsDelegate: MediaStorePermissionsDelegate,
   context: Context
 ) : AssetFactory {
   private val contextRef = WeakReference(context)
@@ -36,6 +38,7 @@ class AssetModernFactory(
     return AssetModernDelegate(
       contentUri,
       assetDeleter,
+      mediaStorePermissionsDelegate,
       contextRef.getOrThrow()
     )
   }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/query/builder/QueryLegacyExecutor.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/query/builder/QueryLegacyExecutor.kt
@@ -7,6 +7,7 @@ import android.provider.MediaStore
 import androidx.annotation.DeprecatedSinceApi
 import expo.modules.medialibrary.next.exceptions.QueryCouldNotBeExecuted
 import expo.modules.medialibrary.next.extensions.resolver.EXTERNAL_CONTENT_URI
+import expo.modules.medialibrary.next.extensions.resolver.safeQuery
 import expo.modules.medialibrary.next.records.SortDescriptor
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -26,7 +27,7 @@ class QueryLegacyExecutor(
     val selection = buildSelection()
     val sortOrder = buildSortOrder()
     val selectionArgs = args.toTypedArray()
-    return@withContext contentResolver.query(EXTERNAL_CONTENT_URI, projection, selection, selectionArgs, sortOrder)
+    return@withContext contentResolver.safeQuery(EXTERNAL_CONTENT_URI, projection, selection, selectionArgs, sortOrder)
       ?: throw QueryCouldNotBeExecuted("Cursor is null")
   }
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/permissions/MediaStorePermissionsDelegate.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/permissions/MediaStorePermissionsDelegate.kt
@@ -1,10 +1,7 @@
 package expo.modules.medialibrary.next.permissions
 
 import android.content.Context
-import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
-import android.os.Binder
 import android.os.Build
 import androidx.annotation.RequiresApi
 import expo.modules.kotlin.AppContext
@@ -56,12 +53,9 @@ class MediaStorePermissionsDelegate(val appContext: AppContext) {
     writeLauncher = registerForActivityResult(WriteContract(appContextProvider))
   }
 
-  private fun hasWritePermissionForUri(uri: Uri): Boolean {
-    return context.checkUriPermission(
-      uri,
-      Binder.getCallingPid(),
-      Binder.getCallingUid(),
-      Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-    ) == PackageManager.PERMISSION_GRANTED
-  }
+  private fun hasWritePermissionForUri(uri: Uri): Boolean =
+    runCatching {
+      context.contentResolver.openOutputStream(uri, "rw")?.close()
+      return true
+    }.getOrDefault(false)
 }


### PR DESCRIPTION
# Why

In the old module, using any function required having all permissions from the manifest granted. The PR splits this responsibility so that each function handles its own permissions separately.

# How

* Responsibility for read permissions was moved to `contentResolver.safeQuery`. When an app does not have permissions,`safeQuery` will throw a `PermissionException`.
* Write permission: `MediaStorePermissionDelegate` and `SystemPermissionsDelegate` were passed to assetDelegates to request permission just before invoking a method that requires this permission.
* `hasWritePermissionForUri` – assets created by an app have write permission by default, but before the change the function would return `false` because permissions were not granted. Now it was changed to check if the permission exists, not if it is granted.

# Test Plan

Added a new test `MediaLibrary@Next/Granular Permissions` to bare-expo.

[Screen_recording_20250929_153316.webm](https://github.com/user-attachments/assets/cba3a0d3-e19d-4ab7-94d9-22858fe3b4f6)
