### PR TITLE
fix(expo-module-scripts): respect mutual exclusion for eslint config files

### DIFF
--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- fix(expo-module-scripts): respect mutual exclusion for eslint config files ([#40078](https://github.com/expo/expo/pull/40078) by [@adam-sajko](https://github.com/adam-sajko))
+
 ### 💡 Others
 
 ## 5.0.7 — 2025-09-10

--- a/packages/expo-module-scripts/bin/expo-module-configure
+++ b/packages/expo-module-scripts/bin/expo-module-configure
@@ -4,15 +4,34 @@ set -eo pipefail
 
 script_dir="$(dirname "$0")"
 
+template_dir="$script_dir/../templates"
+
 shopt -s dotglob
 
 # an optional template file will be synced only if the target file is present in the file system,
 # and its content contains the string `@generated`.
 OPTIONAL_TEMPLATE_FILES=(
   # add a relative file path from `templates/` for each new optional file
-  "eslint.config.js"
   "scripts/with-node.sh"
 )
+
+# mutually exclusive file groups - only one file per group should be present
+# if no files from the group exist, all files in the group will be created
+MUTUALLY_EXCLUSIVE_GROUPS=(
+  ".eslintrc.js eslint.config.js"
+)
+
+# get all mutually exclusive files
+# usage: get_mutually_exclusive_files
+get_mutually_exclusive_files() {
+  local mutually_exclusive_files=""
+  for group in "${MUTUALLY_EXCLUSIVE_GROUPS[@]}"; do
+    for file in $group; do
+      mutually_exclusive_files="$mutually_exclusive_files $file"
+    done
+  done
+  echo "$mutually_exclusive_files"
+}
 
 # returns relative file paths inside a given directory without the leading "./".
 # usage: get_relative_files "/path/to/dir"
@@ -61,17 +80,50 @@ is_optional_file() {
   return
 }
 
+# check if any file from a mutually exclusive group already exists.
+# usage: if has_mutually_exclusive_file "file1 file2 file3"; then ... fi
+has_mutually_exclusive_file() {
+  local group="$1"
+  for file in $group; do
+    if [ -f "$file" ]; then
+      true
+      return
+    fi
+  done
+  false
+  return
+}
+
 #
 # script main starts from here
 #
 
 "$script_dir/expo-module-readme"
 
-template_files=$(get_relative_files "$script_dir/../templates")
+template_files=$(get_relative_files "$template_dir")
+
+mutually_exclusive_files=$(get_mutually_exclusive_files)
+
 for template_relative_file in $template_files; do
+  if [[ " $mutually_exclusive_files " == *" $template_relative_file "* ]]; then
+    for group in "${MUTUALLY_EXCLUSIVE_GROUPS[@]}"; do
+      if [[ " $group " == *" $template_relative_file "* ]]; then
+        if ! has_mutually_exclusive_file "$group"; then
+          for file in $group; do
+            sync_file_if_missing "$template_dir/$file" "$file"
+          done
+          return
+        fi
+        sync_file_if_present "$template_dir/$template_relative_file" "$template_relative_file"
+        break
+      fi
+    done
+    continue
+  fi
+
   if is_optional_file "$template_relative_file"; then
-    sync_file_if_present "$script_dir/../templates/$template_relative_file" "$template_relative_file"
+    sync_file_if_present "$template_dir/$template_relative_file" "$template_relative_file"
   else
-    sync_file_if_missing "$script_dir/../templates/$template_relative_file" "$template_relative_file"
+    sync_file_if_missing "$template_dir/$template_relative_file" "$template_relative_file"
   fi
 done


### PR DESCRIPTION
# Why

The `expo-module-configure` script was creating both `.eslintrc.js` and `eslint.config.js` files when setting up new modules. This is problematic because these files are mutually exclusive - you should only have one ESLint config file. ESLint 9 doesn't accept keeping `.eslintrc.js` and will warn each time.

# How

Fixed the logic in `sync_mutually_exclusive_file` to actually respect the mutual exclusion. Now it:
- Creates both `.eslintrc.js` and `eslint.config.js` when no ESLint config exists (for backward compatibility)
- If `eslint.config.js` already exists, it syncs that instead of creating `.eslintrc.js`
- If `.eslintrc.js` already exists, it syncs that instead of creating `eslint.config.js`

The bug was in a redundant condition that always created both files, regardless of what already existed.

# Test Plan

Tested in a few scenarios:

1. **Fresh directory**: Both `.eslintrc.js` and `eslint.config.js` get created
2. **When `eslint.config.js` exists**: It gets updated, `.eslintrc.js` doesn't get created
3. **When `.eslintrc.js` exists**: It gets updated, `eslint.config.js` doesn't get created

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)