### PR TITLE
[ios][store-review]  Fix 'requestReview' function failing

### DIFF
--- a/packages/expo-store-review/CHANGELOG.md
+++ b/packages/expo-store-review/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix 'requestReview' function failing. ([#40080](https://github.com/expo/expo/pull/40080) by [@hryhoriiK97](https://github.com/hryhoriiK97))
+
 ### 💡 Others
 
 ## 9.0.7 — 2025-09-11

--- a/packages/expo-store-review/ios/StoreReviewExceptions.swift
+++ b/packages/expo-store-review/ios/StoreReviewExceptions.swift
@@ -2,6 +2,7 @@ import ExpoModulesCore
 
 internal final class MissingCurrentWindowSceneException: Exception {
   override var reason: String {
-    "Cannot determine the current window scene in which to present the modal for requesting a review."
+    "Cannot determine the current window scene in which to present the modal for requesting a review. " +
+    "The app may be in the background or the scene is not suitable for presenting the review prompt."
   }
 }

--- a/packages/expo-store-review/ios/StoreReviewModule.swift
+++ b/packages/expo-store-review/ios/StoreReviewModule.swift
@@ -12,6 +12,8 @@ public class StoreReviewModule: Module {
     AsyncFunction("requestReview") {
       try await MainActor.run {
         guard let currentScene = getForegroundActiveScene() else {
+          // If no valid foreground scene is found, throw an exception
+          // as the review prompt won't be visible in background
           throw MissingCurrentWindowSceneException()
         }
         if #available(iOS 16.0, *) {
@@ -37,8 +39,8 @@ public class StoreReviewModule: Module {
       return foregroundScene
     }
 
-    // As a last resort, return any connected window scene
-    return UIApplication.shared.connectedScenes.first(where: { $0 is UIWindowScene }) as? UIWindowScene
+    // If no valid foreground scene is found, return nil
+    return nil
   }
 
   private func isRunningFromTestFlight() -> Bool {

--- a/packages/expo-store-review/ios/StoreReviewModule.swift
+++ b/packages/expo-store-review/ios/StoreReviewModule.swift
@@ -30,9 +30,9 @@ public class StoreReviewModule: Module {
     }
     
     // If no foreground active scene is found (e.g., app is in App Switcher), 
-    // try to find any foreground scene (including inactive ones)
+    // try to find any foreground inactive scene
     if let foregroundScene = UIApplication.shared.connectedScenes.first(where: { 
-      $0.activationState == .foregroundInactive || $0.activationState == .foregroundActive 
+      $0.activationState == .foregroundInactive 
     }) as? UIWindowScene {
       return foregroundScene
     }

--- a/packages/expo-store-review/ios/StoreReviewModule.swift
+++ b/packages/expo-store-review/ios/StoreReviewModule.swift
@@ -24,7 +24,21 @@ public class StoreReviewModule: Module {
   }
 
   private func getForegroundActiveScene() -> UIWindowScene? {
-    return UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
+    // First try to find a foreground active scene
+    if let activeScene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
+      return activeScene
+    }
+    
+    // If no foreground active scene is found (e.g., app is in App Switcher), 
+    // try to find any foreground scene (including inactive ones)
+    if let foregroundScene = UIApplication.shared.connectedScenes.first(where: { 
+      $0.activationState == .foregroundInactive || $0.activationState == .foregroundActive 
+    }) as? UIWindowScene {
+      return foregroundScene
+    }
+    
+    // As a last resort, return any connected window scene
+    return UIApplication.shared.connectedScenes.first(where: { $0 is UIWindowScene }) as? UIWindowScene
   }
 
   private func isRunningFromTestFlight() -> Bool {

--- a/packages/expo-store-review/ios/StoreReviewModule.swift
+++ b/packages/expo-store-review/ios/StoreReviewModule.swift
@@ -28,15 +28,15 @@ public class StoreReviewModule: Module {
     if let activeScene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
       return activeScene
     }
-    
-    // If no foreground active scene is found (e.g., app is in App Switcher), 
+
+    // If no foreground active scene is found (e.g., app is in App Switcher),
     // try to find any foreground inactive scene
-    if let foregroundScene = UIApplication.shared.connectedScenes.first(where: { 
-      $0.activationState == .foregroundInactive 
+    if let foregroundScene = UIApplication.shared.connectedScenes.first(where: {
+      $0.activationState == .foregroundInactive
     }) as? UIWindowScene {
       return foregroundScene
     }
-    
+
     // As a last resort, return any connected window scene
     return UIApplication.shared.connectedScenes.first(where: { $0 is UIWindowScene }) as? UIWindowScene
   }


### PR DESCRIPTION
# Why
Fixes: #35498
The expo-store-review module was throwing "Cannot determine the current window scene" errors when users navigated to the App Switcher. The original implementation only looked for scenes with activationState == .foregroundActive, but when the app is in the App Switcher, the scene's activation state becomes .foregroundInactive, causing the method to return nil and throw the MissingCurrentWindowSceneException.

# How
Updated getForegroundActiveScene() to implement a fallback strategy:
- First attempt: Look for a scene with activationState == .foregroundActive (normal app usage)
- Second attempt: Look for a scene with activationState == .foregroundInactive (App Switcher scenario)
- If neither found: Throw MissingCurrentWindowSceneException with enhanced error message

This handles the App Switcher case while properly rejecting true background scenarios where the review prompt wouldn't be visible to the user.

# Test Plan

The simplest way to test this is to move the app to the App Switcher and trigger the requestReview using setTimeout.
To do this, modify the following lines of code in StoreReview.tsx:

```
     <Button
        onPress={() => {
          setTimeout(() => {
            StoreReview.requestReview();
          }, 7000);
        }}
        style={styles.button}
        buttonStyle={!StoreReview.hasAction() ? styles.disabled : undefined}
        title="Request a Review!"
      />
```

Press the button and move the app to the App Switcher.

Before:

<img width="300" height="700" alt="Zrzut ekranu 2025-09-29 o 18 43 36" src="https://github.com/user-attachments/assets/8e04045c-f848-419a-8a73-89d8c4dc89f9" />


After:

<img width="300" height="700" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-29 at 19 03 06" src="https://github.com/user-attachments/assets/ddf1e078-6cdf-4c26-9286-5944cb9e534f" />



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
