### PR TITLE
[ci][Android] Add `build-cache`

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -152,7 +152,9 @@ runs:
 
     - name: ♻️ Restore Gradle cache
       if: inputs.ndk == 'true' || inputs.gradle == 'true'
-      uses: gradle/actions/setup-gradle@v3
+      uses: gradle/actions/setup-gradle@v4
+      with:
+        cache-read-only: ${{ github.ref != 'refs/heads/main' && !contains(github.ref, 'sdk-') }}
 
     - name: ♻️ Restore Android NDK from cache
       if: inputs.ndk == 'true'

--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -56,6 +56,7 @@ jobs:
           yarn-workspace: 'true'
           yarn-tools: 'true'
           react-native-gradle-downloads: 'true'
+          gradle: 'true'
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🧶 Install node modules in root dir

--- a/apps/bare-expo/scripts/start-android-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-android-e2e-test.ts
@@ -66,7 +66,7 @@ const __dirname = dirname(__filename);
 
 async function buildAsync(projectRoot: string): Promise<void> {
   console.log('\n💿 Building App');
-  await spawnAsync('./gradlew', ['assembleRelease'], {
+  await spawnAsync('./gradlew', ['--build-cache', 'assembleRelease'], {
     stdio: 'inherit',
     cwd: path.join(projectRoot, 'android'),
   });

--- a/tools/src/commands/AndroidNativeUnitTests.ts
+++ b/tools/src/commands/AndroidNativeUnitTests.ts
@@ -123,7 +123,7 @@ async function runGradlew(packages: Packages.Package[], testCommand: string, cwd
   try {
     await spawnAsync(
       './gradlew',
-      packages.map((pkg) => `:${pkg.packageSlug}:${testCommand}`),
+      ['--build-cache', ...packages.map((pkg) => `:${pkg.packageSlug}:${testCommand}`)],
       {
         cwd,
         stdio: 'inherit',


### PR DESCRIPTION
# Why

Starts using Gradle `build-cache` to speed up builds. 

# How

- Bumped Gradle cache action to v4. The previous one wasn't saving anything to the shared cache.
- Started using `--build-cache` flag to reuse data from other jobs.

# Test Plan

Before:
<img width="1892" height="172" alt="image" src="https://github.com/user-attachments/assets/c745c9fb-6f65-410c-8150-3d30fb21784b" />

After:
<img width="1892" height="172" alt="image" src="https://github.com/user-attachments/assets/6f108041-027a-4961-9ee6-1515a2ac8db0" />
