### PR TITLE
[modules-core][android] Refactor getDelayLoadAppHandler to use ReactHost

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [Android] Migrated from `kotlinOptions` to `compilerOptions` DSL. ([#39794](https://github.com/expo/expo/pull/39794) by [@huextrat](https://github.com/huextrat))
 - [iOS] Add explicit CallInvoker and CallbackWrapper imports to EXJSIUtils ([#39818](https://github.com/expo/expo/pull/39818) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [ios] - Set host dimension synchronously on native ([#40017](https://github.com/expo/expo/pull/40017) by [@nishan](https://github.com/intergalacticspacehighway))
+- [Android] Refactor getDelayLoadAppHandler to use ReactHost ([#40084](https://github.com/expo/expo/pull/40084) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 3.0.16 — 2025-09-16
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactActivityHandler.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactActivityHandler.java
@@ -6,7 +6,7 @@ import android.view.ViewGroup;
 
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
-import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactHost;
 
 import androidx.annotation.Nullable;
 
@@ -78,7 +78,7 @@ public interface ReactActivityHandler {
    * Right now it is for expo-updates only.
    */
   @Nullable
-  default DelayLoadAppHandler getDelayLoadAppHandler(ReactActivity activity, ReactNativeHost reactNativeHost) {
+  default DelayLoadAppHandler getDelayLoadAppHandler(ReactActivity activity, ReactHost reactHost) {
     return null;
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import androidx.annotation.UiThread
 import androidx.annotation.WorkerThread
 import com.facebook.react.ReactActivity
-import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactHost
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import expo.modules.core.interfaces.Package
@@ -53,12 +53,12 @@ class UpdatesPackage : Package {
 
   override fun createReactActivityHandlers(activityContext: Context): List<ReactActivityHandler> {
     val handler = object : ReactActivityHandler {
-      override fun getDelayLoadAppHandler(activity: ReactActivity, reactNativeHost: ReactNativeHost): ReactActivityHandler.DelayLoadAppHandler? {
+      override fun getDelayLoadAppHandler(activity: ReactActivity, reactHost: ReactHost): ReactActivityHandler.DelayLoadAppHandler? {
         if (!BuildConfig.EX_UPDATES_ANDROID_DELAY_LOAD_APP || isUsingCustomInit) {
           return null
         }
         val context = activity.applicationContext
-        val useDeveloperSupport = reactNativeHost.useDeveloperSupport
+        val useDeveloperSupport = reactHost.devSupportManager?.devSupportEnabled ?: false
         if (!useDeveloperSupport || isUsingNativeDebug) {
           return ReactActivityHandler.DelayLoadAppHandler { whenReadyRunnable ->
             CoroutineScope(Dispatchers.IO).launch {

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -64,7 +64,7 @@ class ReactActivityDelegateWrapper(
   }
   private val delayLoadAppHandler: DelayLoadAppHandler? by lazy {
     reactActivityHandlers.asSequence()
-      .mapNotNull { it.getDelayLoadAppHandler(activity, reactNativeHost) }
+      .mapNotNull { it.getDelayLoadAppHandler(activity, reactHost) }
       .firstOrNull()
   }
 


### PR DESCRIPTION
# Why

From react-native 0.82, users no longer declare a ReactNativeHost in their MainApplication, so we need to start migrating our methods to use ReactHost instead. This is the first of a series of PR to allow us to remove `ReactNativeHostWrapper` from our template.

# How

Refactor getDelayLoadAppHandler to use ReactHost

# Test Plan

Run BareExpo and MinimalTester

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
