### PR TITLE
[dev-client][android] Make reactNativeHost optional in ReactHostWrapper

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - [Android] Migrated from `kotlinOptions` to `compilerOptions` DSL. ([#39794](https://github.com/expo/expo/pull/39794) by [@huextrat](https://github.com/huextrat))
+- [android] Make reactNativeHost optional in ReactHostWrapper ([#40085](https://github.com/expo/expo/pull/40085) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 6.0.13 - 2025-10-01
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -471,7 +471,7 @@ class DevLauncherController private constructor() :
 
     @JvmStatic
     fun initialize(reactApplication: ReactApplication, additionalPackages: List<ReactPackage>? = null, launcherClass: Class<*>? = null) {
-      initialize(reactApplication as Context, ReactHostWrapper(reactApplication.reactNativeHost, { reactApplication.reactHost }))
+      initialize(reactApplication as Context, ReactHostWrapper(null, { reactApplication.reactHost }))
       sAdditionalPackages = additionalPackages
       sLauncherClass = launcherClass
     }

--- a/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/ReactHostWrapper.kt
+++ b/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/ReactHostWrapper.kt
@@ -16,7 +16,7 @@ import java.lang.reflect.Field
  * An abstract wrapper to host [ReactNativeHost] and [ReactHost],
  * so that call-sites do not have to handle the difference between legacy bridge and bridgeless mode.
  */
-class ReactHostWrapper(reactNativeHost: ReactNativeHost, reactHostProvider: () -> ReactHost?) {
+class ReactHostWrapper(reactNativeHost: ReactNativeHost?, reactHostProvider: () -> ReactHost?) {
   lateinit var reactNativeHost: ReactNativeHost
   lateinit var reactHost: ReactHost
 
@@ -24,7 +24,7 @@ class ReactHostWrapper(reactNativeHost: ReactNativeHost, reactHostProvider: () -
     if (ReactNativeFeatureFlags.enableBridgelessArchitecture) {
       this.reactHost = requireNotNull(reactHostProvider())
     } else {
-      this.reactNativeHost = reactNativeHost
+      this.reactNativeHost = requireNotNull(reactNativeHost)
     }
   }
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - change debugger connection "warning" to a "tip" ([#39942](https://github.com/expo/expo/pull/39942) by [@vonovak](https://github.com/vonovak))
 - Remove unused dev dependencies ([#39987](https://github.com/expo/expo/pull/39987) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [android] Make reactNativeHost optional in ReactHostWrapper ([#40085](https://github.com/expo/expo/pull/40085) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### ⚠️ Notices
 

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuPackage.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuPackage.kt
@@ -44,7 +44,7 @@ class DevMenuPackage : Package, ReactPackage {
           if (!DevMenuManager.isInitialized()) {
             DevMenuManager.initializeWithReactHost(
               ReactHostWrapper(
-                reactNativeHost = (activity.application as ReactApplication).reactNativeHost,
+                reactNativeHost = null,
                 reactHostProvider = { (activity.application as ReactApplication).reactHost }
               )
             )


### PR DESCRIPTION
# Why

From react-native 0.82, users no longer declare a ReactNativeHost in their MainApplication, so we need to start migrating our methods to use ReactHost instead. This is part 2 of a series of PR to allow us to remove ReactNativeHostWrapper from our template.

# How

 Make `reactNativeHost` optional in dev clients `ReactHostWrapper`

# Test Plan

Run BareExpo and MinimalTester

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
