### PR TITLE
[expo][android] Add getDefaultReactHost to ExpoReactHostFactory

### DIFF
--- a/apps/minimal-tester/android/app/src/main/java/com/community/minimaltester/MainApplication.kt
+++ b/apps/minimal-tester/android/app/src/main/java/com/community/minimaltester/MainApplication.kt
@@ -6,35 +6,25 @@ import android.content.res.Configuration
 import com.facebook.react.PackageList
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
-import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
 import com.facebook.react.ReactHost
 import com.facebook.react.defaults.DefaultReactNativeHost
 
 import expo.modules.ApplicationLifecycleDispatcher
-import expo.modules.ReactNativeHostWrapper
+import expo.modules.ExpoReactHostFactory
 
 class MainApplication : Application(), ReactApplication {
 
-  override val reactNativeHost: ReactNativeHost = ReactNativeHostWrapper(
-      this,
-      object : DefaultReactNativeHost(this) {
-        override fun getPackages(): List<ReactPackage> =
-            PackageList(this).packages.apply {
-              // Packages that cannot be autolinked yet can be added manually here, for example:
-              // add(MyReactNativePackage())
-            }
-
-          override fun getJSMainModuleName(): String = ".expo/.virtual-metro-entry"
-
-          override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG
-
-          override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
-      }
-  )
-
-  override val reactHost: ReactHost
-    get() = ReactNativeHostWrapper.createReactHost(applicationContext, reactNativeHost)
+  override val reactHost: ReactHost by lazy {
+    ExpoReactHostFactory.getDefaultReactHost(
+      context = applicationContext,
+      packageList =
+        PackageList(this).packages.apply {
+          // Packages that cannot be autolinked yet can be added manually here, for example:
+          // add(MyReactNativePackage())
+        }
+    )
+  }
 
   override fun onCreate() {
     super.onCreate()

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### 💡 Others
 
+- [android] Add getDefaultReactHost to ExpoReactHostFactory ([#40086](https://github.com/expo/expo/pull/40086) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### ⚠️ Notices
 
 - Added support for React Native 0.82.x. ([#39678](https://github.com/expo/expo/pull/39678) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo/android/src/main/java/expo/modules/ExpoReactHostFactory.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ExpoReactHostFactory.kt
@@ -19,7 +19,6 @@ import com.facebook.react.runtime.BindingsInstaller
 import com.facebook.react.runtime.JSRuntimeFactory
 import com.facebook.react.runtime.ReactHostDelegate
 import com.facebook.react.runtime.ReactHostImpl
-import com.facebook.react.runtime.cxxreactpackage.CxxReactPackage
 import com.facebook.react.runtime.hermes.HermesInstance
 import expo.modules.core.interfaces.ReactNativeHostHandler
 import java.lang.ref.WeakReference
@@ -94,7 +93,8 @@ object ExpoReactHostFactory {
         handler.onWillCreateReactInstance(useDeveloperSupport)
       }
 
-      val reactHostDelegate = ExpoReactHostDelegate(WeakReference(context),
+      val reactHostDelegate = ExpoReactHostDelegate(
+        WeakReference(context),
         reactNativeHost.packages,
         reactNativeHost.jsMainModuleName,
         reactNativeHost.bundleAssetName,
@@ -139,9 +139,8 @@ object ExpoReactHostFactory {
     jsBundleFilePath: String? = null,
     jsRuntimeFactory: JSRuntimeFactory? = null,
     useDevSupport: Boolean = ReactBuildConfig.DEBUG,
-    bindingsInstaller: BindingsInstaller? = null,
+    bindingsInstaller: BindingsInstaller? = null
   ): ReactHost {
-
     if (reactHost == null) {
       val hostHandlers = ExpoModulesPackage.packageList
         .flatMap { it.createReactNativeHostHandlers(context) }
@@ -154,7 +153,7 @@ object ExpoReactHostFactory {
         jsBundleFilePath,
         useDevSupport,
         bindingsInstaller,
-        hostHandlers = hostHandlers,
+        hostHandlers = hostHandlers
       )
       val componentFactory = ComponentFactory()
       DefaultComponentsRegistry.register(componentFactory)

--- a/packages/expo/android/src/test/java/expo/modules/ReactActivityDelegateWrapperDelayLoadTest.kt
+++ b/packages/expo/android/src/test/java/expo/modules/ReactActivityDelegateWrapperDelayLoadTest.kt
@@ -7,7 +7,6 @@ import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactHost
-import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactRootView
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
@@ -252,8 +251,6 @@ internal class MockApplication : Application(), ReactApplication {
   internal fun bindCurrentActivity(activity: Activity?) {
     currentActivity = activity
   }
-
-  override val reactNativeHost: ReactNativeHost = mockk<ReactNativeHost>(relaxed = true)
 
   override val reactHost: ReactHost by lazy {
     mockk<ReactHost>(relaxed = true)


### PR DESCRIPTION
# Why

From react-native 0.82, users no longer declare a ReactNativeHost in their MainApplication, so we need to start migrating our methods to use ReactHost instead. This is part 3 of a series of PR to allow us to remove ReactNativeHostWrapper from our template.

# How

- Add `getDefaultReactHost` function to ExpoReactHostFactory
- Migrate MinimalTester to use the new `ExpoReactHostFactory.getDefaultReactHost`. 
ps: I'm not sure if we should force all users to migrate to only use `reactHost` right now, so I'm only migrating MinimalTester in this PR 

# Test Plan

BareExpo and MinimalTester

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
