### PR TITLE
[docs] Adjusted docs to include Production plan

### DIFF
--- a/docs/pages/accounts/sso.mdx
+++ b/docs/pages/accounts/sso.mdx
@@ -1,12 +1,12 @@
 ---
 title: Single Sign-On (SSO)
-description: Learn how your enterprise organization can use your identity provider to manage Expo users on your team.
+description: Learn how your organization can use your identity provider to manage Expo users on your team.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-Single Sign-On (SSO) is available for [Enterprise plan](https://expo.dev/pricing) customers.
+Single Sign-On (SSO) is available for [Production and Enterprise plan](https://expo.dev/pricing) customers.
 
 To get started, prepare your identity provider (IdP) for Expo SSO and gather information by following the [configuration guide for your IdP](/#identity-provider-support) below. Once you have done this, an owner of your Organization can follow instructions to [enable SSO](#setting-up-sso-on-an-organization).
 
@@ -193,7 +193,7 @@ Click the dropdown next to the member you wish to delete, and click **Delete SSO
 
 ### Change billing or discontinue use of SSO
 
-An active Enterprise Plan is required to continue using SSO. [Contact us](https://expo.dev/contact) if you wish to discontinue the use of SSO or change your plan.
+An active Production or Enterprise Plan is required to continue using SSO. [Contact us](https://expo.dev/contact) if you wish to discontinue the use of SSO or change your plan.
 
 To ensure uninterrupted access to your organization whether or not SSO is enabled, SSO organizations must keep at least one non-SSO user with the Owner role as a member.
 


### PR DESCRIPTION
# Why

Resolves ENG-17589

SSO was previously available only to Enterprise plan customers. With the recent update, Production plan customers can now use SSO as well.

# How

Updated texts (docs/pages/accounts/sso.mdx) to reflect this change.

# Test Plan



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
