### PR TITLE
[docs] Update FCM credentials guide to clarify google-services.json is not required to be ignored

### DIFF
--- a/docs/pages/push-notifications/fcm-credentials.mdx
+++ b/docs/pages/push-notifications/fcm-credentials.mdx
@@ -94,7 +94,7 @@ Upload the JSON file to EAS and configure it for sending Android notifications. 
 
 <Step label="5">
 
-Configure the **google-services.json** file in your project. Download it from the Firebase Console and place it at the root of your project directory. If you're using version control, add it to your ignore file (for example, **.gitignore**) as it contains sensitive data.
+Configure the **google-services.json** file in your project. Download it from the Firebase Console and place it at the root of your project directory.
 
 **Note**: You can skip this step if **google-services.json** has already been set up.
 
@@ -214,7 +214,7 @@ You have to specify to EAS which JSON credential file to use for sending FCM V1 
 
 <Step label="4">
 
-Configure the **google-services.json** file in your project. Download it from the Firebase Console and place it at the root of your project directory. If you're using version control, add it to your ignore file (for example, **.gitignore**) as it contains sensitive data.
+Configure the **google-services.json** file in your project. Download it from the Firebase Console and place it at the root of your project directory.
 
 **Note**: You can skip this step if **google-services.json** has already been set up.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix #40099

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove " add to `.gitignore`" instruction for `google-services.json` file as per the original change in https://github.com/expo/expo/pull/34011.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
