### PR TITLE
[expo-go] Fix loading progress popup issue

### DIFF
--- a/apps/expo-go/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.m
@@ -9,6 +9,7 @@
 @interface EXAppLoadingProgressWindowController ()
 
 @property (nonatomic, assign) BOOL enabled;
+@property (nonatomic, assign) BOOL remainsHidden;
 @property (nonatomic, strong) UIWindow *window;
 @property (nonatomic, strong) UILabel *textLabel;
 
@@ -20,13 +21,14 @@
 {
   if (self = [super init]) {
     _enabled = enabled;
+    _remainsHidden = NO;
   }
   return self;
 }
 
 - (void)show
 {
-  if (!_enabled) {
+  if (!_enabled || _remainsHidden) {
     return;
   }
 
@@ -70,6 +72,8 @@
   if (!_enabled) {
     return;
   }
+
+  _remainsHidden = YES;
 
   EX_WEAKIFY(self);
   dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
# Why
Fixes https://exponent-internal.slack.com/archives/C02T514E4RK/p1758890395225479

# How
The LoadingProgressPopup can potentially get stuck on screen after the call to hide it. This is due to a race condition where we could receive a late progress update that calls `show` again after `hide` has been called causing the popup to remain on screen. 

I've also fixed a logic error on android that was causing the app to crash when we access an invalid activity and also used safe calls  on `mStatusTextView` when setting it's text.

# Test Plan
Expo go works as normal. It's hard to repro reliably because it's a race condition but I can't get it to happen at all now. 
