### PR TITLE
[expo-go] Fix `getDelayLoadAppHandler` signature

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/legacy/SplashScreenReactActivityLifecycleListener.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/legacy/SplashScreenReactActivityLifecycleListener.kt
@@ -3,6 +3,7 @@ package host.exp.exponent.experience.splashscreen.legacy
 import android.app.Activity
 import android.content.Context
 import com.facebook.react.ReactActivity
+import com.facebook.react.ReactHost
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactRootView
 import expo.modules.core.interfaces.ReactActivityHandler
@@ -23,15 +24,17 @@ class SplashScreenReactActivityLifecycleListener : ReactActivityLifecycleListene
 
 class SplashScreenReactActivityHandler : ReactActivityHandler {
   override fun getDelayLoadAppHandler(
-    activity: ReactActivity,
-    reactNativeHost: ReactNativeHost
+    activity: ReactActivity?,
+    reactHost: ReactHost?
   ): ReactActivityHandler.DelayLoadAppHandler? {
-    SplashScreen.ensureShown(
-      activity,
-      getResizeMode(activity),
-      ReactRootView::class.java,
-      getStatusBarTranslucent(activity)
-    )
+    activity?.let {
+      SplashScreen.ensureShown(
+        it,
+        getResizeMode(it),
+        ReactRootView::class.java,
+        getStatusBarTranslucent(it)
+      )
+    }
     return null
   }
 }

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/legacy/SplashScreenReactActivityLifecycleListener.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/legacy/SplashScreenReactActivityLifecycleListener.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.content.Context
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactHost
-import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactRootView
 import expo.modules.core.interfaces.ReactActivityHandler
 import expo.modules.core.interfaces.ReactActivityLifecycleListener


### PR DESCRIPTION
# Why
`getDelayLoadAppHandler` signature was changed in #40084 so expo go fails to build. 

# How
Update the signature

# Test Plan
Expo go builds as normal

