### PR TITLE
[4/n] Upgrade React Native to 0.82.x

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -632,10 +632,10 @@ PODS:
     - Yoga
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
-  - FBLazyVector (0.82.0-rc.4)
-  - hermes-engine (0.82.0-rc.4):
-    - hermes-engine/Pre-built (= 0.82.0-rc.4)
-  - hermes-engine/Pre-built (0.82.0-rc.4)
+  - FBLazyVector (0.82.0-rc.5)
+  - hermes-engine (0.82.0-rc.5):
+    - hermes-engine/Pre-built (= 0.82.0-rc.5)
+  - hermes-engine/Pre-built (0.82.0-rc.5)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -692,32 +692,32 @@ PODS:
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (9.1.0)
   - Quick (7.3.1)
-  - RCTDeprecation (0.82.0-rc.4)
-  - RCTRequired (0.82.0-rc.4)
-  - RCTTypeSafety (0.82.0-rc.4):
-    - FBLazyVector (= 0.82.0-rc.4)
-    - RCTRequired (= 0.82.0-rc.4)
-    - React-Core (= 0.82.0-rc.4)
+  - RCTDeprecation (0.82.0-rc.5)
+  - RCTRequired (0.82.0-rc.5)
+  - RCTTypeSafety (0.82.0-rc.5):
+    - FBLazyVector (= 0.82.0-rc.5)
+    - RCTRequired (= 0.82.0-rc.5)
+    - React-Core (= 0.82.0-rc.5)
   - ReachabilitySwift (5.2.4)
-  - React (0.82.0-rc.4):
-    - React-Core (= 0.82.0-rc.4)
-    - React-Core/DevSupport (= 0.82.0-rc.4)
-    - React-Core/RCTWebSocket (= 0.82.0-rc.4)
-    - React-RCTActionSheet (= 0.82.0-rc.4)
-    - React-RCTAnimation (= 0.82.0-rc.4)
-    - React-RCTBlob (= 0.82.0-rc.4)
-    - React-RCTImage (= 0.82.0-rc.4)
-    - React-RCTLinking (= 0.82.0-rc.4)
-    - React-RCTNetwork (= 0.82.0-rc.4)
-    - React-RCTSettings (= 0.82.0-rc.4)
-    - React-RCTText (= 0.82.0-rc.4)
-    - React-RCTVibration (= 0.82.0-rc.4)
-  - React-callinvoker (0.82.0-rc.4)
-  - React-Core (0.82.0-rc.4):
+  - React (0.82.0-rc.5):
+    - React-Core (= 0.82.0-rc.5)
+    - React-Core/DevSupport (= 0.82.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.82.0-rc.5)
+    - React-RCTActionSheet (= 0.82.0-rc.5)
+    - React-RCTAnimation (= 0.82.0-rc.5)
+    - React-RCTBlob (= 0.82.0-rc.5)
+    - React-RCTImage (= 0.82.0-rc.5)
+    - React-RCTLinking (= 0.82.0-rc.5)
+    - React-RCTNetwork (= 0.82.0-rc.5)
+    - React-RCTSettings (= 0.82.0-rc.5)
+    - React-RCTText (= 0.82.0-rc.5)
+    - React-RCTVibration (= 0.82.0-rc.5)
+  - React-callinvoker (0.82.0-rc.5)
+  - React-Core (0.82.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.82.0-rc.4)
+    - React-Core/Default (= 0.82.0-rc.5)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -732,66 +732,9 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core-prebuilt (0.82.0-rc.4):
+  - React-Core-prebuilt (0.82.0-rc.5):
     - ReactNativeDependencies
-  - React-Core/CoreModulesHeaders (0.82.0-rc.4):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/Default (0.82.0-rc.4):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/DevSupport (0.82.0-rc.4):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default (= 0.82.0-rc.4)
-    - React-Core/RCTWebSocket (= 0.82.0-rc.4)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.82.0-rc.4):
+  - React-Core/CoreModulesHeaders (0.82.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -810,7 +753,45 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.82.0-rc.4):
+  - React-Core/Default (0.82.0-rc.5):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/DevSupport (0.82.0-rc.5):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-Core/Default (= 0.82.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.82.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.82.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -829,7 +810,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTBlobHeaders (0.82.0-rc.4):
+  - React-Core/RCTAnimationHeaders (0.82.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -848,7 +829,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTImageHeaders (0.82.0-rc.4):
+  - React-Core/RCTBlobHeaders (0.82.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -867,7 +848,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.82.0-rc.4):
+  - React-Core/RCTImageHeaders (0.82.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -886,7 +867,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.82.0-rc.4):
+  - React-Core/RCTLinkingHeaders (0.82.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -905,7 +886,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.82.0-rc.4):
+  - React-Core/RCTNetworkHeaders (0.82.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -924,7 +905,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTTextHeaders (0.82.0-rc.4):
+  - React-Core/RCTSettingsHeaders (0.82.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -943,7 +924,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.82.0-rc.4):
+  - React-Core/RCTTextHeaders (0.82.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -962,11 +943,11 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTWebSocket (0.82.0-rc.4):
+  - React-Core/RCTVibrationHeaders (0.82.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.82.0-rc.4)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -981,38 +962,57 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-CoreModules (0.82.0-rc.4):
-    - RCTTypeSafety (= 0.82.0-rc.4)
+  - React-Core/RCTWebSocket (0.82.0-rc.5):
+    - hermes-engine
+    - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/CoreModulesHeaders (= 0.82.0-rc.4)
+    - React-Core/Default (= 0.82.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-CoreModules (0.82.0-rc.5):
+    - RCTTypeSafety (= 0.82.0-rc.5)
+    - React-Core-prebuilt
+    - React-Core/CoreModulesHeaders (= 0.82.0-rc.5)
     - React-debug
-    - React-jsi (= 0.82.0-rc.4)
+    - React-jsi (= 0.82.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.82.0-rc.4)
+    - React-RCTImage (= 0.82.0-rc.5)
     - React-runtimeexecutor
     - ReactCommon
     - ReactNativeDependencies
-  - React-cxxreact (0.82.0-rc.4):
+  - React-cxxreact (0.82.0-rc.5):
     - hermes-engine
-    - React-callinvoker (= 0.82.0-rc.4)
+    - React-callinvoker (= 0.82.0-rc.5)
     - React-Core-prebuilt
-    - React-debug (= 0.82.0-rc.4)
-    - React-jsi (= 0.82.0-rc.4)
+    - React-debug (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.82.0-rc.4)
-    - React-perflogger (= 0.82.0-rc.4)
+    - React-logger (= 0.82.0-rc.5)
+    - React-perflogger (= 0.82.0-rc.5)
     - React-runtimeexecutor
-    - React-timing (= 0.82.0-rc.4)
+    - React-timing (= 0.82.0-rc.5)
     - ReactNativeDependencies
-  - React-debug (0.82.0-rc.4)
-  - React-defaultsnativemodule (0.82.0-rc.4):
+  - React-debug (0.82.0-rc.5)
+  - React-defaultsnativemodule (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-domnativemodule
@@ -1024,7 +1024,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-webperformancenativemodule
     - ReactNativeDependencies
-  - React-domnativemodule (0.82.0-rc.4):
+  - React-domnativemodule (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-Fabric
@@ -1038,7 +1038,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric (0.82.0-rc.4):
+  - React-Fabric (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1046,23 +1046,23 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.82.0-rc.4)
-    - React-Fabric/attributedstring (= 0.82.0-rc.4)
-    - React-Fabric/bridging (= 0.82.0-rc.4)
-    - React-Fabric/componentregistry (= 0.82.0-rc.4)
-    - React-Fabric/componentregistrynative (= 0.82.0-rc.4)
-    - React-Fabric/components (= 0.82.0-rc.4)
-    - React-Fabric/consistency (= 0.82.0-rc.4)
-    - React-Fabric/core (= 0.82.0-rc.4)
-    - React-Fabric/dom (= 0.82.0-rc.4)
-    - React-Fabric/imagemanager (= 0.82.0-rc.4)
-    - React-Fabric/leakchecker (= 0.82.0-rc.4)
-    - React-Fabric/mounting (= 0.82.0-rc.4)
-    - React-Fabric/observers (= 0.82.0-rc.4)
-    - React-Fabric/scheduler (= 0.82.0-rc.4)
-    - React-Fabric/telemetry (= 0.82.0-rc.4)
-    - React-Fabric/templateprocessor (= 0.82.0-rc.4)
-    - React-Fabric/uimanager (= 0.82.0-rc.4)
+    - React-Fabric/animations (= 0.82.0-rc.5)
+    - React-Fabric/attributedstring (= 0.82.0-rc.5)
+    - React-Fabric/bridging (= 0.82.0-rc.5)
+    - React-Fabric/componentregistry (= 0.82.0-rc.5)
+    - React-Fabric/componentregistrynative (= 0.82.0-rc.5)
+    - React-Fabric/components (= 0.82.0-rc.5)
+    - React-Fabric/consistency (= 0.82.0-rc.5)
+    - React-Fabric/core (= 0.82.0-rc.5)
+    - React-Fabric/dom (= 0.82.0-rc.5)
+    - React-Fabric/imagemanager (= 0.82.0-rc.5)
+    - React-Fabric/leakchecker (= 0.82.0-rc.5)
+    - React-Fabric/mounting (= 0.82.0-rc.5)
+    - React-Fabric/observers (= 0.82.0-rc.5)
+    - React-Fabric/scheduler (= 0.82.0-rc.5)
+    - React-Fabric/telemetry (= 0.82.0-rc.5)
+    - React-Fabric/templateprocessor (= 0.82.0-rc.5)
+    - React-Fabric/uimanager (= 0.82.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1074,26 +1074,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/animations (0.82.0-rc.4):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/attributedstring (0.82.0-rc.4):
+  - React-Fabric/animations (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1112,7 +1093,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/bridging (0.82.0-rc.4):
+  - React-Fabric/attributedstring (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1131,7 +1112,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistry (0.82.0-rc.4):
+  - React-Fabric/bridging (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1150,7 +1131,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistrynative (0.82.0-rc.4):
+  - React-Fabric/componentregistry (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1169,30 +1150,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components (0.82.0-rc.4):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.82.0-rc.4)
-    - React-Fabric/components/root (= 0.82.0-rc.4)
-    - React-Fabric/components/scrollview (= 0.82.0-rc.4)
-    - React-Fabric/components/view (= 0.82.0-rc.4)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/components/legacyviewmanagerinterop (0.82.0-rc.4):
+  - React-Fabric/componentregistrynative (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1211,7 +1169,30 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/root (0.82.0-rc.4):
+  - React-Fabric/components (0.82.0-rc.5):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.82.0-rc.5)
+    - React-Fabric/components/root (= 0.82.0-rc.5)
+    - React-Fabric/components/scrollview (= 0.82.0-rc.5)
+    - React-Fabric/components/view (= 0.82.0-rc.5)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/legacyviewmanagerinterop (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1230,7 +1211,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/scrollview (0.82.0-rc.4):
+  - React-Fabric/components/root (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1249,7 +1230,26 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/view (0.82.0-rc.4):
+  - React-Fabric/components/scrollview (0.82.0-rc.5):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/view (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1270,7 +1270,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric/consistency (0.82.0-rc.4):
+  - React-Fabric/consistency (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1289,7 +1289,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/core (0.82.0-rc.4):
+  - React-Fabric/core (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1308,7 +1308,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/dom (0.82.0-rc.4):
+  - React-Fabric/dom (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1327,7 +1327,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/imagemanager (0.82.0-rc.4):
+  - React-Fabric/imagemanager (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1346,7 +1346,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/leakchecker (0.82.0-rc.4):
+  - React-Fabric/leakchecker (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1365,7 +1365,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/mounting (0.82.0-rc.4):
+  - React-Fabric/mounting (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1384,7 +1384,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers (0.82.0-rc.4):
+  - React-Fabric/observers (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1392,7 +1392,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.82.0-rc.4)
+    - React-Fabric/observers/events (= 0.82.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1404,7 +1404,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers/events (0.82.0-rc.4):
+  - React-Fabric/observers/events (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1423,7 +1423,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/scheduler (0.82.0-rc.4):
+  - React-Fabric/scheduler (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1445,7 +1445,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/telemetry (0.82.0-rc.4):
+  - React-Fabric/telemetry (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1464,7 +1464,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/templateprocessor (0.82.0-rc.4):
+  - React-Fabric/templateprocessor (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1483,7 +1483,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager (0.82.0-rc.4):
+  - React-Fabric/uimanager (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1491,7 +1491,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.82.0-rc.4)
+    - React-Fabric/uimanager/consistency (= 0.82.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1504,7 +1504,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager/consistency (0.82.0-rc.4):
+  - React-Fabric/uimanager/consistency (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1524,7 +1524,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-FabricComponents (0.82.0-rc.4):
+  - React-FabricComponents (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1533,8 +1533,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.82.0-rc.4)
-    - React-FabricComponents/textlayoutmanager (= 0.82.0-rc.4)
+    - React-FabricComponents/components (= 0.82.0-rc.5)
+    - React-FabricComponents/textlayoutmanager (= 0.82.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1547,7 +1547,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components (0.82.0-rc.4):
+  - React-FabricComponents/components (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1556,18 +1556,18 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.82.0-rc.4)
-    - React-FabricComponents/components/iostextinput (= 0.82.0-rc.4)
-    - React-FabricComponents/components/modal (= 0.82.0-rc.4)
-    - React-FabricComponents/components/rncore (= 0.82.0-rc.4)
-    - React-FabricComponents/components/safeareaview (= 0.82.0-rc.4)
-    - React-FabricComponents/components/scrollview (= 0.82.0-rc.4)
-    - React-FabricComponents/components/switch (= 0.82.0-rc.4)
-    - React-FabricComponents/components/text (= 0.82.0-rc.4)
-    - React-FabricComponents/components/textinput (= 0.82.0-rc.4)
-    - React-FabricComponents/components/unimplementedview (= 0.82.0-rc.4)
-    - React-FabricComponents/components/virtualview (= 0.82.0-rc.4)
-    - React-FabricComponents/components/virtualviewexperimental (= 0.82.0-rc.4)
+    - React-FabricComponents/components/inputaccessory (= 0.82.0-rc.5)
+    - React-FabricComponents/components/iostextinput (= 0.82.0-rc.5)
+    - React-FabricComponents/components/modal (= 0.82.0-rc.5)
+    - React-FabricComponents/components/rncore (= 0.82.0-rc.5)
+    - React-FabricComponents/components/safeareaview (= 0.82.0-rc.5)
+    - React-FabricComponents/components/scrollview (= 0.82.0-rc.5)
+    - React-FabricComponents/components/switch (= 0.82.0-rc.5)
+    - React-FabricComponents/components/text (= 0.82.0-rc.5)
+    - React-FabricComponents/components/textinput (= 0.82.0-rc.5)
+    - React-FabricComponents/components/unimplementedview (= 0.82.0-rc.5)
+    - React-FabricComponents/components/virtualview (= 0.82.0-rc.5)
+    - React-FabricComponents/components/virtualviewexperimental (= 0.82.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1580,28 +1580,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.82.0-rc.4):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.82.0-rc.4):
+  - React-FabricComponents/components/inputaccessory (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1622,7 +1601,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/modal (0.82.0-rc.4):
+  - React-FabricComponents/components/iostextinput (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1643,7 +1622,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/rncore (0.82.0-rc.4):
+  - React-FabricComponents/components/modal (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1664,7 +1643,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.82.0-rc.4):
+  - React-FabricComponents/components/rncore (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1685,7 +1664,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/scrollview (0.82.0-rc.4):
+  - React-FabricComponents/components/safeareaview (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1706,7 +1685,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/switch (0.82.0-rc.4):
+  - React-FabricComponents/components/scrollview (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1727,7 +1706,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/text (0.82.0-rc.4):
+  - React-FabricComponents/components/switch (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1748,7 +1727,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/textinput (0.82.0-rc.4):
+  - React-FabricComponents/components/text (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1769,7 +1748,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.82.0-rc.4):
+  - React-FabricComponents/components/textinput (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1790,7 +1769,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/virtualview (0.82.0-rc.4):
+  - React-FabricComponents/components/unimplementedview (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1811,7 +1790,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/virtualviewexperimental (0.82.0-rc.4):
+  - React-FabricComponents/components/virtualview (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1832,7 +1811,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.82.0-rc.4):
+  - React-FabricComponents/components/virtualviewexperimental (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1853,27 +1832,48 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricImage (0.82.0-rc.4):
+  - React-FabricComponents/textlayoutmanager (0.82.0-rc.5):
     - hermes-engine
-    - RCTRequired (= 0.82.0-rc.4)
-    - RCTTypeSafety (= 0.82.0-rc.4)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
+  - React-FabricImage (0.82.0-rc.5):
+    - hermes-engine
+    - RCTRequired (= 0.82.0-rc.5)
+    - RCTTypeSafety (= 0.82.0-rc.5)
     - React-Core-prebuilt
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.82.0-rc.4)
+    - React-jsiexecutor (= 0.82.0-rc.5)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-featureflags (0.82.0-rc.4):
+  - React-featureflags (0.82.0-rc.5):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-featureflagsnativemodule (0.82.0-rc.4):
+  - React-featureflagsnativemodule (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1882,27 +1882,27 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-graphics (0.82.0-rc.4):
+  - React-graphics (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
     - React-jsiexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-hermes (0.82.0-rc.4):
+  - React-hermes (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
-    - React-cxxreact (= 0.82.0-rc.4)
+    - React-cxxreact (= 0.82.0-rc.5)
     - React-jsi
-    - React-jsiexecutor (= 0.82.0-rc.4)
+    - React-jsiexecutor (= 0.82.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.82.0-rc.4)
+    - React-perflogger (= 0.82.0-rc.5)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-idlecallbacksnativemodule (0.82.0-rc.4):
+  - React-idlecallbacksnativemodule (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1912,7 +1912,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-ImageManager (0.82.0-rc.4):
+  - React-ImageManager (0.82.0-rc.5):
     - React-Core-prebuilt
     - React-Core/Default
     - React-debug
@@ -1921,7 +1921,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - ReactNativeDependencies
-  - React-jserrorhandler (0.82.0-rc.4):
+  - React-jserrorhandler (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1930,11 +1930,11 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - ReactNativeDependencies
-  - React-jsi (0.82.0-rc.4):
+  - React-jsi (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsiexecutor (0.82.0-rc.4):
+  - React-jsiexecutor (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1946,7 +1946,7 @@ PODS:
     - React-perflogger
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsinspector (0.82.0-rc.4):
+  - React-jsinspector (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1955,44 +1955,44 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.82.0-rc.4)
+    - React-perflogger (= 0.82.0-rc.5)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsinspectorcdp (0.82.0-rc.4):
+  - React-jsinspectorcdp (0.82.0-rc.5):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsinspectornetwork (0.82.0-rc.4):
+  - React-jsinspectornetwork (0.82.0-rc.5):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspectorcdp
     - React-performancetimeline
     - React-timing
     - ReactNativeDependencies
-  - React-jsinspectortracing (0.82.0-rc.4):
+  - React-jsinspectortracing (0.82.0-rc.5):
     - React-Core-prebuilt
     - React-oscompat
     - React-timing
     - ReactNativeDependencies
-  - React-jsitooling (0.82.0-rc.4):
+  - React-jsitooling (0.82.0-rc.5):
     - React-Core-prebuilt
-    - React-cxxreact (= 0.82.0-rc.4)
+    - React-cxxreact (= 0.82.0-rc.5)
     - React-debug
-    - React-jsi (= 0.82.0-rc.4)
+    - React-jsi (= 0.82.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsitracing (0.82.0-rc.4):
+  - React-jsitracing (0.82.0-rc.5):
     - React-jsi
-  - React-logger (0.82.0-rc.4):
+  - React-logger (0.82.0-rc.5):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-Mapbuffer (0.82.0-rc.4):
+  - React-Mapbuffer (0.82.0-rc.5):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-microtasksnativemodule (0.82.0-rc.4):
+  - React-microtasksnativemodule (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -2253,7 +2253,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-NativeModulesApple (0.82.0-rc.4):
+  - React-NativeModulesApple (0.82.0-rc.5):
     - hermes-engine
     - React-callinvoker
     - React-Core
@@ -2268,11 +2268,11 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-oscompat (0.82.0-rc.4)
-  - React-perflogger (0.82.0-rc.4):
+  - React-oscompat (0.82.0-rc.5)
+  - React-perflogger (0.82.0-rc.5):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-performancecdpmetrics (0.82.0-rc.4):
+  - React-performancecdpmetrics (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -2280,16 +2280,16 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - ReactNativeDependencies
-  - React-performancetimeline (0.82.0-rc.4):
+  - React-performancetimeline (0.82.0-rc.5):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspectortracing
     - React-perflogger
     - React-timing
     - ReactNativeDependencies
-  - React-RCTActionSheet (0.82.0-rc.4):
-    - React-Core/RCTActionSheetHeaders (= 0.82.0-rc.4)
-  - React-RCTAnimation (0.82.0-rc.4):
+  - React-RCTActionSheet (0.82.0-rc.5):
+    - React-Core/RCTActionSheetHeaders (= 0.82.0-rc.5)
+  - React-RCTAnimation (0.82.0-rc.5):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTAnimationHeaders
@@ -2299,7 +2299,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTAppDelegate (0.82.0-rc.4):
+  - React-RCTAppDelegate (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2327,7 +2327,7 @@ PODS:
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTBlob (0.82.0-rc.4):
+  - React-RCTBlob (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-Core/RCTBlobHeaders
@@ -2340,7 +2340,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFabric (0.82.0-rc.4):
+  - React-RCTFabric (0.82.0-rc.5):
     - hermes-engine
     - React-Core
     - React-Core-prebuilt
@@ -2370,7 +2370,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-RCTFBReactNativeSpec (0.82.0-rc.4):
+  - React-RCTFBReactNativeSpec (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2378,10 +2378,10 @@ PODS:
     - React-Core-prebuilt
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.82.0-rc.4)
+    - React-RCTFBReactNativeSpec/components (= 0.82.0-rc.5)
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFBReactNativeSpec/components (0.82.0-rc.4):
+  - React-RCTFBReactNativeSpec/components (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2398,7 +2398,7 @@ PODS:
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-RCTImage (0.82.0-rc.4):
+  - React-RCTImage (0.82.0-rc.5):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTImageHeaders
@@ -2408,14 +2408,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTLinking (0.82.0-rc.4):
-    - React-Core/RCTLinkingHeaders (= 0.82.0-rc.4)
-    - React-jsi (= 0.82.0-rc.4)
+  - React-RCTLinking (0.82.0-rc.5):
+    - React-Core/RCTLinkingHeaders (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0-rc.5)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.82.0-rc.4)
-  - React-RCTNetwork (0.82.0-rc.4):
+    - ReactCommon/turbomodule/core (= 0.82.0-rc.5)
+  - React-RCTNetwork (0.82.0-rc.5):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTNetworkHeaders
@@ -2428,7 +2428,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTRuntime (0.82.0-rc.4):
+  - React-RCTRuntime (0.82.0-rc.5):
     - hermes-engine
     - React-Core
     - React-Core-prebuilt
@@ -2443,7 +2443,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - ReactNativeDependencies
-  - React-RCTSettings (0.82.0-rc.4):
+  - React-RCTSettings (0.82.0-rc.5):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTSettingsHeaders
@@ -2452,10 +2452,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTText (0.82.0-rc.4):
-    - React-Core/RCTTextHeaders (= 0.82.0-rc.4)
+  - React-RCTText (0.82.0-rc.5):
+    - React-Core/RCTTextHeaders (= 0.82.0-rc.5)
     - Yoga
-  - React-RCTVibration (0.82.0-rc.4):
+  - React-RCTVibration (0.82.0-rc.5):
     - React-Core-prebuilt
     - React-Core/RCTVibrationHeaders
     - React-jsi
@@ -2463,15 +2463,15 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-rendererconsistency (0.82.0-rc.4)
-  - React-renderercss (0.82.0-rc.4):
+  - React-rendererconsistency (0.82.0-rc.5)
+  - React-renderercss (0.82.0-rc.5):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.82.0-rc.4):
+  - React-rendererdebug (0.82.0-rc.5):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-RuntimeApple (0.82.0-rc.4):
+  - React-RuntimeApple (0.82.0-rc.5):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -2494,7 +2494,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeCore (0.82.0-rc.4):
+  - React-RuntimeCore (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -2510,14 +2510,14 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-runtimeexecutor (0.82.0-rc.4):
+  - React-runtimeexecutor (0.82.0-rc.5):
     - React-Core-prebuilt
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.82.0-rc.4)
+    - React-jsi (= 0.82.0-rc.5)
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeHermes (0.82.0-rc.4):
+  - React-RuntimeHermes (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -2532,7 +2532,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-runtimescheduler (0.82.0-rc.4):
+  - React-runtimescheduler (0.82.0-rc.5):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -2548,15 +2548,15 @@ PODS:
     - React-timing
     - React-utils
     - ReactNativeDependencies
-  - React-timing (0.82.0-rc.4):
+  - React-timing (0.82.0-rc.5):
     - React-debug
-  - React-utils (0.82.0-rc.4):
+  - React-utils (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-debug
-    - React-jsi (= 0.82.0-rc.4)
+    - React-jsi (= 0.82.0-rc.5)
     - ReactNativeDependencies
-  - React-webperformancenativemodule (0.82.0-rc.4):
+  - React-webperformancenativemodule (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -2566,9 +2566,9 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - ReactAppDependencyProvider (0.82.0-rc.4):
+  - ReactAppDependencyProvider (0.82.0-rc.5):
     - ReactCodegen
-  - ReactCodegen (0.82.0-rc.4):
+  - ReactCodegen (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2588,43 +2588,43 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - ReactCommon (0.82.0-rc.4):
+  - ReactCommon (0.82.0-rc.5):
     - React-Core-prebuilt
-    - ReactCommon/turbomodule (= 0.82.0-rc.4)
+    - ReactCommon/turbomodule (= 0.82.0-rc.5)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule (0.82.0-rc.4):
+  - ReactCommon/turbomodule (0.82.0-rc.5):
     - hermes-engine
-    - React-callinvoker (= 0.82.0-rc.4)
+    - React-callinvoker (= 0.82.0-rc.5)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.82.0-rc.4)
-    - React-jsi (= 0.82.0-rc.4)
-    - React-logger (= 0.82.0-rc.4)
-    - React-perflogger (= 0.82.0-rc.4)
-    - ReactCommon/turbomodule/bridging (= 0.82.0-rc.4)
-    - ReactCommon/turbomodule/core (= 0.82.0-rc.4)
+    - React-cxxreact (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0-rc.5)
+    - React-logger (= 0.82.0-rc.5)
+    - React-perflogger (= 0.82.0-rc.5)
+    - ReactCommon/turbomodule/bridging (= 0.82.0-rc.5)
+    - ReactCommon/turbomodule/core (= 0.82.0-rc.5)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/bridging (0.82.0-rc.4):
+  - ReactCommon/turbomodule/bridging (0.82.0-rc.5):
     - hermes-engine
-    - React-callinvoker (= 0.82.0-rc.4)
+    - React-callinvoker (= 0.82.0-rc.5)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.82.0-rc.4)
-    - React-jsi (= 0.82.0-rc.4)
-    - React-logger (= 0.82.0-rc.4)
-    - React-perflogger (= 0.82.0-rc.4)
+    - React-cxxreact (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0-rc.5)
+    - React-logger (= 0.82.0-rc.5)
+    - React-perflogger (= 0.82.0-rc.5)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/core (0.82.0-rc.4):
+  - ReactCommon/turbomodule/core (0.82.0-rc.5):
     - hermes-engine
-    - React-callinvoker (= 0.82.0-rc.4)
+    - React-callinvoker (= 0.82.0-rc.5)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.82.0-rc.4)
-    - React-debug (= 0.82.0-rc.4)
-    - React-featureflags (= 0.82.0-rc.4)
-    - React-jsi (= 0.82.0-rc.4)
-    - React-logger (= 0.82.0-rc.4)
-    - React-perflogger (= 0.82.0-rc.4)
-    - React-utils (= 0.82.0-rc.4)
+    - React-cxxreact (= 0.82.0-rc.5)
+    - React-debug (= 0.82.0-rc.5)
+    - React-featureflags (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0-rc.5)
+    - React-logger (= 0.82.0-rc.5)
+    - React-perflogger (= 0.82.0-rc.5)
+    - React-utils (= 0.82.0-rc.5)
     - ReactNativeDependencies
-  - ReactNativeDependencies (0.82.0-rc.4)
+  - ReactNativeDependencies (0.82.0-rc.5)
   - RNCAsyncStorage (2.2.0):
     - hermes-engine
     - RCTRequired
@@ -3683,8 +3683,8 @@ SPEC CHECKSUMS:
   EXTaskManager: 7d80cb59c1faa3dcfa42035b185bcb5209ca7b1b
   EXUpdates: b96ad490c9456eebc38f949f3c30ce6258845773
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
-  FBLazyVector: e414d023e1ddc41341bb06e7590bc95d5824028a
-  hermes-engine: 883ad6cdbcb152221038266a5908c1fa6c1002f7
+  FBLazyVector: bd5db632a304b99a915e07040696286715b97462
+  hermes-engine: a14f7f403796d60a2ae636a4d5b6c1f7646503f8
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -3693,40 +3693,40 @@ SPEC CHECKSUMS:
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
-  RCTDeprecation: e6bce6cb7d767c2a1ac7b419999e4717ebe87595
-  RCTRequired: 806c21cf70b6a8058daa77729439b0202e2b72e5
-  RCTTypeSafety: 0dce095435551439cb926ac86c041f62ca03c0ab
+  RCTDeprecation: 464a4d4314df84aeafa5cba421aa546f12ea45c2
+  RCTRequired: 7ec2b105ee6a82a849718a97e2769c2b3649eeea
+  RCTTypeSafety: 53fc675982f0fc6a599cfe66d3047b8adda347b1
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 0fde0b13f6cca9b4e4525d888dd952e87e5f2c28
-  React-callinvoker: 841bceb08682edd88affeb3e91e04e7c3cd24f3a
-  React-Core: 3459482292cbf3966d1c55cd61af3869c77a318d
-  React-Core-prebuilt: 67b1d61c958772c696bc9f356a4b88ff8c5e3933
-  React-CoreModules: aa77770e3ca2b983df4ea623b026704b78b600fd
-  React-cxxreact: 98edd32f3e558250a63e6864f753e78a11abe819
-  React-debug: f955b5ab47bd2acfc6d15990e60b4c1b26fd5a55
-  React-defaultsnativemodule: 092d5e1ea973eb0837b27f2fabb7ed965647887a
-  React-domnativemodule: eb0733f87e937da11580225f929e56fd2ec806b2
-  React-Fabric: 54d8f3990411c6f2cc83be64793237d0a97fd025
-  React-FabricComponents: 62d59d52826c0f4d78b0e7b8ee67011d810e1e03
-  React-FabricImage: 5b840611a389f7fc23cd86376881e85c993602f9
-  React-featureflags: 19b9c2ef14b18ad37b5a814b535b0b9f5bf7c702
-  React-featureflagsnativemodule: e824b951f2fefbdedadaf0ff4d2aa8a990e3563b
-  React-graphics: 2289cebd017fa69bc4009fe9e80ab731dd71a97b
-  React-hermes: a8955b344166368f115d2f3c923f03a86a1dc5f6
-  React-idlecallbacksnativemodule: b3e1dfab1006d82282865ed59ef0d218a759e496
-  React-ImageManager: fd109ea859a6377c65298b2c3180e6b0e6a386d9
-  React-jserrorhandler: 23cbbf2c375fe5017c6d1337dac16a22fe908054
-  React-jsi: 5fccf734f969c019fb0a866960574d61f5bdb957
-  React-jsiexecutor: 8a81809979789ff33bde7871d8690da8d5cebee3
-  React-jsinspector: 5046be4d25c8425ea1cafc8c7e33b624a13e36a0
-  React-jsinspectorcdp: 98bcc670d818bdde687dbc023f386842e48de6bb
-  React-jsinspectornetwork: 0ae9e2f2471a32db039a06c9bf5d5373d2f75172
-  React-jsinspectortracing: ae458b882f29ddad0fca6d5a4a1f7227386cc88b
-  React-jsitooling: 4cd202a09c5fee51a4ff919b45bf43699fa6f57d
-  React-jsitracing: 31cdc6136f806f7e2161ec589fb1e7d84d4364b4
-  React-logger: 1aee8c11182049e2d856d885102c0cb753c2411a
-  React-Mapbuffer: 061e9707ff58d79377c05ded98f70686fe7e7307
-  React-microtasksnativemodule: ece68a111bc0c199dc862926912be3888ad7d1af
+  React: 6eb704af98132bfdd36a19d9910b4d317d13100c
+  React-callinvoker: d3ef985f0e471dd4e6bf2d211e6a8a8721a2ca55
+  React-Core: b4b1a97d59b674896e243d70173f829247307d95
+  React-Core-prebuilt: 533958c653ad258eafa63ef14d21383fc2b255a2
+  React-CoreModules: 58a3036f2f1ff1d4db71e96f51ef2abab3da9890
+  React-cxxreact: ddf8df79906abbd0faa8fee7ac42f68669f4a389
+  React-debug: ddc5f4fcd34d349b4f9012c26f74fe043768d72d
+  React-defaultsnativemodule: cba90d0fd3b74c57a41b3404dccd2b774254e32c
+  React-domnativemodule: 2fdee77a7845eb601d32177a3164a7f7213a05e5
+  React-Fabric: a005506975193c8220150ff753db06f62a9f3675
+  React-FabricComponents: 686d531464879d5ce38f19f2a3b8619860e6b2a1
+  React-FabricImage: 1b9e7bdeef180071f5ed3004f32c927ed4bd878e
+  React-featureflags: 1f970af672e5ad345f2fbc046619c355baf6c5a8
+  React-featureflagsnativemodule: 2cd9a2651f405aa34c60e43ccc4ef023608d6f92
+  React-graphics: f574f381582a1eee5632bfd5fa1ef7e05e2cb3cd
+  React-hermes: f8b32be4c35319e8e42fc2988cb37bbe8eb5ee78
+  React-idlecallbacksnativemodule: 41817bea59ab577183de9881d92bb09154c49ab0
+  React-ImageManager: 36738f4bbf09285cbfa1bc0d18bf7715f24e0249
+  React-jserrorhandler: bd8b58138f773c1f3f1e2ea730190beca53a8725
+  React-jsi: 5b21b09133d7364383392112d9b4dd751c8b438f
+  React-jsiexecutor: 7f835364605e2e6590083c1df4d50b360398f185
+  React-jsinspector: 4d962cea0a8cf461d2b0f76de6e3f29ad73c128d
+  React-jsinspectorcdp: 84fefd05d64dce694a19bccc8593bdfde0d3e573
+  React-jsinspectornetwork: c03d2d5eb98dd23f9db9a9c33de3f35bdcb7638f
+  React-jsinspectortracing: c908bcaeb2b16a382ff493d4001810ab57633765
+  React-jsitooling: 9c3161134d505db87731becc8e0c605e05f0f34c
+  React-jsitracing: 466fdc56f44f86c5f19e8db3658b36ca48b1212e
+  React-logger: e3d0d02438e5a397ee0dc439957636f2910205ce
+  React-Mapbuffer: cc64bef8b0da852c7558a219d87e28910a49b9e5
+  React-microtasksnativemodule: bf2d7b592a8beea5e937036969761fac841a019f
   react-native-keyboard-controller: 5587bad7f102125e2020720c4e37e0b58ff5e52e
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
   react-native-pager-view: e37989fc447aa4b5de6d0d2ffb0229e817329246
@@ -3736,39 +3736,39 @@ SPEC CHECKSUMS:
   react-native-slider: b76fa3dd989d25e8c2751c2a546674dfc0c2b6f8
   react-native-view-shot: 26174e54ec6b4b7c5d70b86964b747919759adc1
   react-native-webview: a4f0775a31b73cf13cfc3d2d2b119aa94ec76e49
-  React-NativeModulesApple: 8017cc15d3a1882dde7756889eb45e9be64a5d58
-  React-oscompat: 1a7135f36afc81946a27e2176e8afcb518e73141
-  React-perflogger: e6aae1dbf13c2acde7329f75bbbbde43125715f1
-  React-performancecdpmetrics: 10c75aa358b1e225ab6988e0e15786c623b8d667
-  React-performancetimeline: a02c365e92e0a60d55e15fcfb16576efa44afd6b
-  React-RCTActionSheet: 3107e73516a18b979fcf5457a5c9b2435f7fd507
-  React-RCTAnimation: 24a8b1a758ece2a5d4151b0d0fa773024908c6ec
-  React-RCTAppDelegate: 31a5601f5cd78b87851055891bc2c05194749502
-  React-RCTBlob: 88fccd5827f49ec25bf1e410ba517d0eb2c1b86d
-  React-RCTFabric: cfabd7d39465365b2da6ac945613f87494f6e1d2
-  React-RCTFBReactNativeSpec: b82035ed4924b69791f3d90659ff95e296fc2ceb
-  React-RCTImage: 489131a82db4b0f81ca535a579b66a52b9103b04
-  React-RCTLinking: c2f1c3c9dcd5e4dde8718fa929fb2499cd93377a
-  React-RCTNetwork: fefef5a92bcda86c65bb393b9d10f89510aebbcb
-  React-RCTRuntime: 3a59c15c155deb91bcae2ba64cf3821e6a3ff3ce
-  React-RCTSettings: ddf6c870c7262c25f89cfd8e00c9bbb9d29e9406
-  React-RCTText: 7c0772cbb59343a7a6f5d35fe635788d34e06ce8
-  React-RCTVibration: f8cb58ec075cb6efc57b89c823b2952af795ec09
-  React-rendererconsistency: e08e56ef62e18e4cab71cef9c3daff0b68042964
-  React-renderercss: d1e5364f0352729a46197a7ced88431f767059f2
-  React-rendererdebug: fafafdcc4db1ab78bf02889a08fb79bdb97340b5
-  React-RuntimeApple: 88bedcb3fcd012304ed36b7008e8401b005f3b34
-  React-RuntimeCore: 6d63b92530921c861afb753fbf907e71f93509f5
-  React-runtimeexecutor: 489099099bf02a6fafe8a46e29e2c06645aad842
-  React-RuntimeHermes: ac1a90ca4acc3d568b6d269da0173a1e7dc9df40
-  React-runtimescheduler: 4824af73f099892335c2becdd6765ba231b98972
-  React-timing: 2c6aec379bcf9b622c2f96acbc0eeba546cee5a4
-  React-utils: 84ae8e19fb48744597426cc6cb15efd3991c700b
-  React-webperformancenativemodule: 79193119af8d334422aea59a10c9330a51b72b3b
-  ReactAppDependencyProvider: a5f2664120eb6e9dc431a74a40370652311db139
-  ReactCodegen: abd182f9b0e89e025bf0fc3e0f5a7ba57f6c37e2
-  ReactCommon: e17c8981925f02f0b7bef8d1f464ce0ca74c053e
-  ReactNativeDependencies: 286c6874efa19360604024ff0643273be1de5d91
+  React-NativeModulesApple: 169bb5425798368481b3b4ae911833a0c3822759
+  React-oscompat: dc153eed09ee87bc374b255143ca9339bd5556a8
+  React-perflogger: f763d0787a14c6b595d6d1981faa472bceac4e31
+  React-performancecdpmetrics: 780c8391c0bad88f8f490461028018b3a106a56f
+  React-performancetimeline: 2ef25330a0d61f9263dfc625e12d9ad4969405f2
+  React-RCTActionSheet: 6cf10d77cb47a0d9d4bdae6075f911b362a26344
+  React-RCTAnimation: fcfb0df113ccad9453db609d88085478b20397e3
+  React-RCTAppDelegate: c83a7e414ba6d0632ce65463e2d5a7fc4126b122
+  React-RCTBlob: 1d2e8bdb1429074a81d28de4e2a4d0c56643e6b2
+  React-RCTFabric: 9d8a731289216d71109992c549da99e7079e3e01
+  React-RCTFBReactNativeSpec: ebce52c839314577048ae9a04fe81c731a44e4d2
+  React-RCTImage: 7d7d5d6814e4ad53822d78be6e5d8c6fe0b48e85
+  React-RCTLinking: c13f8ea47e49b72d3d9f67235c315fc1e924e91e
+  React-RCTNetwork: 4d628a356fd2cbe6693ac1ee72684cbb4020149c
+  React-RCTRuntime: fed46908b2fdfdc8c24965f0bc550b05a43f90cc
+  React-RCTSettings: b75244d9ecd5320bbfb19cdc5c6cbe8e378b25ee
+  React-RCTText: 0227dac029b355133f9da975f956ff5fbc3b4555
+  React-RCTVibration: 75292ca92dd22ba089c4adf3487f12dde10ffac1
+  React-rendererconsistency: 358eb8fb00c38ba78cf5e72e8a2a3faf94a633c6
+  React-renderercss: 6a5a7abaaee411d9cdcf23a5802d41f48f2ba0d2
+  React-rendererdebug: 9e4e27b215b65259c7a0418b6d264302c33a3341
+  React-RuntimeApple: 85c518c687ac0be44e6df286904ae7bfcecd2db6
+  React-RuntimeCore: 3b68e7474ca2055d2319afbdfdbcab15f5f0ecb7
+  React-runtimeexecutor: c5390f9a49f9c5d3765ce3aa61e4a1e1965c5792
+  React-RuntimeHermes: a1308f2437b71db23ed200f3b99ab45636be87bd
+  React-runtimescheduler: f3a7dc6ec5679b7a22df23ebca35ed789ab9e46c
+  React-timing: 4121ff074bbaefed0608204e88ec2348c9747198
+  React-utils: 8b54a394f9b7ddcc1fcad731854e70be2ce6a536
+  React-webperformancenativemodule: 7f2f10b926d84f2b10067369c95ed29d459a0bea
+  ReactAppDependencyProvider: 77a7129540c0e06ab6be9a2bcb887d3d2e594431
+  ReactCodegen: 2d2fde196f489991b127afed2b1ac948ac3b7c17
+  ReactCommon: 098214faf94e79d56f004cac54464386c4c5d8e0
+  ReactNativeDependencies: beee42eb54e7ca052bd312c214dbe5d1487e02c7
   RNCAsyncStorage: e85a99325df9eb0191a6ee2b2a842644c7eb29f4
   RNCMaskedView: 3c9d7586e2b9bbab573591dcb823918bc4668005
   RNCPicker: 38a9deb903d9a8ae18b598bac727e6c84b3cf0fa
@@ -3783,7 +3783,7 @@ SPEC CHECKSUMS:
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   UMAppLoader: e1234c45d2b7da239e9e90fc4bbeacee12afd5b6
-  Yoga: 04bf2cd82465bca296727b6157a015fe49ac0304
+  Yoga: c972c838201c115255559220e4e14cf76a5401a6
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 07ca240dc3c89dc461c221729e3f0a73e14e9ad8

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -66,7 +66,7 @@
     "native-component-list": "*",
     "react": "19.1.1",
     "react-dom": "19.1.1",
-    "react-native": "0.82.0-rc.4",
+    "react-native": "0.82.0-rc.5",
     "react-native-edge-to-edge": "~1.6.1",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-keyboard-controller": "^1.18.5",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -363,7 +363,7 @@ PODS:
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.82.0-rc.4)
+  - FBLazyVector (0.82.0-rc.5)
   - FirebaseAnalytics (11.11.0):
     - FirebaseAnalytics/AdIdSupport (= 11.11.0)
     - FirebaseCore (~> 11.11.0)
@@ -486,17 +486,17 @@ PODS:
   - GoogleUtilities/UserDefaults (8.0.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - hermes-engine (0.82.0-rc.4):
-    - hermes-engine/cdp (= 0.82.0-rc.4)
-    - hermes-engine/Hermes (= 0.82.0-rc.4)
-    - hermes-engine/inspector (= 0.82.0-rc.4)
-    - hermes-engine/inspector_chrome (= 0.82.0-rc.4)
-    - hermes-engine/Public (= 0.82.0-rc.4)
-  - hermes-engine/cdp (0.82.0-rc.4)
-  - hermes-engine/Hermes (0.82.0-rc.4)
-  - hermes-engine/inspector (0.82.0-rc.4)
-  - hermes-engine/inspector_chrome (0.82.0-rc.4)
-  - hermes-engine/Public (0.82.0-rc.4)
+  - hermes-engine (0.82.0-rc.5):
+    - hermes-engine/cdp (= 0.82.0-rc.5)
+    - hermes-engine/Hermes (= 0.82.0-rc.5)
+    - hermes-engine/inspector (= 0.82.0-rc.5)
+    - hermes-engine/inspector_chrome (= 0.82.0-rc.5)
+    - hermes-engine/Public (= 0.82.0-rc.5)
+  - hermes-engine/cdp (0.82.0-rc.5)
+  - hermes-engine/Hermes (0.82.0-rc.5)
+  - hermes-engine/inspector (0.82.0-rc.5)
+  - hermes-engine/inspector_chrome (0.82.0-rc.5)
+  - hermes-engine/Public (0.82.0-rc.5)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -574,28 +574,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.82.0-rc.4)
-  - RCTRequired (0.82.0-rc.4)
-  - RCTTypeSafety (0.82.0-rc.4):
-    - FBLazyVector (= 0.82.0-rc.4)
-    - RCTRequired (= 0.82.0-rc.4)
-    - React-Core (= 0.82.0-rc.4)
+  - RCTDeprecation (0.82.0-rc.5)
+  - RCTRequired (0.82.0-rc.5)
+  - RCTTypeSafety (0.82.0-rc.5):
+    - FBLazyVector (= 0.82.0-rc.5)
+    - RCTRequired (= 0.82.0-rc.5)
+    - React-Core (= 0.82.0-rc.5)
   - ReachabilitySwift (5.2.4)
-  - React (0.82.0-rc.4):
-    - React-Core (= 0.82.0-rc.4)
-    - React-Core/DevSupport (= 0.82.0-rc.4)
-    - React-Core/RCTWebSocket (= 0.82.0-rc.4)
-    - React-RCTActionSheet (= 0.82.0-rc.4)
-    - React-RCTAnimation (= 0.82.0-rc.4)
-    - React-RCTBlob (= 0.82.0-rc.4)
-    - React-RCTImage (= 0.82.0-rc.4)
-    - React-RCTLinking (= 0.82.0-rc.4)
-    - React-RCTNetwork (= 0.82.0-rc.4)
-    - React-RCTSettings (= 0.82.0-rc.4)
-    - React-RCTText (= 0.82.0-rc.4)
-    - React-RCTVibration (= 0.82.0-rc.4)
-  - React-callinvoker (0.82.0-rc.4)
-  - React-Core (0.82.0-rc.4):
+  - React (0.82.0-rc.5):
+    - React-Core (= 0.82.0-rc.5)
+    - React-Core/DevSupport (= 0.82.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.82.0-rc.5)
+    - React-RCTActionSheet (= 0.82.0-rc.5)
+    - React-RCTAnimation (= 0.82.0-rc.5)
+    - React-RCTBlob (= 0.82.0-rc.5)
+    - React-RCTImage (= 0.82.0-rc.5)
+    - React-RCTLinking (= 0.82.0-rc.5)
+    - React-RCTNetwork (= 0.82.0-rc.5)
+    - React-RCTSettings (= 0.82.0-rc.5)
+    - React-RCTText (= 0.82.0-rc.5)
+    - React-RCTVibration (= 0.82.0-rc.5)
+  - React-callinvoker (0.82.0-rc.5)
+  - React-Core (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -605,7 +605,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.82.0-rc.4)
+    - React-Core/Default (= 0.82.0-rc.5)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -620,82 +620,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.82.0-rc.4):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.82.0-rc.4):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.82.0-rc.4):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.82.0-rc.4)
-    - React-Core/RCTWebSocket (= 0.82.0-rc.4)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.82.0-rc.4):
+  - React-Core/CoreModulesHeaders (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -720,7 +645,57 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.82.0-rc.4):
+  - React-Core/Default (0.82.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.82.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.82.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.82.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -745,7 +720,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.82.0-rc.4):
+  - React-Core/RCTAnimationHeaders (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -770,7 +745,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.82.0-rc.4):
+  - React-Core/RCTBlobHeaders (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -795,7 +770,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.82.0-rc.4):
+  - React-Core/RCTImageHeaders (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -820,7 +795,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.82.0-rc.4):
+  - React-Core/RCTLinkingHeaders (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -845,7 +820,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.82.0-rc.4):
+  - React-Core/RCTNetworkHeaders (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -870,7 +845,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.82.0-rc.4):
+  - React-Core/RCTSettingsHeaders (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -895,7 +870,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.82.0-rc.4):
+  - React-Core/RCTTextHeaders (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -920,7 +895,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.82.0-rc.4):
+  - React-Core/RCTVibrationHeaders (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -930,7 +905,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.82.0-rc.4)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -945,7 +920,32 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.82.0-rc.4):
+  - React-Core/RCTWebSocket (0.82.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.82.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -953,21 +953,21 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.82.0-rc.4)
-    - React-Core/CoreModulesHeaders (= 0.82.0-rc.4)
+    - RCTTypeSafety (= 0.82.0-rc.5)
+    - React-Core/CoreModulesHeaders (= 0.82.0-rc.5)
     - React-debug
-    - React-jsi (= 0.82.0-rc.4)
+    - React-jsi (= 0.82.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.82.0-rc.4)
+    - React-RCTImage (= 0.82.0-rc.5)
     - React-runtimeexecutor
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.82.0-rc.4):
+  - React-cxxreact (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -976,19 +976,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.82.0-rc.4)
-    - React-debug (= 0.82.0-rc.4)
-    - React-jsi (= 0.82.0-rc.4)
+    - React-callinvoker (= 0.82.0-rc.5)
+    - React-debug (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.82.0-rc.4)
-    - React-perflogger (= 0.82.0-rc.4)
+    - React-logger (= 0.82.0-rc.5)
+    - React-perflogger (= 0.82.0-rc.5)
     - React-runtimeexecutor
-    - React-timing (= 0.82.0-rc.4)
+    - React-timing (= 0.82.0-rc.5)
     - SocketRocket
-  - React-debug (0.82.0-rc.4)
-  - React-defaultsnativemodule (0.82.0-rc.4):
+  - React-debug (0.82.0-rc.5)
+  - React-defaultsnativemodule (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1006,7 +1006,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-webperformancenativemodule
     - SocketRocket
-  - React-domnativemodule (0.82.0-rc.4):
+  - React-domnativemodule (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1026,7 +1026,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.82.0-rc.4):
+  - React-Fabric (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1040,23 +1040,23 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.82.0-rc.4)
-    - React-Fabric/attributedstring (= 0.82.0-rc.4)
-    - React-Fabric/bridging (= 0.82.0-rc.4)
-    - React-Fabric/componentregistry (= 0.82.0-rc.4)
-    - React-Fabric/componentregistrynative (= 0.82.0-rc.4)
-    - React-Fabric/components (= 0.82.0-rc.4)
-    - React-Fabric/consistency (= 0.82.0-rc.4)
-    - React-Fabric/core (= 0.82.0-rc.4)
-    - React-Fabric/dom (= 0.82.0-rc.4)
-    - React-Fabric/imagemanager (= 0.82.0-rc.4)
-    - React-Fabric/leakchecker (= 0.82.0-rc.4)
-    - React-Fabric/mounting (= 0.82.0-rc.4)
-    - React-Fabric/observers (= 0.82.0-rc.4)
-    - React-Fabric/scheduler (= 0.82.0-rc.4)
-    - React-Fabric/telemetry (= 0.82.0-rc.4)
-    - React-Fabric/templateprocessor (= 0.82.0-rc.4)
-    - React-Fabric/uimanager (= 0.82.0-rc.4)
+    - React-Fabric/animations (= 0.82.0-rc.5)
+    - React-Fabric/attributedstring (= 0.82.0-rc.5)
+    - React-Fabric/bridging (= 0.82.0-rc.5)
+    - React-Fabric/componentregistry (= 0.82.0-rc.5)
+    - React-Fabric/componentregistrynative (= 0.82.0-rc.5)
+    - React-Fabric/components (= 0.82.0-rc.5)
+    - React-Fabric/consistency (= 0.82.0-rc.5)
+    - React-Fabric/core (= 0.82.0-rc.5)
+    - React-Fabric/dom (= 0.82.0-rc.5)
+    - React-Fabric/imagemanager (= 0.82.0-rc.5)
+    - React-Fabric/leakchecker (= 0.82.0-rc.5)
+    - React-Fabric/mounting (= 0.82.0-rc.5)
+    - React-Fabric/observers (= 0.82.0-rc.5)
+    - React-Fabric/scheduler (= 0.82.0-rc.5)
+    - React-Fabric/telemetry (= 0.82.0-rc.5)
+    - React-Fabric/templateprocessor (= 0.82.0-rc.5)
+    - React-Fabric/uimanager (= 0.82.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1068,32 +1068,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.82.0-rc.4):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.82.0-rc.4):
+  - React-Fabric/animations (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1118,7 +1093,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/bridging (0.82.0-rc.4):
+  - React-Fabric/attributedstring (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1143,7 +1118,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.82.0-rc.4):
+  - React-Fabric/bridging (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1168,7 +1143,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.82.0-rc.4):
+  - React-Fabric/componentregistry (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1193,36 +1168,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.82.0-rc.4):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.82.0-rc.4)
-    - React-Fabric/components/root (= 0.82.0-rc.4)
-    - React-Fabric/components/scrollview (= 0.82.0-rc.4)
-    - React-Fabric/components/view (= 0.82.0-rc.4)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.82.0-rc.4):
+  - React-Fabric/componentregistrynative (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1247,7 +1193,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.82.0-rc.4):
+  - React-Fabric/components (0.82.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.82.0-rc.5)
+    - React-Fabric/components/root (= 0.82.0-rc.5)
+    - React-Fabric/components/scrollview (= 0.82.0-rc.5)
+    - React-Fabric/components/view (= 0.82.0-rc.5)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1272,7 +1247,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.82.0-rc.4):
+  - React-Fabric/components/root (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1297,7 +1272,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.82.0-rc.4):
+  - React-Fabric/components/scrollview (0.82.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1324,7 +1324,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.82.0-rc.4):
+  - React-Fabric/consistency (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1349,7 +1349,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.82.0-rc.4):
+  - React-Fabric/core (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1374,7 +1374,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.82.0-rc.4):
+  - React-Fabric/dom (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1399,7 +1399,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.82.0-rc.4):
+  - React-Fabric/imagemanager (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1424,7 +1424,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.82.0-rc.4):
+  - React-Fabric/leakchecker (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1449,7 +1449,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.82.0-rc.4):
+  - React-Fabric/mounting (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1474,7 +1474,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.82.0-rc.4):
+  - React-Fabric/observers (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1488,7 +1488,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.82.0-rc.4)
+    - React-Fabric/observers/events (= 0.82.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1500,7 +1500,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.82.0-rc.4):
+  - React-Fabric/observers/events (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1525,7 +1525,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.82.0-rc.4):
+  - React-Fabric/scheduler (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1553,7 +1553,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.82.0-rc.4):
+  - React-Fabric/telemetry (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1578,7 +1578,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.82.0-rc.4):
+  - React-Fabric/templateprocessor (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1603,7 +1603,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.82.0-rc.4):
+  - React-Fabric/uimanager (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1617,7 +1617,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.82.0-rc.4)
+    - React-Fabric/uimanager/consistency (= 0.82.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1630,7 +1630,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager/consistency (0.82.0-rc.4):
+  - React-Fabric/uimanager/consistency (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1656,7 +1656,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.82.0-rc.4):
+  - React-FabricComponents (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1671,8 +1671,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.82.0-rc.4)
-    - React-FabricComponents/textlayoutmanager (= 0.82.0-rc.4)
+    - React-FabricComponents/components (= 0.82.0-rc.5)
+    - React-FabricComponents/textlayoutmanager (= 0.82.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1685,7 +1685,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.82.0-rc.4):
+  - React-FabricComponents/components (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1700,18 +1700,18 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.82.0-rc.4)
-    - React-FabricComponents/components/iostextinput (= 0.82.0-rc.4)
-    - React-FabricComponents/components/modal (= 0.82.0-rc.4)
-    - React-FabricComponents/components/rncore (= 0.82.0-rc.4)
-    - React-FabricComponents/components/safeareaview (= 0.82.0-rc.4)
-    - React-FabricComponents/components/scrollview (= 0.82.0-rc.4)
-    - React-FabricComponents/components/switch (= 0.82.0-rc.4)
-    - React-FabricComponents/components/text (= 0.82.0-rc.4)
-    - React-FabricComponents/components/textinput (= 0.82.0-rc.4)
-    - React-FabricComponents/components/unimplementedview (= 0.82.0-rc.4)
-    - React-FabricComponents/components/virtualview (= 0.82.0-rc.4)
-    - React-FabricComponents/components/virtualviewexperimental (= 0.82.0-rc.4)
+    - React-FabricComponents/components/inputaccessory (= 0.82.0-rc.5)
+    - React-FabricComponents/components/iostextinput (= 0.82.0-rc.5)
+    - React-FabricComponents/components/modal (= 0.82.0-rc.5)
+    - React-FabricComponents/components/rncore (= 0.82.0-rc.5)
+    - React-FabricComponents/components/safeareaview (= 0.82.0-rc.5)
+    - React-FabricComponents/components/scrollview (= 0.82.0-rc.5)
+    - React-FabricComponents/components/switch (= 0.82.0-rc.5)
+    - React-FabricComponents/components/text (= 0.82.0-rc.5)
+    - React-FabricComponents/components/textinput (= 0.82.0-rc.5)
+    - React-FabricComponents/components/unimplementedview (= 0.82.0-rc.5)
+    - React-FabricComponents/components/virtualview (= 0.82.0-rc.5)
+    - React-FabricComponents/components/virtualviewexperimental (= 0.82.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1724,34 +1724,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.82.0-rc.4):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.82.0-rc.4):
+  - React-FabricComponents/components/inputaccessory (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1778,7 +1751,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/modal (0.82.0-rc.4):
+  - React-FabricComponents/components/iostextinput (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1805,7 +1778,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.82.0-rc.4):
+  - React-FabricComponents/components/modal (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1832,7 +1805,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.82.0-rc.4):
+  - React-FabricComponents/components/rncore (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1859,7 +1832,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.82.0-rc.4):
+  - React-FabricComponents/components/safeareaview (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1886,7 +1859,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/switch (0.82.0-rc.4):
+  - React-FabricComponents/components/scrollview (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1913,7 +1886,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.82.0-rc.4):
+  - React-FabricComponents/components/switch (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1940,7 +1913,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.82.0-rc.4):
+  - React-FabricComponents/components/text (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1967,7 +1940,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.82.0-rc.4):
+  - React-FabricComponents/components/textinput (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1994,7 +1967,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualview (0.82.0-rc.4):
+  - React-FabricComponents/components/unimplementedview (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2021,7 +1994,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualviewexperimental (0.82.0-rc.4):
+  - React-FabricComponents/components/virtualview (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2048,7 +2021,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.82.0-rc.4):
+  - React-FabricComponents/components/virtualviewexperimental (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2075,7 +2048,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.82.0-rc.4):
+  - React-FabricComponents/textlayoutmanager (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2084,21 +2057,48 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.82.0-rc.4)
-    - RCTTypeSafety (= 0.82.0-rc.4)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.82.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.82.0-rc.5)
+    - RCTTypeSafety (= 0.82.0-rc.5)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.82.0-rc.4)
+    - React-jsiexecutor (= 0.82.0-rc.5)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.82.0-rc.4):
+  - React-featureflags (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2107,7 +2107,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.82.0-rc.4):
+  - React-featureflagsnativemodule (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2122,7 +2122,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.82.0-rc.4):
+  - React-graphics (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2135,7 +2135,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.82.0-rc.4):
+  - React-hermes (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2144,17 +2144,17 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.82.0-rc.4)
+    - React-cxxreact (= 0.82.0-rc.5)
     - React-jsi
-    - React-jsiexecutor (= 0.82.0-rc.4)
+    - React-jsiexecutor (= 0.82.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.82.0-rc.4)
+    - React-perflogger (= 0.82.0-rc.5)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.82.0-rc.4):
+  - React-idlecallbacksnativemodule (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2170,7 +2170,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.82.0-rc.4):
+  - React-ImageManager (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2185,7 +2185,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jserrorhandler (0.82.0-rc.4):
+  - React-jserrorhandler (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2200,7 +2200,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.82.0-rc.4):
+  - React-jsi (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2210,7 +2210,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.82.0-rc.4):
+  - React-jsiexecutor (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2228,7 +2228,7 @@ PODS:
     - React-perflogger
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspector (0.82.0-rc.4):
+  - React-jsinspector (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2243,10 +2243,10 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.82.0-rc.4)
+    - React-perflogger (= 0.82.0-rc.5)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspectorcdp (0.82.0-rc.4):
+  - React-jsinspectorcdp (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2255,7 +2255,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.82.0-rc.4):
+  - React-jsinspectornetwork (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2268,7 +2268,7 @@ PODS:
     - React-performancetimeline
     - React-timing
     - SocketRocket
-  - React-jsinspectortracing (0.82.0-rc.4):
+  - React-jsinspectortracing (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2279,7 +2279,7 @@ PODS:
     - React-oscompat
     - React-timing
     - SocketRocket
-  - React-jsitooling (0.82.0-rc.4):
+  - React-jsitooling (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2287,17 +2287,17 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.82.0-rc.4)
+    - React-cxxreact (= 0.82.0-rc.5)
     - React-debug
-    - React-jsi (= 0.82.0-rc.4)
+    - React-jsi (= 0.82.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsitracing (0.82.0-rc.4):
+  - React-jsitracing (0.82.0-rc.5):
     - React-jsi
-  - React-logger (0.82.0-rc.4):
+  - React-logger (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2306,7 +2306,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.82.0-rc.4):
+  - React-Mapbuffer (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2316,7 +2316,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.82.0-rc.4):
+  - React-microtasksnativemodule (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2655,7 +2655,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-NativeModulesApple (0.82.0-rc.4):
+  - React-NativeModulesApple (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2676,8 +2676,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.82.0-rc.4)
-  - React-perflogger (0.82.0-rc.4):
+  - React-oscompat (0.82.0-rc.5)
+  - React-perflogger (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2686,7 +2686,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancecdpmetrics (0.82.0-rc.4):
+  - React-performancecdpmetrics (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2700,7 +2700,7 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - SocketRocket
-  - React-performancetimeline (0.82.0-rc.4):
+  - React-performancetimeline (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2713,9 +2713,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.82.0-rc.4):
-    - React-Core/RCTActionSheetHeaders (= 0.82.0-rc.4)
-  - React-RCTAnimation (0.82.0-rc.4):
+  - React-RCTActionSheet (0.82.0-rc.5):
+    - React-Core/RCTActionSheetHeaders (= 0.82.0-rc.5)
+  - React-RCTAnimation (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2731,7 +2731,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.82.0-rc.4):
+  - React-RCTAppDelegate (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2765,7 +2765,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.82.0-rc.4):
+  - React-RCTBlob (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2784,7 +2784,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.82.0-rc.4):
+  - React-RCTFabric (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2820,7 +2820,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.82.0-rc.4):
+  - React-RCTFBReactNativeSpec (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2834,10 +2834,10 @@ PODS:
     - React-Core
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.82.0-rc.4)
+    - React-RCTFBReactNativeSpec/components (= 0.82.0-rc.5)
     - ReactCommon
     - SocketRocket
-  - React-RCTFBReactNativeSpec/components (0.82.0-rc.4):
+  - React-RCTFBReactNativeSpec/components (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2860,7 +2860,7 @@ PODS:
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-RCTImage (0.82.0-rc.4):
+  - React-RCTImage (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2876,14 +2876,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.82.0-rc.4):
-    - React-Core/RCTLinkingHeaders (= 0.82.0-rc.4)
-    - React-jsi (= 0.82.0-rc.4)
+  - React-RCTLinking (0.82.0-rc.5):
+    - React-Core/RCTLinkingHeaders (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0-rc.5)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.82.0-rc.4)
-  - React-RCTNetwork (0.82.0-rc.4):
+    - ReactCommon/turbomodule/core (= 0.82.0-rc.5)
+  - React-RCTNetwork (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2902,7 +2902,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.82.0-rc.4):
+  - React-RCTRuntime (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2923,7 +2923,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.82.0-rc.4):
+  - React-RCTSettings (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2938,10 +2938,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.82.0-rc.4):
-    - React-Core/RCTTextHeaders (= 0.82.0-rc.4)
+  - React-RCTText (0.82.0-rc.5):
+    - React-Core/RCTTextHeaders (= 0.82.0-rc.5)
     - Yoga
-  - React-RCTVibration (0.82.0-rc.4):
+  - React-RCTVibration (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2955,11 +2955,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.82.0-rc.4)
-  - React-renderercss (0.82.0-rc.4):
+  - React-rendererconsistency (0.82.0-rc.5)
+  - React-renderercss (0.82.0-rc.5):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.82.0-rc.4):
+  - React-rendererdebug (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2969,7 +2969,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-RuntimeApple (0.82.0-rc.4):
+  - React-RuntimeApple (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2998,7 +2998,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.82.0-rc.4):
+  - React-RuntimeCore (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3020,7 +3020,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.82.0-rc.4):
+  - React-runtimeexecutor (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3030,10 +3030,10 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.82.0-rc.4)
+    - React-jsi (= 0.82.0-rc.5)
     - React-utils
     - SocketRocket
-  - React-RuntimeHermes (0.82.0-rc.4):
+  - React-RuntimeHermes (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3054,7 +3054,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.82.0-rc.4):
+  - React-runtimescheduler (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3076,9 +3076,9 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.82.0-rc.4):
+  - React-timing (0.82.0-rc.5):
     - React-debug
-  - React-utils (0.82.0-rc.4):
+  - React-utils (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3088,9 +3088,9 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - React-debug
-    - React-jsi (= 0.82.0-rc.4)
+    - React-jsi (= 0.82.0-rc.5)
     - SocketRocket
-  - React-webperformancenativemodule (0.82.0-rc.4):
+  - React-webperformancenativemodule (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3106,9 +3106,9 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactAppDependencyProvider (0.82.0-rc.4):
+  - ReactAppDependencyProvider (0.82.0-rc.5):
     - ReactCodegen
-  - ReactCodegen (0.82.0-rc.4):
+  - ReactCodegen (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3134,7 +3134,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.82.0-rc.4):
+  - ReactCommon (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3142,9 +3142,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.82.0-rc.4)
+    - ReactCommon/turbomodule (= 0.82.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule (0.82.0-rc.4):
+  - ReactCommon/turbomodule (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3153,15 +3153,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.82.0-rc.4)
-    - React-cxxreact (= 0.82.0-rc.4)
-    - React-jsi (= 0.82.0-rc.4)
-    - React-logger (= 0.82.0-rc.4)
-    - React-perflogger (= 0.82.0-rc.4)
-    - ReactCommon/turbomodule/bridging (= 0.82.0-rc.4)
-    - ReactCommon/turbomodule/core (= 0.82.0-rc.4)
+    - React-callinvoker (= 0.82.0-rc.5)
+    - React-cxxreact (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0-rc.5)
+    - React-logger (= 0.82.0-rc.5)
+    - React-perflogger (= 0.82.0-rc.5)
+    - ReactCommon/turbomodule/bridging (= 0.82.0-rc.5)
+    - ReactCommon/turbomodule/core (= 0.82.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.82.0-rc.4):
+  - ReactCommon/turbomodule/bridging (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3170,13 +3170,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.82.0-rc.4)
-    - React-cxxreact (= 0.82.0-rc.4)
-    - React-jsi (= 0.82.0-rc.4)
-    - React-logger (= 0.82.0-rc.4)
-    - React-perflogger (= 0.82.0-rc.4)
+    - React-callinvoker (= 0.82.0-rc.5)
+    - React-cxxreact (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0-rc.5)
+    - React-logger (= 0.82.0-rc.5)
+    - React-perflogger (= 0.82.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.82.0-rc.4):
+  - ReactCommon/turbomodule/core (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3185,14 +3185,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.82.0-rc.4)
-    - React-cxxreact (= 0.82.0-rc.4)
-    - React-debug (= 0.82.0-rc.4)
-    - React-featureflags (= 0.82.0-rc.4)
-    - React-jsi (= 0.82.0-rc.4)
-    - React-logger (= 0.82.0-rc.4)
-    - React-perflogger (= 0.82.0-rc.4)
-    - React-utils (= 0.82.0-rc.4)
+    - React-callinvoker (= 0.82.0-rc.5)
+    - React-cxxreact (= 0.82.0-rc.5)
+    - React-debug (= 0.82.0-rc.5)
+    - React-featureflags (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0-rc.5)
+    - React-logger (= 0.82.0-rc.5)
+    - React-perflogger (= 0.82.0-rc.5)
+    - React-utils (= 0.82.0-rc.5)
     - SocketRocket
   - RNCAsyncStorage (2.2.0):
     - boost
@@ -4382,7 +4382,7 @@ SPEC CHECKSUMS:
   EXUpdates: 7b51bc7f220277034ccb656c467c9a4555266a52
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: 4963926890f2f2b981e1c4e2af79c37d0a9121f3
+  FBLazyVector: 8d893933d9b2b77508382e4baf21f5b5464cb57a
   FirebaseAnalytics: acfa848bf81e1a4dbf60ef1f0eddd7328fe6673e
   FirebaseCore: 2321536f9c423b1f857e047a82b8a42abc6d9e2c
   FirebaseCoreExtension: 3a64994969dd05f4bcb7e6896c654eded238e75b
@@ -4398,7 +4398,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 2fa76bc707893600b11bc608923145721aa909bc
+  hermes-engine: 3d1b94435f41419b5dd515584057b36a27e81ced
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -4411,39 +4411,39 @@ SPEC CHECKSUMS:
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
-  RCTDeprecation: 5f54be68187ef1fc21b4d70a262f0d05d6fba854
-  RCTRequired: e52808dfaf897a452bf296466de8c3c5a3ca9332
-  RCTTypeSafety: 0c96598083fbfd1c605997a7c2d51a25ac97c35b
+  RCTDeprecation: 41e5e0af75686dad802af9706c4eba1efa66ecfe
+  RCTRequired: 4a064c2751982b11344b923951bc7e27d6a9d467
+  RCTTypeSafety: 9c5a00fa9bd7abad20b2c520bbb823613cc2f2e2
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 0fde0b13f6cca9b4e4525d888dd952e87e5f2c28
-  React-callinvoker: 726b0350220fa95dfdf03c81eee83f65bc88de3f
-  React-Core: 3f3476b0109d243df3c3569d44344495cfd9ce7c
-  React-CoreModules: 86275914c7ff2e425499c9b22eb534ca2055c6e3
-  React-cxxreact: 41a2c7c64285dadcd5c537fc215c763e9261f7a0
-  React-debug: c5d7221ff1dd6c84f966ef7e6427d76ba1299f72
-  React-defaultsnativemodule: a142ab2dcc546eb7467e19fbec2a2c6ebae00a5b
-  React-domnativemodule: 4fa78b4145cf34605adfc72e288df2cd30e49d9a
-  React-Fabric: ad73134d464976f3f6c763c61932f7f4bdbd3759
-  React-FabricComponents: c19a5a931137b2f87b7d3cdc085304f14783fac0
-  React-FabricImage: 5f24b11c1ef83880816d41312323b195945c997f
-  React-featureflags: bdf0a3cf931aaaadabd225e1f7e7856de1a4b367
-  React-featureflagsnativemodule: a47979095480a93306a0c12e31994452770539ff
-  React-graphics: 0b06e4876757d19337807427042df1f91d9b9494
-  React-hermes: ffde9d3453084d36e5e085dd4e9dbd4f355ca19d
-  React-idlecallbacksnativemodule: 2a9c551bcdde6e7c9b969efd7558f127f0636d07
-  React-ImageManager: d44b1190347f0139c0cb0df4a759c82f643993c9
-  React-jserrorhandler: 7ca9726661fdea1c607e6487ccc2dd858bb4707a
-  React-jsi: 634bd7de0db396438cc00ba8b07519491d02a430
-  React-jsiexecutor: d05dacc22eb1ba5862c91a305a338082a241b745
-  React-jsinspector: 19969e1030b17fa08b42876ce7f1e1d358803065
-  React-jsinspectorcdp: 589536f53093e88bbc2aa01467606771407e9105
-  React-jsinspectornetwork: ce24874f5ac72ea17a716c2d4e86b11fd75d9bce
-  React-jsinspectortracing: a3f45fda400e99c16e1ed9b4531491a0cfbd9ae3
-  React-jsitooling: bc4a8c7d3532757f99c56a39458488bf5bed6639
-  React-jsitracing: f77703ab7433057301149e2322c357245ddb9370
-  React-logger: feb3f051130f9e1707282929699fe7bbb71675e3
-  React-Mapbuffer: 0e021a42050d684ac8c1536b28fde11b6e710b26
-  React-microtasksnativemodule: cd612606b6d9a6568262a153f8e713c0578112cd
+  React: 6eb704af98132bfdd36a19d9910b4d317d13100c
+  React-callinvoker: f103ec1e45df5713addfb0264a73eb7a4e0b9016
+  React-Core: 8a56e97e5acba6e473e7b2b175e078454cb4dd30
+  React-CoreModules: 4b25453083ea8f1bdfae3a6743d469043b67674e
+  React-cxxreact: 8a584a593a1fdb95483bad85b754aedaf8a60679
+  React-debug: d7c1d26881c507aa4c4c94a4657b9bca1ad4609d
+  React-defaultsnativemodule: d183f5204623c8eb775f163797596c704ca2416b
+  React-domnativemodule: 8e33e02a3290b2d8177b5a9b16495de935ed0b2b
+  React-Fabric: 17ab641193eb6b8bacc5f46b8f76e2f602332680
+  React-FabricComponents: 30400d7971f92a95f1b9620e82b1c98811f2c014
+  React-FabricImage: 23a39b1632ee6f7c1824e16180a8867b87d35f35
+  React-featureflags: 97933c8a06500cd161bd18cf4fbe2c9374d70e14
+  React-featureflagsnativemodule: dc1d536146fd73d070b8c2a89ed4c488b24dd6a4
+  React-graphics: 6f5cbb1167dde595a66d65ba220f9c54314e44d5
+  React-hermes: 50d1474fce48b94e3cc55a6356f00c6ffde3efff
+  React-idlecallbacksnativemodule: 09edf02e62f0d5cef34580156a2ffacd5425d464
+  React-ImageManager: 5d99c989f36b5c592b9582df486d2cd7f9a1da90
+  React-jserrorhandler: 010e321942df06ca3981898029623f85a291ffb2
+  React-jsi: 15dc6cbe84aefb9e6773827ea8ee9fa198a44564
+  React-jsiexecutor: 652a3c67c11c1a161866b06ca2639d5b0758b384
+  React-jsinspector: d22aa6ea27544048de489147a5dc8372422dc95a
+  React-jsinspectorcdp: f0216317d66edc8433fb04a27ff84e391425b582
+  React-jsinspectornetwork: 069620f58fd4215709c8a5d143c8182df1f20b94
+  React-jsinspectortracing: d0f3e3f01514726b3aa4d6c55ec77675ecc2bf10
+  React-jsitooling: 737fd34d451d4119c1f7320fc04fe034ef4da287
+  React-jsitracing: c8cd1009d69ff04eadc768ecdf1c1c43973a304f
+  React-logger: 1cd1f61088c1c6c04c62ddd9770af0955b500a86
+  React-Mapbuffer: 7cfd84b044618d1afe5310362c9e5c932bd43063
+  React-microtasksnativemodule: da1d0d2f783690ad5776a63d45ea9753571f93af
   react-native-google-maps: 7cc1184afe41fbd15a3dffd53c924819f6587b69
   react-native-keyboard-controller: 5e209d13d4c5355ddf8c36be3d41b8dfc879cd91
   react-native-maps: ee1e65647460c3d41e778071be5eda10e3da6225
@@ -4455,38 +4455,38 @@ SPEC CHECKSUMS:
   react-native-slider: 30cea7008de785564de2f4fd064f2deb38614a4a
   react-native-view-shot: aac285cd08144be29c19ab659930172836f0067f
   react-native-webview: 183e0d1f10b3c61c5ddd70f4ecd46488856a3573
-  React-NativeModulesApple: 548ef6da4fc74f59d581eb68684deef655b700e9
-  React-oscompat: 1a6aa7919259f5f49f1f1cf6041d2941acb6dc70
-  React-perflogger: f8bca1b1bcf7f7785b8526a98672382522c6e0e9
-  React-performancecdpmetrics: 5d894f46fa068a44dcfe4a83f5ad62a9cb75ee5f
-  React-performancetimeline: d86d218f21e6256969e20fa36ac8fb94722e64fc
-  React-RCTActionSheet: abf57df1aca1a93f2fb018a48cbf9628617e1081
-  React-RCTAnimation: 1174b63f774a66f4ef01121cf22127daae33293e
-  React-RCTAppDelegate: fd45b8b8c294e67eea5d48071367eb2fdeb56e62
-  React-RCTBlob: eb0efe9d40496c5e68f0788a3528cf79642084d4
-  React-RCTFabric: 0078af9b7db01c49a7b7fb2ade7fce72a3575e91
-  React-RCTFBReactNativeSpec: 36c0e946517080ecb31e7f633b6a38a27db40931
-  React-RCTImage: 16eaed915221cd38daee2d395295b39dcb653469
-  React-RCTLinking: 22bc8b89ae7c87a11a4a59681dadaa9d26aca1e7
-  React-RCTNetwork: d97052f5c5df8475c20307a2054fa3c3b38d97e8
-  React-RCTRuntime: 5a80780f7810b1236c51a22fa852d74f1f40cd91
-  React-RCTSettings: 7144291b1e80e9a12ca53ebdb02bfd253048819f
-  React-RCTText: 0746088c96849c313db22681ead9236299b9c898
-  React-RCTVibration: d895f534f1bf8840aef3bf77dc5ee48dde2b60b2
-  React-rendererconsistency: b10d5a7fab7187ca6224d77b946ed8ebffc27db2
-  React-renderercss: 78625c7c59bdb0fe4e0af7f39c4a0f35e5331995
-  React-rendererdebug: e2703f607fc5d741d1a3da102214edd0b60767bf
-  React-RuntimeApple: 3213f49bcd28cabaa0d38ef78c4e76a8f0f3e083
-  React-RuntimeCore: 86d99a32fb7d5dbeebaa79c320a7c1b103271273
-  React-runtimeexecutor: 48a7ee3125b89195e94ab1be170f4419a52af8da
-  React-RuntimeHermes: 585289fb055a6c87b348d1fd16af90e23bcaf0be
-  React-runtimescheduler: 305dbb58a76a81b6a02a9be94a3891647a71fddc
-  React-timing: 820d7b380bcd822b40a4293d593b225bcb95c3d3
-  React-utils: 77321db49a1bd4db1bc90925c9109fbb724dfd62
-  React-webperformancenativemodule: 8495b40213855a83338b1dc18b6f8378c9d65e5c
-  ReactAppDependencyProvider: a5f2664120eb6e9dc431a74a40370652311db139
-  ReactCodegen: fe87c01d16d840c5a8c0e65cb5af70b503b2c31d
-  ReactCommon: 114c055df7b30fce1a79185416b9b9f28cf9c199
+  React-NativeModulesApple: 67bd0ae88813a06fdab277bb4e0de50a3d470868
+  React-oscompat: 8f6bc162c03dfa41e70b9ab32bd1b692ac81051f
+  React-perflogger: 68b4a7c738f626b9787731d08d9f8a5c0feb2122
+  React-performancecdpmetrics: fb395ba9b7a005d8b0b590bd3aa227cf94451dbb
+  React-performancetimeline: 964e713588b39c91cad8475b3175da4d8677c653
+  React-RCTActionSheet: fde5090d31e027bd3099147d50ac4a69d9817c2c
+  React-RCTAnimation: c82e86775617fd3168b02be78c0b05db7727d013
+  React-RCTAppDelegate: 2a6e85772234b7022d7b017b83701ddeb58df49c
+  React-RCTBlob: 115b25b8f24332a6a21de43923bc655028fff937
+  React-RCTFabric: 9e41b38902cf2f856db99bc6626b7bf6b0fe3bee
+  React-RCTFBReactNativeSpec: db702c31cc71ff31017175aa235b4c9d4435e0f2
+  React-RCTImage: 7a0198ddd93dabadb69340a9385426475e21169e
+  React-RCTLinking: 85d7e02a9952a96e485ee48c3d030643afd587bd
+  React-RCTNetwork: 5cde64476ed1af70569ffc709ffc5663fb08b17b
+  React-RCTRuntime: 7e38a59559a5b9eaceb1fbb41bccc305f4fe434a
+  React-RCTSettings: 35154ee1f399ce54fd17b209f6a73147a5ed9345
+  React-RCTText: d8c98f4db4f1ec054ffb2f58b22b49dcedcfb6d3
+  React-RCTVibration: 23effbb317e27408a360d2467f8424099606678f
+  React-rendererconsistency: a114ca1d18e1c4ba6b8af818844b3bde9db76570
+  React-renderercss: 87aebb3a6a117c252941e68ef15d4ba459a1c03e
+  React-rendererdebug: a0423813386bdb102599789412d15d853ba4de5e
+  React-RuntimeApple: d266813a3d020756b297756dfd32310b7c2bfd26
+  React-RuntimeCore: 69585249c6114cbd75a8c0caa0fc606c9a9b5e0f
+  React-runtimeexecutor: c48455042001ad3cb97d4e6a0d3c7fb85ed5c289
+  React-RuntimeHermes: 050bb22f355a1f19df01149899db615672f76a99
+  React-runtimescheduler: 409d894a239182cb77e89f0a841ed0b36bd92f26
+  React-timing: dd3be228e14215f4300f3b9a891d9ce6f6735c96
+  React-utils: c08f3c5a29941dc41c7bfdf90e8ae76b8b3f9d86
+  React-webperformancenativemodule: 495882f02c4be9e4fb0836d445a6c792d2948615
+  ReactAppDependencyProvider: 77a7129540c0e06ab6be9a2bcb887d3d2e594431
+  ReactCodegen: 9754d3c716175df084aff56b430c67a393c8d113
+  ReactCommon: d07170f92e0e853091a70b2741b7c43f5dfdea73
   RNCAsyncStorage: 302f2fac014fd450046c120567ca364632da682b
   RNCMaskedView: 63268de1986a098b5f4d1fb5b1bc1e97fade0aee
   RNCPicker: 51992b3407f6b70ddb8e417ec5714c3f2d48d8a4
@@ -4511,7 +4511,7 @@ SPEC CHECKSUMS:
   StripePaymentsUI: 05d4be35b34f821d5ddc8617dee04219f3646253
   StripeUICore: d07bd63a4b53dee8cab4d6f81ce5a7ab3e28511e
   UMAppLoader: e1234c45d2b7da239e9e90fc4bbeacee12afd5b6
-  Yoga: e80c5fabbc3e26311152fa20404cdfa14f16a11f
+  Yoga: 47264cc34431da6b66b3687348be283084924f46
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: aaaa821356ecede13bd3ebe65b62ce223458b0fa

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -68,7 +68,7 @@
     "prop-types": "^15.7.2",
     "querystring": "^0.2.0",
     "react": "19.1.1",
-    "react-native": "0.82.0-rc.4",
+    "react-native": "0.82.0-rc.5",
     "react-native-edge-to-edge": "1.6.0",
     "react-native-fade-in-image": "^1.6.1",
     "react-native-gesture-handler": "~2.28.0",

--- a/apps/jest-expo-mock-generator/package.json
+++ b/apps/jest-expo-mock-generator/package.json
@@ -9,6 +9,6 @@
     "expo": "~54.0.8",
     "expo-clipboard": "~8.0.7",
     "react": "19.1.1",
-    "react-native": "0.82.0-rc.4"
+    "react-native": "0.82.0-rc.5"
   }
 }

--- a/apps/minimal-tester/ios/Podfile.lock
+++ b/apps/minimal-tester/ios/Podfile.lock
@@ -342,12 +342,12 @@ PODS:
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.82.0-rc.4)
+  - FBLazyVector (0.82.0-rc.5)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - hermes-engine (0.82.0-rc.4):
-    - hermes-engine/Pre-built (= 0.82.0-rc.4)
-  - hermes-engine/Pre-built (0.82.0-rc.4)
+  - hermes-engine (0.82.0-rc.5):
+    - hermes-engine/Pre-built (= 0.82.0-rc.5)
+  - hermes-engine/Pre-built (0.82.0-rc.5)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -384,28 +384,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.82.0-rc.4)
-  - RCTRequired (0.82.0-rc.4)
-  - RCTTypeSafety (0.82.0-rc.4):
-    - FBLazyVector (= 0.82.0-rc.4)
-    - RCTRequired (= 0.82.0-rc.4)
-    - React-Core (= 0.82.0-rc.4)
+  - RCTDeprecation (0.82.0-rc.5)
+  - RCTRequired (0.82.0-rc.5)
+  - RCTTypeSafety (0.82.0-rc.5):
+    - FBLazyVector (= 0.82.0-rc.5)
+    - RCTRequired (= 0.82.0-rc.5)
+    - React-Core (= 0.82.0-rc.5)
   - ReachabilitySwift (5.2.4)
-  - React (0.82.0-rc.4):
-    - React-Core (= 0.82.0-rc.4)
-    - React-Core/DevSupport (= 0.82.0-rc.4)
-    - React-Core/RCTWebSocket (= 0.82.0-rc.4)
-    - React-RCTActionSheet (= 0.82.0-rc.4)
-    - React-RCTAnimation (= 0.82.0-rc.4)
-    - React-RCTBlob (= 0.82.0-rc.4)
-    - React-RCTImage (= 0.82.0-rc.4)
-    - React-RCTLinking (= 0.82.0-rc.4)
-    - React-RCTNetwork (= 0.82.0-rc.4)
-    - React-RCTSettings (= 0.82.0-rc.4)
-    - React-RCTText (= 0.82.0-rc.4)
-    - React-RCTVibration (= 0.82.0-rc.4)
-  - React-callinvoker (0.82.0-rc.4)
-  - React-Core (0.82.0-rc.4):
+  - React (0.82.0-rc.5):
+    - React-Core (= 0.82.0-rc.5)
+    - React-Core/DevSupport (= 0.82.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.82.0-rc.5)
+    - React-RCTActionSheet (= 0.82.0-rc.5)
+    - React-RCTAnimation (= 0.82.0-rc.5)
+    - React-RCTBlob (= 0.82.0-rc.5)
+    - React-RCTImage (= 0.82.0-rc.5)
+    - React-RCTLinking (= 0.82.0-rc.5)
+    - React-RCTNetwork (= 0.82.0-rc.5)
+    - React-RCTSettings (= 0.82.0-rc.5)
+    - React-RCTText (= 0.82.0-rc.5)
+    - React-RCTVibration (= 0.82.0-rc.5)
+  - React-callinvoker (0.82.0-rc.5)
+  - React-Core (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -415,7 +415,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.82.0-rc.4)
+    - React-Core/Default (= 0.82.0-rc.5)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -430,82 +430,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.82.0-rc.4):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.82.0-rc.4):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.82.0-rc.4):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.82.0-rc.4)
-    - React-Core/RCTWebSocket (= 0.82.0-rc.4)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.82.0-rc.4):
+  - React-Core/CoreModulesHeaders (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -530,7 +455,57 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.82.0-rc.4):
+  - React-Core/Default (0.82.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.82.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.82.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.82.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -555,7 +530,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.82.0-rc.4):
+  - React-Core/RCTAnimationHeaders (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -580,7 +555,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.82.0-rc.4):
+  - React-Core/RCTBlobHeaders (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -605,7 +580,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.82.0-rc.4):
+  - React-Core/RCTImageHeaders (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -630,7 +605,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.82.0-rc.4):
+  - React-Core/RCTLinkingHeaders (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -655,7 +630,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.82.0-rc.4):
+  - React-Core/RCTNetworkHeaders (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -680,7 +655,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.82.0-rc.4):
+  - React-Core/RCTSettingsHeaders (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -705,7 +680,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.82.0-rc.4):
+  - React-Core/RCTTextHeaders (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -730,7 +705,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.82.0-rc.4):
+  - React-Core/RCTVibrationHeaders (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -740,7 +715,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.82.0-rc.4)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -755,7 +730,32 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.82.0-rc.4):
+  - React-Core/RCTWebSocket (0.82.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.82.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -763,21 +763,21 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.82.0-rc.4)
-    - React-Core/CoreModulesHeaders (= 0.82.0-rc.4)
+    - RCTTypeSafety (= 0.82.0-rc.5)
+    - React-Core/CoreModulesHeaders (= 0.82.0-rc.5)
     - React-debug
-    - React-jsi (= 0.82.0-rc.4)
+    - React-jsi (= 0.82.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.82.0-rc.4)
+    - React-RCTImage (= 0.82.0-rc.5)
     - React-runtimeexecutor
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.82.0-rc.4):
+  - React-cxxreact (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -786,19 +786,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.82.0-rc.4)
-    - React-debug (= 0.82.0-rc.4)
-    - React-jsi (= 0.82.0-rc.4)
+    - React-callinvoker (= 0.82.0-rc.5)
+    - React-debug (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.82.0-rc.4)
-    - React-perflogger (= 0.82.0-rc.4)
+    - React-logger (= 0.82.0-rc.5)
+    - React-perflogger (= 0.82.0-rc.5)
     - React-runtimeexecutor
-    - React-timing (= 0.82.0-rc.4)
+    - React-timing (= 0.82.0-rc.5)
     - SocketRocket
-  - React-debug (0.82.0-rc.4)
-  - React-defaultsnativemodule (0.82.0-rc.4):
+  - React-debug (0.82.0-rc.5)
+  - React-defaultsnativemodule (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -816,7 +816,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-webperformancenativemodule
     - SocketRocket
-  - React-domnativemodule (0.82.0-rc.4):
+  - React-domnativemodule (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -836,7 +836,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.82.0-rc.4):
+  - React-Fabric (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -850,23 +850,23 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.82.0-rc.4)
-    - React-Fabric/attributedstring (= 0.82.0-rc.4)
-    - React-Fabric/bridging (= 0.82.0-rc.4)
-    - React-Fabric/componentregistry (= 0.82.0-rc.4)
-    - React-Fabric/componentregistrynative (= 0.82.0-rc.4)
-    - React-Fabric/components (= 0.82.0-rc.4)
-    - React-Fabric/consistency (= 0.82.0-rc.4)
-    - React-Fabric/core (= 0.82.0-rc.4)
-    - React-Fabric/dom (= 0.82.0-rc.4)
-    - React-Fabric/imagemanager (= 0.82.0-rc.4)
-    - React-Fabric/leakchecker (= 0.82.0-rc.4)
-    - React-Fabric/mounting (= 0.82.0-rc.4)
-    - React-Fabric/observers (= 0.82.0-rc.4)
-    - React-Fabric/scheduler (= 0.82.0-rc.4)
-    - React-Fabric/telemetry (= 0.82.0-rc.4)
-    - React-Fabric/templateprocessor (= 0.82.0-rc.4)
-    - React-Fabric/uimanager (= 0.82.0-rc.4)
+    - React-Fabric/animations (= 0.82.0-rc.5)
+    - React-Fabric/attributedstring (= 0.82.0-rc.5)
+    - React-Fabric/bridging (= 0.82.0-rc.5)
+    - React-Fabric/componentregistry (= 0.82.0-rc.5)
+    - React-Fabric/componentregistrynative (= 0.82.0-rc.5)
+    - React-Fabric/components (= 0.82.0-rc.5)
+    - React-Fabric/consistency (= 0.82.0-rc.5)
+    - React-Fabric/core (= 0.82.0-rc.5)
+    - React-Fabric/dom (= 0.82.0-rc.5)
+    - React-Fabric/imagemanager (= 0.82.0-rc.5)
+    - React-Fabric/leakchecker (= 0.82.0-rc.5)
+    - React-Fabric/mounting (= 0.82.0-rc.5)
+    - React-Fabric/observers (= 0.82.0-rc.5)
+    - React-Fabric/scheduler (= 0.82.0-rc.5)
+    - React-Fabric/telemetry (= 0.82.0-rc.5)
+    - React-Fabric/templateprocessor (= 0.82.0-rc.5)
+    - React-Fabric/uimanager (= 0.82.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -878,32 +878,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.82.0-rc.4):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.82.0-rc.4):
+  - React-Fabric/animations (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -928,7 +903,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/bridging (0.82.0-rc.4):
+  - React-Fabric/attributedstring (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -953,7 +928,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.82.0-rc.4):
+  - React-Fabric/bridging (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -978,7 +953,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.82.0-rc.4):
+  - React-Fabric/componentregistry (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1003,36 +978,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.82.0-rc.4):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.82.0-rc.4)
-    - React-Fabric/components/root (= 0.82.0-rc.4)
-    - React-Fabric/components/scrollview (= 0.82.0-rc.4)
-    - React-Fabric/components/view (= 0.82.0-rc.4)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.82.0-rc.4):
+  - React-Fabric/componentregistrynative (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1057,7 +1003,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.82.0-rc.4):
+  - React-Fabric/components (0.82.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.82.0-rc.5)
+    - React-Fabric/components/root (= 0.82.0-rc.5)
+    - React-Fabric/components/scrollview (= 0.82.0-rc.5)
+    - React-Fabric/components/view (= 0.82.0-rc.5)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1082,7 +1057,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.82.0-rc.4):
+  - React-Fabric/components/root (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1107,7 +1082,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.82.0-rc.4):
+  - React-Fabric/components/scrollview (0.82.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1134,7 +1134,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.82.0-rc.4):
+  - React-Fabric/consistency (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1159,7 +1159,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.82.0-rc.4):
+  - React-Fabric/core (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1184,7 +1184,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.82.0-rc.4):
+  - React-Fabric/dom (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1209,7 +1209,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.82.0-rc.4):
+  - React-Fabric/imagemanager (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1234,7 +1234,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.82.0-rc.4):
+  - React-Fabric/leakchecker (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1259,7 +1259,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.82.0-rc.4):
+  - React-Fabric/mounting (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1284,7 +1284,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.82.0-rc.4):
+  - React-Fabric/observers (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1298,7 +1298,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.82.0-rc.4)
+    - React-Fabric/observers/events (= 0.82.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1310,7 +1310,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.82.0-rc.4):
+  - React-Fabric/observers/events (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1335,7 +1335,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.82.0-rc.4):
+  - React-Fabric/scheduler (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1363,7 +1363,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.82.0-rc.4):
+  - React-Fabric/telemetry (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1388,7 +1388,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.82.0-rc.4):
+  - React-Fabric/templateprocessor (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1413,7 +1413,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.82.0-rc.4):
+  - React-Fabric/uimanager (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1427,7 +1427,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.82.0-rc.4)
+    - React-Fabric/uimanager/consistency (= 0.82.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1440,7 +1440,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager/consistency (0.82.0-rc.4):
+  - React-Fabric/uimanager/consistency (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1466,7 +1466,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.82.0-rc.4):
+  - React-FabricComponents (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1481,8 +1481,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.82.0-rc.4)
-    - React-FabricComponents/textlayoutmanager (= 0.82.0-rc.4)
+    - React-FabricComponents/components (= 0.82.0-rc.5)
+    - React-FabricComponents/textlayoutmanager (= 0.82.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1495,7 +1495,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.82.0-rc.4):
+  - React-FabricComponents/components (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1510,18 +1510,18 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.82.0-rc.4)
-    - React-FabricComponents/components/iostextinput (= 0.82.0-rc.4)
-    - React-FabricComponents/components/modal (= 0.82.0-rc.4)
-    - React-FabricComponents/components/rncore (= 0.82.0-rc.4)
-    - React-FabricComponents/components/safeareaview (= 0.82.0-rc.4)
-    - React-FabricComponents/components/scrollview (= 0.82.0-rc.4)
-    - React-FabricComponents/components/switch (= 0.82.0-rc.4)
-    - React-FabricComponents/components/text (= 0.82.0-rc.4)
-    - React-FabricComponents/components/textinput (= 0.82.0-rc.4)
-    - React-FabricComponents/components/unimplementedview (= 0.82.0-rc.4)
-    - React-FabricComponents/components/virtualview (= 0.82.0-rc.4)
-    - React-FabricComponents/components/virtualviewexperimental (= 0.82.0-rc.4)
+    - React-FabricComponents/components/inputaccessory (= 0.82.0-rc.5)
+    - React-FabricComponents/components/iostextinput (= 0.82.0-rc.5)
+    - React-FabricComponents/components/modal (= 0.82.0-rc.5)
+    - React-FabricComponents/components/rncore (= 0.82.0-rc.5)
+    - React-FabricComponents/components/safeareaview (= 0.82.0-rc.5)
+    - React-FabricComponents/components/scrollview (= 0.82.0-rc.5)
+    - React-FabricComponents/components/switch (= 0.82.0-rc.5)
+    - React-FabricComponents/components/text (= 0.82.0-rc.5)
+    - React-FabricComponents/components/textinput (= 0.82.0-rc.5)
+    - React-FabricComponents/components/unimplementedview (= 0.82.0-rc.5)
+    - React-FabricComponents/components/virtualview (= 0.82.0-rc.5)
+    - React-FabricComponents/components/virtualviewexperimental (= 0.82.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1534,34 +1534,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.82.0-rc.4):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.82.0-rc.4):
+  - React-FabricComponents/components/inputaccessory (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1588,7 +1561,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/modal (0.82.0-rc.4):
+  - React-FabricComponents/components/iostextinput (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1615,7 +1588,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.82.0-rc.4):
+  - React-FabricComponents/components/modal (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1642,7 +1615,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.82.0-rc.4):
+  - React-FabricComponents/components/rncore (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1669,7 +1642,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.82.0-rc.4):
+  - React-FabricComponents/components/safeareaview (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1696,7 +1669,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/switch (0.82.0-rc.4):
+  - React-FabricComponents/components/scrollview (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1723,7 +1696,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.82.0-rc.4):
+  - React-FabricComponents/components/switch (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1750,7 +1723,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.82.0-rc.4):
+  - React-FabricComponents/components/text (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1777,7 +1750,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.82.0-rc.4):
+  - React-FabricComponents/components/textinput (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1804,7 +1777,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualview (0.82.0-rc.4):
+  - React-FabricComponents/components/unimplementedview (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1831,7 +1804,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualviewexperimental (0.82.0-rc.4):
+  - React-FabricComponents/components/virtualview (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1858,7 +1831,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.82.0-rc.4):
+  - React-FabricComponents/components/virtualviewexperimental (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1885,7 +1858,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.82.0-rc.4):
+  - React-FabricComponents/textlayoutmanager (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1894,21 +1867,48 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.82.0-rc.4)
-    - RCTTypeSafety (= 0.82.0-rc.4)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.82.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.82.0-rc.5)
+    - RCTTypeSafety (= 0.82.0-rc.5)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.82.0-rc.4)
+    - React-jsiexecutor (= 0.82.0-rc.5)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.82.0-rc.4):
+  - React-featureflags (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1917,7 +1917,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.82.0-rc.4):
+  - React-featureflagsnativemodule (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1932,7 +1932,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.82.0-rc.4):
+  - React-graphics (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1945,7 +1945,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.82.0-rc.4):
+  - React-hermes (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1954,17 +1954,17 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.82.0-rc.4)
+    - React-cxxreact (= 0.82.0-rc.5)
     - React-jsi
-    - React-jsiexecutor (= 0.82.0-rc.4)
+    - React-jsiexecutor (= 0.82.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.82.0-rc.4)
+    - React-perflogger (= 0.82.0-rc.5)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.82.0-rc.4):
+  - React-idlecallbacksnativemodule (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1980,7 +1980,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.82.0-rc.4):
+  - React-ImageManager (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1995,7 +1995,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jserrorhandler (0.82.0-rc.4):
+  - React-jserrorhandler (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2010,7 +2010,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.82.0-rc.4):
+  - React-jsi (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2020,7 +2020,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.82.0-rc.4):
+  - React-jsiexecutor (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2038,7 +2038,7 @@ PODS:
     - React-perflogger
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspector (0.82.0-rc.4):
+  - React-jsinspector (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2053,10 +2053,10 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.82.0-rc.4)
+    - React-perflogger (= 0.82.0-rc.5)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspectorcdp (0.82.0-rc.4):
+  - React-jsinspectorcdp (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2065,7 +2065,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.82.0-rc.4):
+  - React-jsinspectornetwork (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2078,7 +2078,7 @@ PODS:
     - React-performancetimeline
     - React-timing
     - SocketRocket
-  - React-jsinspectortracing (0.82.0-rc.4):
+  - React-jsinspectortracing (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2089,7 +2089,7 @@ PODS:
     - React-oscompat
     - React-timing
     - SocketRocket
-  - React-jsitooling (0.82.0-rc.4):
+  - React-jsitooling (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2097,17 +2097,17 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.82.0-rc.4)
+    - React-cxxreact (= 0.82.0-rc.5)
     - React-debug
-    - React-jsi (= 0.82.0-rc.4)
+    - React-jsi (= 0.82.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsitracing (0.82.0-rc.4):
+  - React-jsitracing (0.82.0-rc.5):
     - React-jsi
-  - React-logger (0.82.0-rc.4):
+  - React-logger (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2116,7 +2116,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.82.0-rc.4):
+  - React-Mapbuffer (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2126,7 +2126,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.82.0-rc.4):
+  - React-microtasksnativemodule (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2140,7 +2140,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-NativeModulesApple (0.82.0-rc.4):
+  - React-NativeModulesApple (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2161,8 +2161,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.82.0-rc.4)
-  - React-perflogger (0.82.0-rc.4):
+  - React-oscompat (0.82.0-rc.5)
+  - React-perflogger (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2171,7 +2171,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancecdpmetrics (0.82.0-rc.4):
+  - React-performancecdpmetrics (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2185,7 +2185,7 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - SocketRocket
-  - React-performancetimeline (0.82.0-rc.4):
+  - React-performancetimeline (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2198,9 +2198,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.82.0-rc.4):
-    - React-Core/RCTActionSheetHeaders (= 0.82.0-rc.4)
-  - React-RCTAnimation (0.82.0-rc.4):
+  - React-RCTActionSheet (0.82.0-rc.5):
+    - React-Core/RCTActionSheetHeaders (= 0.82.0-rc.5)
+  - React-RCTAnimation (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2216,7 +2216,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.82.0-rc.4):
+  - React-RCTAppDelegate (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2250,7 +2250,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.82.0-rc.4):
+  - React-RCTBlob (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2269,7 +2269,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.82.0-rc.4):
+  - React-RCTFabric (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2305,7 +2305,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.82.0-rc.4):
+  - React-RCTFBReactNativeSpec (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2319,10 +2319,10 @@ PODS:
     - React-Core
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.82.0-rc.4)
+    - React-RCTFBReactNativeSpec/components (= 0.82.0-rc.5)
     - ReactCommon
     - SocketRocket
-  - React-RCTFBReactNativeSpec/components (0.82.0-rc.4):
+  - React-RCTFBReactNativeSpec/components (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2345,7 +2345,7 @@ PODS:
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-RCTImage (0.82.0-rc.4):
+  - React-RCTImage (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2361,14 +2361,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.82.0-rc.4):
-    - React-Core/RCTLinkingHeaders (= 0.82.0-rc.4)
-    - React-jsi (= 0.82.0-rc.4)
+  - React-RCTLinking (0.82.0-rc.5):
+    - React-Core/RCTLinkingHeaders (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0-rc.5)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.82.0-rc.4)
-  - React-RCTNetwork (0.82.0-rc.4):
+    - ReactCommon/turbomodule/core (= 0.82.0-rc.5)
+  - React-RCTNetwork (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2387,7 +2387,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.82.0-rc.4):
+  - React-RCTRuntime (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2408,7 +2408,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.82.0-rc.4):
+  - React-RCTSettings (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2423,10 +2423,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.82.0-rc.4):
-    - React-Core/RCTTextHeaders (= 0.82.0-rc.4)
+  - React-RCTText (0.82.0-rc.5):
+    - React-Core/RCTTextHeaders (= 0.82.0-rc.5)
     - Yoga
-  - React-RCTVibration (0.82.0-rc.4):
+  - React-RCTVibration (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2440,11 +2440,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.82.0-rc.4)
-  - React-renderercss (0.82.0-rc.4):
+  - React-rendererconsistency (0.82.0-rc.5)
+  - React-renderercss (0.82.0-rc.5):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.82.0-rc.4):
+  - React-rendererdebug (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2454,7 +2454,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-RuntimeApple (0.82.0-rc.4):
+  - React-RuntimeApple (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2483,7 +2483,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.82.0-rc.4):
+  - React-RuntimeCore (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2505,7 +2505,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.82.0-rc.4):
+  - React-runtimeexecutor (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2515,10 +2515,10 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.82.0-rc.4)
+    - React-jsi (= 0.82.0-rc.5)
     - React-utils
     - SocketRocket
-  - React-RuntimeHermes (0.82.0-rc.4):
+  - React-RuntimeHermes (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2539,7 +2539,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.82.0-rc.4):
+  - React-runtimescheduler (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2561,9 +2561,9 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.82.0-rc.4):
+  - React-timing (0.82.0-rc.5):
     - React-debug
-  - React-utils (0.82.0-rc.4):
+  - React-utils (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2573,9 +2573,9 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - React-debug
-    - React-jsi (= 0.82.0-rc.4)
+    - React-jsi (= 0.82.0-rc.5)
     - SocketRocket
-  - React-webperformancenativemodule (0.82.0-rc.4):
+  - React-webperformancenativemodule (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2591,9 +2591,9 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactAppDependencyProvider (0.82.0-rc.4):
+  - ReactAppDependencyProvider (0.82.0-rc.5):
     - ReactCodegen
-  - ReactCodegen (0.82.0-rc.4):
+  - ReactCodegen (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2619,7 +2619,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.82.0-rc.4):
+  - ReactCommon (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2627,9 +2627,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.82.0-rc.4)
+    - ReactCommon/turbomodule (= 0.82.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule (0.82.0-rc.4):
+  - ReactCommon/turbomodule (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2638,15 +2638,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.82.0-rc.4)
-    - React-cxxreact (= 0.82.0-rc.4)
-    - React-jsi (= 0.82.0-rc.4)
-    - React-logger (= 0.82.0-rc.4)
-    - React-perflogger (= 0.82.0-rc.4)
-    - ReactCommon/turbomodule/bridging (= 0.82.0-rc.4)
-    - ReactCommon/turbomodule/core (= 0.82.0-rc.4)
+    - React-callinvoker (= 0.82.0-rc.5)
+    - React-cxxreact (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0-rc.5)
+    - React-logger (= 0.82.0-rc.5)
+    - React-perflogger (= 0.82.0-rc.5)
+    - ReactCommon/turbomodule/bridging (= 0.82.0-rc.5)
+    - ReactCommon/turbomodule/core (= 0.82.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.82.0-rc.4):
+  - ReactCommon/turbomodule/bridging (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2655,13 +2655,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.82.0-rc.4)
-    - React-cxxreact (= 0.82.0-rc.4)
-    - React-jsi (= 0.82.0-rc.4)
-    - React-logger (= 0.82.0-rc.4)
-    - React-perflogger (= 0.82.0-rc.4)
+    - React-callinvoker (= 0.82.0-rc.5)
+    - React-cxxreact (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0-rc.5)
+    - React-logger (= 0.82.0-rc.5)
+    - React-perflogger (= 0.82.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.82.0-rc.4):
+  - ReactCommon/turbomodule/core (0.82.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2670,14 +2670,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.82.0-rc.4)
-    - React-cxxreact (= 0.82.0-rc.4)
-    - React-debug (= 0.82.0-rc.4)
-    - React-featureflags (= 0.82.0-rc.4)
-    - React-jsi (= 0.82.0-rc.4)
-    - React-logger (= 0.82.0-rc.4)
-    - React-perflogger (= 0.82.0-rc.4)
-    - React-utils (= 0.82.0-rc.4)
+    - React-callinvoker (= 0.82.0-rc.5)
+    - React-cxxreact (= 0.82.0-rc.5)
+    - React-debug (= 0.82.0-rc.5)
+    - React-featureflags (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0-rc.5)
+    - React-logger (= 0.82.0-rc.5)
+    - React-perflogger (= 0.82.0-rc.5)
+    - React-utils (= 0.82.0-rc.5)
     - SocketRocket
   - SDWebImage (5.21.0):
     - SDWebImage/Core (= 5.21.0)
@@ -3037,85 +3037,85 @@ SPEC CHECKSUMS:
   EXUpdates: 0dfa860736d6444c0949e691d53e1320f9bc2cb2
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: 4963926890f2f2b981e1c4e2af79c37d0a9121f3
+  FBLazyVector: 8d893933d9b2b77508382e4baf21f5b5464cb57a
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: 883ad6cdbcb152221038266a5908c1fa6c1002f7
+  hermes-engine: a14f7f403796d60a2ae636a4d5b6c1f7646503f8
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
-  RCTDeprecation: 5f54be68187ef1fc21b4d70a262f0d05d6fba854
-  RCTRequired: e52808dfaf897a452bf296466de8c3c5a3ca9332
-  RCTTypeSafety: 0c96598083fbfd1c605997a7c2d51a25ac97c35b
+  RCTDeprecation: 41e5e0af75686dad802af9706c4eba1efa66ecfe
+  RCTRequired: 4a064c2751982b11344b923951bc7e27d6a9d467
+  RCTTypeSafety: 9c5a00fa9bd7abad20b2c520bbb823613cc2f2e2
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 0fde0b13f6cca9b4e4525d888dd952e87e5f2c28
-  React-callinvoker: 726b0350220fa95dfdf03c81eee83f65bc88de3f
-  React-Core: 3f3476b0109d243df3c3569d44344495cfd9ce7c
-  React-CoreModules: 86275914c7ff2e425499c9b22eb534ca2055c6e3
-  React-cxxreact: 41a2c7c64285dadcd5c537fc215c763e9261f7a0
-  React-debug: c5d7221ff1dd6c84f966ef7e6427d76ba1299f72
-  React-defaultsnativemodule: a142ab2dcc546eb7467e19fbec2a2c6ebae00a5b
-  React-domnativemodule: 4fa78b4145cf34605adfc72e288df2cd30e49d9a
-  React-Fabric: ad73134d464976f3f6c763c61932f7f4bdbd3759
-  React-FabricComponents: c19a5a931137b2f87b7d3cdc085304f14783fac0
-  React-FabricImage: 5f24b11c1ef83880816d41312323b195945c997f
-  React-featureflags: bdf0a3cf931aaaadabd225e1f7e7856de1a4b367
-  React-featureflagsnativemodule: a47979095480a93306a0c12e31994452770539ff
-  React-graphics: 0b06e4876757d19337807427042df1f91d9b9494
-  React-hermes: ffde9d3453084d36e5e085dd4e9dbd4f355ca19d
-  React-idlecallbacksnativemodule: 2a9c551bcdde6e7c9b969efd7558f127f0636d07
-  React-ImageManager: d44b1190347f0139c0cb0df4a759c82f643993c9
-  React-jserrorhandler: 7ca9726661fdea1c607e6487ccc2dd858bb4707a
-  React-jsi: 634bd7de0db396438cc00ba8b07519491d02a430
-  React-jsiexecutor: d05dacc22eb1ba5862c91a305a338082a241b745
-  React-jsinspector: 19969e1030b17fa08b42876ce7f1e1d358803065
-  React-jsinspectorcdp: 589536f53093e88bbc2aa01467606771407e9105
-  React-jsinspectornetwork: ce24874f5ac72ea17a716c2d4e86b11fd75d9bce
-  React-jsinspectortracing: a3f45fda400e99c16e1ed9b4531491a0cfbd9ae3
-  React-jsitooling: bc4a8c7d3532757f99c56a39458488bf5bed6639
-  React-jsitracing: f77703ab7433057301149e2322c357245ddb9370
-  React-logger: feb3f051130f9e1707282929699fe7bbb71675e3
-  React-Mapbuffer: 0e021a42050d684ac8c1536b28fde11b6e710b26
-  React-microtasksnativemodule: cd612606b6d9a6568262a153f8e713c0578112cd
-  React-NativeModulesApple: 548ef6da4fc74f59d581eb68684deef655b700e9
-  React-oscompat: 1a6aa7919259f5f49f1f1cf6041d2941acb6dc70
-  React-perflogger: f8bca1b1bcf7f7785b8526a98672382522c6e0e9
-  React-performancecdpmetrics: 5d894f46fa068a44dcfe4a83f5ad62a9cb75ee5f
-  React-performancetimeline: d86d218f21e6256969e20fa36ac8fb94722e64fc
-  React-RCTActionSheet: abf57df1aca1a93f2fb018a48cbf9628617e1081
-  React-RCTAnimation: 1174b63f774a66f4ef01121cf22127daae33293e
-  React-RCTAppDelegate: fd45b8b8c294e67eea5d48071367eb2fdeb56e62
-  React-RCTBlob: eb0efe9d40496c5e68f0788a3528cf79642084d4
-  React-RCTFabric: 0078af9b7db01c49a7b7fb2ade7fce72a3575e91
-  React-RCTFBReactNativeSpec: 36c0e946517080ecb31e7f633b6a38a27db40931
-  React-RCTImage: 16eaed915221cd38daee2d395295b39dcb653469
-  React-RCTLinking: 22bc8b89ae7c87a11a4a59681dadaa9d26aca1e7
-  React-RCTNetwork: d97052f5c5df8475c20307a2054fa3c3b38d97e8
-  React-RCTRuntime: 5a80780f7810b1236c51a22fa852d74f1f40cd91
-  React-RCTSettings: 7144291b1e80e9a12ca53ebdb02bfd253048819f
-  React-RCTText: 0746088c96849c313db22681ead9236299b9c898
-  React-RCTVibration: d895f534f1bf8840aef3bf77dc5ee48dde2b60b2
-  React-rendererconsistency: b10d5a7fab7187ca6224d77b946ed8ebffc27db2
-  React-renderercss: 78625c7c59bdb0fe4e0af7f39c4a0f35e5331995
-  React-rendererdebug: e2703f607fc5d741d1a3da102214edd0b60767bf
-  React-RuntimeApple: 3213f49bcd28cabaa0d38ef78c4e76a8f0f3e083
-  React-RuntimeCore: 86d99a32fb7d5dbeebaa79c320a7c1b103271273
-  React-runtimeexecutor: 48a7ee3125b89195e94ab1be170f4419a52af8da
-  React-RuntimeHermes: 585289fb055a6c87b348d1fd16af90e23bcaf0be
-  React-runtimescheduler: 305dbb58a76a81b6a02a9be94a3891647a71fddc
-  React-timing: 820d7b380bcd822b40a4293d593b225bcb95c3d3
-  React-utils: 77321db49a1bd4db1bc90925c9109fbb724dfd62
-  React-webperformancenativemodule: 8495b40213855a83338b1dc18b6f8378c9d65e5c
-  ReactAppDependencyProvider: a5f2664120eb6e9dc431a74a40370652311db139
-  ReactCodegen: 5f99156b33a053e88757518e13c9caa00e1c6141
-  ReactCommon: 114c055df7b30fce1a79185416b9b9f28cf9c199
+  React: 6eb704af98132bfdd36a19d9910b4d317d13100c
+  React-callinvoker: f103ec1e45df5713addfb0264a73eb7a4e0b9016
+  React-Core: 8a56e97e5acba6e473e7b2b175e078454cb4dd30
+  React-CoreModules: 4b25453083ea8f1bdfae3a6743d469043b67674e
+  React-cxxreact: 8a584a593a1fdb95483bad85b754aedaf8a60679
+  React-debug: d7c1d26881c507aa4c4c94a4657b9bca1ad4609d
+  React-defaultsnativemodule: d183f5204623c8eb775f163797596c704ca2416b
+  React-domnativemodule: 8e33e02a3290b2d8177b5a9b16495de935ed0b2b
+  React-Fabric: 17ab641193eb6b8bacc5f46b8f76e2f602332680
+  React-FabricComponents: 30400d7971f92a95f1b9620e82b1c98811f2c014
+  React-FabricImage: 23a39b1632ee6f7c1824e16180a8867b87d35f35
+  React-featureflags: 97933c8a06500cd161bd18cf4fbe2c9374d70e14
+  React-featureflagsnativemodule: dc1d536146fd73d070b8c2a89ed4c488b24dd6a4
+  React-graphics: 6f5cbb1167dde595a66d65ba220f9c54314e44d5
+  React-hermes: 50d1474fce48b94e3cc55a6356f00c6ffde3efff
+  React-idlecallbacksnativemodule: 09edf02e62f0d5cef34580156a2ffacd5425d464
+  React-ImageManager: 5d99c989f36b5c592b9582df486d2cd7f9a1da90
+  React-jserrorhandler: 010e321942df06ca3981898029623f85a291ffb2
+  React-jsi: 15dc6cbe84aefb9e6773827ea8ee9fa198a44564
+  React-jsiexecutor: 652a3c67c11c1a161866b06ca2639d5b0758b384
+  React-jsinspector: d22aa6ea27544048de489147a5dc8372422dc95a
+  React-jsinspectorcdp: f0216317d66edc8433fb04a27ff84e391425b582
+  React-jsinspectornetwork: 069620f58fd4215709c8a5d143c8182df1f20b94
+  React-jsinspectortracing: d0f3e3f01514726b3aa4d6c55ec77675ecc2bf10
+  React-jsitooling: 737fd34d451d4119c1f7320fc04fe034ef4da287
+  React-jsitracing: c8cd1009d69ff04eadc768ecdf1c1c43973a304f
+  React-logger: 1cd1f61088c1c6c04c62ddd9770af0955b500a86
+  React-Mapbuffer: 7cfd84b044618d1afe5310362c9e5c932bd43063
+  React-microtasksnativemodule: da1d0d2f783690ad5776a63d45ea9753571f93af
+  React-NativeModulesApple: 67bd0ae88813a06fdab277bb4e0de50a3d470868
+  React-oscompat: 8f6bc162c03dfa41e70b9ab32bd1b692ac81051f
+  React-perflogger: 68b4a7c738f626b9787731d08d9f8a5c0feb2122
+  React-performancecdpmetrics: fb395ba9b7a005d8b0b590bd3aa227cf94451dbb
+  React-performancetimeline: 964e713588b39c91cad8475b3175da4d8677c653
+  React-RCTActionSheet: fde5090d31e027bd3099147d50ac4a69d9817c2c
+  React-RCTAnimation: c82e86775617fd3168b02be78c0b05db7727d013
+  React-RCTAppDelegate: 2a6e85772234b7022d7b017b83701ddeb58df49c
+  React-RCTBlob: 115b25b8f24332a6a21de43923bc655028fff937
+  React-RCTFabric: 9e41b38902cf2f856db99bc6626b7bf6b0fe3bee
+  React-RCTFBReactNativeSpec: db702c31cc71ff31017175aa235b4c9d4435e0f2
+  React-RCTImage: 7a0198ddd93dabadb69340a9385426475e21169e
+  React-RCTLinking: 85d7e02a9952a96e485ee48c3d030643afd587bd
+  React-RCTNetwork: 5cde64476ed1af70569ffc709ffc5663fb08b17b
+  React-RCTRuntime: 7e38a59559a5b9eaceb1fbb41bccc305f4fe434a
+  React-RCTSettings: 35154ee1f399ce54fd17b209f6a73147a5ed9345
+  React-RCTText: d8c98f4db4f1ec054ffb2f58b22b49dcedcfb6d3
+  React-RCTVibration: 23effbb317e27408a360d2467f8424099606678f
+  React-rendererconsistency: a114ca1d18e1c4ba6b8af818844b3bde9db76570
+  React-renderercss: 87aebb3a6a117c252941e68ef15d4ba459a1c03e
+  React-rendererdebug: a0423813386bdb102599789412d15d853ba4de5e
+  React-RuntimeApple: d266813a3d020756b297756dfd32310b7c2bfd26
+  React-RuntimeCore: 69585249c6114cbd75a8c0caa0fc606c9a9b5e0f
+  React-runtimeexecutor: c48455042001ad3cb97d4e6a0d3c7fb85ed5c289
+  React-RuntimeHermes: 050bb22f355a1f19df01149899db615672f76a99
+  React-runtimescheduler: 409d894a239182cb77e89f0a841ed0b36bd92f26
+  React-timing: dd3be228e14215f4300f3b9a891d9ce6f6735c96
+  React-utils: c08f3c5a29941dc41c7bfdf90e8ae76b8b3f9d86
+  React-webperformancenativemodule: 495882f02c4be9e4fb0836d445a6c792d2948615
+  ReactAppDependencyProvider: 77a7129540c0e06ab6be9a2bcb887d3d2e594431
+  ReactCodegen: f1e31c701a2128967832c6ca48dbcd99bcdb90a8
+  ReactCommon: d07170f92e0e853091a70b2741b7c43f5dfdea73
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: e80c5fabbc3e26311152fa20404cdfa14f16a11f
+  Yoga: 47264cc34431da6b66b3687348be283084924f46
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 3d26d20fc75a5b3e209d9b88282589121a9ef56d

--- a/apps/minimal-tester/package.json
+++ b/apps/minimal-tester/package.json
@@ -22,7 +22,7 @@
     "expo-video": "~3.0.11",
     "react": "19.1.1",
     "react-dom": "19.1.1",
-    "react-native": "0.82.0-rc.4",
+    "react-native": "0.82.0-rc.5",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -140,7 +140,7 @@
     "processing-js": "^1.6.6",
     "react": "19.1.1",
     "react-dom": "19.1.1",
-    "react-native": "0.82.0-rc.4",
+    "react-native": "0.82.0-rc.5",
     "react-native-dropdown-picker": "^5.3.0",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-keyboard-controller": "^1.18.5",

--- a/apps/native-tests/ios/Podfile.lock
+++ b/apps/native-tests/ios/Podfile.lock
@@ -433,9 +433,9 @@ PODS:
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
   - FBLazyVector (0.82.0-rc.5)
-  - hermes-engine (0.82.0-rc.4):
-    - hermes-engine/Pre-built (= 0.82.0-rc.4)
-  - hermes-engine/Pre-built (0.82.0-rc.4)
+  - hermes-engine (0.82.0-rc.5):
+    - hermes-engine/Pre-built (= 0.82.0-rc.5)
+  - hermes-engine/Pre-built (0.82.0-rc.5)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -2479,7 +2479,7 @@ SPEC CHECKSUMS:
   EXUpdates: b96ad490c9456eebc38f949f3c30ce6258845773
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   FBLazyVector: bd5db632a304b99a915e07040696286715b97462
-  hermes-engine: 883ad6cdbcb152221038266a5908c1fa6c1002f7
+  hermes-engine: a14f7f403796d60a2ae636a4d5b6c1f7646503f8
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8

--- a/apps/native-tests/ios/Podfile.lock
+++ b/apps/native-tests/ios/Podfile.lock
@@ -432,7 +432,7 @@ PODS:
     - Yoga
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
-  - FBLazyVector (0.82.0-rc.4)
+  - FBLazyVector (0.82.0-rc.5)
   - hermes-engine (0.82.0-rc.4):
     - hermes-engine/Pre-built (= 0.82.0-rc.4)
   - hermes-engine/Pre-built (0.82.0-rc.4)
@@ -468,32 +468,32 @@ PODS:
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (9.1.0)
   - Quick (7.3.0)
-  - RCTDeprecation (0.82.0-rc.4)
-  - RCTRequired (0.82.0-rc.4)
-  - RCTTypeSafety (0.82.0-rc.4):
-    - FBLazyVector (= 0.82.0-rc.4)
-    - RCTRequired (= 0.82.0-rc.4)
-    - React-Core (= 0.82.0-rc.4)
+  - RCTDeprecation (0.82.0-rc.5)
+  - RCTRequired (0.82.0-rc.5)
+  - RCTTypeSafety (0.82.0-rc.5):
+    - FBLazyVector (= 0.82.0-rc.5)
+    - RCTRequired (= 0.82.0-rc.5)
+    - React-Core (= 0.82.0-rc.5)
   - ReachabilitySwift (5.2.4)
-  - React (0.82.0-rc.4):
-    - React-Core (= 0.82.0-rc.4)
-    - React-Core/DevSupport (= 0.82.0-rc.4)
-    - React-Core/RCTWebSocket (= 0.82.0-rc.4)
-    - React-RCTActionSheet (= 0.82.0-rc.4)
-    - React-RCTAnimation (= 0.82.0-rc.4)
-    - React-RCTBlob (= 0.82.0-rc.4)
-    - React-RCTImage (= 0.82.0-rc.4)
-    - React-RCTLinking (= 0.82.0-rc.4)
-    - React-RCTNetwork (= 0.82.0-rc.4)
-    - React-RCTSettings (= 0.82.0-rc.4)
-    - React-RCTText (= 0.82.0-rc.4)
-    - React-RCTVibration (= 0.82.0-rc.4)
-  - React-callinvoker (0.82.0-rc.4)
-  - React-Core (0.82.0-rc.4):
+  - React (0.82.0-rc.5):
+    - React-Core (= 0.82.0-rc.5)
+    - React-Core/DevSupport (= 0.82.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.82.0-rc.5)
+    - React-RCTActionSheet (= 0.82.0-rc.5)
+    - React-RCTAnimation (= 0.82.0-rc.5)
+    - React-RCTBlob (= 0.82.0-rc.5)
+    - React-RCTImage (= 0.82.0-rc.5)
+    - React-RCTLinking (= 0.82.0-rc.5)
+    - React-RCTNetwork (= 0.82.0-rc.5)
+    - React-RCTSettings (= 0.82.0-rc.5)
+    - React-RCTText (= 0.82.0-rc.5)
+    - React-RCTVibration (= 0.82.0-rc.5)
+  - React-callinvoker (0.82.0-rc.5)
+  - React-Core (0.82.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.82.0-rc.4)
+    - React-Core/Default (= 0.82.0-rc.5)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -508,66 +508,9 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core-prebuilt (0.82.0-rc.4):
+  - React-Core-prebuilt (0.82.0-rc.5):
     - ReactNativeDependencies
-  - React-Core/CoreModulesHeaders (0.82.0-rc.4):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/Default (0.82.0-rc.4):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/DevSupport (0.82.0-rc.4):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default (= 0.82.0-rc.4)
-    - React-Core/RCTWebSocket (= 0.82.0-rc.4)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.82.0-rc.4):
+  - React-Core/CoreModulesHeaders (0.82.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -586,7 +529,45 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.82.0-rc.4):
+  - React-Core/Default (0.82.0-rc.5):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/DevSupport (0.82.0-rc.5):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-Core/Default (= 0.82.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.82.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.82.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -605,7 +586,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTBlobHeaders (0.82.0-rc.4):
+  - React-Core/RCTAnimationHeaders (0.82.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -624,7 +605,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTImageHeaders (0.82.0-rc.4):
+  - React-Core/RCTBlobHeaders (0.82.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -643,7 +624,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.82.0-rc.4):
+  - React-Core/RCTImageHeaders (0.82.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -662,7 +643,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.82.0-rc.4):
+  - React-Core/RCTLinkingHeaders (0.82.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -681,7 +662,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.82.0-rc.4):
+  - React-Core/RCTNetworkHeaders (0.82.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -700,7 +681,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTTextHeaders (0.82.0-rc.4):
+  - React-Core/RCTSettingsHeaders (0.82.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -719,7 +700,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.82.0-rc.4):
+  - React-Core/RCTTextHeaders (0.82.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -738,11 +719,11 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTWebSocket (0.82.0-rc.4):
+  - React-Core/RCTVibrationHeaders (0.82.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.82.0-rc.4)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -757,38 +738,57 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-CoreModules (0.82.0-rc.4):
-    - RCTTypeSafety (= 0.82.0-rc.4)
+  - React-Core/RCTWebSocket (0.82.0-rc.5):
+    - hermes-engine
+    - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/CoreModulesHeaders (= 0.82.0-rc.4)
+    - React-Core/Default (= 0.82.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-CoreModules (0.82.0-rc.5):
+    - RCTTypeSafety (= 0.82.0-rc.5)
+    - React-Core-prebuilt
+    - React-Core/CoreModulesHeaders (= 0.82.0-rc.5)
     - React-debug
-    - React-jsi (= 0.82.0-rc.4)
+    - React-jsi (= 0.82.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.82.0-rc.4)
+    - React-RCTImage (= 0.82.0-rc.5)
     - React-runtimeexecutor
     - ReactCommon
     - ReactNativeDependencies
-  - React-cxxreact (0.82.0-rc.4):
+  - React-cxxreact (0.82.0-rc.5):
     - hermes-engine
-    - React-callinvoker (= 0.82.0-rc.4)
+    - React-callinvoker (= 0.82.0-rc.5)
     - React-Core-prebuilt
-    - React-debug (= 0.82.0-rc.4)
-    - React-jsi (= 0.82.0-rc.4)
+    - React-debug (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.82.0-rc.4)
-    - React-perflogger (= 0.82.0-rc.4)
+    - React-logger (= 0.82.0-rc.5)
+    - React-perflogger (= 0.82.0-rc.5)
     - React-runtimeexecutor
-    - React-timing (= 0.82.0-rc.4)
+    - React-timing (= 0.82.0-rc.5)
     - ReactNativeDependencies
-  - React-debug (0.82.0-rc.4)
-  - React-defaultsnativemodule (0.82.0-rc.4):
+  - React-debug (0.82.0-rc.5)
+  - React-defaultsnativemodule (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-domnativemodule
@@ -800,7 +800,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-webperformancenativemodule
     - ReactNativeDependencies
-  - React-domnativemodule (0.82.0-rc.4):
+  - React-domnativemodule (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-Fabric
@@ -814,7 +814,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric (0.82.0-rc.4):
+  - React-Fabric (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -822,23 +822,23 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.82.0-rc.4)
-    - React-Fabric/attributedstring (= 0.82.0-rc.4)
-    - React-Fabric/bridging (= 0.82.0-rc.4)
-    - React-Fabric/componentregistry (= 0.82.0-rc.4)
-    - React-Fabric/componentregistrynative (= 0.82.0-rc.4)
-    - React-Fabric/components (= 0.82.0-rc.4)
-    - React-Fabric/consistency (= 0.82.0-rc.4)
-    - React-Fabric/core (= 0.82.0-rc.4)
-    - React-Fabric/dom (= 0.82.0-rc.4)
-    - React-Fabric/imagemanager (= 0.82.0-rc.4)
-    - React-Fabric/leakchecker (= 0.82.0-rc.4)
-    - React-Fabric/mounting (= 0.82.0-rc.4)
-    - React-Fabric/observers (= 0.82.0-rc.4)
-    - React-Fabric/scheduler (= 0.82.0-rc.4)
-    - React-Fabric/telemetry (= 0.82.0-rc.4)
-    - React-Fabric/templateprocessor (= 0.82.0-rc.4)
-    - React-Fabric/uimanager (= 0.82.0-rc.4)
+    - React-Fabric/animations (= 0.82.0-rc.5)
+    - React-Fabric/attributedstring (= 0.82.0-rc.5)
+    - React-Fabric/bridging (= 0.82.0-rc.5)
+    - React-Fabric/componentregistry (= 0.82.0-rc.5)
+    - React-Fabric/componentregistrynative (= 0.82.0-rc.5)
+    - React-Fabric/components (= 0.82.0-rc.5)
+    - React-Fabric/consistency (= 0.82.0-rc.5)
+    - React-Fabric/core (= 0.82.0-rc.5)
+    - React-Fabric/dom (= 0.82.0-rc.5)
+    - React-Fabric/imagemanager (= 0.82.0-rc.5)
+    - React-Fabric/leakchecker (= 0.82.0-rc.5)
+    - React-Fabric/mounting (= 0.82.0-rc.5)
+    - React-Fabric/observers (= 0.82.0-rc.5)
+    - React-Fabric/scheduler (= 0.82.0-rc.5)
+    - React-Fabric/telemetry (= 0.82.0-rc.5)
+    - React-Fabric/templateprocessor (= 0.82.0-rc.5)
+    - React-Fabric/uimanager (= 0.82.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -850,26 +850,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/animations (0.82.0-rc.4):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/attributedstring (0.82.0-rc.4):
+  - React-Fabric/animations (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -888,7 +869,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/bridging (0.82.0-rc.4):
+  - React-Fabric/attributedstring (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -907,7 +888,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistry (0.82.0-rc.4):
+  - React-Fabric/bridging (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -926,7 +907,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistrynative (0.82.0-rc.4):
+  - React-Fabric/componentregistry (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -945,30 +926,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components (0.82.0-rc.4):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.82.0-rc.4)
-    - React-Fabric/components/root (= 0.82.0-rc.4)
-    - React-Fabric/components/scrollview (= 0.82.0-rc.4)
-    - React-Fabric/components/view (= 0.82.0-rc.4)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/components/legacyviewmanagerinterop (0.82.0-rc.4):
+  - React-Fabric/componentregistrynative (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -987,7 +945,30 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/root (0.82.0-rc.4):
+  - React-Fabric/components (0.82.0-rc.5):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.82.0-rc.5)
+    - React-Fabric/components/root (= 0.82.0-rc.5)
+    - React-Fabric/components/scrollview (= 0.82.0-rc.5)
+    - React-Fabric/components/view (= 0.82.0-rc.5)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/legacyviewmanagerinterop (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1006,7 +987,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/scrollview (0.82.0-rc.4):
+  - React-Fabric/components/root (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1025,7 +1006,26 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/view (0.82.0-rc.4):
+  - React-Fabric/components/scrollview (0.82.0-rc.5):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/view (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1046,7 +1046,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric/consistency (0.82.0-rc.4):
+  - React-Fabric/consistency (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1065,7 +1065,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/core (0.82.0-rc.4):
+  - React-Fabric/core (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1084,7 +1084,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/dom (0.82.0-rc.4):
+  - React-Fabric/dom (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1103,7 +1103,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/imagemanager (0.82.0-rc.4):
+  - React-Fabric/imagemanager (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1122,7 +1122,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/leakchecker (0.82.0-rc.4):
+  - React-Fabric/leakchecker (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1141,7 +1141,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/mounting (0.82.0-rc.4):
+  - React-Fabric/mounting (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1160,7 +1160,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers (0.82.0-rc.4):
+  - React-Fabric/observers (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1168,7 +1168,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.82.0-rc.4)
+    - React-Fabric/observers/events (= 0.82.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1180,7 +1180,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers/events (0.82.0-rc.4):
+  - React-Fabric/observers/events (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1199,7 +1199,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/scheduler (0.82.0-rc.4):
+  - React-Fabric/scheduler (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1221,7 +1221,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/telemetry (0.82.0-rc.4):
+  - React-Fabric/telemetry (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1240,7 +1240,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/templateprocessor (0.82.0-rc.4):
+  - React-Fabric/templateprocessor (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1259,7 +1259,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager (0.82.0-rc.4):
+  - React-Fabric/uimanager (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1267,7 +1267,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.82.0-rc.4)
+    - React-Fabric/uimanager/consistency (= 0.82.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1280,7 +1280,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager/consistency (0.82.0-rc.4):
+  - React-Fabric/uimanager/consistency (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1300,7 +1300,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-FabricComponents (0.82.0-rc.4):
+  - React-FabricComponents (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1309,8 +1309,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.82.0-rc.4)
-    - React-FabricComponents/textlayoutmanager (= 0.82.0-rc.4)
+    - React-FabricComponents/components (= 0.82.0-rc.5)
+    - React-FabricComponents/textlayoutmanager (= 0.82.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1323,7 +1323,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components (0.82.0-rc.4):
+  - React-FabricComponents/components (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1332,18 +1332,18 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.82.0-rc.4)
-    - React-FabricComponents/components/iostextinput (= 0.82.0-rc.4)
-    - React-FabricComponents/components/modal (= 0.82.0-rc.4)
-    - React-FabricComponents/components/rncore (= 0.82.0-rc.4)
-    - React-FabricComponents/components/safeareaview (= 0.82.0-rc.4)
-    - React-FabricComponents/components/scrollview (= 0.82.0-rc.4)
-    - React-FabricComponents/components/switch (= 0.82.0-rc.4)
-    - React-FabricComponents/components/text (= 0.82.0-rc.4)
-    - React-FabricComponents/components/textinput (= 0.82.0-rc.4)
-    - React-FabricComponents/components/unimplementedview (= 0.82.0-rc.4)
-    - React-FabricComponents/components/virtualview (= 0.82.0-rc.4)
-    - React-FabricComponents/components/virtualviewexperimental (= 0.82.0-rc.4)
+    - React-FabricComponents/components/inputaccessory (= 0.82.0-rc.5)
+    - React-FabricComponents/components/iostextinput (= 0.82.0-rc.5)
+    - React-FabricComponents/components/modal (= 0.82.0-rc.5)
+    - React-FabricComponents/components/rncore (= 0.82.0-rc.5)
+    - React-FabricComponents/components/safeareaview (= 0.82.0-rc.5)
+    - React-FabricComponents/components/scrollview (= 0.82.0-rc.5)
+    - React-FabricComponents/components/switch (= 0.82.0-rc.5)
+    - React-FabricComponents/components/text (= 0.82.0-rc.5)
+    - React-FabricComponents/components/textinput (= 0.82.0-rc.5)
+    - React-FabricComponents/components/unimplementedview (= 0.82.0-rc.5)
+    - React-FabricComponents/components/virtualview (= 0.82.0-rc.5)
+    - React-FabricComponents/components/virtualviewexperimental (= 0.82.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1356,28 +1356,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.82.0-rc.4):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.82.0-rc.4):
+  - React-FabricComponents/components/inputaccessory (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1398,7 +1377,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/modal (0.82.0-rc.4):
+  - React-FabricComponents/components/iostextinput (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1419,7 +1398,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/rncore (0.82.0-rc.4):
+  - React-FabricComponents/components/modal (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1440,7 +1419,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.82.0-rc.4):
+  - React-FabricComponents/components/rncore (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1461,7 +1440,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/scrollview (0.82.0-rc.4):
+  - React-FabricComponents/components/safeareaview (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1482,7 +1461,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/switch (0.82.0-rc.4):
+  - React-FabricComponents/components/scrollview (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1503,7 +1482,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/text (0.82.0-rc.4):
+  - React-FabricComponents/components/switch (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1524,7 +1503,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/textinput (0.82.0-rc.4):
+  - React-FabricComponents/components/text (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1545,7 +1524,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.82.0-rc.4):
+  - React-FabricComponents/components/textinput (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1566,7 +1545,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/virtualview (0.82.0-rc.4):
+  - React-FabricComponents/components/unimplementedview (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1587,7 +1566,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/virtualviewexperimental (0.82.0-rc.4):
+  - React-FabricComponents/components/virtualview (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1608,7 +1587,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.82.0-rc.4):
+  - React-FabricComponents/components/virtualviewexperimental (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1629,27 +1608,48 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricImage (0.82.0-rc.4):
+  - React-FabricComponents/textlayoutmanager (0.82.0-rc.5):
     - hermes-engine
-    - RCTRequired (= 0.82.0-rc.4)
-    - RCTTypeSafety (= 0.82.0-rc.4)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
+  - React-FabricImage (0.82.0-rc.5):
+    - hermes-engine
+    - RCTRequired (= 0.82.0-rc.5)
+    - RCTTypeSafety (= 0.82.0-rc.5)
     - React-Core-prebuilt
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.82.0-rc.4)
+    - React-jsiexecutor (= 0.82.0-rc.5)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-featureflags (0.82.0-rc.4):
+  - React-featureflags (0.82.0-rc.5):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-featureflagsnativemodule (0.82.0-rc.4):
+  - React-featureflagsnativemodule (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1658,27 +1658,27 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-graphics (0.82.0-rc.4):
+  - React-graphics (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
     - React-jsiexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-hermes (0.82.0-rc.4):
+  - React-hermes (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
-    - React-cxxreact (= 0.82.0-rc.4)
+    - React-cxxreact (= 0.82.0-rc.5)
     - React-jsi
-    - React-jsiexecutor (= 0.82.0-rc.4)
+    - React-jsiexecutor (= 0.82.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.82.0-rc.4)
+    - React-perflogger (= 0.82.0-rc.5)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-idlecallbacksnativemodule (0.82.0-rc.4):
+  - React-idlecallbacksnativemodule (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1688,7 +1688,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-ImageManager (0.82.0-rc.4):
+  - React-ImageManager (0.82.0-rc.5):
     - React-Core-prebuilt
     - React-Core/Default
     - React-debug
@@ -1697,7 +1697,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - ReactNativeDependencies
-  - React-jserrorhandler (0.82.0-rc.4):
+  - React-jserrorhandler (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1706,11 +1706,11 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - ReactNativeDependencies
-  - React-jsi (0.82.0-rc.4):
+  - React-jsi (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsiexecutor (0.82.0-rc.4):
+  - React-jsiexecutor (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1722,7 +1722,7 @@ PODS:
     - React-perflogger
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsinspector (0.82.0-rc.4):
+  - React-jsinspector (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1731,44 +1731,44 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.82.0-rc.4)
+    - React-perflogger (= 0.82.0-rc.5)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsinspectorcdp (0.82.0-rc.4):
+  - React-jsinspectorcdp (0.82.0-rc.5):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsinspectornetwork (0.82.0-rc.4):
+  - React-jsinspectornetwork (0.82.0-rc.5):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspectorcdp
     - React-performancetimeline
     - React-timing
     - ReactNativeDependencies
-  - React-jsinspectortracing (0.82.0-rc.4):
+  - React-jsinspectortracing (0.82.0-rc.5):
     - React-Core-prebuilt
     - React-oscompat
     - React-timing
     - ReactNativeDependencies
-  - React-jsitooling (0.82.0-rc.4):
+  - React-jsitooling (0.82.0-rc.5):
     - React-Core-prebuilt
-    - React-cxxreact (= 0.82.0-rc.4)
+    - React-cxxreact (= 0.82.0-rc.5)
     - React-debug
-    - React-jsi (= 0.82.0-rc.4)
+    - React-jsi (= 0.82.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsitracing (0.82.0-rc.4):
+  - React-jsitracing (0.82.0-rc.5):
     - React-jsi
-  - React-logger (0.82.0-rc.4):
+  - React-logger (0.82.0-rc.5):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-Mapbuffer (0.82.0-rc.4):
+  - React-Mapbuffer (0.82.0-rc.5):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-microtasksnativemodule (0.82.0-rc.4):
+  - React-microtasksnativemodule (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1776,7 +1776,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-NativeModulesApple (0.82.0-rc.4):
+  - React-NativeModulesApple (0.82.0-rc.5):
     - hermes-engine
     - React-callinvoker
     - React-Core
@@ -1791,11 +1791,11 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-oscompat (0.82.0-rc.4)
-  - React-perflogger (0.82.0-rc.4):
+  - React-oscompat (0.82.0-rc.5)
+  - React-perflogger (0.82.0-rc.5):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-performancecdpmetrics (0.82.0-rc.4):
+  - React-performancecdpmetrics (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1803,16 +1803,16 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - ReactNativeDependencies
-  - React-performancetimeline (0.82.0-rc.4):
+  - React-performancetimeline (0.82.0-rc.5):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspectortracing
     - React-perflogger
     - React-timing
     - ReactNativeDependencies
-  - React-RCTActionSheet (0.82.0-rc.4):
-    - React-Core/RCTActionSheetHeaders (= 0.82.0-rc.4)
-  - React-RCTAnimation (0.82.0-rc.4):
+  - React-RCTActionSheet (0.82.0-rc.5):
+    - React-Core/RCTActionSheetHeaders (= 0.82.0-rc.5)
+  - React-RCTAnimation (0.82.0-rc.5):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTAnimationHeaders
@@ -1822,7 +1822,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTAppDelegate (0.82.0-rc.4):
+  - React-RCTAppDelegate (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1850,7 +1850,7 @@ PODS:
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTBlob (0.82.0-rc.4):
+  - React-RCTBlob (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-Core/RCTBlobHeaders
@@ -1863,7 +1863,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFabric (0.82.0-rc.4):
+  - React-RCTFabric (0.82.0-rc.5):
     - hermes-engine
     - React-Core
     - React-Core-prebuilt
@@ -1893,7 +1893,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-RCTFBReactNativeSpec (0.82.0-rc.4):
+  - React-RCTFBReactNativeSpec (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1901,10 +1901,10 @@ PODS:
     - React-Core-prebuilt
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.82.0-rc.4)
+    - React-RCTFBReactNativeSpec/components (= 0.82.0-rc.5)
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFBReactNativeSpec/components (0.82.0-rc.4):
+  - React-RCTFBReactNativeSpec/components (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1921,7 +1921,7 @@ PODS:
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-RCTImage (0.82.0-rc.4):
+  - React-RCTImage (0.82.0-rc.5):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTImageHeaders
@@ -1931,14 +1931,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTLinking (0.82.0-rc.4):
-    - React-Core/RCTLinkingHeaders (= 0.82.0-rc.4)
-    - React-jsi (= 0.82.0-rc.4)
+  - React-RCTLinking (0.82.0-rc.5):
+    - React-Core/RCTLinkingHeaders (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0-rc.5)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.82.0-rc.4)
-  - React-RCTNetwork (0.82.0-rc.4):
+    - ReactCommon/turbomodule/core (= 0.82.0-rc.5)
+  - React-RCTNetwork (0.82.0-rc.5):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTNetworkHeaders
@@ -1951,7 +1951,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTRuntime (0.82.0-rc.4):
+  - React-RCTRuntime (0.82.0-rc.5):
     - hermes-engine
     - React-Core
     - React-Core-prebuilt
@@ -1966,7 +1966,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - ReactNativeDependencies
-  - React-RCTSettings (0.82.0-rc.4):
+  - React-RCTSettings (0.82.0-rc.5):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTSettingsHeaders
@@ -1975,10 +1975,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTText (0.82.0-rc.4):
-    - React-Core/RCTTextHeaders (= 0.82.0-rc.4)
+  - React-RCTText (0.82.0-rc.5):
+    - React-Core/RCTTextHeaders (= 0.82.0-rc.5)
     - Yoga
-  - React-RCTVibration (0.82.0-rc.4):
+  - React-RCTVibration (0.82.0-rc.5):
     - React-Core-prebuilt
     - React-Core/RCTVibrationHeaders
     - React-jsi
@@ -1986,15 +1986,15 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-rendererconsistency (0.82.0-rc.4)
-  - React-renderercss (0.82.0-rc.4):
+  - React-rendererconsistency (0.82.0-rc.5)
+  - React-renderercss (0.82.0-rc.5):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.82.0-rc.4):
+  - React-rendererdebug (0.82.0-rc.5):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-RuntimeApple (0.82.0-rc.4):
+  - React-RuntimeApple (0.82.0-rc.5):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -2017,7 +2017,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeCore (0.82.0-rc.4):
+  - React-RuntimeCore (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -2033,14 +2033,14 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-runtimeexecutor (0.82.0-rc.4):
+  - React-runtimeexecutor (0.82.0-rc.5):
     - React-Core-prebuilt
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.82.0-rc.4)
+    - React-jsi (= 0.82.0-rc.5)
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeHermes (0.82.0-rc.4):
+  - React-RuntimeHermes (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -2055,7 +2055,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-runtimescheduler (0.82.0-rc.4):
+  - React-runtimescheduler (0.82.0-rc.5):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -2071,15 +2071,15 @@ PODS:
     - React-timing
     - React-utils
     - ReactNativeDependencies
-  - React-timing (0.82.0-rc.4):
+  - React-timing (0.82.0-rc.5):
     - React-debug
-  - React-utils (0.82.0-rc.4):
+  - React-utils (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-debug
-    - React-jsi (= 0.82.0-rc.4)
+    - React-jsi (= 0.82.0-rc.5)
     - ReactNativeDependencies
-  - React-webperformancenativemodule (0.82.0-rc.4):
+  - React-webperformancenativemodule (0.82.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -2089,9 +2089,9 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - ReactAppDependencyProvider (0.82.0-rc.4):
+  - ReactAppDependencyProvider (0.82.0-rc.5):
     - ReactCodegen
-  - ReactCodegen (0.82.0-rc.4):
+  - ReactCodegen (0.82.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2111,43 +2111,43 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - ReactCommon (0.82.0-rc.4):
+  - ReactCommon (0.82.0-rc.5):
     - React-Core-prebuilt
-    - ReactCommon/turbomodule (= 0.82.0-rc.4)
+    - ReactCommon/turbomodule (= 0.82.0-rc.5)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule (0.82.0-rc.4):
+  - ReactCommon/turbomodule (0.82.0-rc.5):
     - hermes-engine
-    - React-callinvoker (= 0.82.0-rc.4)
+    - React-callinvoker (= 0.82.0-rc.5)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.82.0-rc.4)
-    - React-jsi (= 0.82.0-rc.4)
-    - React-logger (= 0.82.0-rc.4)
-    - React-perflogger (= 0.82.0-rc.4)
-    - ReactCommon/turbomodule/bridging (= 0.82.0-rc.4)
-    - ReactCommon/turbomodule/core (= 0.82.0-rc.4)
+    - React-cxxreact (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0-rc.5)
+    - React-logger (= 0.82.0-rc.5)
+    - React-perflogger (= 0.82.0-rc.5)
+    - ReactCommon/turbomodule/bridging (= 0.82.0-rc.5)
+    - ReactCommon/turbomodule/core (= 0.82.0-rc.5)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/bridging (0.82.0-rc.4):
+  - ReactCommon/turbomodule/bridging (0.82.0-rc.5):
     - hermes-engine
-    - React-callinvoker (= 0.82.0-rc.4)
+    - React-callinvoker (= 0.82.0-rc.5)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.82.0-rc.4)
-    - React-jsi (= 0.82.0-rc.4)
-    - React-logger (= 0.82.0-rc.4)
-    - React-perflogger (= 0.82.0-rc.4)
+    - React-cxxreact (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0-rc.5)
+    - React-logger (= 0.82.0-rc.5)
+    - React-perflogger (= 0.82.0-rc.5)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/core (0.82.0-rc.4):
+  - ReactCommon/turbomodule/core (0.82.0-rc.5):
     - hermes-engine
-    - React-callinvoker (= 0.82.0-rc.4)
+    - React-callinvoker (= 0.82.0-rc.5)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.82.0-rc.4)
-    - React-debug (= 0.82.0-rc.4)
-    - React-featureflags (= 0.82.0-rc.4)
-    - React-jsi (= 0.82.0-rc.4)
-    - React-logger (= 0.82.0-rc.4)
-    - React-perflogger (= 0.82.0-rc.4)
-    - React-utils (= 0.82.0-rc.4)
+    - React-cxxreact (= 0.82.0-rc.5)
+    - React-debug (= 0.82.0-rc.5)
+    - React-featureflags (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0-rc.5)
+    - React-logger (= 0.82.0-rc.5)
+    - React-perflogger (= 0.82.0-rc.5)
+    - React-utils (= 0.82.0-rc.5)
     - ReactNativeDependencies
-  - ReactNativeDependencies (0.82.0-rc.4)
+  - ReactNativeDependencies (0.82.0-rc.5)
   - SDWebImage (5.21.0):
     - SDWebImage/Core (= 5.21.0)
   - SDWebImage/Core (5.21.0)
@@ -2478,7 +2478,7 @@ SPEC CHECKSUMS:
   EXStructuredHeaders: c951e77f2d936f88637421e9588c976da5827368
   EXUpdates: b96ad490c9456eebc38f949f3c30ce6258845773
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
-  FBLazyVector: e414d023e1ddc41341bb06e7590bc95d5824028a
+  FBLazyVector: bd5db632a304b99a915e07040696286715b97462
   hermes-engine: 883ad6cdbcb152221038266a5908c1fa6c1002f7
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
@@ -2486,78 +2486,78 @@ SPEC CHECKSUMS:
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: d32871931c05547cb4e0bc9009d66a18b50d8558
-  RCTDeprecation: e6bce6cb7d767c2a1ac7b419999e4717ebe87595
-  RCTRequired: 806c21cf70b6a8058daa77729439b0202e2b72e5
-  RCTTypeSafety: 0dce095435551439cb926ac86c041f62ca03c0ab
+  RCTDeprecation: 464a4d4314df84aeafa5cba421aa546f12ea45c2
+  RCTRequired: 7ec2b105ee6a82a849718a97e2769c2b3649eeea
+  RCTTypeSafety: 53fc675982f0fc6a599cfe66d3047b8adda347b1
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 0fde0b13f6cca9b4e4525d888dd952e87e5f2c28
-  React-callinvoker: 841bceb08682edd88affeb3e91e04e7c3cd24f3a
-  React-Core: 3459482292cbf3966d1c55cd61af3869c77a318d
-  React-Core-prebuilt: 67b1d61c958772c696bc9f356a4b88ff8c5e3933
-  React-CoreModules: aa77770e3ca2b983df4ea623b026704b78b600fd
-  React-cxxreact: 98edd32f3e558250a63e6864f753e78a11abe819
-  React-debug: f955b5ab47bd2acfc6d15990e60b4c1b26fd5a55
-  React-defaultsnativemodule: 092d5e1ea973eb0837b27f2fabb7ed965647887a
-  React-domnativemodule: eb0733f87e937da11580225f929e56fd2ec806b2
-  React-Fabric: 54d8f3990411c6f2cc83be64793237d0a97fd025
-  React-FabricComponents: 62d59d52826c0f4d78b0e7b8ee67011d810e1e03
-  React-FabricImage: 5b840611a389f7fc23cd86376881e85c993602f9
-  React-featureflags: 19b9c2ef14b18ad37b5a814b535b0b9f5bf7c702
-  React-featureflagsnativemodule: e824b951f2fefbdedadaf0ff4d2aa8a990e3563b
-  React-graphics: 2289cebd017fa69bc4009fe9e80ab731dd71a97b
-  React-hermes: a8955b344166368f115d2f3c923f03a86a1dc5f6
-  React-idlecallbacksnativemodule: b3e1dfab1006d82282865ed59ef0d218a759e496
-  React-ImageManager: fd109ea859a6377c65298b2c3180e6b0e6a386d9
-  React-jserrorhandler: 23cbbf2c375fe5017c6d1337dac16a22fe908054
-  React-jsi: 5fccf734f969c019fb0a866960574d61f5bdb957
-  React-jsiexecutor: 8a81809979789ff33bde7871d8690da8d5cebee3
-  React-jsinspector: 5046be4d25c8425ea1cafc8c7e33b624a13e36a0
-  React-jsinspectorcdp: 98bcc670d818bdde687dbc023f386842e48de6bb
-  React-jsinspectornetwork: 0ae9e2f2471a32db039a06c9bf5d5373d2f75172
-  React-jsinspectortracing: ae458b882f29ddad0fca6d5a4a1f7227386cc88b
-  React-jsitooling: 4cd202a09c5fee51a4ff919b45bf43699fa6f57d
-  React-jsitracing: 31cdc6136f806f7e2161ec589fb1e7d84d4364b4
-  React-logger: 1aee8c11182049e2d856d885102c0cb753c2411a
-  React-Mapbuffer: 061e9707ff58d79377c05ded98f70686fe7e7307
-  React-microtasksnativemodule: ece68a111bc0c199dc862926912be3888ad7d1af
-  React-NativeModulesApple: 8017cc15d3a1882dde7756889eb45e9be64a5d58
-  React-oscompat: 1a7135f36afc81946a27e2176e8afcb518e73141
-  React-perflogger: e6aae1dbf13c2acde7329f75bbbbde43125715f1
-  React-performancecdpmetrics: 10c75aa358b1e225ab6988e0e15786c623b8d667
-  React-performancetimeline: a02c365e92e0a60d55e15fcfb16576efa44afd6b
-  React-RCTActionSheet: 3107e73516a18b979fcf5457a5c9b2435f7fd507
-  React-RCTAnimation: 24a8b1a758ece2a5d4151b0d0fa773024908c6ec
-  React-RCTAppDelegate: 31a5601f5cd78b87851055891bc2c05194749502
-  React-RCTBlob: 88fccd5827f49ec25bf1e410ba517d0eb2c1b86d
-  React-RCTFabric: cfabd7d39465365b2da6ac945613f87494f6e1d2
-  React-RCTFBReactNativeSpec: b82035ed4924b69791f3d90659ff95e296fc2ceb
-  React-RCTImage: 489131a82db4b0f81ca535a579b66a52b9103b04
-  React-RCTLinking: c2f1c3c9dcd5e4dde8718fa929fb2499cd93377a
-  React-RCTNetwork: fefef5a92bcda86c65bb393b9d10f89510aebbcb
-  React-RCTRuntime: 3a59c15c155deb91bcae2ba64cf3821e6a3ff3ce
-  React-RCTSettings: ddf6c870c7262c25f89cfd8e00c9bbb9d29e9406
-  React-RCTText: 7c0772cbb59343a7a6f5d35fe635788d34e06ce8
-  React-RCTVibration: f8cb58ec075cb6efc57b89c823b2952af795ec09
-  React-rendererconsistency: e08e56ef62e18e4cab71cef9c3daff0b68042964
-  React-renderercss: d1e5364f0352729a46197a7ced88431f767059f2
-  React-rendererdebug: fafafdcc4db1ab78bf02889a08fb79bdb97340b5
-  React-RuntimeApple: 88bedcb3fcd012304ed36b7008e8401b005f3b34
-  React-RuntimeCore: 6d63b92530921c861afb753fbf907e71f93509f5
-  React-runtimeexecutor: 489099099bf02a6fafe8a46e29e2c06645aad842
-  React-RuntimeHermes: ac1a90ca4acc3d568b6d269da0173a1e7dc9df40
-  React-runtimescheduler: 4824af73f099892335c2becdd6765ba231b98972
-  React-timing: 2c6aec379bcf9b622c2f96acbc0eeba546cee5a4
-  React-utils: 84ae8e19fb48744597426cc6cb15efd3991c700b
-  React-webperformancenativemodule: 79193119af8d334422aea59a10c9330a51b72b3b
-  ReactAppDependencyProvider: a5f2664120eb6e9dc431a74a40370652311db139
-  ReactCodegen: 6298d3515f2e7b659cbaa50e7ba23d75ac08e071
-  ReactCommon: e17c8981925f02f0b7bef8d1f464ce0ca74c053e
-  ReactNativeDependencies: 286c6874efa19360604024ff0643273be1de5d91
+  React: 6eb704af98132bfdd36a19d9910b4d317d13100c
+  React-callinvoker: d3ef985f0e471dd4e6bf2d211e6a8a8721a2ca55
+  React-Core: b4b1a97d59b674896e243d70173f829247307d95
+  React-Core-prebuilt: 533958c653ad258eafa63ef14d21383fc2b255a2
+  React-CoreModules: 58a3036f2f1ff1d4db71e96f51ef2abab3da9890
+  React-cxxreact: ddf8df79906abbd0faa8fee7ac42f68669f4a389
+  React-debug: ddc5f4fcd34d349b4f9012c26f74fe043768d72d
+  React-defaultsnativemodule: cba90d0fd3b74c57a41b3404dccd2b774254e32c
+  React-domnativemodule: 2fdee77a7845eb601d32177a3164a7f7213a05e5
+  React-Fabric: a005506975193c8220150ff753db06f62a9f3675
+  React-FabricComponents: 686d531464879d5ce38f19f2a3b8619860e6b2a1
+  React-FabricImage: 1b9e7bdeef180071f5ed3004f32c927ed4bd878e
+  React-featureflags: 1f970af672e5ad345f2fbc046619c355baf6c5a8
+  React-featureflagsnativemodule: 2cd9a2651f405aa34c60e43ccc4ef023608d6f92
+  React-graphics: f574f381582a1eee5632bfd5fa1ef7e05e2cb3cd
+  React-hermes: f8b32be4c35319e8e42fc2988cb37bbe8eb5ee78
+  React-idlecallbacksnativemodule: 41817bea59ab577183de9881d92bb09154c49ab0
+  React-ImageManager: 36738f4bbf09285cbfa1bc0d18bf7715f24e0249
+  React-jserrorhandler: bd8b58138f773c1f3f1e2ea730190beca53a8725
+  React-jsi: 5b21b09133d7364383392112d9b4dd751c8b438f
+  React-jsiexecutor: 7f835364605e2e6590083c1df4d50b360398f185
+  React-jsinspector: 4d962cea0a8cf461d2b0f76de6e3f29ad73c128d
+  React-jsinspectorcdp: 84fefd05d64dce694a19bccc8593bdfde0d3e573
+  React-jsinspectornetwork: c03d2d5eb98dd23f9db9a9c33de3f35bdcb7638f
+  React-jsinspectortracing: c908bcaeb2b16a382ff493d4001810ab57633765
+  React-jsitooling: 9c3161134d505db87731becc8e0c605e05f0f34c
+  React-jsitracing: 466fdc56f44f86c5f19e8db3658b36ca48b1212e
+  React-logger: e3d0d02438e5a397ee0dc439957636f2910205ce
+  React-Mapbuffer: cc64bef8b0da852c7558a219d87e28910a49b9e5
+  React-microtasksnativemodule: bf2d7b592a8beea5e937036969761fac841a019f
+  React-NativeModulesApple: 169bb5425798368481b3b4ae911833a0c3822759
+  React-oscompat: dc153eed09ee87bc374b255143ca9339bd5556a8
+  React-perflogger: f763d0787a14c6b595d6d1981faa472bceac4e31
+  React-performancecdpmetrics: 780c8391c0bad88f8f490461028018b3a106a56f
+  React-performancetimeline: 2ef25330a0d61f9263dfc625e12d9ad4969405f2
+  React-RCTActionSheet: 6cf10d77cb47a0d9d4bdae6075f911b362a26344
+  React-RCTAnimation: fcfb0df113ccad9453db609d88085478b20397e3
+  React-RCTAppDelegate: c83a7e414ba6d0632ce65463e2d5a7fc4126b122
+  React-RCTBlob: 1d2e8bdb1429074a81d28de4e2a4d0c56643e6b2
+  React-RCTFabric: 9d8a731289216d71109992c549da99e7079e3e01
+  React-RCTFBReactNativeSpec: ebce52c839314577048ae9a04fe81c731a44e4d2
+  React-RCTImage: 7d7d5d6814e4ad53822d78be6e5d8c6fe0b48e85
+  React-RCTLinking: c13f8ea47e49b72d3d9f67235c315fc1e924e91e
+  React-RCTNetwork: 4d628a356fd2cbe6693ac1ee72684cbb4020149c
+  React-RCTRuntime: fed46908b2fdfdc8c24965f0bc550b05a43f90cc
+  React-RCTSettings: b75244d9ecd5320bbfb19cdc5c6cbe8e378b25ee
+  React-RCTText: 0227dac029b355133f9da975f956ff5fbc3b4555
+  React-RCTVibration: 75292ca92dd22ba089c4adf3487f12dde10ffac1
+  React-rendererconsistency: 358eb8fb00c38ba78cf5e72e8a2a3faf94a633c6
+  React-renderercss: 6a5a7abaaee411d9cdcf23a5802d41f48f2ba0d2
+  React-rendererdebug: 9e4e27b215b65259c7a0418b6d264302c33a3341
+  React-RuntimeApple: 85c518c687ac0be44e6df286904ae7bfcecd2db6
+  React-RuntimeCore: 3b68e7474ca2055d2319afbdfdbcab15f5f0ecb7
+  React-runtimeexecutor: c5390f9a49f9c5d3765ce3aa61e4a1e1965c5792
+  React-RuntimeHermes: a1308f2437b71db23ed200f3b99ab45636be87bd
+  React-runtimescheduler: f3a7dc6ec5679b7a22df23ebca35ed789ab9e46c
+  React-timing: 4121ff074bbaefed0608204e88ec2348c9747198
+  React-utils: 8b54a394f9b7ddcc1fcad731854e70be2ce6a536
+  React-webperformancenativemodule: 7f2f10b926d84f2b10067369c95ed29d459a0bea
+  ReactAppDependencyProvider: 77a7129540c0e06ab6be9a2bcb887d3d2e594431
+  ReactCodegen: 858ec16ee37e11e5a8e27c7579cedb80ddd36da9
+  ReactCommon: 098214faf94e79d56f004cac54464386c4c5d8e0
+  ReactNativeDependencies: beee42eb54e7ca052bd312c214dbe5d1487e02c7
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
-  Yoga: 04bf2cd82465bca296727b6157a015fe49ac0304
+  Yoga: c972c838201c115255559220e4e14cf76a5401a6
 
 PODFILE CHECKSUM: 7b324c13881703a862f70f400c68133d3b5568d5
 

--- a/apps/native-tests/package.json
+++ b/apps/native-tests/package.json
@@ -19,7 +19,7 @@
     "expo-updates": "29.0.10",
     "react": "19.1.1",
     "react-dom": "19.1.1",
-    "react-native": "0.82.0-rc.4"
+    "react-native": "0.82.0-rc.5"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -31,7 +31,7 @@
     "expo-task-manager": "14.0.7",
     "react-native-gesture-handler": "~2.28.0",
     "react": "19.1.1",
-    "react-native": "0.82.0-rc.4",
+    "react-native": "0.82.0-rc.5",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.16.0"
   },

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -47,7 +47,7 @@
     "expo-sqlite": "~16.0.8",
     "jose": "^5",
     "react": "19.1.1",
-    "react-native": "0.82.0-rc.4",
+    "react-native": "0.82.0-rc.5",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.16.0",
     "react-native-webview": "13.15.0"

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -15,7 +15,7 @@
     "expo-router": "^6.0.6",
     "expo-splash-screen": "~31.0.10",
     "react": "19.1.1",
-    "react-native": "0.82.0-rc.4",
+    "react-native": "0.82.0-rc.5",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.11.1-nightly-20250611-8b82e081e"
   },

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -51,7 +51,7 @@
     "jasmine-core": "^2.4.1",
     "lodash": "^4.17.19",
     "react": "19.1.1",
-    "react-native": "0.82.0-rc.4",
+    "react-native": "0.82.0-rc.5",
     "react-native-gesture-handler": "~2.28.0",
     "sinon": "^7.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "resolutions": {
     "@expo/metro": "~54.0.0",
-    "react-native": "0.82.0-rc.4",
+    "react-native": "0.82.0-rc.5",
     "react": "19.1.1",
     "react-dom": "19.1.1",
     "@types/babel__core": "^7.20.5",

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -60,7 +60,7 @@
     "@expo/spawn-async": "^1.7.2",
     "@expo/ws-tunnel": "^1.0.1",
     "@expo/xcpretty": "^4.3.0",
-    "@react-native/dev-middleware": "0.82.0-rc.4",
+    "@react-native/dev-middleware": "0.82.0-rc.5",
     "@urql/core": "^5.0.6",
     "@urql/exchange-retry": "^1.3.0",
     "accepts": "^1.3.8",

--- a/packages/@expo/prebuild-config/package.json
+++ b/packages/@expo/prebuild-config/package.json
@@ -45,7 +45,7 @@
     "@expo/config-types": "^54.0.8",
     "@expo/image-utils": "^0.8.7",
     "@expo/json-file": "^10.0.7",
-    "@react-native/normalize-colors": "0.82.0-rc.4",
+    "@react-native/normalize-colors": "0.82.0-rc.5",
     "debug": "^4.3.1",
     "resolve-from": "^5.0.0",
     "semver": "^7.6.0",

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -69,7 +69,7 @@
     "@babel/plugin-transform-parameters": "^7.24.7",
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.23.0",
-    "@react-native/babel-preset": "0.82.0-rc.4",
+    "@react-native/babel-preset": "0.82.0-rc.5",
     "babel-plugin-react-compiler": "^19.1.0-rc.2",
     "babel-plugin-react-native-web": "~0.21.0",
     "babel-plugin-transform-flow-enums": "^0.0.2",

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -42,7 +42,7 @@
     "babel-preset-expo": "~54.0.1",
     "expo-module-scripts": "^5.0.7",
     "react": "19.1.1",
-    "react-native": "0.82.0-rc.4"
+    "react-native": "0.82.0-rc.5"
   },
   "peerDependencies": {
     "expo": "*"

--- a/packages/expo-module-template/$package.json
+++ b/packages/expo-module-template/$package.json
@@ -28,7 +28,7 @@
     "@types/react": "~19.1.1",
     "expo-module-scripts": "^5.0.7",
     "expo": "^54.0.8",
-    "react-native": "0.82.0-rc.4"
+    "react-native": "0.82.0-rc.5"
   },
   "peerDependencies": {
     "expo": "*",

--- a/packages/expo-navigation-bar/package.json
+++ b/packages/expo-navigation-bar/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/navigation-bar",
   "dependencies": {
-    "@react-native/normalize-colors": "0.82.0-rc.4",
+    "@react-native/normalize-colors": "0.82.0-rc.5",
     "debug": "^4.3.2",
     "react-native-is-edge-to-edge": "^1.2.1"
   },

--- a/packages/expo-system-ui/package.json
+++ b/packages/expo-system-ui/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/system-ui",
   "dependencies": {
-    "@react-native/normalize-colors": "0.82.0-rc.4",
+    "@react-native/normalize-colors": "0.82.0-rc.5",
     "debug": "^4.3.2"
   },
   "jest": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -93,7 +93,7 @@
   "lottie-react-native": "~7.3.1",
   "react": "19.1.1",
   "react-dom": "19.1.1",
-  "react-native": "0.82.0-rc.4",
+  "react-native": "0.82.0-rc.5",
   "react-native-web": "~0.21.0",
   "react-native-gesture-handler": "~2.28.0",
   "react-native-get-random-values": "~1.11.0",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -103,7 +103,7 @@
     "expo-module-scripts": "^5.0.7",
     "react": "19.1.1",
     "react-dom": "19.1.1",
-    "react-native": "0.82.0-rc.4",
+    "react-native": "0.82.0-rc.5",
     "web-streams-polyfill": "^3.3.2"
   },
   "peerDependencies": {

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -14,6 +14,6 @@
     "expo": "~54.0.8",
     "expo-status-bar": "~3.0.8",
     "react": "19.1.1",
-    "react-native": "0.82.0-rc.4"
+    "react-native": "0.82.0-rc.5"
   }
 }

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -14,7 +14,7 @@
     "expo": "~54.0.8",
     "expo-status-bar": "~3.0.8",
     "react": "19.1.1",
-    "react-native": "0.82.0-rc.4"
+    "react-native": "0.82.0-rc.5"
   },
   "devDependencies": {
     "@types/react": "~19.1.1",

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -14,6 +14,6 @@
     "expo": "~54.0.8",
     "expo-status-bar": "~3.0.8",
     "react": "19.1.1",
-    "react-native": "0.82.0-rc.4"
+    "react-native": "0.82.0-rc.5"
   }
 }

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -30,7 +30,7 @@
     "expo-web-browser": "~15.0.7",
     "react": "19.1.1",
     "react-dom": "19.1.1",
-    "react-native": "0.82.0-rc.4",
+    "react-native": "0.82.0-rc.5",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-worklets": "0.5.1",
     "react-native-reanimated": "~4.1.1",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -23,7 +23,7 @@
     "expo-web-browser": "~15.0.7",
     "react": "19.1.1",
     "react-dom": "19.1.1",
-    "react-native": "0.82.0-rc.4",
+    "react-native": "0.82.0-rc.5",
     "react-native-worklets": "0.5.1",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3514,23 +3514,23 @@
   resolved "https://registry.yarnpkg.com/@react-native-segmented-control/segmented-control/-/segmented-control-2.5.7.tgz#7c91ef7dede8752796a234321fafa2c604fc82af"
   integrity sha512-l84YeVX8xAU3lvOJSvV4nK/NbGhIm2gBfveYolwaoCbRp+/SLXtc6mYrQmM9ScXNwU14mnzjQTpTHWl5YPnkzQ==
 
-"@react-native/assets-registry@0.82.0-rc.4":
-  version "0.82.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.82.0-rc.4.tgz#956e35c75e824a849d45aad0ccac73b94b4d123a"
-  integrity sha512-UGOSqQZeOqDKqNIXir4hYdx3aKFnEGyPixc/e/OrxCQ9HS0w8l4/8S9g3QcNciHZ9WQvLtNn69ECrMM44Nfc2g==
+"@react-native/assets-registry@0.82.0-rc.5":
+  version "0.82.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.82.0-rc.5.tgz#b9dadc374e7e4d1f34801e20772d6d3783c163e1"
+  integrity sha512-fF2izzU9RizpXJ4AtnAzEbbufVh7a/z5budc4xhLg0qj0hmDpd2VLgBednDSO7I3oSwozU9JnZsUfEf6J1BKkQ==
 
-"@react-native/babel-plugin-codegen@0.82.0-rc.4":
-  version "0.82.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.82.0-rc.4.tgz#8bd00e7fd792bb677f37679c536a7822b7f6679b"
-  integrity sha512-Kw0h5mDqHHks5JPkMDMnn+I1Yldtc+BEpwdBFJ5VJdE1l5CdD20fkFWgxXEzji4BTGanJvS6HLX2OP8lOrX8xA==
+"@react-native/babel-plugin-codegen@0.82.0-rc.5":
+  version "0.82.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.82.0-rc.5.tgz#b350a78a29aa46d8802d9e60ac1c0a6c2f8ab5f4"
+  integrity sha512-0EPKukwkJKwGaDAcNRX783mXRBjBf3hNcfTGnWWVRG61ZUPqDR1l0nRB80lqizWeetXNLC4Llm90y5giNBjZIg==
   dependencies:
     "@babel/traverse" "^7.25.3"
-    "@react-native/codegen" "0.82.0-rc.4"
+    "@react-native/codegen" "0.82.0-rc.5"
 
-"@react-native/babel-preset@0.82.0-rc.4":
-  version "0.82.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.82.0-rc.4.tgz#10711d371522bbab4e4bc781974a0b550de1920d"
-  integrity sha512-DbYsPguILf/qnU/r+CMlhgQejmcuT83u97X3Jex0uzNvqIEL4lP1A5V1GoGnmaTxIxAlO7Kp+RSeGdtwmlMoLQ==
+"@react-native/babel-preset@0.82.0-rc.5":
+  version "0.82.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.82.0-rc.5.tgz#fd91bee023b2ac5530d8dd2846fad205c6aa53cb"
+  integrity sha512-ohBW3EuaT+bYBvwXVqajfcVg7/yquellpmmHwCVnaCJ4TuMzd2e12LOEPRtNEi/PGB6+LYzNZ1F5OGSXCu2NtQ==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/plugin-proposal-export-default-from" "^7.24.7"
@@ -3573,15 +3573,15 @@
     "@babel/plugin-transform-typescript" "^7.25.2"
     "@babel/plugin-transform-unicode-regex" "^7.24.7"
     "@babel/template" "^7.25.0"
-    "@react-native/babel-plugin-codegen" "0.82.0-rc.4"
+    "@react-native/babel-plugin-codegen" "0.82.0-rc.5"
     babel-plugin-syntax-hermes-parser "0.32.0"
     babel-plugin-transform-flow-enums "^0.0.2"
     react-refresh "^0.14.0"
 
-"@react-native/codegen@0.82.0-rc.4":
-  version "0.82.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.82.0-rc.4.tgz#45a5a72fd330d4e5ef8c7715b2d640ef23e94559"
-  integrity sha512-DFkV/8BUKjdv7MDYgRYBOyGidAbDDH+RtzcuCaytTlc/IXLD9snvshQg9C6KL+iTH73ADaZGq1er4eAQq1XKwA==
+"@react-native/codegen@0.82.0-rc.5":
+  version "0.82.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.82.0-rc.5.tgz#db981625df35c4939388022e83b31ea74cb15a99"
+  integrity sha512-/lFzP7Pq4Moj27SuvNzUSCa+QnNjZOFFUjiNjV0rqL5R0jVkTyswloosEusC8y8wgcjzFiEDszDg49ZdXH63yg==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/parser" "^7.25.3"
@@ -3591,12 +3591,12 @@
     nullthrows "^1.1.1"
     yargs "^17.6.2"
 
-"@react-native/community-cli-plugin@0.82.0-rc.4":
-  version "0.82.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.82.0-rc.4.tgz#b5024ea686c7ecf58f0941358a57327b7b7d150b"
-  integrity sha512-ZhdJ+cFOZfTlW2M4LLSBQyVCmmOXK5Z3+d/NraKLoUzasr6Xi+b09nSqM/2n0yYO4JiI10r6JTc00DROxxBF7A==
+"@react-native/community-cli-plugin@0.82.0-rc.5":
+  version "0.82.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.82.0-rc.5.tgz#3c7cc5661768ddd738400f4ac9a5a0c5e0e40093"
+  integrity sha512-phvWerDnECEMPxkCd5+3Qp203OkeMYowTmEbF04TZxEh+n8GfsHx+76AQNlfX47Cc4daFaGa788K7NIzmHT+xw==
   dependencies:
-    "@react-native/dev-middleware" "0.82.0-rc.4"
+    "@react-native/dev-middleware" "0.82.0-rc.5"
     debug "^4.4.0"
     invariant "^2.2.4"
     metro "^0.83.1"
@@ -3604,27 +3604,27 @@
     metro-core "^0.83.1"
     semver "^7.1.3"
 
-"@react-native/debugger-frontend@0.82.0-rc.4":
-  version "0.82.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.82.0-rc.4.tgz#cd24bf052dc5d49a4fbb9859c8f8e382e1db5a08"
-  integrity sha512-y687DB4yAvgLsYPMFb9uaO30Pu55wyrZFXd/IGlBs10H8TDMvRsI5w1unWtRM7fFUsqCFkhJoT7udPG0w0QIVQ==
+"@react-native/debugger-frontend@0.82.0-rc.5":
+  version "0.82.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.82.0-rc.5.tgz#3324c7801ee98c36fe99f7ff211793766adc6c65"
+  integrity sha512-+Jt+oYH19NB2uGJNU8YX88YZn0xIR1fFGOiFht+Dj0OEsBiPDQL5rZ+3XLxgFB5Heg0GebaRFMTJ2zUB7HG6tw==
 
-"@react-native/debugger-shell@0.82.0-rc.4":
-  version "0.82.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@react-native/debugger-shell/-/debugger-shell-0.82.0-rc.4.tgz#bc1392ce1bf7de7649bfad1415158bbe8808fdf7"
-  integrity sha512-xmpzu8My7CEiY3Rs8h31uqsDdO8LLCZcCEKaIM2CoLoDnn2/CH9WSW27A+/K+eDJHqf7+i4m6SnUl3ZFIHZUMA==
+"@react-native/debugger-shell@0.82.0-rc.5":
+  version "0.82.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/debugger-shell/-/debugger-shell-0.82.0-rc.5.tgz#7244dd778c17cc49182f4aa0dbcccc966bba1108"
+  integrity sha512-ELfFrAjrN7WG0Vl0S0OIhwcBDx4DrWBwSqj0duZ0Ml1O6v3PLWSAzBNAGTBm8KRJjHHaE7kkkhEhdLvcg6Otrg==
   dependencies:
     cross-spawn "^7.0.6"
     fb-dotslash "0.5.8"
 
-"@react-native/dev-middleware@0.82.0-rc.4":
-  version "0.82.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.82.0-rc.4.tgz#ac657753b9199857a3aade8dfe42909d976840d7"
-  integrity sha512-Cs3HdaM6O9JIKv0pooooc2xENdFV6uRN6XzOZXBg7DAKeyzWEb/SzMiDS17ICtrB491fmO8pNo8rOYuXWdzr4A==
+"@react-native/dev-middleware@0.82.0-rc.5":
+  version "0.82.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.82.0-rc.5.tgz#d41582ad63cacc75e5ce3b7d36f466de991f8cd1"
+  integrity sha512-pfltRXzzzcwhc+J6/gqnp7xKvd/e0cMECPXTuo45eZ80QdfZ9MmCsbXL7BT503VgF9uFMbyhEJskun8JcKu2DQ==
   dependencies:
     "@isaacs/ttlcache" "^1.4.1"
-    "@react-native/debugger-frontend" "0.82.0-rc.4"
-    "@react-native/debugger-shell" "0.82.0-rc.4"
+    "@react-native/debugger-frontend" "0.82.0-rc.5"
+    "@react-native/debugger-shell" "0.82.0-rc.5"
     chrome-launcher "^0.15.2"
     chromium-edge-launcher "^0.2.0"
     connect "^3.6.5"
@@ -3635,30 +3635,30 @@
     serve-static "^1.16.2"
     ws "^6.2.3"
 
-"@react-native/gradle-plugin@0.82.0-rc.4":
-  version "0.82.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.82.0-rc.4.tgz#68a34f01f274c279f2002c66deeff9f591cec7e0"
-  integrity sha512-m8icMigvsK6FgRU60iNQwkHO+p6YjuNTlhx5T0QQDywi85RAtumu5vSEvqfvgy1a/aXHo4/6GgOj7AsLznuPZQ==
+"@react-native/gradle-plugin@0.82.0-rc.5":
+  version "0.82.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.82.0-rc.5.tgz#67bb21dfc45f8a3cbfa7b4307f1c25b420b35d07"
+  integrity sha512-0Qcpf/H7pbNFj0wQMWfLWpOF4ZNwZ2yf1lSPigDo8Ly75tigiyfXj3KW6+VJHHW7UDDGnpzVj4g8q7zZ2EPGvQ==
 
-"@react-native/js-polyfills@0.82.0-rc.4":
-  version "0.82.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.82.0-rc.4.tgz#378b1ff2e5ec64fb2e188b1fc06f7829153b5891"
-  integrity sha512-oNEKC1E0Nx/BZhUFr61pMWztabHX3SqRn0eHzk0LTE9yYUKAV9j3FnCCzpo+AyCYI0SLuIiClIOrq1aBR7N9qQ==
+"@react-native/js-polyfills@0.82.0-rc.5":
+  version "0.82.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.82.0-rc.5.tgz#cdaeeb6f31e3cd4f6ba2745ad18efa345bdbd932"
+  integrity sha512-C7LWRfaxW47ef1WKCp2hEkpLW+YOthooI0nZ3OIQumjgSwQztzMuV3nDzgvF2SLutTctiI9xbE07/VNACKMxBQ==
 
-"@react-native/normalize-colors@0.82.0-rc.4":
-  version "0.82.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.82.0-rc.4.tgz#41c790b0eccd6867b14ac2af8d9e048286abb8aa"
-  integrity sha512-KhRktVIYJR3ii4zckAgCjz0JlEoiljvB5Bguz4A/YYYv+rmMA8oQZcDIkQoDXJalOj9A5VWElyQskcxGBqT/1Q==
+"@react-native/normalize-colors@0.82.0-rc.5":
+  version "0.82.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.82.0-rc.5.tgz#7879daaa27b7e73bd7c9e2aca772d55f6f7bba1d"
+  integrity sha512-i2AzzVuv8BXRfn2Mkq+xaJnWn3c3txQ/dJHs6fXgx+toVFMovlmARz2CDlZD5aPywZoNb2yh7i9SgrPa4jC1Hw==
 
 "@react-native/normalize-colors@^0.74.1":
   version "0.74.88"
   resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.74.88.tgz#46f4c7270c8e6853281d7dd966e0eb362068e41a"
   integrity sha512-He5oTwPBxvXrxJ91dZzpxR7P+VYmc9IkJfhuH8zUiU50ckrt+xWNjtVugPdUv4LuVjmZ36Vk2EX8bl1gVn2dVA==
 
-"@react-native/virtualized-lists@0.82.0-rc.4":
-  version "0.82.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.82.0-rc.4.tgz#892d0a7608cde7a66d026ba24785c1e99227a7a7"
-  integrity sha512-IWrjEdSqArcmbem/Qm19UBNIVU2GrtU/oTwFupt9EbvqlzQnN2M91IybEc9wkqAtDgR1Ikcg7nmB0xNM7zmNlg==
+"@react-native/virtualized-lists@0.82.0-rc.5":
+  version "0.82.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.82.0-rc.5.tgz#2888c8848794270f29bea4b3ad765485eb3ee2c3"
+  integrity sha512-WZ8fRd2xGFicc1PgKQiG/IJQfPISP8D3YoaUrSSFSwqFdoV+01nMdx7p/lP3UoQDJYApl3Evf1MCsEPWZZfobw==
   dependencies:
     invariant "^2.2.4"
     nullthrows "^1.1.1"
@@ -13900,19 +13900,19 @@ react-native-worklets@0.5.1:
     convert-source-map "^2.0.0"
     semver "7.7.2"
 
-react-native@0.82.0-rc.4:
-  version "0.82.0-rc.4"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.82.0-rc.4.tgz#6f86816e89d081eb7fb10c95a891d0065a702ba9"
-  integrity sha512-SlGtAW/KayPMcCBk0C48CrYk0t46S4d61z9rftsIVVh5FEUWPIv33xo6HI88dZ3gRMAkys8A7rhB2AeOUzZxdA==
+react-native@0.82.0-rc.5:
+  version "0.82.0-rc.5"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.82.0-rc.5.tgz#4fb5b4394ca2fcd93fc5334a8d15bfdb6614d8aa"
+  integrity sha512-94rj9YLMe8jDn+x7IoGjvXb6KVwU6/NIlgPz5WP/YW9xqa+zBd6B1+Rli+0uG/KR9VzepnLaucSShsUQbvxPAA==
   dependencies:
     "@jest/create-cache-key-function" "^29.7.0"
-    "@react-native/assets-registry" "0.82.0-rc.4"
-    "@react-native/codegen" "0.82.0-rc.4"
-    "@react-native/community-cli-plugin" "0.82.0-rc.4"
-    "@react-native/gradle-plugin" "0.82.0-rc.4"
-    "@react-native/js-polyfills" "0.82.0-rc.4"
-    "@react-native/normalize-colors" "0.82.0-rc.4"
-    "@react-native/virtualized-lists" "0.82.0-rc.4"
+    "@react-native/assets-registry" "0.82.0-rc.5"
+    "@react-native/codegen" "0.82.0-rc.5"
+    "@react-native/community-cli-plugin" "0.82.0-rc.5"
+    "@react-native/gradle-plugin" "0.82.0-rc.5"
+    "@react-native/js-polyfills" "0.82.0-rc.5"
+    "@react-native/normalize-colors" "0.82.0-rc.5"
+    "@react-native/virtualized-lists" "0.82.0-rc.5"
     abort-controller "^3.0.0"
     anser "^1.4.9"
     ansi-regex "^5.0.0"


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/expo/pull/39973

# How

- update package versions 
  - `react-native  0.82.0-rc.4 -> 0.82.0-rc.5`  
  - `@react-native/normalize-colors 0.82.0-rc.4 ->  0.82.0-rc.5` 
  - `@react-native/babel-preset 0.82.0-rc.4 ->  0.82.0-rc.5` 
  - `@react-native/dev-middleware 0.82.0-rc.4 ->  0.82.0-rc.5`    
  
# Test Plan

bare-expo ios 
paper-tester ios / android
ci passed


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
