### PR TITLE
[docs] Remove warning about iOS screenshot limitations from screen capture documentation

### DIFF
--- a/docs/pages/versions/unversioned/sdk/screen-capture.mdx
+++ b/docs/pages/versions/unversioned/sdk/screen-capture.mdx
@@ -23,8 +23,6 @@ If you want to use the screen capture callback on Android 13 or lower, you need 
 
 > **warning** The `READ_MEDIA_IMAGES` permission can be added only for apps needing broad access to photos. See [Details on Google Play's Photo and Video Permissions policy](https://support.google.com/googleplay/android-developer/answer/14115180).
 
-> **warning** Currently, taking screenshots on iOS cannot be prevented. This is due to underlying OS limitations.
-
 > **important** For testing screen capture functionality: On Android Emulator, run `adb shell input keyevent 120` in a separate terminal to trigger a screenshot. On iOS Simulator, you can trigger screenshots using **Device** > **Trigger Screenshot** from the menu bar.
 
 ## Installation

--- a/docs/pages/versions/v54.0.0/sdk/screen-capture.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/screen-capture.mdx
@@ -23,8 +23,6 @@ If you want to use the screen capture callback on Android 13 or lower, you need 
 
 > **warning** The `READ_MEDIA_IMAGES` permission can be added only for apps needing broad access to photos. See [Details on Google Play's Photo and Video Permissions policy](https://support.google.com/googleplay/android-developer/answer/14115180).
 
-> **warning** Currently, taking screenshots on iOS cannot be prevented. This is due to underlying OS limitations.
-
 > **important** For testing screen capture functionality: On Android Emulator, run `adb shell input keyevent 120` in a separate terminal to trigger a screenshot. On iOS Simulator, you can trigger screenshots using **Device** > **Trigger Screenshot** from the menu bar.
 
 ## Installation

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Remove warning about iOS screenshot limitations. ([#40115](https://github.com/expo/expo/pull/40115) by [@hryhoriiK97](https://github.com/hryhoriiK97))
+
 ## 8.0.8 — 2025-09-13
 
 ### 🐛 Bug fixes

--- a/packages/expo-screen-capture/README.md
+++ b/packages/expo-screen-capture/README.md
@@ -7,8 +7,6 @@
 
 This is especially important on Android, since the [`android.media.projection`](https://developer.android.com/about/versions/android-5.0.html#ScreenCapture) API allows third-party apps to perform screen capture or screen sharing (even if the app is backgrounded).
 
-> Currently, taking screenshots on iOS cannot be prevented. This is due to underlying OS limitations.
-
 ## API documentation
 
 ## Installation in managed Expo projects


### PR DESCRIPTION
# Why
Starting with Expo SDK 54, it's possible to prevent screenshots. See the following PR for reference: https://github.com/expo/expo/pull/37874
This PR removes the warning regarding the screenshot prevention limitation on iOS.
# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
