### PR TITLE
fix(expo-module-scripts): Double quote to prevent word splitting

### DIFF
--- a/packages/expo-module-scripts/bin/expo-module-configure
+++ b/packages/expo-module-scripts/bin/expo-module-configure
@@ -17,10 +17,10 @@ OPTIONAL_TEMPLATE_FILES=(
 # returns relative file paths inside a given directory without the leading "./".
 # usage: get_relative_files "/path/to/dir"
 get_relative_files() {
-  pushd $1 > /dev/null
+  pushd "$1" > /dev/null
   local files=$(find . -type f | cut -c 3-)
   popd > /dev/null
-  echo $files
+  echo "$files"
 }
 
 


### PR DESCRIPTION
# Why

Currently, `expo-module configure` calls the following function:

```bash
get_relative_files() {
  pushd $1 > /dev/null
  local files=$(find . -type f | cut -c 3-)
  popd > /dev/null
  echo $files
}
```

Because neither `$1` nor `$files` are double quoted, they are subject to potential globbing and word splitting errors, cf. if your current working directory path has spaces, the command `npx expo-module configure` will fail due to word splitting.

Resolves: #40116
See also: https://www.shellcheck.net/wiki/SC2086

# How

The proposed changeset fixes the described issue by adding double quotes to the aforementioned variables.

# Test Plan

In your local workstation run:

```
mkdir my\ folder
cd  my\ folder
git clone git@github.com:bonjourmauko/my-app.git
cd my-app
npm install
npx expo-module configure
```

And you should get the following error:

```
Tried to guess the docs homepage for my-app; add it under the "homepage" entry in package.json
/path/to/my folder/my-app/node_modules/expo-module-scripts/bin/expo-module-configure: line 20: pushd: too many arguments
/path/to/my folder/my-app/node_modules/expo-module-scripts/bin/expo-module-configure: line 22: popd: directory stack empty
rsync: [sender] change_dir "/path/to/my folder/my-app/node_modules/expo-module-scripts/bin/../templates/node_modules/expo-modules-autolinking/scripts/ios" failed: No such file or directory (2)
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1358) [sender=3.4.1]
```

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
