### PR TITLE
[expo-audio][android] Added support for configurable lock screen buttons

### DIFF
--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecords.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecords.kt
@@ -87,15 +87,13 @@ enum class AndroidAudioEncoder(val value: String) : Enumerable {
 }
 
 enum class LockScreenButtons(val value: Int) : Enumerable {
-  PLAY_PAUSE(0),
-  FORWARD(1),
-  BACKWARD(2),
-  NEXT(3),
-  PREVIOUS(4)
+  SEEK_FORWARD(0),
+  SEEK_BACKWARD(1),
 }
 
 class AudioLockScreenOptions(
-  @Field val buttons: Array<LockScreenButtons>
+  @Field val showSeekForward: Boolean,
+  @Field val showSeekBackward: Boolean
 ) : Record
 
 enum class InterruptionMode(val value: String) : Enumerable {

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecords.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecords.kt
@@ -88,7 +88,7 @@ enum class AndroidAudioEncoder(val value: String) : Enumerable {
 
 enum class LockScreenButtons(val value: Int) : Enumerable {
   SEEK_FORWARD(0),
-  SEEK_BACKWARD(1),
+  SEEK_BACKWARD(1)
 }
 
 class AudioLockScreenOptions(

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
@@ -59,7 +59,7 @@ class AudioControlsService : MediaSessionService() {
     .setCustomIconResId(R.drawable.seek_forwards_10s)
     .setSessionCommand(SessionCommand(ACTION_SEEK_FORWARD, Bundle.EMPTY))
     .build()
-  
+
   // Notification helper removed; logic inlined here
 
   inner class AudioControlsBinder : Binder() {

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioMediaSessionCallback.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioMediaSessionCallback.kt
@@ -1,18 +1,46 @@
-package expo.modules.audio.service
+package expo.modules.audio.playbackService
 
+import android.os.Bundle
+import androidx.media3.common.Player
+import androidx.media3.session.MediaSession
+import androidx.media3.session.SessionCommand
+import androidx.media3.session.SessionResult
+import com.google.common.util.concurrent.ListenableFuture
 import androidx.annotation.OptIn
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.session.MediaSession
+import expo.modules.audio.service.AudioControlsService
 
+@OptIn(UnstableApi::class)
 class AudioMediaSessionCallback : MediaSession.Callback {
-  @OptIn(UnstableApi::class)
   override fun onConnect(
     session: MediaSession,
     controller: MediaSession.ControllerInfo
   ): MediaSession.ConnectionResult {
-    return MediaSession.ConnectionResult.AcceptedResultBuilder(session)
-      .setAvailablePlayerCommands(
-        MediaSession.ConnectionResult.DEFAULT_PLAYER_COMMANDS
-      ).build()
+    try {
+      return MediaSession.ConnectionResult.AcceptedResultBuilder(session)
+        .setAvailablePlayerCommands(
+          MediaSession.ConnectionResult.DEFAULT_PLAYER_COMMANDS.buildUpon()
+            .add(Player.COMMAND_SEEK_FORWARD)
+            .add(Player.COMMAND_SEEK_BACK)
+            .build()
+        )
+        .setAvailableSessionCommands(
+          MediaSession.ConnectionResult.DEFAULT_SESSION_COMMANDS.buildUpon()
+            .add(SessionCommand(AudioControlsService.ACTION_SEEK_BACKWARD, Bundle.EMPTY))
+            .add(SessionCommand(AudioControlsService.ACTION_SEEK_FORWARD, Bundle.EMPTY))
+            .build()
+        )
+        .build()
+    } catch (e: Exception) {
+      return MediaSession.ConnectionResult.reject()
+    }
+  }
+
+  override fun onCustomCommand(session: MediaSession, controller: MediaSession.ControllerInfo, customCommand: SessionCommand, args: Bundle): ListenableFuture<SessionResult> {
+    when (customCommand.customAction) {
+      AudioControlsService.ACTION_SEEK_FORWARD -> session.player.seekTo(session.player.currentPosition + AudioControlsService.SEEK_INTERVAL_MS)
+      AudioControlsService.ACTION_SEEK_BACKWARD -> session.player.seekTo(session.player.currentPosition - AudioControlsService.SEEK_INTERVAL_MS)
+    }
+    return super.onCustomCommand(session, controller, customCommand, args)
   }
 }

--- a/packages/expo-audio/android/src/main/res/drawable/seek_backwards_10s.xml
+++ b/packages/expo-audio/android/src/main/res/drawable/seek_backwards_10s.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportWidth="24"
+  android:viewportHeight="24">
+  <group
+    android:pivotX="12"
+    android:pivotY="4"
+    android:scaleX="1.15"
+    android:scaleY="1.15">
+    <path
+      android:fillColor="?android:attr/colorControlNormal"
+      android:pathData="M12,5V1L7,6l5,5V7c3.31,0 6,2.69 6,6s-2.69,6 -6,6 -6,-2.69 -6,-6H4c0,4.42 3.58,8 8,8s8,-3.58 8,-8 -3.58,-8 -8,-8z" />
+    <group
+      android:pivotX="12"
+      android:pivotY="8"
+      android:scaleX="1"
+      android:scaleY="0.9">
+      <path
+        android:fillColor="?android:attr/colorControlNormal"
+        android:pathData="m10.412 17.244h-0.70313v-4.4805q-0.25391 0.24219-0.66797 0.48438-0.41016 0.24219-0.73828 0.36328v-0.67969q0.58984-0.27734 1.0313-0.67188 0.44141-0.39453 0.625-0.76563h0.45313zm1.2008-2.8242q0-1.0156 0.20703-1.6328 0.21094-0.6211 0.6211-0.95703 0.41406-0.33594 1.0391-0.33594 0.46094 0 0.80859 0.1875 0.34766 0.18359 0.57422 0.53516 0.22656 0.34766 0.35547 0.85156 0.12891 0.5 0.12891 1.3516 0 1.0078-0.20703 1.6289-0.20703 0.61719-0.6211 0.95703-0.41016 0.33594-1.0391 0.33594-0.82813 0-1.3008-0.59375-0.56641-0.71484-0.56641-2.3281zm0.72266 0q0 1.4102 0.32812 1.8789 0.33203 0.46484 0.81641 0.46484 0.48438 0 0.8125-0.46875 0.33203-0.46875 0.33203-1.875 0-1.4141-0.33203-1.8789-0.32813-0.46484-0.82031-0.46484-0.48438 0-0.77344 0.41016-0.36328 0.52344-0.36328 1.9336z"/>
+    </group>
+  </group>
+</vector>

--- a/packages/expo-audio/android/src/main/res/drawable/seek_forwards_10s.xml
+++ b/packages/expo-audio/android/src/main/res/drawable/seek_forwards_10s.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportWidth="24"
+  android:viewportHeight="24">
+  <group
+    android:pivotX="12"
+    android:pivotY="4"
+    android:scaleX="1.15"
+    android:scaleY="1.15">
+    <group
+      android:pivotX="12"
+      android:pivotY="12"
+      android:scaleX="-1">
+      <path
+        android:fillColor="?android:attr/colorControlNormal"
+        android:pathData="M12,5V1L7,6l5,5V7c3.31,0 6,2.69 6,6s-2.69,6 -6,6 -6,-2.69 -6,-6H4c0,4.42 3.58,8 8,8s8,-3.58 8,-8 -3.58,-8 -8,-8z" />
+    </group>
+    <group
+      android:pivotX="0"
+      android:pivotY="10"
+      android:scaleX="1"
+      android:scaleY="0.9">
+      <path
+        android:fillColor="?android:attr/colorControlNormal"
+        android:pathData="m10.412 17.244h-0.70313v-4.4805q-0.25391 0.24219-0.66797 0.48438-0.41016 0.24219-0.73828 0.36328v-0.67969q0.58984-0.27734 1.0313-0.67188 0.44141-0.39453 0.625-0.76563h0.45313zm1.2008-2.8242q0-1.0156 0.20703-1.6328 0.21094-0.6211 0.6211-0.95703 0.41406-0.33594 1.0391-0.33594 0.46094 0 0.80859 0.1875 0.34766 0.18359 0.57422 0.53516 0.22656 0.34766 0.35547 0.85156 0.12891 0.5 0.12891 1.3516 0 1.0078-0.20703 1.6289-0.20703 0.61719-0.6211 0.95703-0.41016 0.33594-1.0391 0.33594-0.82813 0-1.3008-0.59375-0.56641-0.71484-0.56641-2.3281zm0.72266 0q0 1.4102 0.32812 1.8789 0.33203 0.46484 0.81641 0.46484 0.48438 0 0.8125-0.46875 0.33203-0.46875 0.33203-1.875 0-1.4141-0.33203-1.8789-0.32813-0.46484-0.82031-0.46484-0.48438 0-0.77344 0.41016-0.36328 0.52344-0.36328 1.9336z" />
+    </group>
+  </group>
+</vector>


### PR DESCRIPTION
# Why

Simplify the lock screen controls for Android audio playback by replacing the previous array of buttons with specific seek forward/backward controls. This change improves the user experience by focusing on the most common audio navigation actions.

# How

- Added types
- Added custom seek forward/backward buttons with 10-second interval functionality
- Implemented the necessary media session callbacks to handle the seek actions
- Added vector drawables for the seek buttons with 10s indicators
- Updated the notification building process to work with the new control scheme

# Test Plan

1. Create an audio player with lock screen controls enabled
2. Test the seek forward and backward buttons on the lock screen
3. Verify that seeking works correctly with the 10-second interval
4. Confirm that the buttons appear/disappear correctly based on the provided options

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).