### PR TITLE
[expo-audio][ios] Added support for configuring lock screen buttons

### DIFF
--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -200,8 +200,8 @@ public class AudioModule: Module {
         }
       }
 
-      Function("setActiveForLockScreen") { (player: AudioPlayer, active: Bool, metadata: Metadata?) in
-        player.setActiveForLockScreen(active, metadata: metadata)
+      Function("setActiveForLockScreen") { (player: AudioPlayer, active: Bool, metadata: Metadata?, options: LockScreenOptions?) in
+        player.setActiveForLockScreen(active, metadata: metadata, options: options)
       }
 
       Function("updateLockScreenMetadata") { (player: AudioPlayer, metadata: Metadata?) in

--- a/packages/expo-audio/ios/AudioPlayer.swift
+++ b/packages/expo-audio/ios/AudioPlayer.swift
@@ -108,10 +108,10 @@ public class AudioPlayer: SharedRef<AVPlayer> {
     ]
   }
 
-  func setActiveForLockScreen(_ active: Bool = true, metadata: Metadata? = nil) {
+  func setActiveForLockScreen(_ active: Bool = true, metadata: Metadata? = nil, options: LockScreenOptions?) {
     self.metadata = metadata
     if active {
-      MediaController.shared.setActivePlayer(self)
+      MediaController.shared.setActivePlayer(self, options: options)
     } else {
       MediaController.shared.setActivePlayer(nil)
     }

--- a/packages/expo-audio/ios/AudioRecords.swift
+++ b/packages/expo-audio/ios/AudioRecords.swift
@@ -52,6 +52,11 @@ struct Metadata: Record {
   @Field var artworkUrl: URL?
 }
 
+struct LockScreenOptions: Record {
+  @Field var showSeekForward: Bool = false
+  @Field var showSeekBackward: Bool = false
+}
+
 enum BitRateStrategy: String, Enumerable {
   case constant
   case longTermAverage

--- a/packages/expo-audio/ios/MediaController.swift
+++ b/packages/expo-audio/ios/MediaController.swift
@@ -16,7 +16,7 @@ class MediaController {
     setupRemoteCommands()
   }
 
-  func setActivePlayer(_ player: AudioPlayer?) {
+  func setActivePlayer(_ player: AudioPlayer?, options: LockScreenOptions? = nil) {
     if let previous = activePlayer, previous.id != player?.id {
       previous.isActiveForLockScreen = false
     }
@@ -25,7 +25,7 @@ class MediaController {
     player?.isActiveForLockScreen = true
 
     if let player {
-      enableRemoteCommands()
+      enableRemoteCommands(options: options)
       updateNowPlayingInfo(for: player)
     } else {
       disableRemoteCommands()
@@ -181,7 +181,7 @@ class MediaController {
       player.ref.seek(to: seekTime, toleranceBefore: .zero, toleranceAfter: .zero)
 
       return .success
-    }
+    }    
   }
 
   private func loadArtworkFromURL(url: URL, completion: @escaping (MPMediaItemArtwork?) -> Void) {
@@ -204,13 +204,13 @@ class MediaController {
     .resume()
   }
 
-  private func enableRemoteCommands() {
+  private func enableRemoteCommands(options: LockScreenOptions?) {
     remoteCommandCenter.playCommand.isEnabled = true
     remoteCommandCenter.pauseCommand.isEnabled = true
     remoteCommandCenter.togglePlayPauseCommand.isEnabled = true
     remoteCommandCenter.changePlaybackPositionCommand.isEnabled = true
-    remoteCommandCenter.skipForwardCommand.isEnabled = true
-    remoteCommandCenter.skipBackwardCommand.isEnabled = true
+    remoteCommandCenter.skipForwardCommand.isEnabled = options?.showSeekForward ?? false
+    remoteCommandCenter.skipBackwardCommand.isEnabled = options?.showSeekBackward ?? false
   }
 
   private func disableRemoteCommands() {


### PR DESCRIPTION
# Why

Added support for configurable lock screen controls in the iOS audio player. This enhancement allows developers to specify whether seek forward and seek backward controls should be displayed on the lock screen media controls.

# How

- Added a new `LockScreenOptions` record with boolean fields for `showSeekForward` and `showSeekBackward`
- Updated the `setActiveForLockScreen` function to accept these options
- Modified the `enableRemoteCommands` method to respect these settings when enabling/disabling the skip forward and backward commands

# Test Plan

Test in BareExpo

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).