### PR TITLE
[ci] spotless failed

### DIFF
--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/button/Button.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/button/Button.kt
@@ -172,9 +172,9 @@ class Button(context: Context, appContext: AppContext) :
               )
             }
           }
-          
+
           Text(text)
-          
+
           trailingIcon?.let { iconName ->
             getImageVector(iconName)?.let {
               Icon(


### PR DESCRIPTION
# Why

Spotless fails

# How

Fixed by running spotlessApply in BareExpo

# Test Plan

CI Green

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).