### PR TITLE
[android][audio] Fix events issue after replacing source

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix issue where after replacing the media source, events are emitted twice.
+- [Android] Fix issue where after replacing the media source, events are emitted twice. ([#40133](https://github.com/expo/expo/pull/40133) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix issue where after replacing the media source, events are emitted twice.
+
 ### 💡 Others
 
 ## 1.0.13 - 2025-09-18

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
@@ -119,6 +119,7 @@ class AudioPlayer(
   }
 
   private fun startUpdating() {
+    updateJob?.cancel()
     updateJob = flow {
       while (true) {
         emit(Unit)
@@ -272,6 +273,7 @@ class AudioPlayer(
   }
 
   override fun sharedObjectDidRelease() {
+    super.sharedObjectDidRelease()
     appContext?.mainQueue?.launch {
       if (isActiveForLockScreen) {
         AudioControlsService.clearSession()


### PR DESCRIPTION
# Why
Closes #40129

# How
After replacing the audio source, we call `setMediaSource` which calls `startUpdating` without cancelling the first flow so you get double the events.

# Test Plan
Tested in the provided repro
