### PR TITLE
[docs] remove Android 5.0 note from secure store docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/securestore.mdx
+++ b/docs/pages/versions/unversioned/sdk/securestore.mdx
@@ -22,8 +22,6 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 **The `requireAuthentication` option is not supported in Expo Go when biometric authentication is available due to a missing `NSFaceIDUsageDescription` key.**
 
-> This API is not compatible with devices running Android 5 or lower.
-
 ## Installation
 
 <APIInstallSection />

--- a/docs/pages/versions/v54.0.0/sdk/securestore.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/securestore.mdx
@@ -22,8 +22,6 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 **The `requireAuthentication` option is not supported in Expo Go when biometric authentication is available due to a missing `NSFaceIDUsageDescription` key.**
 
-> This API is not compatible with devices running Android 5 or lower.
-
 ## Installation
 
 <APIInstallSection />


### PR DESCRIPTION
# Why

minimum supported version is android 7, so it's safe to remove android 5 note

# How

- remove the note

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
