### PR TITLE
[docs] Add deep-linked modal behavior info in Modals guide

### DIFF
--- a/docs/pages/router/advanced/modals.mdx
+++ b/docs/pages/router/advanced/modals.mdx
@@ -192,7 +192,23 @@ const styles = StyleSheet.create({
 });
 ```
 
+### Handle deep-linked modals
+
+While working with stack or nested stack navigators, modals need to be anchored to ensure correct navigation behavior. This is essential when deep-linking to modal routes. Without anchoring, the screen behind the modal will be wiped away, leaving no navigation context.
+
+An _anchor_ serves as the base for the modal. In complex apps, when you have nested stacks, the anchor must be defined for the nested stack, and its value becomes the initial route of the stack.
+
+You can configure an anchor by exporting `unable_settings` from your stack's layout file:
+
+```tsx
+export const unstable_settings = {
+  anchor: 'index', // Anchor to the index route
+};
+```
+
 ## Additional information
+
+In the above example, the `anchor: 'index'` tells the Expo Router that it should maintain the specified anchor route in the background when presenting a modal.
 
 ### Presentation options
 

--- a/docs/pages/router/advanced/modals.mdx
+++ b/docs/pages/router/advanced/modals.mdx
@@ -206,9 +206,9 @@ export const unstable_settings = {
 };
 ```
 
-## Additional information
-
 In the above example, the `anchor: 'index'` tells the Expo Router that it should maintain the specified anchor route in the background when presenting a modal.
+
+## Additional information
 
 ### Presentation options
 

--- a/docs/pages/router/advanced/web-modals.mdx
+++ b/docs/pages/router/advanced/web-modals.mdx
@@ -113,7 +113,7 @@ export const unstable_settings = {
 };
 ```
 
-In the above example, the `anchor: index` tells the Expo Router that it should maintain the specified anchor route in the background when presenting a modal.
+In the above example, the `anchor: 'index'` tells the Expo Router that it should maintain the specified anchor route in the background when presenting a modal.
 
 ## Modal presentation style
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-17611

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add deep-linked modal behavior info in Modals guide with a different section title and slightly different context but mostly the same info from here: https://docs.expo.dev/router/advanced/web-modals/#anchors-and-nested-stacks.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally and visit: http://localhost:3002/router/advanced/modals/.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
