### PR TITLE
[launcher][Android] Prevent the app from crashing in `ErrorViewModel`

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [Android] Migrated from `kotlinOptions` to `compilerOptions` DSL. ([#39794](https://github.com/expo/expo/pull/39794) by [@huextrat](https://github.com/huextrat))
 - [android] Make reactNativeHost optional in ReactHostWrapper ([#40085](https://github.com/expo/expo/pull/40085) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [Android] Prevented the app from crashing during the initialization of the `ErrorViewModel`.
 
 ## 6.0.13 - 2025-10-01
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - [Android] Migrated from `kotlinOptions` to `compilerOptions` DSL. ([#39794](https://github.com/expo/expo/pull/39794) by [@huextrat](https://github.com/huextrat))
 - [android] Make reactNativeHost optional in ReactHostWrapper ([#40085](https://github.com/expo/expo/pull/40085) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- [Android] Prevented the app from crashing during the initialization of the `ErrorViewModel`.
+- [Android] Prevented the app from crashing during the initialization of the `ErrorViewModel`. ([#40148](https://github.com/expo/expo/pull/40148) by [@lukmccall](https://github.com/lukmccall))
 
 ## 6.0.13 - 2025-10-01
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/models/ErrorViewModel.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/models/ErrorViewModel.kt
@@ -14,8 +14,6 @@ sealed interface ErrorAction {
 }
 
 class ErrorViewModel() : ViewModel() {
-  private val devLauncher = inject<DevLauncherController>()
-
   private val _appError = mutableStateOf<DevLauncherAppError?>(null)
 
   val appError
@@ -26,6 +24,8 @@ class ErrorViewModel() : ViewModel() {
   }
 
   fun onAction(action: ErrorAction) {
+    val devLauncher = inject<DevLauncherController>()
+
     when (action) {
       is ErrorAction.Reload -> {
         val appUrl = devLauncher.latestLoadedApp


### PR DESCRIPTION
# Why

Prevents the app from crashing during the initialization of the `ErrorViewModel`

# Test Plan

- bare-expo ✅ 