### PR TITLE
[android][core] Bring back `register` overload in `ModuleRegistry`

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
@@ -176,27 +176,27 @@ open class HomeActivity : BaseExperienceActivity() {
       )
     }
 
-    override fun getModulesList(): List<Class<out Module>> {
-      return listOf(
-        AssetModule::class.java,
-        BlurModule::class.java,
-        CameraViewModule::class.java,
-        ClipboardModule::class.java,
-        ConstantsModule::class.java,
-        DeviceModule::class.java,
-        EASClientModule::class.java,
-        FileSystemModule::class.java,
-        FileSystemLegacyModule::class.java,
-        FontLoaderModule::class.java,
-        FontUtilsModule::class.java,
-        HapticsModule::class.java,
-        KeepAwakeModule::class.java,
-        LinearGradientModule::class.java,
-        SplashScreenModule::class.java,
-        TrackingTransparencyModule::class.java,
-        StoreReviewModule::class.java,
-        WebBrowserModule::class.java,
-        ApplicationModule::class.java
+    override fun getModulesMap(): Map<Class<out Module>, String?> {
+      return mapOf(
+        AssetModule::class.java to null,
+        BlurModule::class.java to null,
+        CameraViewModule::class.java to null,
+        ClipboardModule::class.java to null,
+        ConstantsModule::class.java to null,
+        DeviceModule::class.java to null,
+        EASClientModule::class.java to null,
+        FileSystemModule::class.java to null,
+        FileSystemLegacyModule::class.java to null,
+        FontLoaderModule::class.java to null,
+        FontUtilsModule::class.java to null,
+        HapticsModule::class.java to null,
+        KeepAwakeModule::class.java to null,
+        LinearGradientModule::class.java to null,
+        SplashScreenModule::class.java to null,
+        TrackingTransparencyModule::class.java to null,
+        StoreReviewModule::class.java to null,
+        WebBrowserModule::class.java to null,
+        ApplicationModule::class.java to null
       )
     }
   }

--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
@@ -90,114 +90,113 @@ import expo.modules.videothumbnails.VideoThumbnailsModule
 import expo.modules.webbrowser.WebBrowserModule
 
 object ExperiencePackagePicker : ModulesProvider {
-  private val EXPO_MODULES_PACKAGES = listOf(
-    AVPackage(),
-    ConstantsPackage(),
-    FileSystemPackage(),
-    ExpoLinkingPackage(),
-    ImageLoaderPackage(),
-    KeepAwakePackage(),
-    NavigationBarPackage(),
-    NotificationsPackage(),
-    SplashScreenPackage(),
-    SystemUIPackage(),
-    TaskManagerPackage(),
-    UpdatesPackage()
-  )
+    private val EXPO_MODULES_PACKAGES = listOf(
+        AVPackage(),
+        ConstantsPackage(),
+        FileSystemPackage(),
+        ExpoLinkingPackage(),
+        ImageLoaderPackage(),
+        KeepAwakePackage(),
+        NavigationBarPackage(),
+        NotificationsPackage(),
+        SplashScreenPackage(),
+        SystemUIPackage(),
+        TaskManagerPackage(),
+        UpdatesPackage()
+    )
 
-  /**
-   * Returns all available packages.
-   */
-  fun packages(): List<Package> {
-    return EXPO_MODULES_PACKAGES
-  }
+    /**
+     * Returns all available packages.
+     */
+    fun packages(): List<Package> {
+        return EXPO_MODULES_PACKAGES
+    }
 
-  /**
-   * Returns packages filtered based on the app's manifest.
-   * For now, filtering is not applied but it is on the todo list.
-   */
-  fun packages(manifest: Manifest?): List<Package> {
-    return EXPO_MODULES_PACKAGES
-  }
+    /**
+     * Returns packages filtered based on the app's manifest.
+     * For now, filtering is not applied but it is on the todo list.
+     */
+    fun packages(manifest: Manifest?): List<Package> {
+        return EXPO_MODULES_PACKAGES
+    }
 
-  @OptIn(UnstableReactNativeAPI::class)
-  override fun getModulesList(): List<Class<out Module>> = listOf(
-    AudioModule::class.java,
-    AVModule::class.java,
-    ApplicationModule::class.java,
-    // Sensors
-    AccelerometerModule::class.java,
-    AssetModule::class.java,
-    BarometerModule::class.java,
-    GyroscopeModule::class.java,
-    LightSensorModule::class.java,
-    DeviceMotionModule::class.java,
-    MagnetometerModule::class.java,
-    MagnetometerUncalibratedModule::class.java,
-    PedometerModule::class.java,
-    // End of Sensors
-    // Notifications
-    BadgeModule::class.java,
-    PushTokenModule::class.java,
-    NotificationPermissionsModule::class.java,
-    NotificationChannelManagerModule::class.java,
-    NotificationChannelGroupManagerModule::class.java,
-    ExpoBackgroundNotificationTasksModule::class.java,
-    // End of Notifications
-    BatteryModule::class.java,
-    BackgroundFetchModule::class.java,
-    BackgroundTaskModule::class.java,
-    BlurModule::class.java,
-    CalendarModule::class.java,
-    CameraViewModule::class.java,
-    CellularModule::class.java,
-    ClipboardModule::class.java,
-    CryptoModule::class.java,
-    ConstantsModule::class.java,
-    ContactsModule::class.java,
-    DeviceModule::class.java,
-    DocumentPickerModule::class.java,
-    EASClientModule::class.java,
-    ExpoFetchModule::class.java,
-    FontUtilsModule::class.java,
-    ExpoLinkingModule::class.java,
-    FileSystemModule::class.java,
-    FileSystemLegacyModule::class.java,
-    FontLoaderModule::class.java,
-    PrintModule::class.java,
-    GLViewModule::class.java,
-    GLObjectManagerModule::class.java,
-    HapticsModule::class.java,
-    ImagePickerModule::class.java,
-    ImageManipulatorModule::class.java,
-    ExpoImageModule::class.java,
-    IntentLauncherModule::class.java,
-    KeepAwakeModule::class.java,
-    LinearGradientModule::class.java,
-    LocalAuthenticationModule::class.java,
-    LocalizationModule::class.java,
-    LocationModule::class.java,
-    MailComposerModule::class.java,
-    MediaLibraryModule::class.java,
-    NavigationBarModule::class.java,
-    NetworkModule::class.java,
-    ScreenCaptureModule::class.java,
-    ScreenOrientationModule::class.java,
-    // SecureStoreModule is not added here, instead it is added in ExpoModuleRegistryAdapter.kt,
-    // because it needs access to scopedContext for Expo Go support
-    SMSModule::class.java,
-    SharingModule::class.java,
-    SpeechModule::class.java,
-    SplashScreenModule::class.java,
-    StoreReviewModule::class.java,
-    SQLiteModule::class.java,
-    SystemUIModule::class.java,
-    TaskManagerModule::class.java,
-    TrackingTransparencyModule::class.java,
-    VideoThumbnailsModule::class.java,
-    VideoModule::class.java,
-    VideoViewModule::class.java,
-    WebBrowserModule::class.java,
-    BrightnessModule::class.java
-  )
+    override fun getModulesMap(): Map<Class<out Module>, String?> = mapOf(
+        AudioModule::class.java to null,
+        AVModule::class.java to null,
+        ApplicationModule::class.java to null,
+        // Sensors
+        AccelerometerModule::class.java to null,
+        AssetModule::class.java to null,
+        BarometerModule::class.java to null,
+        GyroscopeModule::class.java to null,
+        LightSensorModule::class.java to null,
+        DeviceMotionModule::class.java to null,
+        MagnetometerModule::class.java to null,
+        MagnetometerUncalibratedModule::class.java to null,
+        PedometerModule::class.java to null,
+        // End of Sensors
+        // Notifications
+        BadgeModule::class.java to null,
+        PushTokenModule::class.java to null,
+        NotificationPermissionsModule::class.java to null,
+        NotificationChannelManagerModule::class.java to null,
+        NotificationChannelGroupManagerModule::class.java to null,
+        ExpoBackgroundNotificationTasksModule::class.java to null,
+        // End of Notifications
+        BatteryModule::class.java to null,
+        BackgroundFetchModule::class.java to null,
+        BackgroundTaskModule::class.java to null,
+        BlurModule::class.java to null,
+        CalendarModule::class.java to null,
+        CameraViewModule::class.java to null,
+        CellularModule::class.java to null,
+        ClipboardModule::class.java to null,
+        CryptoModule::class.java to null,
+        ConstantsModule::class.java to null,
+        ContactsModule::class.java to null,
+        DeviceModule::class.java to null,
+        DocumentPickerModule::class.java to null,
+        EASClientModule::class.java to null,
+        ExpoFetchModule::class.java to null,
+        FontUtilsModule::class.java to null,
+        ExpoLinkingModule::class.java to null,
+        FileSystemModule::class.java to null,
+        FileSystemLegacyModule::class.java to null,
+        FontLoaderModule::class.java to null,
+        PrintModule::class.java to null,
+        GLViewModule::class.java to null,
+        GLObjectManagerModule::class.java to null,
+        HapticsModule::class.java to null,
+        ImagePickerModule::class.java to null,
+        ImageManipulatorModule::class.java to null,
+        ExpoImageModule::class.java to null,
+        IntentLauncherModule::class.java to null,
+        KeepAwakeModule::class.java to null,
+        LinearGradientModule::class.java to null,
+        LocalAuthenticationModule::class.java to null,
+        LocalizationModule::class.java to null,
+        LocationModule::class.java to null,
+        MailComposerModule::class.java to null,
+        MediaLibraryModule::class.java to null,
+        NavigationBarModule::class.java to null,
+        NetworkModule::class.java to null,
+        ScreenCaptureModule::class.java to null,
+        ScreenOrientationModule::class.java to null,
+        // SecureStoreModule is not added here, instead it is added in ExpoModuleRegistryAdapter.kt,
+        // because it needs access to scopedContext for Expo Go support
+        SMSModule::class.java to null,
+        SharingModule::class.java to null,
+        SpeechModule::class.java to null,
+        SplashScreenModule::class.java to null,
+        StoreReviewModule::class.java to null,
+        SQLiteModule::class.java to null,
+        SystemUIModule::class.java to null,
+        TaskManagerModule::class.java to null,
+        TrackingTransparencyModule::class.java to null,
+        VideoThumbnailsModule::class.java to null,
+        VideoModule::class.java to null,
+        VideoViewModule::class.java to null,
+        WebBrowserModule::class.java to null,
+        BrightnessModule::class.java to null,
+    )
 }

--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
@@ -1,6 +1,5 @@
 package versioned.host.exp.exponent
 
-import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import expo.modules.application.ApplicationModule
 import expo.modules.asset.AssetModule
 import expo.modules.audio.AudioModule
@@ -90,113 +89,113 @@ import expo.modules.videothumbnails.VideoThumbnailsModule
 import expo.modules.webbrowser.WebBrowserModule
 
 object ExperiencePackagePicker : ModulesProvider {
-    private val EXPO_MODULES_PACKAGES = listOf(
-        AVPackage(),
-        ConstantsPackage(),
-        FileSystemPackage(),
-        ExpoLinkingPackage(),
-        ImageLoaderPackage(),
-        KeepAwakePackage(),
-        NavigationBarPackage(),
-        NotificationsPackage(),
-        SplashScreenPackage(),
-        SystemUIPackage(),
-        TaskManagerPackage(),
-        UpdatesPackage()
-    )
+  private val EXPO_MODULES_PACKAGES = listOf(
+    AVPackage(),
+    ConstantsPackage(),
+    FileSystemPackage(),
+    ExpoLinkingPackage(),
+    ImageLoaderPackage(),
+    KeepAwakePackage(),
+    NavigationBarPackage(),
+    NotificationsPackage(),
+    SplashScreenPackage(),
+    SystemUIPackage(),
+    TaskManagerPackage(),
+    UpdatesPackage()
+  )
 
-    /**
-     * Returns all available packages.
-     */
-    fun packages(): List<Package> {
-        return EXPO_MODULES_PACKAGES
-    }
+  /**
+   * Returns all available packages.
+   */
+  fun packages(): List<Package> {
+    return EXPO_MODULES_PACKAGES
+  }
 
-    /**
-     * Returns packages filtered based on the app's manifest.
-     * For now, filtering is not applied but it is on the todo list.
-     */
-    fun packages(manifest: Manifest?): List<Package> {
-        return EXPO_MODULES_PACKAGES
-    }
+  /**
+   * Returns packages filtered based on the app's manifest.
+   * For now, filtering is not applied but it is on the todo list.
+   */
+  fun packages(manifest: Manifest?): List<Package> {
+    return EXPO_MODULES_PACKAGES
+  }
 
-    override fun getModulesMap(): Map<Class<out Module>, String?> = mapOf(
-        AudioModule::class.java to null,
-        AVModule::class.java to null,
-        ApplicationModule::class.java to null,
-        // Sensors
-        AccelerometerModule::class.java to null,
-        AssetModule::class.java to null,
-        BarometerModule::class.java to null,
-        GyroscopeModule::class.java to null,
-        LightSensorModule::class.java to null,
-        DeviceMotionModule::class.java to null,
-        MagnetometerModule::class.java to null,
-        MagnetometerUncalibratedModule::class.java to null,
-        PedometerModule::class.java to null,
-        // End of Sensors
-        // Notifications
-        BadgeModule::class.java to null,
-        PushTokenModule::class.java to null,
-        NotificationPermissionsModule::class.java to null,
-        NotificationChannelManagerModule::class.java to null,
-        NotificationChannelGroupManagerModule::class.java to null,
-        ExpoBackgroundNotificationTasksModule::class.java to null,
-        // End of Notifications
-        BatteryModule::class.java to null,
-        BackgroundFetchModule::class.java to null,
-        BackgroundTaskModule::class.java to null,
-        BlurModule::class.java to null,
-        CalendarModule::class.java to null,
-        CameraViewModule::class.java to null,
-        CellularModule::class.java to null,
-        ClipboardModule::class.java to null,
-        CryptoModule::class.java to null,
-        ConstantsModule::class.java to null,
-        ContactsModule::class.java to null,
-        DeviceModule::class.java to null,
-        DocumentPickerModule::class.java to null,
-        EASClientModule::class.java to null,
-        ExpoFetchModule::class.java to null,
-        FontUtilsModule::class.java to null,
-        ExpoLinkingModule::class.java to null,
-        FileSystemModule::class.java to null,
-        FileSystemLegacyModule::class.java to null,
-        FontLoaderModule::class.java to null,
-        PrintModule::class.java to null,
-        GLViewModule::class.java to null,
-        GLObjectManagerModule::class.java to null,
-        HapticsModule::class.java to null,
-        ImagePickerModule::class.java to null,
-        ImageManipulatorModule::class.java to null,
-        ExpoImageModule::class.java to null,
-        IntentLauncherModule::class.java to null,
-        KeepAwakeModule::class.java to null,
-        LinearGradientModule::class.java to null,
-        LocalAuthenticationModule::class.java to null,
-        LocalizationModule::class.java to null,
-        LocationModule::class.java to null,
-        MailComposerModule::class.java to null,
-        MediaLibraryModule::class.java to null,
-        NavigationBarModule::class.java to null,
-        NetworkModule::class.java to null,
-        ScreenCaptureModule::class.java to null,
-        ScreenOrientationModule::class.java to null,
-        // SecureStoreModule is not added here, instead it is added in ExpoModuleRegistryAdapter.kt,
-        // because it needs access to scopedContext for Expo Go support
-        SMSModule::class.java to null,
-        SharingModule::class.java to null,
-        SpeechModule::class.java to null,
-        SplashScreenModule::class.java to null,
-        StoreReviewModule::class.java to null,
-        SQLiteModule::class.java to null,
-        SystemUIModule::class.java to null,
-        TaskManagerModule::class.java to null,
-        TrackingTransparencyModule::class.java to null,
-        VideoThumbnailsModule::class.java to null,
-        VideoModule::class.java to null,
-        VideoViewModule::class.java to null,
-        WebBrowserModule::class.java to null,
-        BrightnessModule::class.java to null,
-    )
+  override fun getModulesMap(): Map<Class<out Module>, String?> = mapOf(
+    AudioModule::class.java to null,
+    AVModule::class.java to null,
+    ApplicationModule::class.java to null,
+    // Sensors
+    AccelerometerModule::class.java to null,
+    AssetModule::class.java to null,
+    BarometerModule::class.java to null,
+    GyroscopeModule::class.java to null,
+    LightSensorModule::class.java to null,
+    DeviceMotionModule::class.java to null,
+    MagnetometerModule::class.java to null,
+    MagnetometerUncalibratedModule::class.java to null,
+    PedometerModule::class.java to null,
+    // End of Sensors
+    // Notifications
+    BadgeModule::class.java to null,
+    PushTokenModule::class.java to null,
+    NotificationPermissionsModule::class.java to null,
+    NotificationChannelManagerModule::class.java to null,
+    NotificationChannelGroupManagerModule::class.java to null,
+    ExpoBackgroundNotificationTasksModule::class.java to null,
+    // End of Notifications
+    BatteryModule::class.java to null,
+    BackgroundFetchModule::class.java to null,
+    BackgroundTaskModule::class.java to null,
+    BlurModule::class.java to null,
+    CalendarModule::class.java to null,
+    CameraViewModule::class.java to null,
+    CellularModule::class.java to null,
+    ClipboardModule::class.java to null,
+    CryptoModule::class.java to null,
+    ConstantsModule::class.java to null,
+    ContactsModule::class.java to null,
+    DeviceModule::class.java to null,
+    DocumentPickerModule::class.java to null,
+    EASClientModule::class.java to null,
+    ExpoFetchModule::class.java to null,
+    FontUtilsModule::class.java to null,
+    ExpoLinkingModule::class.java to null,
+    FileSystemModule::class.java to null,
+    FileSystemLegacyModule::class.java to null,
+    FontLoaderModule::class.java to null,
+    PrintModule::class.java to null,
+    GLViewModule::class.java to null,
+    GLObjectManagerModule::class.java to null,
+    HapticsModule::class.java to null,
+    ImagePickerModule::class.java to null,
+    ImageManipulatorModule::class.java to null,
+    ExpoImageModule::class.java to null,
+    IntentLauncherModule::class.java to null,
+    KeepAwakeModule::class.java to null,
+    LinearGradientModule::class.java to null,
+    LocalAuthenticationModule::class.java to null,
+    LocalizationModule::class.java to null,
+    LocationModule::class.java to null,
+    MailComposerModule::class.java to null,
+    MediaLibraryModule::class.java to null,
+    NavigationBarModule::class.java to null,
+    NetworkModule::class.java to null,
+    ScreenCaptureModule::class.java to null,
+    ScreenOrientationModule::class.java to null,
+    // SecureStoreModule is not added here, instead it is added in ExpoModuleRegistryAdapter.kt,
+    // because it needs access to scopedContext for Expo Go support
+    SMSModule::class.java to null,
+    SharingModule::class.java to null,
+    SpeechModule::class.java to null,
+    SplashScreenModule::class.java to null,
+    StoreReviewModule::class.java to null,
+    SQLiteModule::class.java to null,
+    SystemUIModule::class.java to null,
+    TaskManagerModule::class.java to null,
+    TrackingTransparencyModule::class.java to null,
+    VideoThumbnailsModule::class.java to null,
+    VideoModule::class.java to null,
+    VideoViewModule::class.java to null,
+    WebBrowserModule::class.java to null,
+    BrightnessModule::class.java to null
+  )
 }

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 - [iOS] Fix NSURL to JSIString conversion returning nil. ([#39567](https://github.com/expo/expo/pull/39567) by [@behenate](https://github.com/behenate))
 - Fix SharedObject created with `useReleasingSharedObject` getting destroyed after a fast refresh caused by a change in its dependencies. ([#39753](https://github.com/expo/expo/pull/39753) by [@behenate](https://github.com/behenate))
-- [Android] Restore `register` overload in `ModuleRegistry`.
+- [Android] Restore `register` overload in `ModuleRegistry`. ([#40149](https://github.com/expo/expo/pull/40149) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - [iOS] Fix NSURL to JSIString conversion returning nil. ([#39567](https://github.com/expo/expo/pull/39567) by [@behenate](https://github.com/behenate))
 - Fix SharedObject created with `useReleasingSharedObject` getting destroyed after a fast refresh caused by a change in its dependencies. ([#39753](https://github.com/expo/expo/pull/39753) by [@behenate](https://github.com/behenate))
+- [Android] Restore `register` overload in `ModuleRegistry`.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
@@ -44,6 +44,12 @@ class ModuleRegistry(
     }
   }
 
+  fun register(vararg modules: Module) = apply {
+    modules.forEach { module ->
+      register(module, null)
+    }
+  }
+
   fun hasModule(name: String): Boolean = registry.containsKey(name)
 
   fun getModule(name: String): Module? = registry[name]?.module


### PR DESCRIPTION
# Why
Expo go will not build after the changes in #39985. 

# How
Restore the `register` overload in the `ModuleRegistry` and make the other changes needed for the new api

# Test Plan
Expo go ✅

