### PR TITLE
[expo-go] Fix cli commands

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -443,9 +443,7 @@ abstract class ReactNativeActivity :
     }
 
     val devSettings = reactHost.devSupportManager.devSettings as? DevInternalSettings
-    if (devSettings != null) {
-      devSettings.setExponentActivityId(activityId)
-    }
+    devSettings?.setExponentActivityId(activityId)
 
     val appKey = manifest!!.getAppKey()
     val surface = ReactSurfaceImpl.createWithView(

--- a/apps/expo-go/android/tools/src/main/java/host/exp/exponent/tools/ReactAndroidKotlinTransformer.java
+++ b/apps/expo-go/android/tools/src/main/java/host/exp/exponent/tools/ReactAndroidKotlinTransformer.java
@@ -247,6 +247,14 @@ public class ReactAndroidKotlinTransformer {
             
             content = replaceFunction(content, "hasUpToDateJSBundleInCache", newHasUpToDateImplementation);
 
+            String getExponentActivityIdImplementation = """
+                private fun getExponentActivityId(): Int {
+                    val devInternalSettings = devSettings as? DevInternalSettings
+                    return devInternalSettings?.getExponentActivityId() ?: -1
+                }""";
+
+            content = replaceFunction(content, "getExponentActivityId", getExponentActivityIdImplementation);
+
             return content;
         }
 


### PR DESCRIPTION
# Why
https://exponent-internal.slack.com/archives/CNHBN8LNS/p1759346246760279
We were missing a change in the code transformers so when the app reloads, we didn't have the correct activity id so all the cli commands would begin to fail

# How
Update the transformer to make the correct [change](https://github.com/expo/react-native/commit/cb14ca09a72345bf42f8d91b86428c8426727983) to `DevSupportManagerBase`. 

# Test Plan
Expo go ✅ cli commands work consistently after a reload.

CI will fail until #40149 lands

