### PR TITLE
[dom] Fix typo in types

### DIFF
--- a/packages/expo/src/dom/dom-entry.tsx
+++ b/packages/expo/src/dom/dom-entry.tsx
@@ -92,7 +92,7 @@ export function registerDOMComponent(AppModule: any) {
       // Create a named map { [name: string]: ProxyFunction }
       // TODO(@kitten): Unclear how this is typed or shaped
       return Object.fromEntries(
-        (marshalledProps.names as string[]).map((key: string) => {
+        marshalledProps.names.map((key: string) => {
           return [key, ACTIONS[key]];
         })
       );

--- a/packages/expo/src/dom/dom-entry.tsx
+++ b/packages/expo/src/dom/dom-entry.tsx
@@ -9,7 +9,7 @@ import { addEventListener, getActionsObject } from './marshal';
 import registerRootComponent from '../launch/registerRootComponent';
 
 interface MarshalledProps {
-  name: string[];
+  names: string[];
   props: Record<string, JSONValue>;
   [key: string]: undefined | JSONValue;
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Was reading the expo-dom code and came across this typo

# How

<!--
How did you build this feature or fix this bug and why?
-->

Not a bug technically but it affects later development

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
