### PR TITLE
Add preventAutoHideAsync to SplashScreen

### DIFF
--- a/docs/pages/router/advanced/authentication.mdx
+++ b/docs/pages/router/advanced/authentication.mdx
@@ -182,6 +182,8 @@ Create a **SplashScreenController** to manage the splash screen. Authentication 
 import { SplashScreen } from 'expo-router';
 import { useSession } from './ctx';
 
+SplashScreen.preventAutoHideAsync();
+
 export function SplashScreenController() {
   const { isLoading } = useSession();
 

--- a/docs/pages/router/advanced/authentication.mdx
+++ b/docs/pages/router/advanced/authentication.mdx
@@ -188,7 +188,7 @@ export function SplashScreenController() {
   const { isLoading } = useSession();
 
   if (!isLoading) {
-    SplashScreen.hideAsync();
+    SplashScreen.hide();
   }
 
   return null;


### PR DESCRIPTION
Prevent auto-hiding of the splash screen until loading is complete. 
The current implementation does not hide the splash screen, it just immediately shows the content.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
