### PR TITLE
[e2e-tests] NCL and bare expo prep

### DIFF
--- a/apps/bare-expo/MainNavigator.tsx
+++ b/apps/bare-expo/MainNavigator.tsx
@@ -7,7 +7,7 @@ import * as Linking from 'expo-linking';
 import { StatusBar } from 'expo-status-bar';
 import React from 'react';
 import { Platform } from 'react-native';
-import TestSuite from 'test-suite/AppNavigator';
+import { TestStackNavigator } from 'test-suite/TestStackNavigator';
 
 type NavigationRouteConfigMap = React.ComponentType;
 
@@ -34,12 +34,11 @@ export function optionalRequire(requirer: () => { default: React.ComponentType }
   }
 }
 const routes: RoutesConfig = {
-  [testSuiteRouteName]: TestSuite,
+  [testSuiteRouteName]: TestStackNavigator,
 };
 
-// We'd like to get rid of `native-component-list` being a part of the final bundle.
-// Otherwise, some tests may fail due to timeouts (bundling takes significantly more time).
-// See `babel.config.js` and `moduleResolvers/nullResolver.js` for more details.
+// TODO vonovak there's potential for skipping the require of APIs tab as it's not used in CI
+// could use metro config to exclude it from bundling
 const NativeComponentList: NativeComponentListExportsType = optionalRequire(() =>
   require('native-component-list/src/navigation/MainNavigators')
 ) as any;
@@ -105,7 +104,7 @@ function TabNavigator() {
       safeAreaInsets={Platform.select({
         default: undefined,
       })}
-      initialRouteName="test-suite">
+      initialRouteName={testSuiteRouteName}>
       {Object.keys(routes).map((name) => (
         <Tab.Screen
           name={name}
@@ -119,7 +118,7 @@ function TabNavigator() {
 }
 const PERSISTENCE_KEY = 'NAVIGATION_STATE_V1';
 
-export default () => {
+export default function MainNavigator() {
   const { name: themeName } = useTheme();
   const [isReady, setIsReady] = React.useState(Platform.OS === 'web');
   const [initialState, setInitialState] = React.useState();
@@ -172,4 +171,4 @@ export default () => {
       <StatusBar style={themeName === 'light' ? 'dark' : 'light'} />
     </NavigationContainer>
   );
-};
+}

--- a/apps/bare-expo/babel.config.js
+++ b/apps/bare-expo/babel.config.js
@@ -1,20 +1,7 @@
 module.exports = function (api) {
   api.cache(true);
 
-  const moduleResolverConfig = {
-    alias: {},
-  };
-
-  // We'd like to get rid of `native-component-list` being a part of the final bundle.
-  // Otherwise, some tests may fail due to timeouts (bundling takes significantly more time).
-  if (process.env.CI || process.env.NO_NCL) {
-    moduleResolverConfig.alias['^native-component-list(/.*)?'] = require.resolve(
-      './moduleResolvers/nullResolver.js'
-    );
-  }
-
   return {
     presets: ['babel-preset-expo'],
-    plugins: [['babel-plugin-module-resolver', moduleResolverConfig]],
   };
 };

--- a/apps/bare-expo/moduleResolvers/nullResolver.js
+++ b/apps/bare-expo/moduleResolvers/nullResolver.js
@@ -1,3 +1,0 @@
-// In some cases (e.g. on the CI) we don't want to load some parts of the app
-// as it may significantly slow down bundling process which results in timeouts.
-export default null;

--- a/apps/test-suite/App.js
+++ b/apps/test-suite/App.js
@@ -2,7 +2,7 @@ import { NavigationContainer } from '@react-navigation/native';
 import * as Linking from 'expo-linking';
 import * as React from 'react';
 
-import AppNavigator from './AppNavigator';
+import { TestStackNavigator } from './TestStackNavigator';
 import { ThemeProvider } from '../common/ThemeProvider';
 
 const linking = {
@@ -18,7 +18,7 @@ const linking = {
 export default () => (
   <ThemeProvider>
     <NavigationContainer linking={linking}>
-      <AppNavigator />
+      <TestStackNavigator />
     </NavigationContainer>
   </ThemeProvider>
 );

--- a/apps/test-suite/TestStackNavigator.tsx
+++ b/apps/test-suite/TestStackNavigator.tsx
@@ -1,7 +1,7 @@
 import MaterialCommunityIcons from '@expo/vector-icons/build/MaterialCommunityIcons';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import * as React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import SelectScreen from './screens/SelectScreen';
 import RunTests from './screens/TestScreen';
@@ -13,37 +13,21 @@ import ThemeToggler from '../common/ThemeToggler';
 
 const Stack = createNativeStackNavigator();
 
-const spec = {
-  animation: 'timing',
-  config: {
-    duration: 0,
-  },
-};
-
-// TODO: Disable transition animations in E2E tests
-const shouldDisableTransition = false;
-
-const transitionSpec = shouldDisableTransition ? { open: spec, close: spec } : undefined;
-
-export default function AppNavigator(props) {
+export function TestStackNavigator() {
   const { theme } = useTheme();
 
   return (
     <Stack.Navigator
-      {...props}
+      id={undefined}
       screenOptions={{
         title: 'Tests',
-        transitionSpec,
         headerBackTitle: 'Select',
         headerTitleStyle: {
           color: theme.text.default,
         },
         headerTintColor: theme.icon.info,
         headerStyle: {
-          borderBottomWidth: StyleSheet.hairlineWidth,
-          borderBottomColor: theme.border.secondary,
           backgroundColor: theme.background.default,
-          boxShadow: '',
         },
       }}>
       <Stack.Screen
@@ -69,7 +53,7 @@ export default function AppNavigator(props) {
   );
 }
 
-AppNavigator.navigationOptions = {
+TestStackNavigator.navigationOptions = {
   title: 'Tests',
   tabBarLabel: 'Tests',
   tabBarIcon: TabBarIcon,

--- a/apps/test-suite/screens/SelectScreen.js
+++ b/apps/test-suite/screens/SelectScreen.js
@@ -2,7 +2,7 @@ import { Checkbox } from 'expo-checkbox';
 import Constants from 'expo-constants';
 import React from 'react';
 import { Alert, FlatList, Linking, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { useSafeArea } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useTheme } from '../../common/ThemeProvider';
 import { getTestModules } from '../TestModules';
@@ -186,7 +186,7 @@ export default class SelectScreen extends React.PureComponent {
 }
 
 function Footer({ buttonTitle, canRunTests, onToggle, onRun }) {
-  const { bottom, left, right } = useSafeArea();
+  const { bottom, left, right } = useSafeAreaInsets();
   const { theme } = useTheme();
 
   const isRunningInBareExpo = Constants.expoConfig.slug === 'bare-expo';


### PR DESCRIPTION
# Why

This PR refactors some test suite components 

# How

- Renamed `AppNavigator.js` to `TestStackNavigator.tsx` and converted it to TypeScript
- Removed unused code related to transition animations (uncovered by using TS)
- Removed the babel module resolver configuration that was used to exclude native-component-list from the bundle so CI would include the NCL screens
- Replaced deprecated `useSafeArea` with `useSafeAreaInsets` in `SelectScreen.js` and other minor stuff

# Test Plan

- ci passes at the top of the stack

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)