### PR TITLE
[e2e-tests] update GH workflows

### DIFF
--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -1,0 +1,67 @@
+name: 'Slack Notify'
+description: 'Send test suite notifications to Slack with artifacts download url'
+inputs:
+  channel:
+    description: 'Slack channel'
+    required: true
+  job_name:
+    description: 'Job name for display at the top of slack message'
+    required: true
+  artifact_url:
+    description: 'Artifact download URL'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - uses: 8398a7/action-slack@v3
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
+      with:
+        channel: ${{ inputs.channel }}
+        status: custom
+        fields: job,message,ref,eventName,author,took
+        author_name: ${{ inputs.job_name }}
+        custom_payload: |
+          {
+            attachments: [{
+              color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+              fields: [
+                {
+                  title: '${{ inputs.job_name }}',
+                  value: process.env.AS_JOB,
+                  short: true
+                },
+                {
+                  title: 'Message',
+                  value: process.env.AS_MESSAGE,
+                  short: true
+                },
+                {
+                  title: 'Ref',
+                  value: process.env.AS_REF,
+                  short: true
+                },
+                {
+                  title: 'Event Name',
+                  value: process.env.AS_EVENT_NAME,
+                  short: true
+                },
+                {
+                  title: 'Author',
+                  value: process.env.AS_AUTHOR,
+                  short: true
+                },
+                {
+                  title: 'Took',
+                  value: process.env.AS_TOOK,
+                  short: true
+                },
+                {
+                  title: 'Artifacts URL',
+                  value: '<${{ inputs.artifact_url }}|Download Artifacts>',
+                  short: false
+                }
+              ]
+            }]
+          }

--- a/.github/actions/use-android-emulator/action.yml
+++ b/.github/actions/use-android-emulator/action.yml
@@ -5,7 +5,7 @@ inputs:
   avd-api:
     description: 'API version used in AVD'
     required: false
-    default: '34'
+    default: '36'
   avd-name:
     description: 'Created AVD name'
     required: true
@@ -34,7 +34,8 @@ runs:
         sudo udevadm trigger --name-match=kvm
 
     # NOTE: When updating any emulator settings, please make sure all the settings are also updated in each retry step.
-    # Sorry that we can't use a loop here, because GitHub Actions doesn't support it yet.
+    # We can't use a loop here, because GitHub Actions doesn't support it yet.
+    # When e2e tests fail on one emulator, the next step will retry the whole setup again with the next emulator.
     - name: '💿 Setup Android Emulator #1'
       id: retries-1
       continue-on-error: true
@@ -44,6 +45,8 @@ runs:
         avd-name: ${{ inputs.avd-name }}
         arch: x86_64
         target: google_apis
+        profile: pixel_7_pro # We use pixel 7 pro for alignment with iPhone. Similar screen sizes mean easier test reuse.
+        # gpu hw acceleration is not available on GitHub-hosted runners
         emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
         script: |
           # Wait for emulator to fully ready
@@ -68,6 +71,7 @@ runs:
         avd-name: ${{ inputs.avd-name }}
         arch: x86_64
         target: google_apis
+        profile: pixel_7_pro # We use pixel 7 pro for alignment with iPhone. Similar screen sizes mean easier test reuse.
         emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
         script: |
           # Wait for emulator to fully ready
@@ -92,6 +96,7 @@ runs:
         avd-name: ${{ inputs.avd-name }}
         arch: x86_64
         target: google_apis
+        profile: pixel_7_pro # We use pixel 7 pro for alignment with iPhone. Similar screen sizes mean easier test reuse.
         emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
         script: |
           # Wait for emulator to fully ready

--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -47,7 +47,7 @@ jobs:
       GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=2048m -Dorg.gradle.daemon=false
     strategy:
       matrix:
-        api-level: [34]
+        api-level: [36]
     steps:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/development-client-e2e.yml
+++ b/.github/workflows/development-client-e2e.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        api-level: [34]
+        api-level: [36]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/development-client-latest-e2e.yml
+++ b/.github/workflows/development-client-latest-e2e.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        api-level: [34]
+        api-level: [36]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -214,7 +214,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        api-level: [34]
+        api-level: [36]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -160,30 +160,52 @@ jobs:
       - name: 🧶 Install node modules in root dir
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
+      - name: 🧶 Install image comparison server node modules
+        run: yarn install --frozen-lockfile
+        working-directory: apps/bare-expo/e2e/image-comparison
+      - name: 🖼️ Start image comparison server
+        run: |
+          mkdir -p ~/.maestro/tests
+          ./image-comparison/src/server.ts > ~/.maestro/tests/screenshot-server-logs 2>&1 &
+          echo $! > /tmp/image-server.pid
+        working-directory: apps/bare-expo/e2e
       - name: 🧪 Run e2e tests (bare-expo)
         run: ./scripts/start-ios-e2e-test.ts --test
         working-directory: apps/bare-expo
-        timeout-minutes: 30
+        env:
+          MAESTRO_CLI_NO_ANALYTICS: 1
+        timeout-minutes: 40
       - name: 📸 Store testing artifacts
         if: always()
         uses: actions/upload-artifact@v4
+        id: upload-artifacts
         with:
           name: bare-expo-artifacts-ios
           path: |
             ~/.maestro/tests/**/*
             ~/Library/Logs/maestro/**/*
           overwrite: true
+          include-hidden-files: true # .maestro is skipped otherwise
+      - name: 🔗 Artifacts download URL
+        if: always()
+        run: |
+          echo "Artifacts URL: ${{ steps.upload-artifacts.outputs.artifact-url }}"
       - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
+        uses: ./.github/actions/slack-notify
         if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_ios }}
         with:
           channel: '#expo-ios'
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
-          author_name: Test Suite e2e (iOS)
+          job_name: 'Test Suite e2e (iOS)'
+          artifact_url: ${{ steps.upload-artifacts.outputs.artifact-url }}
+      - name: 🛑 Stop image comparison server
+        if: always()
+        run: |
+          if [ -f /tmp/image-server.pid ]; then
+            kill $(cat /tmp/image-server.pid) 2>/dev/null || true
+            rm -f /tmp/image-server.pid
+          fi
 
   android-build:
     runs-on: ubuntu-24.04
@@ -280,7 +302,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        api-level: [34]
+        api-level: [36]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v5
@@ -307,31 +329,48 @@ jobs:
       - name: 🧶 Install node modules in root dir
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
+      - name: 🧶 Install image comparison server node modules
+        run: yarn install --frozen-lockfile
+        working-directory: apps/bare-expo/e2e/image-comparison
       - name: 🧪 Run e2e tests (bare-expo)
         uses: ./.github/actions/use-android-emulator
         with:
           avd-api: ${{ matrix.api-level }}
           avd-name: avd-${{ matrix.api-level }}
-          script: ./scripts/start-android-e2e-test.ts --test
+          script: |
+            # Start image comparison server (needs adb from use-android-emulator)
+            mkdir -p ~/.maestro/tests
+            ./e2e/image-comparison/src/server.ts > ~/.maestro/tests/screenshot-server-logs 2>&1 &
+            echo $! > /tmp/image-server.pid
+            # Run the actual tests
+            ./scripts/start-android-e2e-test.ts --test
           working-directory: ./apps/bare-expo
       - name: 📸 Store testing artifacts
         if: always()
+        id: upload-artifacts
         uses: actions/upload-artifact@v4
         with:
           name: bare-expo-artifacts-android
           path: |
             ~/.maestro/tests/**/*
-            ~/Library/Logs/maestro/**/*
           overwrite: true
+      - name: 🔗 Artifacts download URL
+        if: always()
+        run: |
+          echo "Artifacts URL: ${{ steps.upload-artifacts.outputs.artifact-url }}"
       - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
+        uses: ./.github/actions/slack-notify
         if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_android }}
-          MATRIX_CONTEXT: ${{ toJson(matrix) }}
         with:
           channel: '#expo-android'
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
-          author_name: Test Suite e2e (Android)
+          job_name: 'Test Suite e2e (Android)'
+          artifact_url: ${{ steps.upload-artifacts.outputs.artifact-url }}
+      - name: 🛑 Stop image comparison server
+        if: always()
+        run: |
+          if [ -f /tmp/image-server.pid ]; then
+            kill $(cat /tmp/image-server.pid) 2>/dev/null || true
+            rm -f /tmp/image-server.pid
+          fi


### PR DESCRIPTION
# Why

This PR improves the e2e test suite GH workflow to support comparing images as implemented one PR down the stack. Also improved are Slack notifications with artifact download links.

# How

- Created a new reusable Slack notification GitHub Action that includes artifact download URLs
- Updated Android emulator API level from 34 to 36 in all GitHub workflows
- Added Pixel 7 Pro profile to Android emulator configuration for more consistent UI testing
- Implemented image comparison server for e2e tests with proper startup and shutdown
- increased timeout extensions for build and test processes

# Test Plan

- green CI

# Checklist

- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).