### PR TITLE
[e2e-tests] update NCL screens for tests

### DIFF
--- a/apps/native-component-list/src/components/E2EKeyValueBox.tsx
+++ b/apps/native-component-list/src/components/E2EKeyValueBox.tsx
@@ -1,0 +1,85 @@
+import { Code } from '@expo/html-elements';
+import * as Clipboard from 'expo-clipboard';
+import { ScrollView, StyleSheet, ViewStyle, Text, TouchableOpacity, View } from 'react-native';
+
+type Props = {
+  style?: ViewStyle;
+  entries: Record<string, string | number | boolean | null | undefined>;
+  title: string;
+};
+
+export function E2EKeyValueBox({ entries, style, title }: Props) {
+  const handleCopyAssertVisible = async () => {
+    const assertVisibleStrings = Object.entries(entries).map(([key, value]) => {
+      const label = `${key} = ${String(value)}`;
+      return `- assertVisible: '${label}'`;
+    });
+
+    const copyText = assertVisibleStrings.join('\n');
+    await Clipboard.setStringAsync(copyText);
+  };
+
+  return (
+    <>
+      <View style={styles.headerRow}>
+        <Text
+          style={{
+            fontWeight: 'bold',
+            opacity: 0.5,
+            fontSize: 12,
+            flex: 1,
+            textAlign: 'left',
+          }}>
+          {title}
+        </Text>
+        <TouchableOpacity style={styles.copyButton} onPress={handleCopyAssertVisible}>
+          <Text style={styles.copyButtonText}>Copy maestro assertions</Text>
+        </TouchableOpacity>
+      </View>
+      <ScrollView
+        style={[styles.scrollView, style]}
+        indicatorStyle="black"
+        contentContainerStyle={styles.contentContainer}>
+        {Object.entries(entries).map(([key, value]) => {
+          const label = `${key} = ${String(value)}`;
+          return (
+            <Code style={styles.monoText} key={label}>
+              {label}
+            </Code>
+          );
+        })}
+      </ScrollView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 2,
+  },
+  scrollView: {
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#666',
+  },
+  contentContainer: {
+    padding: 6,
+  },
+  monoText: {
+    fontSize: 10,
+  },
+  copyButton: {
+    backgroundColor: '#007AFF',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 4,
+    marginLeft: 8,
+  },
+  copyButtonText: {
+    color: '#fff',
+    fontSize: 10,
+    fontWeight: '600',
+  },
+});

--- a/apps/native-component-list/src/components/E2EViewShotContainer.tsx
+++ b/apps/native-component-list/src/components/E2EViewShotContainer.tsx
@@ -1,0 +1,58 @@
+import * as Clipboard from 'expo-clipboard';
+import type { ReactNode } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View, ViewStyle } from 'react-native';
+
+type Props = {
+  testID: string;
+  screenshotOutputPath?: string;
+  mode?: 'normalize' | 'keep-originals';
+  style?: ViewStyle;
+  children: ReactNode;
+};
+
+export function E2EViewShotContainer({
+  testID,
+  style,
+  children,
+  screenshotOutputPath = 'TODO',
+  mode = 'normalize',
+}: Props) {
+  const handleCopyViewShotYaml = async () => {
+    const yaml = `- runFlow:
+    file: ../_nested-flows/viewshot-comparison.yaml
+    env:
+      screenshotOutputPath: '${screenshotOutputPath}'
+      testID: '${testID}'
+      mode: '${mode}'`;
+
+    await Clipboard.setStringAsync(yaml);
+  };
+
+  return (
+    <View style={style}>
+      <TouchableOpacity style={styles.copyButton} onPress={handleCopyViewShotYaml}>
+        <Text style={styles.copyButtonText}>Copy viewshot YAML</Text>
+      </TouchableOpacity>
+
+      <View testID={testID}>{children}</View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  buttonContainer: {},
+  copyButton: {
+    alignSelf: 'flex-start',
+    flex: 0,
+    backgroundColor: '#007AFF',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 4,
+    marginLeft: 8,
+  },
+  copyButtonText: {
+    color: '#fff',
+    fontSize: 10,
+    fontWeight: '600',
+  },
+});

--- a/apps/native-component-list/src/screens/Image/ImageComparisonScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageComparisonScreen.tsx
@@ -4,6 +4,7 @@ import { Animated, SectionList, StyleSheet, Text, View } from 'react-native';
 import { ImageTestListItem } from './ImageTestListItem';
 import imageTests from './tests';
 import { ImageTest } from './types';
+import { E2EViewShotContainer } from '../../components/E2EViewShotContainer';
 import Colors from '../../constants/Colors';
 
 export function ImageComparisonBody({
@@ -27,9 +28,11 @@ export function ImageComparisonBody({
 
   const renderSectionHeader = ({ section }: any) => {
     return (
-      <View style={styles.header}>
-        <Text style={styles.title}>{section.title}</Text>
-      </View>
+      <E2EViewShotContainer testID={`header-${section.title}`} style={{ backgroundColor: 'white' }}>
+        <View style={styles.header}>
+          <Text style={styles.title}>{section.title}</Text>
+        </View>
+      </E2EViewShotContainer>
     );
   };
 
@@ -40,6 +43,7 @@ export function ImageComparisonBody({
   return (
     <View style={styles.container}>
       <SectionList
+        testID="image-comparison-list"
         style={styles.content}
         sections={sections}
         renderItem={renderItem}

--- a/apps/native-component-list/src/screens/Video/VideoEventsScreen.tsx
+++ b/apps/native-component-list/src/screens/Video/VideoEventsScreen.tsx
@@ -7,6 +7,7 @@ import { bigBuckBunnySource, hlsSource } from './videoSources';
 import { styles } from './videoStyles';
 import Button from '../../components/Button';
 import ConsoleBox from '../../components/ConsoleBox';
+import { E2EKeyValueBox } from '../../components/E2EKeyValueBox';
 
 export default function VideoEventsScreen() {
   const ref = useRef<VideoView>(null);
@@ -16,7 +17,6 @@ export default function VideoEventsScreen() {
     player.timeUpdateEventInterval = 0.25;
     player.showNowPlayingNotification = false;
     player.muted = true;
-    player.play();
   });
   const timeUpdate = useEvent(player, 'timeUpdate');
   const { status, error } = useEvent(player, 'statusChange', { status: player.status });
@@ -56,10 +56,36 @@ export default function VideoEventsScreen() {
     player.volume = Math.abs(player.volume - 1);
   }, [player]);
 
+  const currentTime = Math.round((timeUpdate?.currentTime ?? 0) * 100) / 100;
+
   return (
     <View style={styles.contentContainer}>
       <VideoView ref={ref} player={player} style={styles.video} />
-      <ScrollView style={styles.controlsContainer} contentContainerStyle={{ alignItems: 'center' }}>
+
+      <ScrollView
+        style={styles.controlsContainer}
+        contentContainerStyle={{ alignItems: 'center', padding: 10 }}>
+        <View style={styles.row}>
+          <Button
+            style={styles.button}
+            title={isPlaying ? 'Pause' : 'Play'}
+            onPress={() => {
+              if (isPlaying) {
+                player.pause();
+              } else {
+                player.play();
+              }
+            }}
+          />
+          <Button
+            style={styles.button}
+            title="Seek to 30s"
+            onPress={() => {
+              player.currentTime = 30;
+            }}
+          />
+          <Button style={styles.button} title="Trigger an Error" onPress={triggerError} />
+        </View>
         <View style={styles.row}>
           <Button style={styles.button} title="Toggle Source" onPress={toggleSource} />
           <Button style={styles.button} title="Trigger an Error" onPress={triggerError} />
@@ -69,23 +95,35 @@ export default function VideoEventsScreen() {
           <Button style={styles.button} title="Change Volume" onPress={toggleVolume} />
         </View>
 
+        <E2EKeyValueBox
+          title="e2e verified params"
+          style={myStyles.metadataContainer}
+          entries={{
+            source: sourceObject?.metadata?.title ?? 'No title',
+            isPlaying,
+            isAtStart: currentTime === 0,
+            duration: loadedMetadata?.duration,
+            currentTime: Math.round((timeUpdate?.currentTime ?? 0) * 100) / 100,
+
+            mimeType: videoTrack?.mimeType,
+            isSupported: videoTrack?.isSupported,
+            bitratePositive: (videoTrack?.bitrate ?? 0) > 0,
+            volume,
+            status,
+            playbackRate,
+            error: !!error?.message,
+          }}
+        />
+
         <Text style={styles.switchTitle}>Playback:</Text>
         <ConsoleBox style={myStyles.metadataContainer}>
-          Source: {sourceObject?.metadata?.title ?? 'No title'} {'\n'}
-          Duration: {loadedMetadata?.duration ?? 'Unknown'} {'\n'}
-          Is playing: {isPlaying ? 'true' : 'false'} {'\n'}
-          Current time: {Math.round((timeUpdate?.currentTime ?? 0) * 100) / 100} {'\n'}
           Buffered to: {Math.round((timeUpdate?.bufferedPosition ?? 0) * 100) / 100} {'\n'}
           Volume: {volume} {'\n'}
-          Is Muted: {muted ? 'true' : 'false'} {'\n'}
-          Status: {JSON.stringify(status)} {'\n'}
-          Playback rate: {playbackRate} {'\n'}
-          Is external playback active: {isExternalPlaybackActive ? 'true' : 'false'} {'\n'}
+          Is Muted: {String(muted)} {'\n'}
+          Is external playback active: {String(isExternalPlaybackActive)} {'\n'}
           {error && 'Error: ' + error.message} {'\n'}
           Current Video track: {'{\n'}
           {`\tid: "${videoTrack?.id}",\n`}
-          {`\tmimeType: "${videoTrack?.mimeType}",\n`}
-          {`\tisSupported: ${videoTrack?.isSupported},\n`}
           {`\tsize: "${videoTrack?.size.width}x${videoTrack?.size.height}",\n`}
           {`\tbitrate: ${videoTrack?.bitrate}\n`}
           {`\tframe rate: ${videoTrack?.frameRate}\n`}
@@ -123,6 +161,5 @@ function subtitleTracksToString(tracks?: SubtitleTrack[]) {
 const myStyles = StyleSheet.create({
   metadataContainer: {
     alignSelf: 'stretch',
-    padding: 10,
   },
 });

--- a/apps/native-component-list/src/screens/Video/videoStyles.ts
+++ b/apps/native-component-list/src/screens/Video/videoStyles.ts
@@ -3,10 +3,8 @@ import { StyleSheet } from 'react-native';
 export const styles = StyleSheet.create({
   contentContainer: {
     flex: 1,
-    padding: 10,
     alignItems: 'center',
     justifyContent: 'center',
-    paddingHorizontal: 50,
   },
   controlsContainer: {
     alignSelf: 'stretch',
@@ -33,6 +31,8 @@ export const styles = StyleSheet.create({
   video: {
     width: 300,
     height: 225,
+    borderColor: 'black',
+    borderWidth: 1,
   },
   button: {
     margin: 5,


### PR DESCRIPTION
# Why

Added a new `KeyValueBox` component to display key-value pairs with the ability to copy Maestro assertions. Also added `E2EViewShotContainer ` component.

# How

- Created a new `KeyValueBox` component that displays key-value pairs with a "Copy maestro assertions" button
- Added test IDs to the Image Comparison screen for better e2e test targeting
- minor changes in the Video Events screen with

# Test Plan

- topmost stack CI green

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)