### PR TITLE
[workspace] Remove react-native resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "resolutions": {
     "@expo/metro": "~54.0.0",
-    "react-native": "0.82.0-rc.5",
     "react": "19.1.1",
     "react-dom": "19.1.1",
     "@types/babel__core": "^7.20.5",


### PR DESCRIPTION
# Why

Using resolutions for react native prevents us from using different react-native versions inside our apps, which would be useful for testing nightlies before a branch cut. As long as we always bump the react-native version in all of our apps, there shouldn't be a problem with removing this.

# How

Remove react-native resolution from root package.json

# Test Plan

Installed react-native nightly on MinimalTester

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
