### PR TITLE
[expo-calendar][iOS] Fix deleteEventAsync deleting wrong recurring event instance

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - Fixed `NumberFormatException` crash on Android when calendar/event IDs exceed `Integer.MAX_VALUE`. ([#43344](https://github.com/expo/expo/pull/43344) by [@olivier-bouillet](https://github.com/olivier-bouillet))
+- [iOS] Fix `deleteEventAsync` deleting wrong recurring event instance when `instanceStartDate` is provided. ([#40172](https://github.com/expo/expo/pull/40172) by [@marcelogdeandrade](https://github.com/marcelogdeandrade))
 
 ### 💡 Others
 

--- a/packages/expo-calendar/ios/CalendarModule.swift
+++ b/packages/expo-calendar/ios/CalendarModule.swift
@@ -584,7 +584,7 @@ public class CalendarModule: Module {
       return firstEvent
     }
 
-    guard let firstEventStart = firstEvent.startDate, firstEventStart.compare(startDate) == .orderedSame else {
+    if let firstEventStart = firstEvent.startDate, firstEventStart.compare(startDate) == .orderedSame {
       return firstEvent
     }
 

--- a/packages/expo-calendar/ios/CalendarModule.swift
+++ b/packages/expo-calendar/ios/CalendarModule.swift
@@ -594,10 +594,8 @@ public class CalendarModule: Module {
     )
 
     for event in events {
-      if event.calendarItemIdentifier != id {
-        break
-      }
-      if let eventStart = event.startDate, eventStart.compare(startDate) == .orderedSame {
+      if event.calendarItemIdentifier == firstEvent.calendarItemIdentifier,
+        let eventStart = event.startDate, eventStart.compare(startDate) == .orderedSame {
         return event
       }
     }


### PR DESCRIPTION
  # Summary

  Fixes a bug where `deleteEventAsync` with `instanceStartDate` parameter always deleted the first/master instance of a recurring event instead of the specified instance.

  # Motivation

  When users try to delete a specific occurrence of a recurring event (e.g., delete the 3rd occurrence of a weekly event), the first occurrence gets deleted instead. This makes it impossible to delete individual instances of
  recurring events.

  **Reproduction:**
  1. Create a weekly recurring event starting Oct 6
  2. Call `deleteEventAsync` with the Oct 13 instance's `startDate` as `instanceStartDate`
  3. **Bug:** Oct 6 instance gets deleted instead of Oct 13

  # Changes

  ## Root Cause
  In `packages/expo-calendar/ios/CalendarModule.swift`, the `getEvent` function had inverted logic:

  ```swift
  // Before (buggy):
  guard let firstEventStart = firstEvent.startDate, firstEventStart.compare(startDate) == .orderedSame else {
      return firstEvent  // ❌ Returns master event when dates DON'T match
  }
  ```

  The guard statement would return the master event when dates didn't match, preventing the search loop below from executing to find the correct instance.

  ### Fix

  Changed from guard to if statement to only return early when dates do match:
  
  ```
  // After (fixed):
  if let firstEventStart = firstEvent.startDate, firstEventStart.compare(startDate) == .orderedSame {
      return firstEvent  // ✅ Only returns when dates match
  }
  // Falls through to search loop for correct instance
```
### Test Plan

  Automated Test

  Added test in apps/test-suite/tests/Calendar.js that:
  1. Creates a recurring event with 3 weekly occurrences
  2. Deletes the 2nd instance using instanceStartDate
  3. Verifies only the 2nd instance was deleted (1st and 3rd remain)

  Before fix: Test would fail - 1st instance deleted instead of 2ndAfter fix: Test passes - correct instance deleted

  To run:
```
  cd apps/bare-expo
  yarn test:ios
```

  Manual Testing

  Tested manually in native-component-list on iPhone with iOS 18:

  1. Navigate to the native-component-list app:
  ```
  cd apps/native-component-list
  ```
  2. Build and run on device:
  ```
  npx expo run:ios --device
  ```

  5. Test the fix:
    - Navigate to Calendars section
    - Select any calendar → View Events
    - Tap Add New Recurring Event (creates a weekly recurring event)
    - Select a recurring event instance (not the first one)
    - Tap Delete Event on the specific instance
    - Expected: Only that specific instance is deleted
    - Before fix: The first/master instance would be deleted instead
    - After fix: ✅ The correct instance is deleted