### PR TITLE
[bare-expo][Android] Remove `excludeFolder`

### DIFF
--- a/apps/bare-expo/android/.idea/modules/app/BareExpo.app.main.iml
+++ b/apps/bare-expo/android/.idea/modules/app/BareExpo.app.main.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="AdditionalModuleElements">
-    <content url="file://$MODULE_DIR$/../../../../../../node_modules" dumb="true">
-      <excludeFolder url="file://$MODULE_DIR$/../../../../../../node_modules" />
-    </content>
-  </component>
-</module>


### PR DESCRIPTION
# Why

Removes `excludeFolder` in favor of custom AS plugin - https://plugins.jetbrains.com/plugin/28629-better-exclude.

# How

It turns out that AS is conflicting with the configuration file, sometimes removing it. Therefore, this workaround for not indexing `node_modules` does not always work. I've decided to implement the same functionality using the JetBrains plugin platform.

# Test Plan

- replace static config with custom plugin ✅ 