### PR TITLE
[test-suite] update deep linking behavior for test list

### DIFF
--- a/.github/workflows/test-suite-lint.yml
+++ b/.github/workflows/test-suite-lint.yml
@@ -1,4 +1,4 @@
-name: Test Suite Lint
+name: Test Suite Lint & Test
 
 on:
   workflow_dispatch: {}
@@ -36,4 +36,7 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: 🚨 Lint test-suite files
         run: yarn lint --max-warnings 0
+        working-directory: apps/test-suite
+      - name: 🧪 Run unit tests
+        run: yarn test
         working-directory: apps/test-suite

--- a/apps/bare-expo/scripts/deep-link.sh
+++ b/apps/bare-expo/scripts/deep-link.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-function join_by { local d=$1; shift; echo -n "$1"; shift; printf "%s" "${@/$d}"; }
+function join_by { local d=$1; shift; echo -n "$1"; shift; printf "%s" "${@/#/$d}"; }
 
 command="instruments"
 
@@ -19,10 +19,10 @@ function setTraceTemplate {
 
 APP=$1
 PLATFORM=$2
-MODULES=$(join_by , "${@:3}") 
+MODULES=$(join_by , "${@:3}")
 LINK="bareexpo://${APP}/run?tests=${MODULES}"
 
-echo " ☛  Opening ${MODULES} in ${APP}..."
+echo " ☛  Opening ${MODULES} in ${APP} ($LINK)..."
 if [ $PLATFORM = "android" ]; then
     echo $(adb shell am start -W -a android.intent.action.VIEW -d "$LINK" dev.expo.payments)
 elif [ $PLATFORM = "ios" ]; then

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -156,6 +156,7 @@
     "react-native-web": "~0.21.0",
     "react-native-webview": "13.15.0",
     "regl": "^1.3.0",
+		"test-suite": "*",
     "three": "^0.137.4",
     "url": "^0.11.0",
     "victory-native": "^37.0.2"

--- a/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
@@ -2,6 +2,7 @@ import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useTheme } from 'ThemeProvider';
 import * as React from 'react';
+import { getScreenIdForLinking } from 'test-suite/screens/getScreenIdForLinking';
 
 import { optionalRequire } from './routeBuilder';
 import { TabBackground } from '../components/TabBackground';
@@ -55,7 +56,7 @@ export const ScreensList: ScreenConfig[] = [
     getComponent() {
       return optionalRequire(() => require('../screens/CellularScreen'));
     },
-    name: 'Cellular',
+    name: 'Cellular (device-only)',
   },
   {
     getComponent() {
@@ -144,7 +145,7 @@ export const ScreensList: ScreenConfig[] = [
     getComponent() {
       return optionalRequire(() => require('../screens/BrightnessScreen'));
     },
-    name: 'Brightness',
+    name: 'Brightness (device-only)',
   },
   {
     getComponent() {
@@ -454,9 +455,9 @@ export const Screens: ScreenConfig[] = [
   ...CalendarsScreens,
 ];
 
-export const screenApiItems: ScreenApiItem[] = ScreensList.map(({ name, route }) => ({
-  name,
-  route: '/apis/' + (route ?? name.toLowerCase()),
+export const screenApiItems: ScreenApiItem[] = ScreensList.map((config) => ({
+  name: config.name,
+  route: '/apis/' + getScreenIdForLinking(config),
   isAvailable: true,
 }));
 

--- a/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
@@ -2,6 +2,7 @@ import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useTheme } from 'ThemeProvider';
 import * as React from 'react';
+import { getScreenIdForLinking } from 'test-suite/screens/getScreenIdForLinking';
 
 import getStackNavWithConfig from './StackConfig';
 import { optionalRequire } from './routeBuilder';
@@ -229,14 +230,12 @@ const ScreensList: ScreenConfig[] = [
       return optionalRequire(() => require('../screens/Audio/AV/VideoScreen'));
     },
     name: 'Video (expo-av)',
-    route: 'video-expo-av',
   },
   {
     getComponent() {
       return optionalRequire(() => require('../screens/Video/VideoScreen'));
     },
     name: 'Video (expo-video)',
-    route: 'video-expo-video',
   },
   {
     getComponent() {
@@ -313,9 +312,9 @@ export const Screens: ScreenConfig[] = [
   ...MapsScreens,
 ];
 
-export const screenApiItems: ScreenApiItem[] = ScreensList.map(({ name, route }) => ({
-  name,
-  route: '/components/' + (route ?? name.toLowerCase()),
+export const screenApiItems: ScreenApiItem[] = ScreensList.map((config) => ({
+  name: config.name,
+  route: '/components/' + getScreenIdForLinking(config),
   isAvailable: true,
 }));
 

--- a/apps/native-component-list/src/navigation/MainNavigators.tsx
+++ b/apps/native-component-list/src/navigation/MainNavigators.tsx
@@ -3,6 +3,7 @@ import { DrawerNavigationOptions } from '@react-navigation/drawer';
 import { PathConfig } from '@react-navigation/native';
 import { StackNavigationOptions } from '@react-navigation/stack';
 import React from 'react';
+import { getScreenIdForLinking } from 'test-suite/screens/getScreenIdForLinking';
 
 import ExpoApisStackNavigator, { Screens as APIScreens } from './ExpoApisStackNavigator';
 import ExpoComponentsStackNavigator, {
@@ -30,7 +31,7 @@ const apis: ScreenConfig = {
       ...APIScreens.reduce(
         (prev, curr) => ({
           ...prev,
-          [curr.name]: curr.route || curr.name.toLowerCase(),
+          [curr.name]: getScreenIdForLinking(curr),
         }),
         {}
       ),
@@ -48,7 +49,7 @@ const components = {
       ...ComponentScreens.reduce(
         (prev, curr) => ({
           ...prev,
-          [curr.name]: curr.route || curr.name.toLowerCase(),
+          [curr.name]: getScreenIdForLinking(curr),
         }),
         {}
       ),

--- a/apps/test-suite/App.js
+++ b/apps/test-suite/App.js
@@ -4,13 +4,14 @@ import * as React from 'react';
 
 import { TestStackNavigator } from './TestStackNavigator';
 import { ThemeProvider } from '../common/ThemeProvider';
+import { routeNames } from './constants/routeNames';
 
 const linking = {
   prefixes: [Linking.createURL('/')],
   config: {
     screens: {
-      select: '',
-      run: 'run',
+      [routeNames.select]: '',
+      [routeNames.run]: routeNames.run,
     },
   },
 };

--- a/apps/test-suite/TestModules.ts
+++ b/apps/test-suite/TestModules.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import Constants from 'expo-constants';
 import { Platform } from 'expo-modules-core';
 
@@ -39,10 +37,11 @@ const TaskManagerTestScreen = optionalRequire(() => require('./tests/TaskManager
 // caused by missing native module.
 const CameraTestScreen = optionalRequire(() => require('./tests/Camera'));
 
+export type Module = { name: string; route?: string; test: Function };
 // List of all modules for tests. Each file path must be statically present for
 // the packager to pick them all up.
 export function getTestModules() {
-  const modules = [
+  const modules: Module[] = [
     // Sanity
     require('./tests/Basic'),
   ];
@@ -139,9 +138,7 @@ export function getTestModules() {
     modules.push(optionalRequire(() => require('./tests/MediaLibraryNext')));
 
     modules.push(optionalRequire(() => require('./tests/Battery')));
-    if (Constants.isDevice) {
-      modules.push(optionalRequire(() => require('./tests/Brightness')));
-    }
+    modules.push(optionalRequire(() => require('./tests/Brightness')));
     // Crashes app when mounting component
     modules.push(optionalRequire(() => require('./tests/Video')));
     // "sdkUnversionedTestSuite failed: java.lang.NullPointerException: Attempt to invoke interface method

--- a/apps/test-suite/TestStackNavigator.tsx
+++ b/apps/test-suite/TestStackNavigator.tsx
@@ -7,6 +7,7 @@ import SelectScreen from './screens/SelectScreen';
 import RunTests from './screens/TestScreen';
 import { useTheme } from '../common/ThemeProvider';
 import ThemeToggler from '../common/ThemeToggler';
+import { routeNames } from './constants/routeNames';
 
 // @tsapeta: This navigator is also being used by `bare-expo` app,
 // so make sure it still works there once you change something here.
@@ -31,7 +32,7 @@ export function TestStackNavigator() {
         },
       }}>
       <Stack.Screen
-        name="select"
+        name={routeNames.select}
         component={SelectScreen}
         options={{
           title: 'Expo Test Suite',
@@ -48,7 +49,7 @@ export function TestStackNavigator() {
           ),
         }}
       />
-      <Stack.Screen name="run" component={RunTests} options={{ title: 'Test Runner' }} />
+      <Stack.Screen name={routeNames.run} component={RunTests} options={{ title: 'Test Runner' }} />
     </Stack.Navigator>
   );
 }

--- a/apps/test-suite/components/RunnerError.js
+++ b/apps/test-suite/components/RunnerError.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import { useSafeArea } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export default function RunnerError({ children }) {
-  const { top } = useSafeArea();
+  const { top } = useSafeAreaInsets();
 
   return (
     <View style={[styles.container, top || 18]}>

--- a/apps/test-suite/constants/routeNames.ts
+++ b/apps/test-suite/constants/routeNames.ts
@@ -1,0 +1,4 @@
+export const routeNames = {
+  run: 'run',
+  select: 'select',
+} as const;

--- a/apps/test-suite/jest.config.js
+++ b/apps/test-suite/jest.config.js
@@ -1,0 +1,7 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  ...require('expo-module-scripts/jest-preset-cli.js'),
+  preset: 'ts-jest',
+  clearMocks: true,
+  displayName: require('./package').name,
+};

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -4,7 +4,8 @@
   "description": "Test suite for the Expo SDK",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "jest"
   },
   "author": "",
   "license": "MIT",

--- a/apps/test-suite/screens/TestScreen.js
+++ b/apps/test-suite/screens/TestScreen.js
@@ -2,10 +2,11 @@
 import Immutable from 'immutable';
 import jasmineModule from 'jasmine-core/lib/jasmine-core/jasmine';
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, View, ScrollView } from 'react-native';
 
 import ExponentTest from '../ExponentTest';
 import { getTestModules } from '../TestModules';
+import { getScreenIdForLinking, getSelectedTestNames } from './getScreenIdForLinking';
 import Portal from '../components/Portal';
 import RunnerError from '../components/RunnerError';
 import Suites from '../components/Suites';
@@ -26,17 +27,23 @@ export default class TestScreen extends React.Component {
   state = initialState;
   _results = '';
   _failures = '';
-  _scrollViewRef = null;
 
   componentDidMount() {
     const selectionQuery = this.props.route.params?.tests ?? '';
-    const selectedTestNames = selectionQuery.split(/[,\s]/);
 
+    const selectedTestNames = getSelectedTestNames(selectionQuery);
     // We get test modules here to make sure that React Native will reload this component when tests were changed.
-    const selectedModules = getTestModules().filter((m) => selectedTestNames.includes(m.name));
+    const selectedModules = getTestModules().filter((m) =>
+      selectedTestNames.includes(getScreenIdForLinking(m))
+    );
 
     if (!selectedModules.length) {
       console.warn('[TEST_SUITE]', 'No selected modules', selectedTestNames);
+    }
+    if (selectedTestNames.length !== selectedModules.length) {
+      const selectedModuleNames = selectedModules.map((m) => getScreenIdForLinking(m));
+      const missing = selectedTestNames.filter((n) => !selectedModuleNames.includes(n));
+      throw new Error(`[TEST_SUITE]: Some selected modules were not found: ${missing}`);
     }
 
     this._runTests(selectedModules);
@@ -267,11 +274,15 @@ export default class TestScreen extends React.Component {
       selectedModules,
     } = this.state;
     if (!selectedModules?.length) {
+      const moduleLinks = getTestModules().map(getScreenIdForLinking);
+
       return (
-        <RunnerError>
-          No tests were selected. Please provide a correct query to select tests to run.
-          SelectionQuery: "{this.props.route?.params?.tests}"
-        </RunnerError>
+        <ScrollView>
+          <RunnerError>
+            No tests were found for link: "{this.props.route?.params?.tests}"{'\n'}
+            Available links: {JSON.stringify(moduleLinks, null, 2)}
+          </RunnerError>
+        </ScrollView>
       );
     }
     if (testRunnerError) {

--- a/apps/test-suite/screens/__tests__/getScreenIdForLinking.test.ts
+++ b/apps/test-suite/screens/__tests__/getScreenIdForLinking.test.ts
@@ -1,0 +1,59 @@
+import {
+  getScreenIdForLinking,
+  createQueryString,
+  getSelectedTestNames,
+} from '../getScreenIdForLinking';
+
+describe(getScreenIdForLinking, () => {
+  it('should normalize derived routes to lowercase and trim', () => {
+    expect(getScreenIdForLinking({ name: ' MyScreen ' })).toBe('myscreen');
+  });
+
+  it('should preserve case for explicit routes and trim', () => {
+    expect(getScreenIdForLinking({ name: 'MyScreen', route: ' custom-route ' })).toBe(
+      'custom-route'
+    );
+    expect(getScreenIdForLinking({ name: 'MyScreen', route: ' ui/textInput ' })).toBe(
+      'ui/textInput'
+    );
+  });
+
+  it('should convert spaces to hyphens', () => {
+    expect(getScreenIdForLinking({ name: 'Video Thumbnails' })).toBe('video-thumbnails');
+    expect(getScreenIdForLinking({ name: 'Updates Reload Screen' })).toBe('updates-reload-screen');
+  });
+
+  it('should handle parentheses content by incorporating it with hyphens', () => {
+    expect(getScreenIdForLinking({ name: 'Cellular (device-only)' })).toBe('cellular-device-only');
+    expect(getScreenIdForLinking({ name: 'Brightness (device-only)' })).toBe(
+      'brightness-device-only'
+    );
+  });
+
+  it('should remove special characters', () => {
+    expect(getScreenIdForLinking({ name: 'Test & Examples' })).toBe('test-examples');
+    expect(getScreenIdForLinking({ name: "User's Profile" })).toBe('users-profile');
+  });
+
+  it('should collapse multiple hyphens', () => {
+    expect(getScreenIdForLinking({ name: 'Test  -  Screen' })).toBe('test-screen');
+  });
+
+  it('should prefer explicit route over derived route', () => {
+    expect(getScreenIdForLinking({ name: 'Cellular (device-only)', route: 'cellular' })).toBe(
+      'cellular'
+    );
+  });
+});
+
+describe(createQueryString, () => {
+  it('should join normalized test names with commas', () => {
+    expect(createQueryString([' Test1 ', 'TEST2', 'test1'])).toBe('test1,test2');
+  });
+});
+
+describe(getSelectedTestNames, () => {
+  it('should split and normalize query string', () => {
+    expect(getSelectedTestNames(' Test1 , Test2 ')).toEqual(['test1', 'test2']);
+  });
+});

--- a/apps/test-suite/screens/getScreenIdForLinking.ts
+++ b/apps/test-suite/screens/getScreenIdForLinking.ts
@@ -1,0 +1,91 @@
+const SEPARATOR = ',';
+
+/**
+ * Derives a URL-safe route from a screen name.
+ * Converts spaces to hyphens, removes special characters, and handles parentheses.
+ *
+ * Test this:
+ * For the "tests" tab:
+ * `xcrun simctl openurl booted bareexpo://test-suite/run?tests=brightness-device-only,blur`
+ * or `yarn open ios brightness-device-only blur`
+ *
+ * For the "components" tab:
+ * `xcrun simctl openurl booted bareexpo://components/blurview`
+ *
+ * @example
+ * deriveRouteFromName('Cellular (device-only)') // => 'cellular-device-only'
+ * deriveRouteFromName('Video Thumbnails') // => 'video-thumbnails'
+ */
+function deriveRouteFromName(name: string): string {
+  return (
+    name
+      .trim()
+      .toLowerCase()
+      // Handle parentheses: "Test (foo)" -> "test-foo"
+      .replace(/\s*\(([^)]*)\)/g, '-$1')
+      // Remove special characters (keep alphanumeric, hyphens, underscores, spaces)
+      .replace(/[^a-z0-9\-_\s]/g, '')
+      // Convert spaces to hyphens
+      .replace(/\s+/g, '-')
+      // Collapse multiple hyphens/underscores into single hyphen
+      .replace(/[-_]+/g, '-')
+      // Trim leading/trailing hyphens
+      .replace(/^-+|-+$/g, '')
+  );
+}
+
+/**
+ * Validates that a route ID only contains safe characters.
+ * Allows slashes for nested routes and @ symbols.
+ * Allows uppercase letters for explicit routes (camelCase).
+ */
+function isValidRouteId(id: string): boolean {
+  return /^[a-zA-Z0-9\-_\/@]+$/.test(id);
+}
+
+/**
+ * for the "APIs" tab in Bare-Expo:
+ * in ExpoApisStackNavigator.tsx (ScreensList) you may specify a `name` and optional `route`. By default, `name` is used.
+ *
+ * for the "Tests" tab in Bare-Expo: in the test screens in apps/test-suite/tests you may specify (export const ...):
+ * - `name`: visible in the list
+ * - `route`: string used for deep linking (by default, derived from `name`)
+ * */
+export const getScreenIdForLinking = ({
+  name,
+  route,
+}: {
+  name: string;
+  route?: string;
+}): string => {
+  const id = route ? route.trim() : deriveRouteFromName(name);
+
+  if (!id || !isValidRouteId(id)) {
+    console.error(
+      `The screen linking id "${id}" from module name "${name}" is invalid. ` +
+        `Routes must be non-empty and only contain letters, numbers, hyphens, underscores, slashes, and @ symbols.`
+    );
+  }
+
+  return id;
+};
+
+export function createQueryString(tests: string[]): string {
+  if (!Array.isArray(tests) || !tests.every((v) => typeof v === 'string')) {
+    throw new Error(
+      `test-suite: Cannot create query string for runner. Expected array of strings, instead got: ${tests}`
+    );
+  }
+  // Normalize first, then deduplicate
+  const normalized = tests.map((it) => it.trim().toLowerCase());
+  const uniqueTests = Array.from(new Set(normalized).values());
+  // Skip encoding or React Navigation will encode twice
+  return uniqueTests.join(SEPARATOR);
+}
+
+export function getSelectedTestNames(selectionQuery: string): string[] {
+  return selectionQuery
+    .split(SEPARATOR)
+    .map((v) => v.trim().toLowerCase())
+    .filter((v) => v.length > 0);
+}


### PR DESCRIPTION
# Why

- deep linking to the tests tab previously wasn't correct, as it'd split on both empty spaces and commas, meaning `FirebaseJSSDK (Compat)` would split into `FirebaseJSSDK` (which exists) and `(Compat)` which was simply ignored.

# How

- refactored and unified the linking logic in `apps/test-suite/screens/getScreenIdForLinking.ts`


# Test Plan

- green CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
