### PR TITLE
[expo-doctor] bump sentry/react-native to ~7.2.0

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -112,6 +112,6 @@
   "unimodules-image-loader-interface": "~6.1.0",
   "@shopify/react-native-skia": "2.2.12",
   "@shopify/flash-list": "2.0.2",
-  "@sentry/react-native": "~7.1.0",
+  "@sentry/react-native": "~7.2.0",
   "react-native-bootsplash": "^6.3.10"
 }


### PR DESCRIPTION
The https://github.com/getsentry/sentry-react-native/releases/tag/7.2.0 release fixes compatibility with Metro 0.83.2