### PR TITLE
[updates][android] Remove references to reactNativeHost

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - [Android] Migrated from `kotlinOptions` to `compilerOptions` DSL. ([#39794](https://github.com/expo/expo/pull/39794) by [@huextrat](https://github.com/huextrat))
+- [android] Remove references to reactNativeHost ([#40182](https://github.com/expo/expo/pull/40182) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### ⚠️ Notices
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -32,12 +32,10 @@ object UpdatesController {
     }
 
   @JvmStatic
-  fun initializeWithoutStarting(context: Context) {
+  fun initializeWithoutStarting(context: Context, useDeveloperSupport: Boolean) {
     if (singletonInstance != null) {
       return
     }
-    val useDeveloperSupport =
-      (context as? ReactApplication)?.reactNativeHost?.useDeveloperSupport ?: false
     if (useDeveloperSupport && !UpdatesPackage.isUsingNativeDebug) {
       if (BuildConfig.USE_DEV_CLIENT) {
         val devLauncherController = initializeAsDevLauncherWithoutStarting(context)
@@ -135,9 +133,9 @@ object UpdatesController {
    */
   @JvmStatic
   @Synchronized
-  fun initialize(context: Context) {
+  fun initialize(context: Context, useDeveloperSupport: Boolean = false) {
     if (singletonInstance == null) {
-      initializeWithoutStarting(context)
+      initializeWithoutStarting(context, useDeveloperSupport)
       singletonInstance?.start()
     }
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
@@ -33,7 +33,7 @@ class UpdatesPackage : Package {
       }
 
       override fun onWillCreateReactInstance(useDeveloperSupport: Boolean) {
-        UpdatesController.initialize(context)
+        UpdatesController.initialize(context, useDeveloperSupport)
       }
 
       override fun onDidCreateDevSupportManager(devSupportManager: DevSupportManager) {
@@ -62,7 +62,7 @@ class UpdatesPackage : Package {
         if (!useDeveloperSupport || isUsingNativeDebug) {
           return ReactActivityHandler.DelayLoadAppHandler { whenReadyRunnable ->
             CoroutineScope(Dispatchers.IO).launch {
-              startUpdatesController(context)
+              startUpdatesController(context, useDeveloperSupport)
               invokeReadyRunnable(whenReadyRunnable)
             }
           }
@@ -71,10 +71,10 @@ class UpdatesPackage : Package {
       }
 
       @WorkerThread
-      private suspend fun startUpdatesController(context: Context) {
+      private suspend fun startUpdatesController(context: Context, useDeveloperSupport: Boolean) {
         withContext(Dispatchers.IO) {
           if (!UpdatesPackage.isUsingCustomInit) {
-            UpdatesController.initialize(context)
+            UpdatesController.initialize(context, useDeveloperSupport)
             // Call the synchronous `launchAssetFile()` function to wait for updates ready
             UpdatesController.instance.launchAssetFile
           }


### PR DESCRIPTION
# Why

From react-native 0.82, users no longer declare a ReactNativeHost in their MainApplication, so we need to start migrating our methods to use ReactHost instead. This is part 4 of a series of PR to allow us to remove ReactNativeHostWrapper from our template.

# How

Forward `useDeveloperSupport` from `onWillCreateReactInstance` to the `UpdatesController` initialization given that we can no longer read this value from ReactNativeHost and ReactHost is only created after the `UpdatesController` initialization

# Test Plan

Run MininalTester and BareExpo on android

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
