### PR TITLE
[CI] Bump RNTV version for TV compile test

### DIFF
--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -397,7 +397,7 @@ async function preparePackageJson(
       ...packageJson,
       dependencies: {
         ...packageJson.dependencies,
-        'react-native': 'npm:react-native-tvos@0.81.4-0',
+        'react-native': 'npm:react-native-tvos@0.82.0-0rc5',
         '@react-native-tvos/config-tv': '^0.1.4',
       },
       expo: {


### PR DESCRIPTION
# Why

Align React Native TV version with the React Native version used for Expo main. Fix TV compile test.

# Test Plan

CI should pass