### PR TITLE
[bare-expo][Android] Turn on build caching

### DIFF
--- a/apps/bare-expo/android/gradle.properties
+++ b/apps/bare-expo/android/gradle.properties
@@ -19,6 +19,18 @@ org.gradle.vfs.watch=true
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
 
+# Enable the build cache to improve build times.
+org.gradle.caching=true
+
+# The Configuration Cache improves build performance by caching the result of the configuration phase
+# and reusing it for subsequent builds.
+org.gradle.configuration-cache=true
+
+# Turning problems into warnings instead of errors.
+# Some third-party libraries produce errors when the configuration cache is enabled.
+# After manually verifying that these issues are not harmful to the build.
+org.gradle.configuration-cache.problems=warn
+
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn


### PR DESCRIPTION
# Why

Turns on build caching and configuration cache to speed up local development.

# Test Plan

- bare-expo ✅ 