### PR TITLE
[docs] Clarify usage of googleServicesFile in app.json in FCM credentials guide

### DIFF
--- a/docs/pages/push-notifications/fcm-credentials.mdx
+++ b/docs/pages/push-notifications/fcm-credentials.mdx
@@ -96,6 +96,8 @@ Upload the JSON file to EAS and configure it for sending Android notifications. 
 
 Configure the **google-services.json** file in your project. Download it from the Firebase Console and place it at the root of your project directory.
 
+This file is required for your Android app to be registered with FCM. You may commit this file to your repository since it contains public-facing identifiers from your Firebase project.
+
 **Note**: You can skip this step if **google-services.json** has already been set up.
 
 <ContentSpotlight
@@ -215,6 +217,8 @@ You have to specify to EAS which JSON credential file to use for sending FCM V1 
 <Step label="4">
 
 Configure the **google-services.json** file in your project. Download it from the Firebase Console and place it at the root of your project directory.
+
+This file is required for your Android app to be registered with FCM. You may commit this file to your repository since it contains public-facing identifiers from your Firebase project.
 
 **Note**: You can skip this step if **google-services.json** has already been set up.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-17596

# How

<!--
How did you build this feature or fix this bug and why?
-->

Clarify the usage of the googleServicesFile in app.json in the FCM credentials guide and mention that it is required for Android apps.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
