### PR TITLE
[docs] Consolidate SDK callouts to use "later" and "earlier" for SDK version range

### DIFF
--- a/docs/pages/archive/customizing-webpack.mdx
+++ b/docs/pages/archive/customizing-webpack.mdx
@@ -5,7 +5,7 @@ description: Learn about different webpack bundler configurations that can be cu
 
 import { Terminal } from '~/ui/components/Snippet';
 
-> **warning** **Deprecated**: In SDK 50 and above, Expo Webpack has been deprecated in favor of [Expo Router](/router/introduction/). Learn how to [migrate from Expo Webpack to Expo Router](/router/migrate/from-expo-webpack/).
+> **warning** **Deprecated**: In SDK 50 and later, Expo Webpack has been deprecated in favor of [Expo Router](/router/introduction/). Learn how to [migrate from Expo Webpack to Expo Router](/router/migrate/from-expo-webpack/).
 
 To enable Webpack web support, modify your [app config](/workflow/configuration) using the `expo.web.bundler` field:
 

--- a/docs/pages/archive/publishing-websites-webpack.mdx
+++ b/docs/pages/archive/publishing-websites-webpack.mdx
@@ -7,7 +7,7 @@ import { NoIcon } from '~/ui/components/DocIcons';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-> **warning** **Deprecated**: In SDK 50 and above, publishing with `webpack` is deprecated in favor of `metro`. Learn more in [migrating from Webpack to Expo Router](/router/migrate/from-expo-webpack).
+> **warning** **Deprecated**: In SDK 50 and later, publishing with `webpack` is deprecated in favor of `metro`. Learn more in [migrating from Webpack to Expo Router](/router/migrate/from-expo-webpack).
 
 A web app created using Expo can be served locally for testing out the production behavior. Once the testing phase checks out, you can choose from a variety of third-party services to host it.
 

--- a/docs/pages/debugging/tools.mdx
+++ b/docs/pages/debugging/tools.mdx
@@ -209,7 +209,7 @@ If you are using Expo **SDK 50** or **above**, you can use the [Expo dev tools p
 - [React Native DevTools](#debugging-with-react-native-devtools)
 - [Redux DevTools](/debugging/devtools-plugins/#redux)
 
-If you are using Expo SDK 49 or below, you can use the React Native Debugger. This section provides quick get started instructions. For in-depth information, check its [documentation](https://github.com/jhen0409/react-native-debugger#documentation).
+If you are using Expo SDK 49 and earlier, you can use the React Native Debugger. This section provides quick get started instructions. For in-depth information, check its [documentation](https://github.com/jhen0409/react-native-debugger#documentation).
 
 You can install it via the [release page](https://github.com/jhen0409/react-native-debugger/releases), or if you're on macOS you can run:
 

--- a/docs/pages/eas-update/asset-selection.mdx
+++ b/docs/pages/eas-update/asset-selection.mdx
@@ -30,7 +30,7 @@ To use asset selection in SDK versions below 52, include the property `extra.upd
   }
 ```
 
-To use asset selection in SDK 52 and above, include the property `updates.assetPatternsToBeBundled` in your app config. It should define one or more file-matching patterns (regular expressions). For example, an **app.json** file has the patterns defined in the following way:
+To use asset selection in SDK 52 and later, include the property `updates.assetPatternsToBeBundled` in your app config. It should define one or more file-matching patterns (regular expressions). For example, an **app.json** file has the patterns defined in the following way:
 
 ```json app.json
   "expo": {

--- a/docs/pages/eas-update/integration-in-existing-native-apps.mdx
+++ b/docs/pages/eas-update/integration-in-existing-native-apps.mdx
@@ -168,7 +168,7 @@ The following instructions assume you have an app written in Swift, with one or 
 
 <Tabs>
 
-<Tab label="SDK 53 and above">
+<Tab label="SDK 53 and later">
 
 #### AppDelegate changes
 

--- a/docs/pages/guides/analyzing-bundles.mdx
+++ b/docs/pages/guides/analyzing-bundles.mdx
@@ -63,7 +63,7 @@ Inside Atlas, you can hold <kbd>⌘ Cmd</kbd> and click on a graph node to see t
 
 ## Analyzing bundle size with source-map-explorer
 
-> Alternative method for **SDK 50 and below**.
+> Alternative method for **SDK 50 and earlier**.
 
 If you are using SDK 50 or below, you can use the [`source-map-explorer`](https://www.npmjs.com/package/source-map-explorer) library to visualize and analyze the production JavaScript bundle.
 

--- a/docs/pages/guides/configuring-js-engines.mdx
+++ b/docs/pages/guides/configuring-js-engines.mdx
@@ -6,7 +6,7 @@ description: A guide on configuring JS engines for both Android and iOS in an Ex
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 
-JavaScript engines execute your application code and provide various features such as memory management, optimization, and error handling. By default, Expo projects use [Hermes](https://hermesengine.dev/) as the JavaScript engine (in SDK 47 and lower, the default was [JavaScriptCore](https://developer.apple.com/documentation/javascriptcore)). Switching to other engines, such as JSC or V8, for Android and iOS platforms is possible. However, not for the web because the JavaScript engine is included in the web browser.
+JavaScript engines execute your application code and provide various features such as memory management, optimization, and error handling. By default, Expo projects use [Hermes](https://hermesengine.dev/) as the JavaScript engine. Switching to other engines, such as JSC or V8, for Android and iOS platforms is possible. However, not for the web because the JavaScript engine is included in the web browser.
 
 ## Configuring the `jsEngine` through app config
 

--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -8,7 +8,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
-> **info** Available in **SDK 52 and above**.
+> **info** Available in **SDK 52 and later**.
 
 Expo offers a novel approach to work with modern web code directly in a native app via the `'use dom'` directive. This enables incremental migration for an entire website to a universal app by moving on a per-component basis.
 
@@ -209,9 +209,9 @@ export default function App() {
 
 <Tabs>
 
-<Tab label="SDK 53 and above">
+<Tab label="SDK 53 and later">
 
-Expo SDK 53 and above use React 19. This means that the `ref` prop is passed to the component as a prop, and you can use it directly in the component.
+Expo SDK 53 and later use React 19. This means that the `ref` prop is passed to the component as a prop, and you can use it directly in the component.
 
 ```tsx my-component.tsx (web)
 'use dom';
@@ -245,9 +245,9 @@ export default function MyComponent(props: {
 
 </Tab>
 
-<Tab label="SDK 52 and below">
+<Tab label="SDK 52 and earlier">
 
-In Expo SDK 52 and below (React 18), use the legacy `forwardRef` function to access the `ref` handle.
+In Expo SDK 52 and earlier (React 18), use the legacy `forwardRef` function to access the `ref` handle.
 
 ```tsx my-component.tsx (web)
 'use dom';

--- a/docs/pages/guides/expo-ui-swift-ui.mdx
+++ b/docs/pages/guides/expo-ui-swift-ui.mdx
@@ -15,7 +15,7 @@ import { Terminal } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { CODE } from '~/ui/components/Text';
 
-> **info** Available in **SDK 54 and above**.
+> **info** Available in **SDK 54 and later**.
 
 Expo UI brings SwiftUI to React Native. You can use modern SwiftUI primitives to build your apps.
 

--- a/docs/pages/guides/local-app-development.mdx
+++ b/docs/pages/guides/local-app-development.mdx
@@ -74,7 +74,7 @@ To create a development build, you can use [local app compilation](#local-app-co
 
 ## Local builds using Android product flavors
 
-> **warning** This feature is only available for SDK 52 and above.
+> **warning** This feature is only available for SDK 52 and later.
 
 If you have a custom Android project with multiple product flavors using different application IDs, you can configure `npx expo run:android` to use the correct flavor and build type. Expo supports both `--variant` and `--app-id` to customize the build and launch behavior.
 

--- a/docs/pages/guides/minify.mdx
+++ b/docs/pages/guides/minify.mdx
@@ -123,7 +123,7 @@ module.exports = config;
 
 ### Uglify
 
-For projects SDK 48 and above, you can use [`uglify-es`](https://github.com/mishoo/UglifyJS) by following the steps below:
+You can use [`uglify-es`](https://github.com/mishoo/UglifyJS) by following the steps below:
 
 <Step label="1">
 

--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -299,9 +299,9 @@ For [npm](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#overrides),
 
 #### Deduplicating auto-linked native modules
 
-> **important** This is an experimental feature starting in SDK 54 and above.
+> **important** This is an experimental feature starting in SDK 54 and later.
 
-This is an experimental feature starting in SDK 52 and above. The process will be more automated and have better support in future versions.
+This is an experimental feature starting in SDK 54 and later. The process will be more automated and have better support in future versions.
 
 Often, duplicate dependencies won't cause any problems. However, native modules should never be duplicated, because only one version of a native module can be compiled for an app build at a time. Unlike JavaScript dependencies, native builds cannot contain two conflicting versions of a single native module.
 

--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -299,9 +299,7 @@ For [npm](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#overrides),
 
 #### Deduplicating auto-linked native modules
 
-> **important** This is an experimental feature starting in SDK 54 and later.
-
-This is an experimental feature starting in SDK 54 and later. The process will be more automated and have better support in future versions.
+> **important** This is an experimental feature starting in SDK 54 and later. The process will be automated and have better support in future versions.
 
 Often, duplicate dependencies won't cause any problems. However, native modules should never be duplicated, because only one version of a native module can be compiled for an app build at a time. Unlike JavaScript dependencies, native builds cannot contain two conflicting versions of a single native module.
 

--- a/docs/pages/guides/new-architecture.mdx
+++ b/docs/pages/guides/new-architecture.mdx
@@ -69,7 +69,7 @@ You can configure the React Native Directory check in your **package.json** file
 
 <Collapsible summary="See all available options">
 
-- **enabled**: If `true`, the check will warn if any packages are missing from React Native Directory. Set this to `false` to disable this behavior. On SDK 52 and above, this is set to `true` by default, otherwise it is `false` by default. You can also override this setting with the `EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK` environment variable (0 is `false`, 1 is `true`).
+- **enabled**: If `true`, the check will warn if any packages are missing from React Native Directory. Set this to `false` to disable this behavior. In SDK 52 and later, this is set to `true` by default, otherwise it is `false` by default. You can also override this setting with the `EXPO_DOCTOR_ENABLE_DIRECTORY_CHECK` environment variable (0 is `false`, 1 is `true`).
 - **exclude**: List any packages you want to exclude from the check. Supports exact package names and regex patterns. For example, `["exact-package", "/or-a-regex-.*/"]`.
 - **listUnknownPackages**: By default, the check will warn if any packages are missing from React Native Directory. Set this to false to disable this behavior.
 
@@ -84,8 +84,8 @@ You can configure the React Native Directory check in your **package.json** file
 ## Enable the New Architecture in an existing project
 
 <Tabs>
-  <Tab label="SDK 53 and above">
-    **The New Architecture is enabled by default in SDK 53 and above**. If you have explicitly disabled it, remove that configuration to enable it.
+  <Tab label="SDK 53 and later">
+    **The New Architecture is enabled by default in SDK 53 and later**. If you have explicitly disabled it, remove that configuration to enable it.
 
   </Tab>
 
@@ -138,7 +138,7 @@ You can configure the React Native Directory check in your **package.json** file
 
   </Tab>
 
-  <Tab label="SDK 51 and below">
+  <Tab label="SDK 51 and earlier">
     We recommend upgrading to at least SDK 52, preferably SDK 53. It's possible to enable the New Architecture in SDK 51, but you are likely to encounter a variety of issues that have been resolved in more recent releases. To enable it, you need to [install the `expo-build-properties` plugin](/versions/latest/sdk/build-properties/#installation) and set `newArchEnabled` on target platforms.
   </Tab>
 </Tabs>

--- a/docs/pages/guides/prebuilt-expo-modules.mdx
+++ b/docs/pages/guides/prebuilt-expo-modules.mdx
@@ -14,7 +14,7 @@ When building React Native apps, longer build times can slow down your developme
 
 - **Faster local development**: Up to 25% reduction in Android build times on local machines
 - **Improved developer experience**: Less waiting time during development iterations
-- **Automatic optimization**: Works out of the box with new projects for SDK 53 and above
+- **Automatic optimization**: Works out of the box with new projects for SDK 53 and later
 
 ## How prebuilt Expo Modules for Android work
 
@@ -30,7 +30,7 @@ For example, after creating a project with SDK 53's default template, and runnin
 
 ## Configuration
 
-**For SDK 53 and above, no configuration steps are required for projects** that are created with one of the available [Expo templates](/more/create-expo/#--template).
+**For SDK 53 and later, no configuration steps are required for projects** that are created with one of the available [Expo templates](/more/create-expo/#--template).
 
 ### Opting out of prebuilt Expo Modules
 
@@ -76,6 +76,6 @@ You can also opt out of specific modules while keeping others prebuilt by specif
 
 ## Considerations
 
-- Existing projects can benefit from this feature when upgrading to SDK 53 and above
+- Existing projects can benefit from this feature when upgrading to SDK 53 and later
 - Performance improvements may vary based on your hardware configuration
 - Current improvements on EAS Builds are more modest but provide groundwork for future caching mechanisms

--- a/docs/pages/guides/publishing-websites.mdx
+++ b/docs/pages/guides/publishing-websites.mdx
@@ -21,7 +21,7 @@ An Expo web app can be served locally for testing the production behavior, and d
   Icon={Cloud01Icon}
 />
 
-> For SDK 49 and below, you may need the [guide for publishing `webpack` builds](/archive/publishing-websites-webpack/).
+> For SDK 49 and earlier, you may need the [guide for publishing `webpack` builds](/archive/publishing-websites-webpack/).
 
 ## Output targets
 

--- a/docs/pages/guides/react-compiler.mdx
+++ b/docs/pages/guides/react-compiler.mdx
@@ -25,10 +25,10 @@ This will generally verify if your app is following the [**rules of React**](htt
 
 Install `babel-plugin-react-compiler` and the React compiler runtime in your project:
 
-<Tabs tabs={['SDK 54 and above', 'SDK 53', 'SDK 52 and below']}>
+<Tabs tabs={['SDK 54 and later', 'SDK 53', 'SDK 52 and earlier']}>
   <Tab>
 
-    Babel is automatically configured in Expo SDK 54 and above.
+    Babel is automatically configured in Expo SDK 54 and later.
 
   </Tab>
   <Tab>

--- a/docs/pages/guides/server-components.mdx
+++ b/docs/pages/guides/server-components.mdx
@@ -9,7 +9,7 @@ import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
 
-> Experimentally available in **SDK 52 and above**. This is a beta release and subject to breaking changes.
+> Experimentally available in **SDK 52 and later**. This is a beta release and subject to breaking changes.
 
 React Server Components enable a number of exciting capabilities, including:
 
@@ -28,7 +28,7 @@ Your project must use Expo Router and React Native new architecture (default fro
 
 To use React Server Components in your Expo app, you need to:
 
-1. Install the required RSC dependency `react-server-dom-webpack@19.0.0-rc-6230622a1a-20240610` (`react-server-dom-webpack@~19.0.0` for SDK 53 and above).
+1. Install the required RSC dependency `react-server-dom-webpack@19.0.0-rc-6230622a1a-20240610` (`react-server-dom-webpack@~19.0.0` for SDK 53 and later).
 2. Ensure the entry module is `expo-router/entry` (default) in **package.json**.
 3. Enable the flag in the project app config:
 

--- a/docs/pages/guides/tree-shaking.mdx
+++ b/docs/pages/guides/tree-shaking.mdx
@@ -227,7 +227,7 @@ const { View, Image } = require('react-native-web');
 
 ## Remove unused imports and exports
 
-> Experimentally available in SDK 52 and above.
+> Experimentally available in SDK 52 and later.
 
 You can experimentally enable support for automatically removing unused imports and exports across modules. This is useful for speeding up native OTA downloads and optimizing web performance where JavaScript must be parsed and executed using a standard JavaScript engine.
 
@@ -277,13 +277,13 @@ This system scales up to automatically optimize all `import` and `export` syntax
 
 ## Enabling tree shaking
 
-> Experimentally available in SDK 52 and above.
+> Experimentally available in SDK 52 and later.
 
 <Step label="1">
 
 Ensure `experimentalImportSupport` and ensure your app builds and runs as expected.
 
-> **info** **Note**: Enabled by default in SDK 54 and above.
+> **info** **Note**: Enabled by default in SDK 54 and later.
 
 <Collapsible summary="How to enable import support in older SDK versions?">
 
@@ -343,7 +343,7 @@ This feature is very experimental because it changes the fundamental structure o
 
 ## Barrel files
 
-> Experimentally available in SDK 52 and above.
+> Experimentally available in SDK 52 and later.
 
 With Expo tree shaking, star exports will automatically be expanded and shaken based on usage. For example, consider the following code snippet:
 
@@ -365,7 +365,7 @@ You can use this strategy with libraries like `lucide-react` to remove all icons
 
 ## Recursive optimizations
 
-> Experimentally available in SDK 52 and above.
+> Experimentally available in SDK 52 and later.
 
 Expo optimizes a module by recursing through the graph exhaustively to find unused imports. Consider the following code snippet:
 

--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -17,7 +17,7 @@ This guide provides steps to set up and configure ESLint and Prettier.
 
 ### Setup
 
-> **info** **From SDK 53 onwards**, the default ESLint config file uses the [Flat config](https://eslint.org/blog/2022/08/new-config-system-part-2/) format. It also supports legacy config. **For SDK 52 and below**, the default ESLint config file uses legacy config and does not support Flat config.
+> **info** **From SDK 53 onwards**, the default ESLint config file uses the [Flat config](https://eslint.org/blog/2022/08/new-config-system-part-2/) format. It also supports legacy config. **For SDK 52 and earlier**, the default ESLint config file uses legacy config and does not support Flat config.
 
 To set up ESLint in your Expo project, you can use the Expo CLI to install the necessary dependencies. Running this command also creates a **eslint.config.js** file at the root of your project which extends configuration from [`eslint-config-expo`](https://github.com/expo/expo/tree/main/packages/eslint-config-expo).
 
@@ -215,7 +215,7 @@ node_modules
 
 ## Migration to Flat config
 
-> **info** **Note:** Flat config is supported in Expo SDK 53 and above.
+> **info** **Note:** Flat config is supported in Expo SDK 53 and later.
 
 Upgrade ESLint and `eslint-config-expo`:
 

--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -49,7 +49,7 @@ Firebase JS SDK does not support all services for mobile apps. Some of these ser
 
 ### Install and initialize Firebase JS SDK
 
-> **warning** Expo SDK 53 and above only support `firebase@^12.0.0`. Versions before this version cause ES module resolution errors.
+> **warning** Expo SDK 53 and later only support `firebase@^12.0.0`. Versions before this version cause ES module resolution errors.
 
 <Step label="1">
 #### Install the SDK

--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -257,7 +257,7 @@ For example, with the `--platform ios` option, it returns an object in **react-n
 
 ## Dependency resolution and conflicts
 
-> **important** This is an experimental feature starting in SDK 54 and above.
+> **important** This is an experimental feature starting in SDK 54 and later.
 
 Autolinking and Node resolution have different goals and the module resolution algorithm in Node and Metro can sometimes come into conflict. If your app contains duplicate installations of a native module that is picked up by autolinking, your JavaScript bundle may contain both versions of the native module, while autolinking and your native app will only contain one version. This might cause runtime crashes and risks incompatibilities.
 

--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -150,7 +150,7 @@ dependencies {
 <Collapsible summary={<>Are you trying to use a <CODE>.aar</CODE> dependency?</>}>
 
 <Tabs>
-  <Tab label="SDK 52 and above">
+  <Tab label="SDK 52 and later">
     Inside the **android** directory, create another directory called **libs** and place the **.aar** file inside it. Then, add the file as a Gradle project from autolinking:
 
 ```diff expo-module.config.json
@@ -175,7 +175,7 @@ dependencies {
 ```
 
   </Tab>
-  <Tab label="SDK 51 and below">
+  <Tab label="SDK 51 and earlier">
     Inside the **android** directory, create another directory called **libs** and place the **.aar** file inside it. Then, add the directory as a repository:
 
 ```diff android/build.gradle

--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -326,7 +326,7 @@ export default function Blog() {
 
 ### Exporting with webpack
 
-> **warning** **Deprecated**: In SDK 50 and above, Expo Webpack has been deprecated in favor of universal Metro (`npx expo export`). Learn more in [migrating from Webpack to Expo Router](/router/migrate/from-expo-webpack).
+> **warning** **Deprecated**: In SDK 50 and later, Expo Webpack has been deprecated in favor of universal Metro (`npx expo export`). Learn more in [migrating from Webpack to Expo Router](/router/migrate/from-expo-webpack).
 
 You can export the JavaScript and assets for your web app using webpack by running the following:
 

--- a/docs/pages/preview/singular.mdx
+++ b/docs/pages/preview/singular.mdx
@@ -5,7 +5,7 @@ description: Learn how to enforce singular routes.
 
 import { FileTree } from '~/ui/components/FileTree';
 
-> **warning** Singular routes are available from SDK 53 and above. They are currently flagged as `dangerouslySingular` due to an upstream issue with `react-native-screens`. Expo is working with Software Mansion to resolve the issue.
+> **warning** Singular routes are available from SDK 53 and later. They are currently flagged as `dangerouslySingular` due to an upstream issue with `react-native-screens`. Expo is working with Software Mansion to resolve the issue.
 
 While a `Stack` normally operates with `push`/`pop` actions, in advanced scenarios you may wish to enforce a singular version of a screen in the stack. When enabled, any time a new screen is pushed the history will be scanned and any matching screens will be removed to ensure only a singular version exists.
 

--- a/docs/pages/push-notifications/sending-notifications-custom.mdx
+++ b/docs/pages/push-notifications/sending-notifications-custom.mdx
@@ -161,7 +161,7 @@ the Expo config needs to be modified in one of two ways:
 
 If you are not using CNG, then you should [add the push notification entitlement in Xcode](https://developer.apple.com/documentation/usernotifications/registering-your-app-with-apns).
 
-> **Note**: If you are upgrading an Expo app from a version from SDK 51 and below, you should refer to [this FYI document](https://expo.fyi/apns-entitlement-sdk-51).
+> **Note**: If you are upgrading an Expo app from a version from SDK 51 and earlier, you should refer to [this FYI document](https://expo.fyi/apns-entitlement-sdk-51).
 
 ### Authorization
 

--- a/docs/pages/router/advanced/custom-tabs.mdx
+++ b/docs/pages/router/advanced/custom-tabs.mdx
@@ -10,7 +10,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { FileTree } from '~/ui/components/FileTree';
 
-> **important** Experimentally available in SDK 52 and above.
+> **important** Experimentally available in SDK 52 and later.
 
 Expo Router offers a set of components to create custom tab layouts via the submodule [`expo-router/ui`](/versions/latest/sdk/router-ui/). Unlike the React Navigation styled `Tabs`, these components are unstyled and flexible. They are designed to allow you build complex UI patterns from scratch in your project.
 
@@ -251,9 +251,9 @@ export function TabButton({ icon, children, isFocused, ...props }: TabButtonProp
 }
 ```
 
-<Collapsible summary="Expo SDK 52 / React 18 and below">
+<Collapsible summary="Expo SDK 52 / React 18 and earlier">
 
-In Expo SDK 52 and below (React 18), use the legacy `forwardRef` function to access the `ref` handle.
+In Expo SDK 52 and earlier (React 18), use the legacy `forwardRef` function to access the `ref` handle.
 
 ```diff
 - import { ComponentProps, Ref } from 'react';

--- a/docs/pages/router/advanced/drawer.mdx
+++ b/docs/pages/router/advanced/drawer.mdx
@@ -9,7 +9,7 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 A navigation drawer is a common pattern in mobile apps, it allows users to swipe open a menu from a side of their screen to expose navigation options. This menu is also typically toggleable through a button in the app's header.
 
 <Tabs>
-<Tab label="SDK 54 and above">
+<Tab label="SDK 54 and later">
 
 To use [drawer navigator](https://reactnavigation.org/docs/drawer-based-navigation) you'll need to install some additional dependencies if you do not have them already. On Android and iOS, the drawer navigator requires `react-native-reanimated` and `react-native-worklets` to drive its animations. On web, this is handled by CSS animations.
 
@@ -61,7 +61,7 @@ export default function Layout() {
 ```
 
 </Tab>
-<Tab label="SDK 53 and below">
+<Tab label="SDK 53 and earlier">
 ## Installation
 
 <Terminal

--- a/docs/pages/router/advanced/native-tabs.mdx
+++ b/docs/pages/router/advanced/native-tabs.mdx
@@ -9,7 +9,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { FileTree } from '~/ui/components/FileTree';
 
-> **important** Native tabs is an experimental feature available in SDK 54 and above, and its API is subject to change.
+> **important** Native tabs is an experimental feature available in SDK 54 and later, and its API is subject to change.
 
 Tabs are a common way to navigate between different sections of an app. In Expo Router, you can use different tab layouts, depending on your needs. This guide covers the native tabs. Unlike the [other tabs layout](/router/advanced/tabs), native tabs use the native system tab bar.
 
@@ -92,8 +92,6 @@ The tab file named **index.tsx** is the default tab when the app loads. The seco
 
 ## Customizing tab bar items
 
-> **important** Native tabs is an experimental feature available in SDK 54 and above, and its API is subject to change.
-
 When you want to customize the tab bar item, we recommend using the components API designed for this purpose. Currently, you can customize:
 
 - **Icon**: The icon displayed in the tab bar item.
@@ -101,8 +99,6 @@ When you want to customize the tab bar item, we recommend using the components A
 - **Badge**: The badge displayed in the tab bar item.
 
 ### Icon
-
-> **important** Native tabs is an experimental feature available in SDK 54 and above, and its API is subject to change.
 
 You can use the `Icon` component to customize the icon displayed in the tab bar item. The `Icon` component accepts a `drawable` prop for Android drawables, a `sf` prop for Apple's SF Symbols icons, or a `src` prop for custom images.
 
@@ -164,8 +160,6 @@ export default function TabLayout() {
 
 ### Label
 
-> **important** Native tabs is an experimental feature available in SDK 54 and above, and its API is subject to change.
-
 You can use the `Label` component to customize the label displayed in the tab bar item. The `Label` component accepts a string label passed as a child. If no label is provided, the tab bar item will use the route name as the label.
 
 If you don't want to display a label, you can use the `hidden` prop to hide the label.
@@ -188,8 +182,6 @@ export default function TabLayout() {
 ```
 
 ### Badge
-
-> **important** Native tabs is an experimental feature available in SDK 54 and above, and its API is subject to change.
 
 You can use the `Badge` component to customize the badge displayed for the tab bar item. The badge is an additional mark on top of the tab and useful for showing notification or unread message counts.
 

--- a/docs/pages/router/advanced/protected.mdx
+++ b/docs/pages/router/advanced/protected.mdx
@@ -7,7 +7,7 @@ hasVideoLink: true
 import { FileTree } from '~/ui/components/FileTree';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
-> **warning** Protected routes are available in SDK 53 and above.
+> **warning** Protected routes are available in SDK 53 and later.
 
 <VideoBoxLink videoId="zHZjJDTTHJg" title="Watch: Using protected routes" />
 

--- a/docs/pages/router/advanced/web-modals.mdx
+++ b/docs/pages/router/advanced/web-modals.mdx
@@ -7,7 +7,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { FileTree } from '~/ui/components/FileTree';
 
-> **important** Web modals are available in SDK 54 and above.
+> **important** Web modals are available in SDK 54 and later.
 
 Modern web apps require a flexible modal experience that adapts to different content sizes and user interactions. Expo Router provides various modal presentation patterns for modern web experiences. These patterns leverage `presentation` with `modal`, `formSheet`, `transparentModal`, or `containedTransparentModal` to present either a modal based on different screen widths, and provide customizable styling props using `webModalStyle`.
 

--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -217,7 +217,7 @@ Route handlers are executed in a sandboxed environment that is isolated from the
 
 ## Deployment
 
-When you're ready to deploy to production, run [`npx expo export --platform web`](/more/expo-cli#exporting) to create the server bundle in the **dist** directory. This server can be tested locally with `npx expo serve` (available in Expo SDK 52 and higher), visit the URL in a web browser or create a native build with the `origin` set to the local server URL.
+When you're ready to deploy to production, run [`npx expo export --platform web`](/more/expo-cli#exporting) to create the server bundle in the **dist** directory. This server can be tested locally with `npx expo serve` (available in Expo SDK 52 and later), visit the URL in a web browser or create a native build with the `origin` set to the local server URL.
 You can deploy the server for production using [EAS Hosting](/eas/hosting/get-started) or another third-party service.
 
 <BoxLink
@@ -229,7 +229,7 @@ You can deploy the server for production using [EAS Hosting](/eas/hosting/get-st
 
 ### Native deployment
 
-> **important** This is an experimental feature starting in SDK 52 and above. The process will be more automated and have better support in future versions.
+> **important** This is an experimental feature starting in SDK 52 and later. The process will be more automated and have better support in future versions.
 
 Server features (API routes, and React Server Components) in Expo Router are centered around native implementations of `window.location` and `fetch` which point to the remote server. In development, we automatically point to the dev server running with `npx expo start`, but for production native builds to work you'll need to deploy the server to a secure host and set the `origin` property of the Expo Router Config Plugin.
 

--- a/docs/pages/router/reference/link-preview.mdx
+++ b/docs/pages/router/reference/link-preview.mdx
@@ -5,7 +5,7 @@ description: Learn how to add a preview to your link on iOS when using Expo Rout
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-> **important** Link preview is an iOS-only feature available in SDK 54 and above.
+> **important** Link preview is an iOS-only feature available in SDK 54 and later.
 
 <ContentSpotlight
   alt="A video presenting the link preview feature in Expo Router."

--- a/docs/pages/router/reference/middleware.mdx
+++ b/docs/pages/router/reference/middleware.mdx
@@ -7,7 +7,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-> **important** Server middleware is an experimental feature available in SDK 54 and above, and requires a [deployed server](/router/reference/api-routes/#deployment) for production use.
+> **important** Server middleware is an experimental feature available in SDK 54 and later, and requires a [deployed server](/router/reference/api-routes/#deployment) for production use.
 
 Server middleware in Expo Router allows you to run code before requests reach your routes, enabling powerful server-side functionality like authentication and logging for every request. Unlike [API routes](/router/reference/api-routes) that handle specific endpoints, middleware runs for **every** request in your app, so it should run as quickly as possible to avoid slowing down your app's performance. Client-side navigation such as on native, or in a web app when using [`<Link />`](/versions/latest/sdk/router/#link), will not move through the server middleware.
 

--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -581,7 +581,7 @@ export async function GET(req: Request) {
 new Worker(new URL('./worker', window.location.href));
 ```
 
-Expo Metro has experimental web worker support in SDK 53 and above. This feature is currently web-only and does not work on native, usage on native will trigger an error "Property 'Worker' doesn't exist".
+Expo Metro has experimental web worker support. This feature is currently web-only and does not work on native, usage on native will trigger an error "Property 'Worker' doesn't exist".
 
 Web workers can be used to offload work to a separate thread on web, allowing the main thread to remain responsive. This is useful for computationally expensive tasks, such as image processing, cryptography, or other tasks that would otherwise block the main thread.
 

--- a/docs/pages/versions/unversioned/sdk/router-native-tabs.mdx
+++ b/docs/pages/versions/unversioned/sdk/router-native-tabs.mdx
@@ -13,7 +13,7 @@ import APISection from '~/components/plugins/APISection';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { ConfigPluginExample } from '~/ui/components/ConfigSection';
 
-> **important** Native tabs is an experimental feature available in SDK 54 and above, and its API is subject to change.
+> **important** Native tabs is an experimental feature available in SDK 54 and later, and its API is subject to change.
 
 `expo-router/unstable-native-tabs` is a submodule of `expo-router` and exports components to build tab layouts using platform-native system tabs.
 

--- a/docs/pages/versions/v52.0.0/config/metro.mdx
+++ b/docs/pages/versions/v52.0.0/config/metro.mdx
@@ -61,7 +61,7 @@ Expo supports CSS in your project. You can import CSS files from any component. 
 
 <Tabs>
 
-<Tab label="SDK 50 and above">
+<Tab label="SDK 50 and later">
 
 CSS support is enabled by default. You can disable the feature by setting `isCSSEnabled` in the Metro config.
 
@@ -553,7 +553,7 @@ In your `ios/<Project>.xcodeproj/project.pbxproj` file, replace the following sc
 
 #### `"Start Packager"`
 
-Remove the "Start Packager" script in SDK 50 and higher. The dev server must be started with `npx expo` before/after running the app.
+Remove the "Start Packager" script in SDK 50 and later. The dev server must be started with `npx expo` before/after running the app.
 
 ```diff
 -    FD10A7F022414F080027D42C /* Start Packager */ = {

--- a/docs/pages/versions/v53.0.0/config/metro.mdx
+++ b/docs/pages/versions/v53.0.0/config/metro.mdx
@@ -569,7 +569,7 @@ export async function GET(req: Request) {
 new Worker(new URL('./worker', window.location.href));
 ```
 
-Expo Metro has experimental web worker support in SDK 53 and above. This feature is currently web-only and does not work on native, usage on native will trigger an error "Property 'Worker' doesn't exist".
+Expo Metro has experimental web worker support in SDK 53 and later. This feature is currently web-only and does not work on native, usage on native will trigger an error "Property 'Worker' doesn't exist".
 
 Web workers can be used to offload work to a separate thread on web, allowing the main thread to remain responsive. This is useful for computationally expensive tasks, such as image processing, cryptography, or other tasks that would otherwise block the main thread.
 

--- a/docs/pages/versions/v54.0.0/config/metro.mdx
+++ b/docs/pages/versions/v54.0.0/config/metro.mdx
@@ -581,7 +581,7 @@ export async function GET(req: Request) {
 new Worker(new URL('./worker', window.location.href));
 ```
 
-Expo Metro has experimental web worker support in SDK 53 and above. This feature is currently web-only and does not work on native, usage on native will trigger an error "Property 'Worker' doesn't exist".
+Expo Metro has experimental web worker support. This feature is currently web-only and does not work on native, usage on native will trigger an error "Property 'Worker' doesn't exist".
 
 Web workers can be used to offload work to a separate thread on web, allowing the main thread to remain responsive. This is useful for computationally expensive tasks, such as image processing, cryptography, or other tasks that would otherwise block the main thread.
 

--- a/docs/pages/versions/v54.0.0/sdk/router-native-tabs.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/router-native-tabs.mdx
@@ -13,7 +13,7 @@ import APISection from '~/components/plugins/APISection';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { ConfigPluginExample } from '~/ui/components/ConfigSection';
 
-> **important** Native tabs is an experimental feature available in SDK 54 and above, and its API is subject to change.
+> **important** Native tabs is an experimental feature available in SDK 54 and later, and its API is subject to change.
 
 `expo-router/unstable-native-tabs` is a submodule of `expo-router` and exports components to build tab layouts using platform-native system tabs.
 

--- a/guides/Expo Documentation Writing Style Guide.md
+++ b/guides/Expo Documentation Writing Style Guide.md
@@ -284,13 +284,14 @@ When offering guidance for projects that require manually editing native code/di
 
 Any numbered list should start with `1` instead of `0`. This avoids inconsistency across all areas in the documentation.
 
-### SDK availability callouts
+### SDK version range callouts
 
 In Expo and Expo SDK documentation, use _later_ and/or _earlier_ to describe a range of version numbers.
 
-- Correct: **info** Available in **SDK 52 and later**.
-- Correct: **info** Available in **SDK 53 and earlier**.
-- Incorrect: **info** Available in **SDK 52 and above**.
+- Correct: **info** Available in **SDK 54 and later**.
+- Correct: **info** Available in **SDK 54 and earlier**.
+- Incorrect: **info** Available in **SDK 54 and above**.
+- Incorrect: **info** Available in **SDK 54 and below**.
 
 ## Tools to use when using visualization or interactivity to communicate
 

--- a/guides/Expo Documentation Writing Style Guide.md
+++ b/guides/Expo Documentation Writing Style Guide.md
@@ -280,9 +280,17 @@ To avoid using the term "managed workflow", use "using Expo" to represent the cu
 
 When offering guidance for projects that require manually editing native code/directories, put those instructions in a dropdown saying "manual setup", or "usage in bare React Native projects", or "usage in existing React Native projects".
 
-### Numbered Lists
+### Numbered lists
 
 Any numbered list should start with `1` instead of `0`. This avoids inconsistency across all areas in the documentation.
+
+### SDK availability callouts
+
+In Expo and Expo SDK documentation, use _later_ and/or _earlier_ to describe a range of version numbers.
+
+- Correct: **info** Available in **SDK 52 and later**.
+- Correct: **info** Available in **SDK 53 and earlier**.
+- Incorrect: **info** Available in **SDK 52 and above**.
 
 ## Tools to use when using visualization or interactivity to communicate
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-17426

# How

<!--
How did you build this feature or fix this bug and why?
-->

-  Consolidate SDK callouts and mentions to use _later_ and _earlier_ for SDK version range in multiple docs.
- Add the guideline to the Expo Documentation Writing Style Guide


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
