### PR TITLE
[expo-filesystem][android] fix recursive deletion of directories

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 ### 💡 Others
 
+## 19.0.17 - 2025-10-06
+### 🐛 Bug fixes
+
+- [Android] Fix recursive deletion of directories ([#40210](https://github.com/expo/expo/pull/40210) by [@totoluto](https://github.com/totoluto))
+
 ## 19.0.16 - 2025-10-01
 
 ### 🎉 New features

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemPath.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemPath.kt
@@ -68,7 +68,7 @@ abstract class FileSystemPath(var uri: Uri) : SharedObject() {
           if (uri.isContentUri) {
             SAFDocumentFile(appContext?.reactContext ?: throw Exception("No context"), child.uri).delete()
           } else {
-            JavaFile(child.uri).delete()
+            FileSystemPath(child.uri).delete()
           }
         } else {
           if (!child.delete()) {


### PR DESCRIPTION
# Why

I was building an android file management app and wasn't able to delete a folder within a subfolder. Checked open issues on expo and saw following issue #40197

Investigated `expo-file-system` package and spotted mistake.

# How

The [API docs for File](https://docs.oracle.com/javase/tutorial/essential/io/delete.html) in Java shows that deletion on non empty folders throw a exception and it can't be deleted. It should call this function recursively and delete the files within the subdir first.

# Test Plan

1. Create root folder and subfolder with file
```ts
const rootDir = new Directory(Paths.document, "folder");
const subDir = new Directory(rootDir, "subFolder");
const testFile = new File(subDir, "test.txt");

if (!rootDir.exists) {
    rootDir.create();
}

if (!subDir.exists) {
    subDir.create();
}

if (!testFile.exists) {
    testFile.create();
}

testFile.write("Hello, World!");
```

2. Verify Contents
```ts
console.log(rootDir.list());
console.log(subDir.list());
```

3.  Delete root dir and verify once more
```ts
rootDir.delete();
console.log(rootDir.exists); // Should return false
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
