### PR TITLE
[image][Android] Fix `You can't start or clear loads in RequestListener or Target callbacks`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [iOS] Fix NSURL to JSIString conversion returning nil. ([#39567](https://github.com/expo/expo/pull/39567) by [@behenate](https://github.com/behenate))
 - Fix SharedObject created with `useReleasingSharedObject` getting destroyed after a fast refresh caused by a change in its dependencies. ([#39753](https://github.com/expo/expo/pull/39753) by [@behenate](https://github.com/behenate))
 - [Android] Restore `register` overload in `ModuleRegistry`. ([#40149](https://github.com/expo/expo/pull/40149) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Fixed `You can't start or clear loads in RequestListener or Target callbacks`.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -15,7 +15,7 @@
 - [iOS] Fix NSURL to JSIString conversion returning nil. ([#39567](https://github.com/expo/expo/pull/39567) by [@behenate](https://github.com/behenate))
 - Fix SharedObject created with `useReleasingSharedObject` getting destroyed after a fast refresh caused by a change in its dependencies. ([#39753](https://github.com/expo/expo/pull/39753) by [@behenate](https://github.com/behenate))
 - [Android] Restore `register` overload in `ModuleRegistry`. ([#40149](https://github.com/expo/expo/pull/40149) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Fixed `You can't start or clear loads in RequestListener or Target callbacks`.
+- [Android] Fixed `You can't start or clear loads in RequestListener or Target callbacks`. ([#40212](https://github.com/expo/expo/pull/40212) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/39904.
Fixes:
```
Caused by java.lang.IllegalStateException: You can't start or clear loads in RequestListener or Target callbacks. If you're trying to start a fallback request when a load fails, use RequestBuilder#error(RequestBuilder). Otherwise consider posting your into() or clear() calls to the main thread using a Handler instead.
       at com.bumptech.glide.request.SingleRequest.assertNotCallingCallbacks(SingleRequest.java:305)
       at com.bumptech.glide.request.SingleRequest.clear(SingleRequest.java:325)
       at com.bumptech.glide.manager.RequestTracker.clearAndRemove(RequestTracker.java:70)
       at com.bumptech.glide.RequestManager.untrack(RequestManager.java:677)
       at com.bumptech.glide.RequestManager.untrackOrDelegate(RequestManager.java:645)
       at com.bumptech.glide.RequestManager.clear(RequestManager.java:641)
       at com.bumptech.glide.RequestBuilder.into(RequestBuilder.java:856)
       at com.bumptech.glide.RequestBuilder.into(RequestBuilder.java:825)
       at com.bumptech.glide.RequestBuilder.into(RequestBuilder.java:817)
       at expo.modules.image.ExpoImageViewWrapper.rerenderIfNeeded$expo_image_release(ExpoImageViewWrapper.kt:567)
       at expo.modules.image.ExpoImageViewWrapper.rerenderIfNeeded$expo_image_release$default(ExpoImageViewWrapper.kt:482)
       at expo.modules.image.ExpoImageViewWrapper.onSizeChanged(ExpoImageViewWrapper.kt:400)
       at android.view.View.sizeChange(View.java:23088)
       at android.view.View.setFrame(View.java:23040)
       at android.view.View.layout(View.java:22897)
       at android.view.ViewGroup.layout(ViewGroup.java:6389)
       at com.facebook.react.fabric.mounting.SurfaceMountingManager.updateLayout(SurfaceMountingManager.java:842)
       at com.facebook.react.fabric.mounting.mountitems.IntBufferBatchMountItem.execute(IntBufferBatchMountItem.java:157)
       at com.facebook.react.fabric.mounting.MountItemDispatcher.executeOrEnqueue(MountItemDispatcher.java:370)
       at com.facebook.react.fabric.mounting.MountItemDispatcher.dispatchMountItems(MountItemDispatcher.java:265)
       at com.facebook.react.fabric.mounting.MountItemDispatcher.tryDispatchMountItems(MountItemDispatcher.java:122)
       at com.facebook.react.fabric.FabricUIManager$3.runGuarded(FabricUIManager.java:823)
       at com.facebook.react.bridge.GuardedRunnable.run(GuardedRunnable.java:29)
       at com.facebook.react.fabric.FabricUIManager.scheduleMountItem(FabricUIManager.java:827)
       at com.swmansion.reanimated.NativeProxy.performOperations(NativeProxy.java)
       at com.swmansion.reanimated.NodesManager.performOperations(NodesManager.java:121)
       at com.swmansion.reanimated.NodesManager.onEventDispatch(NodesManager.java:192)
       at com.facebook.react.uimanager.events.FabricEventDispatcher.dispatchEvent(FabricEventDispatcher.kt:60)
       at expo.modules.kotlin.events.KEventEmitterWrapper.emit(KModuleEventEmitterWrapper.kt:107)
       at expo.modules.kotlin.viewevent.ViewEvent.invoke(ViewEvent.kt:48)
       at expo.modules.image.events.GlideRequestListener.onResourceReady(GlideRequestListener.kt:54)
       at expo.modules.image.events.GlideRequestListener.onResourceReady(GlideRequestListener.kt:19)
       at com.bumptech.glide.request.SingleRequest.onResourceReady(SingleRequest.java:650)
       at com.bumptech.glide.request.SingleRequest.onResourceReady(SingleRequest.java:596)
       at com.bumptech.glide.load.engine.EngineJob.callCallbackOnResourceReady(EngineJob.java:159)
       at com.bumptech.glide.load.engine.EngineJob$CallResourceReady.run(EngineJob.java:428)
       at android.os.Handler.handleCallback(Handler.java:938)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loop(Looper.java:250)
       at android.app.ActivityThread.main(ActivityThread.java:7868)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:958)
```
A better fix for https://github.com/expo/expo/pull/39091.

# How

It turns out that emitting an event can lead to additional mounts done by Reanimated. It's a bug because our `onLoad` event is not changing the tree, so it should not start any UI operations. I've raised this issue with the Reanimated team. For now, I've delayed the emission of the event so it won't happen in the same frame as `onResourceReady`.

# Test Plan

- bare-expo ✅ (I wasn't able to reproduce this issue, but the `onLoad` event works)