### PR TITLE
Fix typo in `modals.mdx`

### DIFF
--- a/docs/pages/router/advanced/modals.mdx
+++ b/docs/pages/router/advanced/modals.mdx
@@ -198,7 +198,7 @@ While working with stack or nested stack navigators, modals need to be anchored 
 
 An _anchor_ serves as the base for the modal. In complex apps, when you have nested stacks, the anchor must be defined for the nested stack, and its value becomes the initial route of the stack.
 
-You can configure an anchor by exporting `unable_settings` from your stack's layout file:
+You can configure an anchor by exporting `unstable_settings` from your stack's layout file:
 
 ```tsx
 export const unstable_settings = {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixed a typo `unable_settings` –> `unstable_settings`.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
