### PR TITLE
[worfklow-testing] set up concurrency to cancel in-progress workflows

### DIFF
--- a/apps/expo-workflow-testing/.eas/workflows/tv-compile.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/tv-compile.yml
@@ -69,6 +69,10 @@ on:
   schedule:
     - cron: '0 17 * * SUN' # 22:00 UTC every Sunday
 
+concurrency:
+  group: ${{ workflow.filename }}-${{ github.ref }}
+  cancel_in_progress: true
+
 defaults:
   tools:
     node: 22.14.0
@@ -82,7 +86,7 @@ jobs:
       - name: Install applesimutils
         id: ios_simulator
         env:
-          HOMEBREW_NO_AUTO_UPDATE: "1"
+          HOMEBREW_NO_AUTO_UPDATE: '1'
         run: |
           /opt/homebrew/bin/brew tap wix/brew
           /opt/homebrew/bin/brew install applesimutils
@@ -95,7 +99,7 @@ jobs:
         working_directory: ../..
         env:
           UPDATES_HOST: localhost
-          UPDATES_PORT: "4747"
+          UPDATES_PORT: '4747'
         run: |
           yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-eas-project-tv.ts
           ls -la ../updates-e2e

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-bricking-measures-disabled.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-bricking-measures-disabled.yml
@@ -21,6 +21,10 @@ on:
   schedule:
     - cron: '0 18 * * SUN' # 18:00 UTC every Sunday
 
+concurrency:
+  group: ${{ workflow.filename }}-${{ github.ref }}
+  cancel_in_progress: true
+
 defaults:
   tools:
     node: 22.14.0
@@ -40,7 +44,7 @@ jobs:
         working_directory: ../..
         env:
           UPDATES_HOST: localhost
-          UPDATES_PORT: "4747"
+          UPDATES_PORT: '4747'
         run: |
           yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-bricking-measures-disabled-eas-project.ts
           ls -la ../updates-e2e
@@ -76,7 +80,7 @@ jobs:
         working_directory: ../..
         env:
           UPDATES_HOST: localhost
-          UPDATES_PORT: "4747"
+          UPDATES_PORT: '4747'
         run: |
           yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-bricking-measures-disabled-eas-project.ts
           ls -la ../updates-e2e
@@ -98,4 +102,3 @@ jobs:
         working_directory: ../../../updates-e2e
         run: |
           ./maestro/maestro-test-executor.sh ./maestro/tests/updates-e2e-bricking-measures-disabled.yml android release
-

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-cli.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-cli.yml
@@ -18,6 +18,10 @@ defaults:
     node: 22.14.0
     yarn: 1.22.22
 
+concurrency:
+  group: ${{ workflow.filename }}-${{ github.ref }}
+  cancel_in_progress: true
+
 jobs:
   cli:
     runs_on: linux-medium
@@ -28,6 +32,6 @@ jobs:
       - uses: eas/install_node_modules
       - name: Run CLI tests
         id: cli
-        working_directory: ../../packages/expo-updates      
+        working_directory: ../../packages/expo-updates
         run: |
           yarn test:e2e-cli --ci --runInBand

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-custom-init.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-custom-init.yml
@@ -26,6 +26,10 @@ defaults:
     node: 22.14.0
     yarn: 1.22.22
 
+concurrency:
+  group: ${{ workflow.filename }}-${{ github.ref }}
+  cancel_in_progress: true
+
 jobs:
   ios:
     runs_on: macos-large
@@ -40,7 +44,7 @@ jobs:
         working_directory: ../..
         env:
           UPDATES_HOST: localhost
-          UPDATES_PORT: "4747"
+          UPDATES_PORT: '4747'
         run: |
           yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-eas-project-custom-init.ts
           ls -la ../updates-e2e
@@ -88,7 +92,7 @@ jobs:
         working_directory: ../..
         env:
           UPDATES_HOST: localhost
-          UPDATES_PORT: "4747"
+          UPDATES_PORT: '4747'
         run: |
           yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-eas-project-custom-init.ts
           ls -la ../updates-e2e

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-dev-client.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-dev-client.yml
@@ -27,6 +27,10 @@ on:
   schedule:
     - cron: '0 19 * * SUN' # 18:00 UTC every Sunday
 
+concurrency:
+  group: ${{ workflow.filename }}-${{ github.ref }}
+  cancel_in_progress: true
+
 defaults:
   tools:
     node: 22.14.0
@@ -40,7 +44,7 @@ jobs:
       - name: Install applesimutils
         id: ios_simulator
         env:
-          HOMEBREW_NO_AUTO_UPDATE: "1"
+          HOMEBREW_NO_AUTO_UPDATE: '1'
         run: |
           /opt/homebrew/bin/brew tap wix/brew
           /opt/homebrew/bin/brew install applesimutils
@@ -54,7 +58,7 @@ jobs:
         working_directory: ../..
         env:
           UPDATES_HOST: localhost
-          UPDATES_PORT: "4747"
+          UPDATES_PORT: '4747'
         run: |
           yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-dev-client-eas-project.ts
           ls -la ../updates-e2e
@@ -92,7 +96,7 @@ jobs:
         working_directory: ../..
         env:
           UPDATES_HOST: localhost
-          UPDATES_PORT: "4747"
+          UPDATES_PORT: '4747'
         run: |
           yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-dev-client-eas-project.ts
           ls -la ../updates-e2e

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-disabled.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-disabled.yml
@@ -21,6 +21,10 @@ on:
   schedule:
     - cron: '0 19 * * SUN' # 18:00 UTC every Sunday
 
+concurrency:
+  group: ${{ workflow.filename }}-${{ github.ref }}
+  cancel_in_progress: true
+
 defaults:
   tools:
     node: 22.14.0
@@ -34,7 +38,7 @@ jobs:
       - name: Install applesimutils
         id: ios_simulator
         env:
-          HOMEBREW_NO_AUTO_UPDATE: "1"
+          HOMEBREW_NO_AUTO_UPDATE: '1'
         run: |
           /opt/homebrew/bin/brew tap wix/brew
           /opt/homebrew/bin/brew install applesimutils
@@ -48,7 +52,7 @@ jobs:
         working_directory: ../..
         env:
           UPDATES_HOST: localhost
-          UPDATES_PORT: "4747"
+          UPDATES_PORT: '4747'
         run: |
           yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-disabled-eas-project.ts
           ls -la ../updates-e2e
@@ -94,7 +98,7 @@ jobs:
         working_directory: ../..
         env:
           UPDATES_HOST: localhost
-          UPDATES_PORT: "4747"
+          UPDATES_PORT: '4747'
         run: |
           yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-disabled-eas-project.ts
           ls -la ../updates-e2e

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-enabled.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-enabled.yml
@@ -45,6 +45,10 @@ on:
   schedule:
     - cron: '0 20 * * SUN' # 22:00 UTC every Sunday
 
+concurrency:
+  group: ${{ workflow.filename }}-${{ github.ref }}
+  cancel_in_progress: true
+
 defaults:
   tools:
     node: 22.14.0
@@ -64,7 +68,7 @@ jobs:
         working_directory: ../..
         env:
           UPDATES_HOST: localhost
-          UPDATES_PORT: "4747"
+          UPDATES_PORT: '4747'
         run: |
           yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-eas-project.ts
           ls -la ../updates-e2e
@@ -110,7 +114,7 @@ jobs:
         working_directory: ../..
         env:
           UPDATES_HOST: localhost
-          UPDATES_PORT: "4747"
+          UPDATES_PORT: '4747'
         run: |
           yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-eas-project.ts
           ls -la ../updates-e2e

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-error-recovery.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-error-recovery.yml
@@ -21,6 +21,10 @@ on:
   schedule:
     - cron: '0 20 * * SUN' # 18:00 UTC every Sunday
 
+concurrency:
+  group: ${{ workflow.filename }}-${{ github.ref }}
+  cancel_in_progress: true
+
 defaults:
   tools:
     node: 22.14.0
@@ -40,7 +44,7 @@ jobs:
         working_directory: ../..
         env:
           UPDATES_HOST: localhost
-          UPDATES_PORT: "4747"
+          UPDATES_PORT: '4747'
         run: |
           yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-error-recovery-eas-project.ts
           ls -la ../updates-e2e
@@ -76,7 +80,7 @@ jobs:
         working_directory: ../..
         env:
           UPDATES_HOST: localhost
-          UPDATES_PORT: "4747"
+          UPDATES_PORT: '4747'
         run: |
           yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-error-recovery-eas-project.ts
           ls -la ../updates-e2e

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-fingerprint.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-fingerprint.yml
@@ -21,6 +21,10 @@ on:
   schedule:
     - cron: '0 19 * * SUN' # 18:00 UTC every Sunday
 
+concurrency:
+  group: ${{ workflow.filename }}-${{ github.ref }}
+  cancel_in_progress: true
+
 defaults:
   tools:
     node: 22.14.0
@@ -40,7 +44,7 @@ jobs:
         working_directory: ../..
         env:
           UPDATES_HOST: localhost
-          UPDATES_PORT: "4747"
+          UPDATES_PORT: '4747'
         run: |
           yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-fingerprint-eas-project.ts
           ls -la ../updates-e2e
@@ -76,7 +80,7 @@ jobs:
         working_directory: ../..
         env:
           UPDATES_HOST: localhost
-          UPDATES_PORT: "4747"
+          UPDATES_PORT: '4747'
         run: |
           yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-fingerprint-eas-project.ts
           ls -la ../updates-e2e

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-startup.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-startup.yml
@@ -21,6 +21,10 @@ on:
   schedule:
     - cron: '0 23 * * SUN' # 20:00 UTC every Sunday
 
+concurrency:
+  group: ${{ workflow.filename }}-${{ github.ref }}
+  cancel_in_progress: true
+
 defaults:
   tools:
     node: 22.14.0
@@ -40,7 +44,7 @@ jobs:
         working_directory: ../..
         env:
           UPDATES_HOST: localhost
-          UPDATES_PORT: "4747"
+          UPDATES_PORT: '4747'
         run: |
           yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-startup-eas-project.ts
           ls -la ../updates-e2e
@@ -86,7 +90,7 @@ jobs:
         working_directory: ../..
         env:
           UPDATES_HOST: localhost
-          UPDATES_PORT: "4747"
+          UPDATES_PORT: '4747'
         run: |
           yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-startup-eas-project.ts
           ls -la ../updates-e2e


### PR DESCRIPTION
# Why

- the `expo-workflow-testing` project has large numbers of jobs in queue, many that are outdated because a new version of the same code was pushed, and the old jobs are not cancelled

# How

- add concurrency setup to workflows

# Test Plan

- green ci

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
