### PR TITLE
[autolinking][ios] Added workaround to autolinking issue in RN

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Added build phase script for a workaround to autolinking-generated react-native-config output not being used in ReactCodegen script phase due to temp output directory
+- [iOS] Added build phase script for a workaround to autolinking-generated react-native-config output not being used in ReactCodegen script phase due to temp output directory. ([#40219](https://github.com/expo/expo/pull/40219) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Fix passing exclude options. ([#40014](https://github.com/expo/expo/pull/40014) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Added build phase script for a workaround to autolinking-generated react-native-config output not being used in ReactCodegen script phase due to temp output directory
 - [Android] Fix passing exclude options. ([#40014](https://github.com/expo/expo/pull/40014) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others

--- a/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
@@ -52,25 +52,40 @@ module Pod
           phase = react_codegen_native_target.new_shell_script_build_phase(_script_phase_name)
           phase.shell_path = '/bin/sh'
           phase.shell_script = <<~SH
+            # Remove this step when the fix is merged and released.
+            # See: https://github.com/facebook/react-native/pull/54066
+
+            # This re-runs Codegen without the broken "scripts/react_native_pods_utils/script_phases.sh" script, causing Codegen to run without autolinking.
+            # Instead of using "script_phases.sh" which always runs inside DerivedData, we run it in the normal "/ios" folder
+            # See: https://github.com/facebook/react-native/blob/main/packages/react-native/scripts/react_native_pods_utils/script_phases.sh
             pushd "$PODS_ROOT/../" > /dev/null
-            RCT_SCRIPT_POD_INSTALLATION_ROOT=$(pwd)
+              RCT_SCRIPT_POD_INSTALLATION_ROOT="$PODS_ROOT/.."
             popd >/dev/null
 
+            export RCT_SCRIPT_RN_DIR="$REACT_NATIVE_PATH" # This is set by Expo
             export RCT_SCRIPT_APP_PATH="$RCT_SCRIPT_POD_INSTALLATION_ROOT/.."
             export RCT_SCRIPT_OUTPUT_DIR="$RCT_SCRIPT_POD_INSTALLATION_ROOT"
             export RCT_SCRIPT_TYPE="withCodegenDiscovery"
 
-            # This is a workaround to not let Codegen run incorrect paths
-            # Instead of running "/scripts/react_native_pods_utils/script_phases.sh", we run the JS script executed within this shell script
-            # That uses the correct paths for Codegen
-            # Based on: https://github.com/facebook/react-native/blob/3f7f9d8fb8beb41408d092870a7c7cac58029a4d/packages/react-native/scripts/react_native_pods_utils/script_phases.sh#L98C4-L100C30
-            # Based on: https://github.com/facebook/react-native/blob/b9baddfd5d25af27d82c15c0cba09f286335f1d3/packages/react-native/scripts/codegen/generate-artifacts-executor/generateReactCodegenPodspec.js#L82-L93
+            # This is the broken script that runs inside DerivedData, meaning it can't find the autolinking result in `ios/build/generated/autolinking.json`.
+            # Resulting in Codegen running with it's own autolinking, not discovering transitive peer dependencies.
+            # export SCRIPT_PHASES_SCRIPT="$RCT_SCRIPT_RN_DIR/scripts/react_native_pods_utils/script_phases.sh"
+            export WITH_ENVIRONMENT="$RCT_SCRIPT_RN_DIR/scripts/xcode/with-environment.sh"
 
-            source "$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh"
+            # Start of workaround code
 
-            pushd "$REACT_NATIVE_PATH" >/dev/null || exit 1
+            # Load the $NODE_BINARY from the "with-environment.sh" script
+            source "$WITH_ENVIRONMENT"
+
+            # Run this script directly in the right folders:
+            # https://github.com/facebook/react-native/blob/3f7f9d8fb8beb41408d092870a7c7cac58029a4d/packages/react-native/scripts/react_native_pods_utils/script_phases.sh#L96-L101
+            pushd "$RCT_SCRIPT_RN_DIR" >/dev/null || exit 1
+              set -x
               "$NODE_BINARY" "scripts/generate-codegen-artifacts.js" --path "$RCT_SCRIPT_APP_PATH" --outputPath "$RCT_SCRIPT_OUTPUT_DIR" --targetPlatform "ios"
+              set +x
             popd >/dev/null || exit 1
+
+            # End of workaround code
           SH
 
           # Find the index of the "Compile Sources" phase (PBXSourcesBuildPhase)

--- a/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
@@ -41,7 +41,7 @@ module Pod
       if react_codegen_native_target
         # Check if the build phase already exists
         already_exists = react_codegen_native_target.build_phases.any? do |phase|
-          phase.is_a?(Xcodeproj::Project::Object::PBXShellScriptBuildPhase) && phase.name == '[Expo] Resolve Codegen paths'
+          phase.is_a?(Xcodeproj::Project::Object::PBXShellScriptBuildPhase) && phase.name == '[Expo] Run Codegen with autolinking'
         end
 
         if !already_exists

--- a/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
@@ -22,9 +22,75 @@ module Pod
   class Installer
     private
 
+    _original_run_podfile_post_install_hooks = instance_method(:run_podfile_post_install_hooks)
     _original_run_podfile_pre_install_hooks = instance_method(:run_podfile_pre_install_hooks)
 
     public
+
+    define_method(:run_podfile_post_install_hooks) do
+      # Call original implementation first
+      _original_run_podfile_post_install_hooks.bind(self).()
+
+      # Next we'll perform an Expo workaround for Codegen in React Native where it uses the wrong output path for
+      # the generated files. This can be remove when the following PR is merged and released upstream:
+      # https://github.com/facebook/react-native/pull/54066
+      # TODO: chrfalch - remove when RN PR is released
+      # Find the ReactCodegen pod target in the pods project
+      react_codegen_native_target = self.pods_project.targets.find { |target| target.name == 'ReactCodegen' }
+
+      if react_codegen_native_target
+        # Check if the build phase already exists
+        already_exists = react_codegen_native_target.build_phases.any? do |phase|
+          phase.is_a?(Xcodeproj::Project::Object::PBXShellScriptBuildPhase) && phase.name == '[Expo] Resolve Codegen paths'
+        end
+
+        if !already_exists
+          Pod::UI.puts "[Expo] ".blue + "Adding '[Expo Autolinking] Resolve Codegen paths' build phase to ReactCodegen"
+
+          # Create the new shell script build phase
+          phase = react_codegen_native_target.new_shell_script_build_phase('[Expo Autolinking] Resolve Codegen paths')
+          phase.shell_path = '/bin/sh'
+          phase.shell_script = <<~SH
+            pushd "$PODS_ROOT/../" > /dev/null
+            RCT_SCRIPT_POD_INSTALLATION_ROOT=$(pwd)
+            popd >/dev/null
+
+            export RCT_SCRIPT_APP_PATH="$RCT_SCRIPT_POD_INSTALLATION_ROOT/.."
+            export RCT_SCRIPT_OUTPUT_DIR="$RCT_SCRIPT_POD_INSTALLATION_ROOT"
+            export RCT_SCRIPT_TYPE="withCodegenDiscovery"
+
+            # This is a workaround to not let Codegen run incorrect paths
+            # Instead of running "/scripts/react_native_pods_utils/script_phases.sh", we run the JS script executed within this shell script
+            # That uses the correct paths for Codegen
+            # Based on: https://github.com/facebook/react-native/blob/3f7f9d8fb8beb41408d092870a7c7cac58029a4d/packages/react-native/scripts/react_native_pods_utils/script_phases.sh#L98C4-L100C30
+            # Based on: https://github.com/facebook/react-native/blob/b9baddfd5d25af27d82c15c0cba09f286335f1d3/packages/react-native/scripts/codegen/generate-artifacts-executor/generateReactCodegenPodspec.js#L82-L93
+
+            source "$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh"
+
+            pushd "$REACT_NATIVE_PATH" >/dev/null || exit 1
+              "$NODE_BINARY" "scripts/generate-codegen-artifacts.js" --path "$RCT_SCRIPT_APP_PATH" --outputPath "$RCT_SCRIPT_OUTPUT_DIR" --targetPlatform "ios"
+            popd >/dev/null || exit 1
+          SH
+
+          # Find the index of the "Compile Sources" phase (PBXSourcesBuildPhase)
+          compile_sources_index = react_codegen_native_target.build_phases.find_index do |p|
+            p.is_a?(Xcodeproj::Project::Object::PBXSourcesBuildPhase)
+          end
+
+          if compile_sources_index
+            # Remove the phase from its current position (it was added at the end)
+            react_codegen_native_target.build_phases.delete(phase)
+            # Insert it before the "Compile Sources" phase
+            react_codegen_native_target.build_phases.insert(compile_sources_index, phase)
+            Pod::UI.puts "[Expo] ".blue + "Positioned build phase before 'Compile Sources'"
+          else
+            Pod::UI.puts "[Expo] ".yellow + "Could not find 'Compile Sources' phase, build phase added at default position"
+          end
+        end
+      else
+        Pod::UI.puts "[Expo] ".yellow + "ReactCodegen target not found in pods project"
+      end
+    end
 
     define_method(:run_podfile_pre_install_hooks) do
       # Call original implementation first

--- a/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
@@ -24,6 +24,7 @@ module Pod
 
     _original_run_podfile_post_install_hooks = instance_method(:run_podfile_post_install_hooks)
     _original_run_podfile_pre_install_hooks = instance_method(:run_podfile_pre_install_hooks)
+    _script_phase_name = '[Expo Autolinking] Run Codegen with autolinking'
 
     public
 
@@ -41,14 +42,14 @@ module Pod
       if react_codegen_native_target
         # Check if the build phase already exists
         already_exists = react_codegen_native_target.build_phases.any? do |phase|
-          phase.is_a?(Xcodeproj::Project::Object::PBXShellScriptBuildPhase) && phase.name == '[Expo] Run Codegen with autolinking'
+          phase.is_a?(Xcodeproj::Project::Object::PBXShellScriptBuildPhase) && phase.name == _script_phase_name
         end
 
         if !already_exists
-          Pod::UI.puts "[Expo] ".blue + "Adding '[Expo Autolinking] Resolve Codegen paths' build phase to ReactCodegen"
+          Pod::UI.puts "[Expo] ".blue + "Adding '#{_script_phase_name}' build phase to ReactCodegen"
 
           # Create the new shell script build phase
-          phase = react_codegen_native_target.new_shell_script_build_phase('[Expo Autolinking] Run Codegen with autolinking')
+          phase = react_codegen_native_target.new_shell_script_build_phase(_script_phase_name)
           phase.shell_path = '/bin/sh'
           phase.shell_script = <<~SH
             pushd "$PODS_ROOT/../" > /dev/null
@@ -82,7 +83,6 @@ module Pod
             react_codegen_native_target.build_phases.delete(phase)
             # Insert it before the "Compile Sources" phase
             react_codegen_native_target.build_phases.insert(compile_sources_index, phase)
-            Pod::UI.puts "[Expo] ".blue + "Positioned build phase before 'Compile Sources'"
           else
             Pod::UI.puts "[Expo] ".yellow + "Could not find 'Compile Sources' phase, build phase added at default position"
           end

--- a/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
@@ -48,7 +48,7 @@ module Pod
           Pod::UI.puts "[Expo] ".blue + "Adding '[Expo Autolinking] Resolve Codegen paths' build phase to ReactCodegen"
 
           # Create the new shell script build phase
-          phase = react_codegen_native_target.new_shell_script_build_phase('[Expo Autolinking] Resolve Codegen paths')
+          phase = react_codegen_native_target.new_shell_script_build_phase('[Expo Autolinking] Run Codegen with autolinking')
           phase.shell_path = '/bin/sh'
           phase.shell_script = <<~SH
             pushd "$PODS_ROOT/../" > /dev/null


### PR DESCRIPTION
# Why

An earlier change (0.79 and onwards, I believe?) runs the iOS artifacts code generator script in Xcode as well as from Cocoapods. This duplication runs it twice, but the second step isn't able to load the new autolinking.json correctly; See: #53503

This has been fixed upstream here: https://github.com/facebook/react-native/pull/54066

Untill this one is merged, released and available to Expo, we need a workaround.

# How

Added build phase script for a workaround to autolinking-generated react-native-config output not being used in ReactCodegen script phase due to temp output directory.

@byCedric participated in the script, and it has been tested with a new Expo project using pnpm.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
