### PR TITLE
[autolinking][Android] Add support for remote build cache

### DIFF
--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/main/kotlin/expo/modules/plugin/text/Emojis.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/main/kotlin/expo/modules/plugin/text/Emojis.kt
@@ -2,4 +2,5 @@ package expo.modules.plugin.text
 
 object Emojis {
   const val INFORMATION = "\u2139\uFE0F"
+  const val GEAR = "\u2699"
 }

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingSettingsPlugin.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingSettingsPlugin.kt
@@ -1,14 +1,20 @@
 package expo.modules.plugin
 
+import expo.modules.plugin.gradle.addBuildCache
 import expo.modules.plugin.gradle.beforeRootProject
+import expo.modules.plugin.gradle.loadLocalProperties
+import expo.modules.plugin.utils.getPropertiesPrefixedBy
 import org.gradle.api.Plugin
 import org.gradle.api.initialization.Settings
 import java.io.File
+import java.util.Properties
 
 open class ExpoAutolinkingSettingsPlugin : Plugin<Settings> {
   override fun apply(settings: Settings) {
     // Adds a property to the settings that indicates that the `expo-autolinking-plugin` is available.
     settings.gradle.extensions.extraProperties.set("expoAutolinkingSettingsPlugin", true)
+
+    settings.addBuildCache()
 
     // Creates an extension that allows users to link expo modules and add additional configuration.
     settings.extensions.create("expoAutolinking", ExpoAutolinkingSettingsExtension::class.java, settings)

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/gradle/SettingsExtension.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/gradle/SettingsExtension.kt
@@ -3,8 +3,16 @@ package expo.modules.plugin.gradle
 import expo.modules.plugin.configuration.GradleAarProject
 import expo.modules.plugin.configuration.GradlePlugin
 import expo.modules.plugin.configuration.GradleProject
+import expo.modules.plugin.text.Colors
+import expo.modules.plugin.text.Emojis
+import expo.modules.plugin.text.withColor
+import expo.modules.plugin.utils.getPropertiesPrefixedBy
 import org.gradle.api.initialization.Settings
+import org.gradle.api.logging.Logging
+import org.gradle.caching.http.HttpBuildCache
 import java.io.File
+import java.net.URI
+import java.util.Properties
 
 internal fun Settings.linkProject(project: GradleProject) {
   include(":${project.name}")
@@ -22,4 +30,52 @@ internal fun Settings.linkAarProject(aarProject: GradleAarProject) {
     projectDir.mkdirs()
   }
   project(":${aarProject.name}").projectDir = projectDir
+}
+
+internal fun Settings.loadLocalProperties(): Properties {
+  return Properties().apply {
+    val localPropertiesFile = File(settings.rootDir, "local.properties")
+    if (localPropertiesFile.exists()) {
+      localPropertiesFile.reader().use(::load)
+    }
+  }
+}
+
+internal fun Settings.addBuildCache() {
+  val localProperties = settings
+    .loadLocalProperties()
+
+  val remoteCacheConfigPrefix = "expo.cache.remote."
+  val remoteCacheConfig = settings.getPropertiesPrefixedBy(remoteCacheConfigPrefix) +
+    localProperties.getPropertiesPrefixedBy(remoteCacheConfigPrefix)
+
+  val url = remoteCacheConfig["url"] ?: return
+  val username = remoteCacheConfig["username"]
+  val password = remoteCacheConfig["password"]
+  val readonly = remoteCacheConfig["read-only"]?.toBoolean() ?: false
+  val isUnsafe = url.startsWith("http://")
+
+  val logger = Logging.getLogger(Settings::class.java)
+
+  logger.quiet("${Emojis.GEAR} Configuring remote build cache: ${url.withColor(Colors.GREEN)} (username: ${username.withColor(Colors.GREEN)}, read-only: ${readonly.toString().withColor(Colors.GREEN)})")
+
+  settings.buildCache { configuration ->
+    configuration.remote(HttpBuildCache::class.java) { cache ->
+      cache.url = URI.create(url)
+
+      if (username != null && password != null) {
+        cache.credentials {
+          it.username = username
+          it.password = password
+        }
+      }
+
+      cache.isPush = !readonly
+
+      if (isUnsafe) {
+        cache.isAllowInsecureProtocol = true
+        cache.isAllowUntrustedServer = true
+      }
+    }
+  }
 }

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/utils/PropertiesExtension.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/utils/PropertiesExtension.kt
@@ -1,0 +1,25 @@
+package expo.modules.plugin.utils
+
+import org.gradle.api.initialization.Settings
+import java.util.Properties
+
+internal fun Properties.getPropertiesPrefixedBy(prefix: String): Map<String, String> {
+  return entries
+    .mapNotNull { (key, value) ->
+      if (key !is String || value !is String) {
+        return@mapNotNull null
+      }
+
+      if (key.startsWith(prefix)) {
+        key.removePrefix(prefix) to value
+      } else {
+        null
+      }
+    }
+    .toMap()
+}
+
+internal fun Settings.getPropertiesPrefixedBy(prefix: String): Map<String, String> {
+  val prefixedProperty = providers.gradlePropertiesPrefixedBy(prefix).get()
+  return prefixedProperty.mapKeys { (key, _) -> key.removePrefix(prefix) }
+}


### PR DESCRIPTION
# Why

Adds support for the remote build cache.

# How

Users can now specify the following fields in `gradle.properties` or in `local.properties` to enable remote build cache:
```
expo.cache.remote.url=http://example.com
expo.cache.remote.username=user
expo.cache.remote.password=password
expo.cache.remote.read-only=true
```

# Test Plan

- build bare-expo with remote cache ✅ 
<img width="680" height="195" alt="image" src="https://github.com/user-attachments/assets/c836281b-dad2-45f4-9774-5c6d06b6fed4" />
