### PR TITLE
fix(expo-router): resolve relative navigation in NativeTabs index routes

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix relative navigation in NativeTabs index routes. ([#40225](https://github.com/expo/expo/pull/40225) by [@mensonones](https://github.com/mensonones))
+
 ### 💡 Others
 
 ## 6.0.9 - 2025-10-01

--- a/packages/expo-router/src/link/__tests__/href.test.web.ts
+++ b/packages/expo-router/src/link/__tests__/href.test.web.ts
@@ -1,4 +1,4 @@
-import { resolveHref } from '../href';
+import { resolveHref, resolveHrefStringWithSegments } from '../href';
 
 describe(resolveHref, () => {
   it(`passes strings back without resolution`, () => {
@@ -65,5 +65,140 @@ describe(resolveHref, () => {
     expect(resolveHref({ pathname: '/fake/path', params: { value: '++test++' } })).toBe(
       '/fake/path?value=%2B%2Btest%2B%2B'
     );
+  });
+});
+
+describe(resolveHrefStringWithSegments, () => {
+  describe('backwards compatibility', () => {
+    it('resolves relative links without new parameters (original behavior)', () => {
+      // Standard relative link
+      expect(
+        resolveHrefStringWithSegments('./profile', {
+          segments: ['app', 'home'],
+        })
+      ).toBe('/app/profile');
+
+      // Parent directory
+      expect(
+        resolveHrefStringWithSegments('../settings', {
+          segments: ['app', 'home'],
+        })
+      ).toBe('/settings');
+
+      // With relativeToDirectory flag
+      expect(
+        resolveHrefStringWithSegments(
+          './profile',
+          { segments: ['app', 'home'] },
+          { relativeToDirectory: true }
+        )
+      ).toBe('/app/home/profile');
+    });
+
+    it('passes through absolute links unchanged', () => {
+      expect(
+        resolveHrefStringWithSegments('/absolute/path', {
+          segments: ['app', 'home'],
+        })
+      ).toBe('/absolute/path');
+    });
+
+    it('handles dynamic segments', () => {
+      expect(
+        resolveHrefStringWithSegments('./profile', {
+          segments: ['app', '[id]'],
+          params: { id: '123' },
+        })
+      ).toBe('/app/profile');
+    });
+  });
+
+  describe('NativeTabs fix', () => {
+    it('resolves relative links with isIndex flag (NativeTabs case)', () => {
+      // When on an index route in NativeTabs
+      expect(
+        resolveHrefStringWithSegments('./profile', {
+          segments: ['app', 'tabs', 'home'],
+          pathname: '/app/tabs/home/index',
+          isIndex: true,
+        })
+      ).toBe('/app/tabs/home/profile');
+    });
+
+    it('resolves relative links when pathname ends with /index', () => {
+      expect(
+        resolveHrefStringWithSegments('./profile', {
+          segments: ['app', 'tabs', 'home'],
+          pathname: '/app/tabs/home/index',
+        })
+      ).toBe('/app/tabs/home/profile');
+    });
+
+    it('handles case where only isIndex is provided', () => {
+      expect(
+        resolveHrefStringWithSegments('./profile', {
+          segments: ['app', 'tabs', 'home'],
+          isIndex: true,
+        })
+      ).toBe('/app/tabs/home/profile');
+    });
+
+    it('handles case where isIndex is false (not an index route)', () => {
+      expect(
+        resolveHrefStringWithSegments('./other', {
+          segments: ['app', 'tabs', 'profile'],
+          pathname: '/app/tabs/profile',
+          isIndex: false,
+        })
+      ).toBe('/app/tabs/profile/other');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles empty segments', () => {
+      expect(
+        resolveHrefStringWithSegments('./page', {
+          segments: [],
+        })
+      ).toBe('/page');
+    });
+
+    it('handles undefined pathname safely', () => {
+      expect(
+        resolveHrefStringWithSegments('./page', {
+          segments: ['app'],
+          pathname: undefined,
+        })
+      ).toBe('/page');
+    });
+
+    it('handles malformed pathname safely', () => {
+      expect(
+        resolveHrefStringWithSegments('./page', {
+          segments: ['app'],
+          pathname: '///invalid//path///',
+        })
+      ).toBe('/page');
+    });
+
+    it('prioritizes isIndex when it conflicts with segments', () => {
+      // segments don't end with 'index', but isIndex is true
+      expect(
+        resolveHrefStringWithSegments('./page', {
+          segments: ['app', 'profile'],
+          isIndex: true,
+        })
+      ).toBe('/app/profile/page');
+    });
+
+    it('handles query strings in relative links', () => {
+      expect(
+        resolveHrefStringWithSegments('./profile?tab=settings', {
+          segments: ['app', 'home'],
+          pathname: '/app/home/index',
+          isIndex: true,
+        })
+      ).toBe('/app/home/profile?tab=settings');
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes relative navigation issues in NativeTabs where links like `./example-one` from `/tabs/one/index` were incorrectly resolving to `/tabs/example-one` instead of `/tabs/one/example-one`.

## Problem

React Navigation simplifies navigation state during transitions in NativeTabs, moving route info from `route.state` to `route.params.screen`. The original code only checked `route.state`, missing the NativeTabs nested params, causing incorrect path resolution for relative links from index routes.

## Solution

### 1. Enhanced `routeInfo.ts`:
- Extract segments from `route.params.screen` when `route.state` is unavailable
- Track `lastRouteName` to detect index routes in NativeTabs scenarios
- Set `isIndex: true` when appropriate for better route identification

### 2. Improved `href.ts`:
- Enhanced `shouldTreatAsDirectory` logic with multiple detection methods:
  - `pathname.endsWith('/index')` for NativeTabs scenarios
  - `isIndex` flag from routeInfo
  - Pathname segments pattern matching for safety
- Add trailing `/` to base path when on index route

## Testing

✅ **Before fix:**
- `./example-one` from `/tabs/one/index` → ❌ `/tabs/example-one` (incorrect)

✅ **After fix:**
- `./example-one` from `/tabs/one/index` → ✅ `/tabs/one/example-one` (correct)
- `../two` from `/tabs/one/index` → ✅ `/tabs/two` (correct)
- Absolute links continue working: `/tabs/one/example-one` → ✅ `/tabs/one/example-one`

## Platforms Tested
- ✅ Web
- ✅ Android

## Breaking Changes
None. This fix maintains backward compatibility while resolving the NativeTabs relative navigation issue.

Fixes #40199
