### PR TITLE
[docs] update mcp as private beta

### DIFF
--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -12,7 +12,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-> **important** Expo MCP Server is currently in **preview** and is only available for [EAS paid plan subscribers](https://expo.dev/pricing).
+> **important** Expo MCP Server is currently in **private beta** and is only available for [EAS paid plan subscribers](https://expo.dev/pricing) and individuals who have been invited to the beta. The broader availability is coming soon.
 
 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is a standard protocol that allows AI models to integrate with external data sources, providing enhanced context for more precise responses. It enables AI tools to understand your development environment more deeply, allowing them to provide better assistance with your codebase.
 


### PR DESCRIPTION
# Why

likely we won't launch this week let's keep the doc as the actual state

# How

use "private beta" than "preview"

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
