### PR TITLE
Clarify MCP Server private beta eligibility

### DIFF
--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -12,7 +12,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-> **important** Expo MCP Server is currently in **private beta** and is only available for [EAS paid plan subscribers](https://expo.dev/pricing) and individuals who have been invited to the beta. The broader availability is coming soon.
+> **important** Expo MCP Server is currently in **private beta**. Access is limited to a select group of [EAS paid plan subscribers](https://expo.dev/pricing) who have been invited to participate, as well as other invited individuals. The broader availability is coming soon.
 
 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is a standard protocol that allows AI models to integrate with external data sources, providing enhanced context for more precise responses. It enables AI tools to understand your development environment more deeply, allowing them to provide better assistance with your codebase.
 


### PR DESCRIPTION
Clarify MCP Server private beta eligibility

# Why

This update clarifies that access to the Expo MCP Server private beta is not automatically included with all EAS paid plans, but limited to invited users (including some paid plan subscribers). The previous wording could be misinterpreted as implying that all paid plan subscribers have access.

<img width="582" height="468" alt="Screenshot 2025-10-07 at 12 13 14" src="https://github.com/user-attachments/assets/15adc78d-fb9d-422b-91fe-543ab5a51fe7" />

<img width="664" height="101" alt="Screenshot 2025-10-07 at 12 13 33" src="https://github.com/user-attachments/assets/132536ae-9a5a-49c9-8e43-2f467d46bb10" />

# How

I just reformulated the phrase to be understood by all users, since for some people it remains unclear if they are available to test it or not.

# Test Plan

Nothing to test.

# Checklist

There is no checklist.
