### PR TITLE
[docs] Add SDKRangeTag component

### DIFF
--- a/docs/ui/components/Tag/SDKRangeTag.tsx
+++ b/docs/ui/components/Tag/SDKRangeTag.tsx
@@ -7,18 +7,28 @@ import * as Tooltip from '~/ui/components/Tooltip';
 type SDKRangeTagProps = {
   // Minimum SDK version (e.g., 54 renders "SDK 54+")
   min?: number | string;
+  // Maximum SDK version (e.g., 53 renders "SDK <=53")
+  max?: number | string;
   // Render an exact SDK version without the trailing plus
   exact?: number | string;
 } & HTMLAttributes<HTMLDivElement>;
 
-export const SDKRangeTag = ({ min, exact, className, ...rest }: SDKRangeTagProps) => {
-  const value = exact ?? min;
-  const label = value ? `SDK ${value}${exact ? '' : '+'}` : 'SDK';
-  const tooltip = exact
-    ? `Available in SDK ${value} only`
-    : value
-      ? `Available in SDK ${value} and later`
-      : undefined;
+export const SDKRangeTag = ({ min, max, exact, className, ...rest }: SDKRangeTagProps) => {
+  const has = (v?: number | string) => v !== undefined && v !== null && `${v}`.length > 0;
+
+  let label = 'SDK';
+  let tooltip: string | undefined;
+
+  if (has(exact)) {
+    label = `SDK ${exact}`;
+    tooltip = `Available in SDK ${exact} only`;
+  } else if (has(min)) {
+    label = `SDK ${min}+`;
+    tooltip = `Available in SDK ${min} and later`;
+  } else if (has(max)) {
+    label = `SDK <=${max}`;
+    tooltip = `Available in SDK ${max} and earlier`;
+  }
 
   return (
     <Tooltip.Root>

--- a/docs/ui/components/Tag/SDKRangeTag.tsx
+++ b/docs/ui/components/Tag/SDKRangeTag.tsx
@@ -1,0 +1,53 @@
+import { mergeClasses } from '@expo/styleguide';
+import type { HTMLAttributes } from 'react';
+
+import { FOOTNOTE } from '~/ui/components/Text';
+import * as Tooltip from '~/ui/components/Tooltip';
+
+type SDKRangeTagProps = {
+  // Minimum SDK version (e.g., 54 renders "SDK 54+")
+  min?: number | string;
+  // Render an exact SDK version without the trailing plus
+  exact?: number | string;
+} & HTMLAttributes<HTMLDivElement>;
+
+export const SDKRangeTag = ({ min, exact, className, ...rest }: SDKRangeTagProps) => {
+  const value = exact ?? min;
+  const label = value ? `SDK ${value}${exact ? '' : '+'}` : 'SDK';
+  const tooltip = exact
+    ? `Available in SDK ${value} only`
+    : value
+      ? `Available in SDK ${value} and later`
+      : undefined;
+
+  return (
+    <Tooltip.Root>
+      <Tooltip.Trigger asChild>
+        <div
+          className={mergeClasses(
+            'inline-flex min-h-[21px] select-none items-center gap-1 rounded-full border border-default bg-element px-[7px] py-0.5 align-middle',
+            '[table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5',
+            '[h2_&]:px-2 [h2_&]:py-1',
+            '[h3_&]:px-2 [h3_&]:py-0.5',
+            '[h4_&]:px-2 [h4_&]:py-0.5',
+            '[h5_&]:px-2 [h5_&]:py-0.5',
+            className
+          )}
+          {...rest}>
+          <span
+            className={mergeClasses(
+              'whitespace-nowrap text-3xs font-normal leading-none',
+              '[h2_&]:text-2xs'
+            )}>
+            {label}
+          </span>
+        </div>
+      </Tooltip.Trigger>
+      {tooltip && (
+        <Tooltip.Content side="bottom" align="start">
+          <FOOTNOTE>{tooltip}</FOOTNOTE>
+        </Tooltip.Content>
+      )}
+    </Tooltip.Root>
+  );
+};


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-17517

# How

<!--
How did you build this feature or fix this bug and why?
-->

Create `SDKRangeTag` component that can be used with section headers.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

<img width="2432" height="734" alt="CleanShot 2025-10-07 at 17 06 33@2x" src="https://github.com/user-attachments/assets/aa2520a7-502e-48d1-bd54-e616b47e7028" />

<img width="2324" height="692" alt="CleanShot 2025-10-07 at 17 06 38@2x" src="https://github.com/user-attachments/assets/d22d0794-f56f-4d88-819b-c7fb006da41d" />

<img width="2718" height="762" alt="CleanShot 2025-10-07 at 17 06 45@2x" src="https://github.com/user-attachments/assets/11d15411-4de9-447a-8ae0-a8d9eb3fc563" />

<img width="2348" height="696" alt="CleanShot 2025-10-07 at 17 06 49@2x" src="https://github.com/user-attachments/assets/fbbf8b62-4138-4ab5-b906-ddff41a26826" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
