### PR TITLE
[ui][ios] Fix crash on reload

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -23,7 +23,7 @@
 - [iOS] Add explicit CallInvoker and CallbackWrapper imports to EXJSIUtils ([#39818](https://github.com/expo/expo/pull/39818) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Refactor getDelayLoadAppHandler to use ReactHost ([#40084](https://github.com/expo/expo/pull/40084) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Use module name from `expo-module.config.json`. ([#39985](https://github.com/expo/expo/pull/39985) by [@jakex7](https://github.com/jakex7))
-- [iOS] Add `invalidate` callback to SwiftUIVirtualView. ([#53708](https://github.com/facebook/react-native/pull/53708) by [@nishan](https://github.com/facebook/react-native/pull/53708))
+- [iOS] Add `invalidate` callback to SwiftUIVirtualView. ([#40237](https://github.com/facebook/react-native/pull/40237) by [@nishan](https://github.com/facebook/react-native/pull/40237))
 
 ## 3.0.19 - 2025-10-01
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [iOS] Fix NSURL to JSIString conversion returning nil. ([#39567](https://github.com/expo/expo/pull/39567) by [@behenate](https://github.com/behenate))
 - Fix SharedObject created with `useReleasingSharedObject` getting destroyed after a fast refresh caused by a change in its dependencies. ([#39753](https://github.com/expo/expo/pull/39753) by [@behenate](https://github.com/behenate))
 - [Android] Restore `register` overload in `ModuleRegistry`. ([#40149](https://github.com/expo/expo/pull/40149) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Add `invalidate` callback to SwiftUIVirtualView. ([#40237](https://github.com/expo/expo/pull/40237) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 
 ### 💡 Others
 
@@ -23,7 +24,6 @@
 - [iOS] Add explicit CallInvoker and CallbackWrapper imports to EXJSIUtils ([#39818](https://github.com/expo/expo/pull/39818) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Refactor getDelayLoadAppHandler to use ReactHost ([#40084](https://github.com/expo/expo/pull/40084) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Use module name from `expo-module.config.json`. ([#39985](https://github.com/expo/expo/pull/39985) by [@jakex7](https://github.com/jakex7))
-- [iOS] Add `invalidate` callback to SwiftUIVirtualView. ([#40237](https://github.com/facebook/react-native/pull/40237) by [@nishan](https://github.com/intergalacticspacehighway))
 
 ## 3.0.19 - 2025-10-01
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -23,7 +23,7 @@
 - [iOS] Add explicit CallInvoker and CallbackWrapper imports to EXJSIUtils ([#39818](https://github.com/expo/expo/pull/39818) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Refactor getDelayLoadAppHandler to use ReactHost ([#40084](https://github.com/expo/expo/pull/40084) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Use module name from `expo-module.config.json`. ([#39985](https://github.com/expo/expo/pull/39985) by [@jakex7](https://github.com/jakex7))
-- [iOS] Add `invalidate` callback to SwiftUIVirtualView. ([#40237](https://github.com/facebook/react-native/pull/40237) by [@nishan](https://github.com/facebook/react-native/pull/40237))
+- [iOS] Add `invalidate` callback to SwiftUIVirtualView. ([#40237](https://github.com/facebook/react-native/pull/40237) by [@nishan](https://github.com/intergalacticspacehighway))
 
 ## 3.0.19 - 2025-10-01
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [iOS] Add explicit CallInvoker and CallbackWrapper imports to EXJSIUtils ([#39818](https://github.com/expo/expo/pull/39818) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Refactor getDelayLoadAppHandler to use ReactHost ([#40084](https://github.com/expo/expo/pull/40084) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Use module name from `expo-module.config.json`. ([#39985](https://github.com/expo/expo/pull/39985) by [@jakex7](https://github.com/jakex7))
+- [iOS] Add `invalidate` callback to SwiftUIVirtualView. ([#53708](https://github.com/facebook/react-native/pull/53708) by [@nishan](https://github.com/facebook/react-native/pull/53708))
 
 ## 3.0.19 - 2025-10-01
 

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualViewObjC.mm
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualViewObjC.mm
@@ -375,7 +375,7 @@ static std::unordered_map<std::string, expo::ExpoViewComponentDescriptor::Flavor
 - (void)invalidate
 {
   // Default implementation does nothing.
-  _eventEmitter.reset();
+  [self prepareForRecycle];
 }
 
 @end

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualViewObjC.mm
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualViewObjC.mm
@@ -372,4 +372,10 @@ static std::unordered_map<std::string, expo::ExpoViewComponentDescriptor::Flavor
   return NO;
 }
 
+- (void)invalidate
+{
+  // Default implementation does nothing.
+  _eventEmitter.reset();
+}
+
 @end


### PR DESCRIPTION
# Why

- App crashes on reload (Pressing R) if there is Expo UI component mounted.
- https://github.com/facebook/react-native/pull/53708 Added invalidate callback, it [gets called](https://github.com/facebook/react-native/pull/53708/files#diff-7dd260b9d5b1465363f553eaa9fd5963b50f4f0be23717e7ff2cb038b5c2e8a9R111) for non recycled component and it can lead to crash if the method does not exist. 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Add invalidate call to SwiftUIVirtualViewObjc
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

App should not crash on reload.

Try below snippet in App.tsx in NCL app and press R.

```jsx
 <Host matchContents>
   <Text>Hello</Text>
 </Host>
```

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
