### PR TITLE
[autolinking][Android] Sync flavor dimensions and product flavors from app to expo module

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Added support for cli command extensions in the interactive devtools menu ([#39598](https://github.com/expo/expo/pull/39598) by [@chrfalch](https://github.com/chrfalch))
+- [Android] Sync flavor dimensions and product flavors from app to expo module ([#40238](https://github.com/expo/expo/pull/40238) by [@kosmydel](https://github.com/kosmydel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingPlugin.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingPlugin.kt
@@ -31,7 +31,6 @@ open class ExpoAutolinkingPlugin : Plugin<Project> {
     var appProject: Project? = null
     appProject = findAppProject(project.rootProject) { found ->
       appProject = found
-      project.logger.quiet("Found Android application module: ${found.path}")
     }
 
     appProject?.let { copyAppDimensionsAndFlavorsToProject(project, it) }

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingPlugin.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingPlugin.kt
@@ -118,11 +118,9 @@ open class ExpoAutolinkingPlugin : Plugin<Project> {
     appProject: Project
   ) {
     val appAndroid = appProject.extensions.findByName("android") as? BaseExtension ?: run {
-      project.logger.quiet("App project '${appProject.path}' has no Android extension.")
       return
     }
     val consumerAndroid = project.extensions.findByName("android") as? BaseExtension ?: run {
-      project.logger.quiet("Consumer project '${project.path}' has no Android extension.")
       return
     }
 
@@ -163,7 +161,6 @@ open class ExpoAutolinkingPlugin : Plugin<Project> {
     appDimensions: List<String>
   ) {
     val appFlavors = appAndroid.productFlavors ?: run {
-      project.logger.quiet("  -> App has no productFlavors — nothing to copy.")
       return
     }
 

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingPlugin.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingPlugin.kt
@@ -1,6 +1,7 @@
 package expo.modules.plugin
 
 import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.internal.tasks.factory.dependsOn
 import expo.modules.plugin.configuration.ExpoModule
 import expo.modules.plugin.text.Colors
@@ -26,6 +27,14 @@ open class ExpoAutolinkingPlugin : Plugin<Project> {
 
     project.logger.quiet("")
     project.logger.quiet("Using expo modules")
+
+    var appProject: Project? = null
+    appProject = findAppProject(project.rootProject) { found ->
+      appProject = found
+      project.logger.quiet("Found Android application module: ${found.path}")
+    }
+
+    appProject?.let { copyAppDimensionsAndFlavorsToProject(project, it) }
 
     val (prebuiltProjects, projects) = config.allProjects.partition { project ->
       project.usePublication
@@ -86,6 +95,96 @@ open class ExpoAutolinkingPlugin : Plugin<Project> {
       it.namespace.set(generatedPackageListNamespace)
       it.outputFile.set(getPackageListFile(project))
       it.modules = modules
+    }
+  }
+
+  private fun findAppProject(root: Project, onFound: (Project) -> Unit): Project? {
+    val immediate = root.allprojects.firstOrNull { it.plugins.hasPlugin("com.android.application") }
+    if (immediate != null) {
+      onFound(immediate)
+      return immediate
+    }
+
+    root.allprojects.forEach { p ->
+      p.pluginManager.withPlugin("com.android.application") {
+        onFound(p)
+      }
+    }
+    return null
+  }
+
+  private fun copyAppDimensionsAndFlavorsToProject(
+    project: Project,
+    appProject: Project
+  ) {
+    val appAndroid = appProject.extensions.findByName("android") as? BaseExtension ?: run {
+      project.logger.quiet("App project '${appProject.path}' has no Android extension.")
+      return
+    }
+    val consumerAndroid = project.extensions.findByName("android") as? BaseExtension ?: run {
+      project.logger.quiet("Consumer project '${project.path}' has no Android extension.")
+      return
+    }
+
+    val appDimensions = syncFlavorDimensions(project, consumerAndroid, appAndroid)
+    copyMissingProductFlavors(project, consumerAndroid, appAndroid, appDimensions)
+  }
+
+  private fun syncFlavorDimensions(
+    project: Project,
+    consumerAndroid: BaseExtension,
+    appAndroid: BaseExtension
+  ): List<String> {
+    val appDimensions = appAndroid.flavorDimensionList ?: emptyList()
+    if (appDimensions.isEmpty()) return emptyList()
+
+    val consumerDimensions = (consumerAndroid.flavorDimensionList ?: emptyList()).toMutableList()
+    val dimensionsAdded = appDimensions.any { dimension ->
+      if (dimension !in consumerDimensions) {
+        consumerDimensions.add(dimension)
+        true
+      } else {
+        false
+      }
+    }
+
+    if (dimensionsAdded || consumerAndroid.flavorDimensionList.isNullOrEmpty()) {
+      consumerAndroid.flavorDimensions(*consumerDimensions.toTypedArray())
+      project.logger.quiet("  -> Copied/merged flavorDimensions: ${consumerDimensions.joinToString()}")
+    }
+
+    return appDimensions
+  }
+
+  private fun copyMissingProductFlavors(
+    project: Project,
+    consumerAndroid: BaseExtension,
+    appAndroid: BaseExtension,
+    appDimensions: List<String>
+  ) {
+    val appFlavors = appAndroid.productFlavors ?: run {
+      project.logger.quiet("  -> App has no productFlavors — nothing to copy.")
+      return
+    }
+
+    val consumerFlavors = consumerAndroid.productFlavors
+    val existingFlavorNames = consumerFlavors?.map { it.name }?.toSet() ?: emptySet()
+
+    appFlavors.forEach { appFlavor ->
+      if (appFlavor.name !in existingFlavorNames) {
+        val dimension = appFlavor.dimension ?: appDimensions.singleOrNull()
+        
+        consumerFlavors.create(appFlavor.name).apply {
+          this.dimension = dimension
+          appFlavor.applicationIdSuffix?.let { this.applicationIdSuffix = it }
+          appFlavor.versionNameSuffix?.let { this.versionNameSuffix = it }
+          if (appFlavor.manifestPlaceholders.isNotEmpty()) {
+            this.manifestPlaceholders.putAll(appFlavor.manifestPlaceholders)
+          }
+        }
+        
+        project.logger.quiet("  -> Created flavor '${appFlavor.name}' (dimension='$dimension') in :${project.path}")
+      }
     }
   }
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR adds support for **product flavors** in Expo apps and modules.

Learn more: 
- https://developer.android.com/build/build-variants#product-flavors
- https://developers.meta.com/horizon/documentation/android-apps/product-flavors

# How

<!--
How did you build this feature or fix this bug and why?
-->

The implementation copies the flavor configuration from the main app module to the expo module.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

1. Test the `apps/bare-expo` on Android without any changes.
2. Apply the patch file: https://privatebin.swmansion.com/?6908e708eb238f9a#7DG36rK8XXKemexe2DZ7MArqERQ2c622rzSxNPFbRxoL
3. Open the `apps/bare-expo/android` folder in Android Studio.
4. Test the `:app` build variants: questDebug and mobileDebug.
5. Navigate to `APIs` -> `Battery`: on the `mobileDebug`, it should indicate that the feature is not supported.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
