### PR TITLE
[android][audio] Fix prepare issue

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [iOS/Android] Aligned Android and iOS pitch correction by changing the default quality on iOS to match Android. `shouldCorrectPitch` now defaults to `true`. ([#40176](https://github.com/expo/expo/pull/40176) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Fix issue where after replacing the media source, events are emitted twice. ([#40133](https://github.com/expo/expo/pull/40133) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Fix issue where if `prepare` fails on android there was no error and the user would receive an empty file.
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - [iOS/Android] Aligned Android and iOS pitch correction by changing the default quality on iOS to match Android. `shouldCorrectPitch` now defaults to `true`. ([#40176](https://github.com/expo/expo/pull/40176) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Fix issue where after replacing the media source, events are emitted twice. ([#40133](https://github.com/expo/expo/pull/40133) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Fix issue where if `prepare` fails on android there was no error and the user would receive an empty file.
+- [Android] Fix issue where if `prepare` fails on android there was no error and the user would receive an empty file. ([#40239](https://github.com/expo/expo/pull/40239) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioExceptions.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioExceptions.kt
@@ -16,3 +16,9 @@ internal class DeviceInfoNotFoundException :
 
 internal class PreferredInputNotFoundException :
   CodedException("Could not set preferred device input")
+
+internal class AudioRecorderPrepareException(cause: Throwable) :
+  CodedException("Failed to prepare the AudioRecorder", cause)
+
+internal class AudioRecorderAlreadyPreparedException :
+  CodedException("AudioRecorder has already been prepared. Stop or release the current session before preparing again.")

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
@@ -9,7 +9,6 @@ import android.media.MediaRecorder
 import android.media.MediaRecorder.MEDIA_ERROR_SERVER_DIED
 import android.media.MediaRecorder.MEDIA_RECORDER_ERROR_UNKNOWN
 import android.media.MediaRecorder.MEDIA_RECORDER_INFO_MAX_FILESIZE_REACHED
-import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import androidx.core.content.ContextCompat

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
@@ -9,9 +9,11 @@ import android.media.MediaRecorder
 import android.media.MediaRecorder.MEDIA_ERROR_SERVER_DIED
 import android.media.MediaRecorder.MEDIA_RECORDER_ERROR_UNKNOWN
 import android.media.MediaRecorder.MEDIA_RECORDER_INFO_MAX_FILESIZE_REACHED
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.sharedobjects.SharedObject
 import kotlinx.coroutines.Job
@@ -21,7 +23,6 @@ import java.io.File
 import java.io.IOException
 import java.util.UUID
 import kotlin.math.log10
-import androidx.core.net.toUri
 
 private const val RECORDING_STATUS_UPDATE = "recordingStatusUpdate"
 
@@ -43,6 +44,9 @@ class AudioRecorder(
   var isRecording = false
   var isPaused = false
   private var recordingTimerJob: Job? = null
+
+  private fun currentFileUrl(): String? =
+    filePath?.let(::File)?.toUri()?.toString()
 
   private fun getAudioRecorderLevels(): Double? {
     if (!meteringEnabled || recorder == null || !isRecording) {
@@ -66,14 +70,20 @@ class AudioRecorder(
   }
 
   fun prepareRecording(options: RecordingOptions?) {
-    recorder = options?.let { createRecorder(it) } ?: createRecorder(this.options)
+    if (recorder != null || isPrepared || isRecording || isPaused) {
+      throw AudioRecorderAlreadyPreparedException()
+    }
+    val recordingOptions = options ?: this.options
+    val mediaRecorder = createRecorder(recordingOptions)
+    recorder = mediaRecorder
     try {
-      recorder?.prepare()
+      mediaRecorder.prepare()
       isPrepared = true
-    } catch (_: Exception) {
-      recorder?.release()
+    } catch (cause: Exception) {
+      mediaRecorder.release()
       recorder = null
       isPrepared = false
+      throw AudioRecorderPrepareException(cause)
     }
   }
 
@@ -125,10 +135,21 @@ class AudioRecorder(
   }
 
   fun stopRecording(): Bundle {
+    val url = currentFileUrl()
+    var durationMillis: Long
+
     try {
       recorder?.stop()
+      durationMillis = getAudioRecorderDurationMillis()
     } finally {
       reset()
+    }
+
+    val status = Bundle().apply {
+      putBoolean("canRecord", false)
+      putBoolean("isRecording", false)
+      putLong("durationMillis", durationMillis)
+      url?.let { putString("url", it) }
     }
 
     // Emit completion event on the main thread
@@ -140,12 +161,12 @@ class AudioRecorder(
           "isFinished" to true,
           "hasError" to false,
           "error" to null,
-          "url" to filePath?.toUri().toString()
+          "url" to url
         )
       )
     }
 
-    return getAudioRecorderStatus()
+    return status
   }
 
   private fun reset() {
@@ -229,9 +250,7 @@ class AudioRecorder(
       getAudioRecorderLevels()?.let {
         putDouble("metering", it)
       }
-      filePath?.let {
-        putString("url", it.toUri().toString())
-      }
+      currentFileUrl()?.let { putString("url", it) }
     }
   } else {
     Bundle().apply {
@@ -277,7 +296,7 @@ class AudioRecorder(
             "isFinished" to true,
             "hasError" to true,
             "error" to null,
-            "url" to filePath?.toUri().toString()
+            "url" to currentFileUrl()
           )
         )
       }


### PR DESCRIPTION
# Why
Closes #40174

# How
On android, preparing the recording could fail silently. From a users perspective, everything proceeds as normal but they receive an empty recording after starting and stopping one. We should emit a proper error if preparing fails like we do on iOS and also prevent calling prepare multiple times. It should be called once before start and only again after stop is called.

# Test Plan
Bare-expo
