### PR TITLE
[docs] Add info for debugOptimized variant

### DIFF
--- a/docs/pages/build-reference/apk.mdx
+++ b/docs/pages/build-reference/apk.mdx
@@ -15,7 +15,7 @@ To generate an **.apk**, modify the [**eas.json**](/build/eas-json) by adding on
 - `developmentClient` to `true` (**default**)
 - `distribution` to `internal`
 - `android.buildType` to `apk`
-- `android.gradleCommand` to `:app:assembleRelease`, `:app:assembleDebug` or any other gradle command that produces **.apk**
+- `android.gradleCommand` to `:app:assembleRelease`, `:app:assembleDebug`, [`:app:assembleDebugOptimized`](/more/expo-cli/#compiling-android) (available for SDK 54 and later), or any other Gradle command that produces an **.apk**
 
 ```json eas.json
 {

--- a/docs/pages/guides/local-app-development.mdx
+++ b/docs/pages/guides/local-app-development.mdx
@@ -38,6 +38,7 @@ The above commands compile your project, using your locally installed Android SD
 - These compilation commands initially run `npx expo prebuild` to generate native directories (**android** and **ios**) before building, if they do not exist yet. If they already exist, this will be skipped.
 - You can also add the `--device` flag to select a device to run the app on — you can select a physically connected device or emulator/simulator.
 - You can pass in `--variant release` (Android) or `--configuration Release` (iOS) to build a [production build of your app](/deploy/build-project/#production-builds-locally). Note that these builds are not signed and you cannot submit them to app stores. To sign your production build, see [Local app production](/guides/local-app-production/).
+- **Android only**: Starting in SDK 54, you can pass the `-- variant debugOptimized` variant for faster development iteration. See [Compiling Android in Expo CLI reference](/more/expo-cli/#compiling-android) for more information.
 
 To modify your project's configuration or native code after the first build, you will have to rebuild your project. Running `npx expo prebuild` again layers the changes on top of existing files. It may also produce different results after the build.
 

--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -211,8 +211,8 @@ Use the `debugOptimized` variant for faster development with performance close t
 When using this variant, keep the following in mind:
 
 - Optimizes C++ libraries as in release builds, improving runtime performance
-- **Limitation**: C++ debugging is disabled and C++ crashes may have less readable stack traces
 - In EAS Build, use a matching Gradle command like [`:app:assembleDebugOptimized` in **eas.json**](/build-reference/apk/#configuring-a-profile-to-build-apks)
+- **Limitation**: C++ debugging is disabled and C++ crashes may have less readable stack traces
 
 **`release` variant**
 

--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -181,7 +181,7 @@ If your project does not have the corresponding native directories, the `npx exp
 
 For example, if your project does not have an **ios** directory in the root of your project, then `npx expo run:ios` will first run `npx expo prebuild -p ios` before compiling your app. For more information on this process, see [Expo Prebuild](/workflow/prebuild).
 
-**Cross-Platform Arguments**
+**Cross-platform arguments**
 
 - `--no-build-cache`: Clear the native cache before building. On iOS, this is the **derived data** directory. Cache clearing is useful for profiling your build times.
 - `--no-install`: Skip installing dependencies. On iOS, this will also skip running `npx pod-install` if the `dependencies` field in the project's `package.json` has changed.
@@ -194,13 +194,35 @@ For example, if your project does not have an **ios** directory in the root of y
 
 Android apps can have multiple different **variants** which are defined in the project's `build.gradle` file. Variants can be selected with the `--variant` flag:
 
+**`debug` variant**
+
+Use the `debug` variant for a debug build:
+
 <Terminal cmd={['$ npx expo run:android --variant debug']} />
+
+**`debugOptimized` variant**
+
+> **important** `debugOptimized` is available in SDK 54 and later.
+
+Use the `debugOptimized` variant for faster development with performance close to release builds while keeping the overall build in a debug-friendly mode:
+
+<Terminal cmd={['$ npx expo run:android --variant debugOptimized']} />
+
+When using this variant, keep the following in mind:
+
+- Optimizes C++ libraries as in release builds, improving runtime performance
+- **Limitation**: C++ debugging is disabled and C++ crashes may have less readable stack traces
+- In EAS Build, use a matching Gradle command like [`:app:assembleDebugOptimized` in **eas.json**](/build-reference/apk/#configuring-a-profile-to-build-apks)
+
+**`release` variant**
 
 You can compile the Android app for production by running:
 
 <Terminal cmd={['$ npx expo run:android --variant release']} />
 
 This build is not automatically code-signed for submission to the Google Play Store. This command should be used to test bugs that may only show up in production builds. To generate a production build that is code signed for the Play Store, we recommend using [EAS Build](/build/introduction).
+
+**Debugging native Android project**
 
 You can debug the native Android project using native debugging tools by opening the **android** directory in Android Studio:
 
@@ -264,7 +286,7 @@ The following options are provided:
 
 #### Hosting with sub-paths
 
-> Experimental functionality.
+> **important** Experimental functionality.
 
 You can configure the prefix for static assets by setting the `experiments.baseUrl` field in your [app config](/workflow/configuration/):
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-17528

# How

<!--
How did you build this feature or fix this bug and why?
-->

* Added documentation for the `debugOptimized` variant, explaining its benefits (faster builds with near-release performance), usage instructions, and limitations in Expo CLI
* Backported the above as a link from Local app development guide and Build APKs for Android Emulators and devices

In Expo CLI reference:
* Improved clarity and consistency in section headings and notes (e.g., changed "Cross-Platform Arguments" to "Cross-platform arguments") to follow writing style guide.
* Updated experimental feature note to use a more prominent "important" style for better visibility.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally and visit:

- http://localhost:3002/more/expo-cli/#compiling-android
<img width="1150" height="1004" alt="CleanShot 2025-10-07 at 18 54 33" src="https://github.com/user-attachments/assets/8e84c7be-f567-446b-9ab3-50a4d66f99f2" />

- http://localhost:3002/build-reference/apk/#configuring-a-profile-to-build-apks
<img width="1129" height="265" alt="CleanShot 2025-10-07 at 18 54 45" src="https://github.com/user-attachments/assets/908f7994-acab-46b9-8abe-9ee28d2a2214" />

- http://localhost:3002/guides/local-app-development/#local-app-compilation
<img width="1115" height="562" alt="CleanShot 2025-10-07 at 18 55 00" src="https://github.com/user-attachments/assets/d8bc22ad-1e31-4c40-ae4a-e722dcf860ee" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
