### PR TITLE
feat(cli): Add `_expo/.routes.json` server manifest subset to `static` export output

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - Update usage of `@expo/server` API ([#39894](https://github.com/expo/expo/pull/39894) by [@kitten](https://github.com/kitten))
 - Rename to `@expo/server` to `expo-server` ([#40087](https://github.com/expo/expo/pull/40087) by [@kitten](https://github.com/kitten))
+- Export `_expo/.routes.json` metadata file for `static` outputs ([#40243](https://github.com/expo/expo/pull/40243) by [@kitten](https://github.com/kitten))
 
 ### ⚠️ Notices
 

--- a/packages/@expo/cli/e2e/__tests__/export/static-rendering.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-rendering.test.ts
@@ -89,6 +89,8 @@ describe('exports static', () => {
     expect(files).toContain('[post].html');
     expect(files).toContain('welcome-to-the-universe.html');
     expect(files).toContain('other.html');
+
+    expect(files).toContain('_expo/.routes.json');
   });
 
   it('has source maps', async () => {

--- a/packages/@expo/cli/e2e/__tests__/export/tailwind-postcss.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/tailwind-postcss.test.ts
@@ -30,6 +30,7 @@ describe('exports with tailwind and postcss', () => {
     // The wrapper should not be included as a route.
     expect(files).toEqual([
       '+not-found.html',
+      '_expo/.routes.json',
       expect.stringMatching(/_expo\/static\/css\/global-.*\.css/),
       expect.stringMatching(/_expo\/static\/css\/modal\.module-.*\.css/),
       expect.stringMatching(/_expo\/static\/js\/web\/entry-.*\.js/),

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -477,6 +477,7 @@ export async function exportApiRoutesStandaloneAsync(
     // TODO: Export an HTML entry for each file. This is a temporary solution until we have SSR/SSG for RSC.
     await getFilesToExportFromServerAsync(devServer.projectRoot, {
       manifest: htmlManifest,
+      serverManifest,
       exportServer: true,
       files,
       renderAsync: async ({ pathname, filePath }) => {


### PR DESCRIPTION
# Why

This adds an `_expo/.routes.json` to the exported files for `static` exports. It feels a little bit too risky to add this to the `single` output as well. The export code is in an odd shape and has many branches, even just for `web` outputs.

The `_expo/.routes.json` will be picked up by `eas-cli` and used during `eas-cli`'s uploads to EAS Hosting. The subset of configs (`headers` and `redirects`) are uploaded, so they can eventually be used by EAS Hosting to support these (usually server-only) configs in `static` outputs.

# How

- Add `_expo/.routes.json` client output to static exports with a server manifest subset

# Test Plan

- Tested manually and added a quick E2E check whether the file is created

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
