### PR TITLE
[e-m-c] fix typo in ValueOrUndefined

### DIFF
--- a/packages/expo-modules-core/ValueOrUndefinedSpec.swift
+++ b/packages/expo-modules-core/ValueOrUndefinedSpec.swift
@@ -49,59 +49,59 @@ final class ValueOrUndefinedSpec: ExpoSpec {
       }
       
       it("converts from undefined to ValueOrUndefinedSpec<Int>") {
-        let wasUndefinded = try runtime
+        let wasUndefined = try runtime
           .eval("expo.modules.ValueOrUndefinedModule.undefined_of_int(undefined)")
           .asBool()
         
-        expect(wasUndefinded).to(beTrue())
+        expect(wasUndefined).to(beTrue())
       }
       
       it("converts from int to ValueOrUndefinedSpec<Int>") {
-        let wasUndefinded = try runtime
+        let wasUndefined = try runtime
           .eval("expo.modules.ValueOrUndefinedModule.undefined_of_int(10)")
           .asBool()
         
-        expect(wasUndefinded).to(beFalse())
+        expect(wasUndefined).to(beFalse())
       }
       
       it("converts from undefined to ValueOrUndefinedSpec<Int?>") {
-        let wasUndefinded = try runtime
+        let wasUndefined = try runtime
           .eval("expo.modules.ValueOrUndefinedModule.undefined_of_optional_int(undefined, null)")
           .asBool()
         
-        expect(wasUndefinded).to(beTrue())
+        expect(wasUndefined).to(beTrue())
       }
       
       it("converts from int to ValueOrUndefinedSpec<Int?>") {
-        let wasUndefinded = try runtime
+        let wasUndefined = try runtime
           .eval("expo.modules.ValueOrUndefinedModule.undefined_of_optional_int(10, 10)")
           .asBool()
         
-        expect(wasUndefinded).to(beFalse())
+        expect(wasUndefined).to(beFalse())
       }
       
       it("converts from null to ValueOrUndefinedSpec<Int?>") {
-        let wasUndefinded = try runtime
+        let wasUndefined = try runtime
           .eval("expo.modules.ValueOrUndefinedModule.undefined_of_optional_int(null, null)")
           .asBool()
         
-        expect(wasUndefinded).to(beFalse())
+        expect(wasUndefined).to(beFalse())
       }
       
       it("converts from array to [ValueOrUndefinedSpec<Int>]") {
-        let wereUndefinded = try runtime
+        let wereUndefined = try runtime
           .eval("expo.modules.ValueOrUndefinedModule.array_of_undefined_of_int([1, undefined, 2, undefined, 3])")
           .asArray().map { try $0!.asBool() }
         
-        expect(wereUndefinded).to(equal([false, true, false, true, false]))
+        expect(wereUndefined).to(equal([false, true, false, true, false]))
       }
       
       it("converts from array to [ValueOrUndefinedSpec<Int?>]") {
-        let wereUndefinded = try runtime
+        let wereUndefined = try runtime
           .eval("expo.modules.ValueOrUndefinedModule.array_of_undefined_of_optional_int([1, undefined, null, 2, undefined, null], [1, null, null, 2, null, null])")
           .asArray().map { try $0!.asBool() }
         
-        expect(wereUndefinded).to(equal([false, true, false, false, true, false]))
+        expect(wereUndefined).to(equal([false, true, false, false, true, false]))
       }
     }
   }
@@ -112,21 +112,21 @@ fileprivate final class UndefinedSpecModule: Module {
     Name("ValueOrUndefinedModule")
     
     Function("undefined_of_int") { (value: ValueOrUndefined<Int>) in
-      return value.isUndefinded
+      return value.isUndefined
     }
     
     Function("undefined_of_optional_int") { (value: ValueOrUndefined<Int?>, expectedValue: Int?) in
       expect(value.optional).to(expectedValue == nil ? beNil() : equal(expectedValue))
-      return value.isUndefinded
+      return value.isUndefined
     }
     
     Function("array_of_undefined_of_int") { (values: [ValueOrUndefined<Int>]) in
-      return values.map { $0.isUndefinded }
+      return values.map { $0.isUndefined }
     }
     
     Function("array_of_undefined_of_optional_int") { (values: [ValueOrUndefined<Int?>], expectedValues: [Int?]) in
       expect(values.map{ $0.optional} ).to(equal(expectedValues))
-      return values.map { $0.isUndefinded }
+      return values.map { $0.isUndefined }
     }
   }
 }

--- a/packages/expo-modules-core/ios/Core/Arguments/ValueOrUndefined.swift
+++ b/packages/expo-modules-core/ios/Core/Arguments/ValueOrUndefined.swift
@@ -11,46 +11,50 @@ public enum ValueOrUndefined<InnerType: AnyArgument>: AnyValueOrUndefined {
   case value(unwrapped: InnerType)
 
   var optional: InnerType? {
-    switch self {
+    return switch self {
     // We want to produce Optional(nil) instead of nil - that's what DynamicOptionalType does
-    case .undefined: return Any??.some(nil) as Any?? as! InnerType?
-    case .value(let value): return value
+    case .undefined: Any??.some(nil) as Any?? as! InnerType?
+    case .value(let value): value
     }
   }
 
-  var isUndefinded: Bool {
-    if case .undefined = self {
-      return true
+  var isUndefined: Bool {
+    return switch self {
+    case .undefined: true
+    default: false
     }
+  }
 
-    return false
+  // @deprecated because of the typo
+  var isUndefinded: Bool {
+    return self.isUndefined
   }
 }
 
 extension ValueOrUndefined: Equatable where InnerType: Equatable {
   public static func == (lhs: ValueOrUndefined, rhs: ValueOrUndefined) -> Bool {
-    switch (lhs, rhs) {
+    return switch (lhs, rhs) {
     case (.undefined, .undefined):
-      return true
+      true
     case (.value(let lhsValue), .value(let rhsValue)):
-      return lhsValue == rhsValue
+      lhsValue == rhsValue
     default:
-      return false
+      false
     }
   }
 }
 
 extension ValueOrUndefined: Comparable where InnerType: Comparable {
   public static func < (lhs: ValueOrUndefined, rhs: ValueOrUndefined) -> Bool {
-    switch (lhs, rhs) {
+    return switch (lhs, rhs) {
     case (.undefined, .undefined):
-      return false // undefined is considered equal to another undefined
+      false // undefined is considered equal to another undefined
     case (.undefined, _):
-      return false
+      false
     case (_, .undefined):
-      return false
+      false
     case (.value(let lhsValue), .value(let rhsValue)):
-      return lhsValue < rhsValue
+      lhsValue < rhsValue
     }
   }
 }


### PR DESCRIPTION
# Why

- fix typo in the `ValueOrUndefinded` var

# How

fix typos, minor code changes

# Test Plan

- green CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
