### PR TITLE
[core][Android] Drop `thread_local` from `JSIContext` registry

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
@@ -356,7 +356,7 @@ bool JSIContext::wasDeallocated() const noexcept {
   return wasDeallocated_;
 }
 
-thread_local std::unordered_map<uintptr_t, JSIContext *> jsiContexts;
+std::unordered_map<uintptr_t, JSIContext *> jsiContexts;
 
 void bindJSIContext(const jsi::Runtime &runtime, JSIContext *jsiContext) {
   jsiContexts[reinterpret_cast<uintptr_t>(&runtime)] = jsiContext;

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
@@ -194,10 +194,8 @@ private:
 /**
  * We are binding the JSIContext to the runtime using a thread-local map.
  * This is a simplification of how we're accessing the JSIContext from different places.
- * We're using a thread-local map to prevent from accessing the wrong JSIContext from a different thread.
- * It's much safer than passing around the JSIContext as a parameter.
  */
-extern thread_local std::unordered_map<uintptr_t, JSIContext *> jsiContexts;
+extern std::unordered_map<uintptr_t, JSIContext *> jsiContexts;
 
 /**
  * Binds the JSIContext to the runtime.


### PR DESCRIPTION
# Why

Drops `thread_local` from `JSIContext` registry.

# How

When the jsiContexts were added, I assumed that the JSIContext and the connected jsi::Runtime would be used only on the thread that is bound to the runtime. However, with the upcoming worklets integration, this is not necessarily true. The UI runtime can be accessed from the JS thread when running runOnUISync. 

> [!NOTE]
> This change shouldn't affect the current code, although it allows accessing JSIContext from an incorrect thread.


# Test Plan

- bare-expo ✅ 
