### PR TITLE
[expo-localization][android] Fix Android AAPT error with locale format in resourceConfigurations

### DIFF
--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+
+- [Android] Fixed AAPT error when using locale format with region codes (e.g., `en-US`, `pt-BR`) in `supportedLocales` by converting to Android resource configuration format (`en-rUS`, `pt-rBR`). ([#40253](https://github.com/expo/expo/pull/40253) by [@mensonones](https://github.com/mensonones))
 - Correct types for getCalendars and getLocales ([#39703](https://github.com/expo/expo/pull/39703) by [@kadikraman](https://github.com/kadikraman))
 
 ### 💡 Others


### PR DESCRIPTION
## Summary

Fixes Android AAPT build error when using `supportedLocales` with region codes in `app.json`. This PR converts locale formats to the correct Android resource configuration format while preserving ISO format where needed.

## Problem

When configuring `supportedLocales` in `app.json` with region codes (e.g., `en-US`, `pt-BR`, `es-419`), the Android build fails with:

```
AAPT: error: invalid config 'en-US' for -c option.
```

**Root Cause:**
The `expo-localization` config plugin was directly using ISO locale format (`en-US`) in the Gradle `resourceConfigurations` property. However, Android's AAPT tool requires a different format with an 'r' prefix before the region code (e.g., `en-rUS`, `pt-rBR`).

**Important:** This only affects `resourceConfigurations` in `app/build.gradle`. The XML locale configuration (`locales_config.xml`) correctly expects and continues to use ISO format.

## Solution

Added a `convertLocaleToAndroidFormat()` function that:
1. Detects if a locale already has the Android format (`-r` prefix)
2. Converts ISO format to Android format when needed
3. Preserves language-only locales (e.g., `en`, `pt`)
4. Handles complex locales (e.g., `es-419`, `zh-Hans-CN`)

**Example conversions:**
- `en-US` → `en-rUS`
- `pt-BR` → `pt-rBR`
- `es-419` → `es-r419`
- `zh-Hans-CN` → `zh-rHans-CN`
- `en` → `en` (unchanged)
- `en-rUS` → `en-rUS` (already correct)

**What changes:**
```gradle
// Before (causes AAPT error):
resourceConfigurations += ["en-US", "pt-BR"]

// After (correct):
resourceConfigurations += ["en-rUS", "pt-rBR"]
```

**What stays the same:**
```xml
<!-- locales_config.xml - still uses ISO format -->
<locale android:name="en-US"/>
<locale android:name="pt-BR"/>
```

## Impact

**Who is affected:**
- All users configuring `supportedLocales` with region codes in `app.json`
- Primarily affects Android builds (iOS uses different format)

**Breaking changes:**
- None. This is a bug fix that makes the plugin work as intended

**Backward compatibility:**
- ✅ Locales without region codes work as before
- ✅ Locales already in Android format are preserved
- ✅ XML configuration unchanged

##  Before/After

**Before this PR:**
```typescript
// app.json
{
  "expo": {
    "plugins": [
      ["expo-localization", {
        "supportedLocales": ["en-US", "pt-BR"]
      }]
    ]
  }
}

// Generated app/build.gradle
resourceConfigurations += ["en-US", "pt-BR"]  // ❌ AAPT error!
```

**After this PR:**
```typescript
// app.json (unchanged)
{
  "expo": {
    "plugins": [
      ["expo-localization", {
        "supportedLocales": ["en-US", "pt-BR"]
      }]
    ]
  }
}

// Generated app/build.gradle
resourceConfigurations += ["en-rUS", "pt-rBR"]  // ✅ Works!
```

## Related

- Fixes #40205
- Related documentation: 
  - [Android locale configuration](https://developer.android.com/guide/topics/resources/multilingual-support)
  - [Android alternative resources](https://developer.android.com/guide/topics/resources/providing-resources?hl=pt-br#AlternativeResources) 
