### PR TITLE
[ci] dogfooding repack action

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -10,7 +10,7 @@ on:
       - apps/test-suite/**
       - packages/**
       - yarn.lock
-      # Adding new paths should also update the following "Get the base commit" step's paths
+      # When adding new paths, also update the paths of the "Get the base commit" step below
   pull_request:
     types: [opened, synchronize]
     paths:
@@ -33,7 +33,7 @@ jobs:
     permissions:
       # REQUIRED: Allow comments of PRs
       pull-requests: write
-      # REQUIRED: Allow updating fingerprint in acton caches
+      # REQUIRED: Allow updating fingerprint in action caches
       actions: write
     steps:
       - name: 👀 Checkout

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -62,7 +62,7 @@ jobs:
           echo base-commit=$(git log -n 1 main --pretty=format:'%H' -- .github/workflows/pr-labeler.yml apps/bare-expo apps/test-suite packages yarn.lock) >> "$GITHUB_OUTPUT"
       - name: 📷 Check fingerprint
         id: fingerprint
-        uses: expo/expo-github-action/fingerprint@main
+        uses: expo/actions/fingerprint@main
         with:
           working-directory: apps/bare-expo
           previous-git-commit: ${{ steps.base-commit.outputs.base-commit }}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -35,8 +35,6 @@ jobs:
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v5
-        with:
-          submodules: true
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -73,7 +71,7 @@ jobs:
         run: yarn expo-modules-autolinking react-native-config --platform ios
         working-directory: apps/bare-expo
       - name: ⬇️ Fetch commits from base branch
-        run: git fetch origin main:main --depth 100
+        run: git fetch origin main:main --depth 100 --no-recurse-submodules
         if: github.event_name == 'pull_request'
       - name: 🔎 Get the base commit
         id: base-commit
@@ -197,8 +195,6 @@ jobs:
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v5
-        with:
-          submodules: true
       - name: 🧹 Cleanup GitHub Linux runner disk space
         uses: ./.github/actions/cleanup-linux-disk-space
       - name: 🏗️ Setup Bun
@@ -229,7 +225,7 @@ jobs:
         run: yarn expo-modules-autolinking react-native-config --platform android
         working-directory: apps/bare-expo
       - name: ⬇️ Fetch commits from base branch
-        run: git fetch origin main:main --depth 100
+        run: git fetch origin main:main --depth 100 --no-recurse-submodules
         if: github.event_name == 'pull_request'
       - name: 🔎 Get the base commit
         id: base-commit

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -10,7 +10,7 @@ on:
       - apps/test-suite/**
       - packages/**
       - yarn.lock
-      # Adding new paths should also update the following "Get the base commit" step's paths
+      # When adding new paths, also update the paths of the "Get the base commit" step below
   pull_request:
     paths:
       - .github/workflows/test-suite.yml
@@ -30,7 +30,7 @@ jobs:
   ios-build:
     runs-on: macos-15
     permissions:
-      # REQUIRED: Allow updating fingerprint in acton caches
+      # REQUIRED: Allow updating fingerprint in action caches
       actions: write
     steps:
       - name: 👀 Checkout
@@ -186,7 +186,7 @@ jobs:
   android-build:
     runs-on: ubuntu-24.04
     permissions:
-      # REQUIRED: Allow updating fingerprint in acton caches
+      # REQUIRED: Allow updating fingerprint in action caches
       actions: write
     env:
       ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -10,6 +10,7 @@ on:
       - apps/test-suite/**
       - packages/**
       - yarn.lock
+      # Adding new paths should also update the following "Get the base commit" step's paths
   pull_request:
     paths:
       - .github/workflows/test-suite.yml
@@ -21,12 +22,16 @@ on:
       - '!packages/@expo/cli/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  # When pushing main branch, we should limit single concurrency with pr-labeler workflow to prevent multiple fingerprints being updated at the same time
+  group: ${{ github.event_name != 'pull_request' && 'fingerprint-main' || format('{0}-{1}-{2}', github.workflow, github.event_name, github.ref) }}
   cancel-in-progress: true
 
 jobs:
   ios-build:
     runs-on: macos-15
+    permissions:
+      # REQUIRED: Allow updating fingerprint in acton caches
+      actions: write
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v5
@@ -67,28 +72,38 @@ jobs:
       - name: ⚛️ Display React Native config
         run: yarn expo-modules-autolinking react-native-config --platform ios
         working-directory: apps/bare-expo
-      - name: 🌳 Display pod environment
-        run: pod env
-        working-directory: apps/bare-expo/ios
-      - name: 🥥 Install pods in apps/bare-expo/ios
-        if: steps.expo-caches.outputs.ios-pods-hit != 'true'
-        run: pod install
-        env:
-          RCT_USE_PREBUILT_RNCORE: 1
-          RCT_USE_RN_DEP: 1
-        working-directory: apps/bare-expo/ios
-      - name: 🏗️ Build iOS project (bare-expo)
-        run: ./scripts/start-ios-e2e-test.ts --build
-        working-directory: apps/bare-expo
+      - name: 🔎 Get the base commit
+        id: base-commit
+        run: |
+          # Since we limit this workflow only triggered from limited paths, we should use custom base commit
+          echo base-commit=$(git log -n 1 main --pretty=format:'%H' -- .github/workflows/test-suite.yml apps/bare-expo apps/test-suite packages yarn.lock) >> "$GITHUB_OUTPUT"
+      - name: 📹 Check fingerprint
+        id: fingerprint
+        uses: expo/actions/fingerprint@main
+        with:
+          working-directory: apps/bare-expo
+          previous-git-commit: ${{ steps.base-commit.outputs.base-commit }}
+          fingerprint-state-output-file: ${{ runner.temp }}/fingerprint-state.json
+      - name: 🏗️ Build/Repack iOS project (bare-expo)
+        uses: expo/actions/repack-app-artifact@main
         timeout-minutes: 55
         env:
           EXPO_DEBUG: 1
           NODE_ENV: production
-      - name: 📸 Upload builds
-        uses: actions/upload-artifact@v4
+          RCT_USE_PREBUILT_RNCORE: 1
+          RCT_USE_RN_DEP: 1
         with:
-          name: bare-expo-ios-builds
-          path: apps/bare-expo/ios/build/BareExpo.app
+          platform: ios
+          fingerprint-state-file: ${{ runner.temp }}/fingerprint-state.json
+          working-directory: apps/bare-expo
+          build-command: |
+            pushd ios
+            pod env
+            pod install
+            popd
+            ./scripts/start-ios-e2e-test.ts --build
+          build-output: apps/bare-expo/ios/build/BareExpo.app
+          artifact-name: bare-expo-ios-builds
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
         if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
@@ -170,6 +185,9 @@ jobs:
 
   android-build:
     runs-on: ubuntu-24.04
+    permissions:
+      # REQUIRED: Allow updating fingerprint in acton caches
+      actions: write
     env:
       ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
       GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx4096m -XX:MaxMetaspaceSize=4096m"
@@ -207,21 +225,32 @@ jobs:
       - name: ⚛️ Display React Native config
         run: yarn expo-modules-autolinking react-native-config --platform android
         working-directory: apps/bare-expo
-      - name: 🏗️ Gradle prebuild for Android project (workaround to fix build error)
-        run: ./gradlew preBuild
-        working-directory: apps/bare-expo/android
-      - name: 🏗️ Build Android project (bare-expo)
-        run: ./scripts/start-android-e2e-test.ts --build
-        working-directory: apps/bare-expo
+      - name: 🔎 Get the base commit
+        id: base-commit
+        run: |
+          # Since we limit this workflow only triggered from limited paths, we should use custom base commit
+          echo base-commit=$(git log -n 1 main --pretty=format:'%H' -- .github/workflows/test-suite.yml apps/bare-expo apps/test-suite packages yarn.lock) >> "$GITHUB_OUTPUT"
+      - name: 📹 Check fingerprint
+        id: fingerprint
+        uses: expo/actions/fingerprint@main
+        with:
+          working-directory: apps/bare-expo
+          previous-git-commit: ${{ steps.base-commit.outputs.base-commit }}
+          fingerprint-state-output-file: ${{ runner.temp }}/fingerprint-state.json
+      - name: 🏗️ Build/Repack Android project (bare-expo)
+        uses: expo/actions/repack-app-artifact@main
         timeout-minutes: 35
         env:
           EXPO_DEBUG: 1
           NODE_ENV: production
-      - name: 📸 Upload builds
-        uses: actions/upload-artifact@v4
         with:
-          name: bare-expo-android-builds
-          path: apps/bare-expo/android/app/build/outputs/apk
+          platform: android
+          fingerprint-state-file: ${{ runner.temp }}/fingerprint-state.json
+          working-directory: apps/bare-expo
+          build-command: |
+            ./scripts/start-android-e2e-test.ts --build
+          build-output: apps/bare-expo/android/app/build/outputs/apk
+          artifact-name: bare-expo-android-builds
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
         if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -37,7 +37,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: true
-          fetch-depth: 100
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -73,6 +72,11 @@ jobs:
       - name: ⚛️ Display React Native config
         run: yarn expo-modules-autolinking react-native-config --platform ios
         working-directory: apps/bare-expo
+      - name: 👀 Checkout main branch
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 100
       - name: 🔎 Get the base commit
         id: base-commit
         run: |
@@ -197,7 +201,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: true
-          fetch-depth: 100
       - name: 🧹 Cleanup GitHub Linux runner disk space
         uses: ./.github/actions/cleanup-linux-disk-space
       - name: 🏗️ Setup Bun
@@ -227,6 +230,11 @@ jobs:
       - name: ⚛️ Display React Native config
         run: yarn expo-modules-autolinking react-native-config --platform android
         working-directory: apps/bare-expo
+      - name: 👀 Checkout main branch
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 100
       - name: 🔎 Get the base commit
         id: base-commit
         run: |

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -72,11 +72,9 @@ jobs:
       - name: ⚛️ Display React Native config
         run: yarn expo-modules-autolinking react-native-config --platform ios
         working-directory: apps/bare-expo
-      - name: 👀 Checkout main branch
-        uses: actions/checkout@v5
-        with:
-          ref: main
-          fetch-depth: 100
+      - name: ⬇️ Fetch commits from base branch
+        run: git fetch origin main:main --depth 100
+        if: github.event_name == 'pull_request'
       - name: 🔎 Get the base commit
         id: base-commit
         run: |
@@ -230,11 +228,9 @@ jobs:
       - name: ⚛️ Display React Native config
         run: yarn expo-modules-autolinking react-native-config --platform android
         working-directory: apps/bare-expo
-      - name: 👀 Checkout main branch
-        uses: actions/checkout@v5
-        with:
-          ref: main
-          fetch-depth: 100
+      - name: ⬇️ Fetch commits from base branch
+        run: git fetch origin main:main --depth 100
+        if: github.event_name == 'pull_request'
       - name: 🔎 Get the base commit
         id: base-commit
         run: |

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: true
+          fetch-depth: 100
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -196,6 +197,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: true
+          fetch-depth: 100
       - name: 🧹 Cleanup GitHub Linux runner disk space
         uses: ./.github/actions/cleanup-linux-disk-space
       - name: 🏗️ Setup Bun

--- a/apps/bare-expo/scripts/start-android-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-android-e2e-test.ts
@@ -66,7 +66,7 @@ const __dirname = dirname(__filename);
 
 async function buildAsync(projectRoot: string): Promise<void> {
   console.log('\n💿 Building App');
-  await spawnAsync('./gradlew', ['--build-cache', 'assembleRelease'], {
+  await spawnAsync('./gradlew', ['--build-cache', ':app:assembleRelease'], {
     stdio: 'inherit',
     cwd: path.join(projectRoot, 'android'),
   });


### PR DESCRIPTION
# Why

dogfood and test the repack github action

# How

- migrate expo-github-actions to actions
- use fingerprint + repack-app-artifact to do build/repack
- a tricky part for the pr is that to keep the `fingerprint-db` write safely to the main branch. we have to limit single job (concurrent group as `fingerprint-main`) when pushing to main.

# Test Plan

- this pr can only check build and artifact upload
- repack flow can only be tested after merge and then create a new fingerprint compatible pr
# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
