### PR TITLE
[docs] Update ExpoAppAwardsBanner to animate in

### DIFF
--- a/docs/ui/components/ExpoAppAwardsBanner.tsx
+++ b/docs/ui/components/ExpoAppAwardsBanner.tsx
@@ -11,9 +11,13 @@ export function ExpoAppAwardsBanner() {
   });
 
   const [isLoaded, setIsLoaded] = useState(false);
+  const [isAnimated, setIsAnimated] = useState(false);
 
   useEffect(function didMount() {
     setIsLoaded(true);
+    requestAnimationFrame(() => {
+      setIsAnimated(true);
+    });
   }, []);
 
   if (lastDismissDate || !isLoaded) {
@@ -21,27 +25,32 @@ export function ExpoAppAwardsBanner() {
   }
 
   return (
-    <div className="mb-6 flex h-[52px] w-full items-center justify-between gap-3 rounded-lg bg-[linear-gradient(88deg,#978365_0.18%,#18191B_15.14%)] px-3">
-      <Link href="https://expo.dev/awards" openInNewTab className="ml-1 flex items-center gap-3">
-        {logo}
-        <p className="font-medium text-palette-white max-md-gutters:hidden">
-          Celebrating the best apps built with Expo
-        </p>
-      </Link>
-      <div className="flex items-center gap-1">
-        <Link
-          href="https://expo.dev/awards"
-          openInNewTab
-          className="rounded-full bg-palette-white px-4 py-1 text-3xs font-semibold text-palette-black max-sm-gutters:hidden">
-          Submit your app
+    <div
+      className={`backface-hidden h-[52px] w-full transform-gpu overflow-hidden rounded-lg bg-[linear-gradient(88deg,#978365_0.18%,#18191B_15.14%)] transition-all duration-500 ease-in-out ${
+        isAnimated ? 'mb-6 max-h-[52px] opacity-100' : 'mb-0 max-h-0 opacity-0'
+      }`}>
+      <div className="flex min-h-0 items-center justify-between gap-3 p-3">
+        <Link href="https://expo.dev/awards" openInNewTab className="ml-1 flex items-center gap-3">
+          {logo}
+          <p className="font-medium text-palette-white max-md-gutters:hidden">
+            Celebrating the best apps built with Expo
+          </p>
         </Link>
-        <button
-          className="rounded-full p-1"
-          onClick={() => {
-            setLastDismissDate(new Date().toDateString());
-          }}>
-          <XIcon className="text-palette-gray10" />
-        </button>
+        <div className="flex items-center gap-1">
+          <Link
+            href="https://expo.dev/awards"
+            openInNewTab
+            className="rounded-full bg-palette-white px-4 py-1 text-3xs font-semibold text-palette-black max-sm-gutters:hidden">
+            Submit your app
+          </Link>
+          <button
+            className="rounded-full p-1"
+            onClick={() => {
+              setLastDismissDate(new Date().toDateString());
+            }}>
+            <XIcon className="text-palette-gray10" />
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/docs/ui/components/ExpoAppAwardsBanner.tsx
+++ b/docs/ui/components/ExpoAppAwardsBanner.tsx
@@ -15,9 +15,14 @@ export function ExpoAppAwardsBanner() {
 
   useEffect(function didMount() {
     setIsLoaded(true);
-    requestAnimationFrame(() => {
+    // we need to wait for the next frame to ensure the banner is rendered to the DOM
+    const raf = requestAnimationFrame(() => {
       setIsAnimated(true);
     });
+
+    return function cleanup() {
+      cancelAnimationFrame(raf);
+    };
   }, []);
 
   if (lastDismissDate || !isLoaded) {


### PR DESCRIPTION
# Why

The Expo App Awards banner (and all of our dismissible banners in general), cause a weird flicker when they mount and it doesn’t look good. We should use animation to address this. It will make the banners more noticeable and more appealing.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

First I tried using Framer, but it didn’t do a great job animating height and opacity, so I switched to pure CSS animations with an additional state update to achieve the effect.

While animating margin and height properties is usually not the most ideal thing to do, it does look much better in this case, and doesn't impact performance. We should think about making banners float in the future so it doesn't cause vertical layout shifts.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Test Chrome, Safari, Mobile Safari and Firefox. Was working correctly in all browsers.

https://github.com/user-attachments/assets/d94c754c-c0bf-4734-9c1c-5841ab591ffb



<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
