### PR TITLE
[expo/core][android] Fix `androidNavigationBar.enforceContrast` app config property not working

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix SharedObject created with `useReleasingSharedObject` getting destroyed after a fast refresh caused by a change in its dependencies. ([#39753](https://github.com/expo/expo/pull/39753) by [@behenate](https://github.com/behenate))
 - [Android] Restore `register` overload in `ModuleRegistry`. ([#40149](https://github.com/expo/expo/pull/40149) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Add `invalidate` callback to SwiftUIVirtualView. ([#40237](https://github.com/expo/expo/pull/40237) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
+- [Android] Fix `androidNavigationBar.enforceContrast` app config property not working. ([#40263](https://github.com/expo/expo/pull/40263) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/edgeToEdge/EdgeToEdgePackage.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/edgeToEdge/EdgeToEdgePackage.kt
@@ -1,0 +1,69 @@
+package expo.modules.kotlin.edgeToEdge
+
+import android.R
+import android.app.Activity
+import android.content.Context
+import android.content.res.TypedArray
+import android.os.Build
+import android.os.Bundle
+import android.util.Log
+import android.view.Window
+import androidx.annotation.RequiresApi
+import expo.modules.core.BasePackage
+import expo.modules.core.interfaces.ReactActivityLifecycleListener
+import kotlin.Unit
+
+class EdgeToEdgePackage: BasePackage() {
+  override fun createReactActivityLifecycleListeners(activityContext: Context?): List<ReactActivityLifecycleListener?>? {
+    return listOf(object : ReactActivityLifecycleListener {
+      override fun onCreate(activity: Activity?, savedInstanceState: Bundle?) {
+        val edgeToEdgeEnabled = invokeWindowUtilKtMethod<Boolean>("isEdgeToEdgeFeatureFlagOn") ?: true
+
+        if (edgeToEdgeEnabled) {
+          invokeWindowUtilKtMethod<Unit>("enableEdgeToEdge", Pair(Window::class.java, activity?.window))
+
+          // React-native sets `window.isNavigationBarContrastEnforced` to `true` in `WindowUtilKt.enableEdgeToEdge`.
+          // We have to set it back to the value defined in the app styles, which comes from our config plugin.
+          activity?.enforceNavigationBarContrastFromTheme()
+        }
+      }
+    })
+  }
+}
+
+@RequiresApi(Build.VERSION_CODES.Q)
+private fun Activity.getEnforceContrastFromTheme(): Boolean {
+  val attrs = intArrayOf(R.attr.enforceNavigationBarContrast)
+  val typedArray: TypedArray = theme.obtainStyledAttributes(attrs)
+
+  return try {
+    typedArray.getBoolean(0, true)
+  } finally {
+    typedArray.recycle()
+  }
+}
+
+private fun Activity.enforceNavigationBarContrastFromTheme() {
+  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+    window.isNavigationBarContrastEnforced = getEnforceContrastFromTheme()
+  }
+}
+
+private inline fun <reified T> invokeWindowUtilKtMethod(
+  methodName: String,
+  vararg args: Pair<Class<*>, Any?>
+): T? {
+  val windowUtilClassName = "com.facebook.react.views.view.WindowUtilKt"
+
+  return runCatching {
+    val windowUtilKtClass = Class.forName(windowUtilClassName)
+    val parameterTypes = args.map { it.first }.toTypedArray()
+    val parameterValues = args.map { it.second }.toTypedArray()
+    val method = windowUtilKtClass.getDeclaredMethod(methodName, *parameterTypes)
+
+    method.isAccessible = true
+    method.invoke(null, *parameterValues) as? T
+  }.onFailure {
+    Log.e("EdgeToEdgePackage", "Failed to invoke '$methodName' on $windowUtilClassName", it)
+  }.getOrNull()
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/edgeToEdge/EdgeToEdgePackage.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/edgeToEdge/EdgeToEdgePackage.kt
@@ -13,7 +13,7 @@ import expo.modules.core.BasePackage
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
 import kotlin.Unit
 
-class EdgeToEdgePackage: BasePackage() {
+class EdgeToEdgePackage : BasePackage() {
   override fun createReactActivityLifecycleListeners(activityContext: Context?): List<ReactActivityLifecycleListener?>? {
     return listOf(object : ReactActivityLifecycleListener {
       override fun onCreate(activity: Activity?, savedInstanceState: Bundle?) {

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### 💡 Others
 
 - [android] Add getDefaultReactHost to ExpoReactHostFactory ([#40086](https://github.com/expo/expo/pull/40086) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [Android] Remove edge-to-edge logic from `ReactActivityDelegateWrapper`. ([#40263](https://github.com/expo/expo/pull/40263) by [@behenate](https://github.com/behenate))
 
 ### ⚠️ Notices
 

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -12,7 +12,6 @@ import android.os.Bundle
 import android.util.Log
 import android.view.KeyEvent
 import android.view.ViewGroup
-import android.view.Window
 import androidx.annotation.VisibleForTesting
 import androidx.collection.ArrayMap
 import androidx.lifecycle.lifecycleScope
@@ -146,11 +145,6 @@ class ReactActivityDelegateWrapper(
 
         if (VERSION.SDK_INT >= Build.VERSION_CODES.O && isWideColorGamutEnabled) {
           activity.window.colorMode = ActivityInfo.COLOR_MODE_WIDE_COLOR_GAMUT
-        }
-
-        val edgeToEdgeEnabled = invokeWindowUtilKtMethod<Boolean>("isEdgeToEdgeFeatureFlagOn") ?: true
-        if (edgeToEdgeEnabled) {
-          invokeWindowUtilKtMethod<Unit>("enableEdgeToEdge", Pair(Window::class.java, plainActivity.window))
         }
 
         val launchOptions = composeLaunchOptions()
@@ -422,25 +416,6 @@ class ReactActivityDelegateWrapper(
       methodMap[name] = method
     }
     return method!!.invoke(delegate, *args) as T
-  }
-
-  private inline fun <reified T> invokeWindowUtilKtMethod(
-    methodName: String,
-    vararg args: Pair<Class<*>, Any?>
-  ): T? {
-    val windowUtilClassName = "com.facebook.react.views.view.WindowUtilKt"
-
-    return runCatching {
-      val windowUtilKtClass = Class.forName(windowUtilClassName)
-      val parameterTypes = args.map { it.first }.toTypedArray()
-      val parameterValues = args.map { it.second }.toTypedArray()
-      val method = windowUtilKtClass.getDeclaredMethod(methodName, *parameterTypes)
-
-      method.isAccessible = true
-      method.invoke(null, *parameterValues) as? T
-    }.onFailure {
-      Log.e(TAG, "Failed to invoke '$methodName' on $windowUtilClassName", it)
-    }.getOrNull()
   }
 
   private suspend fun loadAppImpl(appKey: String?, supportsDelayLoad: Boolean) {


### PR DESCRIPTION
# Why

> I was investigating the react-conf app, and discovered that our enforceContrast property, which is based only on editing styles.xml is not working.
I’ve traced back the issue to these lines in react-native
[https://github.com/facebook/react-native/blame/50273758510a6d756494d05dc91055516c2[…]droid/src/main/java/com/facebook/react/views/view/WindowUtil.kt](https://github.com/facebook/react-native/blame/50273758510a6d756494d05dc91055516c2a6aca/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/WindowUtil.kt#L111-L114)
Setting isNavigationBarContrastEnforced = true overrides all settings from the theme.

# How

Moved all edge-to-edge logic into the `EdgeToEdge` package in `expo-modules-core`, I felt like it's not worth cluttering  the ReactActivityDelegateWrapper with it.
After we apply the edge to edge method, we call `activity?.enforceNavigationBarContrastFromTheme()` to restore `isNavigationBarContrastEnforced` to the value set in styles (this value comes from our config plugin)

# Test Plan

Tested in Android 11.0 and 16.0 in both bare-expo and a fresh test app.
