### PR TITLE
[video][ios] Fix crashes when loading HLS video tracks

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix `FOREGROUND_SERVICE_MEDIA_PLAYBACK` being always present in the manifest. ([#40074](https://github.com/expo/expo/pull/40074) by [@behenate](https://github.com/behenate))
+- [iOS] Fix crashes when rapidly replacing HLS sources. ([#40265](https://github.com/expo/expo/pull/40265) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -268,9 +268,10 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   }
 
   private func clearCurrentItem() {
-    DispatchQueue.main.async { [ref, videoSourceLoader, dangerousPropertiesStore] in
+    videoSourceLoader.cancelCurrentTask()
+
+    DispatchQueue.main.async { [ref, dangerousPropertiesStore] in
       ref.replaceCurrentItem(with: nil)
-      videoSourceLoader.cancelCurrentTask()
       dangerousPropertiesStore.reset()
       dangerousPropertiesStore.ownerIsReplacing = false
     }

--- a/packages/expo-video/ios/VideoPlayerItem.swift
+++ b/packages/expo-video/ios/VideoPlayerItem.swift
@@ -49,6 +49,10 @@ class VideoPlayerItem: AVPlayerItem {
     self.createTracksLoadingTask()
   }
 
+  deinit {
+    tracksLoadingTask?.cancel()
+  }
+
   func createTracksLoadingTask() {
     tracksLoadingTask = Task { [weak self] in
       var tracks: [VideoTrack] = []


### PR DESCRIPTION
# Why

When rapidly replacing video sources and releasing the players, sometimes the tracks loading task will outlive the VideoPlayerItem and/or the VideoPlayer, causing crashes upon conversion when sending an event. This happens only for HLS sources - we use a custom track loading solution for HLS.

Here is a loop that would cause a crash within ~5-10 seconds.

```
setInterval(() => {
  playerRef.current.release();
  playerRef.current = createVideoPlayer(null);
  playerRef.current.replaceAsync(hlsSource);
}, 500);
```

# How

Cancel the loading task on deinit and when a new source begins loading.

# Test Plan

Tested in bare expo on iOS simulator. Ran the loop above for about 10 minutes and didn't experience any crashes.
