### PR TITLE
[core][Android] Move module registry from `RuntimeContext` to `AppContext`

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
@@ -86,19 +86,18 @@ internal inline fun withJSIInterop(
   repeat(numberOfReloads) {
     val coreModule = run {
       val module = CoreModule()
-      module._runtimeContext = runtimeContext
+      module._appContextHolder = appContextMock.weak()
       ModuleHolder(module, "CoreModule")
     }
     every { runtimeContext.coreModule } answers { coreModule }
 
-    val registry = ModuleRegistry(appContextMock.hostingRuntimeContext.weak()).apply {
+    val registry = ModuleRegistry(appContextMock.weak()).apply {
       modules.forEach {
         register(it, null)
       }
     }
     val sharedObjectRegistry = SharedObjectRegistry(appContextMock.hostingRuntimeContext)
     every { appContextMock.registry } answers { registry }
-    every { runtimeContext.registry } answers { registry }
     every { runtimeContext.sharedObjectRegistry } answers { sharedObjectRegistry }
 
     // We aim to closely replicate the lifecycle of each part as it functions in the real app.

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -92,8 +92,7 @@ class AppContext(
       CoroutineName("expo.modules.MainQueue")
   )
 
-  val registry
-    get() = hostingRuntimeContext.registry
+  val registry = ModuleRegistry(this.weak())
 
   internal var legacyModulesProxyHolder: WeakReference<NativeModulesProxy>? = null
 
@@ -124,7 +123,7 @@ class AppContext(
   }
 
   fun onCreate() = trace("AppContext.onCreate") {
-    hostingRuntimeContext.registry.postOnCreate()
+    registry.postOnCreate()
   }
 
   /**
@@ -234,7 +233,7 @@ class AppContext(
     val legacyEventEmitter = legacyModule<expo.modules.core.interfaces.services.EventEmitter>()
       ?: return null
     return KModuleEventEmitterWrapper(
-      requireNotNull(hostingRuntimeContext.registry.getModuleHolder(module)) {
+      requireNotNull(registry.getModuleHolder(module)) {
         "Cannot create an event emitter for the module that isn't present in the module registry."
       },
       legacyEventEmitter,
@@ -251,17 +250,17 @@ class AppContext(
 
   @Deprecated("Use AppContext.jsLogger instead")
   val errorManager: ErrorManagerModule? by lazy {
-    hostingRuntimeContext.registry.getModule()
+    registry.getModule()
   }
 
   val jsLogger by lazy {
-    hostingRuntimeContext.registry.getModule<JSLoggerModule>()?.logger
+    registry.getModule<JSLoggerModule>()?.logger
   }
 
   internal fun onDestroy() = trace("AppContext.onDestroy") {
     hostingRuntimeContext.reactContext?.removeLifecycleEventListener(reactLifecycleDelegate)
-    hostingRuntimeContext.registry.post(EventName.MODULE_DESTROY)
-    hostingRuntimeContext.registry.cleanUp()
+    registry.post(EventName.MODULE_DESTROY)
+    registry.cleanUp()
     modulesQueue.cancel(ContextDestroyedException())
     mainQueue.cancel(ContextDestroyedException())
     backgroundCoroutineScope.cancel(ContextDestroyedException())
@@ -280,19 +279,19 @@ class AppContext(
     // We need to re-register activity contracts when reusing AppContext with new Activity after host destruction.
     if (hostWasDestroyed) {
       hostWasDestroyed = false
-      hostingRuntimeContext.registry.registerActivityContracts()
+      registry.registerActivityContracts()
     }
 
     activityResultsManager.onHostResume(activity)
-    hostingRuntimeContext.registry.post(EventName.ACTIVITY_ENTERS_FOREGROUND)
+    registry.post(EventName.ACTIVITY_ENTERS_FOREGROUND)
   }
 
   internal fun onHostPause() {
-    hostingRuntimeContext.registry.post(EventName.ACTIVITY_ENTERS_BACKGROUND)
+    registry.post(EventName.ACTIVITY_ENTERS_BACKGROUND)
   }
 
   internal fun onUserLeaveHint() {
-    hostingRuntimeContext.registry.post(EventName.ON_USER_LEAVES_ACTIVITY)
+    registry.post(EventName.ON_USER_LEAVES_ACTIVITY)
   }
 
   internal fun onHostDestroy() {
@@ -303,7 +302,7 @@ class AppContext(
 
       activityResultsManager.onHostDestroy(it)
     }
-    hostingRuntimeContext.registry.post(EventName.ACTIVITY_DESTROYS)
+    registry.post(EventName.ACTIVITY_DESTROYS)
     // The host (Activity) was destroyed, but it doesn't mean that modules will be destroyed too.
     // So we save that information, and we will re-register activity contracts when the host will be resumed with new Activity.
     hostWasDestroyed = true
@@ -311,7 +310,7 @@ class AppContext(
 
   internal fun onActivityResult(activity: Activity, requestCode: Int, resultCode: Int, data: Intent?) {
     activityResultsManager.onActivityResult(requestCode, resultCode, data)
-    hostingRuntimeContext.registry.post(
+    registry.post(
       EventName.ON_ACTIVITY_RESULT,
       activity,
       OnActivityResultPayload(
@@ -323,7 +322,7 @@ class AppContext(
   }
 
   internal fun onNewIntent(intent: Intent?) {
-    hostingRuntimeContext.registry.post(
+    registry.post(
       EventName.ON_NEW_INTENT,
       intent
     )

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
@@ -23,7 +23,7 @@ class KotlinInteropModuleRegistry(
   val appContext = AppContext(modulesProvider, legacyModuleRegistry, reactContext)
 
   private val registry: ModuleRegistry
-    get() = appContext.hostingRuntimeContext.registry
+    get() = appContext.registry
 
   fun hasModule(name: String): Boolean = registry.hasModule(name)
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.SupervisorJob
 import java.lang.ref.WeakReference
 
 class ModuleRegistry(
-  private val runtimeContext: WeakReference<RuntimeContext>
+  private val appContextHolder: WeakReference<AppContext>
 ) : Iterable<ModuleHolder<*>> {
   @PublishedApi
   internal val registry = mutableMapOf<String, ModuleHolder<*>>()
@@ -22,7 +22,9 @@ class ModuleRegistry(
   private var isReadyForPostingEvents = false
 
   fun <T : Module> register(module: T, name: String?) = trace("ModuleRegistry.register(${module.javaClass})") {
-    module._runtimeContext = requireNotNull(runtimeContext.get()) { "Cannot create a module for invalid runtime context." }
+    requireNotNull(appContextHolder.get()) { "Cannot register a module to an invalid app context." }
+
+    module._appContextHolder = appContextHolder
 
     val holder = ModuleHolder(module, name)
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/RuntimeContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/RuntimeContext.kt
@@ -28,8 +28,6 @@ class RuntimeContext(
   inline val reactContext: ReactApplicationContext?
     get() = reactContextHolder.get()
 
-  val registry = ModuleRegistry(this.weak())
-
   internal lateinit var jsiContext: JSIContext
 
   private fun isJSIContextInitialized(): Boolean {
@@ -50,7 +48,7 @@ class RuntimeContext(
    */
   internal val coreModule = run {
     val module = CoreModule()
-    module._runtimeContext = this
+    module._appContextHolder = appContextHolder
     ModuleHolder(module, null)
   }
 
@@ -105,7 +103,6 @@ class RuntimeContext(
   }
 
   fun deallocate() {
-    coreModule.module._runtimeContext = null
     jniDeallocator.deallocate()
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/CoreModule.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/CoreModule.kt
@@ -57,7 +57,7 @@ class CoreModule : Module() {
     }
 
     Function("getViewConfig") { moduleName: String, viewName: String? ->
-      val holder = runtimeContext.registry.getModuleHolder(moduleName)
+      val holder = appContext.registry.getModuleHolder(moduleName)
         ?: return@Function null
 
       val viewManagerDefinition = holder

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
@@ -113,13 +113,13 @@ class JSIContext : Destructible, AutoCloseable {
   @Suppress("unused")
   @DoNotStrip
   fun getJavaScriptModuleObject(name: String): JavaScriptModuleObject? {
-    return runtimeContextHolder.get()?.registry?.getModuleHolder(name)?.jsObject
+    return runtimeContextHolder.get()?.appContext?.registry?.getModuleHolder(name)?.jsObject
   }
 
   @Suppress("unused")
   @DoNotStrip
   fun hasModule(name: String): Boolean {
-    return runtimeContextHolder.get()?.registry?.hasModule(name) ?: false
+    return runtimeContextHolder.get()?.appContext?.registry?.hasModule(name) ?: false
   }
 
   /**
@@ -128,7 +128,7 @@ class JSIContext : Destructible, AutoCloseable {
   @Suppress("unused")
   @DoNotStrip
   fun getJavaScriptModulesName(): Array<String> {
-    return runtimeContextHolder.get()?.registry?.registry?.keys?.toTypedArray() ?: emptyArray()
+    return runtimeContextHolder.get()?.appContext?.registry?.registry?.keys?.toTypedArray() ?: emptyArray()
   }
 
   @Suppress("unused")

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEvent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEvent.kt
@@ -26,11 +26,11 @@ open class ViewEvent<T>(
     val appContext = nativeModulesProxy.kotlinInteropModuleRegistry.appContext
 
     if (!isValidated) {
-      val holder = appContext.hostingRuntimeContext.registry.getModuleHolder(view::class.java).ifNull {
+      val holder = appContext.registry.getModuleHolder(view::class.java).ifNull {
         logger.warn("⚠️ Cannot get module holder for ${view::class.java}")
         return
       }
-      val callbacks = appContext.hostingRuntimeContext.registry.getViewDefinition(holder, view::class.java)?.callbacksDefinition.ifNull {
+      val callbacks = appContext.registry.getViewDefinition(holder, view::class.java)?.callbacksDefinition.ifNull {
         logger.warn("⚠️ Cannot get callbacks for ${holder.module::class.java}")
         return
       }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
@@ -64,7 +64,7 @@ class ViewManagerWrapperDelegate(internal var moduleHolder: ModuleHolder<*>, int
       val key = iterator.nextKey()
       expoProps[key]?.let { expoProp ->
         try {
-          expoProp.set(propsMap.getDynamic(key), view, moduleHolder.module._runtimeContext?.appContext)
+          expoProp.set(propsMap.getDynamic(key), view, moduleHolder.module.appContext)
         } catch (exception: Throwable) {
           // The view wasn't constructed correctly, so errors are expected.
           // We can ignore them.


### PR DESCRIPTION
# Why

My initial idea was to export a different set of modules. However, I currently don't think that's the path we want to take. It would be better if the module could export a different version of its functions that are runtime/thread-aware. We don't need to duplicate module instances; we only need to change the bindings.

# How

Moved registry from `RuntimeContext` to `AppContext`.

# Test Plan

- bare-expo ✅ 
- unit test ✅ 