### PR TITLE
[template-tabs] Fix useColorScheme to reflect actual color scheme on web

### DIFF
--- a/templates/expo-template-tabs/components/useColorScheme.web.ts
+++ b/templates/expo-template-tabs/components/useColorScheme.web.ts
@@ -1,8 +1,11 @@
-// NOTE: The default React Native styling doesn't support server rendering.
-// Server rendered styles should not change between the first render of the HTML
-// and the first render on the client. Typically, web developers will use CSS media queries
-// to render different styles on the client and server, these aren't directly supported in React Native
-// but can be achieved using a styling library like Nativewind.
+import { useColorScheme as useRNColorScheme } from 'react-native';
+
+import { useClientOnlyValue } from './useClientOnlyValue';
+
+/**
+ * To support static rendering, this value needs to be re-calculated on the client side for web
+ */
 export function useColorScheme() {
-  return 'light';
+  const colorScheme = useRNColorScheme();
+  return useClientOnlyValue('light', colorScheme);
 }


### PR DESCRIPTION
# Why

This applies the same fix from #33071 to `expo-template-tabs`. Currently, the tabs template always returns `'light'` for the color scheme on web. But it should align with the default template, which properly sync with system's color scheme.

# How

Updated `useColorScheme.web.ts` to use the existing `useClientOnlyValue` helper, which properly handles hydration by returning `'light'` during static generation/initial render and then switching to the actual color scheme after hydration on the client side.

This leverages the `useClientOnlyValue` helper that already exists in the tabs template for this exact purpose.

# Test Plan

Static export test:
```bash
npx create-expo-app test-app --template tabs
cd test-app
npx expo export -p web
npx serve dist
```
- Open in a browser with dark mode enabled
- Verify color scheme correctly reflects dark mode after page load
- Check browser console for no hydration warnings

Dev server test:
```bash
npx expo start --web
```
- Verify color scheme works correctly in dev mode as well

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).