### PR TITLE
[docs] Add info on default iOS 26 Liquid Glass headers behavior in Stack guide

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -283,3 +283,5 @@ exceptions:
   - Use Stacks
   - 'Mode 1: Auto-with-overrides mode'
   - 'Mode 2: Payload mode'
+  - 'Method 1: Use'
+  - 'Method 2: Use'

--- a/docs/pages/router/advanced/stack.mdx
+++ b/docs/pages/router/advanced/stack.mdx
@@ -490,11 +490,11 @@ For more information on available options, see [`@react-navigation/stack` docume
 
 ## iOS 26 Liquid Glass headers
 
-Starting from iOS 26, navigation headers adopt the system's "Liquid Glass" effect by default. This appearance also applies to headers. It cannot be disabled per screen, so you need to opt out using a global configuration.
+Starting from iOS 26, navigation headers adopt the system's "Liquid Glass" effect by default. It cannot be disabled per screen, so you need to opt out using a global configuration.
 
 ### Method 1: Use `UIDesignRequiresCompatibility`
 
-> **Note**: This method is a temporary workaround. From iOS 27, this option will be removed by Apple and you cannot opt out of the Liquid Glass effect.
+> **Note**: Not supported in Expo Go.This method is a temporary workaround. From iOS 27, this option will be removed by Apple and you cannot opt out of the Liquid Glass effect.
 
 Create a [development build](/develop/development-builds/create-a-build/#prerequisites) and set the [`UIDesignRequiresCompatibility`](https://developer.apple.com/documentation/BundleResources/Information-Property-List/UIDesignRequiresCompatibility) property to `true` in [app config](/workflow/configuration/):
 
@@ -509,8 +509,6 @@ Create a [development build](/develop/development-builds/create-a-build/#prerequ
 ```
 
 ### Method 2: Use JavaScript-based navigation stack
-
-> **Note**: This method can be used with Expo Go.
 
 Switch from native navigation library ([`@react-navigation/native`](https://reactnavigation.org/docs/native-stack-navigator/)) to a JavaScript-based stack navigator library such as [`@react-navigation/stack`](https://reactnavigation.org/docs/stack-navigator/), which gives you full control over the header UI but at the cost of performance benefits of using the highly optimized iOS navigation views/controllers.
 

--- a/docs/pages/router/advanced/stack.mdx
+++ b/docs/pages/router/advanced/stack.mdx
@@ -487,3 +487,31 @@ export default function Layout() {
 ```
 
 For more information on available options, see [`@react-navigation/stack` documentation](https://reactnavigation.org/docs/stack-navigator).
+
+## iOS 26 Liquid Glass headers
+
+Starting from iOS 26, navigation headers adopt the system's "Liquid Glass" effect by default. This appearance also applies to headers. It cannot be disabled per screen, so you need to opt out using a global configuration.
+
+### Method 1: Use `UIDesignRequiresCompatibility`
+
+> **Note**: This method is a temporary workaround. From iOS 27, this option will be removed by Apple and you cannot opt out of the Liquid Glass effect.
+
+Create a [development build](/develop/development-builds/create-a-build/#prerequisites) and set the [`UIDesignRequiresCompatibility`](https://developer.apple.com/documentation/BundleResources/Information-Property-List/UIDesignRequiresCompatibility) property to `true` in [app config](/workflow/configuration/):
+
+```json app.json
+{
+  "ios": {
+    "infoPlist": {
+      "UIDesignRequiresCompatibility": true
+    }
+  }
+}
+```
+
+### Method 2: Use JavaScript-based navigation stack
+
+> **Note**: This method can be used with Expo Go.
+
+Switch from native navigation library ([`@react-navigation/native`](https://reactnavigation.org/docs/native-stack-navigator/)) to a JavaScript-based stack navigator library such as [`@react-navigation/stack`](https://reactnavigation.org/docs/stack-navigator/), which gives you full control over the header UI but at the cost of performance benefits of using the highly optimized iOS navigation views/controllers.
+
+For more information, see [JavaScript stack with `@react-navigation/stack`](#javascript-stack-with-react-navigationstack).


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-17380

# How

<!--
How did you build this feature or fix this bug and why?
-->

-  Add a section on default iOS 26 Liquid Glass headers behavior in Stack guide and different methods to disable it.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally and visit: http://localhost:3002/router/advanced/stack/#ios-26-liquid-glass-headers

## Preview

<img width="2192" height="1624" alt="CleanShot 2025-10-08 at 23 12 58@2x" src="https://github.com/user-attachments/assets/f3d5a65e-ac75-433a-aef6-f78312195c1e" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
