### PR TITLE
[expo-audio][ios] fixed issue with configured buttons not showing up correctly

### DIFF
--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -530,8 +530,12 @@ public class AudioModule: Module {
       }
 
 #if !os(tvOS)
-      if category == .playAndRecord || category == .playback {
+      if category == .playAndRecord {
+#if compiler(>=6.0)
+        categoryOptions.insert(.allowBluetoothHFP)
+#else
         categoryOptions.insert(.allowBluetooth)
+#endif
       }
 #endif
 

--- a/packages/expo-audio/ios/MediaController.swift
+++ b/packages/expo-audio/ios/MediaController.swift
@@ -11,11 +11,7 @@ class MediaController {
 
   private var currentArtworkUrl: URL?
   private var cachedArtwork: MPMediaItemArtwork?
-
-  private init() {
-    setupRemoteCommands()
-  }
-
+  
   func setActivePlayer(_ player: AudioPlayer?, options: LockScreenOptions? = nil) {
     if let previous = activePlayer, previous.id != player?.id {
       previous.isActiveForLockScreen = false
@@ -24,12 +20,14 @@ class MediaController {
     activePlayer = player
     player?.isActiveForLockScreen = true
 
-    if let player {
-      enableRemoteCommands(options: options)
-      updateNowPlayingInfo(for: player)
-    } else {
-      disableRemoteCommands()
-      clearNowPlayingInfo()
+    DispatchQueue.main.async {
+      if let player {
+        self.enableRemoteCommands(options: options)
+        self.updateNowPlayingInfo(for: player)
+      } else {
+        self.disableRemoteCommands()
+        self.clearNowPlayingInfo()
+      }
     }
   }
 
@@ -112,6 +110,13 @@ class MediaController {
   }
 
   private func setupRemoteCommands() {
+    remoteCommandCenter.playCommand.removeTarget(self);
+    remoteCommandCenter.pauseCommand.removeTarget(self);
+    remoteCommandCenter.togglePlayPauseCommand.removeTarget(self);
+    remoteCommandCenter.changePlaybackPositionCommand.removeTarget(self);
+    remoteCommandCenter.skipForwardCommand.removeTarget(self);
+    remoteCommandCenter.skipBackwardCommand.removeTarget(self);
+    
     remoteCommandCenter.playCommand.addTarget { [weak self] _ in
       guard let player = self?.activePlayer else {
         return .commandFailed
@@ -205,6 +210,8 @@ class MediaController {
   }
 
   private func enableRemoteCommands(options: LockScreenOptions?) {
+    setupRemoteCommands()
+    
     remoteCommandCenter.playCommand.isEnabled = true
     remoteCommandCenter.pauseCommand.isEnabled = true
     remoteCommandCenter.togglePlayPauseCommand.isEnabled = true


### PR DESCRIPTION
# Why

On the lock screen on iOS the lock screen buttons wasn't showing up correctly the first time you enabled it in an audio session, but next time they started working.

This commit fixes this.

# How

The issue was that we tried initializing the remote command center before the app was made the active now-playing app since the setupRemoteCommands() method was called in the ctor/init of the MediaController and not when setting the player as the active player.

Fixes:
- Added initialization of the remote command center after we've activated and set up the player.
- Removed the init method from the MediaController class
- Been a bit more explicit about cleaning up targets and disabling unwanted commands.
- Added a fix to the category options that supports Xcode 26

# Test Plan

✅ BareExpo

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
