### PR TITLE
[5/n] Upgrade React Native to 0.82.x 

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -632,10 +632,10 @@ PODS:
     - Yoga
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
-  - FBLazyVector (0.82.0-rc.5)
-  - hermes-engine (0.82.0-rc.5):
-    - hermes-engine/Pre-built (= 0.82.0-rc.5)
-  - hermes-engine/Pre-built (0.82.0-rc.5)
+  - FBLazyVector (0.82.0)
+  - hermes-engine (0.82.0):
+    - hermes-engine/Pre-built (= 0.82.0)
+  - hermes-engine/Pre-built (0.82.0)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -692,32 +692,32 @@ PODS:
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (9.1.0)
   - Quick (7.3.1)
-  - RCTDeprecation (0.82.0-rc.5)
-  - RCTRequired (0.82.0-rc.5)
-  - RCTTypeSafety (0.82.0-rc.5):
-    - FBLazyVector (= 0.82.0-rc.5)
-    - RCTRequired (= 0.82.0-rc.5)
-    - React-Core (= 0.82.0-rc.5)
+  - RCTDeprecation (0.82.0)
+  - RCTRequired (0.82.0)
+  - RCTTypeSafety (0.82.0):
+    - FBLazyVector (= 0.82.0)
+    - RCTRequired (= 0.82.0)
+    - React-Core (= 0.82.0)
   - ReachabilitySwift (5.2.4)
-  - React (0.82.0-rc.5):
-    - React-Core (= 0.82.0-rc.5)
-    - React-Core/DevSupport (= 0.82.0-rc.5)
-    - React-Core/RCTWebSocket (= 0.82.0-rc.5)
-    - React-RCTActionSheet (= 0.82.0-rc.5)
-    - React-RCTAnimation (= 0.82.0-rc.5)
-    - React-RCTBlob (= 0.82.0-rc.5)
-    - React-RCTImage (= 0.82.0-rc.5)
-    - React-RCTLinking (= 0.82.0-rc.5)
-    - React-RCTNetwork (= 0.82.0-rc.5)
-    - React-RCTSettings (= 0.82.0-rc.5)
-    - React-RCTText (= 0.82.0-rc.5)
-    - React-RCTVibration (= 0.82.0-rc.5)
-  - React-callinvoker (0.82.0-rc.5)
-  - React-Core (0.82.0-rc.5):
+  - React (0.82.0):
+    - React-Core (= 0.82.0)
+    - React-Core/DevSupport (= 0.82.0)
+    - React-Core/RCTWebSocket (= 0.82.0)
+    - React-RCTActionSheet (= 0.82.0)
+    - React-RCTAnimation (= 0.82.0)
+    - React-RCTBlob (= 0.82.0)
+    - React-RCTImage (= 0.82.0)
+    - React-RCTLinking (= 0.82.0)
+    - React-RCTNetwork (= 0.82.0)
+    - React-RCTSettings (= 0.82.0)
+    - React-RCTText (= 0.82.0)
+    - React-RCTVibration (= 0.82.0)
+  - React-callinvoker (0.82.0)
+  - React-Core (0.82.0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.82.0-rc.5)
+    - React-Core/Default (= 0.82.0)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -732,66 +732,9 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core-prebuilt (0.82.0-rc.5):
+  - React-Core-prebuilt (0.82.0):
     - ReactNativeDependencies
-  - React-Core/CoreModulesHeaders (0.82.0-rc.5):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/Default (0.82.0-rc.5):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/DevSupport (0.82.0-rc.5):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default (= 0.82.0-rc.5)
-    - React-Core/RCTWebSocket (= 0.82.0-rc.5)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.82.0-rc.5):
+  - React-Core/CoreModulesHeaders (0.82.0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -810,7 +753,45 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.82.0-rc.5):
+  - React-Core/Default (0.82.0):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/DevSupport (0.82.0):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-Core/Default (= 0.82.0)
+    - React-Core/RCTWebSocket (= 0.82.0)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.82.0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -829,7 +810,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTBlobHeaders (0.82.0-rc.5):
+  - React-Core/RCTAnimationHeaders (0.82.0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -848,7 +829,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTImageHeaders (0.82.0-rc.5):
+  - React-Core/RCTBlobHeaders (0.82.0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -867,7 +848,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.82.0-rc.5):
+  - React-Core/RCTImageHeaders (0.82.0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -886,7 +867,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.82.0-rc.5):
+  - React-Core/RCTLinkingHeaders (0.82.0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -905,7 +886,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.82.0-rc.5):
+  - React-Core/RCTNetworkHeaders (0.82.0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -924,7 +905,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTTextHeaders (0.82.0-rc.5):
+  - React-Core/RCTSettingsHeaders (0.82.0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -943,7 +924,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.82.0-rc.5):
+  - React-Core/RCTTextHeaders (0.82.0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -962,11 +943,11 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTWebSocket (0.82.0-rc.5):
+  - React-Core/RCTVibrationHeaders (0.82.0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.82.0-rc.5)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -981,38 +962,57 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-CoreModules (0.82.0-rc.5):
-    - RCTTypeSafety (= 0.82.0-rc.5)
+  - React-Core/RCTWebSocket (0.82.0):
+    - hermes-engine
+    - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/CoreModulesHeaders (= 0.82.0-rc.5)
+    - React-Core/Default (= 0.82.0)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-CoreModules (0.82.0):
+    - RCTTypeSafety (= 0.82.0)
+    - React-Core-prebuilt
+    - React-Core/CoreModulesHeaders (= 0.82.0)
     - React-debug
-    - React-jsi (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.82.0-rc.5)
+    - React-RCTImage (= 0.82.0)
     - React-runtimeexecutor
     - ReactCommon
     - ReactNativeDependencies
-  - React-cxxreact (0.82.0-rc.5):
+  - React-cxxreact (0.82.0):
     - hermes-engine
-    - React-callinvoker (= 0.82.0-rc.5)
+    - React-callinvoker (= 0.82.0)
     - React-Core-prebuilt
-    - React-debug (= 0.82.0-rc.5)
-    - React-jsi (= 0.82.0-rc.5)
+    - React-debug (= 0.82.0)
+    - React-jsi (= 0.82.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.82.0-rc.5)
-    - React-perflogger (= 0.82.0-rc.5)
+    - React-logger (= 0.82.0)
+    - React-perflogger (= 0.82.0)
     - React-runtimeexecutor
-    - React-timing (= 0.82.0-rc.5)
+    - React-timing (= 0.82.0)
     - ReactNativeDependencies
-  - React-debug (0.82.0-rc.5)
-  - React-defaultsnativemodule (0.82.0-rc.5):
+  - React-debug (0.82.0)
+  - React-defaultsnativemodule (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-domnativemodule
@@ -1024,7 +1024,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-webperformancenativemodule
     - ReactNativeDependencies
-  - React-domnativemodule (0.82.0-rc.5):
+  - React-domnativemodule (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-Fabric
@@ -1038,7 +1038,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric (0.82.0-rc.5):
+  - React-Fabric (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1046,23 +1046,23 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.82.0-rc.5)
-    - React-Fabric/attributedstring (= 0.82.0-rc.5)
-    - React-Fabric/bridging (= 0.82.0-rc.5)
-    - React-Fabric/componentregistry (= 0.82.0-rc.5)
-    - React-Fabric/componentregistrynative (= 0.82.0-rc.5)
-    - React-Fabric/components (= 0.82.0-rc.5)
-    - React-Fabric/consistency (= 0.82.0-rc.5)
-    - React-Fabric/core (= 0.82.0-rc.5)
-    - React-Fabric/dom (= 0.82.0-rc.5)
-    - React-Fabric/imagemanager (= 0.82.0-rc.5)
-    - React-Fabric/leakchecker (= 0.82.0-rc.5)
-    - React-Fabric/mounting (= 0.82.0-rc.5)
-    - React-Fabric/observers (= 0.82.0-rc.5)
-    - React-Fabric/scheduler (= 0.82.0-rc.5)
-    - React-Fabric/telemetry (= 0.82.0-rc.5)
-    - React-Fabric/templateprocessor (= 0.82.0-rc.5)
-    - React-Fabric/uimanager (= 0.82.0-rc.5)
+    - React-Fabric/animations (= 0.82.0)
+    - React-Fabric/attributedstring (= 0.82.0)
+    - React-Fabric/bridging (= 0.82.0)
+    - React-Fabric/componentregistry (= 0.82.0)
+    - React-Fabric/componentregistrynative (= 0.82.0)
+    - React-Fabric/components (= 0.82.0)
+    - React-Fabric/consistency (= 0.82.0)
+    - React-Fabric/core (= 0.82.0)
+    - React-Fabric/dom (= 0.82.0)
+    - React-Fabric/imagemanager (= 0.82.0)
+    - React-Fabric/leakchecker (= 0.82.0)
+    - React-Fabric/mounting (= 0.82.0)
+    - React-Fabric/observers (= 0.82.0)
+    - React-Fabric/scheduler (= 0.82.0)
+    - React-Fabric/telemetry (= 0.82.0)
+    - React-Fabric/templateprocessor (= 0.82.0)
+    - React-Fabric/uimanager (= 0.82.0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1074,26 +1074,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/animations (0.82.0-rc.5):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/attributedstring (0.82.0-rc.5):
+  - React-Fabric/animations (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1112,7 +1093,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/bridging (0.82.0-rc.5):
+  - React-Fabric/attributedstring (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1131,7 +1112,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistry (0.82.0-rc.5):
+  - React-Fabric/bridging (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1150,7 +1131,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistrynative (0.82.0-rc.5):
+  - React-Fabric/componentregistry (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1169,30 +1150,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components (0.82.0-rc.5):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.82.0-rc.5)
-    - React-Fabric/components/root (= 0.82.0-rc.5)
-    - React-Fabric/components/scrollview (= 0.82.0-rc.5)
-    - React-Fabric/components/view (= 0.82.0-rc.5)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/components/legacyviewmanagerinterop (0.82.0-rc.5):
+  - React-Fabric/componentregistrynative (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1211,7 +1169,30 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/root (0.82.0-rc.5):
+  - React-Fabric/components (0.82.0):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.82.0)
+    - React-Fabric/components/root (= 0.82.0)
+    - React-Fabric/components/scrollview (= 0.82.0)
+    - React-Fabric/components/view (= 0.82.0)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/legacyviewmanagerinterop (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1230,7 +1211,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/scrollview (0.82.0-rc.5):
+  - React-Fabric/components/root (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1249,7 +1230,26 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/view (0.82.0-rc.5):
+  - React-Fabric/components/scrollview (0.82.0):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/view (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1270,7 +1270,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric/consistency (0.82.0-rc.5):
+  - React-Fabric/consistency (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1289,7 +1289,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/core (0.82.0-rc.5):
+  - React-Fabric/core (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1308,7 +1308,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/dom (0.82.0-rc.5):
+  - React-Fabric/dom (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1327,7 +1327,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/imagemanager (0.82.0-rc.5):
+  - React-Fabric/imagemanager (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1346,7 +1346,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/leakchecker (0.82.0-rc.5):
+  - React-Fabric/leakchecker (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1365,7 +1365,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/mounting (0.82.0-rc.5):
+  - React-Fabric/mounting (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1384,7 +1384,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers (0.82.0-rc.5):
+  - React-Fabric/observers (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1392,7 +1392,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.82.0-rc.5)
+    - React-Fabric/observers/events (= 0.82.0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1404,7 +1404,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers/events (0.82.0-rc.5):
+  - React-Fabric/observers/events (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1423,7 +1423,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/scheduler (0.82.0-rc.5):
+  - React-Fabric/scheduler (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1445,7 +1445,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/telemetry (0.82.0-rc.5):
+  - React-Fabric/telemetry (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1464,7 +1464,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/templateprocessor (0.82.0-rc.5):
+  - React-Fabric/templateprocessor (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1483,7 +1483,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager (0.82.0-rc.5):
+  - React-Fabric/uimanager (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1491,7 +1491,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.82.0-rc.5)
+    - React-Fabric/uimanager/consistency (= 0.82.0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1504,7 +1504,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager/consistency (0.82.0-rc.5):
+  - React-Fabric/uimanager/consistency (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1524,7 +1524,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-FabricComponents (0.82.0-rc.5):
+  - React-FabricComponents (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1533,8 +1533,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.82.0-rc.5)
-    - React-FabricComponents/textlayoutmanager (= 0.82.0-rc.5)
+    - React-FabricComponents/components (= 0.82.0)
+    - React-FabricComponents/textlayoutmanager (= 0.82.0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1547,7 +1547,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components (0.82.0-rc.5):
+  - React-FabricComponents/components (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1556,18 +1556,18 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.82.0-rc.5)
-    - React-FabricComponents/components/iostextinput (= 0.82.0-rc.5)
-    - React-FabricComponents/components/modal (= 0.82.0-rc.5)
-    - React-FabricComponents/components/rncore (= 0.82.0-rc.5)
-    - React-FabricComponents/components/safeareaview (= 0.82.0-rc.5)
-    - React-FabricComponents/components/scrollview (= 0.82.0-rc.5)
-    - React-FabricComponents/components/switch (= 0.82.0-rc.5)
-    - React-FabricComponents/components/text (= 0.82.0-rc.5)
-    - React-FabricComponents/components/textinput (= 0.82.0-rc.5)
-    - React-FabricComponents/components/unimplementedview (= 0.82.0-rc.5)
-    - React-FabricComponents/components/virtualview (= 0.82.0-rc.5)
-    - React-FabricComponents/components/virtualviewexperimental (= 0.82.0-rc.5)
+    - React-FabricComponents/components/inputaccessory (= 0.82.0)
+    - React-FabricComponents/components/iostextinput (= 0.82.0)
+    - React-FabricComponents/components/modal (= 0.82.0)
+    - React-FabricComponents/components/rncore (= 0.82.0)
+    - React-FabricComponents/components/safeareaview (= 0.82.0)
+    - React-FabricComponents/components/scrollview (= 0.82.0)
+    - React-FabricComponents/components/switch (= 0.82.0)
+    - React-FabricComponents/components/text (= 0.82.0)
+    - React-FabricComponents/components/textinput (= 0.82.0)
+    - React-FabricComponents/components/unimplementedview (= 0.82.0)
+    - React-FabricComponents/components/virtualview (= 0.82.0)
+    - React-FabricComponents/components/virtualviewexperimental (= 0.82.0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1580,28 +1580,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.82.0-rc.5):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.82.0-rc.5):
+  - React-FabricComponents/components/inputaccessory (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1622,7 +1601,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/modal (0.82.0-rc.5):
+  - React-FabricComponents/components/iostextinput (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1643,7 +1622,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/rncore (0.82.0-rc.5):
+  - React-FabricComponents/components/modal (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1664,7 +1643,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.82.0-rc.5):
+  - React-FabricComponents/components/rncore (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1685,7 +1664,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/scrollview (0.82.0-rc.5):
+  - React-FabricComponents/components/safeareaview (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1706,7 +1685,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/switch (0.82.0-rc.5):
+  - React-FabricComponents/components/scrollview (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1727,7 +1706,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/text (0.82.0-rc.5):
+  - React-FabricComponents/components/switch (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1748,7 +1727,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/textinput (0.82.0-rc.5):
+  - React-FabricComponents/components/text (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1769,7 +1748,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.82.0-rc.5):
+  - React-FabricComponents/components/textinput (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1790,7 +1769,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/virtualview (0.82.0-rc.5):
+  - React-FabricComponents/components/unimplementedview (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1811,7 +1790,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/virtualviewexperimental (0.82.0-rc.5):
+  - React-FabricComponents/components/virtualview (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1832,7 +1811,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.82.0-rc.5):
+  - React-FabricComponents/components/virtualviewexperimental (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1853,27 +1832,48 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricImage (0.82.0-rc.5):
+  - React-FabricComponents/textlayoutmanager (0.82.0):
     - hermes-engine
-    - RCTRequired (= 0.82.0-rc.5)
-    - RCTTypeSafety (= 0.82.0-rc.5)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
+  - React-FabricImage (0.82.0):
+    - hermes-engine
+    - RCTRequired (= 0.82.0)
+    - RCTTypeSafety (= 0.82.0)
     - React-Core-prebuilt
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.82.0-rc.5)
+    - React-jsiexecutor (= 0.82.0)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-featureflags (0.82.0-rc.5):
+  - React-featureflags (0.82.0):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-featureflagsnativemodule (0.82.0-rc.5):
+  - React-featureflagsnativemodule (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1882,27 +1882,27 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-graphics (0.82.0-rc.5):
+  - React-graphics (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
     - React-jsiexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-hermes (0.82.0-rc.5):
+  - React-hermes (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
-    - React-cxxreact (= 0.82.0-rc.5)
+    - React-cxxreact (= 0.82.0)
     - React-jsi
-    - React-jsiexecutor (= 0.82.0-rc.5)
+    - React-jsiexecutor (= 0.82.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.82.0-rc.5)
+    - React-perflogger (= 0.82.0)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-idlecallbacksnativemodule (0.82.0-rc.5):
+  - React-idlecallbacksnativemodule (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1912,7 +1912,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-ImageManager (0.82.0-rc.5):
+  - React-ImageManager (0.82.0):
     - React-Core-prebuilt
     - React-Core/Default
     - React-debug
@@ -1921,7 +1921,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - ReactNativeDependencies
-  - React-jserrorhandler (0.82.0-rc.5):
+  - React-jserrorhandler (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1930,11 +1930,11 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - ReactNativeDependencies
-  - React-jsi (0.82.0-rc.5):
+  - React-jsi (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsiexecutor (0.82.0-rc.5):
+  - React-jsiexecutor (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1946,7 +1946,7 @@ PODS:
     - React-perflogger
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsinspector (0.82.0-rc.5):
+  - React-jsinspector (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1955,44 +1955,44 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.82.0-rc.5)
+    - React-perflogger (= 0.82.0)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsinspectorcdp (0.82.0-rc.5):
+  - React-jsinspectorcdp (0.82.0):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsinspectornetwork (0.82.0-rc.5):
+  - React-jsinspectornetwork (0.82.0):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspectorcdp
     - React-performancetimeline
     - React-timing
     - ReactNativeDependencies
-  - React-jsinspectortracing (0.82.0-rc.5):
+  - React-jsinspectortracing (0.82.0):
     - React-Core-prebuilt
     - React-oscompat
     - React-timing
     - ReactNativeDependencies
-  - React-jsitooling (0.82.0-rc.5):
+  - React-jsitooling (0.82.0):
     - React-Core-prebuilt
-    - React-cxxreact (= 0.82.0-rc.5)
+    - React-cxxreact (= 0.82.0)
     - React-debug
-    - React-jsi (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsitracing (0.82.0-rc.5):
+  - React-jsitracing (0.82.0):
     - React-jsi
-  - React-logger (0.82.0-rc.5):
+  - React-logger (0.82.0):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-Mapbuffer (0.82.0-rc.5):
+  - React-Mapbuffer (0.82.0):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-microtasksnativemodule (0.82.0-rc.5):
+  - React-microtasksnativemodule (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -2253,7 +2253,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-NativeModulesApple (0.82.0-rc.5):
+  - React-NativeModulesApple (0.82.0):
     - hermes-engine
     - React-callinvoker
     - React-Core
@@ -2268,11 +2268,11 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-oscompat (0.82.0-rc.5)
-  - React-perflogger (0.82.0-rc.5):
+  - React-oscompat (0.82.0)
+  - React-perflogger (0.82.0):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-performancecdpmetrics (0.82.0-rc.5):
+  - React-performancecdpmetrics (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -2280,16 +2280,16 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - ReactNativeDependencies
-  - React-performancetimeline (0.82.0-rc.5):
+  - React-performancetimeline (0.82.0):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspectortracing
     - React-perflogger
     - React-timing
     - ReactNativeDependencies
-  - React-RCTActionSheet (0.82.0-rc.5):
-    - React-Core/RCTActionSheetHeaders (= 0.82.0-rc.5)
-  - React-RCTAnimation (0.82.0-rc.5):
+  - React-RCTActionSheet (0.82.0):
+    - React-Core/RCTActionSheetHeaders (= 0.82.0)
+  - React-RCTAnimation (0.82.0):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTAnimationHeaders
@@ -2299,7 +2299,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTAppDelegate (0.82.0-rc.5):
+  - React-RCTAppDelegate (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2327,7 +2327,7 @@ PODS:
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTBlob (0.82.0-rc.5):
+  - React-RCTBlob (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-Core/RCTBlobHeaders
@@ -2340,7 +2340,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFabric (0.82.0-rc.5):
+  - React-RCTFabric (0.82.0):
     - hermes-engine
     - React-Core
     - React-Core-prebuilt
@@ -2370,7 +2370,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-RCTFBReactNativeSpec (0.82.0-rc.5):
+  - React-RCTFBReactNativeSpec (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2378,10 +2378,10 @@ PODS:
     - React-Core-prebuilt
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.82.0-rc.5)
+    - React-RCTFBReactNativeSpec/components (= 0.82.0)
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFBReactNativeSpec/components (0.82.0-rc.5):
+  - React-RCTFBReactNativeSpec/components (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2398,7 +2398,7 @@ PODS:
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-RCTImage (0.82.0-rc.5):
+  - React-RCTImage (0.82.0):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTImageHeaders
@@ -2408,14 +2408,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTLinking (0.82.0-rc.5):
-    - React-Core/RCTLinkingHeaders (= 0.82.0-rc.5)
-    - React-jsi (= 0.82.0-rc.5)
+  - React-RCTLinking (0.82.0):
+    - React-Core/RCTLinkingHeaders (= 0.82.0)
+    - React-jsi (= 0.82.0)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.82.0-rc.5)
-  - React-RCTNetwork (0.82.0-rc.5):
+    - ReactCommon/turbomodule/core (= 0.82.0)
+  - React-RCTNetwork (0.82.0):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTNetworkHeaders
@@ -2428,7 +2428,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTRuntime (0.82.0-rc.5):
+  - React-RCTRuntime (0.82.0):
     - hermes-engine
     - React-Core
     - React-Core-prebuilt
@@ -2443,7 +2443,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - ReactNativeDependencies
-  - React-RCTSettings (0.82.0-rc.5):
+  - React-RCTSettings (0.82.0):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTSettingsHeaders
@@ -2452,10 +2452,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTText (0.82.0-rc.5):
-    - React-Core/RCTTextHeaders (= 0.82.0-rc.5)
+  - React-RCTText (0.82.0):
+    - React-Core/RCTTextHeaders (= 0.82.0)
     - Yoga
-  - React-RCTVibration (0.82.0-rc.5):
+  - React-RCTVibration (0.82.0):
     - React-Core-prebuilt
     - React-Core/RCTVibrationHeaders
     - React-jsi
@@ -2463,15 +2463,15 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-rendererconsistency (0.82.0-rc.5)
-  - React-renderercss (0.82.0-rc.5):
+  - React-rendererconsistency (0.82.0)
+  - React-renderercss (0.82.0):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.82.0-rc.5):
+  - React-rendererdebug (0.82.0):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-RuntimeApple (0.82.0-rc.5):
+  - React-RuntimeApple (0.82.0):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -2494,7 +2494,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeCore (0.82.0-rc.5):
+  - React-RuntimeCore (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -2510,14 +2510,14 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-runtimeexecutor (0.82.0-rc.5):
+  - React-runtimeexecutor (0.82.0):
     - React-Core-prebuilt
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0)
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeHermes (0.82.0-rc.5):
+  - React-RuntimeHermes (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -2532,7 +2532,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-runtimescheduler (0.82.0-rc.5):
+  - React-runtimescheduler (0.82.0):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -2548,15 +2548,15 @@ PODS:
     - React-timing
     - React-utils
     - ReactNativeDependencies
-  - React-timing (0.82.0-rc.5):
+  - React-timing (0.82.0):
     - React-debug
-  - React-utils (0.82.0-rc.5):
+  - React-utils (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-debug
-    - React-jsi (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0)
     - ReactNativeDependencies
-  - React-webperformancenativemodule (0.82.0-rc.5):
+  - React-webperformancenativemodule (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -2566,9 +2566,9 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - ReactAppDependencyProvider (0.82.0-rc.5):
+  - ReactAppDependencyProvider (0.82.0):
     - ReactCodegen
-  - ReactCodegen (0.82.0-rc.5):
+  - ReactCodegen (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2588,43 +2588,43 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - ReactCommon (0.82.0-rc.5):
+  - ReactCommon (0.82.0):
     - React-Core-prebuilt
-    - ReactCommon/turbomodule (= 0.82.0-rc.5)
+    - ReactCommon/turbomodule (= 0.82.0)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule (0.82.0-rc.5):
+  - ReactCommon/turbomodule (0.82.0):
     - hermes-engine
-    - React-callinvoker (= 0.82.0-rc.5)
+    - React-callinvoker (= 0.82.0)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.82.0-rc.5)
-    - React-jsi (= 0.82.0-rc.5)
-    - React-logger (= 0.82.0-rc.5)
-    - React-perflogger (= 0.82.0-rc.5)
-    - ReactCommon/turbomodule/bridging (= 0.82.0-rc.5)
-    - ReactCommon/turbomodule/core (= 0.82.0-rc.5)
+    - React-cxxreact (= 0.82.0)
+    - React-jsi (= 0.82.0)
+    - React-logger (= 0.82.0)
+    - React-perflogger (= 0.82.0)
+    - ReactCommon/turbomodule/bridging (= 0.82.0)
+    - ReactCommon/turbomodule/core (= 0.82.0)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/bridging (0.82.0-rc.5):
+  - ReactCommon/turbomodule/bridging (0.82.0):
     - hermes-engine
-    - React-callinvoker (= 0.82.0-rc.5)
+    - React-callinvoker (= 0.82.0)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.82.0-rc.5)
-    - React-jsi (= 0.82.0-rc.5)
-    - React-logger (= 0.82.0-rc.5)
-    - React-perflogger (= 0.82.0-rc.5)
+    - React-cxxreact (= 0.82.0)
+    - React-jsi (= 0.82.0)
+    - React-logger (= 0.82.0)
+    - React-perflogger (= 0.82.0)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/core (0.82.0-rc.5):
+  - ReactCommon/turbomodule/core (0.82.0):
     - hermes-engine
-    - React-callinvoker (= 0.82.0-rc.5)
+    - React-callinvoker (= 0.82.0)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.82.0-rc.5)
-    - React-debug (= 0.82.0-rc.5)
-    - React-featureflags (= 0.82.0-rc.5)
-    - React-jsi (= 0.82.0-rc.5)
-    - React-logger (= 0.82.0-rc.5)
-    - React-perflogger (= 0.82.0-rc.5)
-    - React-utils (= 0.82.0-rc.5)
+    - React-cxxreact (= 0.82.0)
+    - React-debug (= 0.82.0)
+    - React-featureflags (= 0.82.0)
+    - React-jsi (= 0.82.0)
+    - React-logger (= 0.82.0)
+    - React-perflogger (= 0.82.0)
+    - React-utils (= 0.82.0)
     - ReactNativeDependencies
-  - ReactNativeDependencies (0.82.0-rc.5)
+  - ReactNativeDependencies (0.82.0)
   - RNCAsyncStorage (2.2.0):
     - hermes-engine
     - RCTRequired
@@ -3683,8 +3683,8 @@ SPEC CHECKSUMS:
   EXTaskManager: 7d80cb59c1faa3dcfa42035b185bcb5209ca7b1b
   EXUpdates: b96ad490c9456eebc38f949f3c30ce6258845773
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
-  FBLazyVector: bd5db632a304b99a915e07040696286715b97462
-  hermes-engine: a14f7f403796d60a2ae636a4d5b6c1f7646503f8
+  FBLazyVector: 29edfec67fa1c03cb022a4d9891782c3ee86055b
+  hermes-engine: 8642d8f14a548ab718ec112e9bebdfdd154138b5
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -3693,40 +3693,40 @@ SPEC CHECKSUMS:
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
-  RCTDeprecation: 464a4d4314df84aeafa5cba421aa546f12ea45c2
-  RCTRequired: 7ec2b105ee6a82a849718a97e2769c2b3649eeea
-  RCTTypeSafety: 53fc675982f0fc6a599cfe66d3047b8adda347b1
+  RCTDeprecation: f4041d4bf5adb181d7d9a14982539a83726165a7
+  RCTRequired: 89f3ec1cf8e1a9b8f5cb9a833790d89c26ef3256
+  RCTTypeSafety: aaa22f943b01aa305257dd98baf8539dce718e2d
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 6eb704af98132bfdd36a19d9910b4d317d13100c
-  React-callinvoker: d3ef985f0e471dd4e6bf2d211e6a8a8721a2ca55
-  React-Core: b4b1a97d59b674896e243d70173f829247307d95
-  React-Core-prebuilt: 533958c653ad258eafa63ef14d21383fc2b255a2
-  React-CoreModules: 58a3036f2f1ff1d4db71e96f51ef2abab3da9890
-  React-cxxreact: ddf8df79906abbd0faa8fee7ac42f68669f4a389
-  React-debug: ddc5f4fcd34d349b4f9012c26f74fe043768d72d
-  React-defaultsnativemodule: cba90d0fd3b74c57a41b3404dccd2b774254e32c
-  React-domnativemodule: 2fdee77a7845eb601d32177a3164a7f7213a05e5
-  React-Fabric: a005506975193c8220150ff753db06f62a9f3675
-  React-FabricComponents: 686d531464879d5ce38f19f2a3b8619860e6b2a1
-  React-FabricImage: 1b9e7bdeef180071f5ed3004f32c927ed4bd878e
-  React-featureflags: 1f970af672e5ad345f2fbc046619c355baf6c5a8
-  React-featureflagsnativemodule: 2cd9a2651f405aa34c60e43ccc4ef023608d6f92
-  React-graphics: f574f381582a1eee5632bfd5fa1ef7e05e2cb3cd
-  React-hermes: f8b32be4c35319e8e42fc2988cb37bbe8eb5ee78
-  React-idlecallbacksnativemodule: 41817bea59ab577183de9881d92bb09154c49ab0
-  React-ImageManager: 36738f4bbf09285cbfa1bc0d18bf7715f24e0249
-  React-jserrorhandler: bd8b58138f773c1f3f1e2ea730190beca53a8725
-  React-jsi: 5b21b09133d7364383392112d9b4dd751c8b438f
-  React-jsiexecutor: 7f835364605e2e6590083c1df4d50b360398f185
-  React-jsinspector: 4d962cea0a8cf461d2b0f76de6e3f29ad73c128d
-  React-jsinspectorcdp: 84fefd05d64dce694a19bccc8593bdfde0d3e573
-  React-jsinspectornetwork: c03d2d5eb98dd23f9db9a9c33de3f35bdcb7638f
-  React-jsinspectortracing: c908bcaeb2b16a382ff493d4001810ab57633765
-  React-jsitooling: 9c3161134d505db87731becc8e0c605e05f0f34c
-  React-jsitracing: 466fdc56f44f86c5f19e8db3658b36ca48b1212e
-  React-logger: e3d0d02438e5a397ee0dc439957636f2910205ce
-  React-Mapbuffer: cc64bef8b0da852c7558a219d87e28910a49b9e5
-  React-microtasksnativemodule: bf2d7b592a8beea5e937036969761fac841a019f
+  React: ade831e2e38887292c2c7d40f2f4098826a9dda4
+  React-callinvoker: 0496e88932950260bbced6f84c633c40ec865f7f
+  React-Core: c039131635f507742ca871a0f130aabdb7a2c57b
+  React-Core-prebuilt: 265a5ea421d251f0caf7b834230aa1044b1395db
+  React-CoreModules: 89efc8cd313843796b11ef62caf9f73169d79a94
+  React-cxxreact: 532f14ce8e3490a6053f96a2fe964f29b0b530de
+  React-debug: c1ec6ee07de860f9113e88d96fb3dad6a69d4afd
+  React-defaultsnativemodule: b0adda9eadf092d9e3760750e474fdcc898b5909
+  React-domnativemodule: 51cd3704392647ed2fa9a0952008bcc76a8f1944
+  React-Fabric: 9fb2aed9c12753b86e97b9cd6c8d50e9864ab8eb
+  React-FabricComponents: 1d5d4e6013ae322e439383558ee733d95557e22a
+  React-FabricImage: 10889c43137086693bac8444c3c7827d4d6cdec4
+  React-featureflags: c3e12691fa93fce9e417de9e5fd780af5115f043
+  React-featureflagsnativemodule: 2055ac07f2cc666419b0271edbc5c2d4ff1c4ccc
+  React-graphics: f21ad2e5faf8d203cc3705b8703878a61490b0c2
+  React-hermes: ba4a5d452895b642831eff988019f2c002843b32
+  React-idlecallbacksnativemodule: 44b43c36bd2bb7ba345b4ceec5087bfd66b54729
+  React-ImageManager: 680e0b07cb02cfad6353e3b09153449f71e93812
+  React-jserrorhandler: 647cbdcc7b2275c44c7698e04d082150542dbd08
+  React-jsi: 9238bbc79cfecaf171c601c6515f5223745803fd
+  React-jsiexecutor: afd0471837e86ef75ef48688bc94b6e6db95f012
+  React-jsinspector: c19192b014f5ee3b2598b59bb9f746de02cc2a0e
+  React-jsinspectorcdp: 9f09c76847135fef9944da8dc64e292003e5673c
+  React-jsinspectornetwork: 88be53aebae981a1a08e7e9866b0eb94434c9de5
+  React-jsinspectortracing: ef3cb072cfb358b21ea4e139fb72052ff43466aa
+  React-jsitooling: caba2b81da0481d3782412f7ff744d80c3c6c3f7
+  React-jsitracing: f825f7cd52aa0a4b788de75724039e7bb25bad4b
+  React-logger: 339eafcd00ba20e35c3bde279f6ccad8a5403cd3
+  React-Mapbuffer: c3ddd60df73fd3fca0db89732799cd35bcfa62ea
+  React-microtasksnativemodule: d2e85587cd55f7360c12a9d116b53dd2056e133c
   react-native-keyboard-controller: 5587bad7f102125e2020720c4e37e0b58ff5e52e
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
   react-native-pager-view: e37989fc447aa4b5de6d0d2ffb0229e817329246
@@ -3736,39 +3736,39 @@ SPEC CHECKSUMS:
   react-native-slider: b76fa3dd989d25e8c2751c2a546674dfc0c2b6f8
   react-native-view-shot: 26174e54ec6b4b7c5d70b86964b747919759adc1
   react-native-webview: a4f0775a31b73cf13cfc3d2d2b119aa94ec76e49
-  React-NativeModulesApple: 169bb5425798368481b3b4ae911833a0c3822759
-  React-oscompat: dc153eed09ee87bc374b255143ca9339bd5556a8
-  React-perflogger: f763d0787a14c6b595d6d1981faa472bceac4e31
-  React-performancecdpmetrics: 780c8391c0bad88f8f490461028018b3a106a56f
-  React-performancetimeline: 2ef25330a0d61f9263dfc625e12d9ad4969405f2
-  React-RCTActionSheet: 6cf10d77cb47a0d9d4bdae6075f911b362a26344
-  React-RCTAnimation: fcfb0df113ccad9453db609d88085478b20397e3
-  React-RCTAppDelegate: c83a7e414ba6d0632ce65463e2d5a7fc4126b122
-  React-RCTBlob: 1d2e8bdb1429074a81d28de4e2a4d0c56643e6b2
-  React-RCTFabric: 9d8a731289216d71109992c549da99e7079e3e01
-  React-RCTFBReactNativeSpec: ebce52c839314577048ae9a04fe81c731a44e4d2
-  React-RCTImage: 7d7d5d6814e4ad53822d78be6e5d8c6fe0b48e85
-  React-RCTLinking: c13f8ea47e49b72d3d9f67235c315fc1e924e91e
-  React-RCTNetwork: 4d628a356fd2cbe6693ac1ee72684cbb4020149c
-  React-RCTRuntime: fed46908b2fdfdc8c24965f0bc550b05a43f90cc
-  React-RCTSettings: b75244d9ecd5320bbfb19cdc5c6cbe8e378b25ee
-  React-RCTText: 0227dac029b355133f9da975f956ff5fbc3b4555
-  React-RCTVibration: 75292ca92dd22ba089c4adf3487f12dde10ffac1
-  React-rendererconsistency: 358eb8fb00c38ba78cf5e72e8a2a3faf94a633c6
-  React-renderercss: 6a5a7abaaee411d9cdcf23a5802d41f48f2ba0d2
-  React-rendererdebug: 9e4e27b215b65259c7a0418b6d264302c33a3341
-  React-RuntimeApple: 85c518c687ac0be44e6df286904ae7bfcecd2db6
-  React-RuntimeCore: 3b68e7474ca2055d2319afbdfdbcab15f5f0ecb7
-  React-runtimeexecutor: c5390f9a49f9c5d3765ce3aa61e4a1e1965c5792
-  React-RuntimeHermes: a1308f2437b71db23ed200f3b99ab45636be87bd
-  React-runtimescheduler: f3a7dc6ec5679b7a22df23ebca35ed789ab9e46c
-  React-timing: 4121ff074bbaefed0608204e88ec2348c9747198
-  React-utils: 8b54a394f9b7ddcc1fcad731854e70be2ce6a536
-  React-webperformancenativemodule: 7f2f10b926d84f2b10067369c95ed29d459a0bea
-  ReactAppDependencyProvider: 77a7129540c0e06ab6be9a2bcb887d3d2e594431
-  ReactCodegen: 2d2fde196f489991b127afed2b1ac948ac3b7c17
-  ReactCommon: 098214faf94e79d56f004cac54464386c4c5d8e0
-  ReactNativeDependencies: beee42eb54e7ca052bd312c214dbe5d1487e02c7
+  React-NativeModulesApple: 170fda2f874957992d47d3ab6438b3e6b6464aae
+  React-oscompat: 6ed19a860bd0cabd1bb3b387c358710ce709ee3a
+  React-perflogger: 3ba2cad8e8ba66bd2029ad9f3dc852624ff6ecc9
+  React-performancecdpmetrics: b79e9d0e806cb0adc4a60280d772bffc7791ec71
+  React-performancetimeline: 3f3cbc21de73f7af9cd93880f1e4cd2736403957
+  React-RCTActionSheet: d0ba12d6d8bc7206ae5b9d44e673382247d5ca78
+  React-RCTAnimation: fc148a894ccbc83a73fdd114a4fcf925c729d502
+  React-RCTAppDelegate: 009ead3ae703342fab0e511266c252102daa2fd9
+  React-RCTBlob: db37198e35e44b8149cc47a2e08bf34616254503
+  React-RCTFabric: 953f1b132801661b66c97ef3568b0cc42c2a4cde
+  React-RCTFBReactNativeSpec: 4cfd22512d295d1b70390b3ba42641c2fe734ddd
+  React-RCTImage: 5d197bb172296961b33b0d721a158abfc17e6701
+  React-RCTLinking: 074aefb4b1d55cacb8ddceb8e1117b48479f8b70
+  React-RCTNetwork: a531cd83edbb469232b3cd98e2d7504ac3198005
+  React-RCTRuntime: 144f94bbfe5cdc137bcbce7c297f0c1d7c4607cc
+  React-RCTSettings: 27cd0ea882f8eb7d10d944a75bd496b088fbf747
+  React-RCTText: 978f82284d7b0e0c7ea5b3d10ec123d8bd887d60
+  React-RCTVibration: d6aabbaa6f893184a961bb5736756bf10d7bf0f1
+  React-rendererconsistency: 17a5d2f591eb55f7bfe451dc5ce2dd5b8b3bd197
+  React-renderercss: 3f95a2021bdcd0bcb58c99f02f1be59d96bfc456
+  React-rendererdebug: 67cee42df22362e413b059382ffd3f8a68fa5f26
+  React-RuntimeApple: c3192a173268302c27c977780b220d0d3a1a8979
+  React-RuntimeCore: 59d070ed07882749c4a19804fdd84ed91fa74ff5
+  React-runtimeexecutor: 99de7104a83fcbac9018afd109f9d59395c7058d
+  React-RuntimeHermes: ff90d1e2cc7c23453e0628ace0583bf5de8c8a2c
+  React-runtimescheduler: c5222c0cd2c6a7d6eb3085ff1b0d66c12dbd10be
+  React-timing: 40cbae59f7123e2ec2492a015348f7a7ac3a420e
+  React-utils: 248dcc79c8ae283ff7b30e24dbca0af70a40a12c
+  React-webperformancenativemodule: 0699c6f71a93270225830fe46520649576a1465c
+  ReactAppDependencyProvider: d5f21b5da644b33685d4f2685cba86e3c7ea64ff
+  ReactCodegen: 9b81cfc4c6ca029f763fb96e191ed77d0db85a8d
+  ReactCommon: e63ee799a93b4c3dea223339a660c392dead4d76
+  ReactNativeDependencies: 1b2d8e7c970b245dbc0daa4b9e770de205bc4230
   RNCAsyncStorage: e85a99325df9eb0191a6ee2b2a842644c7eb29f4
   RNCMaskedView: 3c9d7586e2b9bbab573591dcb823918bc4668005
   RNCPicker: 38a9deb903d9a8ae18b598bac727e6c84b3cf0fa
@@ -3783,7 +3783,7 @@ SPEC CHECKSUMS:
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   UMAppLoader: e1234c45d2b7da239e9e90fc4bbeacee12afd5b6
-  Yoga: c972c838201c115255559220e4e14cf76a5401a6
+  Yoga: 1f093bc30adea87fd3a14ceaa0b2cb46468d06f9
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 07ca240dc3c89dc461c221729e3f0a73e14e9ad8

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -66,7 +66,7 @@
     "native-component-list": "*",
     "react": "19.1.1",
     "react-dom": "19.1.1",
-    "react-native": "0.82.0-rc.5",
+    "react-native": "0.82.0",
     "react-native-edge-to-edge": "~1.6.1",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-keyboard-controller": "^1.18.5",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -363,7 +363,7 @@ PODS:
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.82.0-rc.5)
+  - FBLazyVector (0.82.0)
   - FirebaseAnalytics (11.11.0):
     - FirebaseAnalytics/AdIdSupport (= 11.11.0)
     - FirebaseCore (~> 11.11.0)
@@ -486,17 +486,17 @@ PODS:
   - GoogleUtilities/UserDefaults (8.0.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - hermes-engine (0.82.0-rc.5):
-    - hermes-engine/cdp (= 0.82.0-rc.5)
-    - hermes-engine/Hermes (= 0.82.0-rc.5)
-    - hermes-engine/inspector (= 0.82.0-rc.5)
-    - hermes-engine/inspector_chrome (= 0.82.0-rc.5)
-    - hermes-engine/Public (= 0.82.0-rc.5)
-  - hermes-engine/cdp (0.82.0-rc.5)
-  - hermes-engine/Hermes (0.82.0-rc.5)
-  - hermes-engine/inspector (0.82.0-rc.5)
-  - hermes-engine/inspector_chrome (0.82.0-rc.5)
-  - hermes-engine/Public (0.82.0-rc.5)
+  - hermes-engine (0.82.0):
+    - hermes-engine/cdp (= 0.82.0)
+    - hermes-engine/Hermes (= 0.82.0)
+    - hermes-engine/inspector (= 0.82.0)
+    - hermes-engine/inspector_chrome (= 0.82.0)
+    - hermes-engine/Public (= 0.82.0)
+  - hermes-engine/cdp (0.82.0)
+  - hermes-engine/Hermes (0.82.0)
+  - hermes-engine/inspector (0.82.0)
+  - hermes-engine/inspector_chrome (0.82.0)
+  - hermes-engine/Public (0.82.0)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -574,28 +574,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.82.0-rc.5)
-  - RCTRequired (0.82.0-rc.5)
-  - RCTTypeSafety (0.82.0-rc.5):
-    - FBLazyVector (= 0.82.0-rc.5)
-    - RCTRequired (= 0.82.0-rc.5)
-    - React-Core (= 0.82.0-rc.5)
+  - RCTDeprecation (0.82.0)
+  - RCTRequired (0.82.0)
+  - RCTTypeSafety (0.82.0):
+    - FBLazyVector (= 0.82.0)
+    - RCTRequired (= 0.82.0)
+    - React-Core (= 0.82.0)
   - ReachabilitySwift (5.2.4)
-  - React (0.82.0-rc.5):
-    - React-Core (= 0.82.0-rc.5)
-    - React-Core/DevSupport (= 0.82.0-rc.5)
-    - React-Core/RCTWebSocket (= 0.82.0-rc.5)
-    - React-RCTActionSheet (= 0.82.0-rc.5)
-    - React-RCTAnimation (= 0.82.0-rc.5)
-    - React-RCTBlob (= 0.82.0-rc.5)
-    - React-RCTImage (= 0.82.0-rc.5)
-    - React-RCTLinking (= 0.82.0-rc.5)
-    - React-RCTNetwork (= 0.82.0-rc.5)
-    - React-RCTSettings (= 0.82.0-rc.5)
-    - React-RCTText (= 0.82.0-rc.5)
-    - React-RCTVibration (= 0.82.0-rc.5)
-  - React-callinvoker (0.82.0-rc.5)
-  - React-Core (0.82.0-rc.5):
+  - React (0.82.0):
+    - React-Core (= 0.82.0)
+    - React-Core/DevSupport (= 0.82.0)
+    - React-Core/RCTWebSocket (= 0.82.0)
+    - React-RCTActionSheet (= 0.82.0)
+    - React-RCTAnimation (= 0.82.0)
+    - React-RCTBlob (= 0.82.0)
+    - React-RCTImage (= 0.82.0)
+    - React-RCTLinking (= 0.82.0)
+    - React-RCTNetwork (= 0.82.0)
+    - React-RCTSettings (= 0.82.0)
+    - React-RCTText (= 0.82.0)
+    - React-RCTVibration (= 0.82.0)
+  - React-callinvoker (0.82.0)
+  - React-Core (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -605,7 +605,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.82.0-rc.5)
+    - React-Core/Default (= 0.82.0)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -620,82 +620,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.82.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.82.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.82.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.82.0-rc.5)
-    - React-Core/RCTWebSocket (= 0.82.0-rc.5)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.82.0-rc.5):
+  - React-Core/CoreModulesHeaders (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -720,7 +645,57 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.82.0-rc.5):
+  - React-Core/Default (0.82.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.82.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.82.0)
+    - React-Core/RCTWebSocket (= 0.82.0)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -745,7 +720,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.82.0-rc.5):
+  - React-Core/RCTAnimationHeaders (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -770,7 +745,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.82.0-rc.5):
+  - React-Core/RCTBlobHeaders (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -795,7 +770,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.82.0-rc.5):
+  - React-Core/RCTImageHeaders (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -820,7 +795,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.82.0-rc.5):
+  - React-Core/RCTLinkingHeaders (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -845,7 +820,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.82.0-rc.5):
+  - React-Core/RCTNetworkHeaders (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -870,7 +845,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.82.0-rc.5):
+  - React-Core/RCTSettingsHeaders (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -895,7 +870,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.82.0-rc.5):
+  - React-Core/RCTTextHeaders (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -920,7 +895,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.82.0-rc.5):
+  - React-Core/RCTVibrationHeaders (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -930,7 +905,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.82.0-rc.5)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -945,7 +920,32 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.82.0-rc.5):
+  - React-Core/RCTWebSocket (0.82.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.82.0)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -953,21 +953,21 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.82.0-rc.5)
-    - React-Core/CoreModulesHeaders (= 0.82.0-rc.5)
+    - RCTTypeSafety (= 0.82.0)
+    - React-Core/CoreModulesHeaders (= 0.82.0)
     - React-debug
-    - React-jsi (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.82.0-rc.5)
+    - React-RCTImage (= 0.82.0)
     - React-runtimeexecutor
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.82.0-rc.5):
+  - React-cxxreact (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -976,19 +976,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.82.0-rc.5)
-    - React-debug (= 0.82.0-rc.5)
-    - React-jsi (= 0.82.0-rc.5)
+    - React-callinvoker (= 0.82.0)
+    - React-debug (= 0.82.0)
+    - React-jsi (= 0.82.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.82.0-rc.5)
-    - React-perflogger (= 0.82.0-rc.5)
+    - React-logger (= 0.82.0)
+    - React-perflogger (= 0.82.0)
     - React-runtimeexecutor
-    - React-timing (= 0.82.0-rc.5)
+    - React-timing (= 0.82.0)
     - SocketRocket
-  - React-debug (0.82.0-rc.5)
-  - React-defaultsnativemodule (0.82.0-rc.5):
+  - React-debug (0.82.0)
+  - React-defaultsnativemodule (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1006,7 +1006,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-webperformancenativemodule
     - SocketRocket
-  - React-domnativemodule (0.82.0-rc.5):
+  - React-domnativemodule (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1026,7 +1026,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.82.0-rc.5):
+  - React-Fabric (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1040,23 +1040,23 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.82.0-rc.5)
-    - React-Fabric/attributedstring (= 0.82.0-rc.5)
-    - React-Fabric/bridging (= 0.82.0-rc.5)
-    - React-Fabric/componentregistry (= 0.82.0-rc.5)
-    - React-Fabric/componentregistrynative (= 0.82.0-rc.5)
-    - React-Fabric/components (= 0.82.0-rc.5)
-    - React-Fabric/consistency (= 0.82.0-rc.5)
-    - React-Fabric/core (= 0.82.0-rc.5)
-    - React-Fabric/dom (= 0.82.0-rc.5)
-    - React-Fabric/imagemanager (= 0.82.0-rc.5)
-    - React-Fabric/leakchecker (= 0.82.0-rc.5)
-    - React-Fabric/mounting (= 0.82.0-rc.5)
-    - React-Fabric/observers (= 0.82.0-rc.5)
-    - React-Fabric/scheduler (= 0.82.0-rc.5)
-    - React-Fabric/telemetry (= 0.82.0-rc.5)
-    - React-Fabric/templateprocessor (= 0.82.0-rc.5)
-    - React-Fabric/uimanager (= 0.82.0-rc.5)
+    - React-Fabric/animations (= 0.82.0)
+    - React-Fabric/attributedstring (= 0.82.0)
+    - React-Fabric/bridging (= 0.82.0)
+    - React-Fabric/componentregistry (= 0.82.0)
+    - React-Fabric/componentregistrynative (= 0.82.0)
+    - React-Fabric/components (= 0.82.0)
+    - React-Fabric/consistency (= 0.82.0)
+    - React-Fabric/core (= 0.82.0)
+    - React-Fabric/dom (= 0.82.0)
+    - React-Fabric/imagemanager (= 0.82.0)
+    - React-Fabric/leakchecker (= 0.82.0)
+    - React-Fabric/mounting (= 0.82.0)
+    - React-Fabric/observers (= 0.82.0)
+    - React-Fabric/scheduler (= 0.82.0)
+    - React-Fabric/telemetry (= 0.82.0)
+    - React-Fabric/templateprocessor (= 0.82.0)
+    - React-Fabric/uimanager (= 0.82.0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1068,32 +1068,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.82.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.82.0-rc.5):
+  - React-Fabric/animations (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1118,7 +1093,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/bridging (0.82.0-rc.5):
+  - React-Fabric/attributedstring (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1143,7 +1118,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.82.0-rc.5):
+  - React-Fabric/bridging (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1168,7 +1143,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.82.0-rc.5):
+  - React-Fabric/componentregistry (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1193,36 +1168,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.82.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.82.0-rc.5)
-    - React-Fabric/components/root (= 0.82.0-rc.5)
-    - React-Fabric/components/scrollview (= 0.82.0-rc.5)
-    - React-Fabric/components/view (= 0.82.0-rc.5)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.82.0-rc.5):
+  - React-Fabric/componentregistrynative (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1247,7 +1193,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.82.0-rc.5):
+  - React-Fabric/components (0.82.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.82.0)
+    - React-Fabric/components/root (= 0.82.0)
+    - React-Fabric/components/scrollview (= 0.82.0)
+    - React-Fabric/components/view (= 0.82.0)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1272,7 +1247,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.82.0-rc.5):
+  - React-Fabric/components/root (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1297,7 +1272,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.82.0-rc.5):
+  - React-Fabric/components/scrollview (0.82.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1324,7 +1324,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.82.0-rc.5):
+  - React-Fabric/consistency (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1349,7 +1349,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.82.0-rc.5):
+  - React-Fabric/core (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1374,7 +1374,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.82.0-rc.5):
+  - React-Fabric/dom (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1399,7 +1399,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.82.0-rc.5):
+  - React-Fabric/imagemanager (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1424,7 +1424,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.82.0-rc.5):
+  - React-Fabric/leakchecker (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1449,7 +1449,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.82.0-rc.5):
+  - React-Fabric/mounting (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1474,7 +1474,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.82.0-rc.5):
+  - React-Fabric/observers (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1488,7 +1488,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.82.0-rc.5)
+    - React-Fabric/observers/events (= 0.82.0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1500,7 +1500,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.82.0-rc.5):
+  - React-Fabric/observers/events (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1525,7 +1525,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.82.0-rc.5):
+  - React-Fabric/scheduler (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1553,7 +1553,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.82.0-rc.5):
+  - React-Fabric/telemetry (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1578,7 +1578,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.82.0-rc.5):
+  - React-Fabric/templateprocessor (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1603,7 +1603,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.82.0-rc.5):
+  - React-Fabric/uimanager (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1617,7 +1617,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.82.0-rc.5)
+    - React-Fabric/uimanager/consistency (= 0.82.0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1630,7 +1630,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager/consistency (0.82.0-rc.5):
+  - React-Fabric/uimanager/consistency (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1656,7 +1656,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.82.0-rc.5):
+  - React-FabricComponents (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1671,8 +1671,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.82.0-rc.5)
-    - React-FabricComponents/textlayoutmanager (= 0.82.0-rc.5)
+    - React-FabricComponents/components (= 0.82.0)
+    - React-FabricComponents/textlayoutmanager (= 0.82.0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1685,7 +1685,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.82.0-rc.5):
+  - React-FabricComponents/components (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1700,18 +1700,18 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.82.0-rc.5)
-    - React-FabricComponents/components/iostextinput (= 0.82.0-rc.5)
-    - React-FabricComponents/components/modal (= 0.82.0-rc.5)
-    - React-FabricComponents/components/rncore (= 0.82.0-rc.5)
-    - React-FabricComponents/components/safeareaview (= 0.82.0-rc.5)
-    - React-FabricComponents/components/scrollview (= 0.82.0-rc.5)
-    - React-FabricComponents/components/switch (= 0.82.0-rc.5)
-    - React-FabricComponents/components/text (= 0.82.0-rc.5)
-    - React-FabricComponents/components/textinput (= 0.82.0-rc.5)
-    - React-FabricComponents/components/unimplementedview (= 0.82.0-rc.5)
-    - React-FabricComponents/components/virtualview (= 0.82.0-rc.5)
-    - React-FabricComponents/components/virtualviewexperimental (= 0.82.0-rc.5)
+    - React-FabricComponents/components/inputaccessory (= 0.82.0)
+    - React-FabricComponents/components/iostextinput (= 0.82.0)
+    - React-FabricComponents/components/modal (= 0.82.0)
+    - React-FabricComponents/components/rncore (= 0.82.0)
+    - React-FabricComponents/components/safeareaview (= 0.82.0)
+    - React-FabricComponents/components/scrollview (= 0.82.0)
+    - React-FabricComponents/components/switch (= 0.82.0)
+    - React-FabricComponents/components/text (= 0.82.0)
+    - React-FabricComponents/components/textinput (= 0.82.0)
+    - React-FabricComponents/components/unimplementedview (= 0.82.0)
+    - React-FabricComponents/components/virtualview (= 0.82.0)
+    - React-FabricComponents/components/virtualviewexperimental (= 0.82.0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1724,34 +1724,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.82.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.82.0-rc.5):
+  - React-FabricComponents/components/inputaccessory (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1778,7 +1751,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/modal (0.82.0-rc.5):
+  - React-FabricComponents/components/iostextinput (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1805,7 +1778,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.82.0-rc.5):
+  - React-FabricComponents/components/modal (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1832,7 +1805,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.82.0-rc.5):
+  - React-FabricComponents/components/rncore (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1859,7 +1832,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.82.0-rc.5):
+  - React-FabricComponents/components/safeareaview (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1886,7 +1859,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/switch (0.82.0-rc.5):
+  - React-FabricComponents/components/scrollview (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1913,7 +1886,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.82.0-rc.5):
+  - React-FabricComponents/components/switch (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1940,7 +1913,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.82.0-rc.5):
+  - React-FabricComponents/components/text (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1967,7 +1940,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.82.0-rc.5):
+  - React-FabricComponents/components/textinput (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1994,7 +1967,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualview (0.82.0-rc.5):
+  - React-FabricComponents/components/unimplementedview (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2021,7 +1994,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualviewexperimental (0.82.0-rc.5):
+  - React-FabricComponents/components/virtualview (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2048,7 +2021,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.82.0-rc.5):
+  - React-FabricComponents/components/virtualviewexperimental (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2075,7 +2048,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.82.0-rc.5):
+  - React-FabricComponents/textlayoutmanager (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2084,21 +2057,48 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.82.0-rc.5)
-    - RCTTypeSafety (= 0.82.0-rc.5)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.82.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.82.0)
+    - RCTTypeSafety (= 0.82.0)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.82.0-rc.5)
+    - React-jsiexecutor (= 0.82.0)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.82.0-rc.5):
+  - React-featureflags (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2107,7 +2107,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.82.0-rc.5):
+  - React-featureflagsnativemodule (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2122,7 +2122,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.82.0-rc.5):
+  - React-graphics (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2135,7 +2135,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.82.0-rc.5):
+  - React-hermes (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2144,17 +2144,17 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.82.0-rc.5)
+    - React-cxxreact (= 0.82.0)
     - React-jsi
-    - React-jsiexecutor (= 0.82.0-rc.5)
+    - React-jsiexecutor (= 0.82.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.82.0-rc.5)
+    - React-perflogger (= 0.82.0)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.82.0-rc.5):
+  - React-idlecallbacksnativemodule (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2170,7 +2170,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.82.0-rc.5):
+  - React-ImageManager (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2185,7 +2185,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jserrorhandler (0.82.0-rc.5):
+  - React-jserrorhandler (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2200,7 +2200,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.82.0-rc.5):
+  - React-jsi (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2210,7 +2210,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.82.0-rc.5):
+  - React-jsiexecutor (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2228,7 +2228,7 @@ PODS:
     - React-perflogger
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspector (0.82.0-rc.5):
+  - React-jsinspector (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2243,10 +2243,10 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.82.0-rc.5)
+    - React-perflogger (= 0.82.0)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspectorcdp (0.82.0-rc.5):
+  - React-jsinspectorcdp (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2255,7 +2255,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.82.0-rc.5):
+  - React-jsinspectornetwork (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2268,7 +2268,7 @@ PODS:
     - React-performancetimeline
     - React-timing
     - SocketRocket
-  - React-jsinspectortracing (0.82.0-rc.5):
+  - React-jsinspectortracing (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2279,7 +2279,7 @@ PODS:
     - React-oscompat
     - React-timing
     - SocketRocket
-  - React-jsitooling (0.82.0-rc.5):
+  - React-jsitooling (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2287,17 +2287,17 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.82.0-rc.5)
+    - React-cxxreact (= 0.82.0)
     - React-debug
-    - React-jsi (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsitracing (0.82.0-rc.5):
+  - React-jsitracing (0.82.0):
     - React-jsi
-  - React-logger (0.82.0-rc.5):
+  - React-logger (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2306,7 +2306,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.82.0-rc.5):
+  - React-Mapbuffer (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2316,7 +2316,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.82.0-rc.5):
+  - React-microtasksnativemodule (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2655,7 +2655,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-NativeModulesApple (0.82.0-rc.5):
+  - React-NativeModulesApple (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2676,8 +2676,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.82.0-rc.5)
-  - React-perflogger (0.82.0-rc.5):
+  - React-oscompat (0.82.0)
+  - React-perflogger (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2686,7 +2686,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancecdpmetrics (0.82.0-rc.5):
+  - React-performancecdpmetrics (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2700,7 +2700,7 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - SocketRocket
-  - React-performancetimeline (0.82.0-rc.5):
+  - React-performancetimeline (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2713,9 +2713,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.82.0-rc.5):
-    - React-Core/RCTActionSheetHeaders (= 0.82.0-rc.5)
-  - React-RCTAnimation (0.82.0-rc.5):
+  - React-RCTActionSheet (0.82.0):
+    - React-Core/RCTActionSheetHeaders (= 0.82.0)
+  - React-RCTAnimation (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2731,7 +2731,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.82.0-rc.5):
+  - React-RCTAppDelegate (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2765,7 +2765,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.82.0-rc.5):
+  - React-RCTBlob (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2784,7 +2784,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.82.0-rc.5):
+  - React-RCTFabric (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2820,7 +2820,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.82.0-rc.5):
+  - React-RCTFBReactNativeSpec (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2834,10 +2834,10 @@ PODS:
     - React-Core
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.82.0-rc.5)
+    - React-RCTFBReactNativeSpec/components (= 0.82.0)
     - ReactCommon
     - SocketRocket
-  - React-RCTFBReactNativeSpec/components (0.82.0-rc.5):
+  - React-RCTFBReactNativeSpec/components (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2860,7 +2860,7 @@ PODS:
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-RCTImage (0.82.0-rc.5):
+  - React-RCTImage (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2876,14 +2876,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.82.0-rc.5):
-    - React-Core/RCTLinkingHeaders (= 0.82.0-rc.5)
-    - React-jsi (= 0.82.0-rc.5)
+  - React-RCTLinking (0.82.0):
+    - React-Core/RCTLinkingHeaders (= 0.82.0)
+    - React-jsi (= 0.82.0)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.82.0-rc.5)
-  - React-RCTNetwork (0.82.0-rc.5):
+    - ReactCommon/turbomodule/core (= 0.82.0)
+  - React-RCTNetwork (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2902,7 +2902,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.82.0-rc.5):
+  - React-RCTRuntime (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2923,7 +2923,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.82.0-rc.5):
+  - React-RCTSettings (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2938,10 +2938,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.82.0-rc.5):
-    - React-Core/RCTTextHeaders (= 0.82.0-rc.5)
+  - React-RCTText (0.82.0):
+    - React-Core/RCTTextHeaders (= 0.82.0)
     - Yoga
-  - React-RCTVibration (0.82.0-rc.5):
+  - React-RCTVibration (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2955,11 +2955,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.82.0-rc.5)
-  - React-renderercss (0.82.0-rc.5):
+  - React-rendererconsistency (0.82.0)
+  - React-renderercss (0.82.0):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.82.0-rc.5):
+  - React-rendererdebug (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2969,7 +2969,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-RuntimeApple (0.82.0-rc.5):
+  - React-RuntimeApple (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2998,7 +2998,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.82.0-rc.5):
+  - React-RuntimeCore (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3020,7 +3020,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.82.0-rc.5):
+  - React-runtimeexecutor (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3030,10 +3030,10 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0)
     - React-utils
     - SocketRocket
-  - React-RuntimeHermes (0.82.0-rc.5):
+  - React-RuntimeHermes (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3054,7 +3054,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.82.0-rc.5):
+  - React-runtimescheduler (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3076,9 +3076,9 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.82.0-rc.5):
+  - React-timing (0.82.0):
     - React-debug
-  - React-utils (0.82.0-rc.5):
+  - React-utils (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3088,9 +3088,9 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - React-debug
-    - React-jsi (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0)
     - SocketRocket
-  - React-webperformancenativemodule (0.82.0-rc.5):
+  - React-webperformancenativemodule (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3106,9 +3106,9 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactAppDependencyProvider (0.82.0-rc.5):
+  - ReactAppDependencyProvider (0.82.0):
     - ReactCodegen
-  - ReactCodegen (0.82.0-rc.5):
+  - ReactCodegen (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3134,7 +3134,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.82.0-rc.5):
+  - ReactCommon (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3142,9 +3142,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.82.0-rc.5)
+    - ReactCommon/turbomodule (= 0.82.0)
     - SocketRocket
-  - ReactCommon/turbomodule (0.82.0-rc.5):
+  - ReactCommon/turbomodule (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3153,15 +3153,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.82.0-rc.5)
-    - React-cxxreact (= 0.82.0-rc.5)
-    - React-jsi (= 0.82.0-rc.5)
-    - React-logger (= 0.82.0-rc.5)
-    - React-perflogger (= 0.82.0-rc.5)
-    - ReactCommon/turbomodule/bridging (= 0.82.0-rc.5)
-    - ReactCommon/turbomodule/core (= 0.82.0-rc.5)
+    - React-callinvoker (= 0.82.0)
+    - React-cxxreact (= 0.82.0)
+    - React-jsi (= 0.82.0)
+    - React-logger (= 0.82.0)
+    - React-perflogger (= 0.82.0)
+    - ReactCommon/turbomodule/bridging (= 0.82.0)
+    - ReactCommon/turbomodule/core (= 0.82.0)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.82.0-rc.5):
+  - ReactCommon/turbomodule/bridging (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3170,13 +3170,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.82.0-rc.5)
-    - React-cxxreact (= 0.82.0-rc.5)
-    - React-jsi (= 0.82.0-rc.5)
-    - React-logger (= 0.82.0-rc.5)
-    - React-perflogger (= 0.82.0-rc.5)
+    - React-callinvoker (= 0.82.0)
+    - React-cxxreact (= 0.82.0)
+    - React-jsi (= 0.82.0)
+    - React-logger (= 0.82.0)
+    - React-perflogger (= 0.82.0)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.82.0-rc.5):
+  - ReactCommon/turbomodule/core (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3185,14 +3185,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.82.0-rc.5)
-    - React-cxxreact (= 0.82.0-rc.5)
-    - React-debug (= 0.82.0-rc.5)
-    - React-featureflags (= 0.82.0-rc.5)
-    - React-jsi (= 0.82.0-rc.5)
-    - React-logger (= 0.82.0-rc.5)
-    - React-perflogger (= 0.82.0-rc.5)
-    - React-utils (= 0.82.0-rc.5)
+    - React-callinvoker (= 0.82.0)
+    - React-cxxreact (= 0.82.0)
+    - React-debug (= 0.82.0)
+    - React-featureflags (= 0.82.0)
+    - React-jsi (= 0.82.0)
+    - React-logger (= 0.82.0)
+    - React-perflogger (= 0.82.0)
+    - React-utils (= 0.82.0)
     - SocketRocket
   - RNCAsyncStorage (2.2.0):
     - boost
@@ -4382,7 +4382,7 @@ SPEC CHECKSUMS:
   EXUpdates: 7b51bc7f220277034ccb656c467c9a4555266a52
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: 8d893933d9b2b77508382e4baf21f5b5464cb57a
+  FBLazyVector: 41b4dd99afd0aad861444ee141abdedaa6c3d238
   FirebaseAnalytics: acfa848bf81e1a4dbf60ef1f0eddd7328fe6673e
   FirebaseCore: 2321536f9c423b1f857e047a82b8a42abc6d9e2c
   FirebaseCoreExtension: 3a64994969dd05f4bcb7e6896c654eded238e75b
@@ -4398,7 +4398,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 3d1b94435f41419b5dd515584057b36a27e81ced
+  hermes-engine: 9d903fb0be22907dab4f665df1ebf922f5137586
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -4411,39 +4411,39 @@ SPEC CHECKSUMS:
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
-  RCTDeprecation: 41e5e0af75686dad802af9706c4eba1efa66ecfe
-  RCTRequired: 4a064c2751982b11344b923951bc7e27d6a9d467
-  RCTTypeSafety: 9c5a00fa9bd7abad20b2c520bbb823613cc2f2e2
+  RCTDeprecation: 22bf66112da540a7d40e536366ddd8557934fca1
+  RCTRequired: a0ed4dc41b35f79fbb6d8ba320e06882a8c792cf
+  RCTTypeSafety: 59a046ff1e602409a86b89fcd6edff367a5b14af
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 6eb704af98132bfdd36a19d9910b4d317d13100c
-  React-callinvoker: f103ec1e45df5713addfb0264a73eb7a4e0b9016
-  React-Core: 8a56e97e5acba6e473e7b2b175e078454cb4dd30
-  React-CoreModules: 4b25453083ea8f1bdfae3a6743d469043b67674e
-  React-cxxreact: 8a584a593a1fdb95483bad85b754aedaf8a60679
-  React-debug: d7c1d26881c507aa4c4c94a4657b9bca1ad4609d
-  React-defaultsnativemodule: d183f5204623c8eb775f163797596c704ca2416b
-  React-domnativemodule: 8e33e02a3290b2d8177b5a9b16495de935ed0b2b
-  React-Fabric: 17ab641193eb6b8bacc5f46b8f76e2f602332680
-  React-FabricComponents: 30400d7971f92a95f1b9620e82b1c98811f2c014
-  React-FabricImage: 23a39b1632ee6f7c1824e16180a8867b87d35f35
-  React-featureflags: 97933c8a06500cd161bd18cf4fbe2c9374d70e14
-  React-featureflagsnativemodule: dc1d536146fd73d070b8c2a89ed4c488b24dd6a4
-  React-graphics: 6f5cbb1167dde595a66d65ba220f9c54314e44d5
-  React-hermes: 50d1474fce48b94e3cc55a6356f00c6ffde3efff
-  React-idlecallbacksnativemodule: 09edf02e62f0d5cef34580156a2ffacd5425d464
-  React-ImageManager: 5d99c989f36b5c592b9582df486d2cd7f9a1da90
-  React-jserrorhandler: 010e321942df06ca3981898029623f85a291ffb2
-  React-jsi: 15dc6cbe84aefb9e6773827ea8ee9fa198a44564
-  React-jsiexecutor: 652a3c67c11c1a161866b06ca2639d5b0758b384
-  React-jsinspector: d22aa6ea27544048de489147a5dc8372422dc95a
-  React-jsinspectorcdp: f0216317d66edc8433fb04a27ff84e391425b582
-  React-jsinspectornetwork: 069620f58fd4215709c8a5d143c8182df1f20b94
-  React-jsinspectortracing: d0f3e3f01514726b3aa4d6c55ec77675ecc2bf10
-  React-jsitooling: 737fd34d451d4119c1f7320fc04fe034ef4da287
-  React-jsitracing: c8cd1009d69ff04eadc768ecdf1c1c43973a304f
-  React-logger: 1cd1f61088c1c6c04c62ddd9770af0955b500a86
-  React-Mapbuffer: 7cfd84b044618d1afe5310362c9e5c932bd43063
-  React-microtasksnativemodule: da1d0d2f783690ad5776a63d45ea9753571f93af
+  React: ade831e2e38887292c2c7d40f2f4098826a9dda4
+  React-callinvoker: fb097304922c5da47152147a5fb0712713438575
+  React-Core: 2f7181fccf31a895720bb0668ac9f67985d6a4a1
+  React-CoreModules: 3f7a8f9d28ba287fc07240c5bc53aa4d5e23450a
+  React-cxxreact: dca5689d4332bbf71495302103bb24f73fa1de00
+  React-debug: c855f7565d8c4aeceb23219ca3baa0e1ebfb578a
+  React-defaultsnativemodule: e1770db1c0e635b2dd8545616dd22962c6315c24
+  React-domnativemodule: a3a0a508c6f13565e1d042e1ee682ef5881325ef
+  React-Fabric: 4630570529e467827e40398626e95340734020cc
+  React-FabricComponents: 95b3ec1f3b9398ad75e78f69e612a6093a99d737
+  React-FabricImage: 96ec67d419d4d036ecc987bc14378afcd34d0653
+  React-featureflags: 8cbf892b2c12fc0e9cc08039287385dfcf2f3de6
+  React-featureflagsnativemodule: 7428b30d83749445157a8c253a77852e17217347
+  React-graphics: f1ad789bd076f99a76640d7f49a799ddf81b231d
+  React-hermes: b2c927f43e28ea4e8c915b7acdd907b24bfa9cdb
+  React-idlecallbacksnativemodule: 9392f0359575b41a42a71dcf5a2ada0c74dacb6f
+  React-ImageManager: 1736dbd4b93d78ae34cda2837c2da521a9feccb7
+  React-jserrorhandler: aad40898954bbc65c21a2e4524709e492675a750
+  React-jsi: 7d348c6ad689f8d044f5dbfea343d88e18cd6d57
+  React-jsiexecutor: 41b2cfc540fbe0eaa0d205a85c4f665c1d8b8683
+  React-jsinspector: 8559a86427c4b09546fb61cb96b4e60ab7490508
+  React-jsinspectorcdp: 0d3e1839d4cb22013e77f62834fff071b154d290
+  React-jsinspectornetwork: 5e2919805485b0b1f8acf16a6e508a5807eca7e5
+  React-jsinspectortracing: 123a7cf440721def804b188fb86b2f47366448d6
+  React-jsitooling: 9d0d29865180ecd51002986a60f89ca6897a10b7
+  React-jsitracing: fe4c3ca546e438a923add79d37a864546caba75f
+  React-logger: 2021eb67660b673cc654635832136fbbf2c79103
+  React-Mapbuffer: 9bda44c983f9c683047546a338ebe9a21020babd
+  React-microtasksnativemodule: 9b52faf56750d7e3c67d9cf96b650f14c31524c2
   react-native-google-maps: 7cc1184afe41fbd15a3dffd53c924819f6587b69
   react-native-keyboard-controller: 5e209d13d4c5355ddf8c36be3d41b8dfc879cd91
   react-native-maps: ee1e65647460c3d41e778071be5eda10e3da6225
@@ -4455,38 +4455,38 @@ SPEC CHECKSUMS:
   react-native-slider: 30cea7008de785564de2f4fd064f2deb38614a4a
   react-native-view-shot: aac285cd08144be29c19ab659930172836f0067f
   react-native-webview: 183e0d1f10b3c61c5ddd70f4ecd46488856a3573
-  React-NativeModulesApple: 67bd0ae88813a06fdab277bb4e0de50a3d470868
-  React-oscompat: 8f6bc162c03dfa41e70b9ab32bd1b692ac81051f
-  React-perflogger: 68b4a7c738f626b9787731d08d9f8a5c0feb2122
-  React-performancecdpmetrics: fb395ba9b7a005d8b0b590bd3aa227cf94451dbb
-  React-performancetimeline: 964e713588b39c91cad8475b3175da4d8677c653
-  React-RCTActionSheet: fde5090d31e027bd3099147d50ac4a69d9817c2c
-  React-RCTAnimation: c82e86775617fd3168b02be78c0b05db7727d013
-  React-RCTAppDelegate: 2a6e85772234b7022d7b017b83701ddeb58df49c
-  React-RCTBlob: 115b25b8f24332a6a21de43923bc655028fff937
-  React-RCTFabric: 9e41b38902cf2f856db99bc6626b7bf6b0fe3bee
-  React-RCTFBReactNativeSpec: db702c31cc71ff31017175aa235b4c9d4435e0f2
-  React-RCTImage: 7a0198ddd93dabadb69340a9385426475e21169e
-  React-RCTLinking: 85d7e02a9952a96e485ee48c3d030643afd587bd
-  React-RCTNetwork: 5cde64476ed1af70569ffc709ffc5663fb08b17b
-  React-RCTRuntime: 7e38a59559a5b9eaceb1fbb41bccc305f4fe434a
-  React-RCTSettings: 35154ee1f399ce54fd17b209f6a73147a5ed9345
-  React-RCTText: d8c98f4db4f1ec054ffb2f58b22b49dcedcfb6d3
-  React-RCTVibration: 23effbb317e27408a360d2467f8424099606678f
-  React-rendererconsistency: a114ca1d18e1c4ba6b8af818844b3bde9db76570
-  React-renderercss: 87aebb3a6a117c252941e68ef15d4ba459a1c03e
-  React-rendererdebug: a0423813386bdb102599789412d15d853ba4de5e
-  React-RuntimeApple: d266813a3d020756b297756dfd32310b7c2bfd26
-  React-RuntimeCore: 69585249c6114cbd75a8c0caa0fc606c9a9b5e0f
-  React-runtimeexecutor: c48455042001ad3cb97d4e6a0d3c7fb85ed5c289
-  React-RuntimeHermes: 050bb22f355a1f19df01149899db615672f76a99
-  React-runtimescheduler: 409d894a239182cb77e89f0a841ed0b36bd92f26
-  React-timing: dd3be228e14215f4300f3b9a891d9ce6f6735c96
-  React-utils: c08f3c5a29941dc41c7bfdf90e8ae76b8b3f9d86
-  React-webperformancenativemodule: 495882f02c4be9e4fb0836d445a6c792d2948615
-  ReactAppDependencyProvider: 77a7129540c0e06ab6be9a2bcb887d3d2e594431
-  ReactCodegen: 9754d3c716175df084aff56b430c67a393c8d113
-  ReactCommon: d07170f92e0e853091a70b2741b7c43f5dfdea73
+  React-NativeModulesApple: 1b4d9722d8df62e881684abadf320e7a8fa1b7f6
+  React-oscompat: 80ca388c4831481cd03a6b45ecfc82739ca9a95e
+  React-perflogger: 2e155343fa744b02ec2eab0f134639beb8fff659
+  React-performancecdpmetrics: b626b58b66880204b88428cd0f07f185910731ef
+  React-performancetimeline: 544c6abb44a10c47f10874aec41ae80693109875
+  React-RCTActionSheet: 2f0a844b3f4b749ce54bee10e5006aacbcb754e0
+  React-RCTAnimation: 3cda5b35147099142a3f4850da4b28e9cd6992a8
+  React-RCTAppDelegate: 7d0daf291219f3fca0d4e8a46f8042e977d94fcb
+  React-RCTBlob: 4e9cf72bbe40c2da7d358197c2f8d104d4aeba7a
+  React-RCTFabric: aa6982c39f6133fb280a5e401ea2e8438c3ba4c8
+  React-RCTFBReactNativeSpec: f388594e3dd33e67652c5e2339d299de06fcceba
+  React-RCTImage: d0dca6c29f03b5dc913be8a92f486d242997741f
+  React-RCTLinking: e3deaaa812a549c8410a413b44b6a2eb6027ddf9
+  React-RCTNetwork: 820ba7697a8c90ea66e339e9bd63a879010bdecf
+  React-RCTRuntime: 9bf02501880b487e921675db600bd4797dfd9743
+  React-RCTSettings: d887be78c915d0a51c91bffe1a39120a65a0e564
+  React-RCTText: 857ec084500001382d6bfe981e68373ca8178af6
+  React-RCTVibration: 02b4437b8b05ad7219c5e129a85e121d0b97635d
+  React-rendererconsistency: 74f53d2a1fa3bd87ed3fdbc83ad69cecf4bd0cb7
+  React-renderercss: 9530312be5919a6100391d7d920fb80e9303aafd
+  React-rendererdebug: afd65121fd0cfa79c62620085718424d481ca739
+  React-RuntimeApple: 702d4db49dc81193688132355709993009e73f86
+  React-RuntimeCore: 021216f96d7ef9e8b9ba5d8ffc0631410967f9ac
+  React-runtimeexecutor: 1a27868c5ef637814a55e1e0b46df71f7d102ed3
+  React-RuntimeHermes: 71b757553eb2f2c32ce796c88c0af8732fde9f58
+  React-runtimescheduler: 8f1fb375b46f4e34faf0caa2893f6d7585bb4e89
+  React-timing: 7a90be5e49292f093b8b1f5cbf87c0d0e8539699
+  React-utils: f840cea5cd05fdc26711327b522fb8de1b65cbe4
+  React-webperformancenativemodule: 365f718ced9c8b7042dea17f360a0a7ea49dfbb7
+  ReactAppDependencyProvider: d5f21b5da644b33685d4f2685cba86e3c7ea64ff
+  ReactCodegen: dff4f5cbb2542cf9e5de30c38bbada3adfb7d3fd
+  ReactCommon: 17f21c8e189e290113e40fd8652758ec9694897b
   RNCAsyncStorage: 302f2fac014fd450046c120567ca364632da682b
   RNCMaskedView: 63268de1986a098b5f4d1fb5b1bc1e97fade0aee
   RNCPicker: 51992b3407f6b70ddb8e417ec5714c3f2d48d8a4
@@ -4511,7 +4511,7 @@ SPEC CHECKSUMS:
   StripePaymentsUI: 05d4be35b34f821d5ddc8617dee04219f3646253
   StripeUICore: d07bd63a4b53dee8cab4d6f81ce5a7ab3e28511e
   UMAppLoader: e1234c45d2b7da239e9e90fc4bbeacee12afd5b6
-  Yoga: 47264cc34431da6b66b3687348be283084924f46
+  Yoga: edeb9900b9e5bb5b27b9a6a2d5914e4fe4033c1b
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: aaaa821356ecede13bd3ebe65b62ce223458b0fa

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -68,7 +68,7 @@
     "prop-types": "^15.7.2",
     "querystring": "^0.2.0",
     "react": "19.1.1",
-    "react-native": "0.82.0-rc.5",
+    "react-native": "0.82.0",
     "react-native-edge-to-edge": "1.6.0",
     "react-native-fade-in-image": "^1.6.1",
     "react-native-gesture-handler": "~2.28.0",

--- a/apps/jest-expo-mock-generator/package.json
+++ b/apps/jest-expo-mock-generator/package.json
@@ -9,6 +9,6 @@
     "expo": "~54.0.8",
     "expo-clipboard": "~8.0.7",
     "react": "19.1.1",
-    "react-native": "0.82.0-rc.5"
+    "react-native": "0.82.0"
   }
 }

--- a/apps/minimal-tester/ios/Podfile.lock
+++ b/apps/minimal-tester/ios/Podfile.lock
@@ -342,12 +342,12 @@ PODS:
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.82.0-rc.5)
+  - FBLazyVector (0.82.0)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - hermes-engine (0.82.0-rc.5):
-    - hermes-engine/Pre-built (= 0.82.0-rc.5)
-  - hermes-engine/Pre-built (0.82.0-rc.5)
+  - hermes-engine (0.82.0):
+    - hermes-engine/Pre-built (= 0.82.0)
+  - hermes-engine/Pre-built (0.82.0)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -384,28 +384,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.82.0-rc.5)
-  - RCTRequired (0.82.0-rc.5)
-  - RCTTypeSafety (0.82.0-rc.5):
-    - FBLazyVector (= 0.82.0-rc.5)
-    - RCTRequired (= 0.82.0-rc.5)
-    - React-Core (= 0.82.0-rc.5)
+  - RCTDeprecation (0.82.0)
+  - RCTRequired (0.82.0)
+  - RCTTypeSafety (0.82.0):
+    - FBLazyVector (= 0.82.0)
+    - RCTRequired (= 0.82.0)
+    - React-Core (= 0.82.0)
   - ReachabilitySwift (5.2.4)
-  - React (0.82.0-rc.5):
-    - React-Core (= 0.82.0-rc.5)
-    - React-Core/DevSupport (= 0.82.0-rc.5)
-    - React-Core/RCTWebSocket (= 0.82.0-rc.5)
-    - React-RCTActionSheet (= 0.82.0-rc.5)
-    - React-RCTAnimation (= 0.82.0-rc.5)
-    - React-RCTBlob (= 0.82.0-rc.5)
-    - React-RCTImage (= 0.82.0-rc.5)
-    - React-RCTLinking (= 0.82.0-rc.5)
-    - React-RCTNetwork (= 0.82.0-rc.5)
-    - React-RCTSettings (= 0.82.0-rc.5)
-    - React-RCTText (= 0.82.0-rc.5)
-    - React-RCTVibration (= 0.82.0-rc.5)
-  - React-callinvoker (0.82.0-rc.5)
-  - React-Core (0.82.0-rc.5):
+  - React (0.82.0):
+    - React-Core (= 0.82.0)
+    - React-Core/DevSupport (= 0.82.0)
+    - React-Core/RCTWebSocket (= 0.82.0)
+    - React-RCTActionSheet (= 0.82.0)
+    - React-RCTAnimation (= 0.82.0)
+    - React-RCTBlob (= 0.82.0)
+    - React-RCTImage (= 0.82.0)
+    - React-RCTLinking (= 0.82.0)
+    - React-RCTNetwork (= 0.82.0)
+    - React-RCTSettings (= 0.82.0)
+    - React-RCTText (= 0.82.0)
+    - React-RCTVibration (= 0.82.0)
+  - React-callinvoker (0.82.0)
+  - React-Core (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -415,7 +415,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.82.0-rc.5)
+    - React-Core/Default (= 0.82.0)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -430,82 +430,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.82.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.82.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.82.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.82.0-rc.5)
-    - React-Core/RCTWebSocket (= 0.82.0-rc.5)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.82.0-rc.5):
+  - React-Core/CoreModulesHeaders (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -530,7 +455,57 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.82.0-rc.5):
+  - React-Core/Default (0.82.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.82.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.82.0)
+    - React-Core/RCTWebSocket (= 0.82.0)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -555,7 +530,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.82.0-rc.5):
+  - React-Core/RCTAnimationHeaders (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -580,7 +555,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.82.0-rc.5):
+  - React-Core/RCTBlobHeaders (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -605,7 +580,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.82.0-rc.5):
+  - React-Core/RCTImageHeaders (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -630,7 +605,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.82.0-rc.5):
+  - React-Core/RCTLinkingHeaders (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -655,7 +630,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.82.0-rc.5):
+  - React-Core/RCTNetworkHeaders (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -680,7 +655,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.82.0-rc.5):
+  - React-Core/RCTSettingsHeaders (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -705,7 +680,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.82.0-rc.5):
+  - React-Core/RCTTextHeaders (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -730,7 +705,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.82.0-rc.5):
+  - React-Core/RCTVibrationHeaders (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -740,7 +715,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.82.0-rc.5)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -755,7 +730,32 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.82.0-rc.5):
+  - React-Core/RCTWebSocket (0.82.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.82.0)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -763,21 +763,21 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.82.0-rc.5)
-    - React-Core/CoreModulesHeaders (= 0.82.0-rc.5)
+    - RCTTypeSafety (= 0.82.0)
+    - React-Core/CoreModulesHeaders (= 0.82.0)
     - React-debug
-    - React-jsi (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.82.0-rc.5)
+    - React-RCTImage (= 0.82.0)
     - React-runtimeexecutor
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.82.0-rc.5):
+  - React-cxxreact (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -786,19 +786,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.82.0-rc.5)
-    - React-debug (= 0.82.0-rc.5)
-    - React-jsi (= 0.82.0-rc.5)
+    - React-callinvoker (= 0.82.0)
+    - React-debug (= 0.82.0)
+    - React-jsi (= 0.82.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.82.0-rc.5)
-    - React-perflogger (= 0.82.0-rc.5)
+    - React-logger (= 0.82.0)
+    - React-perflogger (= 0.82.0)
     - React-runtimeexecutor
-    - React-timing (= 0.82.0-rc.5)
+    - React-timing (= 0.82.0)
     - SocketRocket
-  - React-debug (0.82.0-rc.5)
-  - React-defaultsnativemodule (0.82.0-rc.5):
+  - React-debug (0.82.0)
+  - React-defaultsnativemodule (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -816,7 +816,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-webperformancenativemodule
     - SocketRocket
-  - React-domnativemodule (0.82.0-rc.5):
+  - React-domnativemodule (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -836,7 +836,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.82.0-rc.5):
+  - React-Fabric (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -850,23 +850,23 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.82.0-rc.5)
-    - React-Fabric/attributedstring (= 0.82.0-rc.5)
-    - React-Fabric/bridging (= 0.82.0-rc.5)
-    - React-Fabric/componentregistry (= 0.82.0-rc.5)
-    - React-Fabric/componentregistrynative (= 0.82.0-rc.5)
-    - React-Fabric/components (= 0.82.0-rc.5)
-    - React-Fabric/consistency (= 0.82.0-rc.5)
-    - React-Fabric/core (= 0.82.0-rc.5)
-    - React-Fabric/dom (= 0.82.0-rc.5)
-    - React-Fabric/imagemanager (= 0.82.0-rc.5)
-    - React-Fabric/leakchecker (= 0.82.0-rc.5)
-    - React-Fabric/mounting (= 0.82.0-rc.5)
-    - React-Fabric/observers (= 0.82.0-rc.5)
-    - React-Fabric/scheduler (= 0.82.0-rc.5)
-    - React-Fabric/telemetry (= 0.82.0-rc.5)
-    - React-Fabric/templateprocessor (= 0.82.0-rc.5)
-    - React-Fabric/uimanager (= 0.82.0-rc.5)
+    - React-Fabric/animations (= 0.82.0)
+    - React-Fabric/attributedstring (= 0.82.0)
+    - React-Fabric/bridging (= 0.82.0)
+    - React-Fabric/componentregistry (= 0.82.0)
+    - React-Fabric/componentregistrynative (= 0.82.0)
+    - React-Fabric/components (= 0.82.0)
+    - React-Fabric/consistency (= 0.82.0)
+    - React-Fabric/core (= 0.82.0)
+    - React-Fabric/dom (= 0.82.0)
+    - React-Fabric/imagemanager (= 0.82.0)
+    - React-Fabric/leakchecker (= 0.82.0)
+    - React-Fabric/mounting (= 0.82.0)
+    - React-Fabric/observers (= 0.82.0)
+    - React-Fabric/scheduler (= 0.82.0)
+    - React-Fabric/telemetry (= 0.82.0)
+    - React-Fabric/templateprocessor (= 0.82.0)
+    - React-Fabric/uimanager (= 0.82.0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -878,32 +878,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.82.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.82.0-rc.5):
+  - React-Fabric/animations (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -928,7 +903,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/bridging (0.82.0-rc.5):
+  - React-Fabric/attributedstring (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -953,7 +928,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.82.0-rc.5):
+  - React-Fabric/bridging (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -978,7 +953,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.82.0-rc.5):
+  - React-Fabric/componentregistry (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1003,36 +978,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.82.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.82.0-rc.5)
-    - React-Fabric/components/root (= 0.82.0-rc.5)
-    - React-Fabric/components/scrollview (= 0.82.0-rc.5)
-    - React-Fabric/components/view (= 0.82.0-rc.5)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.82.0-rc.5):
+  - React-Fabric/componentregistrynative (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1057,7 +1003,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.82.0-rc.5):
+  - React-Fabric/components (0.82.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.82.0)
+    - React-Fabric/components/root (= 0.82.0)
+    - React-Fabric/components/scrollview (= 0.82.0)
+    - React-Fabric/components/view (= 0.82.0)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1082,7 +1057,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.82.0-rc.5):
+  - React-Fabric/components/root (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1107,7 +1082,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.82.0-rc.5):
+  - React-Fabric/components/scrollview (0.82.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1134,7 +1134,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.82.0-rc.5):
+  - React-Fabric/consistency (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1159,7 +1159,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.82.0-rc.5):
+  - React-Fabric/core (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1184,7 +1184,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.82.0-rc.5):
+  - React-Fabric/dom (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1209,7 +1209,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.82.0-rc.5):
+  - React-Fabric/imagemanager (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1234,7 +1234,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.82.0-rc.5):
+  - React-Fabric/leakchecker (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1259,7 +1259,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.82.0-rc.5):
+  - React-Fabric/mounting (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1284,7 +1284,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.82.0-rc.5):
+  - React-Fabric/observers (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1298,7 +1298,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.82.0-rc.5)
+    - React-Fabric/observers/events (= 0.82.0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1310,7 +1310,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.82.0-rc.5):
+  - React-Fabric/observers/events (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1335,7 +1335,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.82.0-rc.5):
+  - React-Fabric/scheduler (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1363,7 +1363,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.82.0-rc.5):
+  - React-Fabric/telemetry (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1388,7 +1388,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.82.0-rc.5):
+  - React-Fabric/templateprocessor (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1413,7 +1413,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.82.0-rc.5):
+  - React-Fabric/uimanager (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1427,7 +1427,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.82.0-rc.5)
+    - React-Fabric/uimanager/consistency (= 0.82.0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1440,7 +1440,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager/consistency (0.82.0-rc.5):
+  - React-Fabric/uimanager/consistency (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1466,7 +1466,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.82.0-rc.5):
+  - React-FabricComponents (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1481,8 +1481,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.82.0-rc.5)
-    - React-FabricComponents/textlayoutmanager (= 0.82.0-rc.5)
+    - React-FabricComponents/components (= 0.82.0)
+    - React-FabricComponents/textlayoutmanager (= 0.82.0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1495,7 +1495,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.82.0-rc.5):
+  - React-FabricComponents/components (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1510,18 +1510,18 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.82.0-rc.5)
-    - React-FabricComponents/components/iostextinput (= 0.82.0-rc.5)
-    - React-FabricComponents/components/modal (= 0.82.0-rc.5)
-    - React-FabricComponents/components/rncore (= 0.82.0-rc.5)
-    - React-FabricComponents/components/safeareaview (= 0.82.0-rc.5)
-    - React-FabricComponents/components/scrollview (= 0.82.0-rc.5)
-    - React-FabricComponents/components/switch (= 0.82.0-rc.5)
-    - React-FabricComponents/components/text (= 0.82.0-rc.5)
-    - React-FabricComponents/components/textinput (= 0.82.0-rc.5)
-    - React-FabricComponents/components/unimplementedview (= 0.82.0-rc.5)
-    - React-FabricComponents/components/virtualview (= 0.82.0-rc.5)
-    - React-FabricComponents/components/virtualviewexperimental (= 0.82.0-rc.5)
+    - React-FabricComponents/components/inputaccessory (= 0.82.0)
+    - React-FabricComponents/components/iostextinput (= 0.82.0)
+    - React-FabricComponents/components/modal (= 0.82.0)
+    - React-FabricComponents/components/rncore (= 0.82.0)
+    - React-FabricComponents/components/safeareaview (= 0.82.0)
+    - React-FabricComponents/components/scrollview (= 0.82.0)
+    - React-FabricComponents/components/switch (= 0.82.0)
+    - React-FabricComponents/components/text (= 0.82.0)
+    - React-FabricComponents/components/textinput (= 0.82.0)
+    - React-FabricComponents/components/unimplementedview (= 0.82.0)
+    - React-FabricComponents/components/virtualview (= 0.82.0)
+    - React-FabricComponents/components/virtualviewexperimental (= 0.82.0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1534,34 +1534,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.82.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.82.0-rc.5):
+  - React-FabricComponents/components/inputaccessory (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1588,7 +1561,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/modal (0.82.0-rc.5):
+  - React-FabricComponents/components/iostextinput (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1615,7 +1588,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.82.0-rc.5):
+  - React-FabricComponents/components/modal (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1642,7 +1615,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.82.0-rc.5):
+  - React-FabricComponents/components/rncore (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1669,7 +1642,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.82.0-rc.5):
+  - React-FabricComponents/components/safeareaview (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1696,7 +1669,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/switch (0.82.0-rc.5):
+  - React-FabricComponents/components/scrollview (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1723,7 +1696,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.82.0-rc.5):
+  - React-FabricComponents/components/switch (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1750,7 +1723,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.82.0-rc.5):
+  - React-FabricComponents/components/text (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1777,7 +1750,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.82.0-rc.5):
+  - React-FabricComponents/components/textinput (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1804,7 +1777,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualview (0.82.0-rc.5):
+  - React-FabricComponents/components/unimplementedview (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1831,7 +1804,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualviewexperimental (0.82.0-rc.5):
+  - React-FabricComponents/components/virtualview (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1858,7 +1831,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.82.0-rc.5):
+  - React-FabricComponents/components/virtualviewexperimental (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1885,7 +1858,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.82.0-rc.5):
+  - React-FabricComponents/textlayoutmanager (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1894,21 +1867,48 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.82.0-rc.5)
-    - RCTTypeSafety (= 0.82.0-rc.5)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.82.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.82.0)
+    - RCTTypeSafety (= 0.82.0)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.82.0-rc.5)
+    - React-jsiexecutor (= 0.82.0)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.82.0-rc.5):
+  - React-featureflags (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1917,7 +1917,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.82.0-rc.5):
+  - React-featureflagsnativemodule (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1932,7 +1932,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.82.0-rc.5):
+  - React-graphics (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1945,7 +1945,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.82.0-rc.5):
+  - React-hermes (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1954,17 +1954,17 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.82.0-rc.5)
+    - React-cxxreact (= 0.82.0)
     - React-jsi
-    - React-jsiexecutor (= 0.82.0-rc.5)
+    - React-jsiexecutor (= 0.82.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.82.0-rc.5)
+    - React-perflogger (= 0.82.0)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.82.0-rc.5):
+  - React-idlecallbacksnativemodule (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1980,7 +1980,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.82.0-rc.5):
+  - React-ImageManager (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1995,7 +1995,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jserrorhandler (0.82.0-rc.5):
+  - React-jserrorhandler (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2010,7 +2010,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.82.0-rc.5):
+  - React-jsi (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2020,7 +2020,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.82.0-rc.5):
+  - React-jsiexecutor (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2038,7 +2038,7 @@ PODS:
     - React-perflogger
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspector (0.82.0-rc.5):
+  - React-jsinspector (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2053,10 +2053,10 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.82.0-rc.5)
+    - React-perflogger (= 0.82.0)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspectorcdp (0.82.0-rc.5):
+  - React-jsinspectorcdp (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2065,7 +2065,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.82.0-rc.5):
+  - React-jsinspectornetwork (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2078,7 +2078,7 @@ PODS:
     - React-performancetimeline
     - React-timing
     - SocketRocket
-  - React-jsinspectortracing (0.82.0-rc.5):
+  - React-jsinspectortracing (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2089,7 +2089,7 @@ PODS:
     - React-oscompat
     - React-timing
     - SocketRocket
-  - React-jsitooling (0.82.0-rc.5):
+  - React-jsitooling (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2097,17 +2097,17 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.82.0-rc.5)
+    - React-cxxreact (= 0.82.0)
     - React-debug
-    - React-jsi (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsitracing (0.82.0-rc.5):
+  - React-jsitracing (0.82.0):
     - React-jsi
-  - React-logger (0.82.0-rc.5):
+  - React-logger (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2116,7 +2116,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.82.0-rc.5):
+  - React-Mapbuffer (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2126,7 +2126,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.82.0-rc.5):
+  - React-microtasksnativemodule (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2140,7 +2140,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-NativeModulesApple (0.82.0-rc.5):
+  - React-NativeModulesApple (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2161,8 +2161,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.82.0-rc.5)
-  - React-perflogger (0.82.0-rc.5):
+  - React-oscompat (0.82.0)
+  - React-perflogger (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2171,7 +2171,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancecdpmetrics (0.82.0-rc.5):
+  - React-performancecdpmetrics (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2185,7 +2185,7 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - SocketRocket
-  - React-performancetimeline (0.82.0-rc.5):
+  - React-performancetimeline (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2198,9 +2198,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.82.0-rc.5):
-    - React-Core/RCTActionSheetHeaders (= 0.82.0-rc.5)
-  - React-RCTAnimation (0.82.0-rc.5):
+  - React-RCTActionSheet (0.82.0):
+    - React-Core/RCTActionSheetHeaders (= 0.82.0)
+  - React-RCTAnimation (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2216,7 +2216,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.82.0-rc.5):
+  - React-RCTAppDelegate (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2250,7 +2250,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.82.0-rc.5):
+  - React-RCTBlob (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2269,7 +2269,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.82.0-rc.5):
+  - React-RCTFabric (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2305,7 +2305,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.82.0-rc.5):
+  - React-RCTFBReactNativeSpec (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2319,10 +2319,10 @@ PODS:
     - React-Core
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.82.0-rc.5)
+    - React-RCTFBReactNativeSpec/components (= 0.82.0)
     - ReactCommon
     - SocketRocket
-  - React-RCTFBReactNativeSpec/components (0.82.0-rc.5):
+  - React-RCTFBReactNativeSpec/components (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2345,7 +2345,7 @@ PODS:
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-RCTImage (0.82.0-rc.5):
+  - React-RCTImage (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2361,14 +2361,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.82.0-rc.5):
-    - React-Core/RCTLinkingHeaders (= 0.82.0-rc.5)
-    - React-jsi (= 0.82.0-rc.5)
+  - React-RCTLinking (0.82.0):
+    - React-Core/RCTLinkingHeaders (= 0.82.0)
+    - React-jsi (= 0.82.0)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.82.0-rc.5)
-  - React-RCTNetwork (0.82.0-rc.5):
+    - ReactCommon/turbomodule/core (= 0.82.0)
+  - React-RCTNetwork (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2387,7 +2387,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.82.0-rc.5):
+  - React-RCTRuntime (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2408,7 +2408,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.82.0-rc.5):
+  - React-RCTSettings (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2423,10 +2423,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.82.0-rc.5):
-    - React-Core/RCTTextHeaders (= 0.82.0-rc.5)
+  - React-RCTText (0.82.0):
+    - React-Core/RCTTextHeaders (= 0.82.0)
     - Yoga
-  - React-RCTVibration (0.82.0-rc.5):
+  - React-RCTVibration (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2440,11 +2440,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.82.0-rc.5)
-  - React-renderercss (0.82.0-rc.5):
+  - React-rendererconsistency (0.82.0)
+  - React-renderercss (0.82.0):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.82.0-rc.5):
+  - React-rendererdebug (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2454,7 +2454,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-RuntimeApple (0.82.0-rc.5):
+  - React-RuntimeApple (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2483,7 +2483,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.82.0-rc.5):
+  - React-RuntimeCore (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2505,7 +2505,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.82.0-rc.5):
+  - React-runtimeexecutor (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2515,10 +2515,10 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0)
     - React-utils
     - SocketRocket
-  - React-RuntimeHermes (0.82.0-rc.5):
+  - React-RuntimeHermes (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2539,7 +2539,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.82.0-rc.5):
+  - React-runtimescheduler (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2561,9 +2561,9 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.82.0-rc.5):
+  - React-timing (0.82.0):
     - React-debug
-  - React-utils (0.82.0-rc.5):
+  - React-utils (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2573,9 +2573,9 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - React-debug
-    - React-jsi (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0)
     - SocketRocket
-  - React-webperformancenativemodule (0.82.0-rc.5):
+  - React-webperformancenativemodule (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2591,9 +2591,9 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactAppDependencyProvider (0.82.0-rc.5):
+  - ReactAppDependencyProvider (0.82.0):
     - ReactCodegen
-  - ReactCodegen (0.82.0-rc.5):
+  - ReactCodegen (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2619,7 +2619,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.82.0-rc.5):
+  - ReactCommon (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2627,9 +2627,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.82.0-rc.5)
+    - ReactCommon/turbomodule (= 0.82.0)
     - SocketRocket
-  - ReactCommon/turbomodule (0.82.0-rc.5):
+  - ReactCommon/turbomodule (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2638,15 +2638,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.82.0-rc.5)
-    - React-cxxreact (= 0.82.0-rc.5)
-    - React-jsi (= 0.82.0-rc.5)
-    - React-logger (= 0.82.0-rc.5)
-    - React-perflogger (= 0.82.0-rc.5)
-    - ReactCommon/turbomodule/bridging (= 0.82.0-rc.5)
-    - ReactCommon/turbomodule/core (= 0.82.0-rc.5)
+    - React-callinvoker (= 0.82.0)
+    - React-cxxreact (= 0.82.0)
+    - React-jsi (= 0.82.0)
+    - React-logger (= 0.82.0)
+    - React-perflogger (= 0.82.0)
+    - ReactCommon/turbomodule/bridging (= 0.82.0)
+    - ReactCommon/turbomodule/core (= 0.82.0)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.82.0-rc.5):
+  - ReactCommon/turbomodule/bridging (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2655,13 +2655,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.82.0-rc.5)
-    - React-cxxreact (= 0.82.0-rc.5)
-    - React-jsi (= 0.82.0-rc.5)
-    - React-logger (= 0.82.0-rc.5)
-    - React-perflogger (= 0.82.0-rc.5)
+    - React-callinvoker (= 0.82.0)
+    - React-cxxreact (= 0.82.0)
+    - React-jsi (= 0.82.0)
+    - React-logger (= 0.82.0)
+    - React-perflogger (= 0.82.0)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.82.0-rc.5):
+  - ReactCommon/turbomodule/core (0.82.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2670,14 +2670,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.82.0-rc.5)
-    - React-cxxreact (= 0.82.0-rc.5)
-    - React-debug (= 0.82.0-rc.5)
-    - React-featureflags (= 0.82.0-rc.5)
-    - React-jsi (= 0.82.0-rc.5)
-    - React-logger (= 0.82.0-rc.5)
-    - React-perflogger (= 0.82.0-rc.5)
-    - React-utils (= 0.82.0-rc.5)
+    - React-callinvoker (= 0.82.0)
+    - React-cxxreact (= 0.82.0)
+    - React-debug (= 0.82.0)
+    - React-featureflags (= 0.82.0)
+    - React-jsi (= 0.82.0)
+    - React-logger (= 0.82.0)
+    - React-perflogger (= 0.82.0)
+    - React-utils (= 0.82.0)
     - SocketRocket
   - SDWebImage (5.21.0):
     - SDWebImage/Core (= 5.21.0)
@@ -3037,85 +3037,85 @@ SPEC CHECKSUMS:
   EXUpdates: 0dfa860736d6444c0949e691d53e1320f9bc2cb2
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: 8d893933d9b2b77508382e4baf21f5b5464cb57a
+  FBLazyVector: 41b4dd99afd0aad861444ee141abdedaa6c3d238
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: a14f7f403796d60a2ae636a4d5b6c1f7646503f8
+  hermes-engine: 8642d8f14a548ab718ec112e9bebdfdd154138b5
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
-  RCTDeprecation: 41e5e0af75686dad802af9706c4eba1efa66ecfe
-  RCTRequired: 4a064c2751982b11344b923951bc7e27d6a9d467
-  RCTTypeSafety: 9c5a00fa9bd7abad20b2c520bbb823613cc2f2e2
+  RCTDeprecation: 22bf66112da540a7d40e536366ddd8557934fca1
+  RCTRequired: a0ed4dc41b35f79fbb6d8ba320e06882a8c792cf
+  RCTTypeSafety: 59a046ff1e602409a86b89fcd6edff367a5b14af
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 6eb704af98132bfdd36a19d9910b4d317d13100c
-  React-callinvoker: f103ec1e45df5713addfb0264a73eb7a4e0b9016
-  React-Core: 8a56e97e5acba6e473e7b2b175e078454cb4dd30
-  React-CoreModules: 4b25453083ea8f1bdfae3a6743d469043b67674e
-  React-cxxreact: 8a584a593a1fdb95483bad85b754aedaf8a60679
-  React-debug: d7c1d26881c507aa4c4c94a4657b9bca1ad4609d
-  React-defaultsnativemodule: d183f5204623c8eb775f163797596c704ca2416b
-  React-domnativemodule: 8e33e02a3290b2d8177b5a9b16495de935ed0b2b
-  React-Fabric: 17ab641193eb6b8bacc5f46b8f76e2f602332680
-  React-FabricComponents: 30400d7971f92a95f1b9620e82b1c98811f2c014
-  React-FabricImage: 23a39b1632ee6f7c1824e16180a8867b87d35f35
-  React-featureflags: 97933c8a06500cd161bd18cf4fbe2c9374d70e14
-  React-featureflagsnativemodule: dc1d536146fd73d070b8c2a89ed4c488b24dd6a4
-  React-graphics: 6f5cbb1167dde595a66d65ba220f9c54314e44d5
-  React-hermes: 50d1474fce48b94e3cc55a6356f00c6ffde3efff
-  React-idlecallbacksnativemodule: 09edf02e62f0d5cef34580156a2ffacd5425d464
-  React-ImageManager: 5d99c989f36b5c592b9582df486d2cd7f9a1da90
-  React-jserrorhandler: 010e321942df06ca3981898029623f85a291ffb2
-  React-jsi: 15dc6cbe84aefb9e6773827ea8ee9fa198a44564
-  React-jsiexecutor: 652a3c67c11c1a161866b06ca2639d5b0758b384
-  React-jsinspector: d22aa6ea27544048de489147a5dc8372422dc95a
-  React-jsinspectorcdp: f0216317d66edc8433fb04a27ff84e391425b582
-  React-jsinspectornetwork: 069620f58fd4215709c8a5d143c8182df1f20b94
-  React-jsinspectortracing: d0f3e3f01514726b3aa4d6c55ec77675ecc2bf10
-  React-jsitooling: 737fd34d451d4119c1f7320fc04fe034ef4da287
-  React-jsitracing: c8cd1009d69ff04eadc768ecdf1c1c43973a304f
-  React-logger: 1cd1f61088c1c6c04c62ddd9770af0955b500a86
-  React-Mapbuffer: 7cfd84b044618d1afe5310362c9e5c932bd43063
-  React-microtasksnativemodule: da1d0d2f783690ad5776a63d45ea9753571f93af
-  React-NativeModulesApple: 67bd0ae88813a06fdab277bb4e0de50a3d470868
-  React-oscompat: 8f6bc162c03dfa41e70b9ab32bd1b692ac81051f
-  React-perflogger: 68b4a7c738f626b9787731d08d9f8a5c0feb2122
-  React-performancecdpmetrics: fb395ba9b7a005d8b0b590bd3aa227cf94451dbb
-  React-performancetimeline: 964e713588b39c91cad8475b3175da4d8677c653
-  React-RCTActionSheet: fde5090d31e027bd3099147d50ac4a69d9817c2c
-  React-RCTAnimation: c82e86775617fd3168b02be78c0b05db7727d013
-  React-RCTAppDelegate: 2a6e85772234b7022d7b017b83701ddeb58df49c
-  React-RCTBlob: 115b25b8f24332a6a21de43923bc655028fff937
-  React-RCTFabric: 9e41b38902cf2f856db99bc6626b7bf6b0fe3bee
-  React-RCTFBReactNativeSpec: db702c31cc71ff31017175aa235b4c9d4435e0f2
-  React-RCTImage: 7a0198ddd93dabadb69340a9385426475e21169e
-  React-RCTLinking: 85d7e02a9952a96e485ee48c3d030643afd587bd
-  React-RCTNetwork: 5cde64476ed1af70569ffc709ffc5663fb08b17b
-  React-RCTRuntime: 7e38a59559a5b9eaceb1fbb41bccc305f4fe434a
-  React-RCTSettings: 35154ee1f399ce54fd17b209f6a73147a5ed9345
-  React-RCTText: d8c98f4db4f1ec054ffb2f58b22b49dcedcfb6d3
-  React-RCTVibration: 23effbb317e27408a360d2467f8424099606678f
-  React-rendererconsistency: a114ca1d18e1c4ba6b8af818844b3bde9db76570
-  React-renderercss: 87aebb3a6a117c252941e68ef15d4ba459a1c03e
-  React-rendererdebug: a0423813386bdb102599789412d15d853ba4de5e
-  React-RuntimeApple: d266813a3d020756b297756dfd32310b7c2bfd26
-  React-RuntimeCore: 69585249c6114cbd75a8c0caa0fc606c9a9b5e0f
-  React-runtimeexecutor: c48455042001ad3cb97d4e6a0d3c7fb85ed5c289
-  React-RuntimeHermes: 050bb22f355a1f19df01149899db615672f76a99
-  React-runtimescheduler: 409d894a239182cb77e89f0a841ed0b36bd92f26
-  React-timing: dd3be228e14215f4300f3b9a891d9ce6f6735c96
-  React-utils: c08f3c5a29941dc41c7bfdf90e8ae76b8b3f9d86
-  React-webperformancenativemodule: 495882f02c4be9e4fb0836d445a6c792d2948615
-  ReactAppDependencyProvider: 77a7129540c0e06ab6be9a2bcb887d3d2e594431
-  ReactCodegen: f1e31c701a2128967832c6ca48dbcd99bcdb90a8
-  ReactCommon: d07170f92e0e853091a70b2741b7c43f5dfdea73
+  React: ade831e2e38887292c2c7d40f2f4098826a9dda4
+  React-callinvoker: fb097304922c5da47152147a5fb0712713438575
+  React-Core: 2f7181fccf31a895720bb0668ac9f67985d6a4a1
+  React-CoreModules: 3f7a8f9d28ba287fc07240c5bc53aa4d5e23450a
+  React-cxxreact: dca5689d4332bbf71495302103bb24f73fa1de00
+  React-debug: c855f7565d8c4aeceb23219ca3baa0e1ebfb578a
+  React-defaultsnativemodule: e1770db1c0e635b2dd8545616dd22962c6315c24
+  React-domnativemodule: a3a0a508c6f13565e1d042e1ee682ef5881325ef
+  React-Fabric: 4630570529e467827e40398626e95340734020cc
+  React-FabricComponents: 95b3ec1f3b9398ad75e78f69e612a6093a99d737
+  React-FabricImage: 96ec67d419d4d036ecc987bc14378afcd34d0653
+  React-featureflags: 8cbf892b2c12fc0e9cc08039287385dfcf2f3de6
+  React-featureflagsnativemodule: 7428b30d83749445157a8c253a77852e17217347
+  React-graphics: f1ad789bd076f99a76640d7f49a799ddf81b231d
+  React-hermes: b2c927f43e28ea4e8c915b7acdd907b24bfa9cdb
+  React-idlecallbacksnativemodule: 9392f0359575b41a42a71dcf5a2ada0c74dacb6f
+  React-ImageManager: 1736dbd4b93d78ae34cda2837c2da521a9feccb7
+  React-jserrorhandler: aad40898954bbc65c21a2e4524709e492675a750
+  React-jsi: 7d348c6ad689f8d044f5dbfea343d88e18cd6d57
+  React-jsiexecutor: 41b2cfc540fbe0eaa0d205a85c4f665c1d8b8683
+  React-jsinspector: 8559a86427c4b09546fb61cb96b4e60ab7490508
+  React-jsinspectorcdp: 0d3e1839d4cb22013e77f62834fff071b154d290
+  React-jsinspectornetwork: 5e2919805485b0b1f8acf16a6e508a5807eca7e5
+  React-jsinspectortracing: 123a7cf440721def804b188fb86b2f47366448d6
+  React-jsitooling: 9d0d29865180ecd51002986a60f89ca6897a10b7
+  React-jsitracing: fe4c3ca546e438a923add79d37a864546caba75f
+  React-logger: 2021eb67660b673cc654635832136fbbf2c79103
+  React-Mapbuffer: 9bda44c983f9c683047546a338ebe9a21020babd
+  React-microtasksnativemodule: 9b52faf56750d7e3c67d9cf96b650f14c31524c2
+  React-NativeModulesApple: 1b4d9722d8df62e881684abadf320e7a8fa1b7f6
+  React-oscompat: 80ca388c4831481cd03a6b45ecfc82739ca9a95e
+  React-perflogger: 2e155343fa744b02ec2eab0f134639beb8fff659
+  React-performancecdpmetrics: b626b58b66880204b88428cd0f07f185910731ef
+  React-performancetimeline: 544c6abb44a10c47f10874aec41ae80693109875
+  React-RCTActionSheet: 2f0a844b3f4b749ce54bee10e5006aacbcb754e0
+  React-RCTAnimation: 3cda5b35147099142a3f4850da4b28e9cd6992a8
+  React-RCTAppDelegate: 7d0daf291219f3fca0d4e8a46f8042e977d94fcb
+  React-RCTBlob: 4e9cf72bbe40c2da7d358197c2f8d104d4aeba7a
+  React-RCTFabric: aa6982c39f6133fb280a5e401ea2e8438c3ba4c8
+  React-RCTFBReactNativeSpec: f388594e3dd33e67652c5e2339d299de06fcceba
+  React-RCTImage: d0dca6c29f03b5dc913be8a92f486d242997741f
+  React-RCTLinking: e3deaaa812a549c8410a413b44b6a2eb6027ddf9
+  React-RCTNetwork: 820ba7697a8c90ea66e339e9bd63a879010bdecf
+  React-RCTRuntime: 9bf02501880b487e921675db600bd4797dfd9743
+  React-RCTSettings: d887be78c915d0a51c91bffe1a39120a65a0e564
+  React-RCTText: 857ec084500001382d6bfe981e68373ca8178af6
+  React-RCTVibration: 02b4437b8b05ad7219c5e129a85e121d0b97635d
+  React-rendererconsistency: 74f53d2a1fa3bd87ed3fdbc83ad69cecf4bd0cb7
+  React-renderercss: 9530312be5919a6100391d7d920fb80e9303aafd
+  React-rendererdebug: afd65121fd0cfa79c62620085718424d481ca739
+  React-RuntimeApple: 702d4db49dc81193688132355709993009e73f86
+  React-RuntimeCore: 021216f96d7ef9e8b9ba5d8ffc0631410967f9ac
+  React-runtimeexecutor: 1a27868c5ef637814a55e1e0b46df71f7d102ed3
+  React-RuntimeHermes: 71b757553eb2f2c32ce796c88c0af8732fde9f58
+  React-runtimescheduler: 8f1fb375b46f4e34faf0caa2893f6d7585bb4e89
+  React-timing: 7a90be5e49292f093b8b1f5cbf87c0d0e8539699
+  React-utils: f840cea5cd05fdc26711327b522fb8de1b65cbe4
+  React-webperformancenativemodule: 365f718ced9c8b7042dea17f360a0a7ea49dfbb7
+  ReactAppDependencyProvider: d5f21b5da644b33685d4f2685cba86e3c7ea64ff
+  ReactCodegen: 89fd37fe167462f854e43bf738c137f274d1ca0d
+  ReactCommon: 17f21c8e189e290113e40fd8652758ec9694897b
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 47264cc34431da6b66b3687348be283084924f46
+  Yoga: edeb9900b9e5bb5b27b9a6a2d5914e4fe4033c1b
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 3d26d20fc75a5b3e209d9b88282589121a9ef56d

--- a/apps/minimal-tester/package.json
+++ b/apps/minimal-tester/package.json
@@ -22,7 +22,7 @@
     "expo-video": "~3.0.11",
     "react": "19.1.1",
     "react-dom": "19.1.1",
-    "react-native": "0.82.0-rc.5",
+    "react-native": "0.82.0",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -140,7 +140,7 @@
     "processing-js": "^1.6.6",
     "react": "19.1.1",
     "react-dom": "19.1.1",
-    "react-native": "0.82.0-rc.5",
+    "react-native": "0.82.0",
     "react-native-dropdown-picker": "^5.3.0",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-keyboard-controller": "^1.18.5",

--- a/apps/native-tests/ios/Podfile.lock
+++ b/apps/native-tests/ios/Podfile.lock
@@ -432,10 +432,10 @@ PODS:
     - Yoga
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
-  - FBLazyVector (0.82.0-rc.5)
-  - hermes-engine (0.82.0-rc.5):
-    - hermes-engine/Pre-built (= 0.82.0-rc.5)
-  - hermes-engine/Pre-built (0.82.0-rc.5)
+  - FBLazyVector (0.82.0)
+  - hermes-engine (0.82.0):
+    - hermes-engine/Pre-built (= 0.82.0)
+  - hermes-engine/Pre-built (0.82.0)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -468,32 +468,32 @@ PODS:
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (9.1.0)
   - Quick (7.3.0)
-  - RCTDeprecation (0.82.0-rc.5)
-  - RCTRequired (0.82.0-rc.5)
-  - RCTTypeSafety (0.82.0-rc.5):
-    - FBLazyVector (= 0.82.0-rc.5)
-    - RCTRequired (= 0.82.0-rc.5)
-    - React-Core (= 0.82.0-rc.5)
+  - RCTDeprecation (0.82.0)
+  - RCTRequired (0.82.0)
+  - RCTTypeSafety (0.82.0):
+    - FBLazyVector (= 0.82.0)
+    - RCTRequired (= 0.82.0)
+    - React-Core (= 0.82.0)
   - ReachabilitySwift (5.2.4)
-  - React (0.82.0-rc.5):
-    - React-Core (= 0.82.0-rc.5)
-    - React-Core/DevSupport (= 0.82.0-rc.5)
-    - React-Core/RCTWebSocket (= 0.82.0-rc.5)
-    - React-RCTActionSheet (= 0.82.0-rc.5)
-    - React-RCTAnimation (= 0.82.0-rc.5)
-    - React-RCTBlob (= 0.82.0-rc.5)
-    - React-RCTImage (= 0.82.0-rc.5)
-    - React-RCTLinking (= 0.82.0-rc.5)
-    - React-RCTNetwork (= 0.82.0-rc.5)
-    - React-RCTSettings (= 0.82.0-rc.5)
-    - React-RCTText (= 0.82.0-rc.5)
-    - React-RCTVibration (= 0.82.0-rc.5)
-  - React-callinvoker (0.82.0-rc.5)
-  - React-Core (0.82.0-rc.5):
+  - React (0.82.0):
+    - React-Core (= 0.82.0)
+    - React-Core/DevSupport (= 0.82.0)
+    - React-Core/RCTWebSocket (= 0.82.0)
+    - React-RCTActionSheet (= 0.82.0)
+    - React-RCTAnimation (= 0.82.0)
+    - React-RCTBlob (= 0.82.0)
+    - React-RCTImage (= 0.82.0)
+    - React-RCTLinking (= 0.82.0)
+    - React-RCTNetwork (= 0.82.0)
+    - React-RCTSettings (= 0.82.0)
+    - React-RCTText (= 0.82.0)
+    - React-RCTVibration (= 0.82.0)
+  - React-callinvoker (0.82.0)
+  - React-Core (0.82.0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.82.0-rc.5)
+    - React-Core/Default (= 0.82.0)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -508,66 +508,9 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core-prebuilt (0.82.0-rc.5):
+  - React-Core-prebuilt (0.82.0):
     - ReactNativeDependencies
-  - React-Core/CoreModulesHeaders (0.82.0-rc.5):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/Default (0.82.0-rc.5):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/DevSupport (0.82.0-rc.5):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default (= 0.82.0-rc.5)
-    - React-Core/RCTWebSocket (= 0.82.0-rc.5)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.82.0-rc.5):
+  - React-Core/CoreModulesHeaders (0.82.0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -586,7 +529,45 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.82.0-rc.5):
+  - React-Core/Default (0.82.0):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/DevSupport (0.82.0):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-Core/Default (= 0.82.0)
+    - React-Core/RCTWebSocket (= 0.82.0)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.82.0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -605,7 +586,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTBlobHeaders (0.82.0-rc.5):
+  - React-Core/RCTAnimationHeaders (0.82.0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -624,7 +605,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTImageHeaders (0.82.0-rc.5):
+  - React-Core/RCTBlobHeaders (0.82.0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -643,7 +624,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.82.0-rc.5):
+  - React-Core/RCTImageHeaders (0.82.0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -662,7 +643,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.82.0-rc.5):
+  - React-Core/RCTLinkingHeaders (0.82.0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -681,7 +662,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.82.0-rc.5):
+  - React-Core/RCTNetworkHeaders (0.82.0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -700,7 +681,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTTextHeaders (0.82.0-rc.5):
+  - React-Core/RCTSettingsHeaders (0.82.0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -719,7 +700,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.82.0-rc.5):
+  - React-Core/RCTTextHeaders (0.82.0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -738,11 +719,11 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTWebSocket (0.82.0-rc.5):
+  - React-Core/RCTVibrationHeaders (0.82.0):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.82.0-rc.5)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -757,38 +738,57 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-CoreModules (0.82.0-rc.5):
-    - RCTTypeSafety (= 0.82.0-rc.5)
+  - React-Core/RCTWebSocket (0.82.0):
+    - hermes-engine
+    - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/CoreModulesHeaders (= 0.82.0-rc.5)
+    - React-Core/Default (= 0.82.0)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-CoreModules (0.82.0):
+    - RCTTypeSafety (= 0.82.0)
+    - React-Core-prebuilt
+    - React-Core/CoreModulesHeaders (= 0.82.0)
     - React-debug
-    - React-jsi (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.82.0-rc.5)
+    - React-RCTImage (= 0.82.0)
     - React-runtimeexecutor
     - ReactCommon
     - ReactNativeDependencies
-  - React-cxxreact (0.82.0-rc.5):
+  - React-cxxreact (0.82.0):
     - hermes-engine
-    - React-callinvoker (= 0.82.0-rc.5)
+    - React-callinvoker (= 0.82.0)
     - React-Core-prebuilt
-    - React-debug (= 0.82.0-rc.5)
-    - React-jsi (= 0.82.0-rc.5)
+    - React-debug (= 0.82.0)
+    - React-jsi (= 0.82.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.82.0-rc.5)
-    - React-perflogger (= 0.82.0-rc.5)
+    - React-logger (= 0.82.0)
+    - React-perflogger (= 0.82.0)
     - React-runtimeexecutor
-    - React-timing (= 0.82.0-rc.5)
+    - React-timing (= 0.82.0)
     - ReactNativeDependencies
-  - React-debug (0.82.0-rc.5)
-  - React-defaultsnativemodule (0.82.0-rc.5):
+  - React-debug (0.82.0)
+  - React-defaultsnativemodule (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-domnativemodule
@@ -800,7 +800,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-webperformancenativemodule
     - ReactNativeDependencies
-  - React-domnativemodule (0.82.0-rc.5):
+  - React-domnativemodule (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-Fabric
@@ -814,7 +814,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric (0.82.0-rc.5):
+  - React-Fabric (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -822,23 +822,23 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.82.0-rc.5)
-    - React-Fabric/attributedstring (= 0.82.0-rc.5)
-    - React-Fabric/bridging (= 0.82.0-rc.5)
-    - React-Fabric/componentregistry (= 0.82.0-rc.5)
-    - React-Fabric/componentregistrynative (= 0.82.0-rc.5)
-    - React-Fabric/components (= 0.82.0-rc.5)
-    - React-Fabric/consistency (= 0.82.0-rc.5)
-    - React-Fabric/core (= 0.82.0-rc.5)
-    - React-Fabric/dom (= 0.82.0-rc.5)
-    - React-Fabric/imagemanager (= 0.82.0-rc.5)
-    - React-Fabric/leakchecker (= 0.82.0-rc.5)
-    - React-Fabric/mounting (= 0.82.0-rc.5)
-    - React-Fabric/observers (= 0.82.0-rc.5)
-    - React-Fabric/scheduler (= 0.82.0-rc.5)
-    - React-Fabric/telemetry (= 0.82.0-rc.5)
-    - React-Fabric/templateprocessor (= 0.82.0-rc.5)
-    - React-Fabric/uimanager (= 0.82.0-rc.5)
+    - React-Fabric/animations (= 0.82.0)
+    - React-Fabric/attributedstring (= 0.82.0)
+    - React-Fabric/bridging (= 0.82.0)
+    - React-Fabric/componentregistry (= 0.82.0)
+    - React-Fabric/componentregistrynative (= 0.82.0)
+    - React-Fabric/components (= 0.82.0)
+    - React-Fabric/consistency (= 0.82.0)
+    - React-Fabric/core (= 0.82.0)
+    - React-Fabric/dom (= 0.82.0)
+    - React-Fabric/imagemanager (= 0.82.0)
+    - React-Fabric/leakchecker (= 0.82.0)
+    - React-Fabric/mounting (= 0.82.0)
+    - React-Fabric/observers (= 0.82.0)
+    - React-Fabric/scheduler (= 0.82.0)
+    - React-Fabric/telemetry (= 0.82.0)
+    - React-Fabric/templateprocessor (= 0.82.0)
+    - React-Fabric/uimanager (= 0.82.0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -850,26 +850,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/animations (0.82.0-rc.5):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/attributedstring (0.82.0-rc.5):
+  - React-Fabric/animations (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -888,7 +869,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/bridging (0.82.0-rc.5):
+  - React-Fabric/attributedstring (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -907,7 +888,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistry (0.82.0-rc.5):
+  - React-Fabric/bridging (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -926,7 +907,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistrynative (0.82.0-rc.5):
+  - React-Fabric/componentregistry (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -945,30 +926,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components (0.82.0-rc.5):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.82.0-rc.5)
-    - React-Fabric/components/root (= 0.82.0-rc.5)
-    - React-Fabric/components/scrollview (= 0.82.0-rc.5)
-    - React-Fabric/components/view (= 0.82.0-rc.5)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/components/legacyviewmanagerinterop (0.82.0-rc.5):
+  - React-Fabric/componentregistrynative (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -987,7 +945,30 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/root (0.82.0-rc.5):
+  - React-Fabric/components (0.82.0):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.82.0)
+    - React-Fabric/components/root (= 0.82.0)
+    - React-Fabric/components/scrollview (= 0.82.0)
+    - React-Fabric/components/view (= 0.82.0)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/legacyviewmanagerinterop (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1006,7 +987,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/scrollview (0.82.0-rc.5):
+  - React-Fabric/components/root (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1025,7 +1006,26 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/view (0.82.0-rc.5):
+  - React-Fabric/components/scrollview (0.82.0):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/view (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1046,7 +1046,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric/consistency (0.82.0-rc.5):
+  - React-Fabric/consistency (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1065,7 +1065,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/core (0.82.0-rc.5):
+  - React-Fabric/core (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1084,7 +1084,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/dom (0.82.0-rc.5):
+  - React-Fabric/dom (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1103,7 +1103,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/imagemanager (0.82.0-rc.5):
+  - React-Fabric/imagemanager (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1122,7 +1122,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/leakchecker (0.82.0-rc.5):
+  - React-Fabric/leakchecker (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1141,7 +1141,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/mounting (0.82.0-rc.5):
+  - React-Fabric/mounting (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1160,7 +1160,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers (0.82.0-rc.5):
+  - React-Fabric/observers (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1168,7 +1168,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.82.0-rc.5)
+    - React-Fabric/observers/events (= 0.82.0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1180,7 +1180,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers/events (0.82.0-rc.5):
+  - React-Fabric/observers/events (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1199,7 +1199,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/scheduler (0.82.0-rc.5):
+  - React-Fabric/scheduler (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1221,7 +1221,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/telemetry (0.82.0-rc.5):
+  - React-Fabric/telemetry (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1240,7 +1240,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/templateprocessor (0.82.0-rc.5):
+  - React-Fabric/templateprocessor (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1259,7 +1259,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager (0.82.0-rc.5):
+  - React-Fabric/uimanager (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1267,7 +1267,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.82.0-rc.5)
+    - React-Fabric/uimanager/consistency (= 0.82.0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1280,7 +1280,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager/consistency (0.82.0-rc.5):
+  - React-Fabric/uimanager/consistency (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1300,7 +1300,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-FabricComponents (0.82.0-rc.5):
+  - React-FabricComponents (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1309,8 +1309,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.82.0-rc.5)
-    - React-FabricComponents/textlayoutmanager (= 0.82.0-rc.5)
+    - React-FabricComponents/components (= 0.82.0)
+    - React-FabricComponents/textlayoutmanager (= 0.82.0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1323,7 +1323,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components (0.82.0-rc.5):
+  - React-FabricComponents/components (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1332,18 +1332,18 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.82.0-rc.5)
-    - React-FabricComponents/components/iostextinput (= 0.82.0-rc.5)
-    - React-FabricComponents/components/modal (= 0.82.0-rc.5)
-    - React-FabricComponents/components/rncore (= 0.82.0-rc.5)
-    - React-FabricComponents/components/safeareaview (= 0.82.0-rc.5)
-    - React-FabricComponents/components/scrollview (= 0.82.0-rc.5)
-    - React-FabricComponents/components/switch (= 0.82.0-rc.5)
-    - React-FabricComponents/components/text (= 0.82.0-rc.5)
-    - React-FabricComponents/components/textinput (= 0.82.0-rc.5)
-    - React-FabricComponents/components/unimplementedview (= 0.82.0-rc.5)
-    - React-FabricComponents/components/virtualview (= 0.82.0-rc.5)
-    - React-FabricComponents/components/virtualviewexperimental (= 0.82.0-rc.5)
+    - React-FabricComponents/components/inputaccessory (= 0.82.0)
+    - React-FabricComponents/components/iostextinput (= 0.82.0)
+    - React-FabricComponents/components/modal (= 0.82.0)
+    - React-FabricComponents/components/rncore (= 0.82.0)
+    - React-FabricComponents/components/safeareaview (= 0.82.0)
+    - React-FabricComponents/components/scrollview (= 0.82.0)
+    - React-FabricComponents/components/switch (= 0.82.0)
+    - React-FabricComponents/components/text (= 0.82.0)
+    - React-FabricComponents/components/textinput (= 0.82.0)
+    - React-FabricComponents/components/unimplementedview (= 0.82.0)
+    - React-FabricComponents/components/virtualview (= 0.82.0)
+    - React-FabricComponents/components/virtualviewexperimental (= 0.82.0)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1356,28 +1356,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.82.0-rc.5):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.82.0-rc.5):
+  - React-FabricComponents/components/inputaccessory (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1398,7 +1377,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/modal (0.82.0-rc.5):
+  - React-FabricComponents/components/iostextinput (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1419,7 +1398,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/rncore (0.82.0-rc.5):
+  - React-FabricComponents/components/modal (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1440,7 +1419,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.82.0-rc.5):
+  - React-FabricComponents/components/rncore (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1461,7 +1440,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/scrollview (0.82.0-rc.5):
+  - React-FabricComponents/components/safeareaview (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1482,7 +1461,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/switch (0.82.0-rc.5):
+  - React-FabricComponents/components/scrollview (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1503,7 +1482,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/text (0.82.0-rc.5):
+  - React-FabricComponents/components/switch (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1524,7 +1503,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/textinput (0.82.0-rc.5):
+  - React-FabricComponents/components/text (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1545,7 +1524,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.82.0-rc.5):
+  - React-FabricComponents/components/textinput (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1566,7 +1545,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/virtualview (0.82.0-rc.5):
+  - React-FabricComponents/components/unimplementedview (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1587,7 +1566,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/virtualviewexperimental (0.82.0-rc.5):
+  - React-FabricComponents/components/virtualview (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1608,7 +1587,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.82.0-rc.5):
+  - React-FabricComponents/components/virtualviewexperimental (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1629,27 +1608,48 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricImage (0.82.0-rc.5):
+  - React-FabricComponents/textlayoutmanager (0.82.0):
     - hermes-engine
-    - RCTRequired (= 0.82.0-rc.5)
-    - RCTTypeSafety (= 0.82.0-rc.5)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
+  - React-FabricImage (0.82.0):
+    - hermes-engine
+    - RCTRequired (= 0.82.0)
+    - RCTTypeSafety (= 0.82.0)
     - React-Core-prebuilt
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.82.0-rc.5)
+    - React-jsiexecutor (= 0.82.0)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-featureflags (0.82.0-rc.5):
+  - React-featureflags (0.82.0):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-featureflagsnativemodule (0.82.0-rc.5):
+  - React-featureflagsnativemodule (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1658,27 +1658,27 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-graphics (0.82.0-rc.5):
+  - React-graphics (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
     - React-jsiexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-hermes (0.82.0-rc.5):
+  - React-hermes (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
-    - React-cxxreact (= 0.82.0-rc.5)
+    - React-cxxreact (= 0.82.0)
     - React-jsi
-    - React-jsiexecutor (= 0.82.0-rc.5)
+    - React-jsiexecutor (= 0.82.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.82.0-rc.5)
+    - React-perflogger (= 0.82.0)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-idlecallbacksnativemodule (0.82.0-rc.5):
+  - React-idlecallbacksnativemodule (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1688,7 +1688,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-ImageManager (0.82.0-rc.5):
+  - React-ImageManager (0.82.0):
     - React-Core-prebuilt
     - React-Core/Default
     - React-debug
@@ -1697,7 +1697,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - ReactNativeDependencies
-  - React-jserrorhandler (0.82.0-rc.5):
+  - React-jserrorhandler (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1706,11 +1706,11 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - ReactNativeDependencies
-  - React-jsi (0.82.0-rc.5):
+  - React-jsi (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsiexecutor (0.82.0-rc.5):
+  - React-jsiexecutor (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1722,7 +1722,7 @@ PODS:
     - React-perflogger
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsinspector (0.82.0-rc.5):
+  - React-jsinspector (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1731,44 +1731,44 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.82.0-rc.5)
+    - React-perflogger (= 0.82.0)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsinspectorcdp (0.82.0-rc.5):
+  - React-jsinspectorcdp (0.82.0):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsinspectornetwork (0.82.0-rc.5):
+  - React-jsinspectornetwork (0.82.0):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspectorcdp
     - React-performancetimeline
     - React-timing
     - ReactNativeDependencies
-  - React-jsinspectortracing (0.82.0-rc.5):
+  - React-jsinspectortracing (0.82.0):
     - React-Core-prebuilt
     - React-oscompat
     - React-timing
     - ReactNativeDependencies
-  - React-jsitooling (0.82.0-rc.5):
+  - React-jsitooling (0.82.0):
     - React-Core-prebuilt
-    - React-cxxreact (= 0.82.0-rc.5)
+    - React-cxxreact (= 0.82.0)
     - React-debug
-    - React-jsi (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsitracing (0.82.0-rc.5):
+  - React-jsitracing (0.82.0):
     - React-jsi
-  - React-logger (0.82.0-rc.5):
+  - React-logger (0.82.0):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-Mapbuffer (0.82.0-rc.5):
+  - React-Mapbuffer (0.82.0):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-microtasksnativemodule (0.82.0-rc.5):
+  - React-microtasksnativemodule (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1776,7 +1776,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-NativeModulesApple (0.82.0-rc.5):
+  - React-NativeModulesApple (0.82.0):
     - hermes-engine
     - React-callinvoker
     - React-Core
@@ -1791,11 +1791,11 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-oscompat (0.82.0-rc.5)
-  - React-perflogger (0.82.0-rc.5):
+  - React-oscompat (0.82.0)
+  - React-perflogger (0.82.0):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-performancecdpmetrics (0.82.0-rc.5):
+  - React-performancecdpmetrics (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1803,16 +1803,16 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - ReactNativeDependencies
-  - React-performancetimeline (0.82.0-rc.5):
+  - React-performancetimeline (0.82.0):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspectortracing
     - React-perflogger
     - React-timing
     - ReactNativeDependencies
-  - React-RCTActionSheet (0.82.0-rc.5):
-    - React-Core/RCTActionSheetHeaders (= 0.82.0-rc.5)
-  - React-RCTAnimation (0.82.0-rc.5):
+  - React-RCTActionSheet (0.82.0):
+    - React-Core/RCTActionSheetHeaders (= 0.82.0)
+  - React-RCTAnimation (0.82.0):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTAnimationHeaders
@@ -1822,7 +1822,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTAppDelegate (0.82.0-rc.5):
+  - React-RCTAppDelegate (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1850,7 +1850,7 @@ PODS:
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTBlob (0.82.0-rc.5):
+  - React-RCTBlob (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-Core/RCTBlobHeaders
@@ -1863,7 +1863,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFabric (0.82.0-rc.5):
+  - React-RCTFabric (0.82.0):
     - hermes-engine
     - React-Core
     - React-Core-prebuilt
@@ -1893,7 +1893,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-RCTFBReactNativeSpec (0.82.0-rc.5):
+  - React-RCTFBReactNativeSpec (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1901,10 +1901,10 @@ PODS:
     - React-Core-prebuilt
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.82.0-rc.5)
+    - React-RCTFBReactNativeSpec/components (= 0.82.0)
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFBReactNativeSpec/components (0.82.0-rc.5):
+  - React-RCTFBReactNativeSpec/components (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1921,7 +1921,7 @@ PODS:
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-RCTImage (0.82.0-rc.5):
+  - React-RCTImage (0.82.0):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTImageHeaders
@@ -1931,14 +1931,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTLinking (0.82.0-rc.5):
-    - React-Core/RCTLinkingHeaders (= 0.82.0-rc.5)
-    - React-jsi (= 0.82.0-rc.5)
+  - React-RCTLinking (0.82.0):
+    - React-Core/RCTLinkingHeaders (= 0.82.0)
+    - React-jsi (= 0.82.0)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.82.0-rc.5)
-  - React-RCTNetwork (0.82.0-rc.5):
+    - ReactCommon/turbomodule/core (= 0.82.0)
+  - React-RCTNetwork (0.82.0):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTNetworkHeaders
@@ -1951,7 +1951,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTRuntime (0.82.0-rc.5):
+  - React-RCTRuntime (0.82.0):
     - hermes-engine
     - React-Core
     - React-Core-prebuilt
@@ -1966,7 +1966,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - ReactNativeDependencies
-  - React-RCTSettings (0.82.0-rc.5):
+  - React-RCTSettings (0.82.0):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTSettingsHeaders
@@ -1975,10 +1975,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTText (0.82.0-rc.5):
-    - React-Core/RCTTextHeaders (= 0.82.0-rc.5)
+  - React-RCTText (0.82.0):
+    - React-Core/RCTTextHeaders (= 0.82.0)
     - Yoga
-  - React-RCTVibration (0.82.0-rc.5):
+  - React-RCTVibration (0.82.0):
     - React-Core-prebuilt
     - React-Core/RCTVibrationHeaders
     - React-jsi
@@ -1986,15 +1986,15 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-rendererconsistency (0.82.0-rc.5)
-  - React-renderercss (0.82.0-rc.5):
+  - React-rendererconsistency (0.82.0)
+  - React-renderercss (0.82.0):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.82.0-rc.5):
+  - React-rendererdebug (0.82.0):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-RuntimeApple (0.82.0-rc.5):
+  - React-RuntimeApple (0.82.0):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -2017,7 +2017,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeCore (0.82.0-rc.5):
+  - React-RuntimeCore (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -2033,14 +2033,14 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-runtimeexecutor (0.82.0-rc.5):
+  - React-runtimeexecutor (0.82.0):
     - React-Core-prebuilt
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0)
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeHermes (0.82.0-rc.5):
+  - React-RuntimeHermes (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -2055,7 +2055,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-runtimescheduler (0.82.0-rc.5):
+  - React-runtimescheduler (0.82.0):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -2071,15 +2071,15 @@ PODS:
     - React-timing
     - React-utils
     - ReactNativeDependencies
-  - React-timing (0.82.0-rc.5):
+  - React-timing (0.82.0):
     - React-debug
-  - React-utils (0.82.0-rc.5):
+  - React-utils (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-debug
-    - React-jsi (= 0.82.0-rc.5)
+    - React-jsi (= 0.82.0)
     - ReactNativeDependencies
-  - React-webperformancenativemodule (0.82.0-rc.5):
+  - React-webperformancenativemodule (0.82.0):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -2089,9 +2089,9 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - ReactAppDependencyProvider (0.82.0-rc.5):
+  - ReactAppDependencyProvider (0.82.0):
     - ReactCodegen
-  - ReactCodegen (0.82.0-rc.5):
+  - ReactCodegen (0.82.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2111,43 +2111,43 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - ReactCommon (0.82.0-rc.5):
+  - ReactCommon (0.82.0):
     - React-Core-prebuilt
-    - ReactCommon/turbomodule (= 0.82.0-rc.5)
+    - ReactCommon/turbomodule (= 0.82.0)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule (0.82.0-rc.5):
+  - ReactCommon/turbomodule (0.82.0):
     - hermes-engine
-    - React-callinvoker (= 0.82.0-rc.5)
+    - React-callinvoker (= 0.82.0)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.82.0-rc.5)
-    - React-jsi (= 0.82.0-rc.5)
-    - React-logger (= 0.82.0-rc.5)
-    - React-perflogger (= 0.82.0-rc.5)
-    - ReactCommon/turbomodule/bridging (= 0.82.0-rc.5)
-    - ReactCommon/turbomodule/core (= 0.82.0-rc.5)
+    - React-cxxreact (= 0.82.0)
+    - React-jsi (= 0.82.0)
+    - React-logger (= 0.82.0)
+    - React-perflogger (= 0.82.0)
+    - ReactCommon/turbomodule/bridging (= 0.82.0)
+    - ReactCommon/turbomodule/core (= 0.82.0)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/bridging (0.82.0-rc.5):
+  - ReactCommon/turbomodule/bridging (0.82.0):
     - hermes-engine
-    - React-callinvoker (= 0.82.0-rc.5)
+    - React-callinvoker (= 0.82.0)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.82.0-rc.5)
-    - React-jsi (= 0.82.0-rc.5)
-    - React-logger (= 0.82.0-rc.5)
-    - React-perflogger (= 0.82.0-rc.5)
+    - React-cxxreact (= 0.82.0)
+    - React-jsi (= 0.82.0)
+    - React-logger (= 0.82.0)
+    - React-perflogger (= 0.82.0)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/core (0.82.0-rc.5):
+  - ReactCommon/turbomodule/core (0.82.0):
     - hermes-engine
-    - React-callinvoker (= 0.82.0-rc.5)
+    - React-callinvoker (= 0.82.0)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.82.0-rc.5)
-    - React-debug (= 0.82.0-rc.5)
-    - React-featureflags (= 0.82.0-rc.5)
-    - React-jsi (= 0.82.0-rc.5)
-    - React-logger (= 0.82.0-rc.5)
-    - React-perflogger (= 0.82.0-rc.5)
-    - React-utils (= 0.82.0-rc.5)
+    - React-cxxreact (= 0.82.0)
+    - React-debug (= 0.82.0)
+    - React-featureflags (= 0.82.0)
+    - React-jsi (= 0.82.0)
+    - React-logger (= 0.82.0)
+    - React-perflogger (= 0.82.0)
+    - React-utils (= 0.82.0)
     - ReactNativeDependencies
-  - ReactNativeDependencies (0.82.0-rc.5)
+  - ReactNativeDependencies (0.82.0)
   - SDWebImage (5.21.0):
     - SDWebImage/Core (= 5.21.0)
   - SDWebImage/Core (5.21.0)
@@ -2478,86 +2478,86 @@ SPEC CHECKSUMS:
   EXStructuredHeaders: c951e77f2d936f88637421e9588c976da5827368
   EXUpdates: b96ad490c9456eebc38f949f3c30ce6258845773
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
-  FBLazyVector: bd5db632a304b99a915e07040696286715b97462
-  hermes-engine: a14f7f403796d60a2ae636a4d5b6c1f7646503f8
+  FBLazyVector: 29edfec67fa1c03cb022a4d9891782c3ee86055b
+  hermes-engine: 8642d8f14a548ab718ec112e9bebdfdd154138b5
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: d32871931c05547cb4e0bc9009d66a18b50d8558
-  RCTDeprecation: 464a4d4314df84aeafa5cba421aa546f12ea45c2
-  RCTRequired: 7ec2b105ee6a82a849718a97e2769c2b3649eeea
-  RCTTypeSafety: 53fc675982f0fc6a599cfe66d3047b8adda347b1
+  RCTDeprecation: f4041d4bf5adb181d7d9a14982539a83726165a7
+  RCTRequired: 89f3ec1cf8e1a9b8f5cb9a833790d89c26ef3256
+  RCTTypeSafety: aaa22f943b01aa305257dd98baf8539dce718e2d
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 6eb704af98132bfdd36a19d9910b4d317d13100c
-  React-callinvoker: d3ef985f0e471dd4e6bf2d211e6a8a8721a2ca55
-  React-Core: b4b1a97d59b674896e243d70173f829247307d95
-  React-Core-prebuilt: 533958c653ad258eafa63ef14d21383fc2b255a2
-  React-CoreModules: 58a3036f2f1ff1d4db71e96f51ef2abab3da9890
-  React-cxxreact: ddf8df79906abbd0faa8fee7ac42f68669f4a389
-  React-debug: ddc5f4fcd34d349b4f9012c26f74fe043768d72d
-  React-defaultsnativemodule: cba90d0fd3b74c57a41b3404dccd2b774254e32c
-  React-domnativemodule: 2fdee77a7845eb601d32177a3164a7f7213a05e5
-  React-Fabric: a005506975193c8220150ff753db06f62a9f3675
-  React-FabricComponents: 686d531464879d5ce38f19f2a3b8619860e6b2a1
-  React-FabricImage: 1b9e7bdeef180071f5ed3004f32c927ed4bd878e
-  React-featureflags: 1f970af672e5ad345f2fbc046619c355baf6c5a8
-  React-featureflagsnativemodule: 2cd9a2651f405aa34c60e43ccc4ef023608d6f92
-  React-graphics: f574f381582a1eee5632bfd5fa1ef7e05e2cb3cd
-  React-hermes: f8b32be4c35319e8e42fc2988cb37bbe8eb5ee78
-  React-idlecallbacksnativemodule: 41817bea59ab577183de9881d92bb09154c49ab0
-  React-ImageManager: 36738f4bbf09285cbfa1bc0d18bf7715f24e0249
-  React-jserrorhandler: bd8b58138f773c1f3f1e2ea730190beca53a8725
-  React-jsi: 5b21b09133d7364383392112d9b4dd751c8b438f
-  React-jsiexecutor: 7f835364605e2e6590083c1df4d50b360398f185
-  React-jsinspector: 4d962cea0a8cf461d2b0f76de6e3f29ad73c128d
-  React-jsinspectorcdp: 84fefd05d64dce694a19bccc8593bdfde0d3e573
-  React-jsinspectornetwork: c03d2d5eb98dd23f9db9a9c33de3f35bdcb7638f
-  React-jsinspectortracing: c908bcaeb2b16a382ff493d4001810ab57633765
-  React-jsitooling: 9c3161134d505db87731becc8e0c605e05f0f34c
-  React-jsitracing: 466fdc56f44f86c5f19e8db3658b36ca48b1212e
-  React-logger: e3d0d02438e5a397ee0dc439957636f2910205ce
-  React-Mapbuffer: cc64bef8b0da852c7558a219d87e28910a49b9e5
-  React-microtasksnativemodule: bf2d7b592a8beea5e937036969761fac841a019f
-  React-NativeModulesApple: 169bb5425798368481b3b4ae911833a0c3822759
-  React-oscompat: dc153eed09ee87bc374b255143ca9339bd5556a8
-  React-perflogger: f763d0787a14c6b595d6d1981faa472bceac4e31
-  React-performancecdpmetrics: 780c8391c0bad88f8f490461028018b3a106a56f
-  React-performancetimeline: 2ef25330a0d61f9263dfc625e12d9ad4969405f2
-  React-RCTActionSheet: 6cf10d77cb47a0d9d4bdae6075f911b362a26344
-  React-RCTAnimation: fcfb0df113ccad9453db609d88085478b20397e3
-  React-RCTAppDelegate: c83a7e414ba6d0632ce65463e2d5a7fc4126b122
-  React-RCTBlob: 1d2e8bdb1429074a81d28de4e2a4d0c56643e6b2
-  React-RCTFabric: 9d8a731289216d71109992c549da99e7079e3e01
-  React-RCTFBReactNativeSpec: ebce52c839314577048ae9a04fe81c731a44e4d2
-  React-RCTImage: 7d7d5d6814e4ad53822d78be6e5d8c6fe0b48e85
-  React-RCTLinking: c13f8ea47e49b72d3d9f67235c315fc1e924e91e
-  React-RCTNetwork: 4d628a356fd2cbe6693ac1ee72684cbb4020149c
-  React-RCTRuntime: fed46908b2fdfdc8c24965f0bc550b05a43f90cc
-  React-RCTSettings: b75244d9ecd5320bbfb19cdc5c6cbe8e378b25ee
-  React-RCTText: 0227dac029b355133f9da975f956ff5fbc3b4555
-  React-RCTVibration: 75292ca92dd22ba089c4adf3487f12dde10ffac1
-  React-rendererconsistency: 358eb8fb00c38ba78cf5e72e8a2a3faf94a633c6
-  React-renderercss: 6a5a7abaaee411d9cdcf23a5802d41f48f2ba0d2
-  React-rendererdebug: 9e4e27b215b65259c7a0418b6d264302c33a3341
-  React-RuntimeApple: 85c518c687ac0be44e6df286904ae7bfcecd2db6
-  React-RuntimeCore: 3b68e7474ca2055d2319afbdfdbcab15f5f0ecb7
-  React-runtimeexecutor: c5390f9a49f9c5d3765ce3aa61e4a1e1965c5792
-  React-RuntimeHermes: a1308f2437b71db23ed200f3b99ab45636be87bd
-  React-runtimescheduler: f3a7dc6ec5679b7a22df23ebca35ed789ab9e46c
-  React-timing: 4121ff074bbaefed0608204e88ec2348c9747198
-  React-utils: 8b54a394f9b7ddcc1fcad731854e70be2ce6a536
-  React-webperformancenativemodule: 7f2f10b926d84f2b10067369c95ed29d459a0bea
-  ReactAppDependencyProvider: 77a7129540c0e06ab6be9a2bcb887d3d2e594431
-  ReactCodegen: 858ec16ee37e11e5a8e27c7579cedb80ddd36da9
-  ReactCommon: 098214faf94e79d56f004cac54464386c4c5d8e0
-  ReactNativeDependencies: beee42eb54e7ca052bd312c214dbe5d1487e02c7
+  React: ade831e2e38887292c2c7d40f2f4098826a9dda4
+  React-callinvoker: 0496e88932950260bbced6f84c633c40ec865f7f
+  React-Core: c039131635f507742ca871a0f130aabdb7a2c57b
+  React-Core-prebuilt: 265a5ea421d251f0caf7b834230aa1044b1395db
+  React-CoreModules: 89efc8cd313843796b11ef62caf9f73169d79a94
+  React-cxxreact: 532f14ce8e3490a6053f96a2fe964f29b0b530de
+  React-debug: c1ec6ee07de860f9113e88d96fb3dad6a69d4afd
+  React-defaultsnativemodule: b0adda9eadf092d9e3760750e474fdcc898b5909
+  React-domnativemodule: 51cd3704392647ed2fa9a0952008bcc76a8f1944
+  React-Fabric: 9fb2aed9c12753b86e97b9cd6c8d50e9864ab8eb
+  React-FabricComponents: 1d5d4e6013ae322e439383558ee733d95557e22a
+  React-FabricImage: 10889c43137086693bac8444c3c7827d4d6cdec4
+  React-featureflags: c3e12691fa93fce9e417de9e5fd780af5115f043
+  React-featureflagsnativemodule: 2055ac07f2cc666419b0271edbc5c2d4ff1c4ccc
+  React-graphics: f21ad2e5faf8d203cc3705b8703878a61490b0c2
+  React-hermes: ba4a5d452895b642831eff988019f2c002843b32
+  React-idlecallbacksnativemodule: 44b43c36bd2bb7ba345b4ceec5087bfd66b54729
+  React-ImageManager: 680e0b07cb02cfad6353e3b09153449f71e93812
+  React-jserrorhandler: 647cbdcc7b2275c44c7698e04d082150542dbd08
+  React-jsi: 9238bbc79cfecaf171c601c6515f5223745803fd
+  React-jsiexecutor: afd0471837e86ef75ef48688bc94b6e6db95f012
+  React-jsinspector: c19192b014f5ee3b2598b59bb9f746de02cc2a0e
+  React-jsinspectorcdp: 9f09c76847135fef9944da8dc64e292003e5673c
+  React-jsinspectornetwork: 88be53aebae981a1a08e7e9866b0eb94434c9de5
+  React-jsinspectortracing: ef3cb072cfb358b21ea4e139fb72052ff43466aa
+  React-jsitooling: caba2b81da0481d3782412f7ff744d80c3c6c3f7
+  React-jsitracing: f825f7cd52aa0a4b788de75724039e7bb25bad4b
+  React-logger: 339eafcd00ba20e35c3bde279f6ccad8a5403cd3
+  React-Mapbuffer: c3ddd60df73fd3fca0db89732799cd35bcfa62ea
+  React-microtasksnativemodule: d2e85587cd55f7360c12a9d116b53dd2056e133c
+  React-NativeModulesApple: 170fda2f874957992d47d3ab6438b3e6b6464aae
+  React-oscompat: 6ed19a860bd0cabd1bb3b387c358710ce709ee3a
+  React-perflogger: 3ba2cad8e8ba66bd2029ad9f3dc852624ff6ecc9
+  React-performancecdpmetrics: b79e9d0e806cb0adc4a60280d772bffc7791ec71
+  React-performancetimeline: 3f3cbc21de73f7af9cd93880f1e4cd2736403957
+  React-RCTActionSheet: d0ba12d6d8bc7206ae5b9d44e673382247d5ca78
+  React-RCTAnimation: fc148a894ccbc83a73fdd114a4fcf925c729d502
+  React-RCTAppDelegate: 009ead3ae703342fab0e511266c252102daa2fd9
+  React-RCTBlob: db37198e35e44b8149cc47a2e08bf34616254503
+  React-RCTFabric: 953f1b132801661b66c97ef3568b0cc42c2a4cde
+  React-RCTFBReactNativeSpec: 4cfd22512d295d1b70390b3ba42641c2fe734ddd
+  React-RCTImage: 5d197bb172296961b33b0d721a158abfc17e6701
+  React-RCTLinking: 074aefb4b1d55cacb8ddceb8e1117b48479f8b70
+  React-RCTNetwork: a531cd83edbb469232b3cd98e2d7504ac3198005
+  React-RCTRuntime: 144f94bbfe5cdc137bcbce7c297f0c1d7c4607cc
+  React-RCTSettings: 27cd0ea882f8eb7d10d944a75bd496b088fbf747
+  React-RCTText: 978f82284d7b0e0c7ea5b3d10ec123d8bd887d60
+  React-RCTVibration: d6aabbaa6f893184a961bb5736756bf10d7bf0f1
+  React-rendererconsistency: 17a5d2f591eb55f7bfe451dc5ce2dd5b8b3bd197
+  React-renderercss: 3f95a2021bdcd0bcb58c99f02f1be59d96bfc456
+  React-rendererdebug: 67cee42df22362e413b059382ffd3f8a68fa5f26
+  React-RuntimeApple: c3192a173268302c27c977780b220d0d3a1a8979
+  React-RuntimeCore: 59d070ed07882749c4a19804fdd84ed91fa74ff5
+  React-runtimeexecutor: 99de7104a83fcbac9018afd109f9d59395c7058d
+  React-RuntimeHermes: ff90d1e2cc7c23453e0628ace0583bf5de8c8a2c
+  React-runtimescheduler: c5222c0cd2c6a7d6eb3085ff1b0d66c12dbd10be
+  React-timing: 40cbae59f7123e2ec2492a015348f7a7ac3a420e
+  React-utils: 248dcc79c8ae283ff7b30e24dbca0af70a40a12c
+  React-webperformancenativemodule: 0699c6f71a93270225830fe46520649576a1465c
+  ReactAppDependencyProvider: d5f21b5da644b33685d4f2685cba86e3c7ea64ff
+  ReactCodegen: d8950dbac0e916f9de4c5bc62eff85c2fb8fcbc4
+  ReactCommon: e63ee799a93b4c3dea223339a660c392dead4d76
+  ReactNativeDependencies: 1b2d8e7c970b245dbc0daa4b9e770de205bc4230
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
-  Yoga: c972c838201c115255559220e4e14cf76a5401a6
+  Yoga: 1f093bc30adea87fd3a14ceaa0b2cb46468d06f9
 
 PODFILE CHECKSUM: 7b324c13881703a862f70f400c68133d3b5568d5
 

--- a/apps/native-tests/package.json
+++ b/apps/native-tests/package.json
@@ -19,7 +19,7 @@
     "expo-updates": "29.0.10",
     "react": "19.1.1",
     "react-dom": "19.1.1",
-    "react-native": "0.82.0-rc.5"
+    "react-native": "0.82.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -31,7 +31,7 @@
     "expo-task-manager": "14.0.7",
     "react-native-gesture-handler": "~2.28.0",
     "react": "19.1.1",
-    "react-native": "0.82.0-rc.5",
+    "react-native": "0.82.0",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.16.0"
   },

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -49,7 +49,7 @@
     "expo-sqlite": "~16.0.8",
     "jose": "^5",
     "react": "19.1.1",
-    "react-native": "0.82.0-rc.5",
+    "react-native": "0.82.0",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.16.0",
     "react-native-webview": "13.15.0"

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -15,7 +15,7 @@
     "expo-router": "^6.0.6",
     "expo-splash-screen": "~31.0.10",
     "react": "19.1.1",
-    "react-native": "0.82.0-rc.5",
+    "react-native": "0.82.0",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.11.1-nightly-20250611-8b82e081e"
   },

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -51,7 +51,7 @@
     "jasmine-core": "^2.4.1",
     "lodash": "^4.17.19",
     "react": "19.1.1",
-    "react-native": "0.82.0-rc.5",
+    "react-native": "0.82.0",
     "react-native-gesture-handler": "~2.28.0",
     "sinon": "^7.1.1"
   },

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -60,7 +60,7 @@
     "@expo/spawn-async": "^1.7.2",
     "@expo/ws-tunnel": "^1.0.1",
     "@expo/xcpretty": "^4.3.0",
-    "@react-native/dev-middleware": "0.82.0-rc.5",
+    "@react-native/dev-middleware": "0.82.0",
     "@urql/core": "^5.0.6",
     "@urql/exchange-retry": "^1.3.0",
     "accepts": "^1.3.8",

--- a/packages/@expo/prebuild-config/package.json
+++ b/packages/@expo/prebuild-config/package.json
@@ -45,7 +45,7 @@
     "@expo/config-types": "^54.0.8",
     "@expo/image-utils": "^0.8.7",
     "@expo/json-file": "^10.0.7",
-    "@react-native/normalize-colors": "0.82.0-rc.5",
+    "@react-native/normalize-colors": "0.82.0",
     "debug": "^4.3.1",
     "resolve-from": "^5.0.0",
     "semver": "^7.6.0",

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -69,7 +69,7 @@
     "@babel/plugin-transform-parameters": "^7.24.7",
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.23.0",
-    "@react-native/babel-preset": "0.82.0-rc.5",
+    "@react-native/babel-preset": "0.82.0",
     "babel-plugin-react-compiler": "^19.1.0-rc.2",
     "babel-plugin-react-native-web": "~0.21.0",
     "babel-plugin-transform-flow-enums": "^0.0.2",

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -42,7 +42,7 @@
     "babel-preset-expo": "~54.0.1",
     "expo-module-scripts": "^5.0.7",
     "react": "19.1.1",
-    "react-native": "0.82.0-rc.5"
+    "react-native": "0.82.0"
   },
   "peerDependencies": {
     "expo": "*"

--- a/packages/expo-module-template/$package.json
+++ b/packages/expo-module-template/$package.json
@@ -28,7 +28,7 @@
     "@types/react": "~19.1.1",
     "expo-module-scripts": "^5.0.7",
     "expo": "^54.0.8",
-    "react-native": "0.82.0-rc.5"
+    "react-native": "0.82.0"
   },
   "peerDependencies": {
     "expo": "*",

--- a/packages/expo-navigation-bar/package.json
+++ b/packages/expo-navigation-bar/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/navigation-bar",
   "dependencies": {
-    "@react-native/normalize-colors": "0.82.0-rc.5",
+    "@react-native/normalize-colors": "0.82.0",
     "debug": "^4.3.2",
     "react-native-is-edge-to-edge": "^1.2.1"
   },

--- a/packages/expo-system-ui/package.json
+++ b/packages/expo-system-ui/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/system-ui",
   "dependencies": {
-    "@react-native/normalize-colors": "0.82.0-rc.5",
+    "@react-native/normalize-colors": "0.82.0",
     "debug": "^4.3.2"
   },
   "jest": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -93,7 +93,7 @@
   "lottie-react-native": "~7.3.1",
   "react": "19.1.1",
   "react-dom": "19.1.1",
-  "react-native": "0.82.0-rc.5",
+  "react-native": "0.82.0",
   "react-native-web": "~0.21.0",
   "react-native-gesture-handler": "~2.28.0",
   "react-native-get-random-values": "~1.11.0",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -103,7 +103,7 @@
     "expo-module-scripts": "^5.0.7",
     "react": "19.1.1",
     "react-dom": "19.1.1",
-    "react-native": "0.82.0-rc.5",
+    "react-native": "0.82.0",
     "web-streams-polyfill": "^3.3.2"
   },
   "peerDependencies": {

--- a/patches/react-native-reanimated+4.1.1.patch
+++ b/patches/react-native-reanimated+4.1.1.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/react-native-reanimated/compatibility.json b/node_modules/react-native-reanimated/compatibility.json
+index e2d75ff..80611b6 100644
+--- a/node_modules/react-native-reanimated/compatibility.json
++++ b/node_modules/react-native-reanimated/compatibility.json
+@@ -4,7 +4,7 @@
+     "react-native-worklets": ["nightly"]
+   },
+   "4.1.x": {
+-    "react-native": ["0.78", "0.79", "0.80", "0.81"],
++    "react-native": ["0.78", "0.79", "0.80", "0.81", "0.82"],
+     "react-native-worklets": ["0.5.x"]
+   },
+   "4.0.x": {

--- a/patches/react-native-worklets+0.5.1.patch
+++ b/patches/react-native-worklets+0.5.1.patch
@@ -11,3 +11,16 @@ index 1d949d6..5e60310 100644
  
    if(${HERMES_ENABLE_DEBUGGER})
      string(APPEND CMAKE_CXX_FLAGS " -DHERMES_ENABLE_DEBUGGER=1")
+diff --git a/node_modules/react-native-worklets/compatibility.json b/node_modules/react-native-worklets/compatibility.json
+index 523807f..012dd2a 100644
+--- a/node_modules/react-native-worklets/compatibility.json
++++ b/node_modules/react-native-worklets/compatibility.json
+@@ -3,7 +3,7 @@
+     "react-native": ["0.78", "0.79", "0.80", "0.81"]
+   },
+   "0.5.x": {
+-    "react-native": ["0.78", "0.79", "0.80", "0.81"]
++    "react-native": ["0.78", "0.79", "0.80", "0.81", "0.82"]
+   },
+   "0.4.x": {
+     "react-native": ["0.78", "0.79", "0.80", "0.81"]

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -14,6 +14,6 @@
     "expo": "~54.0.8",
     "expo-status-bar": "~3.0.8",
     "react": "19.1.1",
-    "react-native": "0.82.0-rc.5"
+    "react-native": "0.82.0"
   }
 }

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -14,7 +14,7 @@
     "expo": "~54.0.8",
     "expo-status-bar": "~3.0.8",
     "react": "19.1.1",
-    "react-native": "0.82.0-rc.5"
+    "react-native": "0.82.0"
   },
   "devDependencies": {
     "@types/react": "~19.1.1",

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -14,6 +14,6 @@
     "expo": "~54.0.8",
     "expo-status-bar": "~3.0.8",
     "react": "19.1.1",
-    "react-native": "0.82.0-rc.5"
+    "react-native": "0.82.0"
   }
 }

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -30,7 +30,7 @@
     "expo-web-browser": "~15.0.7",
     "react": "19.1.1",
     "react-dom": "19.1.1",
-    "react-native": "0.82.0-rc.5",
+    "react-native": "0.82.0",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-worklets": "0.5.1",
     "react-native-reanimated": "~4.1.1",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -23,7 +23,7 @@
     "expo-web-browser": "~15.0.7",
     "react": "19.1.1",
     "react-dom": "19.1.1",
-    "react-native": "0.82.0-rc.5",
+    "react-native": "0.82.0",
     "react-native-worklets": "0.5.1",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3519,23 +3519,23 @@
   resolved "https://registry.yarnpkg.com/@react-native-segmented-control/segmented-control/-/segmented-control-2.5.7.tgz#7c91ef7dede8752796a234321fafa2c604fc82af"
   integrity sha512-l84YeVX8xAU3lvOJSvV4nK/NbGhIm2gBfveYolwaoCbRp+/SLXtc6mYrQmM9ScXNwU14mnzjQTpTHWl5YPnkzQ==
 
-"@react-native/assets-registry@0.82.0-rc.5":
-  version "0.82.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.82.0-rc.5.tgz#b9dadc374e7e4d1f34801e20772d6d3783c163e1"
-  integrity sha512-fF2izzU9RizpXJ4AtnAzEbbufVh7a/z5budc4xhLg0qj0hmDpd2VLgBednDSO7I3oSwozU9JnZsUfEf6J1BKkQ==
+"@react-native/assets-registry@0.82.0":
+  version "0.82.0"
+  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.82.0.tgz#d71b796e32b9ddeae3806ab65a4ef9e7a26b44a7"
+  integrity sha512-SHRZxH+VHb6RwcHNskxyjso6o91Lq0DPgOpE5cDrppn1ziYhI723rjufFgh59RcpH441eci0/cXs/b0csXTtnw==
 
-"@react-native/babel-plugin-codegen@0.82.0-rc.5":
-  version "0.82.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.82.0-rc.5.tgz#b350a78a29aa46d8802d9e60ac1c0a6c2f8ab5f4"
-  integrity sha512-0EPKukwkJKwGaDAcNRX783mXRBjBf3hNcfTGnWWVRG61ZUPqDR1l0nRB80lqizWeetXNLC4Llm90y5giNBjZIg==
+"@react-native/babel-plugin-codegen@0.82.0":
+  version "0.82.0"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.82.0.tgz#0af2c438fbae11550816cd12989a242b2d44d868"
+  integrity sha512-BLGT/3NuCMpFk9FYPB1IYNGgcN8t8/HGcuEZqRpqGLJRRfAsnbwmlx7zsc1mMDRM1w/CVUWzDhxocF35Rpw1oQ==
   dependencies:
     "@babel/traverse" "^7.25.3"
-    "@react-native/codegen" "0.82.0-rc.5"
+    "@react-native/codegen" "0.82.0"
 
-"@react-native/babel-preset@0.82.0-rc.5":
-  version "0.82.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.82.0-rc.5.tgz#fd91bee023b2ac5530d8dd2846fad205c6aa53cb"
-  integrity sha512-ohBW3EuaT+bYBvwXVqajfcVg7/yquellpmmHwCVnaCJ4TuMzd2e12LOEPRtNEi/PGB6+LYzNZ1F5OGSXCu2NtQ==
+"@react-native/babel-preset@0.82.0":
+  version "0.82.0"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.82.0.tgz#a2f5c6d3979ae8fd18f0727602de3db3db6d74a9"
+  integrity sha512-k5U5+ogEwFamkR2a39l6z0Vih+1Vpmb/fqL9qv/Lttr+WRC5czH/p3CUWT5M5SojjDCxf77Hla4fRgkav+G4/g==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/plugin-proposal-export-default-from" "^7.24.7"
@@ -3578,15 +3578,15 @@
     "@babel/plugin-transform-typescript" "^7.25.2"
     "@babel/plugin-transform-unicode-regex" "^7.24.7"
     "@babel/template" "^7.25.0"
-    "@react-native/babel-plugin-codegen" "0.82.0-rc.5"
+    "@react-native/babel-plugin-codegen" "0.82.0"
     babel-plugin-syntax-hermes-parser "0.32.0"
     babel-plugin-transform-flow-enums "^0.0.2"
     react-refresh "^0.14.0"
 
-"@react-native/codegen@0.82.0-rc.5":
-  version "0.82.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.82.0-rc.5.tgz#db981625df35c4939388022e83b31ea74cb15a99"
-  integrity sha512-/lFzP7Pq4Moj27SuvNzUSCa+QnNjZOFFUjiNjV0rqL5R0jVkTyswloosEusC8y8wgcjzFiEDszDg49ZdXH63yg==
+"@react-native/codegen@0.82.0":
+  version "0.82.0"
+  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.82.0.tgz#d034f75bd6b4d4070ae298058783e895a6ddeeaa"
+  integrity sha512-DJKDwyr6s0EtoPKmAaOsx2EnS2sV/qICNWn/KA+8lohSY6gJF1wuA+DOjitivBfU0soADoo8tqGq50C5rlzmCA==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/parser" "^7.25.3"
@@ -3596,12 +3596,12 @@
     nullthrows "^1.1.1"
     yargs "^17.6.2"
 
-"@react-native/community-cli-plugin@0.82.0-rc.5":
-  version "0.82.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.82.0-rc.5.tgz#3c7cc5661768ddd738400f4ac9a5a0c5e0e40093"
-  integrity sha512-phvWerDnECEMPxkCd5+3Qp203OkeMYowTmEbF04TZxEh+n8GfsHx+76AQNlfX47Cc4daFaGa788K7NIzmHT+xw==
+"@react-native/community-cli-plugin@0.82.0":
+  version "0.82.0"
+  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.82.0.tgz#5211bd54a18c80518c37491f1527a1faeb98ecf5"
+  integrity sha512-n5dxQowsRAjruG5sNl6MEPUzANUiVERaL7w4lHGmm/pz/ey1JOM9sFxL6RpZp1FJSVu4QKmbx6sIHrKb2MCekg==
   dependencies:
-    "@react-native/dev-middleware" "0.82.0-rc.5"
+    "@react-native/dev-middleware" "0.82.0"
     debug "^4.4.0"
     invariant "^2.2.4"
     metro "^0.83.1"
@@ -3609,27 +3609,27 @@
     metro-core "^0.83.1"
     semver "^7.1.3"
 
-"@react-native/debugger-frontend@0.82.0-rc.5":
-  version "0.82.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.82.0-rc.5.tgz#3324c7801ee98c36fe99f7ff211793766adc6c65"
-  integrity sha512-+Jt+oYH19NB2uGJNU8YX88YZn0xIR1fFGOiFht+Dj0OEsBiPDQL5rZ+3XLxgFB5Heg0GebaRFMTJ2zUB7HG6tw==
+"@react-native/debugger-frontend@0.82.0":
+  version "0.82.0"
+  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.82.0.tgz#c15492ab15473fbbf7e6f07b63abfdf8c79a0d1f"
+  integrity sha512-rlTDcjf0ecjOHmygdBACAQCqPG0z/itAxnbhk8ZiQts7m4gRJiA/iCGFyC8/T9voUA0azAX6QCl4tHlnuUy7mQ==
 
-"@react-native/debugger-shell@0.82.0-rc.5":
-  version "0.82.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@react-native/debugger-shell/-/debugger-shell-0.82.0-rc.5.tgz#7244dd778c17cc49182f4aa0dbcccc966bba1108"
-  integrity sha512-ELfFrAjrN7WG0Vl0S0OIhwcBDx4DrWBwSqj0duZ0Ml1O6v3PLWSAzBNAGTBm8KRJjHHaE7kkkhEhdLvcg6Otrg==
+"@react-native/debugger-shell@0.82.0":
+  version "0.82.0"
+  resolved "https://registry.yarnpkg.com/@react-native/debugger-shell/-/debugger-shell-0.82.0.tgz#e190b730d8980e6c43653addb3da37943312eab2"
+  integrity sha512-XbXABIMzaH7SvapNWcW+zix1uHeSX/MoXYKKWWTs99a12TgwNuTeLKKTEj/ZkAjWtaCCqb/sMI4aJDLXKppCGg==
   dependencies:
     cross-spawn "^7.0.6"
     fb-dotslash "0.5.8"
 
-"@react-native/dev-middleware@0.82.0-rc.5":
-  version "0.82.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.82.0-rc.5.tgz#d41582ad63cacc75e5ce3b7d36f466de991f8cd1"
-  integrity sha512-pfltRXzzzcwhc+J6/gqnp7xKvd/e0cMECPXTuo45eZ80QdfZ9MmCsbXL7BT503VgF9uFMbyhEJskun8JcKu2DQ==
+"@react-native/dev-middleware@0.82.0":
+  version "0.82.0"
+  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.82.0.tgz#06fb2b24329011258b751fb054596370327345ad"
+  integrity sha512-SHvpo89RSzH06yZCmY3Xwr1J82EdUljC2lcO4YvXfHmytFG453Nz6kyZQcDEqGCfWDjznIUFUyT2UcLErmRWQg==
   dependencies:
     "@isaacs/ttlcache" "^1.4.1"
-    "@react-native/debugger-frontend" "0.82.0-rc.5"
-    "@react-native/debugger-shell" "0.82.0-rc.5"
+    "@react-native/debugger-frontend" "0.82.0"
+    "@react-native/debugger-shell" "0.82.0"
     chrome-launcher "^0.15.2"
     chromium-edge-launcher "^0.2.0"
     connect "^3.6.5"
@@ -3640,30 +3640,30 @@
     serve-static "^1.16.2"
     ws "^6.2.3"
 
-"@react-native/gradle-plugin@0.82.0-rc.5":
-  version "0.82.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.82.0-rc.5.tgz#67bb21dfc45f8a3cbfa7b4307f1c25b420b35d07"
-  integrity sha512-0Qcpf/H7pbNFj0wQMWfLWpOF4ZNwZ2yf1lSPigDo8Ly75tigiyfXj3KW6+VJHHW7UDDGnpzVj4g8q7zZ2EPGvQ==
+"@react-native/gradle-plugin@0.82.0":
+  version "0.82.0"
+  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.82.0.tgz#0c21e524eeb822abb4383964559314e189ecf414"
+  integrity sha512-PTfmQ6cYsJgMXJ49NzB4Sz/DmRUtwatGtcA6MuskRvQpSinno/00Sns7wxphkTVMHGAwk3Xh0t0SFNd1d1HCyw==
 
-"@react-native/js-polyfills@0.82.0-rc.5":
-  version "0.82.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.82.0-rc.5.tgz#cdaeeb6f31e3cd4f6ba2745ad18efa345bdbd932"
-  integrity sha512-C7LWRfaxW47ef1WKCp2hEkpLW+YOthooI0nZ3OIQumjgSwQztzMuV3nDzgvF2SLutTctiI9xbE07/VNACKMxBQ==
+"@react-native/js-polyfills@0.82.0":
+  version "0.82.0"
+  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.82.0.tgz#0d963d943656d5e27dd92d4890ff5d5d3f072de4"
+  integrity sha512-7K1K64rfq0sKoGxB2DTsZROxal0B04Q+ftia0JyCOGOto/tyBQIQqiQgVtMVEBZSEXZyXmGx3HzF4EEPlvrEtw==
 
-"@react-native/normalize-colors@0.82.0-rc.5":
-  version "0.82.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.82.0-rc.5.tgz#7879daaa27b7e73bd7c9e2aca772d55f6f7bba1d"
-  integrity sha512-i2AzzVuv8BXRfn2Mkq+xaJnWn3c3txQ/dJHs6fXgx+toVFMovlmARz2CDlZD5aPywZoNb2yh7i9SgrPa4jC1Hw==
+"@react-native/normalize-colors@0.82.0":
+  version "0.82.0"
+  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.82.0.tgz#33f756b5027a9816477244adea8e268641ac6ddb"
+  integrity sha512-oinsK6TYEz5RnFTSk9P+hJ/N/E0pOG76O0euU0Gf3BlXArDpS8m3vrGcTjqeQvajRIaYVHIRAY9hCO6q+exyLg==
 
 "@react-native/normalize-colors@^0.74.1":
   version "0.74.88"
   resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.74.88.tgz#46f4c7270c8e6853281d7dd966e0eb362068e41a"
   integrity sha512-He5oTwPBxvXrxJ91dZzpxR7P+VYmc9IkJfhuH8zUiU50ckrt+xWNjtVugPdUv4LuVjmZ36Vk2EX8bl1gVn2dVA==
 
-"@react-native/virtualized-lists@0.82.0-rc.5":
-  version "0.82.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.82.0-rc.5.tgz#2888c8848794270f29bea4b3ad765485eb3ee2c3"
-  integrity sha512-WZ8fRd2xGFicc1PgKQiG/IJQfPISP8D3YoaUrSSFSwqFdoV+01nMdx7p/lP3UoQDJYApl3Evf1MCsEPWZZfobw==
+"@react-native/virtualized-lists@0.82.0":
+  version "0.82.0"
+  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.82.0.tgz#5af0ee37cee62a3100fd42ae0c3ea029c8b50ec5"
+  integrity sha512-fReDITtqwWdN29doPHhmeQEqa12ATJ4M2Y1MrT8Q1Hoy5a0H3oEn9S7fknGr7Pj+/I77yHyJajUbCupnJ8vkFA==
   dependencies:
     invariant "^2.2.4"
     nullthrows "^1.1.1"
@@ -7956,7 +7956,51 @@ eslint-visitor-keys@^4.2.0, eslint-visitor-keys@^4.2.1:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz#4cfea60fe7dd0ad8e816e1ed026c1d5251b512c1"
   integrity sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==
 
-"eslint8@npm:eslint@^8.57.1", eslint@^8.57.1:
+"eslint8@npm:eslint@^8.57.1":
+  version "8.57.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.57.1.tgz#7df109654aba7e3bbe5c8eae533c5e461d3c6ca9"
+  integrity sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.2.0"
+    "@eslint-community/regexpp" "^4.6.1"
+    "@eslint/eslintrc" "^2.1.4"
+    "@eslint/js" "8.57.1"
+    "@humanwhocodes/config-array" "^0.13.0"
+    "@humanwhocodes/module-importer" "^1.0.1"
+    "@nodelib/fs.walk" "^1.2.8"
+    "@ungap/structured-clone" "^1.2.0"
+    ajv "^6.12.4"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+    debug "^4.3.2"
+    doctrine "^3.0.0"
+    escape-string-regexp "^4.0.0"
+    eslint-scope "^7.2.2"
+    eslint-visitor-keys "^3.4.3"
+    espree "^9.6.1"
+    esquery "^1.4.2"
+    esutils "^2.0.2"
+    fast-deep-equal "^3.1.3"
+    file-entry-cache "^6.0.1"
+    find-up "^5.0.0"
+    glob-parent "^6.0.2"
+    globals "^13.19.0"
+    graphemer "^1.4.0"
+    ignore "^5.2.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    is-path-inside "^3.0.3"
+    js-yaml "^4.1.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.4.1"
+    lodash.merge "^4.6.2"
+    minimatch "^3.1.2"
+    natural-compare "^1.4.0"
+    optionator "^0.9.3"
+    strip-ansi "^6.0.1"
+    text-table "^0.2.0"
+
+eslint@^8.57.1:
   version "8.57.1"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.57.1.tgz#7df109654aba7e3bbe5c8eae533c5e461d3c6ca9"
   integrity sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==
@@ -13861,19 +13905,19 @@ react-native-worklets@0.5.1:
     convert-source-map "^2.0.0"
     semver "7.7.2"
 
-react-native@0.82.0-rc.5:
-  version "0.82.0-rc.5"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.82.0-rc.5.tgz#4fb5b4394ca2fcd93fc5334a8d15bfdb6614d8aa"
-  integrity sha512-94rj9YLMe8jDn+x7IoGjvXb6KVwU6/NIlgPz5WP/YW9xqa+zBd6B1+Rli+0uG/KR9VzepnLaucSShsUQbvxPAA==
+react-native@0.82.0:
+  version "0.82.0"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.82.0.tgz#e4471196ad6f00c84d9f9ec64232b1343e272a98"
+  integrity sha512-E+sBFDgpwzoZzPn86gSGRBGLnS9Q6r4y6Xk5I57/QbkqkDOxmQb/bzQq/oCdUCdHImKiow2ldC3WJfnvAKIfzg==
   dependencies:
     "@jest/create-cache-key-function" "^29.7.0"
-    "@react-native/assets-registry" "0.82.0-rc.5"
-    "@react-native/codegen" "0.82.0-rc.5"
-    "@react-native/community-cli-plugin" "0.82.0-rc.5"
-    "@react-native/gradle-plugin" "0.82.0-rc.5"
-    "@react-native/js-polyfills" "0.82.0-rc.5"
-    "@react-native/normalize-colors" "0.82.0-rc.5"
-    "@react-native/virtualized-lists" "0.82.0-rc.5"
+    "@react-native/assets-registry" "0.82.0"
+    "@react-native/codegen" "0.82.0"
+    "@react-native/community-cli-plugin" "0.82.0"
+    "@react-native/gradle-plugin" "0.82.0"
+    "@react-native/js-polyfills" "0.82.0"
+    "@react-native/normalize-colors" "0.82.0"
+    "@react-native/virtualized-lists" "0.82.0"
     abort-controller "^3.0.0"
     anser "^1.4.9"
     ansi-regex "^5.0.0"
@@ -15329,7 +15373,16 @@ string-length@^5.0.1:
     char-regex "^2.0.0"
     strip-ansi "^7.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -15420,7 +15473,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15433,6 +15486,13 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -17025,7 +17085,7 @@ workerd@^1.20250807.0:
     "@cloudflare/workerd-linux-arm64" "1.20250807.0"
     "@cloudflare/workerd-windows-64" "1.20250807.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -17038,6 +17098,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/expo/pull/40114

# How

- update package versions 
  - `react-native  0.82.0-rc.5 -> 0.82.0`  
  - `@react-native/normalize-colors 0.82.0-rc.5 ->  0.82.0` 
  - `@react-native/babel-preset 0.82.0-rc.5 ->  0.82.0` 
  - `@react-native/dev-middleware 0.82.0-rc.5 ->  0.82.0`    
  
# Test Plan

bare-expo ios 
paper-tester ios / android
ci passed


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
