### PR TITLE
[fix] Don't use cache for Android publish tasks

### DIFF
--- a/apps/bare-expo/android/gradle.properties
+++ b/apps/bare-expo/android/gradle.properties
@@ -19,6 +19,18 @@ org.gradle.vfs.watch=true
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
 
+# Enable the build cache to improve build times.
+org.gradle.caching=true
+
+# The Configuration Cache improves build performance by caching the result of the configuration phase
+# and reusing it for subsequent builds.
+org.gradle.configuration-cache=true
+
+# Turning problems into warnings instead of errors.
+# Some third-party libraries produce errors when the configuration cache is enabled.
+# After manually verifying that these issues are not harmful to the build.
+org.gradle.configuration-cache.problems=warn
+
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn

--- a/apps/bare-expo/android/gradle.properties
+++ b/apps/bare-expo/android/gradle.properties
@@ -19,18 +19,6 @@ org.gradle.vfs.watch=true
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
 
-# Enable the build cache to improve build times.
-org.gradle.caching=true
-
-# The Configuration Cache improves build performance by caching the result of the configuration phase
-# and reusing it for subsequent builds.
-org.gradle.configuration-cache=true
-
-# Turning problems into warnings instead of errors.
-# Some third-party libraries produce errors when the configuration cache is enabled.
-# After manually verifying that these issues are not harmful to the build.
-org.gradle.configuration-cache.problems=warn
-
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn

--- a/tools/src/publish-packages/tasks/publishAndroidPackages.ts
+++ b/tools/src/publish-packages/tasks/publishAndroidPackages.ts
@@ -78,10 +78,14 @@ export const publishAndroidArtifacts = new Task<TaskArgs>(
 
     logger.log('  ', 'Publishing Android artifacts...');
     // Run Gradle tasks in one batch to speed up the process.
-    await spawnAsync('./gradlew', gradleTasks, {
-      cwd: path.join(EXPO_DIR, 'apps/bare-expo/android'),
-      stdio: 'inherit',
-    });
+    await spawnAsync(
+      './gradlew',
+      [...gradleTasks, '--no-build-cache', '--no-configuration-cache'],
+      {
+        cwd: path.join(EXPO_DIR, 'apps/bare-expo/android'),
+        stdio: 'inherit',
+      }
+    );
     logger.success('  ', 'Done!');
   }
 );


### PR DESCRIPTION
This reverts commit 7a49dc578e525e063225ede06299403268dad6d2.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

After the build caching was enabled the canary releases started to fail. This might not need full revert, but after I reverted the change the canary release are working again. 

Example failed from main
https://github.com/expo/expo/actions/runs/18299287276

Example working after the PR removed
https://github.com/expo/expo/actions/runs/18357461022