### PR TITLE
[doctor] Improve autolinking check output for isolated and corrupted installations

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Update autolinking messages to be clearer about isolated dependencies and add note on corrupted installations ([#40279](https://github.com/expo/expo/pull/40279) by [@kitten](https://github.com/kitten))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-doctor/src/checks/AutolinkingDependencyDuplicatesCheck.ts
+++ b/packages/expo-doctor/src/checks/AutolinkingDependencyDuplicatesCheck.ts
@@ -65,10 +65,7 @@ export class AutolinkingDependencyDuplicatesCheck implements DoctorCheck<DoctorC
 
     function getDependencyVersion(dependency: BaseDependencyResolution): string | null {
       if (!dependency.version) {
-        const pkgContents = fs.readFileSync(
-          path.join(dependency.path, 'package.json'),
-          'utf8'
-        );
+        const pkgContents = fs.readFileSync(path.join(dependency.path, 'package.json'), 'utf8');
         try {
           const pkg: unknown = JSON.parse(pkgContents);
           if (
@@ -147,12 +144,11 @@ export class AutolinkingDependencyDuplicatesCheck implements DoctorCheck<DoctorC
     const advice: string[] = [];
     if (issues.length) {
       if (corruptedInstallations.length) {
-        let message = `Your node_modules folder may be corrupted. Multiple copies of the same version exist for: ${corruptedInstallations.map((x) => x.name).join(', ')}.\n` +
-          '- Try deleting your node_modules folders and reinstall your dependencies after.';
-        if (corruptedInstallations.some((value) => value.path.includes('.bun'))) {
-          message += '\n- If the issue persists, try disabling Bun\'s auto-installing peer dependencies or use its hoisted installs instead.';
-        }
-        advice.push(message);
+        advice.push(
+          `Your node_modules folder may be corrupted. Multiple copies of the same version exist for: ${corruptedInstallations.map((x) => x.name).join(', ')}.\n` +
+            '- Try deleting your node_modules folders and reinstall your dependencies after.\n' +
+            '- If this error persists, delete your node_modules as well as your lockfile and reinstall.'
+        );
       }
       advice.push(
         `Resolve your dependency issues and deduplicate your dependencies. ${learnMore('https://expo.fyi/resolving-dependency-issues')}`

--- a/packages/expo-doctor/src/checks/AutolinkingDependencyDuplicatesCheck.ts
+++ b/packages/expo-doctor/src/checks/AutolinkingDependencyDuplicatesCheck.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import type {
   BaseDependencyResolution,
   DependencyResolution,
@@ -109,11 +110,14 @@ export class AutolinkingDependencyDuplicatesCheck implements DoctorCheck<DoctorC
           // of the non store paths to assure the user that this check is aware of isolated dependencies
           if (
             hasStorePaths &&
-            !STORE_PATH.test(duplicate.originPath) &&
+            duplicate.originPath !== duplicate.path &&
             STORE_PATH.test(duplicate.path)
           ) {
-            const relative = path.relative(projectRoot, dependency.path);
-            line.push(`  │  └─ linked to: ${relative}`);
+            const linkedOutput = !STORE_PATH.test(duplicate.originPath)
+              ? `linked to: ${path.relative(projectRoot, dependency.path)}`
+              : 'linked to a different installation';
+            const prefix = idx !== versions.length - 1 ? '│' : ' ';
+            line.push(`  ${prefix}  ` + chalk.grey(`└─ ${linkedOutput}`));
           }
         }
         issues.push(line.join('\n'));

--- a/packages/expo-doctor/src/checks/AutolinkingDependencyDuplicatesCheck.ts
+++ b/packages/expo-doctor/src/checks/AutolinkingDependencyDuplicatesCheck.ts
@@ -143,10 +143,12 @@ export class AutolinkingDependencyDuplicatesCheck implements DoctorCheck<DoctorC
     const advice: string[] = [];
     if (issues.length) {
       if (corruptedInstallations.length) {
-        advice.push(
-          `Multiple copies of the same version exist for: ${corruptedInstallations.map((x) => x.name).join(', ')}.\n` +
-            '- Try deleting your node_modules folders and reinstall your dependencies after.'
-        );
+        let message = `Your node_modules folder may be corrupted. Multiple copies of the same version exist for: ${corruptedInstallations.map((x) => x.name).join(', ')}.\n` +
+          '- Try deleting your node_modules folders and reinstall your dependencies after.';
+        if (corruptedInstallations.some((value) => value.path.includes('.bun'))) {
+          message += '\n- If the issue persists, try disabling Bun\'s auto-installing peer dependencies or use its hoisted installs instead.';
+        }
+        advice.push(message);
       }
       advice.push(
         `Resolve your dependency issues and deduplicate your dependencies. ${learnMore('https://expo.fyi/resolving-dependency-issues')}`

--- a/packages/expo-doctor/src/checks/__tests__/AutolinkingDependencyDuplicatesCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/AutolinkingDependencyDuplicatesCheck.test.ts
@@ -155,8 +155,9 @@ describe('AutolinkingDependencyDuplicatesCheck', () => {
     `);
     expect(result.advice).toMatchInlineSnapshot(`
       [
-        "Multiple copies of the same version exist for: expo-constants.
-      - Try deleting your node_modules folders and reinstall your dependencies after.",
+        "Your node_modules folder may be corrupted. Multiple copies of the same version exist for: expo-constants.
+      - Try deleting your node_modules folders and reinstall your dependencies after.
+      - If this error persists, delete your node_modules as well as your lockfile and reinstall.",
         "Resolve your dependency issues and deduplicate your dependencies. Learn more: https://expo.fyi/resolving-dependency-issues",
       ]
     `);


### PR DESCRIPTION
# Why

The messages in this check basically have two problems right now:
- It's not obvious to users that we support isolated dependencies and that the check is aware of them
- Corrupted installations aren't always detected and the action the message for them advises users to take is incomplete

The first problem basically is that we may present mixed store and non-store paths. This could be misunderstood by users that are trying out isolated dependencies that this check isn't aware of isolated dependencies, which isn't correct.

The second problem is specifically that we didn't always detect corrupted installations, but that we also didn't give actionable advice for a bug in Bun with isolated dependencies. We have to tell users explicitly to remove the lockfile if the first advice doesn't work.

# How

- If we're list any path that is a store path, we should display the realpath i.e. what the origin path of the dependency is symlinked to
- If `version` isn't provided/scanned by autolinking, we must load it manually when checking for corrupted installations
- When telling users how to fix corrupted installations, if the first step fails (deleting `node_modules`) we should tell them to also delete the lockfile
- I've chosen to hide some symlinked path, since the output can otherwise get really noisy. It's always accurate for us to just say "a different installation" since we know the `path`s differ

This is what all of these changes look like together in practice:

<img width="1332" height="603" alt="Screenshot 2025-10-09 at 03 44 47" src="https://github.com/user-attachments/assets/dea84945-7e2e-4741-9dd9-b130f7aff2a4" />

# Test Plan

You can reproduce a corrupted installation pretty quickly:
- create a project with `bunx create-expo`
- cd into it and run `bun install --linker=isolated`

The old messages will not show that this is a corrupted installation, but the doctor output will speak for itself. When this PR is applied the improved messages (as seen in the above screenshot) will be displayed instead.

When Bun is in this state, only deleting the lockfile and `node_modules` will restore the correct installation behaviour. (No matter if that's followed by `--linker=isolated` or `--linker=hoisted`). This Bun bug is specific to an initial isolated on top of a hoisted installation specifically.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
