### PR TITLE
feat(babel-preset-expo): Update to `babel-plugin-react-compiler@^1.0.0`

### DIFF
--- a/apps/router-e2e/__e2e__/compiler/app/index.tsx
+++ b/apps/router-e2e/__e2e__/compiler/app/index.tsx
@@ -3,8 +3,16 @@ import { Text } from 'react-native';
 
 import { useBananas, useFruit } from './hooks/useFruit';
 
+let count = 0;
+
+const getCount = () => ++count;
+
 export default function Page() {
   const [isMounted, setIsMounted] = useState(false);
+
+  // If React Compiler works, we expect the update above to not
+  // update the count result from this invocation
+  const count = getCount();
 
   useBananas();
 
@@ -20,15 +28,11 @@ export default function Page() {
   return (
     <>
       <Text testID="test-anchor">Test</Text>
-      {isMounted && <CompilerSlots />}
+      {isMounted && count === 1 && <Child />}
     </>
   );
 }
 
-function CompilerSlots() {
-  const compilerSlots = eval('$');
-  if ('length' in compilerSlots) {
-    return <Text testID="react-compiler">{compilerSlots.length}</Text>;
-  }
-  return null;
+function Child() {
+  return <Text testID="react-compiler">2</Text>;
 }

--- a/docs/pages/guides/react-compiler.mdx
+++ b/docs/pages/guides/react-compiler.mdx
@@ -170,7 +170,7 @@ module.exports = function (api) {
         {
           'react-compiler': {
             // Passed directly to the React Compiler Babel plugin.
-            compilationMode: 'strict',
+            compilationMode: 'all',
             panicThreshold: 'all_errors',
           },
           web: {

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Update to `babel-plugin-react-compiler@^1.0.0` ([#40281](https://github.com/expo/expo/pull/40281) by [@kitten](https://github.com/kitten))
+
 ### ⚠️ Notices
 
 - Added support for React Native 0.82.x. ([#39678](https://github.com/expo/expo/pull/39678) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/babel-preset-expo/build/index.d.ts
+++ b/packages/babel-preset-expo/build/index.d.ts
@@ -1,4 +1,5 @@
 import type { ConfigAPI, TransformOptions } from '@babel/core';
+import type { PluginOptions as ReactCompilerOptions } from 'babel-plugin-react-compiler';
 type BabelPresetExpoPlatformOptions = {
     /** Disable or configure the `@babel/plugin-proposal-decorators` plugin. */
     decorators?: false | {
@@ -24,52 +25,7 @@ type BabelPresetExpoPlatformOptions = {
     enableBabelRuntime?: boolean | string;
     unstable_transformProfile?: 'default' | 'hermes-stable' | 'hermes-canary';
     /** Settings to pass to `babel-plugin-react-compiler`. Set as `false` to disable the plugin. */
-    'react-compiler'?: false | {
-        enableUseMemoCachePolyfill?: boolean;
-        compilationMode?: 'infer' | 'strict';
-        panicThreshold?: 'none' | 'all_errors' | 'critical_errors';
-        logger?: any;
-        environment?: {
-            customHooks?: unknown;
-            enableResetCacheOnSourceFileChanges?: boolean;
-            enablePreserveExistingMemoizationGuarantees?: boolean;
-            /** @default true */
-            validatePreserveExistingMemoizationGuarantees?: boolean;
-            enableForest?: boolean;
-            enableUseTypeAnnotations?: boolean;
-            /** @default true */
-            enableReactiveScopesInHIR?: boolean;
-            /** @default true */
-            validateHooksUsage?: boolean;
-            validateRefAccessDuringRender?: boolean;
-            /** @default true */
-            validateNoSetStateInRender?: boolean;
-            validateMemoizedEffectDependencies?: boolean;
-            validateNoCapitalizedCalls?: string[] | null;
-            /** @default true */
-            enableAssumeHooksFollowRulesOfReact?: boolean;
-            /** @default true */
-            enableTransitivelyFreezeFunctionExpressions: boolean;
-            enableEmitFreeze?: unknown;
-            enableEmitHookGuards?: unknown;
-            enableEmitInstrumentForget?: unknown;
-            assertValidMutableRanges?: boolean;
-            enableChangeVariableCodegen?: boolean;
-            enableMemoizationComments?: boolean;
-            throwUnknownException__testonly?: boolean;
-            enableTreatFunctionDepsAsConditional?: boolean;
-            /** Automatically enabled when reanimated plugin is added. */
-            enableCustomTypeDefinitionForReanimated?: boolean;
-            /** @default `null` */
-            hookPattern?: string | null;
-        };
-        gating?: unknown;
-        noEmit?: boolean;
-        runtimeModule?: string | null;
-        eslintSuppressionRules?: unknown | null;
-        flowSuppressions?: boolean;
-        ignoreUseNoForget?: boolean;
-    };
+    'react-compiler'?: false | ReactCompilerOptions;
     /** Enable `typeof window` runtime checks. The default behavior is to minify `typeof window` on web clients to `"object"` and `"undefined"` on servers. */
     minifyTypeofWindow?: boolean;
     /**

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -70,7 +70,7 @@
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.23.0",
     "@react-native/babel-preset": "0.82.0",
-    "babel-plugin-react-compiler": "^19.1.0-rc.2",
+    "babel-plugin-react-compiler": "^1.0.0",
     "babel-plugin-react-native-web": "~0.21.0",
     "babel-plugin-transform-flow-enums": "^0.0.2",
     "babel-plugin-syntax-hermes-parser": "^0.29.1",

--- a/packages/babel-preset-expo/src/__tests__/__snapshots__/compiler.test.ts.snap
+++ b/packages/babel-preset-expo/src/__tests__/__snapshots__/compiler.test.ts.snap
@@ -23,9 +23,9 @@ function SIDE_EFFECT_MAY_THROW() {}
 
 // NOTE(EvanBacon): React compiler throws:
 // Cannot read properties of undefined (reading 'preds')
-function useSideEffectMayThrow() {var t0;try {
+function useSideEffectMayThrow() {var t0;
 
-
+  try {
     SIDE_EFFECT_MAY_THROW();
     t0 = true;} catch {
 
@@ -44,19 +44,19 @@ function App() {var $ = (0, _compilerRuntime.c)(5);
 
     t0 = () => {
       loadAssetsAsync(setAssetsAreLoaded);};
-    t1 = [];$[0] = t0;$[1] = t1;} else {t0 = $[0];t1 = $[1];}(0, _react.useEffect)(t0, t1);if (!
+    t1 = [];$[0] = t0;$[1] = t1;} else {t0 = $[0];t1 = $[1];}(0, _react.useEffect)(t0, t1);
 
-  assetsAreLoaded) {var _t;if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
+  if (!assetsAreLoaded) {var _t;if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
       _t = /*#__PURE__*/(0, _jsxRuntime.jsx)(_expoAppLoading.default, {});$[2] = _t;} else {_t = $[2];}return _t;}var t2;if ($[3] !== assetsAreLoaded) {
 
 
-    t2 = !assetsAreLoaded ? /*#__PURE__*/
-    (0, _jsxRuntime.jsx)(_expoAppLoading.default, {}) : /*#__PURE__*/
+    t2 = !assetsAreLoaded ? /*#__PURE__*/(0, _jsxRuntime.jsx)(
+      _expoAppLoading.default, {}
 
-    (0, _jsxRuntime.jsx)(_reactNative.View, { style: styles.container, children: /*#__PURE__*/
-      (0, _jsxRuntime.jsx)(_vectorIcons.Ionicons, { name: "md-options", size: 28 }) }
-    );$[3] = assetsAreLoaded;$[4] = t2;} else {t2 = $[4];}return t2;}function
 
+
+
+    ) : /*#__PURE__*/(0, _jsxRuntime.jsx)(_reactNative.View, { style: styles.container, children: /*#__PURE__*/(0, _jsxRuntime.jsx)(_vectorIcons.Ionicons, { name: "md-options", size: 28 }) });$[3] = assetsAreLoaded;$[4] = t2;} else {t2 = $[4];}return t2;}function
 
 
 loadAssetsAsync(_x) {return _loadAssetsAsync.apply(this, arguments);}function _loadAssetsAsync() {_loadAssetsAsync = (0, _asyncToGenerator2.default)(function* (

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -1,4 +1,5 @@
 import type { ConfigAPI, PluginItem, TransformOptions } from '@babel/core';
+import type { PluginOptions as ReactCompilerOptions } from 'babel-plugin-react-compiler';
 
 import { reactClientReferencesPlugin } from './client-module-proxy-plugin';
 import {
@@ -56,55 +57,7 @@ type BabelPresetExpoPlatformOptions = {
   unstable_transformProfile?: 'default' | 'hermes-stable' | 'hermes-canary';
 
   /** Settings to pass to `babel-plugin-react-compiler`. Set as `false` to disable the plugin. */
-  'react-compiler'?:
-    | false
-    | {
-        // TODO: Add full types and doc blocks.
-        enableUseMemoCachePolyfill?: boolean;
-        compilationMode?: 'infer' | 'strict';
-        panicThreshold?: 'none' | 'all_errors' | 'critical_errors';
-        logger?: any;
-        environment?: {
-          customHooks?: unknown;
-          enableResetCacheOnSourceFileChanges?: boolean;
-          enablePreserveExistingMemoizationGuarantees?: boolean;
-          /** @default true */
-          validatePreserveExistingMemoizationGuarantees?: boolean;
-          enableForest?: boolean;
-          enableUseTypeAnnotations?: boolean;
-          /** @default true */
-          enableReactiveScopesInHIR?: boolean;
-          /** @default true */
-          validateHooksUsage?: boolean;
-          validateRefAccessDuringRender?: boolean;
-          /** @default true */
-          validateNoSetStateInRender?: boolean;
-          validateMemoizedEffectDependencies?: boolean;
-          validateNoCapitalizedCalls?: string[] | null;
-          /** @default true */
-          enableAssumeHooksFollowRulesOfReact?: boolean;
-          /** @default true */
-          enableTransitivelyFreezeFunctionExpressions: boolean;
-          enableEmitFreeze?: unknown;
-          enableEmitHookGuards?: unknown;
-          enableEmitInstrumentForget?: unknown;
-          assertValidMutableRanges?: boolean;
-          enableChangeVariableCodegen?: boolean;
-          enableMemoizationComments?: boolean;
-          throwUnknownException__testonly?: boolean;
-          enableTreatFunctionDepsAsConditional?: boolean;
-          /** Automatically enabled when reanimated plugin is added. */
-          enableCustomTypeDefinitionForReanimated?: boolean;
-          /** @default `null` */
-          hookPattern?: string | null;
-        };
-        gating?: unknown;
-        noEmit?: boolean;
-        runtimeModule?: string | null;
-        eslintSuppressionRules?: unknown | null;
-        flowSuppressions?: boolean;
-        ignoreUseNoForget?: boolean;
-      };
+  'react-compiler'?: false | ReactCompilerOptions;
 
   /** Enable `typeof window` runtime checks. The default behavior is to minify `typeof window` on web clients to `"object"` and `"undefined"` on servers. */
   minifyTypeofWindow?: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5578,10 +5578,10 @@ babel-plugin-polyfill-regenerator@^0.6.1:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.6.2"
 
-babel-plugin-react-compiler@^19.1.0-rc.2:
-  version "19.1.0-rc.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-react-compiler/-/babel-plugin-react-compiler-19.1.0-rc.2.tgz#ef77f4316a2086d81f95ad8edbe081e2840d87a4"
-  integrity sha512-kSNA//p5fMO6ypG8EkEVPIqAjwIXm5tMjfD1XRPL/sRjYSbJ6UsvORfaeolNWnZ9n310aM0xJP7peW26BuCVzA==
+babel-plugin-react-compiler@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz#bdf7360a23a4d5ebfca090255da3893efd07425f"
+  integrity sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==
   dependencies:
     "@babel/types" "^7.26.0"
 


### PR DESCRIPTION
# Why

Stable version has been released

# How

- Update to `babel-plugin-react-compiler@^1.0.0`
- Reuse types exported by `babel-plugin-react-compiler` since this is not an optional peer dep anymore
- Update docs (Cherry-pick: #39584)

# Test Plan

- Existing E2E tests (`e2e/playwright/dev/react-compiler.test.ts`)
- Manually ran `yarn start:native-tabs --clear` in `apps/router-e2e`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
