### PR TITLE
[ci] fix ios unit tests

### DIFF
--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/ios-unit-tests.yml
       - apps/expo-go/ios/**
       - packages/**/ios/**
+      - apps/native-tests/ios/**
       - tools/src/dynamic-macros/**
       - tools/src/commands/IosGenerateDynamicMacros.ts
       - tools/src/commands/IosNativeUnitTests.ts

--- a/apps/native-tests/ios/NativeTests.xcodeproj/project.pbxproj
+++ b/apps/native-tests/ios/NativeTests.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 					"$(inherited)",
 					"-ObjC",
 					"-lc++",
+					"-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME)",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = org.name.NativeTests;
@@ -340,6 +341,7 @@
 					"$(inherited)",
 					"-ObjC",
 					"-lc++",
+					"-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME)",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = org.name.NativeTests;


### PR DESCRIPTION
# Why

iOS unit test build is [failing](https://github.com/expo/expo/actions/runs/18364389407/job/52314420288) with below error. Also reproducible locally. It has been like this for a while. This seems like a related [issue](https://github.com/CocoaPods/CocoaPods/issues/11960#issuecomment-1611411450)

```
Error: Undefined symbols for architecture arm64
Error:   "__swift_FORCE_LOAD_$_swiftCompatibility56", referenced from:
Warning:       __swift_FORCE_LOAD_$_swiftCompatibility56_$_EASClient in libEASClient.a[3](EASClientID.o)
Warning:       __swift_FORCE_LOAD_$_swiftCompatibility56_$_EXManifests in libEXManifests.a[3](EmbeddedManifest.o)
Warning:       __swift_FORCE_LOAD_$_swiftCompatibility56_$_EXNotifications in libEXNotifications.a[5](BackgroundEventTransformer.o)
Warning:       __swift_FORCE_LOAD_$_swiftCompatibility56_$_EXUpdates in libEXUpdates.a[4](AppController.o)
Warning:       __swift_FORCE_LOAD_$_swiftCompatibility56_$_EXUpdatesInterface in libEXUpdatesInterface.a[4](UpdatesControllerRegistry.o)
Warning:       __swift_FORCE_LOAD_$_swiftCompatibility56_$_Expo in libExpo.a[7](AppDelegatesLoaderDelegate.o)
Warning:       __swift_FORCE_LOAD_$_swiftCompatibility56_$_ExpoClipboard in libExpoClipboard.a[3](ClipboardExceptions.o)
Error: ld: symbol(s) not found for architecture arm64
Error: clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Not sure what broke it and why it needs explicit search path, but adding linker flag fixes it `-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME)`


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

iOS unit tests CI should pass.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
