### PR TITLE
[core][iOS] Fix `ValueOrUndefined` conversion in record

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -19,7 +19,7 @@
 - [Android] Restore `register` overload in `ModuleRegistry`. ([#40149](https://github.com/expo/expo/pull/40149) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Add `invalidate` callback to SwiftUIVirtualView. ([#40237](https://github.com/expo/expo/pull/40237) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [Android] Fix `androidNavigationBar.enforceContrast` app config property not working. ([#40263](https://github.com/expo/expo/pull/40263) by [@behenate](https://github.com/behenate))
-- [iOS] Fix `ValueOrUndefined` conversion in record.
+- [iOS] Fix `ValueOrUndefined` conversion in record. ([#40289](https://github.com/expo/expo/pull/40289) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [Android] Restore `register` overload in `ModuleRegistry`. ([#40149](https://github.com/expo/expo/pull/40149) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Add `invalidate` callback to SwiftUIVirtualView. ([#40237](https://github.com/expo/expo/pull/40237) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [Android] Fix `androidNavigationBar.enforceContrast` app config property not working. ([#40263](https://github.com/expo/expo/pull/40263) by [@behenate](https://github.com/behenate))
+- [iOS] Fix `ValueOrUndefined` conversion in record.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicValueOrUndefinedType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicValueOrUndefinedType.swift
@@ -28,6 +28,21 @@ internal struct DynamicValueOrUndefinedType<InnerType: AnyArgument>: AnyDynamicT
     return ValueOrUndefined<InnerType>.value(unwrapped: try dynamicInnerType.cast(value, appContext: appContext) as! InnerType)
   }
 
+  func convertResult<ResultType>(_ result: ResultType, appContext: AppContext) throws -> Any {
+    let value = result as! ValueOrUndefined<InnerType>
+    if case .undefined = value {
+      return JavaScriptValue.undefined
+    }
+    return try dynamicInnerType.convertResult(value.optional, appContext: appContext)
+  }
+
+  func castToJS<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue {
+    if let jaValue = value as? JavaScriptValue {
+      return jaValue
+    }
+    return try dynamicInnerType.castToJS(value, appContext: appContext)
+  }
+
   var description: String {
     return "ValueOrUndefined<\(dynamicInnerType)>"
   }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicValueOrUndefinedType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicValueOrUndefinedType.swift
@@ -31,6 +31,7 @@ internal struct DynamicValueOrUndefinedType<InnerType: AnyArgument>: AnyDynamicT
   func convertResult<ResultType>(_ result: ResultType, appContext: AppContext) throws -> Any {
     let value = result as! ValueOrUndefined<InnerType>
     if case .undefined = value {
+      // JavaScriptValue.undefined is not runtime specific, so it's safe to return here, even if it's not on the JS thread.
       return JavaScriptValue.undefined
     }
     return try dynamicInnerType.convertResult(value.optional, appContext: appContext)

--- a/packages/expo-modules-core/ios/Tests/RecordSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/RecordSpec.swift
@@ -45,6 +45,21 @@ class RecordSpec: ExpoSpec {
       expect(record.toDictionary()["b"] as? Int).to(equal(dict["b"]! as! Int))
     }
 
+    it("works back and forth with ValueOrUndefined") {
+      struct TestRecord: Record {
+        @Field var a: ValueOrUndefined<Double> = .value(unwrapped: 1.0)
+        @Field var b: ValueOrUndefined<Double> = .undefined
+      }
+      let record = try TestRecord(from: [:], appContext: appContext)
+
+      expect(record.a.optional).to(equal(1.0))
+      expect(record.b.isUndefined).to(beTrue())
+
+      let asDict = record.toDictionary(appContext: appContext)
+      expect(asDict["a"] as? Double).to(equal(1.0))
+      expect((asDict["b"] as? JavaScriptValue)?.kind).to(equal(.undefined))
+    }
+
     it("works back and forth with a keyed field") {
       struct TestRecord: Record {
         @Field("key") var a: String?


### PR DESCRIPTION
# Why

`ValueOrUndefined` were not converted correctly when used inside record.

# How

Add `convertResult` and `castToJS`.

# Test Plan

I've added test cases that should cover this.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
