### PR TITLE
[ui][ios] Fix empty section header spacing when no title provided

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Add `buttonStyle` modifier. ([#40119](https://github.com/expo/expo/pull/40119) by [@nishan](https://github.com/intergalacticspacehighway))
+- [iOS] remove empty section header spacing when no title provided ([#40296](https://github.com/expo/expo/pull/40296) by [@dylancom](https://github.com/dylancom))
 
 ### 💡 Others
 

--- a/packages/expo-ui/ios/SectionView.swift
+++ b/packages/expo-ui/ios/SectionView.swift
@@ -16,10 +16,21 @@ final class SectionProps: ExpoSwiftUI.ViewProps, CommonViewModifierProps {
 internal struct SectionView: ExpoSwiftUI.View {
   @ObservedObject var props: SectionProps
 
-  var body: some View {
-    Section(header: Text(props.title ?? "").textCase(nil)) {
-      Children()
+  @ViewBuilder
+  private var section: some View {
+    if let title = props.title, !title.isEmpty {
+      Section(header: Text(title).textCase(nil)) {
+        Children()
+      }
+    } else {
+      Section {
+        Children()
+      }
     }
-    .modifier(CommonViewModifiers(props: props))
+  }
+
+  var body: some View {
+    section
+      .modifier(CommonViewModifiers(props: props))
   }
 }


### PR DESCRIPTION
# Why
When no title is provided, currently a section header is rendered anyway, taking unnecessary space.

# How
Conditionally render a section header.

# Test Plan
```
<Section title="Section Title" />

// Should not reserve header space above anymore.
<Section />
```

# Checklist
- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
