### PR TITLE
[expo-audio] Removed unneeded call to setIsAudioActiveAsync(true)

### DIFF
--- a/apps/native-component-list/src/screens/Audio/expo-audio/AudioControlsScreen.tsx
+++ b/apps/native-component-list/src/screens/Audio/expo-audio/AudioControlsScreen.tsx
@@ -39,8 +39,9 @@ export default function AudioControlsScreen(props: any) {
       interruptionMode: 'doNotMix',
       playsInSilentMode: true,
       allowsRecording: false,
-    });
-    AudioModule.setIsAudioActiveAsync(true);
+    }).catch((error: unknown) =>
+      console.warn(`Error calling setAudioModeAsync: ${JSON.stringify(error)}`)
+    );
     props.navigation.setOptions({
       title: 'Audio Controls',
     });


### PR DESCRIPTION
# Why

Previously we added a call to setIsAudioActiveAsync(true) in the example screen before enabling the lock-screen otherwise it wouldn't become visible.

# How

This commit removes the call to setIsAudioActiveAsync before playing sound in the AudioControlsScreen. Also added a catch clause to get help if something is wrong.

# Test Plan

Tested in Bare-Expo + client project:
✅ Android
✅ iOS

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
