### PR TITLE
[core][iOS] Add `convertResult` to `Convertible`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [iOS] Introduce ExpoAppDelegateSubscriberManager class ([#40008](https://github.com/expo/expo/pull/40008) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Add `AppContext` to views environment so it can be accessed if needed. ([#39207](https://github.com/expo/expo/pull/39207) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Add experimental formatters API. ([#38946](https://github.com/expo/expo/pull/38946) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Add `convertResult` to `Convertible`.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,7 +11,7 @@
 - [iOS] Introduce ExpoAppDelegateSubscriberManager class ([#40008](https://github.com/expo/expo/pull/40008) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Add `AppContext` to views environment so it can be accessed if needed. ([#39207](https://github.com/expo/expo/pull/39207) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Add experimental formatters API. ([#38946](https://github.com/expo/expo/pull/38946) by [@lukmccall](https://github.com/lukmccall))
-- [iOS] Add `convertResult` to `Convertible`.
+- [iOS] Add `convertResult` to `Convertible`. ([#40302](https://github.com/expo/expo/pull/40302) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Core/Arguments/Convertible.swift
+++ b/packages/expo-modules-core/ios/Core/Arguments/Convertible.swift
@@ -12,11 +12,15 @@ public protocol Convertible: AnyArgument {
    Throws an error when given value cannot be converted.
    */
   static func convert(from value: Any?, appContext: AppContext) throws -> Self
+  static func convertResult(_ result: Any, appContext: AppContext) throws -> Any
 }
 
 extension Convertible {
   public static func getDynamicType() -> AnyDynamicType {
     return DynamicConvertibleType(innerType: Self.self)
+  }
+  public static func convertResult(_ result: Any, appContext: AppContext) throws -> Any {
+    return result
   }
 }
 

--- a/packages/expo-modules-core/ios/Core/Arguments/Convertibles.swift
+++ b/packages/expo-modules-core/ios/Core/Arguments/Convertibles.swift
@@ -58,6 +58,13 @@ extension CGPoint: Convertible {
     }
     throw Conversions.ConvertingException<CGPoint>(value)
   }
+
+  public static func convertResult(_ result: Any, appContext: AppContext) throws -> Any {
+    if let value = result as? CGPoint {
+      return ["x": value.x, "y": value.y]
+    }
+    return result
+  }
 }
 
 extension CGSize: Convertible {
@@ -73,6 +80,13 @@ extension CGSize: Convertible {
       return size
     }
     throw Conversions.ConvertingException<CGSize>(value)
+  }
+
+  public static func convertResult(_ result: Any, appContext: AppContext) throws -> Any {
+    if let value = result as? CGSize {
+      return ["width": value.width, "height": value.height]
+    }
+    return result
   }
 }
 
@@ -90,6 +104,16 @@ extension CGVector: Convertible {
     }
     throw Conversions.ConvertingException<CGVector>(value)
   }
+  
+  public static func convertSadas(_ result: Self, appContext: AppContext) throws -> Any {
+    return ["dx": result.dx, "dy": result.dy]
+  }
+  public static func convertResult(_ result: Any, appContext: AppContext) throws -> Any {
+    if let value = result as? CGVector {
+      return ["dx": value.dx, "dy": value.dy]
+    }
+    return result
+  }
 }
 
 extension CGRect: Convertible {
@@ -105,6 +129,13 @@ extension CGRect: Convertible {
       return rect
     }
     throw Conversions.ConvertingException<CGRect>(value)
+  }
+
+  public static func convertResult(_ result: Any, appContext: AppContext) throws -> Any {
+    if let value = result as? CGRect {
+      return ["x": value.minX, "y": value.minY, "width": value.width, "height": value.height]
+    }
+    return result
   }
 }
 

--- a/packages/expo-modules-core/ios/Core/Arguments/Convertibles.swift
+++ b/packages/expo-modules-core/ios/Core/Arguments/Convertibles.swift
@@ -104,10 +104,7 @@ extension CGVector: Convertible {
     }
     throw Conversions.ConvertingException<CGVector>(value)
   }
-  
-  public static func convertSadas(_ result: Self, appContext: AppContext) throws -> Any {
-    return ["dx": result.dx, "dy": result.dy]
-  }
+
   public static func convertResult(_ result: Any, appContext: AppContext) throws -> Any {
     if let value = result as? CGVector {
       return ["dx": value.dx, "dy": value.dy]

--- a/packages/expo-modules-core/ios/Core/Convertibles/Convertibles+Color.swift
+++ b/packages/expo-modules-core/ios/Core/Convertibles/Convertibles+Color.swift
@@ -95,9 +95,15 @@ extension UIColor {
     var g: CGFloat = 0
     var b: CGFloat = 0
     var a: CGFloat = 0
+
+#if os(macOS)
+    getRed(&r, green: &g, blue: &b, alpha: &a)
+    return String(format: "#%02x%02x%02x%02x", Int(r * 255), Int(g * 255), Int(b * 255), Int(a * 255) )
+#else
     if getRed(&r, green: &g, blue: &b, alpha: &a) {
       return String(format: "#%02x%02x%02x%02x", Int(r * 255), Int(g * 255), Int(b * 255), Int(a * 255) )
     }
+#endif
     return "#00000000"
   }
 }

--- a/packages/expo-modules-core/ios/Core/Convertibles/Convertibles+Color.swift
+++ b/packages/expo-modules-core/ios/Core/Convertibles/Convertibles+Color.swift
@@ -80,6 +80,26 @@ extension UIColor: Convertible {
     throw Conversions.ConvertingException<UIColor>(value)
     // swiftlint:enable force_cast
   }
+
+  public static func convertResult(_ result: Any, appContext: AppContext) throws -> Any {
+    if let value = result as? UIColor {
+      return value.string
+    }
+    return result
+  }
+}
+
+extension UIColor {
+  public var string: String {
+    var r: CGFloat = 0
+    var g: CGFloat = 0
+    var b: CGFloat = 0
+    var a: CGFloat = 0
+    if getRed(&r, green: &g, blue: &b, alpha: &a) {
+      return String(format: "#%02x%02x%02x%02x", Int(r * 255), Int(g * 255), Int(b * 255), Int(a * 255) )
+    }
+    return "#00000000"
+  }
 }
 
 extension CGColor: Convertible {
@@ -92,6 +112,12 @@ extension CGColor: Convertible {
       throw Conversions.ConvertingException<CGColor>(value)
     }
     // swiftlint:enable force_cast
+  }
+
+  public static func convertResult(_ result: Any, appContext: AppContext) throws -> Any {
+    let cgColor = result as! CGColor
+    let uiColor = UIColor(cgColor: cgColor)
+    return try UIColor.convertResult(uiColor, appContext: appContext)
   }
 }
 

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicConvertibleType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicConvertibleType.swift
@@ -22,10 +22,7 @@ internal struct DynamicConvertibleType: AnyDynamicType {
   }
 
   func convertResult<ResultType>(_ result: ResultType, appContext: AppContext) throws -> Any {
-    if let record = result as? Record {
-      return record.toDictionary(appContext: appContext)
-    }
-    return result
+    return try innerType.convertResult(result, appContext: appContext)
   }
 
   var description: String {

--- a/packages/expo-modules-core/ios/Core/Records/Record.swift
+++ b/packages/expo-modules-core/ios/Core/Records/Record.swift
@@ -66,6 +66,13 @@ public extension Record {
       }
     }
   }
+
+  static func convertResult(_ result: Any, appContext: AppContext) throws -> Any {
+    if let value = result as? Record {
+      return value.toDictionary(appContext: appContext)
+    }
+    return result
+  }
 }
 
 /**


### PR DESCRIPTION
# Why

To use `Convertibles` in `Record`, we need to have a function that converts it back to JavaScript.

# How

* Added `convertResult` function to `Convertible` protocol
* Implemented convertResult in our convertibles 

# Test Plan

I've added a test case for all our convertibles used in Record.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
