### PR TITLE
[docs] Add an overview for Compile locally section and use consistent terminology

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -187,6 +187,7 @@ export const general = [
     makeGroup(
       'Compile locally',
       [
+        makePage('guides/local-app-overview.mdx'),
         makePage('guides/local-app-development.mdx'),
         makePage('guides/local-app-production.mdx'),
         makePage('guides/cache-builds-remotely.mdx'),

--- a/docs/pages/deploy/build-project.mdx
+++ b/docs/pages/deploy/build-project.mdx
@@ -125,9 +125,9 @@ The workflow above will create Android and iOS builds on every commit to your pr
 
 Learn more about common patterns with the [workflows examples guide](/eas/workflows/examples).
 
-## Production builds locally
+## Release builds locally
 
-To create a production build locally, see the following React Native guides for more information on the necessary steps for Android and iOS.
+To create a release (also known as production) build locally, see the following React Native guides for more information on the necessary steps for Android and iOS.
 
 These guides assume your project has **android** and/or **ios** directories containing the respective native projects. If you use [Continuous Native Generation](/workflow/continuous-native-generation) then you will need to run [prebuild](/workflow/prebuild) to generate the directories before following the guides.
 

--- a/docs/pages/guides/local-app-overview.mdx
+++ b/docs/pages/guides/local-app-overview.mdx
@@ -1,0 +1,75 @@
+---
+title: 'Compile locally: Overview'
+sidebar_title: Overview
+description: An overview on local app compilation process for your Expo apps.
+---
+
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+
+You can leverage your local development environment to compile your app locally by utilizing Android Studio and Xcode. This compilation process can be done for both debug and release builds. This page provides an overview of the local app compilation process and references to other guides that might be necessary in this workflow.
+
+## When to compile your app locally
+
+There are different scenarios when you want to compile your app on your developer machine. It includes:
+
+- You want to iterate quickly on native code changes or test platform-specific changes in your debug build
+- You want to manually generate native code to test your debug build
+- Any scenario where you are required to create builds inside an environment where access to network is restricted
+- You want to locally manage your own credentials (such as upload key, and so on)
+- You want to test or integrate your own custom build cache provider
+- You want to opt out of prebuilt Expo Modules for Android and compile them from source locally once
+
+> **Note**: Compiling your app locally complements EAS Build. You can keep using the build service for cloud automation and fall back to local builds whenever you want to generate native code locally.
+
+## Prerequisites
+
+You need to install and set up Android Studio and Xcode to compile and run Android and iOS projects on your local machine. See the following guides on how to set up these tools:
+
+- [Android Studio](/get-started/set-up-your-environment/?platform=android&device=physical&mode=development-build&buildEnv=local#set-up-an-android-device-with-a-development-build)
+- [Xcode](/get-started/set-up-your-environment/?platform=ios&device=physical&mode=development-build&buildEnv=local#set-up-an-ios-device-with-a-development-build)
+
+## Compiling your debug build
+
+To quickly build and iterate a debug build, you can use Expo CLI's `npx expo run:[android|ios]` commands. These commands compile your project, using your locally installed Android SDK or Xcode, into a debug build of your app.
+
+<BoxLink
+  title="Local app development"
+  description="Learn how to compile and build your Expo app locally."
+  href="/guides/local-app-development/"
+  Icon={BookOpen02Icon}
+/>
+
+## Compiling your release build
+
+To create a release build (also known as production build) of your app, you generate signing credentials by utilizing tools provided by Android Studio and Xcode. Then, you can generate a release build and follow the process of manually submitting your app to Google Play Store or Apple App Store.
+
+<BoxLink
+  title="Create a production build locally"
+  description="Generate signed Android App Bundles, archive iOS builds in Xcode, and submit them manually."
+  href="/guides/local-app-production/"
+  Icon={BookOpen02Icon}
+/>
+
+## Reuse previous builds from a provider
+
+You can accelerate your local development by caching and reusing builds from a provider. You can use EAS as a build provider or create your own custom provider.
+
+<BoxLink
+  title="Use build cache providers"
+  description="Enable EAS build caching or ship a custom provider to shorten local build times."
+  href="/guides/cache-builds-remotely/"
+  Icon={BookOpen02Icon}
+/>
+
+## Prebuilt Expo Modules for Android
+
+SDK 53 and later ship with prebuilt Expo Modules for Android that reduce the work Gradle performs on each build. You can continue using the defaults or selectively opt out when you need to modify a module's source code.
+
+<BoxLink
+  title="Prebuilt Expo Modules for Android"
+  description="Understand how prebuilt modules work and learn how to opt out globally or per package."
+  href="/guides/prebuilt-expo-modules/"
+  Icon={CpuChip01Icon}
+/>

--- a/docs/pages/guides/local-app-overview.mdx
+++ b/docs/pages/guides/local-app-overview.mdx
@@ -71,5 +71,5 @@ SDK 53 and later ship with prebuilt Expo Modules for Android that reduce the wor
   title="Prebuilt Expo Modules for Android"
   description="Understand how prebuilt modules work and learn how to opt out globally or per package."
   href="/guides/prebuilt-expo-modules/"
-  Icon={CpuChip01Icon}
+  Icon={BookOpen02Icon}
 />

--- a/docs/pages/guides/local-app-overview.mdx
+++ b/docs/pages/guides/local-app-overview.mdx
@@ -21,7 +21,7 @@ There are different scenarios when you want to compile your app on your develope
 - You want to test or integrate your own custom build cache provider
 - You want to opt out of prebuilt Expo Modules for Android and compile them from source locally once
 
-> **Note**: Compiling your app locally complements EAS Build. You can keep using the build service for cloud automation and fall back to local builds whenever you want to generate native code locally.
+> **Note**: Compiling your app locally complements EAS Build. You can keep using the build service for cloud automation and fall back to local builds for development.
 
 ## Prerequisites
 

--- a/docs/pages/guides/local-app-overview.mdx
+++ b/docs/pages/guides/local-app-overview.mdx
@@ -16,7 +16,7 @@ There are different scenarios when you want to compile your app on your develope
 
 - You want to iterate quickly on native code changes or test platform-specific changes in your debug build
 - You want to manually generate native code to test your debug build
-- Any scenario where you are required to create builds inside an environment where access to network is restricted
+- Any scenario where you are required to create builds inside an environment where access to a network is restricted
 - You want to locally manage your own credentials (such as upload key, and so on)
 - You want to test or integrate your own custom build cache provider
 - You want to opt out of prebuilt Expo Modules for Android and compile them from source locally once
@@ -32,7 +32,7 @@ You need to install and set up Android Studio and Xcode to compile and run Andro
 
 ## Compiling your debug build
 
-To quickly build and iterate a debug build, you can use Expo CLI's `npx expo run:[android|ios]` commands. These commands compile your project, using your locally installed Android SDK or Xcode, into a debug build of your app.
+To quickly build and iterate on a debug build, you can use Expo CLI's `npx expo run:[android|ios]` commands. These commands compile your project, using your locally installed Android SDK or Xcode, into a debug build of your app.
 
 <BoxLink
   title="Local app development"

--- a/docs/pages/guides/local-app-production.mdx
+++ b/docs/pages/guides/local-app-production.mdx
@@ -1,7 +1,7 @@
 ---
-title: Create a production build locally
-sidebar_title: Production
-description: Learn how to create a production build for your Expo app locally.
+title: Create a release build locally
+sidebar_title: Release
+description: Learn how to create a release (production) build for your Expo app locally.
 ---
 
 import { GoogleAppStoreIcon } from '@expo/styleguide-icons/custom/GoogleAppStoreIcon';
@@ -11,11 +11,11 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { DiffBlock, Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-To create your app's production build (also known as release build) locally, you need to follow separate steps on your computer and use the tools required to create any native app. This guide provides the necessary steps for Android and iOS.
+To create your app's release build (also known as production build) locally, you need to follow separate steps on your computer and use the tools required to create any native app. This guide provides the necessary steps for Android and iOS.
 
 ## Android
 
-Creating a production build locally for Android requires signing it with an [upload key](https://developer.android.com/studio/publish/app-signing#certificates-keystores) and generating an Android Application Bundle (**.aab**). Follow the steps below:
+Creating a release build locally for Android requires signing it with an [upload key](https://developer.android.com/studio/publish/app-signing#certificates-keystores) and generating an Android Application Bundle (**.aab**). Follow the steps below:
 
 ### Prerequisites
 
@@ -88,7 +88,7 @@ Open **android/app/build.gradle** file and add the following configuration:
 
 ### Generate release Android Application Bundle (aab)
 
-Navigate inside the **android** directory and create a production build in **.aab** format by running Gradle's `bundleRelease` command:
+Navigate inside the **android** directory and create a release build in **.aab** format by running Gradle's `bundleRelease` command:
 
 <Terminal
   cmd={['$ cd android', '', '$ ./gradlew app:bundleRelease']}
@@ -116,7 +116,7 @@ Google Play Store requires manual app submission when submitting the **.aab** fi
 
 ## iOS
 
-To create an iOS production build locally for Apple App Store, you need to use Xcode which handles the signing and submission process via App Store Connect.
+To create an iOS release build locally for Apple App Store, you need to use Xcode which handles the signing and submission process via App Store Connect.
 
 ### Prerequisites
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-15153 ENG-10296

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add an overview for the " Compile locally" section.
- For local compilation of production builds, use the term "Release build(s)"

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview:
- /guides/local-app-overview/
- /deploy/build-project/#release-builds-locally
- /guides/local-app-production/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
