### PR TITLE
[file-system][iOS] Add missing createFile and createDirectory methods

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix recursive file deletion. ([#40248](https://github.com/expo/expo/pull/40248) by [@aleqsio](https://github.com/aleqsio))
+- [iOS] Add missing `createFile` and `createDirectory` methods.
 
 ### 💡 Others
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix recursive file deletion. ([#40248](https://github.com/expo/expo/pull/40248) by [@aleqsio](https://github.com/aleqsio))
-- [iOS] Add missing `createFile` and `createDirectory` methods.
+- [iOS] Add missing `createFile` and `createDirectory` methods. ([#40314](https://github.com/expo/expo/pull/40314) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/ios/FileSystemModule.swift
+++ b/packages/expo-file-system/ios/FileSystemModule.swift
@@ -335,6 +335,18 @@ public final class FileSystemModule: Module {
         try directory.listAsRecords()
       }
 
+      Function("createFile") { (directory, name: String, content: String?) in
+        let file = FileSystemFile(url: directory.url.appendingPathComponent(name))
+        try file.create(CreateOptions())
+        return file
+      }
+
+      Function("createDirectory") { (directory, name: String) in
+        let newDirectory = FileSystemDirectory(url: directory.url.appendingPathComponent(name))
+        try newDirectory.create(CreateOptions())
+        return newDirectory
+      }
+
       Property("uri") { directory in
         return directory.url.absoluteString
       }

--- a/packages/expo-file-system/ios/FileSystemPath.swift
+++ b/packages/expo-file-system/ios/FileSystemPath.swift
@@ -25,7 +25,7 @@ internal class FileSystemPath: SharedObject {
 
   func validateCanCreate(_ options: CreateOptions) throws {
     if try !options.overwrite && exists {
-      throw FileAlreadyExistsException("File already exists")
+      throw FileAlreadyExistsException(url.absoluteString)
     }
   }
 


### PR DESCRIPTION
# Why

Fixes #40312
`createFile` and `createDirectory` were missing on iOS.

# How

Added missing methods.

# Test Plan

Tested in BareExpo
```
<Button
  title="Create and file"
  onPress={async () => {
    const dir = await Directory.pickDirectoryAsync();
    const dir2 = dir.createDirectory('NewDir');
    const file = dir2.createFile('test.txt', null);
    console.log('dir1', dir);
    console.log('dir2', dir2);
    console.log('file', file);
    console.log('list', dir.list());
    console.log('list2', dir2.list());
  }}
/>
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
