### PR TITLE
[audio][iOS] Fix xcode version check

### DIFF
--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -531,7 +531,7 @@ public class AudioModule: Module {
 
 #if !os(tvOS)
       if category == .playAndRecord {
-#if compiler(>=6.0)
+#if compiler(>=6.2) // Xcode 26
         categoryOptions.insert(.allowBluetoothHFP)
 #else
         categoryOptions.insert(.allowBluetooth)


### PR DESCRIPTION
# Why

#40275 added `#if compiler(>=6.0)` to fix builds on Xcode 26, but it's too low so it stopped building on Xcode 16.3

# How

Use `>=6.2` instead like in other places in our codebase https://github.com/expo/expo/blob/cf8d786c352d82bf548f20fb2c569e7b689b745c/packages/expo-ui/ios/Button/Button.swift#L70 https://github.com/expo/expo/blob/cf8d786c352d82bf548f20fb2c569e7b689b745c/packages/expo-glass-effect/ios/GlassStyle.swift#L8 https://github.com/expo/expo/blob/cf8d786c352d82bf548f20fb2c569e7b689b745c/packages/expo-ui/ios/Modifiers/ViewModifierRegistry.swift#L597

# Test Plan

CI should be green
