### PR TITLE
[ios][dev-launcher] Fix empty updates tab on initial launch

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixes updates not being viewable on first launch.
+
 ### 💡 Others
 
 - [Android] Migrated from `kotlinOptions` to `compilerOptions` DSL. ([#39794](https://github.com/expo/expo/pull/39794) by [@huextrat](https://github.com/huextrat))

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixes updates not being viewable on first launch.
+- [iOS] Fixes updates not being viewable on first launch. ([#40324](https://github.com/expo/expo/pull/40324) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why
Fixes https://exponent-internal.slack.com/archives/C011V63429H/p1760100531608579
This was a regression from #37820

# How
The code regressed by trying to read from the the manifest instead of from constants. The manifest is not available on first launch causing the appId and projectURL to always be nil. I've added some extra fallbacks to try and ensure we have an appId and projectUrl available immediately. 

# Test Plan
Test project. Updates are viewable immediately after log in.

<img width="450" height="978" alt="Simulator Screenshot - iPhone 17 - 2025-10-10 at 14 57 07" src="https://github.com/user-attachments/assets/068e4642-7ec0-4870-a12f-6aa17e2dd64f" />
