### PR TITLE
[docs] Fix formatting in app-extensions.mdx

### DIFF
--- a/docs/pages/build-reference/app-extensions.mdx
+++ b/docs/pages/build-reference/app-extensions.mdx
@@ -28,13 +28,14 @@ Declaring app extensions with `extra.eas.build.experimental.ios.appExtensions` i
                     "com.apple.example": "entitlement value"
                   }
                 }
-              }
-            ]
+              ]
+            }
           }
         }
       }
     }
   }
+}
 ```
 
 ## Bare projects


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
This pull request makes a minor update to the documentation for declaring app extensions in iOS builds. The change fixes the formatting of a JSON code example by properly closing the object and array brackets.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
