### PR TITLE
[android][media-library] Fix deleteAssetsAsync using incorrect MediaStore URI on Android 11+

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- [android] Fix deleteAssetsAsync using incorrect MediaStore URI on Android 11+ ([#40343](https://github.com/expo/expo/pull/40343) by [@fanderzon](https://github.com/fanderzon))
 - [next][iOS] Convert `id` to URI format ([#39920](https://github.com/expo/expo/pull/39920) by [@Wenszel](https://github.com/Wenszel))
 - [next][android] Fix `delete()` throwing security exception ([#39914](https://github.com/expo/expo/pull/39914) by [@Wenszel](https://github.com/Wenszel))
 - [next][android] Change default root directory to Pictures ([#39716](https://github.com/expo/expo/pull/39716) by [@Wenszel](https://github.com/Wenszel))


### PR DESCRIPTION
# Why

Fixes #29896 (which was because of a uri error, but an unrelated fix regarding permissions was used to close the issue)

The `deleteAssetsAsync()` method fails on Android 11+ (API 30+) with error `E_UNABLE_TO_DELETE` when attempting to delete media assets. This is caused by using an incorrect MediaStore URI format.

As reported in #29896, the method uses the generic `content://media/external/file/` URI which doesn't work for deletion operations on modern Android versions. The correct approach is to use media-type-specific URIs like `content://media/external/images/media/`.

# How

Modified `MediaLibraryUtils.deleteAssets()` to query the `MIME_TYPE` column and use the existing `mimeTypeToExternalUri()` helper function to construct the correct MediaStore URI based on media type (image/video/audio).

Changes:
- Added `MIME_TYPE` to projection query (line 88)
- Query mime type for each asset during deletion loop (line 106)
- Use `mimeTypeToExternalUri()` to get correct base URI (line 110)
- Build proper content URI with correct collection path (line 111)

This uses an existing helper function that was already being used in other parts of the codebase (e.g., `getAssetsUris()`).

# Test Plan

## Reproducible Test App

**Repository:** https://github.com/fanderzon/expo-media-library-delete-test

A minimal Expo app demonstrating the bug and fix. The repo includes a `patch-package` patch that applies this fix.

### Testing WITHOUT the fix (reproduces bug):

```bash
git clone https://github.com/fanderzon/expo-media-library-delete-test
cd expo-media-library-delete-test
rm -rf patches  # Remove the patch
npm install
npx expo prebuild --clean
npx expo run:android
```

**Test steps:**
1. App launches and requests media permissions → Grant "Allow access to all photos"
2. Grid of 20 photos displays
3. Tap a photo → Blue border appears (selected)
4. Tap "Delete Selected Photo" button
5. Confirm in dialog

# Checklist
- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md) No added documentation
