### PR TITLE
fix(docs): Complete TabLayout function in native-tabs.mdx

### DIFF
--- a/docs/pages/router/advanced/native-tabs.mdx
+++ b/docs/pages/router/advanced/native-tabs.mdx
@@ -130,6 +130,8 @@ export default function TabLayout() {
         />
       </NativeTabs.Trigger>
   </NativeTabs>
+  );
+}
 ```
 
 Liquid glass on iOS automatically changes colors based on if the background color is light or dark. There is no callback for this, so you need to use a `PlatformColor` to set the color of the icon.

--- a/docs/pages/router/advanced/native-tabs.mdx
+++ b/docs/pages/router/advanced/native-tabs.mdx
@@ -122,14 +122,12 @@ export default function TabLayout() {
   return (
     <NativeTabs>
       <NativeTabs.Trigger name="index">
-        <Icon sf={{ default: "house", selected: "house.fill" }} drawable="custom_home_drawable" />
+        <Icon sf={{ default: 'house', selected: 'house.fill' }} drawable="custom_home_drawable" />
       </NativeTabs.Trigger>
       <NativeTabs.Trigger name="settings">
-        <Icon
-          src={require('../../../assets/setting_icon.png')}
-        />
+        <Icon src={require('../../../assets/setting_icon.png')} />
       </NativeTabs.Trigger>
-  </NativeTabs>
+    </NativeTabs>
   );
 }
 ```


### PR DESCRIPTION
# Why

The code example in the Native Tabs documentation had a small syntax issue — the <NativeTabs> component was not properly closed.
This caused copy-paste errors for readers trying to run the example.

# How

Fixed the missing </NativeTabs> and closing ); in the code block.
No other content or behavior changes were made.

# Test Plan


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
