### PR TITLE
[docs] Add `browserAction` support in `Terminal` component

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -473,18 +473,48 @@ If you just want to hide a single page from the sidebar, set `hideInSidebar: tru
 
 Whenever shell commands are used or referred, use `Terminal` component to make the code snippets copy/pasteable. This component can be imported into any markdown file.
 
+#### Supported props
+
+| Option          | Type                              | Description                                                                                                                                                                    |
+| --------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `cmd`           | `string[]`                        | **Required**. Lines to render. Use `$` to mark commands, `#` for comments, and empty strings for spacing.                                                                      |
+| `cmdCopy`       | `string`                          | **Optional**. Overrides the auto-generated copy text. Helpful when multiple commands should be chained (for example with `&&`) or when you want to control the copied content. |
+| `title`         | `string`                          | **Optional**. Overrides the default header label of "Terminal".                                                                                                                |
+| `browserAction` | `{ href: string; label: string }` | **Optional**. Adds a launch button in the header that opens the link in a new tab—ideal for flows that continue in a web UI.                                                   |
+| `hideOverflow`  | `boolean`                         | **Optional**. Prevents horizontal scrollbars when you prefer the content to clip instead of scroll.                                                                            |
+| `className`     | `string`                          | **Optional**. Additional utility classes for adjusting layout or spacing around the snippet.                                                                                   |
+
 ```mdx
 import { Terminal } from '~/ui/components/Snippet';
 
-{/* for single command and one prop: */}
+{/* For single command and one prop */}
 
 <Terminal cmd={['$ npx expo install package']} />
 
-{/* for multiple commands: */}
+{/* For multiple commands */}
 
 <Terminal
   cmd={['# Create a new Expo project', '$ npx create-expo-app --template bare-minimum', '']}
   cmdCopy="npx create-expo-app --template bare-minimum"
+/>
+
+{/* Clamp long outputs and tweak spacing */}
+
+<Terminal
+  className="mt-6"
+  hideOverflow
+  cmd={[
+    '$ npx expo config --json',
+    '# Output is trimmed visually because hideOverflow is enabled.',
+  ]}
+/>
+
+{/* Surface a button that opens related browser flows */}
+
+<Terminal
+  title="Deploy website with EAS"
+  cmd={['$ npx eas-cli deploy']}
+  browserAction={{ href: 'https://expo.dev/eas', label: 'Open in expo.dev' }}
 />
 ```
 

--- a/docs/ui/components/Snippet/Terminal.test.tsx
+++ b/docs/ui/components/Snippet/Terminal.test.tsx
@@ -77,7 +77,11 @@ describe(Terminal, () => {
     const user = userEvent.setup();
     await user.click(screen.getByText('Open in expo.dev'));
 
-    expect(openMock).toHaveBeenCalledWith('https://expo.dev/login', '_blank', 'noopener,noreferrer');
+    expect(openMock).toHaveBeenCalledWith(
+      'https://expo.dev/login',
+      '_blank',
+      'noopener,noreferrer'
+    );
 
     window.open = originalWindowOpen;
   });

--- a/docs/ui/components/Snippet/Terminal.test.tsx
+++ b/docs/ui/components/Snippet/Terminal.test.tsx
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -57,5 +58,27 @@ describe(Terminal, () => {
   it('do not generate copyCmd if there is more than one command', () => {
     render(<Terminal cmd={['$ npx create-expo-app init test', '$ cd test']} />);
     expect(screen.queryByText('Copy')).toBe(null);
+  });
+
+  it('renders browser action when provided', async () => {
+    const originalWindowOpen = window.open;
+    const openMock = jest.fn();
+    window.open = openMock as unknown as typeof window.open;
+
+    render(
+      <Terminal
+        cmd={['$ expo login']}
+        browserAction={{ href: 'https://expo.dev/login', label: 'Open in expo.dev' }}
+      />
+    );
+
+    expect(screen.getByText('Open in expo.dev')).toBeVisible();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText('Open in expo.dev'));
+
+    expect(openMock).toHaveBeenCalledWith('https://expo.dev/login', '_blank', 'noopener,noreferrer');
+
+    window.open = originalWindowOpen;
   });
 });

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -1,10 +1,12 @@
 import { mergeClasses } from '@expo/styleguide';
 import { TerminalSquareIcon } from '@expo/styleguide-icons/outline/TerminalSquareIcon';
+import { ArrowUpRightIcon } from '@expo/styleguide-icons/outline/ArrowUpRightIcon';
 import { Language, Prism } from 'prism-react-renderer';
 
 import { CODE } from '~/ui/components/Text';
 
 import { Snippet } from '../Snippet';
+import { SnippetAction } from '../SnippetAction';
 import { SnippetContent } from '../SnippetContent';
 import { SnippetHeader } from '../SnippetHeader';
 import { CopyAction } from '../actions/CopyAction';
@@ -15,6 +17,10 @@ type TerminalProps = {
   hideOverflow?: boolean;
   title?: string;
   className?: string;
+  browserAction?: {
+    href: string;
+    label: string;
+  };
 };
 
 export const Terminal = ({
@@ -23,9 +29,11 @@ export const Terminal = ({
   hideOverflow,
   className,
   title = 'Terminal',
+  browserAction,
 }: TerminalProps) => (
   <Snippet className={mergeClasses('terminal-snippet [li_&]:mt-4', className)}>
     <SnippetHeader alwaysDark title={title} Icon={TerminalSquareIcon}>
+      {renderBrowserAction(browserAction)}
       {renderCopyButton({ cmd, cmdCopy })}
     </SnippetHeader>
     <SnippetContent alwaysDark hideOverflow={hideOverflow} className="flex flex-col">
@@ -49,6 +57,28 @@ function getDefaultCmdCopy(cmd: TerminalProps['cmd']) {
 function renderCopyButton({ cmd, cmdCopy }: TerminalProps) {
   const copyText = cmdCopy ?? getDefaultCmdCopy(cmd);
   return copyText && <CopyAction alwaysDark text={copyText} />;
+}
+
+function renderBrowserAction(browserAction: TerminalProps['browserAction']) {
+  if (!browserAction) {
+    return null;
+  }
+
+  const { href, label } = browserAction;
+
+  return (
+    <SnippetAction
+      alwaysDark
+      className="max-sm-gutters:gap-0 [&_p]:max-sm-gutters:hidden"
+      rightSlot={<ArrowUpRightIcon className="icon-sm shrink-0 text-icon-secondary" />}
+      onClick={() => {
+        if (typeof window !== 'undefined') {
+          window.open(href, '_blank', 'noopener,noreferrer');
+        }
+      }}>
+      {label}
+    </SnippetAction>
+  );
 }
 
 /**

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -23,6 +23,10 @@ type TerminalProps = {
   };
 };
 
+type CopyButtonProps = Pick<TerminalProps, 'cmd' | 'cmdCopy'>;
+
+type BrowserActionProps = NonNullable<TerminalProps['browserAction']>;
+
 export const Terminal = ({
   cmd,
   cmdCopy,
@@ -33,8 +37,8 @@ export const Terminal = ({
 }: TerminalProps) => (
   <Snippet className={mergeClasses('terminal-snippet [li_&]:mt-4', className)}>
     <SnippetHeader alwaysDark title={title} Icon={TerminalSquareIcon}>
-      {renderBrowserAction(browserAction)}
-      {renderCopyButton({ cmd, cmdCopy })}
+      {browserAction && <BrowserAction {...browserAction} />}
+      <CopyButton cmd={cmd} cmdCopy={cmdCopy} />
     </SnippetHeader>
     <SnippetContent alwaysDark hideOverflow={hideOverflow} className="flex flex-col">
       {cmd.map(cmdMapper)}
@@ -54,32 +58,29 @@ function getDefaultCmdCopy(cmd: TerminalProps['cmd']) {
   return undefined;
 }
 
-function renderCopyButton({ cmd, cmdCopy }: TerminalProps) {
+const CopyButton = ({ cmd, cmdCopy }: CopyButtonProps) => {
   const copyText = cmdCopy ?? getDefaultCmdCopy(cmd);
-  return copyText && <CopyAction alwaysDark text={copyText} />;
-}
 
-function renderBrowserAction(browserAction: TerminalProps['browserAction']) {
-  if (!browserAction) {
+  if (!copyText) {
     return null;
   }
 
-  const { href, label } = browserAction;
+  return <CopyAction alwaysDark text={copyText} />;
+};
 
-  return (
-    <SnippetAction
-      alwaysDark
-      className="max-sm-gutters:gap-0 [&_p]:max-sm-gutters:hidden"
-      rightSlot={<ArrowUpRightIcon className="icon-sm shrink-0 text-icon-secondary" />}
-      onClick={() => {
-        if (typeof window !== 'undefined') {
-          window.open(href, '_blank', 'noopener,noreferrer');
-        }
-      }}>
-      {label}
-    </SnippetAction>
-  );
-}
+const BrowserAction = ({ href, label }: BrowserActionProps) => (
+  <SnippetAction
+    alwaysDark
+    className="max-sm-gutters:gap-0 [&_p]:max-sm-gutters:hidden"
+    rightSlot={<ArrowUpRightIcon className="icon-sm shrink-0 text-icon-secondary" />}
+    onClick={() => {
+      if (typeof window !== 'undefined') {
+        window.open(href, '_blank', 'noopener,noreferrer');
+      }
+    }}>
+    {label}
+  </SnippetAction>
+);
 
 /**
  * Map all provided lines and render the correct component.

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -1,6 +1,6 @@
 import { mergeClasses } from '@expo/styleguide';
-import { TerminalSquareIcon } from '@expo/styleguide-icons/outline/TerminalSquareIcon';
 import { ArrowUpRightIcon } from '@expo/styleguide-icons/outline/ArrowUpRightIcon';
+import { TerminalSquareIcon } from '@expo/styleguide-icons/outline/TerminalSquareIcon';
 import { Language, Prism } from 'prism-react-renderer';
 
 import { CODE } from '~/ui/components/Text';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-15349

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add `browserAction` support in `Terminal` component to allow opening a link in browser from `Terminal` component.
	- Add a test accordingly.
- Update README.md file to add all supported props for `Terminal` component with their descirption and examples.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Example:

```mdx
<Terminal
  cmd={['$ npx create-expo-app@latest']}
  browserAction={{
    href: 'https://expo.dev/signup',
    label: 'Sign up for Expo',
  }}
/>
```


## Preview

<img width="2352" height="1148" alt="CleanShot 2025-10-13 at 16 41 23@2x" src="https://github.com/user-attachments/assets/c34d0cf4-1af0-4a48-822a-842020c8e0d6" />
<img width="2438" height="1226" alt="CleanShot 2025-10-13 at 16 41 27@2x" src="https://github.com/user-attachments/assets/5e4cb0f8-ce4c-45af-886b-cac283141442" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
