### PR TITLE
[ci] repack integration - 2

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           working-directory: apps/bare-expo
           previous-git-commit: ${{ steps.base-commit.outputs.base-commit }}
+          fingerprint-db-cache-path: .fingerprint.db
 
       - name: 👀 Debug fingerprint
         run: |

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -22,8 +22,7 @@ on:
       - '!packages/@expo/cli/**'
 
 concurrency:
-  # When pushing main branch, we should limit single concurrency with pr-labeler workflow to prevent multiple fingerprints being updated at the same time
-  group: ${{ github.event_name != 'pull_request' && 'fingerprint-main' || format('{0}-{1}-{2}', github.workflow, github.event_name, github.ref) }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -85,6 +84,7 @@ jobs:
           working-directory: apps/bare-expo
           previous-git-commit: ${{ steps.base-commit.outputs.base-commit }}
           fingerprint-state-output-file: ${{ runner.temp }}/fingerprint-state.json
+          fingerprint-db-cache-path: .fingerprint.db
       - name: 🏗️ Build/Repack iOS project (bare-expo)
         uses: expo/actions/repack-app-artifact@main
         timeout-minutes: 55
@@ -96,6 +96,7 @@ jobs:
         with:
           platform: ios
           fingerprint-state-file: ${{ runner.temp }}/fingerprint-state.json
+          fingerprint-db-cache-path: .fingerprint.db
           working-directory: apps/bare-expo
           build-command: |
             pushd ios
@@ -239,6 +240,7 @@ jobs:
           working-directory: apps/bare-expo
           previous-git-commit: ${{ steps.base-commit.outputs.base-commit }}
           fingerprint-state-output-file: ${{ runner.temp }}/fingerprint-state.json
+          fingerprint-db-cache-path: .fingerprint.db
       - name: 🏗️ Build/Repack Android project (bare-expo)
         uses: expo/actions/repack-app-artifact@main
         timeout-minutes: 35
@@ -248,6 +250,7 @@ jobs:
         with:
           platform: android
           fingerprint-state-file: ${{ runner.temp }}/fingerprint-state.json
+          fingerprint-db-cache-path: .fingerprint.db
           working-directory: apps/bare-expo
           build-command: |
             ./scripts/start-android-e2e-test.ts --build


### PR DESCRIPTION
# Why

i noticed some problems from the previous repack integration from #40257
- fingerprint db is always cache miss on ios runner.
- because of the concurrent group as `fingerprint-main` and cancel-in-progress=true, sometimes the job is canceled from different job, e.g. pr-babeler will cancel the test-suite job. that is not great.

# How

- for cache miss, try to specify a `fingerprint-db-cache-path` with cross-platform consistent path, i.e. the `.fingerprint.db`
- revert the concurrent group cache. there's still chance that fingerprint db were overwritten by other ci jobs (from race condition). but that's better than entirely canceled. will keep eyes on the overwritten cases

# Test Plan

still need to test after merge to main

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
