### PR TITLE
[video][ios] Load track information in asynchronous context

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### 💡 Others
 
 - [Android] Remove @UnstableReactNativeAPI annotations. ([#39921](https://github.com/expo/expo/pull/39921) by [@jakex7](https://github.com/jakex7))
+- [iOS] Load track information for events in asynchronous context.
 
 ## 3.0.11 — 2025-09-10
 

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -16,7 +16,7 @@
 ### 💡 Others
 
 - [Android] Remove @UnstableReactNativeAPI annotations. ([#39921](https://github.com/expo/expo/pull/39921) by [@jakex7](https://github.com/jakex7))
-- [iOS] Load track information for events in asynchronous context.
+- [iOS] Load track information for events in asynchronous context. ([#40355](https://github.com/expo/expo/pull/40355) by [@behenate](https://github.com/behenate))
 
 ## 3.0.11 — 2025-09-10
 

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -12,6 +12,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   private var dangerousPropertiesStore = DangerousPropertiesStore()
   lazy var audioTracks: VideoPlayerAudioTracks = VideoPlayerAudioTracks(owner: self)
   lazy var seeker: VideoPlayerSeeker = VideoPlayerSeeker(player: self)
+  private var tracksLoadingTask: Task<(), Never>?
 
   var loop = false
   var audioMixingMode: AudioMixingMode = .doNotMix {
@@ -185,6 +186,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
     VideoManager.shared.unregister(videoPlayer: self)
 
     videoSourceLoader.cancelCurrentTask()
+    tracksLoadingTask?.cancel()
 
     // We have to replace from the main thread because of KVOs (see comment in VideoSourceLoader).
     // Moreover, in this case we have to keep a strong reference to AVPlayer and remove its item
@@ -355,28 +357,19 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   }
 
   func onLoadedPlayerItem(player: AVPlayer, playerItem: AVPlayerItem?) {
-    // This event means that a new player item has been loaded so the subtitle tracks should change
-    let oldTracks = subtitles.availableSubtitleTracks
-    self.subtitles.onNewPlayerItemLoaded(playerItem: playerItem)
-    let payload = SubtitleTracksChangedEventPayload(
-      availableSubtitleTracks: subtitles.availableSubtitleTracks,
-      oldAvailableSubtitleTracks: oldTracks
-    )
-    safeEmit(event: "availableSubtitleTracksChange", payload: payload)
-
-    // Handle audio tracks
-    let oldAudioTracks = audioTracks.availableAudioTracks
-    self.audioTracks.onNewPlayerItemLoaded(playerItem: playerItem)
-    let audioPayload = AudioTracksChangedEventPayload(
-      availableAudioTracks: audioTracks.availableAudioTracks,
-      oldAvailableAudioTracks: oldAudioTracks
-    )
-    safeEmit(event: "availableAudioTracksChange", payload: audioPayload)
-
-    Task {
+    // Loading tracks requires doing some long tasks, this callback can be called from the main thread
+    // Which could cause hangs
+    tracksLoadingTask?.cancel()
+    tracksLoadingTask = Task {
+      let audioPayload = await self.audioTracks.onNewPlayerItemLoaded(playerItem: playerItem)
+      let subtitlesChangePayload = await self.subtitles.onNewPlayerItemLoaded(playerItem: playerItem)
       let videoPlayerItem: VideoPlayerItem? = playerItem as? VideoPlayerItem
-      // Those properties will be already loaded 99.9% of time, so the event delay should be almost 0
+
       availableVideoTracks = await videoPlayerItem?.videoTracks ?? []
+
+      guard !Task.isCancelled else {
+        return
+      }
 
       let videoSourceLoadedPayload = VideoSourceLoadedEventPayload(
         videoSource: videoPlayerItem?.videoSource,
@@ -385,7 +378,10 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
         availableSubtitleTracks: subtitles.availableSubtitleTracks,
         availableAudioTracks: audioTracks.availableAudioTracks
       )
+
       safeEmit(event: "sourceLoad", payload: videoSourceLoadedPayload)
+      safeEmit(event: "availableSubtitleTracksChange", payload: subtitlesChangePayload)
+      safeEmit(event: "availableAudioTracksChange", payload: audioPayload)
     }
   }
 

--- a/packages/expo-video/ios/VideoPlayerObserver.swift
+++ b/packages/expo-video/ios/VideoPlayerObserver.swift
@@ -12,6 +12,37 @@ private struct Weak<T: AnyObject> {
   }
 }
 
+private enum ObserverTaskKey {
+  case sourceLoading
+  case subtitleTrackLoad
+  case audioTrackLoad
+  case trackChange
+}
+
+private actor ObserverTaskManager {
+  private var tasks: [ObserverTaskKey: Task<Void, Never>] = [:]
+
+  func run(
+    forKey key: ObserverTaskKey,
+    operation: @escaping @Sendable () async -> Void
+  ) {
+    tasks[key]?.cancel()
+
+    let newTask = Task {
+      await operation()
+      tasks[key] = nil
+    }
+    tasks[key] = newTask
+  }
+
+  func cancelAll() {
+    for task in tasks.values {
+      task.cancel()
+    }
+    tasks.removeAll()
+  }
+}
+
 protocol VideoPlayerObserverDelegate: AnyObject {
   func onStatusChanged(player: AVPlayer, oldStatus: PlayerStatus?, newStatus: PlayerStatus, error: Exception?)
   func onIsPlayingChanged(player: AVPlayer, oldIsPlaying: Bool?, newIsPlaying: Bool)
@@ -74,6 +105,8 @@ final class WeakPlayerObserverDelegate: Hashable {
 class VideoPlayerObserver: VideoSourceLoaderListener {
   private weak var owner: VideoPlayer?
   private weak var videoSourceLoader: VideoSourceLoader?
+  private let taskManager = ObserverTaskManager()
+
   var player: AVPlayer? {
     owner?.ref
   }
@@ -157,8 +190,6 @@ class VideoPlayerObserver: VideoSourceLoaderListener {
   private var currentSubtitlesObserver: NSObjectProtocol?
   private var currentAudioTracksObserver: NSObjectProtocol?
 
-  private var videoTrackUpdateTask: Task<Void, Never>?
-
   init(owner: VideoPlayer, videoSourceLoader: VideoSourceLoader) {
     self.owner = owner
     self.videoSourceLoader = videoSourceLoader
@@ -241,8 +272,7 @@ class VideoPlayerObserver: VideoSourceLoaderListener {
       // For HLS sources AVPlayer doesn't provide the tracks when they change
       // But it does call this event when they are loaded and when the current track changes.
       // We have to extract the necessary information ourselves.
-        self?.videoTrackUpdateTask?.cancel()
-        self?.videoTrackUpdateTask = Task { [weak self, playerItem] in
+      self?.runTask(forKey: .trackChange) { [weak self, item] in
         // For HLS sources
         if let videoPlayerItem = playerItem as? VideoPlayerItem, videoPlayerItem.isHls {
           guard let itemUri = videoPlayerItem.videoSource.uri else {
@@ -290,9 +320,16 @@ class VideoPlayerObserver: VideoSourceLoaderListener {
       object: playerItem,
       queue: nil
     ) { [weak self] _ in
-      self?.delegates.forEach { delegate in
-        let subtitleTrack = VideoPlayerSubtitles.findCurrentSubtitleTrack(for: playerItem)
-        delegate.value?.onSubtitleSelectionChanged(player: player, playerItem: playerItem, subtitleTrack: subtitleTrack)
+      self?.runTask(forKey: .subtitleTrackLoad) { [weak self] in
+        let subtitleTrack = await VideoPlayerSubtitles.findCurrentSubtitleTrack(for: playerItem)
+
+        guard !Task.isCancelled else {
+          return
+        }
+
+        self?.delegates.forEach { delegate in
+          delegate.value?.onSubtitleSelectionChanged(player: player, playerItem: playerItem, subtitleTrack: subtitleTrack)
+        }
       }
     }
 
@@ -301,9 +338,16 @@ class VideoPlayerObserver: VideoSourceLoaderListener {
       object: playerItem,
       queue: nil
     ) { [weak self] _ in
-      self?.delegates.forEach { delegate in
-        let audioTrack = VideoPlayerAudioTracks.findCurrentAudioTrack(for: playerItem)
-        delegate.value?.onAudioTrackSelectionChanged(player: player, playerItem: playerItem, audioTrack: audioTrack)
+      self?.runTask(forKey: .audioTrackLoad) { [weak self] in
+        let audioTrack = await VideoPlayerAudioTracks.findCurrentAudioTrack(for: playerItem)
+
+        guard !Task.isCancelled else {
+          return
+        }
+
+        self?.delegates.forEach { delegate in
+          delegate.value?.onAudioTrackSelectionChanged(player: player, playerItem: playerItem, audioTrack: audioTrack)
+        }
       }
     }
   }
@@ -314,8 +358,9 @@ class VideoPlayerObserver: VideoSourceLoaderListener {
     playerItemStatusObserver?.invalidate()
     tracksObserver?.invalidate()
 
-    videoTrackUpdateTask?.cancel()
-    videoTrackUpdateTask = nil
+    Task { [taskManager] in
+      await taskManager.cancelAll()
+    }
 
     NotificationCenter.default.removeObserver(playerItemObserver as Any)
     NotificationCenter.default.removeObserver(currentSubtitlesObserver as Any)
@@ -506,6 +551,17 @@ class VideoPlayerObserver: VideoSourceLoaderListener {
 
   private func onIsExternalPlaybackActiveChanged(_ player: AVPlayer, _ change: NSKeyValueObservedChange<Bool>) {
     self.isExternalPlaybackActive = player.isExternalPlaybackActive
+  }
+
+  private func runTask(
+    forKey key: ObserverTaskKey,
+    operation: @escaping @Sendable () async -> Void
+  ) {
+    // Delegate the entire operation to the actor.
+    // This requires making the call from an asynchronous context.
+    Task { [weak self] in
+      await self?.taskManager.run(forKey: key, operation: operation)
+    }
   }
 
   // MARK: - VideoSourceLoaderListener

--- a/packages/expo-video/ios/VideoPlayerSubtitles.swift
+++ b/packages/expo-video/ios/VideoPlayerSubtitles.swift
@@ -14,8 +14,25 @@ class VideoPlayerSubtitles {
     currentSubtitleTrack = subtitleTrack
   }
 
-  func onNewPlayerItemLoaded(playerItem: AVPlayerItem?) {
-    availableSubtitleTracks = Self.findAvailableSubtitleTracks(for: playerItem)
+  /// Updates the available subtitle tracks for a new player item and returns an event with the changes.
+  ///
+  /// - Parameter playerItem: The new `AVPlayerItem` from which to load subtitle tracks.
+  /// - Returns: A js-ready `SubtitleTracksChangedEventPayload` containing the list of subtitle tracks before and after the update.
+  func onNewPlayerItemLoaded(playerItem: AVPlayerItem?) async -> SubtitleTracksChangedEventPayload {
+    let oldAvailableSubtitleTracks = availableSubtitleTracks
+
+    do {
+      availableSubtitleTracks = try await Self.findAvailableSubtitleTracks(for: playerItem)
+    } catch {
+      let uri = (playerItem as? VideoPlayerItem)?.videoSource.uri?.absoluteString ?? "the current source"
+      owner?.appContext?.jsLogger.warn("Failed to load available subtitle tracks for \(uri). Error: \(error)")
+      availableSubtitleTracks = []
+    }
+
+    return SubtitleTracksChangedEventPayload(
+      availableSubtitleTracks: availableSubtitleTracks,
+      oldAvailableSubtitleTracks: oldAvailableSubtitleTracks
+    )
   }
 
   func selectSubtitleTrack(subtitleTrack: SubtitleTrack?) {
@@ -31,20 +48,20 @@ class VideoPlayerSubtitles {
     }
   }
 
-  static func findAvailableSubtitleTracks(for playerItem: AVPlayerItem?) -> [SubtitleTrack] {
+  private static func findAvailableSubtitleTracks(for playerItem: AVPlayerItem?) async throws -> [SubtitleTrack] {
     var availableSubtitleTracks: [SubtitleTrack] = []
 
-    guard let asset = playerItem?.asset else {
+    guard let asset = await playerItem?.asset else {
       return availableSubtitleTracks
     }
-    let mediaSelectionCharacteristics = asset.availableMediaCharacteristicsWithMediaSelectionOptions
+    let mediaSelectionCharacteristics = try await asset.load(.availableMediaCharacteristicsWithMediaSelectionOptions)
 
     for characteristic in mediaSelectionCharacteristics {
       guard characteristic == .legible else {
         continue
       }
 
-      if let group = asset.mediaSelectionGroup(forMediaCharacteristic: characteristic) {
+      if let group = try await asset.loadMediaSelectionGroup(for: characteristic) {
         for option in group.options {
           guard let subtitleTrack = SubtitleTrack.from(mediaSelectionOption: option) else {
             continue
@@ -57,11 +74,11 @@ class VideoPlayerSubtitles {
     return availableSubtitleTracks
   }
 
-  static func findCurrentSubtitleTrack(for playerItem: AVPlayerItem?) -> SubtitleTrack? {
+  static func findCurrentSubtitleTrack(for playerItem: AVPlayerItem?) async -> SubtitleTrack? {
     guard
       let currentItem = playerItem,
-      let mediaSelectionGroup = currentItem.asset.mediaSelectionGroup(forMediaCharacteristic: .legible),
-      let selectedMediaOption = currentItem.currentMediaSelection.selectedMediaOption(in: mediaSelectionGroup)
+      let mediaSelectionGroup = try? await currentItem.asset.loadMediaSelectionGroup(for: .legible),
+      let selectedMediaOption = await currentItem.currentMediaSelection.selectedMediaOption(in: mediaSelectionGroup)
     else {
       return nil
     }


### PR DESCRIPTION
# Why

Event handlers are most often run on the main queue (property changes we listen to happen on the main queue) and we are using some deprecated synchronous methods to load track information when a change is detected, this can cause main thread lockups for slow-loading sources.
New methods, which load the track information asynchronously are available, but quite a lot of changes is needed to adapt them to the current, synchronous nature of expo-video event system.

# How

Added a TaskManager actor to `VideoPlayerObserver`. When the observer has to do asynchronous loading of track data, the load should go through the task manager. The manager will cancel the current load (if exists) and add the current load into the tasks dictionary.

# Test Plan

Tested in BareExpo on iOS
