### PR TITLE
[docs] Improve discoverability of `debugOptimized` and other variants in Expo CLI

### DIFF
--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -194,13 +194,13 @@ For example, if your project does not have an **ios** directory in the root of y
 
 Android apps can have multiple different **variants** which are defined in the project's `build.gradle` file. Variants can be selected with the `--variant` flag:
 
-**`debug` variant**
+##### `debug` variant
 
 Use the `debug` variant for a debug build:
 
 <Terminal cmd={['$ npx expo run:android --variant debug']} />
 
-**`debugOptimized` variant**
+##### `debugOptimized` variant
 
 > **important** `debugOptimized` is available in SDK 54 and later.
 
@@ -214,7 +214,7 @@ When using this variant, keep the following in mind:
 - In EAS Build, use a matching Gradle command like [`:app:assembleDebugOptimized` in **eas.json**](/build-reference/apk/#configuring-a-profile-to-build-apks)
 - **Limitation**: C++ debugging is disabled and C++ crashes may have less readable stack traces
 
-**`release` variant**
+##### `release` variant
 
 You can compile the Android app for production by running:
 
@@ -222,7 +222,7 @@ You can compile the Android app for production by running:
 
 This build is not automatically code-signed for submission to the Google Play Store. This command should be used to test bugs that may only show up in production builds. To generate a production build that is code signed for the Play Store, we recommend using [EAS Build](/build/introduction).
 
-**Debugging native Android project**
+##### Debugging native Android project
 
 You can debug the native Android project using native debugging tools by opening the **android** directory in Android Studio:
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, searching `debugOptimized` doesn't show in Search because the section starts with bold text. Instead, for all variants listed under "Compiling Android" in Expo CLI, use H5.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
