### PR TITLE
[iOS] Initial support for Swift 6 and its strict concurrency checks

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -3614,7 +3614,7 @@ SPEC CHECKSUMS:
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
   EXManifests: 7469efed75d694ce3c43a6da9c6f3886f66d3c26
   EXNotifications: a9eb811deeb51fb8e50ef45569be6ffab3994648
-  Expo: 40b8889f991ca5f25ead0bfcbc1f818b01efab9e
+  Expo: 6a74d387f5fbbf568cfdb71dbf368184a4126ef5
   expo-dev-client: b0363ce1f16a248d7c9b67ceaee2dbee058c1e05
   expo-dev-launcher: 22c7fd41da4b547115df0169a2cf00afa7f3f82e
   expo-dev-menu: 196a6c270f38af3aebb150ee3de7cf9a6945d092
@@ -3643,7 +3643,7 @@ SPEC CHECKSUMS:
   ExpoGL: 39262a8c3d4c36d48a28bc412e3392c25c5391c9
   ExpoGlassEffect: 02d9577dfe05a6b6c9856fd71514120e96792052
   ExpoHaptics: b48d913e7e5f23816c6f130e525c9a6501b160b5
-  ExpoImage: 306dd755c842dba9f3ee654c51834a9cc657e6ca
+  ExpoImage: 0fc185a4a4e462fedfe877ae66204a7c541dfee0
   ExpoImageManipulator: dbf5b8fc805b55463811cb3da96ab60c532faae8
   ExpoImagePicker: bd0a5c81d7734548f6908a480609257e85d19ea8
   ExpoInsights: fa66f3e1c5b612e08641eae42140a9d42af385ed
@@ -3658,7 +3658,7 @@ SPEC CHECKSUMS:
   ExpoMaps: ac5024fd6b3db82da997bdc4074bda5c3e2e7764
   ExpoMediaLibrary: 648cee3f5dcba13410ec9cc8ac9a426e89a61a31
   ExpoMeshGradient: 763087d3b1e6e9a0974e9700ea24cb598816d93c
-  ExpoModulesCore: 40c0e84daa07c9a47ae9dfd8bed43aa72d6fadbe
+  ExpoModulesCore: ce55349fc14e3a993eeea921f6b56ee5581d6686
   ExpoModulesTestCore: e65555b75a4ed7dd3bcf421ad01d7748bd372c88
   ExpoNetwork: 97073786edfe405aba5d0987a544617ed0671ad1
   ExpoPrint: ad836bb90da10793509651c0ea1f39e120db001e

--- a/apps/native-tests/ios/NativeTests.xcodeproj/project.pbxproj
+++ b/apps/native-tests/ios/NativeTests.xcodeproj/project.pbxproj
@@ -242,7 +242,6 @@
 				"${PODS_CONFIGURATION_BUILD_DIR}/React-cxxreact/React-cxxreact_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/SDWebImage/SDWebImage.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/expo-dev-launcher/EXDevLauncher.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/expo-dev-menu/EXDevMenu.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -254,7 +253,6 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-cxxreact_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SDWebImage.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXDevLauncher.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXDevMenu.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/apps/native-tests/ios/Podfile.lock
+++ b/apps/native-tests/ios/Podfile.lock
@@ -2466,14 +2466,14 @@ SPEC CHECKSUMS:
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
   EXManifests: 7469efed75d694ce3c43a6da9c6f3886f66d3c26
   EXNotifications: a9eb811deeb51fb8e50ef45569be6ffab3994648
-  Expo: 40b8889f991ca5f25ead0bfcbc1f818b01efab9e
+  Expo: 6a74d387f5fbbf568cfdb71dbf368184a4126ef5
   expo-dev-launcher: 22c7fd41da4b547115df0169a2cf00afa7f3f82e
-  expo-dev-menu: d40b0e877599650dd31bd6ad7b97e866f0e890c6
+  expo-dev-menu: 196a6c270f38af3aebb150ee3de7cf9a6945d092
   expo-dev-menu-interface: 600df12ea01efecdd822daaf13cc0ac091775533
   ExpoClipboard: 99109306a2d9ed2fbd16f6b856e6267b2afa8472
-  ExpoImage: 306dd755c842dba9f3ee654c51834a9cc657e6ca
+  ExpoImage: 0fc185a4a4e462fedfe877ae66204a7c541dfee0
   ExpoMediaLibrary: 648cee3f5dcba13410ec9cc8ac9a426e89a61a31
-  ExpoModulesCore: 40c0e84daa07c9a47ae9dfd8bed43aa72d6fadbe
+  ExpoModulesCore: ce55349fc14e3a993eeea921f6b56ee5581d6686
   ExpoModulesTestCore: e65555b75a4ed7dd3bcf421ad01d7748bd372c88
   EXStructuredHeaders: c951e77f2d936f88637421e9588c976da5827368
   EXUpdates: b96ad490c9456eebc38f949f3c30ce6258845773

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [Android] Upgrades Glide to `5.0.5`. ([#39713](https://github.com/expo/expo/pull/39713) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Added support for HDR images ([#40242](https://github.com/expo/expo/pull/40242) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Adopted Swift 6 ([#40369](https://github.com/expo/expo/pull/40369) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-image/ios/ExpoImage.podspec
+++ b/packages/expo-image/ios/ExpoImage.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     :ios => '15.1',
     :tvos => '15.1'
   }
-  s.swift_version  = '5.9'
+  s.swift_version  = '6.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-image/ios/ImageLoadTask.swift
+++ b/packages/expo-image/ios/ImageLoadTask.swift
@@ -14,7 +14,7 @@ internal final class ImageLoadTask: SharedObject {
   }
 
   func load() async throws -> UIImage {
-    let task = self.task ?? Task {
+    let task = self.task ?? Task { [source, maxSize] in
       return try await ImageLoader.shared.load(source, maxSize: maxSize)
     }
     self.task = task

--- a/packages/expo-image/ios/ImageLoader.swift
+++ b/packages/expo-image/ios/ImageLoader.swift
@@ -4,7 +4,7 @@ import SDWebImage
 import ExpoModulesCore
 
 internal final class ImageLoader {
-  static let shared = ImageLoader()
+  nonisolated(unsafe) static let shared = ImageLoader()
 
   lazy var imageManager = SDWebImageManager(
     cache: SDImageCache.shared,

--- a/packages/expo-image/ios/WebPCoder.swift
+++ b/packages/expo-image/ios/WebPCoder.swift
@@ -10,7 +10,7 @@ internal let imageCoderOptionUseAppleWebpCodec = SDImageCoderOption(rawValue: "u
  based on the passed `imageCoderOptionUseAppleWebpCodec` option.
  */
 internal final class WebPCoder: NSObject, SDAnimatedImageCoder {
-  static let shared = WebPCoder()
+  nonisolated(unsafe) static let shared = WebPCoder()
 
   private var useAppleWebpCodec: Bool = true
   private var instantiatedCoder: SDAnimatedImageCoder?

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [iOS] Add `AppContext` to views environment so it can be accessed if needed. ([#39207](https://github.com/expo/expo/pull/39207) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Add experimental formatters API. ([#38946](https://github.com/expo/expo/pull/38946) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Add `convertResult` to `Convertible`. ([#40302](https://github.com/expo/expo/pull/40302) by [@jakex7](https://github.com/jakex7))
+- [iOS] Adopted Swift 6 ([#40369](https://github.com/expo/expo/pull/40369) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ExpoModulesCore.podspec
@@ -55,7 +55,7 @@ Pod::Spec.new do |s|
     :osx => '11.0',
     :tvos => '15.1'
   }
-  s.swift_version  = '5.9'
+  s.swift_version  = '6.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
   s.header_dir     = 'ExpoModulesCore'

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriberManager.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriberManager.swift
@@ -1,6 +1,7 @@
 import Dispatch
 import Foundation
 
+@MainActor
 public class ExpoAppDelegateSubscriberManager: NSObject {
 #if os(iOS) || os(tvOS)
 

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriberManager.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriberManager.swift
@@ -2,6 +2,7 @@ import Dispatch
 import Foundation
 
 @MainActor
+@preconcurrency
 public class ExpoAppDelegateSubscriberManager: NSObject {
 #if os(iOS) || os(tvOS)
 

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriberRepository.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriberRepository.swift
@@ -1,12 +1,14 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-private var _subscribers = [ExpoAppDelegateSubscriberProtocol]()
-private var _reactDelegateHandlers = [ExpoReactDelegateHandler]()
+@MainActor private var _subscribers = [ExpoAppDelegateSubscriberProtocol]()
+@MainActor private var _reactDelegateHandlers = [ExpoReactDelegateHandler]()
 
 /**
  Class responsible for managing access to app delegate subscribers and react delegates.
  It should be used to access subscribers without depending on the `Expo` package where they are registered.
  */
+@MainActor
+@preconcurrency
 @objc(EXExpoAppDelegateSubscriberRepository)
 public class ExpoAppDelegateSubscriberRepository: NSObject {
   @objc

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -1,10 +1,10 @@
-import React
+@preconcurrency import React
 
 /**
  The app context is an interface to a single Expo app.
  */
 @objc(EXAppContext)
-public final class AppContext: NSObject {
+public final class AppContext: NSObject, @unchecked Sendable {
   internal static func create() -> AppContext {
     let appContext = AppContext()
 

--- a/packages/expo-modules-core/ios/Core/Arguments/AnyArgument.swift
+++ b/packages/expo-modules-core/ios/Core/Arguments/AnyArgument.swift
@@ -4,7 +4,7 @@
  A protocol for classes/structs accepted as an argument of functions.
  */
 public protocol AnyArgument {
-  static func getDynamicType() -> AnyDynamicType
+  nonisolated static func getDynamicType() -> AnyDynamicType
 }
 
 extension AnyArgument {

--- a/packages/expo-modules-core/ios/Core/Arguments/Either.swift
+++ b/packages/expo-modules-core/ios/Core/Arguments/Either.swift
@@ -136,7 +136,7 @@ open class EitherOfFour<FirstType, SecondType, ThirdType, FourthType>: EitherOfT
 /**
  An exception thrown when the value is of neither type.
  */
-internal class NeitherTypeException: GenericException<[AnyDynamicType]> {
+internal final class NeitherTypeException: GenericException<[AnyDynamicType]>, @unchecked Sendable {
   override var reason: String {
     var typeDescriptions = param.map({ $0.description })
     let lastTypeDescription = typeDescriptions.removeLast()

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/AnyDynamicType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/AnyDynamicType.swift
@@ -4,7 +4,7 @@
  A protocol whose intention is to wrap any type
  to keep its real signature and not type-erase it by the compiler.
  */
-public protocol AnyDynamicType: CustomStringConvertible {
+public protocol AnyDynamicType: CustomStringConvertible, Sendable {
   /**
    Checks whether the inner type is the same as the given type.
    */

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicRawType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicRawType.swift
@@ -7,7 +7,7 @@
 internal struct DynamicRawType<InnerType>: AnyDynamicType {
   let innerType: InnerType.Type
 
-  func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
+  func wraps<AnyInnerType>(_ type: AnyInnerType.Type) -> Bool {
     return type == innerType
   }
 

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicValueOrUndefinedType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicValueOrUndefinedType.swift
@@ -4,7 +4,7 @@ internal struct DynamicValueOrUndefinedType<InnerType: AnyArgument>: AnyDynamicT
   let innerType: InnerType.Type = InnerType.self
   let dynamicInnerType: AnyDynamicType = InnerType.getDynamicType()
 
-  func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
+  func wraps<AnyInnerType>(_ type: AnyInnerType.Type) -> Bool {
     return innerType == type
   }
 

--- a/packages/expo-modules-core/ios/Core/EventListener.swift
+++ b/packages/expo-modules-core/ios/Core/EventListener.swift
@@ -40,13 +40,13 @@ internal struct EventListener: AnyDefinition {
   }
 }
 
-class InvalidSenderTypeException: GenericException<(eventName: EventName, senderType: Any.Type)> {
+final class InvalidSenderTypeException: GenericException<(eventName: EventName, senderType: Any.Type)>, @unchecked Sendable {
   override var reason: String {
     "Sender for event '\(param.eventName)' must be of type \(param.senderType)"
   }
 }
 
-public enum EventName: Equatable {
+public enum EventName: Equatable, Sendable {
   case custom(_ name: String)
 
   // MARK: Module lifecycle

--- a/packages/expo-modules-core/ios/Core/Events/EventObservingDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Events/EventObservingDefinition.swift
@@ -5,7 +5,7 @@ internal enum EventObservingType: String {
   case stopObserving
 }
 
-internal protocol AnyEventObservingDefinition: AnyDefinition {
+internal protocol AnyEventObservingDefinition: AnyDefinition, Sendable {
   var event: String? { get }
 
   var type: EventObservingType { get }
@@ -13,7 +13,7 @@ internal protocol AnyEventObservingDefinition: AnyDefinition {
   func call()
 }
 
-public final class EventObservingDefinition: AnyEventObservingDefinition {
+public final class EventObservingDefinition: AnyEventObservingDefinition, @unchecked Sendable {
   public typealias ClosureType = () -> Void
 
   let type: EventObservingType

--- a/packages/expo-modules-core/ios/Core/Exceptions/Exception.swift
+++ b/packages/expo-modules-core/ios/Core/Exceptions/Exception.swift
@@ -1,6 +1,6 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
-open class Exception: CodedError, ChainableException, CustomStringConvertible, CustomDebugStringConvertible {
+open class Exception: CodedError, ChainableException, CustomStringConvertible, CustomDebugStringConvertible, @unchecked Sendable {
   open lazy var name: String = String(describing: Self.self)
 
   /**
@@ -75,3 +75,4 @@ private func concatDescription(_ description: String, withCause cause: Error?, d
     return description
   }
 }
+

--- a/packages/expo-modules-core/ios/Core/Exceptions/ExceptionOrigin.swift
+++ b/packages/expo-modules-core/ios/Core/Exceptions/ExceptionOrigin.swift
@@ -3,7 +3,7 @@
 /**
  Represents the place in code where the exception was created.
  */
-public struct ExceptionOrigin: CustomStringConvertible {
+public struct ExceptionOrigin: CustomStringConvertible, Sendable {
   /**
    The path to the file in which the exception was created.
    */

--- a/packages/expo-modules-core/ios/Core/Exceptions/GenericException.swift
+++ b/packages/expo-modules-core/ios/Core/Exceptions/GenericException.swift
@@ -3,7 +3,7 @@
 /**
  The exception that needs some additional parameters to be best described.
  */
-open class GenericException<ParamType>: Exception {
+open class GenericException<ParamType>: Exception, @unchecked Sendable {
   /**
    The additional parameter passed to the initializer.
    */

--- a/packages/expo-modules-core/ios/Core/Functions/AnyFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/AnyFunctionDefinition.swift
@@ -44,7 +44,12 @@ internal protocol AnyFunctionDefinition: AnyDefinition, JavaScriptObjectBuilder 
       - appContext: An app context where the function is being executed.
       - callback: A callback that receives a result of the function execution.
    */
-  func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext, callback: @escaping (FunctionCallResult) -> ())
+  func call(
+    by owner: AnyObject?,
+    withArguments args: [Any],
+    appContext: AppContext,
+    callback: @Sendable @escaping (FunctionCallResult) -> ()
+  )
 }
 
 extension AnyFunctionDefinition {
@@ -75,7 +80,7 @@ extension AnyFunctionDefinition {
   }
 }
 
-internal class FunctionCallException: GenericException<String> {
+internal final class FunctionCallException: GenericException<String>, @unchecked Sendable {
   override var reason: String {
     "Calling the '\(param)' function has failed"
   }
@@ -88,7 +93,7 @@ internal class FunctionCallException: GenericException<String> {
   }
 }
 
-internal class ArgumentConversionException: Exception {
+internal final class ArgumentConversionException: Exception, @unchecked Sendable {
   override var reason: String {
     "Failed to downcast arguments"
   }

--- a/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
@@ -21,7 +21,7 @@ private let defaultQueue = DispatchQueue(label: "expo.modules.AsyncFunctionQueue
 /**
  Represents a function that can only be called asynchronously, thus its JavaScript equivalent returns a Promise.
  */
-public final class AsyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnyAsyncFunctionDefinition {
+public final class AsyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnyAsyncFunctionDefinition, @unchecked Sendable {
   typealias ClosureType = (Args) throws -> ReturnType
 
   /**
@@ -63,7 +63,12 @@ public final class AsyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnyA
 
   var takesOwner: Bool = false
 
-  func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext, callback: @escaping (FunctionCallResult) -> ()) {
+  func call(
+    by owner: AnyObject?,
+    withArguments args: [Any],
+    appContext: AppContext,
+    callback: @Sendable @escaping (FunctionCallResult) -> ()
+  ) {
     let promise = Promise(appContext: appContext) { value in
       callback(.success(Conversions.convertFunctionResult(value, appContext: appContext, dynamicType: ~ReturnType.self)))
     } rejecter: { exception in
@@ -174,13 +179,5 @@ public final class AsyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnyA
   public func runOnQueue(_ queue: DispatchQueue?) -> Self {
     self.queue = queue
     return self
-  }
-}
-
-// MARK: - Exceptions
-
-internal final class NativeFunctionUnavailableException: GenericException<String> {
-  override var reason: String {
-    return "Native function '\(param)' is no longer available in memory"
   }
 }

--- a/packages/expo-modules-core/ios/Core/Functions/SyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/SyncFunctionDefinition.swift
@@ -26,7 +26,7 @@ internal protocol AnySyncFunctionDefinition: AnyFunctionDefinition {
 /**
  Represents a function that can only be called synchronously.
  */
-public final class SyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnySyncFunctionDefinition {
+public final class SyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnySyncFunctionDefinition, @unchecked Sendable {
   typealias ClosureType = (Args) throws -> ReturnType
 
   /**

--- a/packages/expo-modules-core/ios/Core/JavaScriptFunction.swift
+++ b/packages/expo-modules-core/ios/Core/JavaScriptFunction.swift
@@ -3,7 +3,7 @@
 /**
  Represents a JavaScript function that can be called by the native code and that must return the given generic `ReturnType`.
  */
-public final class JavaScriptFunction<ReturnType>: AnyArgument, AnyJavaScriptValue {
+public final class JavaScriptFunction<ReturnType>: AnyArgument, AnyJavaScriptValue, @unchecked Sendable {
   /**
    Raw representation of the JavaScript function that doesn't impose any restrictions on the returned type.
    */

--- a/packages/expo-modules-core/ios/Core/JavaScriptUtils.swift
+++ b/packages/expo-modules-core/ios/Core/JavaScriptUtils.swift
@@ -109,7 +109,7 @@ internal func concat(
 
 // MARK: - Exceptions
 
-internal class InvalidArgsNumberException: GenericException<(received: Int, expected: Int, required: Int)> {
+internal final class InvalidArgsNumberException: GenericException<(received: Int, expected: Int, required: Int)>, @unchecked Sendable {
   override var reason: String {
     if param.required < param.expected {
       return "Received \(param.received) arguments, but \(param.expected) was expected and at least \(param.required) is required"
@@ -119,7 +119,7 @@ internal class InvalidArgsNumberException: GenericException<(received: Int, expe
   }
 }
 
-internal class ArgumentCastException: GenericException<(index: Int, type: AnyDynamicType)> {
+internal final class ArgumentCastException: GenericException<(index: Int, type: AnyDynamicType)>, @unchecked Sendable {
   override var reason: String {
     "The \(formatOrdinalNumber(param.index + 1)) argument cannot be cast to type \(param.type.description)"
   }
@@ -132,7 +132,7 @@ internal class ArgumentCastException: GenericException<(index: Int, type: AnyDyn
   }
 }
 
-private class ModuleUnavailableException: GenericException<String> {
+private final class ModuleUnavailableException: GenericException<String>, @unchecked Sendable {
   override var reason: String {
     "Module '\(param)' is no longer available"
   }

--- a/packages/expo-modules-core/ios/Core/Logging/Logger.swift
+++ b/packages/expo-modules-core/ios/Core/Logging/Logger.swift
@@ -10,7 +10,7 @@ public typealias LoggerTimerFormatterBlock = (_ duration: Double) -> String
  Native iOS logging class for Expo, with options to direct logs
  to different destinations.
  */
-public class Logger {
+public class Logger: @unchecked Sendable {
   public static let EXPO_MODULES_LOG_SUBSYSTEM = "dev.expo.modules"
   public static let EXPO_LOG_CATEGORY = "expo"
 

--- a/packages/expo-modules-core/ios/Core/Logging/PersistentFileLog.swift
+++ b/packages/expo-modules-core/ios/Core/Logging/PersistentFileLog.swift
@@ -25,6 +25,7 @@ public typealias PersistentFileLogCompletionHandler = (Error?) -> Void
  * - Clear the file (remove all entries)
  *
  */
+@preconcurrency
 public class PersistentFileLog {
   private static let EXPO_MODULES_CORE_LOG_QUEUE_LABEL = "dev.expo.modules.core.logging"
   private static let serialQueue = DispatchQueue(label: EXPO_MODULES_CORE_LOG_QUEUE_LABEL)

--- a/packages/expo-modules-core/ios/Core/ModuleHolder.swift
+++ b/packages/expo-modules-core/ios/Core/ModuleHolder.swift
@@ -54,6 +54,7 @@ public final class ModuleHolder {
 
   // MARK: Calling functions
 
+  @preconcurrency
   func call(function functionName: String, args: [Any], _ callback: @Sendable @escaping (FunctionCallResult) -> () = { _ in }) {
     guard let appContext else {
       callback(.failure(Exceptions.AppContextLost()))

--- a/packages/expo-modules-core/ios/Core/ModuleHolder.swift
+++ b/packages/expo-modules-core/ios/Core/ModuleHolder.swift
@@ -54,7 +54,7 @@ public final class ModuleHolder {
 
   // MARK: Calling functions
 
-  func call(function functionName: String, args: [Any], _ callback: @escaping (FunctionCallResult) -> () = { _ in }) {
+  func call(function functionName: String, args: [Any], _ callback: @Sendable @escaping (FunctionCallResult) -> () = { _ in }) {
     guard let appContext else {
       callback(.failure(Exceptions.AppContextLost()))
       return

--- a/packages/expo-modules-core/ios/Core/Modules/Module.swift
+++ b/packages/expo-modules-core/ios/Core/Modules/Module.swift
@@ -5,7 +5,7 @@
  but doesn't implement that protocol explicitly, though — it would have to provide a definition which would require
  other modules to use `override` keyword in the function returning the definition.
  */
-open class BaseModule: @unchecked Sendable {
+open class BaseModule {
   public private(set) weak var appContext: AppContext?
 
   @available(*, unavailable, message: "Module's initializer cannot be overriden, use \"onCreate\" definition component instead.")

--- a/packages/expo-modules-core/ios/Core/Modules/Module.swift
+++ b/packages/expo-modules-core/ios/Core/Modules/Module.swift
@@ -5,7 +5,7 @@
  but doesn't implement that protocol explicitly, though — it would have to provide a definition which would require
  other modules to use `override` keyword in the function returning the definition.
  */
-open class BaseModule {
+open class BaseModule: @unchecked Sendable {
   public private(set) weak var appContext: AppContext?
 
   @available(*, unavailable, message: "Module's initializer cannot be overriden, use \"onCreate\" definition component instead.")

--- a/packages/expo-modules-core/ios/Core/Modules/ModuleDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Modules/ModuleDefinition.swift
@@ -5,7 +5,7 @@ let DEFAULT_MODULE_VIEW = "DEFAULT_MODULE_VIEW"
  of the module and what it exports to the JavaScript world.
  See `ModuleDefinitionBuilder` for more details on how to create it.
  */
-public final class ModuleDefinition: ObjectDefinition {
+public final class ModuleDefinition: ObjectDefinition, @unchecked Sendable {
   /**
    The module's type associated with the definition. It's used to create the module instance.
    */

--- a/packages/expo-modules-core/ios/Core/Modules/ModuleDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Modules/ModuleDefinition.swift
@@ -5,7 +5,7 @@ let DEFAULT_MODULE_VIEW = "DEFAULT_MODULE_VIEW"
  of the module and what it exports to the JavaScript world.
  See `ModuleDefinitionBuilder` for more details on how to create it.
  */
-public final class ModuleDefinition: ObjectDefinition, @unchecked Sendable {
+public final class ModuleDefinition: ObjectDefinition {
   /**
    The module's type associated with the definition. It's used to create the module instance.
    */

--- a/packages/expo-modules-core/ios/Core/Objects/ConstantDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Objects/ConstantDefinition.swift
@@ -101,13 +101,13 @@ public final class ConstantDefinition<ReturnType>: AnyDefinition, AnyConstantDef
 
 // MARK: - Exceptions
 
-internal final class NativeConstantUnavailableException: GenericException<String> {
+internal final class NativeConstantUnavailableException: GenericException<String>, @unchecked Sendable {
   override var reason: String {
     return "Native constant '\(param)' is no longer available in memory"
   }
 }
 
-internal final class NativeConstantWithoutGetterException: GenericException<String> {
+internal final class NativeConstantWithoutGetterException: GenericException<String>, @unchecked Sendable {
   override var reason: String {
     return "Native constant '\(param)' doesn't have a getter"
   }

--- a/packages/expo-modules-core/ios/Core/Objects/ObjectDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Objects/ObjectDefinition.swift
@@ -3,7 +3,7 @@
 /**
  Base class for other definitions representing an object, such as `ModuleDefinition`.
  */
-public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder, @unchecked Sendable {
+public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
   /**
    A dictionary of functions defined by the object.
    */

--- a/packages/expo-modules-core/ios/Core/Objects/ObjectDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Objects/ObjectDefinition.swift
@@ -3,7 +3,7 @@
 /**
  Base class for other definitions representing an object, such as `ModuleDefinition`.
  */
-public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
+public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder, @unchecked Sendable {
   /**
    A dictionary of functions defined by the object.
    */

--- a/packages/expo-modules-core/ios/Core/Objects/PropertyDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Objects/PropertyDefinition.swift
@@ -1,6 +1,6 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
-protocol AnyPropertyDefinition: Sendable {
+protocol AnyPropertyDefinition {
   /**
    Name of the property.
    */

--- a/packages/expo-modules-core/ios/Core/Objects/PropertyDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Objects/PropertyDefinition.swift
@@ -1,6 +1,6 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
-protocol AnyPropertyDefinition {
+protocol AnyPropertyDefinition: Sendable {
   /**
    Name of the property.
    */
@@ -12,7 +12,7 @@ protocol AnyPropertyDefinition {
   func buildDescriptor(appContext: AppContext) throws -> JavaScriptObject
 }
 
-public final class PropertyDefinition<OwnerType>: AnyDefinition, AnyPropertyDefinition {
+public final class PropertyDefinition<OwnerType>: AnyDefinition, AnyPropertyDefinition, @unchecked Sendable {
   /**
    Name of the property.
    */
@@ -190,7 +190,7 @@ public final class PropertyDefinition<OwnerType>: AnyDefinition, AnyPropertyDefi
 
 // MARK: - Exceptions
 
-internal final class NativePropertyUnavailableException: GenericException<String> {
+internal final class NativePropertyUnavailableException: GenericException<String>, @unchecked Sendable {
   override var reason: String {
     return "Native property '\(param)' is no longer available in memory"
   }

--- a/packages/expo-modules-core/ios/Core/Promise.swift
+++ b/packages/expo-modules-core/ios/Core/Promise.swift
@@ -1,8 +1,8 @@
 // Copyright 2021-present 650 Industries. All rights reserved.
 
-public struct Promise: AnyArgument {
-  public typealias ResolveClosure = (Any?) -> Void
-  public typealias RejectClosure = (Exception) -> Void
+public struct Promise: AnyArgument, Sendable {
+  public typealias ResolveClosure = @Sendable (Any?) -> Void
+  public typealias RejectClosure = @Sendable (Exception) -> Void
 
   internal weak var appContext: AppContext?
   public var resolver: ResolveClosure

--- a/packages/expo-modules-core/ios/Core/Protocols/AnyViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Protocols/AnyViewDefinition.swift
@@ -1,7 +1,7 @@
 /**
  A protocol for any type-erased view definition.
  */
-public protocol AnyViewDefinition {
+public protocol AnyViewDefinition: Sendable {
   /**
    An array of view props supported by the view.
    */

--- a/packages/expo-modules-core/ios/Core/Records/Field.swift
+++ b/packages/expo-modules-core/ios/Core/Records/Field.swift
@@ -3,7 +3,7 @@
  For supported field types, see https://docs.expo.dev/modules/module-api/#argument-types
  */
 @propertyWrapper
-public final class Field<Type: AnyArgument>: AnyFieldInternal {
+public final class Field<Type: AnyArgument>: AnyFieldInternal, @unchecked Sendable {
   /**
    The wrapped value.
    */
@@ -89,13 +89,13 @@ public final class Field<Type: AnyArgument>: AnyFieldInternal {
   }
 }
 
-internal class FieldRequiredException: GenericException<String> {
+internal final class FieldRequiredException: GenericException<String>, @unchecked Sendable {
   override var reason: String {
     "Value for field '\(param)' is required, got nil"
   }
 }
 
-internal class FieldInvalidTypeException: GenericException<(fieldKey: String, value: Any?, desiredType: Any.Type)> {
+internal final class FieldInvalidTypeException: GenericException<(fieldKey: String, value: Any?, desiredType: Any.Type)>, @unchecked Sendable {
   override var reason: String {
     let value = String(describing: param.value ?? "null")
     let desiredType = String(describing: param.desiredType)

--- a/packages/expo-modules-core/ios/Core/Records/FieldOption.swift
+++ b/packages/expo-modules-core/ios/Core/Records/FieldOption.swift
@@ -2,12 +2,13 @@
  Enum-like struct representing field options that for example can specify if the field
  is required and so it must be provided by the dictionary from which the field is created.
  */
-public struct FieldOption: Equatable, Hashable, ExpressibleByIntegerLiteral, ExpressibleByStringLiteral {
+public struct FieldOption: Equatable, Hashable, ExpressibleByIntegerLiteral, ExpressibleByStringLiteral, Sendable {
   public let rawValue: Int
-  public var key: String?
+  public let key: String?
 
-  public init(_ rawValue: Int) {
+  public init(_ rawValue: Int, key: String? = nil) {
     self.rawValue = rawValue
+    self.key = key
   }
 
   // MARK: `Equatable`
@@ -34,7 +35,7 @@ public struct FieldOption: Equatable, Hashable, ExpressibleByIntegerLiteral, Exp
    Initializer that allows to create an instance from int literal.
    */
   public init(integerLiteral value: Int) {
-    self.rawValue = value
+    self.init(value)
   }
 
   // MARK: `ExpressibleByStringLiteral`
@@ -43,8 +44,7 @@ public struct FieldOption: Equatable, Hashable, ExpressibleByIntegerLiteral, Exp
    Initializer that allows to create an instance from string literal.
    */
   public init(stringLiteral value: String) {
-    self.rawValue = 0
-    self.key = value
+    self.init(0, key: value)
   }
 }
 

--- a/packages/expo-modules-core/ios/Core/Records/Record.swift
+++ b/packages/expo-modules-core/ios/Core/Records/Record.swift
@@ -11,7 +11,7 @@ public protocol Record: Convertible {
   /**
    The default initializer. It enforces the structs not to have any uninitialized properties.
    */
-  init()
+  nonisolated init()
 
   /**
    Initializes a record from given dictionary. Only members wrapped by `@Field` will be set in the object.

--- a/packages/expo-modules-core/ios/Core/TypedArrays/GenericTypedArray.swift
+++ b/packages/expo-modules-core/ios/Core/TypedArrays/GenericTypedArray.swift
@@ -3,7 +3,7 @@
 /**
  Generic TypedArray with an associated numeric ContentType (e.g. UInt8, Int16, Double).
  */
-public class GenericTypedArray<ContentType: Numeric>: TypedArray {
+public class GenericTypedArray<ContentType: Numeric>: TypedArray, @unchecked Sendable {
   /**
    The unsafe mutable typed buffer that shares the same memory as the underlying JavaScript `ArrayBuffer`.
    */

--- a/packages/expo-modules-core/ios/Core/TypedArrays/GenericTypedArray.swift
+++ b/packages/expo-modules-core/ios/Core/TypedArrays/GenericTypedArray.swift
@@ -3,7 +3,7 @@
 /**
  Generic TypedArray with an associated numeric ContentType (e.g. UInt8, Int16, Double).
  */
-public class GenericTypedArray<ContentType: Numeric>: TypedArray, @unchecked Sendable {
+public class GenericTypedArray<ContentType: Numeric>: TypedArray {
   /**
    The unsafe mutable typed buffer that shares the same memory as the underlying JavaScript `ArrayBuffer`.
    */

--- a/packages/expo-modules-core/ios/Core/TypedArrays/TypedArray.swift
+++ b/packages/expo-modules-core/ios/Core/TypedArrays/TypedArray.swift
@@ -3,7 +3,7 @@
 /**
  The base class for any type of the typed array.
  */
-public class TypedArray: AnyTypedArray {
+public class TypedArray: AnyTypedArray, @unchecked Sendable {
   /**
    Creates a concrete TypedArray from the given JavaScriptTypedArray
    */

--- a/packages/expo-modules-core/ios/Core/TypedArrays/TypedArray.swift
+++ b/packages/expo-modules-core/ios/Core/TypedArrays/TypedArray.swift
@@ -3,7 +3,7 @@
 /**
  The base class for any type of the typed array.
  */
-public class TypedArray: AnyTypedArray, @unchecked Sendable {
+public class TypedArray: AnyTypedArray {
   /**
    Creates a concrete TypedArray from the given JavaScriptTypedArray
    */

--- a/packages/expo-modules-core/ios/Core/Views/AppleView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/AppleView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 /**
  An abstract view supports both UIKit and SwiftUI.
  */
-public enum AppleView {
+public enum AppleView: Sendable {
   case uikit(UIView)
   case swiftui(any ExpoSwiftUI.View)
 

--- a/packages/expo-modules-core/ios/Core/Views/ConcreteViewProp.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ConcreteViewProp.swift
@@ -3,7 +3,7 @@
 /**
  Specialized class for the view prop. Specifies the prop name and its setter.
  */
-public final class ConcreteViewProp<ViewType: UIView, PropType: AnyArgument>: AnyViewProp {
+public final class ConcreteViewProp<ViewType: UIView, PropType: AnyArgument>: AnyViewProp, @unchecked Sendable {
   public typealias SetterType = (ViewType, PropType) -> Void
 
   /**

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/AutoSizingStack.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/AutoSizingStack.swift
@@ -3,7 +3,7 @@
 import SwiftUI
 
 extension ExpoSwiftUI {
-  public struct AxisSet: OptionSet {
+  public struct AxisSet: OptionSet, Sendable {
     public init(rawValue: Int) {
       self.rawValue = rawValue
     }

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
@@ -42,7 +42,7 @@ extension ExpoSwiftUI {
   /**
    A hosting view that renders a SwiftUI view inside the UIKit view hierarchy.
    */
-  public final class HostingView<Props: ViewProps, ContentView: View<Props>>: ExpoView, AnyExpoSwiftUIHostingView {
+  public final class HostingView<Props: ViewProps, ContentView: View<Props>>: ExpoView, @MainActor AnyExpoSwiftUIHostingView {
     /**
      Props object that stores all the props for this particular view.
      It's an environment object that is observed by the content view.

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIShadowNodeProxy.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIShadowNodeProxy.swift
@@ -1,6 +1,7 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
+
 extension ExpoSwiftUI {
-  open class ShadowNodeProxy: ObservableObject, Record {
+  open class ShadowNodeProxy: ObservableObject, Record, @unchecked Sendable {
     public required init() {}
 
     // We use Double.nan to mark a dimension as unset. This value is passed to https://github.com/facebook/yoga/blob/49ee855f99fb67079c24d507a4ea1b6d80fa2ebf/yoga/style/StyleLength.h#L33

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
@@ -2,7 +2,6 @@
 
 import SwiftUI
 import Combine
-@preconcurrency import UIKit
 
 /**
  A protocol for SwiftUI views that need to access props.

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
@@ -90,6 +90,9 @@ extension ExpoSwiftUI {
     }
 
     public override func createView(appContext: AppContext) -> AppleView? {
+      // It's assumed that this function is called only from the main thread.
+      // In the ideal scenario it would be marked as `@MainActor`, but then `ViewModuleWrapper`
+      // would be incompatible with `RCTViewManager` as it doesn't specify the actor.
       return MainActor.assumeIsolated {
 #if RCT_NEW_ARCH_ENABLED
         let props = Props()

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewFrameObserver.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewFrameObserver.swift
@@ -4,6 +4,7 @@ extension ExpoSwiftUI {
   /**
    Observes for view frame changes, usually applied by React Native.
    */
+  @MainActor
   internal class UIViewFrameObserver {
     private let view: UIView
     private var observer: NSKeyValueObservation?
@@ -12,7 +13,7 @@ extension ExpoSwiftUI {
       self.view = view
     }
 
-    func observe(_ callback: @escaping (CGRect) -> Void) {
+    func observe(_ callback: @Sendable @escaping (CGRect) -> Void) {
       // When React Native lays out views, it sets `center` and `bounds` properties to control the `frame`.
       // You can find this implementation in `updateLayoutMetrics:oldLayoutMetrics:` in `UIView+ComponentViewProtocol.mm`.
       // We observe changes on `bounds` because:
@@ -30,3 +31,4 @@ extension ExpoSwiftUI {
     }
   }
 }
+

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualView.swift
@@ -7,7 +7,7 @@ extension ExpoSwiftUI {
    An NSObject acting as a fake UIView for RCTMountingManager to represent a SwiftUI view.
    This class is the Swift component of SwiftUIVirtualView, as referenced in ExpoFabricView.swift.
    */
-  final class SwiftUIVirtualView<Props: ViewProps, ContentView: View<Props>>: SwiftUIVirtualViewObjC, @preconcurrency ExpoSwiftUIView {
+  final class SwiftUIVirtualView<Props: ViewProps, ContentView: View<Props>>: SwiftUIVirtualViewObjC, ExpoSwiftUIView {
     /**
      A weak reference to the app context associated with this view.
      The app context is injected into the class after the context is initialized.
@@ -92,16 +92,16 @@ extension ExpoSwiftUI {
     /**
      Calls lifecycle methods registered by `OnViewDidUpdateProps` definition component.
      */
+    @MainActor
+    @preconcurrency
     override func viewDidUpdateProps() {
-      MainActor.assumeIsolated {
-        guard let viewDefinition else {
-          return
-        }
-        guard let view = AppleView.from(self) else {
-          return
-        }
-        viewDefinition.callLifecycleMethods(withType: .didUpdateProps, forView: view)
+      guard let viewDefinition else {
+        return
       }
+      guard let view = AppleView.from(self) else {
+        return
+      }
+      viewDefinition.callLifecycleMethods(withType: .didUpdateProps, forView: view)
     }
 
     /**

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualView.swift
@@ -2,12 +2,12 @@
 
 import SwiftUI
 
-/**
- An NSObject acting as a fake UIView for RCTMountingManager to represent a SwiftUI view.
- This class is the Swift component of SwiftUIVirtualView, as referenced in ExpoFabricView.swift.
- */
 extension ExpoSwiftUI {
-  final class SwiftUIVirtualView<Props: ViewProps, ContentView: View<Props>>: SwiftUIVirtualViewObjC, ExpoSwiftUIView {
+  /**
+   An NSObject acting as a fake UIView for RCTMountingManager to represent a SwiftUI view.
+   This class is the Swift component of SwiftUIVirtualView, as referenced in ExpoFabricView.swift.
+   */
+  final class SwiftUIVirtualView<Props: ViewProps, ContentView: View<Props>>: SwiftUIVirtualViewObjC, @preconcurrency ExpoSwiftUIView {
     /**
      A weak reference to the app context associated with this view.
      The app context is injected into the class after the context is initialized.
@@ -93,13 +93,15 @@ extension ExpoSwiftUI {
      Calls lifecycle methods registered by `OnViewDidUpdateProps` definition component.
      */
     override func viewDidUpdateProps() {
-      guard let viewDefinition else {
-        return
+      MainActor.assumeIsolated {
+        guard let viewDefinition else {
+          return
+        }
+        guard let view = AppleView.from(self) else {
+          return
+        }
+        viewDefinition.callLifecycleMethods(withType: .didUpdateProps, forView: view)
       }
-      guard let view = AppleView.from(self) else {
-        return
-      }
-      viewDefinition.callLifecycleMethods(withType: .didUpdateProps, forView: view)
     }
 
     /**

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualViewObjC.h
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualViewObjC.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)updateProps:(nonnull NSDictionary<NSString *, id> *)props;
 
-- (void)viewDidUpdateProps;
+- (void)viewDidUpdateProps NS_SWIFT_UI_ACTOR;
 
 - (void)setShadowNodeSize:(float) width height:(float) height;
 

--- a/packages/expo-modules-core/ios/Core/Views/ViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ViewDefinition.swift
@@ -51,6 +51,9 @@ public class ViewDefinition<ViewType>: ObjectDefinition, AnyViewDefinition, @unc
   // MARK: - AnyViewDefinition
 
   public func createView(appContext: AppContext) -> AppleView? {
+    // It's assumed that this function is called only from the main thread.
+    // In the ideal scenario it would be marked as `@MainActor`, but then `ViewModuleWrapper`
+    // would be incompatible with `RCTViewManager` as it doesn't specify the actor.
     return MainActor.assumeIsolated {
       if let expoViewType = ViewType.self as? AnyExpoView.Type {
 #if RCT_NEW_ARCH_ENABLED

--- a/packages/expo-modules-core/ios/Core/Views/ViewLifecycleMethod.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ViewLifecycleMethod.swift
@@ -3,7 +3,7 @@
 /**
  An enum that identifies lifecycle method types.
  */
-public enum ViewLifecycleMethodType {
+public enum ViewLifecycleMethodType: Sendable {
   case didUpdateProps
 }
 

--- a/packages/expo-modules-core/ios/Core/Views/ViewModuleWrapper.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ViewModuleWrapper.swift
@@ -90,7 +90,7 @@ public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtoc
    */
   @objc
   public func viewName() -> String {
-    guard let moduleHolder, let viewDefinition else {
+    guard let viewDefinition else {
       fatalError("Failed to create ModuleHolder or a viewDefinition")
     }
     return self.isDefaultModuleView ? DEFAULT_MODULE_VIEW : viewDefinition.name
@@ -160,4 +160,4 @@ public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtoc
 }
 
 // The direct event implementation can be cached and lazy-loaded (global and static variables are lazy by default in Swift).
-let directEventBlockImplementation = imp_implementationWithBlock({ ["RCTDirectEventBlock"] } as @convention(block) () -> [String])
+nonisolated(unsafe) let directEventBlockImplementation = imp_implementationWithBlock({ ["RCTDirectEventBlock"] } as @convention(block) () -> [String])

--- a/packages/expo-modules-core/ios/DevTools/CdpNetworkTypes.swift
+++ b/packages/expo-modules-core/ios/DevTools/CdpNetworkTypes.swift
@@ -79,7 +79,7 @@ struct CdpNetwork {
 
   // MARK: Events
 
-  struct RequestWillBeSentParams: EventParms {
+  struct RequestWillBeSentParams: EventParams {
     let requestId: RequestId
     var loaderId = ""
     var documentURL = "mobile"
@@ -108,7 +108,7 @@ struct CdpNetwork {
     }
   }
 
-  struct RequestWillBeSentExtraInfoParams: EventParms {
+  struct RequestWillBeSentExtraInfoParams: EventParams {
     let requestId: RequestId
     var associatedCookies = [String: String]()
     let headers: Headers
@@ -121,7 +121,7 @@ struct CdpNetwork {
     }
   }
 
-  struct ResponseReceivedParams: EventParms {
+  struct ResponseReceivedParams: EventParams {
     let requestId: RequestId
     var loaderId = ""
     let timestamp: MonotonicTime
@@ -137,7 +137,7 @@ struct CdpNetwork {
     }
   }
 
-  struct LoadingFinishedParams: EventParms {
+  struct LoadingFinishedParams: EventParams {
     let requestId: RequestId
     let timestamp: MonotonicTime
     let encodedDataLength: Int64
@@ -149,7 +149,7 @@ struct CdpNetwork {
     }
   }
 
-  struct ExpoReceivedResponseBodyParams: EventParms {
+  struct ExpoReceivedResponseBodyParams: EventParams {
     let requestId: RequestId
     let body: String
     let base64Encoded: Bool
@@ -167,9 +167,9 @@ struct CdpNetwork {
     }
   }
 
-  typealias EventParms = Encodable
+  typealias EventParams = Encodable & Sendable
 
-  struct Event<T: EventParms>: Encodable {
+  struct Event<T: EventParams>: Encodable, Sendable {
     let method: String
     let params: T
   }

--- a/packages/expo-modules-core/ios/DevTools/ExpoRequestCdpInterceptor.swift
+++ b/packages/expo-modules-core/ios/DevTools/ExpoRequestCdpInterceptor.swift
@@ -7,7 +7,7 @@ import Foundation
  dispatch CDP (Chrome DevTools Protocol: https://chromedevtools.github.io/devtools-protocol/) events.
  */
 @objc(EXRequestCdpInterceptor)
-public final class ExpoRequestCdpInterceptor: NSObject, ExpoRequestInterceptorProtocolDelegate {
+public final class ExpoRequestCdpInterceptor: NSObject, ExpoRequestInterceptorProtocolDelegate, @unchecked Sendable {
   private weak var delegate: ExpoRequestCdpInterceptorDelegate?
   public var dispatchQueue = DispatchQueue(label: "expo.requestCdpInterceptor")
 
@@ -23,7 +23,7 @@ public final class ExpoRequestCdpInterceptor: NSObject, ExpoRequestInterceptorPr
     }
   }
 
-  private func dispatchEvent<T: CdpNetwork.EventParms>(_ event: CdpNetwork.Event<T>) {
+  private func dispatchEvent<T: CdpNetwork.EventParams>(_ event: CdpNetwork.Event<T>) {
     dispatchQueue.async {
       let encoder = JSONEncoder()
       if let jsonData = try? encoder.encode(event), let payload = String(data: jsonData, encoding: .utf8) {
@@ -77,7 +77,7 @@ public final class ExpoRequestCdpInterceptor: NSObject, ExpoRequestInterceptorPr
  The delegate to dispatch CDP events for ExpoRequestCdpInterceptor
  */
 @objc(EXRequestCdpInterceptorDelegate)
-public protocol ExpoRequestCdpInterceptorDelegate {
+public protocol ExpoRequestCdpInterceptorDelegate: Sendable {
   @objc
   func dispatch(_ event: String)
 }

--- a/packages/expo-modules-core/ios/DevTools/ExpoRequestInterceptorProtocol.swift
+++ b/packages/expo-modules-core/ios/DevTools/ExpoRequestInterceptorProtocol.swift
@@ -6,8 +6,8 @@ import Foundation
  A `URLSession` interceptor which passes network events to its delegate
  */
 @objc(EXRequestInterceptorProtocol)
-public final class ExpoRequestInterceptorProtocol: URLProtocol, URLSessionDataDelegate {
-  private static var requestIdProvider = RequestIdProvider()
+public final class ExpoRequestInterceptorProtocol: URLProtocol, URLSessionDataDelegate, @unchecked Sendable {
+  nonisolated(unsafe) private static var requestIdProvider = RequestIdProvider()
   private static let sessionDelegate
     = URLSessionSessionDelegateProxy(dispatchQueue: ExpoRequestCdpInterceptor.shared.dispatchQueue)
   private static let urlSession = URLSession(
@@ -218,7 +218,7 @@ public final class ExpoRequestInterceptorProtocol: URLProtocol, URLSessionDataDe
  The delegate to dispatch network request events
  */
 @objc(EXRequestInterceptorProtocolDelegate)
-protocol ExpoRequestInterceptorProtocolDelegate {
+protocol ExpoRequestInterceptorProtocolDelegate: Sendable {
   @objc
   func willSendRequest(requestId: String, task: URLSessionTask, request: URLRequest, redirectResponse: HTTPURLResponse?)
 

--- a/packages/expo-modules-core/ios/EXDefines.h
+++ b/packages/expo-modules-core/ios/EXDefines.h
@@ -91,8 +91,8 @@ typedef struct EXModuleInfo {
 } EXModuleInfo;
 
 typedef void (^EXDirectEventBlock)(NSDictionary *body);
-typedef void (^EXPromiseResolveBlock)(id result);
-typedef void (^EXPromiseRejectBlock)(NSString *code, NSString *message, NSError *error);
+typedef void (NS_SWIFT_SENDABLE ^EXPromiseResolveBlock)(id result);
+typedef void (NS_SWIFT_SENDABLE ^EXPromiseRejectBlock)(NSString *code, NSString *message, NSError *error);
 
 #pragma mark - Externs
 

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
@@ -21,8 +21,8 @@ typedef void (^JSRuntimeExecutionBlock)(void);
 
 typedef void (^JSAsyncFunctionBlock)(EXJavaScriptValue *_Nonnull thisValue,
                                      NSArray<EXJavaScriptValue *> *_Nonnull arguments,
-                                     RCTPromiseResolveBlock _Nonnull resolve,
-                                     RCTPromiseRejectBlock _Nonnull reject);
+                                     NS_SWIFT_SENDABLE RCTPromiseResolveBlock _Nonnull resolve,
+                                     NS_SWIFT_SENDABLE RCTPromiseRejectBlock _Nonnull reject);
 
 typedef EXJavaScriptValue *_Nullable (^JSSyncFunctionBlock)(EXJavaScriptValue *_Nonnull thisValue,
                                                             NSArray<EXJavaScriptValue *> *_Nonnull arguments,

--- a/packages/expo-modules-core/ios/JSI/EXRawJavaScriptFunction.h
+++ b/packages/expo-modules-core/ios/JSI/EXRawJavaScriptFunction.h
@@ -9,6 +9,7 @@
 namespace jsi = facebook::jsi;
 #endif // __cplusplus
 
+NS_SWIFT_SENDABLE
 NS_SWIFT_NAME(RawJavaScriptFunction)
 @interface EXRawJavaScriptFunction : NSObject
 

--- a/packages/expo-modules-core/ios/Tests/ExpoRequestCdpInterceptorSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ExpoRequestCdpInterceptorSpec.swift
@@ -5,7 +5,7 @@ import ExpoModulesTestCore
 @testable import ExpoModulesCore
 
 final class MockCdpInterceptorDelegate: ExpoRequestCdpInterceptorDelegate {
-  var events: [String] = []
+  nonisolated(unsafe) var events: [String] = []
 
   // ExpoRequestCdpInterceptorDelegate implementations
 
@@ -14,6 +14,7 @@ final class MockCdpInterceptorDelegate: ExpoRequestCdpInterceptorDelegate {
   }
 }
 
+@MainActor
 final class ExpoRequestCdpInterceptorSpec: ExpoSpec {
   private static let mockDelegate = MockCdpInterceptorDelegate()
   private static var session: URLSession = {

--- a/packages/expo-modules-core/ios/Utilities.swift
+++ b/packages/expo-modules-core/ios/Utilities.swift
@@ -84,6 +84,18 @@ internal func convertToUrl(string value: String) -> URL? {
 }
 
 /**
+ Helper class that lets us bypass the compiler's data-race protection checks by taking the value out of isolation.
+ - TODO: Remove it once the code is refactored to deal better with the concurrency model.
+ */
+internal class NonisolatedUnsafeVar<VarType>: @unchecked Sendable {
+  nonisolated(unsafe) var value: VarType
+
+  init(_ value: VarType) {
+    self.value = value
+  }
+}
+
+/**
  A collection of utility functions for various Expo Modules common tasks.
  */
 public struct Utilities {

--- a/packages/expo-modules-test-core/ios/ExpoSpec.swift
+++ b/packages/expo-modules-test-core/ios/ExpoSpec.swift
@@ -1,9 +1,11 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
 #if DEBUG
-@_exported import Quick
-@_exported import Nimble
-@_exported @testable import ExpoModulesCore
+@_exported @preconcurrency import Quick
+@_exported @preconcurrency import Nimble
+@_exported @testable @preconcurrency import ExpoModulesCore
 
+@MainActor
+@preconcurrency
 open class ExpoSpec: QuickSpec {}
 #endif

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Remove `ExpoAppDelegate` inheritance requirement in ExpoReactNativeFactory ([#39417](https://github.com/expo/expo/pull/39417) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Remove bindReactNativeFactory function ([#39418](https://github.com/expo/expo/pull/39418) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Adopted Swift 6 ([#40369](https://github.com/expo/expo/pull/40369) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/Expo.podspec
+++ b/packages/expo/Expo.podspec
@@ -40,6 +40,7 @@ Pod::Spec.new do |s|
     :osx => '11.0',
     :tvos => '15.1'
   }
+  s.swift_version  = '6.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
   s.header_dir     = 'Expo'

--- a/packages/expo/ios/AppDelegates/AppDelegatesLoaderDelegate.swift
+++ b/packages/expo/ios/AppDelegates/AppDelegatesLoaderDelegate.swift
@@ -2,6 +2,7 @@
 
 import ExpoModulesCore
 
+@MainActor
 @objc
 public class AppDelegatesLoaderDelegate: NSObject {
   /**

--- a/packages/expo/ios/AppDelegates/AppDelegatesLoaderDelegate.swift
+++ b/packages/expo/ios/AppDelegates/AppDelegatesLoaderDelegate.swift
@@ -3,6 +3,7 @@
 import ExpoModulesCore
 
 @MainActor
+@preconcurrency
 @objc
 public class AppDelegatesLoaderDelegate: NSObject {
   /**

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
@@ -4,6 +4,8 @@ import React
 
 public class ExpoReactNativeFactory: RCTReactNativeFactory, ExpoReactNativeFactoryProtocol {
   private let defaultModuleName = "main"
+
+  @MainActor
   private lazy var reactDelegate: ExpoReactDelegate = {
     ExpoReactDelegate(
       handlers: ExpoAppDelegateSubscriberRepository.reactDelegateHandlers,

--- a/packages/expo/ios/Fetch/ExpoFetchModule.swift
+++ b/packages/expo/ios/Fetch/ExpoFetchModule.swift
@@ -3,10 +3,10 @@
 @preconcurrency import ExpoModulesCore
 
 private let fetchRequestQueue = DispatchQueue(label: "expo.modules.fetch.RequestQueue")
-@MainActor internal var urlSessionConfigurationProvider: NSURLSessionConfigurationProvider?
+nonisolated(unsafe) internal var urlSessionConfigurationProvider: NSURLSessionConfigurationProvider?
 
 public final class ExpoFetchModule: Module {
-  @MainActor private lazy var urlSession = createURLSession()
+  private lazy var urlSession = createURLSession()
   private let urlSessionDelegate: URLSessionSessionDelegateProxy
 
   public required init(appContext: AppContext) {
@@ -18,11 +18,7 @@ public final class ExpoFetchModule: Module {
     Name("ExpoFetchModule")
 
     OnDestroy {
-      // Assume the lifecycle event is called from the main thread.
-      // Switching to the `MainActor` context with the `Task` would defer the execution which is not exactly what we want.
-      MainActor.assumeIsolated {
-        urlSession.invalidateAndCancel()
-      }
+      urlSession.invalidateAndCancel()
     }
 
     // swiftlint:disable:next closure_body_length

--- a/packages/expo/ios/Fetch/ExpoFetchModule.swift
+++ b/packages/expo/ios/Fetch/ExpoFetchModule.swift
@@ -1,11 +1,11 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-@preconcurrency import ExpoModulesCore
+import ExpoModulesCore
 
 private let fetchRequestQueue = DispatchQueue(label: "expo.modules.fetch.RequestQueue")
-@MainActor internal var urlSessionConfigurationProvider: NSURLSessionConfigurationProvider?
+nonisolated(unsafe) internal var urlSessionConfigurationProvider: NSURLSessionConfigurationProvider?
 
-@MainActor public final class ExpoFetchModule: @preconcurrency Module {
+public final class ExpoFetchModule: Module {
   private lazy var urlSession = createURLSession()
   private let urlSessionDelegate: URLSessionSessionDelegateProxy
 


### PR DESCRIPTION
# Why

Swift 6 introduced strict concurrency checks during compile time. So far our packages were set to use Swift 5 language mode, so these checks were turned off.

# How

Unfortunately, our code is not fully ready to adopt Swift 6 entirely and take advantage of its features. It means that we have to use some unsafe keywords and hacky ways to instruct the compiler and suppress some errors. I mostly mean `@unchecked Sendable` in protocol conformance and `nonisolated(unsafe)` keyword for global or static mutable variables. Ideally if we can remove those in the future.

We should rethink and refactor some places where we're using other mechanisms that ensure thread safety (dispatch queues and locks) and try to use actors instead.

This PR adopts Swift 6 only in `expo-modules-core`, `expo` and `expo-image` packages. I'll be adding more soon.

# Test Plan

bare-expo compiles and seems to work as expected. I also ran native tests.