### PR TITLE
fix(apps/router-e2e): set `autolinkingModuleResolution: true` to prevent `react` and `react-dom` resolution errors

### DIFF
--- a/apps/router-e2e/app.config.js
+++ b/apps/router-e2e/app.config.js
@@ -34,6 +34,7 @@ module.exports = {
     backgroundColor: '#ffffff',
   },
   experiments: {
+    autolinkingModuleResolution: true,
     baseUrl: process.env.EXPO_E2E_BASE_PATH || undefined,
     tsconfigPaths: process.env.EXPO_USE_PATH_ALIASES,
     typedRoutes: true,


### PR DESCRIPTION
# Why

[The root-level resolutions for `react` and `react-dom` were removed](https://github.com/expo/expo/pull/40170/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) in #40170, which in turn caused `Invalid hook call. Hooks can only be called inside of the body of a function component.` errors when running `expo start` from `apps/router-e2e`.

# How

Added `autolinkingModuleResolution: true` to `apps/router-e2e/app.config.js`.

# Test Plan

Manually tested.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
