### PR TITLE
[docs] Add global context and other improvements in SDK Ask AI 

### DIFF
--- a/docs/components/DocumentationNestedScrollLayout.tsx
+++ b/docs/components/DocumentationNestedScrollLayout.tsx
@@ -132,7 +132,7 @@ export default class DocumentationNestedScrollLayout extends Component<Props> {
                 className={mergeClasses(
                   'mx-auto max-w-screen-xl transition-[padding,max-width,margin] duration-200 ease-out',
                   isChatExpanded &&
-                    'lg:pr-[360px] lg:pl-8 lg:max-w-[calc(100%-360px)] max-lg-gutters:pr-0 max-lg-gutters:pl-0 max-lg-gutters:max-w-screen-xl'
+                    'lg:pr-[360px] lg:pl-8 lg:max-w-[calc(100%-360px)] max-lg-gutters:max-w-screen-xl max-lg-gutters:pl-0 max-lg-gutters:pr-0'
                 )}>
                 {children}
               </div>

--- a/docs/components/DocumentationNestedScrollLayout.tsx
+++ b/docs/components/DocumentationNestedScrollLayout.tsx
@@ -1,4 +1,6 @@
-import { mergeClasses } from '@expo/styleguide';
+import { Button, mergeClasses } from '@expo/styleguide';
+import { ChevronLeftIcon } from '@expo/styleguide-icons/outline/ChevronLeftIcon';
+import { ChevronRightIcon } from '@expo/styleguide-icons/outline/ChevronRightIcon';
 import {
   Component,
   cloneElement,
@@ -22,6 +24,9 @@ type Props = PropsWithChildren<{
   sidebar: ReactNode;
   sidebarActiveGroup: string;
   sidebarRight: ReactElement<TableOfContentsProps>;
+  onSidebarToggle?: () => void;
+  isSidebarCollapsed?: boolean;
+  isChatExpanded?: boolean;
 }>;
 
 export default class DocumentationNestedScrollLayout extends Component<Props> {
@@ -51,25 +56,70 @@ export default class DocumentationNestedScrollLayout extends Component<Props> {
       isMobileMenuVisible,
       hideTOC,
       children,
+      onSidebarToggle,
+      isSidebarCollapsed = false,
+      isChatExpanded = false,
     } = this.props;
 
     return (
       <div className="mx-auto flex h-dvh w-full flex-col overflow-hidden">
         <div className="max-lg-gutters:sticky">{header}</div>
         <div className="mx-auto flex h-[calc(100dvh-60px)] w-full items-center justify-between">
-          <div
-            className={mergeClasses(
-              'flex h-full max-w-[280px] shrink-0 flex-col overflow-hidden border-r border-r-default',
-              'max-lg-gutters:hidden'
-            )}>
-            <SidebarHead sidebarActiveGroup={sidebarActiveGroup} />
-            <ScrollContainer
-              ref={this.sidebarRef}
-              scrollPosition={sidebarScrollPosition}
-              className="pt-1.5">
-              {sidebar}
-              <SidebarFooter />
-            </ScrollContainer>
+          <div className="relative h-full max-lg-gutters:hidden">
+            {onSidebarToggle ? (
+              <div
+                className={mergeClasses(
+                  'absolute z-20 flex items-center justify-center transition-all duration-200 ease-out',
+                  'bottom-6',
+                  isSidebarCollapsed ? 'left-5 translate-x-0' : 'left-[280px] -translate-x-1/2'
+                )}>
+                <Button
+                  type="button"
+                  theme="quaternary"
+                  size="xs"
+                  className={mergeClasses(
+                    'inline-flex size-9 items-center justify-center rounded-full border !p-0 transition-colors duration-150 ease-out',
+                    'shadow-sm',
+                    isSidebarCollapsed
+                      ? 'border-palette-gray5 bg-palette-gray4 text-icon-secondary dark:border-palette-gray6 dark:bg-palette-gray5'
+                      : 'border-default bg-default text-icon-secondary',
+                    'hover:bg-element focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-palette-blue9'
+                  )}
+                  aria-label={isSidebarCollapsed ? 'Show navigation' : 'Hide navigation'}
+                  title={isSidebarCollapsed ? 'Show navigation' : 'Hide navigation'}
+                  aria-pressed={!isSidebarCollapsed}
+                  onClick={onSidebarToggle}>
+                  {isSidebarCollapsed ? (
+                    <ChevronRightIcon className="icon-sm" />
+                  ) : (
+                    <ChevronLeftIcon className="icon-sm" />
+                  )}
+                  <span className="sr-only">
+                    {isSidebarCollapsed ? 'Show navigation' : 'Hide navigation'}
+                  </span>
+                </Button>
+              </div>
+            ) : null}
+            <div
+              className={mergeClasses(
+                'flex h-full max-w-[280px] flex-col overflow-hidden border-r border-r-default transition-[max-width,opacity,width] duration-200 ease-out',
+                isSidebarCollapsed
+                  ? 'w-0 max-w-0 border-r-0 opacity-0'
+                  : 'w-[280px] max-w-[280px] opacity-100'
+              )}>
+              {isSidebarCollapsed ? null : (
+                <>
+                  <SidebarHead sidebarActiveGroup={sidebarActiveGroup} />
+                  <ScrollContainer
+                    ref={this.sidebarRef}
+                    scrollPosition={sidebarScrollPosition}
+                    className="pt-1.5">
+                    {sidebar}
+                    <SidebarFooter />
+                  </ScrollContainer>
+                </>
+              )}
+            </div>
           </div>
           <div
             className={mergeClasses(
@@ -78,7 +128,14 @@ export default class DocumentationNestedScrollLayout extends Component<Props> {
               isMobileMenuVisible && 'hidden'
             )}>
             <ScrollContainer ref={this.contentRef} scrollHandler={this.scrollHandler}>
-              <div className="mx-auto max-w-screen-xl">{children}</div>
+              <div
+                className={mergeClasses(
+                  'mx-auto max-w-screen-xl transition-[padding,max-width,margin] duration-200 ease-out',
+                  isChatExpanded &&
+                    'lg:pr-[360px] lg:pl-8 lg:max-w-[calc(100%-360px)] max-lg-gutters:pr-0 max-lg-gutters:pl-0 max-lg-gutters:max-w-screen-xl'
+                )}>
+                {children}
+              </div>
             </ScrollContainer>
           </div>
           {!hideTOC && (

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -1,7 +1,7 @@
 import { mergeClasses } from '@expo/styleguide';
 import { breakpoints } from '@expo/styleguide-base';
 import { useRouter } from 'next/compat/router';
-import { useEffect, useState, createRef, type PropsWithChildren, useRef } from 'react';
+import { useEffect, useState, createRef, type PropsWithChildren, useRef, useCallback } from 'react';
 
 import { InlineHelp } from 'ui/components/InlineHelp';
 import { PageHeader } from 'ui/components/PageHeader';
@@ -45,6 +45,9 @@ export default function DocumentationPage({
 }: DocPageProps) {
   const [isMobileMenuVisible, setMobileMenuVisible] = useState(false);
   const [isAskAIVisible, setAskAIVisible] = useState(false);
+  const [isSidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [isAskAIExpanded, setAskAIExpanded] = useState(false);
+  const [didChatForceSidebarCollapse, setDidChatForceSidebarCollapse] = useState(false);
   const { version } = usePageApiVersion();
   const router = useRouter();
 
@@ -61,16 +64,40 @@ export default function DocumentationPage({
   const isAskAIEligiblePage = isLatestSdkPage || isLatestConfigPage;
   const askAIButtonVariant = isLatestConfigPage ? 'config' : 'default';
 
+  const handleAskAIExpandedChange = useCallback(
+    (expanded: boolean) => {
+      setAskAIExpanded(expanded);
+      if (expanded) {
+        if (!isSidebarCollapsed) {
+          setSidebarCollapsed(true);
+          setDidChatForceSidebarCollapse(true);
+        } else {
+          setDidChatForceSidebarCollapse(false);
+        }
+        return;
+      }
+
+      if (didChatForceSidebarCollapse) {
+        setSidebarCollapsed(false);
+        setDidChatForceSidebarCollapse(false);
+      }
+    },
+    [didChatForceSidebarCollapse, isSidebarCollapsed]
+  );
+
   useEffect(() => {
     if (!isAskAIEligiblePage && isAskAIVisible) {
       setAskAIVisible(false);
+      handleAskAIExpandedChange(false);
     }
-  }, [isAskAIEligiblePage, isAskAIVisible]);
+  }, [handleAskAIExpandedChange, isAskAIEligiblePage, isAskAIVisible]);
 
   const handleAskAIChatClose = () => {
+    handleAskAIExpandedChange(false);
     setAskAIVisible(false);
   };
   const handleAskAIMinimize = () => {
+    handleAskAIExpandedChange(false);
     setAskAIVisible(false);
   };
   const handleAskAIToggle = () => {
@@ -78,7 +105,14 @@ export default function DocumentationPage({
       return;
     }
 
-    setAskAIVisible(previous => !previous);
+    const nextVisibility = !isAskAIVisible;
+    setAskAIVisible(nextVisibility);
+    handleAskAIExpandedChange(false);
+  };
+
+  const handleSidebarToggle = () => {
+    setSidebarCollapsed(previous => !previous);
+    setDidChatForceSidebarCollapse(false);
   };
 
   useEffect(() => {
@@ -179,7 +213,10 @@ export default function DocumentationPage({
         hideTOC={hideSidebarRight}
         isMobileMenuVisible={isMobileMenuVisible}
         onContentScroll={handleContentScroll}
-        sidebarScrollPosition={sidebarScrollPosition}>
+        sidebarScrollPosition={sidebarScrollPosition}
+        onSidebarToggle={handleSidebarToggle}
+        isSidebarCollapsed={isSidebarCollapsed}
+        isChatExpanded={isAskAIExpanded}>
         <DocumentationHead
           title={title}
           description={description}
@@ -249,6 +286,8 @@ export default function DocumentationPage({
           pageTitle={title}
           isExpoSdkPage={isLatestSdkPage}
           isVisible={isAskAIVisible}
+          isExpanded={isAskAIExpanded}
+          onExpandedChange={handleAskAIExpandedChange}
         />
       )}
     </>

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -124,17 +124,6 @@ export function AskPageAIChat({
   }, [conversation.length, contextScope, resetLocalState]);
 
   useEffect(() => {
-    if (conversation.length === 0) {
-      resetLocalState();
-    } else {
-      setContextScope('page');
-      setGlobalSearchRequests({});
-      setGlobalSwitchNotices({});
-      setPendingGlobalQuestionKey(null);
-    }
-  }, [conversation.length, displayContextLabel, resetLocalState]);
-
-  useEffect(() => {
     if (conversation.length <= askedQuestions.length) {
       return;
     }

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -664,7 +664,7 @@ export function AskPageAIChat({
         <FOOTNOTE className="text-palette-white">
           Ask a question about{' '}
           <span className="font-semibold">
-            {contextScope === 'page' ? displayContextLabel : 'the Expo docs'}
+            {contextScope === 'page' ? displayContextLabel : 'Expo docs'}
           </span>
           .
         </FOOTNOTE>

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -357,6 +357,39 @@ export function AskPageAIChat({
     [buildPrompt, conversation.length, globalSearchRequests, isBusy, submitQuery]
   );
 
+  const handleSwitchBackToPageContext = useCallback(() => {
+    if (contextScope !== 'global') {
+      return;
+    }
+
+    setContextScope('page');
+    if (pendingGlobalQuestionKey) {
+      setGlobalSearchRequests(prev => {
+        if (!(pendingGlobalQuestionKey in prev)) {
+          return prev;
+        }
+        const next = { ...prev };
+        delete next[pendingGlobalQuestionKey];
+        return next;
+      });
+      setGlobalSwitchNotices(prev => {
+        if (!prev[pendingGlobalQuestionKey]) {
+          return prev;
+        }
+        return { ...prev, [pendingGlobalQuestionKey]: 'done' };
+      });
+      setPendingGlobalQuestionKey(null);
+    }
+    setContextMarkers(prev => [
+      ...prev,
+      {
+        id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        at: conversation.length,
+        label: displayContextLabel,
+      },
+    ]);
+  }, [contextScope, conversation.length, displayContextLabel, pendingGlobalQuestionKey]);
+
   const markdownComponents = useChatMarkdownComponents({ onNavigate: handleNavigation });
 
   const messageEntries = useMemo(
@@ -379,6 +412,7 @@ export function AskPageAIChat({
         contextScope={contextScope}
         isExpanded={isExpanded}
         onToggleExpand={onToggleExpand}
+        onSwitchToPageContext={handleSwitchBackToPageContext}
         onReset={handleConversationReset}
         onClose={handleClose}
         feedbackTarget={feedbackTarget}

--- a/docs/ui/components/AskPageAI/AskPageAIChat.types.ts
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.types.ts
@@ -1,0 +1,13 @@
+import type { Reaction } from '@kapaai/react-sdk';
+
+export type ContextScope = 'page' | 'global';
+
+export type GlobalSwitchStatus = 'pending' | 'done';
+
+export type ContextMarker = { id: string; at: number; label: string };
+
+export type FeedbackTarget = {
+  id?: string | null;
+  reaction: Reaction | null;
+  isFeedbackSubmissionEnabled: boolean;
+} | null;

--- a/docs/ui/components/AskPageAI/AskPageAIChat.utils.ts
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.utils.ts
@@ -1,0 +1,14 @@
+import type { ContextMarker } from './AskPageAIChat.types';
+
+export const normalizeQuestion = (question: string) => question.trim().toLowerCase();
+
+export const createMarkerMap = (markers: ContextMarker[]) => {
+  const map: Record<number, ContextMarker[]> = {};
+  for (const marker of markers) {
+    if (!map[marker.at]) {
+      map[marker.at] = [];
+    }
+    map[marker.at].push(marker);
+  }
+  return map;
+};

--- a/docs/ui/components/AskPageAI/AskPageAIChatHeader.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChatHeader.tsx
@@ -3,6 +3,7 @@ import { Maximize02Icon } from '@expo/styleguide-icons/outline/Maximize02Icon';
 import { Minimize02Icon } from '@expo/styleguide-icons/outline/Minimize02Icon';
 import { RefreshCcw02Icon } from '@expo/styleguide-icons/outline/RefreshCcw02Icon';
 import { Star06Icon } from '@expo/styleguide-icons/outline/Star06Icon';
+import { SwitchHorizontal01Icon } from '@expo/styleguide-icons/outline/SwitchHorizontal01Icon';
 import { ThumbsDownIcon } from '@expo/styleguide-icons/outline/ThumbsDownIcon';
 import { ThumbsUpIcon } from '@expo/styleguide-icons/outline/ThumbsUpIcon';
 import { XIcon } from '@expo/styleguide-icons/outline/XIcon';
@@ -17,6 +18,7 @@ type AskPageAIChatHeaderProps = {
   contextScope: ContextScope;
   isExpanded: boolean;
   onToggleExpand?: () => void;
+  onSwitchToPageContext?: () => void;
   onReset: () => void;
   onClose: () => void;
   feedbackTarget: FeedbackTarget;
@@ -28,6 +30,7 @@ export function AskPageAIChatHeader({
   contextScope,
   isExpanded,
   onToggleExpand,
+  onSwitchToPageContext,
   onReset,
   onClose,
   feedbackTarget,
@@ -51,7 +54,7 @@ export function AskPageAIChatHeader({
   );
 
   return (
-    <div className="flex flex-col gap-3 border-b border-default bg-palette-black px-4 py-3 text-palette-white">
+    <div className="flex flex-col gap-3 border-b border-default bg-palette-black px-4 py-2.5 text-palette-white">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <span
@@ -138,13 +141,27 @@ export function AskPageAIChatHeader({
           </Button>
         </div>
       </div>
-      <FOOTNOTE className="text-palette-white">
-        Ask a question about{' '}
-        <span className="font-semibold">
-          {contextScope === 'page' ? displayContextLabel : 'the Expo docs'}
-        </span>
-        .
-      </FOOTNOTE>
+      <div className="flex flex-col gap-2">
+        <FOOTNOTE className="text-palette-white">
+          Ask a question about{' '}
+          <span className="font-semibold">
+            {contextScope === 'page' ? displayContextLabel : 'the Expo docs'}
+          </span>
+          .
+        </FOOTNOTE>
+        {contextScope === 'global' && onSwitchToPageContext ? (
+          <Button
+            type="button"
+            theme="quaternary"
+            size="xs"
+            className="inline-flex items-center self-start px-2 py-1.5 !text-palette-white hover:!text-palette-white focus:!text-palette-white"
+            style={closeButtonThemeOverrides}
+            onClick={onSwitchToPageContext}>
+            <SwitchHorizontal01Icon className="icon-xs mr-2 self-center text-palette-white" />
+            <span className="leading-snug">Switch back to {displayContextLabel} docs</span>
+          </Button>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/docs/ui/components/AskPageAI/AskPageAIChatHeader.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChatHeader.tsx
@@ -1,0 +1,150 @@
+import { Button, mergeClasses } from '@expo/styleguide';
+import { Maximize02Icon } from '@expo/styleguide-icons/outline/Maximize02Icon';
+import { Minimize02Icon } from '@expo/styleguide-icons/outline/Minimize02Icon';
+import { RefreshCcw02Icon } from '@expo/styleguide-icons/outline/RefreshCcw02Icon';
+import { Star06Icon } from '@expo/styleguide-icons/outline/Star06Icon';
+import { ThumbsDownIcon } from '@expo/styleguide-icons/outline/ThumbsDownIcon';
+import { ThumbsUpIcon } from '@expo/styleguide-icons/outline/ThumbsUpIcon';
+import { XIcon } from '@expo/styleguide-icons/outline/XIcon';
+import type { Reaction } from '@kapaai/react-sdk';
+import { useMemo, type CSSProperties } from 'react';
+
+import type { ContextScope, FeedbackTarget } from './AskPageAIChat.types';
+import { FOOTNOTE } from '../Text';
+
+type AskPageAIChatHeaderProps = {
+  displayContextLabel: string;
+  contextScope: ContextScope;
+  isExpanded: boolean;
+  onToggleExpand?: () => void;
+  onReset: () => void;
+  onClose: () => void;
+  feedbackTarget: FeedbackTarget;
+  onFeedback: (reaction: Reaction) => void;
+};
+
+export function AskPageAIChatHeader({
+  displayContextLabel,
+  contextScope,
+  isExpanded,
+  onToggleExpand,
+  onReset,
+  onClose,
+  feedbackTarget,
+  onFeedback,
+}: AskPageAIChatHeaderProps) {
+  const closeButtonThemeOverrides = useMemo(
+    () =>
+      ({
+        '--expo-theme-button-quaternary-hover': 'rgba(255,255,255,0.12)',
+        '--expo-theme-button-quaternary-text': '#ffffff',
+        '--expo-theme-button-quaternary-icon': '#ffffff',
+      }) as CSSProperties,
+    []
+  );
+
+  const headerAccentBackground = useMemo(() => ({ backgroundColor: 'rgba(255,255,255,0.1)' }), []);
+
+  const activeFeedbackBackground = useMemo(
+    () => ({ backgroundColor: 'rgba(255,255,255,0.12)' }),
+    []
+  );
+
+  return (
+    <div className="flex flex-col gap-3 border-b border-default bg-palette-black px-4 py-3 text-palette-white">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span
+            className={mergeClasses(
+              'inline-flex size-8 items-center justify-center rounded-full bg-palette-white shadow-xs'
+            )}
+            style={headerAccentBackground}>
+            <Star06Icon className="icon-sm text-palette-white" />
+          </span>
+          <span className="text-sm font-medium leading-tight text-palette-white">
+            Expo AI Assistant
+          </span>
+        </div>
+        <div className="flex items-center gap-1">
+          <Button
+            type="button"
+            aria-label="Provide positive feedback"
+            theme="quaternary"
+            size="xs"
+            className="px-2 !text-palette-white hover:!text-palette-white focus:!text-palette-white"
+            style={{
+              ...closeButtonThemeOverrides,
+              ...(feedbackTarget?.reaction === 'upvote' ? activeFeedbackBackground : {}),
+            }}
+            aria-pressed={feedbackTarget?.reaction === 'upvote'}
+            disabled={!feedbackTarget?.isFeedbackSubmissionEnabled}
+            onClick={() => {
+              onFeedback('upvote');
+            }}>
+            <ThumbsUpIcon className="icon-xs text-palette-white" />
+          </Button>
+          <Button
+            type="button"
+            aria-label="Provide negative feedback"
+            theme="quaternary"
+            size="xs"
+            className="px-2 !text-palette-white hover:!text-palette-white focus:!text-palette-white"
+            style={{
+              ...closeButtonThemeOverrides,
+              ...(feedbackTarget?.reaction === 'downvote' ? activeFeedbackBackground : {}),
+            }}
+            aria-pressed={feedbackTarget?.reaction === 'downvote'}
+            disabled={!feedbackTarget?.isFeedbackSubmissionEnabled}
+            onClick={() => {
+              onFeedback('downvote');
+            }}>
+            <ThumbsDownIcon className="icon-xs text-palette-white" />
+          </Button>
+          {onToggleExpand ? (
+            <Button
+              type="button"
+              aria-label={isExpanded ? 'Restore Ask AI assistant size' : 'Expand Ask AI assistant'}
+              theme="quaternary"
+              size="xs"
+              className="px-2 !text-palette-white hover:!text-palette-white focus:!text-palette-white"
+              style={closeButtonThemeOverrides}
+              aria-pressed={isExpanded}
+              onClick={onToggleExpand}>
+              {isExpanded ? (
+                <Minimize02Icon className="icon-xs text-palette-white" />
+              ) : (
+                <Maximize02Icon className="icon-xs text-palette-white" />
+              )}
+            </Button>
+          ) : null}
+          <Button
+            type="button"
+            aria-label="Reset conversation"
+            theme="quaternary"
+            size="xs"
+            className="px-2 !text-palette-white hover:!text-palette-white focus:!text-palette-white"
+            style={closeButtonThemeOverrides}
+            onClick={onReset}>
+            <RefreshCcw02Icon className="icon-xs text-palette-white" />
+          </Button>
+          <Button
+            aria-label="Close Ask AI assistant"
+            theme="quaternary"
+            size="xs"
+            className="px-2 !text-palette-white hover:!text-palette-white focus:!text-palette-white"
+            style={closeButtonThemeOverrides}
+            onClick={onClose}>
+            <XIcon className="icon-xs text-palette-white" />
+          </Button>
+        </div>
+      </div>
+      <FOOTNOTE className="text-palette-white">
+        Ask a question about{' '}
+        <span className="font-semibold">
+          {contextScope === 'page' ? displayContextLabel : 'the Expo docs'}
+        </span>
+        .
+      </FOOTNOTE>
+    </div>
+  );
+}

--- a/docs/ui/components/AskPageAI/AskPageAIChatInput.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChatInput.tsx
@@ -1,0 +1,53 @@
+import { Button } from '@expo/styleguide';
+import { Send03Icon } from '@expo/styleguide-icons/outline/Send03Icon';
+import type { FormEvent } from 'react';
+
+type AskPageAIChatInputProps = {
+  question: string;
+  onQuestionChange: (value: string) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  isBusy: boolean;
+  conversationLength: number;
+};
+
+export function AskPageAIChatInput({
+  question,
+  onQuestionChange,
+  onSubmit,
+  isBusy,
+  conversationLength,
+}: AskPageAIChatInputProps) {
+  return (
+    <div className="mt-auto border-t border-default px-5 pb-6 pt-4">
+      <form
+        className="flex items-center gap-1 rounded-md border border-default bg-default px-2 py-1.5"
+        onSubmit={onSubmit}
+        aria-label="Ask AI form">
+        <textarea
+          aria-label="Ask AI about this page"
+          className="min-h-[72px] flex-1 resize-none rounded-md border border-transparent bg-subtle p-2 text-sm leading-relaxed outline-none focus:!shadow-none focus:!outline-none focus:ring-0 focus-visible:!shadow-none focus-visible:!outline-none focus-visible:ring-0"
+          rows={3}
+          value={question}
+          onChange={event => {
+            onQuestionChange(event.target.value);
+          }}
+          disabled={isBusy && conversationLength === 0}
+          onKeyDown={event => {
+            if (event.key === 'Enter' && !event.shiftKey) {
+              event.preventDefault();
+              event.currentTarget.form?.requestSubmit();
+            }
+          }}
+        />
+        <Button
+          type="submit"
+          theme="quaternary"
+          size="sm"
+          className="flex size-6 items-center justify-center rounded-full !p-0"
+          disabled={isBusy || question.trim().length === 0}>
+          <Send03Icon className="icon-xs text-icon-default" />
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/docs/ui/components/AskPageAI/AskPageAIChatMessages.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChatMessages.tsx
@@ -1,0 +1,174 @@
+import { Button } from '@expo/styleguide';
+import { FileSearch02Icon } from '@expo/styleguide-icons/outline/FileSearch02Icon';
+import type { MouseEvent } from 'react';
+import type { Components } from 'react-markdown';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+import type { ContextScope, GlobalSwitchStatus, ContextMarker } from './AskPageAIChat.types';
+import { FOOTNOTE } from '../Text';
+import { normalizeQuestion } from './AskPageAIChat.utils';
+
+type ConversationEntry = {
+  id: string | null;
+  question: string;
+  answer: string;
+  sources?: { source_url: string; title?: string }[];
+  isFeedbackSubmissionEnabled?: boolean;
+};
+
+type AskPageAIChatMessagesProps = {
+  conversation: ConversationEntry[];
+  askedQuestions: string[];
+  fallbackResponse: string;
+  contextScope: ContextScope;
+  globalSearchRequests: Record<string, boolean>;
+  globalSwitchNotices: Record<string, GlobalSwitchStatus>;
+  pendingGlobalQuestionKey: string | null;
+  markersByIndex: Record<number, ContextMarker[]>;
+  isBusy: boolean;
+  markdownComponents: Components;
+  onSearchAcrossDocs: (question: string) => void;
+  extractUserQuestion: (prompt: string, fallback: string) => string;
+  onNavigate: (event?: MouseEvent<HTMLAnchorElement>) => void;
+};
+
+export function AskPageAIChatMessages({
+  conversation,
+  askedQuestions,
+  fallbackResponse,
+  contextScope,
+  globalSearchRequests,
+  globalSwitchNotices,
+  pendingGlobalQuestionKey,
+  markersByIndex,
+  isBusy,
+  markdownComponents,
+  onSearchAcrossDocs,
+  extractUserQuestion,
+  onNavigate,
+}: AskPageAIChatMessagesProps) {
+  if (conversation.length === 0) {
+    return (
+      <div className="rounded-md border border-default bg-subtle px-3 py-2 shadow-xs">
+        <FOOTNOTE className="font-medium text-default">AI Assistant</FOOTNOTE>
+        <div className="mt-1 space-y-3 text-xs text-secondary">
+          I'm an SDK AI assistant — ask me a question about the{' '}
+          <span className="font-medium text-default">
+            {contextScope === 'page' ? 'current page' : 'Expo docs'}
+          </span>
+          .
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      {conversation.map((qa, index) => {
+        const markers = markersByIndex[index] ?? [];
+        const questionFromPrompt = extractUserQuestion(qa.question, qa.question);
+        const normalizedQuestion = normalizeQuestion(questionFromPrompt);
+        const displayQuestion = askedQuestions[index] ?? questionFromPrompt;
+        const normalizedAnswer = qa.answer
+          ?.replace(/<br\s*\/?>((\n)?)/gi, '\n')
+          ?.replace(/<sup[^>]*>(.*?)<\/sup>/gi, '$1');
+        const trimmedAnswer = normalizedAnswer?.trim();
+        const isFallbackAnswer = trimmedAnswer === fallbackResponse;
+        const hasTriggeredGlobalSearch = Boolean(globalSearchRequests[normalizedQuestion]);
+        const isPendingGlobal = pendingGlobalQuestionKey === normalizedQuestion;
+        const isFinalAnswer =
+          'isFeedbackSubmissionEnabled' in qa && Boolean((qa as any).isFeedbackSubmissionEnabled);
+        const shouldOfferGlobalSearch =
+          isFinalAnswer && contextScope === 'page' && isFallbackAnswer;
+        const switchStatus = globalSwitchNotices[normalizedQuestion];
+        const showSwitchingNotice = Boolean(switchStatus);
+        const switchNoticeText =
+          switchStatus === 'pending' ? 'Switching to Expo docs.' : 'Switched to Expo docs.';
+
+        return (
+          <div key={qa.id ?? `${qa.question}-${index}`} className="space-y-2">
+            {markers.map(marker => (
+              <div key={`marker-${marker.id}`} className="flex justify-center">
+                <FOOTNOTE
+                  theme="secondary"
+                  className="inline-block rounded-md border border-default bg-subtle px-2 py-1">
+                  Switched to <span className="font-medium text-default">{marker.label}.</span>
+                </FOOTNOTE>
+              </div>
+            ))}
+            <div className="flex justify-end pr-1">
+              <div className="ml-auto max-w-[85%] rounded-md border border-default bg-subtle px-3 py-1.5 text-right text-sm leading-snug text-secondary shadow-xs">
+                {displayQuestion}
+              </div>
+            </div>
+            <div className="px-0">
+              <FOOTNOTE className="font-medium text-default">AI Assistant</FOOTNOTE>
+              <div className="mt-1 space-y-3 text-xs text-secondary">
+                {normalizedAnswer ? (
+                  <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+                    {normalizedAnswer}
+                  </ReactMarkdown>
+                ) : (
+                  <FOOTNOTE theme="secondary">
+                    {index === conversation.length - 1 && isBusy ? 'Preparing answer...' : ''}
+                  </FOOTNOTE>
+                )}
+              </div>
+              {shouldOfferGlobalSearch ? (
+                <div className="mt-2 flex flex-col gap-2">
+                  <Button
+                    type="button"
+                    theme="quaternary"
+                    size="xs"
+                    className="inline-flex items-center gap-2 rounded-md border border-default bg-subtle px-3 py-1 text-xs font-medium text-default shadow-xs transition-colors hover:bg-element focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-palette-blue9 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+                    disabled={isBusy || hasTriggeredGlobalSearch || isPendingGlobal}
+                    onClick={() => {
+                      onSearchAcrossDocs(displayQuestion);
+                    }}>
+                    <FileSearch02Icon className="icon-xs text-icon-secondary" />
+                    {hasTriggeredGlobalSearch || isPendingGlobal
+                      ? 'Searching Expo docs…'
+                      : 'Search Expo docs'}
+                  </Button>
+                  {showSwitchingNotice ? (
+                    <FOOTNOTE theme="secondary" className="text-xs">
+                      {switchNoticeText}
+                    </FOOTNOTE>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+            {qa.sources?.length ? (
+              <FOOTNOTE theme="secondary" className="ml-1 text-xs">
+                Sources:{' '}
+                {qa.sources.map((source, sourceIdx, sources) => (
+                  <span key={source.source_url}>
+                    <a
+                      className="text-link"
+                      href={source.source_url}
+                      onClick={event => {
+                        onNavigate(event);
+                      }}>
+                      {source.title ?? `Source ${sourceIdx + 1}`}
+                    </a>
+                    {sourceIdx < sources.length - 1 ? ', ' : ''}
+                  </span>
+                ))}
+              </FOOTNOTE>
+            ) : null}
+          </div>
+        );
+      })}
+      {markersByIndex[conversation.length]?.map(marker => (
+        <div key={`marker-${marker.id}`} className="flex justify-center">
+          <FOOTNOTE
+            theme="secondary"
+            className="inline-block rounded-md border border-default bg-subtle px-2 py-1">
+            Switched to <span className="font-medium text-default">{marker.label}.</span>
+          </FOOTNOTE>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/docs/ui/components/AskPageAI/AskPageAIChatMessages.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChatMessages.tsx
@@ -126,7 +126,7 @@ export function AskPageAIChatMessages({
                     onClick={() => {
                       onSearchAcrossDocs(displayQuestion);
                     }}>
-                    <FileSearch02Icon className="icon-xs text-icon-secondary" />
+                    <FileSearch02Icon className="icon-xs text-icon-secondary mr-2" />
                     {hasTriggeredGlobalSearch || isPendingGlobal
                       ? 'Searching Expo docs…'
                       : 'Search Expo docs'}

--- a/docs/ui/components/AskPageAI/AskPageAIChatMessages.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChatMessages.tsx
@@ -126,7 +126,7 @@ export function AskPageAIChatMessages({
                     onClick={() => {
                       onSearchAcrossDocs(displayQuestion);
                     }}>
-                    <FileSearch02Icon className="icon-xs text-icon-secondary mr-2" />
+                    <FileSearch02Icon className="icon-xs mr-2 text-icon-secondary" />
                     {hasTriggeredGlobalSearch || isPendingGlobal
                       ? 'Searching Expo docs…'
                       : 'Search Expo docs'}

--- a/docs/ui/components/AskPageAI/AskPageAIOverlay.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIOverlay.tsx
@@ -37,7 +37,7 @@ export function AskPageAIOverlay({
   }
 
   return createPortal(
-    <div className="pointer-events-none fixed inset-0 z-[70]">
+    <div className="pointer-events-none fixed inset-0 z-[120]">
       <div
         className={mergeClasses(
           'max-sm:left-4 sm:bottom-8 sm:right-8 fixed bottom-4 right-4 flex h-full w-[min(420px,calc(100vw-24px))] flex-col overflow-hidden rounded-2xl border border-default bg-default transition-all duration-150 ease-out',

--- a/docs/ui/components/AskPageAI/AskPageAIOverlay.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIOverlay.tsx
@@ -10,6 +10,8 @@ type AskPageAIOverlayProps = {
   pageTitle?: string;
   isExpoSdkPage?: boolean;
   isVisible: boolean;
+  isExpanded: boolean;
+  onExpandedChange?: (expanded: boolean) => void;
 };
 
 export function AskPageAIOverlay({
@@ -18,19 +20,20 @@ export function AskPageAIOverlay({
   pageTitle,
   isExpoSdkPage,
   isVisible,
+  isExpanded,
+  onExpandedChange,
 }: AskPageAIOverlayProps) {
   const [isMounted, setMounted] = useState(false);
-  const [isExpanded, setExpanded] = useState(false);
 
   useEffect(() => {
     setMounted(true);
   }, []);
 
   useEffect(() => {
-    if (!isVisible) {
-      setExpanded(false);
+    if (!isVisible && isExpanded) {
+      onExpandedChange?.(false);
     }
-  }, [isVisible]);
+  }, [isExpanded, isVisible, onExpandedChange]);
 
   if (!isMounted) {
     return null;
@@ -40,8 +43,11 @@ export function AskPageAIOverlay({
     <div className="pointer-events-none fixed inset-0 z-[120]">
       <div
         className={mergeClasses(
-          'max-sm:left-4 sm:bottom-8 sm:right-8 fixed bottom-4 right-4 flex h-full w-[min(420px,calc(100vw-24px))] flex-col overflow-hidden rounded-2xl border border-default bg-default transition-all duration-150 ease-out',
-          isExpanded ? 'h-[min(97vh,860px)] max-h-[min(97vh,860px)]' : 'max-h-[min(85vh,600px)]',
+          'fixed bottom-4 right-4 flex h-full flex-col overflow-hidden rounded-2xl border border-default bg-default transition-all duration-200 ease-out',
+          'max-sm:left-4 sm:bottom-8',
+          isExpanded
+            ? 'sm:top-8 sm:bottom-8 sm:right-12 bottom-4 top-4 h-auto w-[min(600px,calc(100vw-72px))] max-w-[min(600px,calc(100vw-72px))]'
+            : 'sm:right-8 max-h-[min(85vh,600px)] w-[min(420px,calc(100vw-24px))]',
           isVisible
             ? 'pointer-events-auto translate-y-0 opacity-100 shadow-xl'
             : 'pointer-events-none translate-y-3 opacity-0 shadow-none'
@@ -57,7 +63,7 @@ export function AskPageAIOverlay({
             isExpoSdkPage={isExpoSdkPage}
             isExpanded={isExpanded}
             onToggleExpand={() => {
-              setExpanded(prev => !prev);
+              onExpandedChange?.(!isExpanded);
             }}
           />
         )}

--- a/docs/ui/components/AskPageAI/AskPageAIOverlay.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIOverlay.tsx
@@ -24,9 +24,35 @@ export function AskPageAIOverlay({
   onExpandedChange,
 }: AskPageAIOverlayProps) {
   const [isMounted, setMounted] = useState(false);
+  const [isSmallScreen, setSmallScreen] = useState(false);
 
   useEffect(() => {
     setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia('(max-width: 639px)');
+    const updateSmallScreen = (event: MediaQueryListEvent | MediaQueryList) => {
+      setSmallScreen(event.matches);
+    };
+
+    updateSmallScreen(mediaQuery);
+
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', updateSmallScreen);
+      return () => {
+        mediaQuery.removeEventListener('change', updateSmallScreen);
+      };
+    }
+
+    mediaQuery.addListener(updateSmallScreen);
+    return () => {
+      mediaQuery.removeListener(updateSmallScreen);
+    };
   }, []);
 
   useEffect(() => {
@@ -34,6 +60,17 @@ export function AskPageAIOverlay({
       onExpandedChange?.(false);
     }
   }, [isExpanded, isVisible, onExpandedChange]);
+
+  useEffect(() => {
+    if (!isSmallScreen || !isExpanded) {
+      return;
+    }
+
+    onExpandedChange?.(false);
+  }, [isExpanded, isSmallScreen, onExpandedChange]);
+
+  const shouldShowExpandedLayout = isExpanded && !isSmallScreen;
+  const canToggleExpand = !isSmallScreen;
 
   if (!isMounted) {
     return null;
@@ -45,7 +82,7 @@ export function AskPageAIOverlay({
         className={mergeClasses(
           'fixed bottom-4 right-4 flex h-full flex-col overflow-hidden rounded-2xl border border-default bg-default transition-all duration-200 ease-out',
           'max-sm:left-4 sm:bottom-8',
-          isExpanded
+          shouldShowExpandedLayout
             ? 'sm:top-8 sm:bottom-8 sm:right-12 bottom-4 top-4 h-auto w-[min(600px,calc(100vw-72px))] max-w-[min(600px,calc(100vw-72px))]'
             : 'sm:right-8 max-h-[min(85vh,600px)] w-[min(420px,calc(100vw-24px))]',
           isVisible
@@ -61,10 +98,14 @@ export function AskPageAIOverlay({
             onMinimize={onMinimize}
             pageTitle={pageTitle}
             isExpoSdkPage={isExpoSdkPage}
-            isExpanded={isExpanded}
-            onToggleExpand={() => {
-              onExpandedChange?.(!isExpanded);
-            }}
+            isExpanded={shouldShowExpandedLayout}
+            onToggleExpand={
+              canToggleExpand
+                ? () => {
+                    onExpandedChange?.(!isExpanded);
+                  }
+                : undefined
+            }
           />
         )}
       </div>

--- a/docs/ui/components/AskPageAI/useChatMarkdownComponents.tsx
+++ b/docs/ui/components/AskPageAI/useChatMarkdownComponents.tsx
@@ -1,0 +1,188 @@
+import { Button, mergeClasses } from '@expo/styleguide';
+import { CheckIcon } from '@expo/styleguide-icons/outline/CheckIcon';
+import { ClipboardIcon } from '@expo/styleguide-icons/outline/ClipboardIcon';
+import type { AnchorHTMLAttributes, ComponentType, MouseEvent } from 'react';
+import { useMemo, useState, useEffect } from 'react';
+import type { Components } from 'react-markdown';
+
+import { cleanCopyValue, getCodeBlockDataFromChildren } from '~/common/code-utilities';
+import { markdownComponents as docsMarkdownComponents } from '~/ui/components/Markdown';
+
+type UseChatMarkdownComponentsOptions = {
+  onNavigate: (event?: MouseEvent<HTMLAnchorElement>) => void;
+};
+
+export function useChatMarkdownComponents({ onNavigate }: UseChatMarkdownComponentsOptions) {
+  return useMemo<Components>(() => {
+    const AnchorComponent =
+      (docsMarkdownComponents.a as ComponentType<AnchorHTMLAttributes<HTMLAnchorElement>>) ?? 'a';
+    const ParagraphComponent = (docsMarkdownComponents.p as ComponentType<any>) ?? 'p';
+    const OrderedListComponent = (docsMarkdownComponents.ol as ComponentType<any>) ?? 'ol';
+    const UnorderedListComponent = (docsMarkdownComponents.ul as ComponentType<any>) ?? 'ul';
+    const ListItemComponent = (docsMarkdownComponents.li as ComponentType<any>) ?? 'li';
+    const Heading1Component = (docsMarkdownComponents.h1 as ComponentType<any>) ?? 'h1';
+    const Heading2Component = (docsMarkdownComponents.h2 as ComponentType<any>) ?? 'h2';
+    const Heading3Component = (docsMarkdownComponents.h3 as ComponentType<any>) ?? 'h3';
+    const Heading4Component = (docsMarkdownComponents.h4 as ComponentType<any>) ?? 'h4';
+    const Heading5Component = (docsMarkdownComponents.h5 as ComponentType<any>) ?? 'h5';
+    const PreComponent = (docsMarkdownComponents.pre as ComponentType<any>) ?? 'pre';
+
+    const ChatPre: ComponentType<any> = preProps => {
+      const { value } = useMemo(
+        () => getCodeBlockDataFromChildren(preProps.children, preProps.className),
+        [preProps.children, preProps.className]
+      );
+      const codeToCopy = useMemo(() => cleanCopyValue(value ?? ''), [value]);
+      const [copied, setCopied] = useState(false);
+
+      useEffect(() => {
+        if (!copied) {
+          return undefined;
+        }
+        const timer = setTimeout(() => {
+          setCopied(false);
+        }, 2000);
+        return () => {
+          clearTimeout(timer);
+        };
+      }, [copied]);
+
+      const handleCopy = () => {
+        if (!codeToCopy) {
+          return;
+        }
+        void navigator.clipboard?.writeText(codeToCopy);
+        setCopied(true);
+      };
+
+      return (
+        <div className="relative">
+          <PreComponent {...preProps} className={mergeClasses('px-3 py-2', preProps.className)} />
+          <Button
+            type="button"
+            theme="quaternary"
+            size="xs"
+            className="pointer-events-auto absolute right-2 top-2 z-10 flex size-7 items-center justify-center rounded-full !border !border-default !bg-default !p-0 shadow-sm"
+            onClick={handleCopy}
+            aria-label="Copy code block">
+            {copied ? (
+              <CheckIcon className="icon-xs text-success" aria-hidden />
+            ) : (
+              <ClipboardIcon className="icon-xs text-icon-secondary" aria-hidden />
+            )}
+          </Button>
+        </div>
+      );
+    };
+
+    return {
+      ...docsMarkdownComponents,
+      h1: props => (
+        <Heading1Component
+          {...props}
+          className={mergeClasses('!text-[14px] font-semibold text-default', props.className)}
+        />
+      ),
+      h2: props => (
+        <Heading2Component
+          {...props}
+          className={mergeClasses('!text-[14px] font-semibold text-default', props.className)}
+        />
+      ),
+      h3: props => (
+        <Heading3Component
+          {...props}
+          className={mergeClasses('!text-[12px] font-semibold text-default', props.className)}
+        />
+      ),
+      h4: props => (
+        <Heading4Component
+          {...props}
+          className={mergeClasses('!text-[12px] font-semibold text-default', props.className)}
+        />
+      ),
+      h5: props => (
+        <Heading5Component
+          {...props}
+          className={mergeClasses('!text-[10px] font-semibold text-default', props.className)}
+        />
+      ),
+      p: ({ className, style, ...rest }) => (
+        <ParagraphComponent
+          {...rest}
+          style={{ ...(style ?? {}), fontSize: '14px', lineHeight: '1.5' }}
+          className={mergeClasses(
+            '!mb-2 text-secondary',
+            className,
+            '!text-[10px] !leading-[1.55]'
+          )}
+        />
+      ),
+      ol: ({ className, style, ...rest }) => (
+        <OrderedListComponent
+          {...rest}
+          style={{ ...(style ?? {}), fontSize: '14px', lineHeight: '1.5' }}
+          className={mergeClasses('text-secondary', className, '!text-[10px] leading-normal')}
+        />
+      ),
+      ul: ({ className, style, ...rest }) => (
+        <UnorderedListComponent
+          {...rest}
+          style={{ ...(style ?? {}), fontSize: '14px', lineHeight: '1.5' }}
+          className={mergeClasses('text-secondary', className, '!text-[10px] leading-normal')}
+        />
+      ),
+      li: ({ className, style, ...rest }) => (
+        <ListItemComponent
+          {...rest}
+          style={{ ...(style ?? {}), fontSize: '14px', lineHeight: '1.45' }}
+          className={mergeClasses('text-secondary', className, '!text-[10px] !leading-[1.45]')}
+        />
+      ),
+      sup: () => null,
+      section: ({ className, children, ...props }: any) => {
+        if (className?.includes('footnotes')) {
+          return null;
+        }
+        return (
+          <section className={className} {...props}>
+            {children}
+          </section>
+        );
+      },
+      hr: ({ className, ...props }: any) => {
+        if (className?.includes('footnotes-sep')) {
+          return null;
+        }
+        const HR = (docsMarkdownComponents.hr as ComponentType<any>) ?? 'hr';
+        return <HR className={className} {...props} />;
+      },
+      a: ({
+        href,
+        children,
+        onClick: originalOnClick,
+        ...props
+      }: AnchorHTMLAttributes<HTMLAnchorElement>) => (
+        <AnchorComponent
+          {...props}
+          href={href ?? '#'}
+          onClick={(event: MouseEvent<HTMLAnchorElement>) => {
+            originalOnClick?.(event);
+            if (
+              event.defaultPrevented ||
+              event.metaKey ||
+              event.ctrlKey ||
+              event.shiftKey ||
+              event.button !== 0
+            ) {
+              return;
+            }
+            onNavigate(event);
+          }}>
+          {children}
+        </AnchorComponent>
+      ),
+      pre: ChatPre,
+    } as Components;
+  }, [onNavigate]);
+}

--- a/docs/ui/components/Sidebar/SidebarHead.tsx
+++ b/docs/ui/components/Sidebar/SidebarHead.tsx
@@ -34,11 +34,7 @@ export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
 
   return (
     <>
-      <div
-        className={mergeClasses(
-          'flex flex-col gap-0.5 border-b border-default bg-default p-4',
-          'compact-height:pb-3'
-        )}>
+      <div className="flex flex-col gap-0.5 border-b border-default bg-default p-4 compact-height:pb-3">
         <Search />
         <div
           className={mergeClasses(


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-17745 ENG-17702 ENG-17703

# How

<!--
How did you build this feature or fix this bug and why?
-->

* Updated `DocumentationPage.tsx` to pass new props to the chat component, enabling expanded/collapsed state and proper event handling.
* Added sidebar collapse/expand functionality with a button and smooth transitions in `DocumentationNestedScrollLayout.tsx`.
* Updated `DocumentationPage.tsx` to manage sidebar and chat expansion state, ensuring the sidebar collapses automatically when the AI chat is expanded and restores when closed.
* Fixed the `z-index` issue when you expand the AI Assistant window.
* Added a way to enable global (Expo docs wide context) within the chat window to search through Expo docs without switching to Ask AI in the Search modal.
* Break `AskPageAIChat.tsx` into different files to improve maintainability.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally, visit an SDK page under latest to test out all features.

<img width="4102" height="2388" alt="CleanShot 2025-10-14 at 19 11 04@2x" src="https://github.com/user-attachments/assets/75565297-8a52-4c00-b0da-e3b4f484f23d" />

<img width="4104" height="2484" alt="CleanShot 2025-10-14 at 19 11 20@2x" src="https://github.com/user-attachments/assets/db5fe900-26ea-4400-ace8-e349aa20dcb0" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
