### PR TITLE
@kosmydel/file system/config plugin

### DIFF
--- a/docs/pages/versions/unversioned/sdk/filesystem.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem.mdx
@@ -12,12 +12,73 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { CODE } from '~/ui/components/Text';
+import {
+  ConfigReactNative,
+  ConfigPluginExample,
+  ConfigPluginProperties,
+} from '~/ui/components/ConfigSection';
 
 `expo-file-system` provides access to files and directories stored on a device or bundled as assets into the native project. It also allows downloading files from the network.
 
 ## Installation
 
 <APIInstallSection />
+
+## Configuration in app config
+
+You can configure `expo-file-system` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-file-system",
+        {
+          "supportsOpeningDocumentsInPlace": true,
+          "enableFileSharing": true
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'supportsOpeningDocumentsInPlace',
+      platform: 'ios',
+      description:
+        'A boolean to enable `LSSupportsOpeningDocumentsInPlace` in **Info.plist**. This allows the app to open documents in place.',
+      default: 'false',
+    },
+    {
+      name: 'enableFileSharing',
+      platform: 'ios',
+      description:
+        "A boolean to enable `UIFileSharingEnabled` in **Info.plist**. This enables file sharing in the iOS Files app, making the app's Documents folder accessible to users through the Files app, iTunes File Sharing, and other file management tools.",
+      default: 'false',
+    },
+  ]}
+/>
+
+<ConfigReactNative>
+
+If you're not using Continuous Native Generation ([CNG](/workflow/continuous-native-generation/)) or you're using native **ios** project manually, then you need to add the `LSSupportsOpeningDocumentsInPlace` and `UIFileSharingEnabled` keys to your project's **ios/[app]/Info.plist**:
+
+```xml
+<key>LSSupportsOpeningDocumentsInPlace</key>
+<true/>
+<key>UIFileSharingEnabled</key>
+<true/>
+```
+
+</ConfigReactNative>
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/filesystem.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem.mdx
@@ -11,12 +11,12 @@ isNew: true
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { Collapsible } from '~/ui/components/Collapsible';
-import { CODE } from '~/ui/components/Text';
 import {
   ConfigReactNative,
   ConfigPluginExample,
   ConfigPluginProperties,
 } from '~/ui/components/ConfigSection';
+import { CODE } from '~/ui/components/Text';
 
 `expo-file-system` provides access to files and directories stored on a device or bundled as assets into the native project. It also allows downloading files from the network.
 
@@ -61,7 +61,7 @@ You can configure `expo-file-system` using its built-in [config plugin](/config-
       name: 'enableFileSharing',
       platform: 'ios',
       description:
-        "A boolean to enable `UIFileSharingEnabled` in **Info.plist**. This enables file sharing in the iOS Files app, making the app's Documents folder accessible to users through the Files app, iTunes File Sharing, and other file management tools.",
+        "A boolean to enable `UIFileSharingEnabled` in **Info.plist**. This enables file sharing in the iOS Files app, making the app's Documents directory accessible to users through the Files app, iTunes File Sharing, and other file management tools.",
       default: 'false',
     },
   ]}

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -79,6 +79,7 @@ _This version does not introduce any user-facing changes._
 
 - Add `rename` method for files and directories ([#39138](https://github.com/expo/expo/pull/39138) by [@kosmydel](https://github.com/kosmydel))
 - Add `idempotent` option for creating directories ([#39121](https://github.com/expo/expo/pull/39121) by [@kosmydel](https://github.com/kosmydel))
+- [iOS] Add file sharing config options ([#39286](https://github.com/expo/expo/pull/39286) by [@kosmydel](https://github.com/kosmydel))
 
 ## 19.0.6 — 2025-08-26
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### 🎉 New features
 
 - Add write options for base64 encoded bytes. ([#39963](https://github.com/expo/expo/pull/39963) by [@aleqsio](https://github.com/aleqsio))
+- [iOS] Add file sharing config options ([#39286](https://github.com/expo/expo/pull/39286) by [@kosmydel](https://github.com/kosmydel))
 
 ### 🐛 Bug fixes
 
@@ -79,7 +80,6 @@ _This version does not introduce any user-facing changes._
 
 - Add `rename` method for files and directories ([#39138](https://github.com/expo/expo/pull/39138) by [@kosmydel](https://github.com/kosmydel))
 - Add `idempotent` option for creating directories ([#39121](https://github.com/expo/expo/pull/39121) by [@kosmydel](https://github.com/kosmydel))
-- [iOS] Add file sharing config options ([#39286](https://github.com/expo/expo/pull/39286) by [@kosmydel](https://github.com/kosmydel))
 
 ## 19.0.6 — 2025-08-26
 

--- a/packages/expo-file-system/plugin/build/withFileSystem.d.ts
+++ b/packages/expo-file-system/plugin/build/withFileSystem.d.ts
@@ -1,3 +1,7 @@
 import { ConfigPlugin } from 'expo/config-plugins';
-declare const _default: ConfigPlugin<void>;
+type FileSystemProps = {
+    supportsOpeningDocumentsInPlace?: boolean;
+    enableFileSharing?: boolean;
+};
+declare const _default: ConfigPlugin<FileSystemProps>;
 export default _default;

--- a/packages/expo-file-system/plugin/build/withFileSystem.js
+++ b/packages/expo-file-system/plugin/build/withFileSystem.js
@@ -2,11 +2,23 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const config_plugins_1 = require("expo/config-plugins");
 const pkg = require('expo-file-system/package.json');
-const withFileSystem = (config) => {
-    return config_plugins_1.AndroidConfig.Permissions.withPermissions(config, [
+const withFileSystem = (config, options = {}) => {
+    const { supportsOpeningDocumentsInPlace = false, enableFileSharing = false } = options;
+    // Apply Android permissions
+    config = config_plugins_1.AndroidConfig.Permissions.withPermissions(config, [
         'android.permission.READ_EXTERNAL_STORAGE',
         'android.permission.WRITE_EXTERNAL_STORAGE',
         'android.permission.INTERNET',
     ]);
+    // Apply iOS modifications
+    return (0, config_plugins_1.withInfoPlist)(config, (config) => {
+        if (supportsOpeningDocumentsInPlace) {
+            config.modResults.LSSupportsOpeningDocumentsInPlace = true;
+        }
+        if (enableFileSharing) {
+            config.modResults.UIFileSharingEnabled = true;
+        }
+        return config;
+    });
 };
 exports.default = (0, config_plugins_1.createRunOncePlugin)(withFileSystem, pkg.name, pkg.version);

--- a/packages/expo-file-system/plugin/build/withFileSystem.js
+++ b/packages/expo-file-system/plugin/build/withFileSystem.js
@@ -3,7 +3,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const config_plugins_1 = require("expo/config-plugins");
 const pkg = require('expo-file-system/package.json');
 const withFileSystem = (config, options = {}) => {
-    const { supportsOpeningDocumentsInPlace = false, enableFileSharing = false } = options;
     // Apply Android permissions
     config = config_plugins_1.AndroidConfig.Permissions.withPermissions(config, [
         'android.permission.READ_EXTERNAL_STORAGE',
@@ -12,11 +11,11 @@ const withFileSystem = (config, options = {}) => {
     ]);
     // Apply iOS modifications
     return (0, config_plugins_1.withInfoPlist)(config, (config) => {
-        if (supportsOpeningDocumentsInPlace) {
-            config.modResults.LSSupportsOpeningDocumentsInPlace = true;
+        if ('supportsOpeningDocumentsInPlace' in options) {
+            config.modResults.LSSupportsOpeningDocumentsInPlace = options.supportsOpeningDocumentsInPlace;
         }
-        if (enableFileSharing) {
-            config.modResults.UIFileSharingEnabled = true;
+        if ('enableFileSharing' in options) {
+            config.modResults.UIFileSharingEnabled = options.enableFileSharing;
         }
         return config;
     });

--- a/packages/expo-file-system/plugin/src/withFileSystem.ts
+++ b/packages/expo-file-system/plugin/src/withFileSystem.ts
@@ -13,8 +13,6 @@ type FileSystemProps = {
 };
 
 const withFileSystem: ConfigPlugin<FileSystemProps> = (config, options = {}) => {
-  const { supportsOpeningDocumentsInPlace = false, enableFileSharing = false } = options;
-
   // Apply Android permissions
   config = AndroidConfig.Permissions.withPermissions(config, [
     'android.permission.READ_EXTERNAL_STORAGE',
@@ -24,11 +22,11 @@ const withFileSystem: ConfigPlugin<FileSystemProps> = (config, options = {}) => 
 
   // Apply iOS modifications
   return withInfoPlist(config, (config) => {
-    if (supportsOpeningDocumentsInPlace) {
-      config.modResults.LSSupportsOpeningDocumentsInPlace = true;
+    if ('supportsOpeningDocumentsInPlace' in options) {
+      config.modResults.LSSupportsOpeningDocumentsInPlace = options.supportsOpeningDocumentsInPlace;
     }
-    if (enableFileSharing) {
-      config.modResults.UIFileSharingEnabled = true;
+    if ('enableFileSharing' in options) {
+      config.modResults.UIFileSharingEnabled = options.enableFileSharing;
     }
     return config;
   });

--- a/packages/expo-file-system/plugin/src/withFileSystem.ts
+++ b/packages/expo-file-system/plugin/src/withFileSystem.ts
@@ -1,13 +1,37 @@
-import { AndroidConfig, ConfigPlugin, createRunOncePlugin } from 'expo/config-plugins';
+import {
+  AndroidConfig,
+  ConfigPlugin,
+  createRunOncePlugin,
+  withInfoPlist,
+} from 'expo/config-plugins';
 
 const pkg = require('expo-file-system/package.json');
 
-const withFileSystem: ConfigPlugin = (config) => {
-  return AndroidConfig.Permissions.withPermissions(config, [
+type FileSystemProps = {
+  supportsOpeningDocumentsInPlace?: boolean;
+  enableFileSharing?: boolean;
+};
+
+const withFileSystem: ConfigPlugin<FileSystemProps> = (config, options = {}) => {
+  const { supportsOpeningDocumentsInPlace = false, enableFileSharing = false } = options;
+
+  // Apply Android permissions
+  config = AndroidConfig.Permissions.withPermissions(config, [
     'android.permission.READ_EXTERNAL_STORAGE',
     'android.permission.WRITE_EXTERNAL_STORAGE',
     'android.permission.INTERNET',
   ]);
+
+  // Apply iOS modifications
+  return withInfoPlist(config, (config) => {
+    if (supportsOpeningDocumentsInPlace) {
+      config.modResults.LSSupportsOpeningDocumentsInPlace = true;
+    }
+    if (enableFileSharing) {
+      config.modResults.UIFileSharingEnabled = true;
+    }
+    return config;
+  });
 };
 
 export default createRunOncePlugin(withFileSystem, pkg.name, pkg.version);


### PR DESCRIPTION
# Why

Reopening https://github.com/expo/expo/pull/39286 as a PR from this repo branch.
Also made it so the plugin correctly unsets values if they are set to false and doesn't touch config if undefined.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
