### PR TITLE
Update documentation links in expo-web-browser

### DIFF
--- a/packages/expo-web-browser/src/WebBrowser.ts
+++ b/packages/expo-web-browser/src/WebBrowser.ts
@@ -74,7 +74,7 @@ export async function getCustomTabsSupportingBrowsersAsync(): Promise<WebBrowser
 
 // @needsAudit
 /**
- * This method calls `warmUp` method on [CustomTabsClient](https://developer.android.com/reference/android/support/customtabs/CustomTabsClient.html#warmup(long))
+ * This method calls `warmUp` method on [CustomTabsClient](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsClient#warmup(long))
  * for specified package.
  *
  * @param browserPackage Package of browser to be warmed up. If not set, preferred browser will be warmed.
@@ -95,7 +95,7 @@ export async function warmUpAsync(browserPackage?: string): Promise<WebBrowserWa
 
 // @needsAudit
 /**
- * This method initiates (if needed) [CustomTabsSession](https://developer.android.com/reference/android/support/customtabs/CustomTabsSession.html#maylaunchurl)
+ * This method initiates (if needed) [CustomTabsSession](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsSession#mayLaunchUrl)
  * and calls its `mayLaunchUrl` method for browser specified by the package.
  *
  * @param url The url of page that is likely to be loaded first when opening browser.


### PR DESCRIPTION
# Why

Point links to the androidx documentation, used by expo, instead of the old deprecated documentation

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting) (no changelog)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
