### PR TITLE
[core][Android] Consume worklets library

### DIFF
--- a/packages/expo-modules-core/android/CMakeLists.txt
+++ b/packages/expo-modules-core/android/CMakeLists.txt
@@ -36,12 +36,12 @@ endmacro()
 add_library(CommonSettings INTERFACE)
 
 add_library(
-        ${PACKAGE_NAME}
-        SHARED
-        ${common_sources}
-        ${sources_android}
-        ${sources_android_types}
-        ${sources_android_javaclasses}
+  ${PACKAGE_NAME}
+  SHARED
+  ${common_sources}
+  ${sources_android}
+  ${sources_android_types}
+  ${sources_android_javaclasses}
 )
 
 target_precompile_headers(${PACKAGE_NAME} PRIVATE ${SRC_DIR}/main/cpp/ExpoHeader.pch)
@@ -99,24 +99,33 @@ get_target_property(INCLUDE_reactnativejni
 )
 
 target_include_directories(
-       ${PACKAGE_NAME}
-       PRIVATE
-       ${INCLUDE_reactnativejni}/react
+  ${PACKAGE_NAME}
+  PRIVATE
+  ${INCLUDE_reactnativejni}/react
 
-        # header only imports from turbomodule, e.g. CallInvokerHolder.h
-       "${REACT_NATIVE_DIR}/ReactAndroid/src/main/jni/react/turbomodule"
-       "${COMMON_DIR}"
-       "${SRC_DIR}/fabric"
+  # header only imports from turbomodule, e.g. CallInvokerHolder.h
+  "${REACT_NATIVE_DIR}/ReactAndroid/src/main/jni/react/turbomodule"
+  "${COMMON_DIR}"
+  "${SRC_DIR}/fabric"
 )
+
+if (REACT_NATIVE_WORKLETS_DIR)
+  target_include_directories(
+    ${PACKAGE_NAME}
+    PRIVATE
+    "${REACT_NATIVE_WORKLETS_DIR}/Common/cpp"
+    "${REACT_NATIVE_WORKLETS_DIR}/android/src/main/cpp"
+  )
+endif()
 
 # linking
 
 include("${REACT_NATIVE_DIR}/ReactAndroid/cmake-utils/folly-flags.cmake")
 
 target_compile_options(
-        ${PACKAGE_NAME}
-        PRIVATE
-        ${folly_FLAGS}
+  ${PACKAGE_NAME}
+  PRIVATE
+  ${folly_FLAGS}
 )
 
 target_link_libraries(
@@ -135,3 +144,19 @@ target_link_libraries(
   ${PACKAGE_NAME}
   ReactAndroid::reactnative
 )
+
+if (REACT_NATIVE_WORKLETS_DIR)
+  add_library(worklets SHARED IMPORTED)
+
+  set_target_properties(
+    worklets
+    PROPERTIES
+    IMPORTED_LOCATION
+    "${REACT_NATIVE_WORKLETS_DIR}/android/build/intermediates/cmake/${BUILD_TYPE}/obj/${ANDROID_ABI}/libworklets.so"
+  )
+
+  target_link_libraries(
+    ${PACKAGE_NAME}
+    worklets
+  )
+endif()

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -63,6 +63,14 @@ def isNewArchitectureEnabled = findProperty("newArchEnabled") == "true"
 
 def shouldTurnWarningsIntoErrors = findProperty("EXPO_TURN_WARNINGS_INTO_ERRORS") == "true"
 
+def enableWorkletsIntegration = findProperty("expo.core.worklets") == "true"
+if (enableWorkletsIntegration) {
+  evaluationDependsOn(":react-native-worklets")
+}
+
+def workletsProject = enableWorkletsIntegration ? findProject(":react-native-worklets") : null
+def reactNativeWorkletsRootDir = workletsProject?.projectDir?.parentFile
+
 expoModule {
   canBePublished false
 }
@@ -87,14 +95,22 @@ android {
 
     externalNativeBuild {
       cmake {
-        abiFilters(*reactNativeArchitectures())
-        arguments "-DANDROID_STL=c++_shared",
+        def cppArguments = [
+          "-DANDROID_STL=c++_shared",
           "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON",
           "-DREACT_NATIVE_DIR=${expoModuleExtension.reactNativeDir}",
           "-DREACT_NATIVE_TARGET_VERSION=${expoModuleExtension.reactNativeVersion.minor}",
           "-DUSE_HERMES=${USE_HERMES}",
           "-DIS_NEW_ARCHITECTURE_ENABLED=${isNewArchitectureEnabled}",
           "-DUNIT_TEST=${isExpoModulesCoreTests}"
+        ]
+
+        if (reactNativeWorkletsRootDir != null) {
+          cppArguments += "-DREACT_NATIVE_WORKLETS_DIR=${reactNativeWorkletsRootDir.absolutePath}"
+        }
+
+        abiFilters(*reactNativeArchitectures())
+        arguments(*cppArguments)
       }
     }
   }
@@ -286,4 +302,20 @@ def generatePCHTask = tasks.register("generatePCH") {
 // This task will run on the IDE project sync, ensuring the PCH file is generated early enough
 tasks.register("prepareKotlinBuildScriptModel") {
   dependsOn(generatePCHTask)
+}
+
+if (workletsProject != null) {
+  afterEvaluate {
+    tasks.named("externalNativeBuildDebug") { externalNativeBuildTask ->
+      workletsProject.tasks.named("externalNativeBuildDebug") { workletsExternalNativeBuildTask ->
+        externalNativeBuildTask.dependsOn(workletsExternalNativeBuildTask)
+      }
+    }
+
+    tasks.named("externalNativeBuildRelease") { externalNativeBuildTask ->
+      workletsProject.tasks.named("externalNativeBuildRelease") { workletsExternalNativeBuildTask ->
+        externalNativeBuildTask.dependsOn(workletsExternalNativeBuildTask)
+      }
+    }
+  }
 }

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -64,11 +64,16 @@ def isNewArchitectureEnabled = findProperty("newArchEnabled") == "true"
 def shouldTurnWarningsIntoErrors = findProperty("EXPO_TURN_WARNINGS_INTO_ERRORS") == "true"
 
 def enableWorkletsIntegration = findProperty("expo.core.worklets") == "true"
-if (enableWorkletsIntegration) {
+def workletsProject = enableWorkletsIntegration ? findProject(":react-native-worklets") : null
+
+if (enableWorkletsIntegration && workletsProject == null) {
+  throw new GradleException("The 'expo.core.worklets' property is set to true, but the ':react-native-worklets' project is not found.")
+}
+
+if (workletsProject != null) {
   evaluationDependsOn(":react-native-worklets")
 }
 
-def workletsProject = enableWorkletsIntegration ? findProject(":react-native-worklets") : null
 def reactNativeWorkletsRootDir = workletsProject?.projectDir?.parentFile
 
 expoModule {


### PR DESCRIPTION
# Why

Consumes the worklets library. 
Currently, it's hidden behind the `expo.core.worklets` flag.

# How

Add integration between `worklets` and `e-m-c` library. 

# Test Plan

- tested in `minimal-tester` ✅ 
