### PR TITLE
fix(expo-modules-core): fix RSC and add tests

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### 🐛 Bug fixes
 
-- [RSC] Fix server components asserting from missing native modules.
+- [RSC] Fix server components asserting from missing native modules. ([#40388](https://github.com/expo/expo/pull/40388) by [@EvanBacon](https://github.com/EvanBacon))
 - [iOS] Fix NSURL to JSIString conversion returning nil. ([#39567](https://github.com/expo/expo/pull/39567) by [@behenate](https://github.com/behenate))
 - Fix SharedObject created with `useReleasingSharedObject` getting destroyed after a fast refresh caused by a change in its dependencies. ([#39753](https://github.com/expo/expo/pull/39753) by [@behenate](https://github.com/behenate))
 - [Android] Restore `register` overload in `ModuleRegistry`. ([#40149](https://github.com/expo/expo/pull/40149) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- [RSC] Fix server components asserting from missing native modules.
 - [iOS] Fix NSURL to JSIString conversion returning nil. ([#39567](https://github.com/expo/expo/pull/39567) by [@behenate](https://github.com/behenate))
 - Fix SharedObject created with `useReleasingSharedObject` getting destroyed after a fast refresh caused by a change in its dependencies. ([#39753](https://github.com/expo/expo/pull/39753) by [@behenate](https://github.com/behenate))
 - [Android] Restore `register` overload in `ModuleRegistry`. ([#40149](https://github.com/expo/expo/pull/40149) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-modules-core/build/__rsc_tests__/index.test.d.ts
+++ b/packages/expo-modules-core/build/__rsc_tests__/index.test.d.ts
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=index.test.d.ts.map

--- a/packages/expo-modules-core/build/__rsc_tests__/index.test.d.ts.map
+++ b/packages/expo-modules-core/build/__rsc_tests__/index.test.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"index.test.d.ts","sourceRoot":"","sources":["../../src/__rsc_tests__/index.test.ts"],"names":[],"mappings":""}

--- a/packages/expo-modules-core/jest-rsc.config.js
+++ b/packages/expo-modules-core/jest-rsc.config.js
@@ -1,0 +1,1 @@
+module.exports = require('jest-expo/rsc/jest-preset');

--- a/packages/expo-modules-core/package.json
+++ b/packages/expo-modules-core/package.json
@@ -29,6 +29,7 @@
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "expo-module test",
+    "test:rsc": "jest --config jest-rsc.config.js",
     "prepare": "expo-module prepare",
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module"

--- a/packages/expo-modules-core/src/__rsc_tests__/index.test.ts
+++ b/packages/expo-modules-core/src/__rsc_tests__/index.test.ts
@@ -4,11 +4,14 @@
 // Other tests like expo-linking will accidentally break and CI won't catch it otherwise.
 
 const originalError = console.error;
+const originalWarn = console.warn;
 beforeAll(() => {
   console.error = jest.fn(originalError);
+  console.warn = jest.fn(originalWarn);
 });
 afterAll(() => {
   console.error = originalError;
+  console.warn = originalWarn;
 });
 
 it('has platform defined', () => {
@@ -16,4 +19,5 @@ it('has platform defined', () => {
   expect(Platform.OS).toBeDefined();
 
   expect(console.error).not.toHaveBeenCalled();
+  expect(console.warn).not.toHaveBeenCalled();
 });

--- a/packages/expo-modules-core/src/__rsc_tests__/index.test.ts
+++ b/packages/expo-modules-core/src/__rsc_tests__/index.test.ts
@@ -1,0 +1,19 @@
+// This test primarily ensures that the native code is correctly defined as optional when
+// evaluating server code with a native platform target.
+//
+// Other tests like expo-linking will accidentally break and CI won't catch it otherwise.
+
+const originalError = console.error;
+beforeAll(() => {
+  console.error = jest.fn(originalError);
+});
+afterAll(() => {
+  console.error = originalError;
+});
+
+it('has platform defined', () => {
+  const { Platform } = require('expo-modules-core');
+  expect(Platform.OS).toBeDefined();
+
+  expect(console.error).not.toHaveBeenCalled();
+});

--- a/packages/expo-modules-core/src/ensureNativeModulesAreInstalled.native.ts
+++ b/packages/expo-modules-core/src/ensureNativeModulesAreInstalled.native.ts
@@ -5,7 +5,7 @@ import { TurboModuleRegistry } from 'react-native';
  * Otherwise, it synchronously calls a native function that installs them.
  */
 export function ensureNativeModulesAreInstalled(): void {
-  if (globalThis.expo) {
+  if (globalThis.expo || typeof window === 'undefined') {
     return;
   }
 

--- a/packages/expo-modules-core/src/sweet/setUpJsLogger.fx.ts
+++ b/packages/expo-modules-core/src/sweet/setUpJsLogger.fx.ts
@@ -1,50 +1,56 @@
-import NativeJSLogger from './NativeJSLogger';
-import Platform from '../Platform';
 import { CodedError } from '../errors/CodedError';
+import { requireOptionalNativeModule } from '../requireNativeModule';
 
 type LogListener = {
   action: (...data: any[]) => void;
   eventName: string;
 };
 
-if (__DEV__ && (Platform.OS === 'android' || Platform.OS === 'ios') && NativeJSLogger) {
-  const onNewException: LogListener = {
-    eventName: 'ExpoModulesCoreJSLogger.onNewError',
-    action: console.error,
-  };
+if (
+  __DEV__ &&
+  typeof window !== 'undefined' &&
+  (process.env.EXPO_OS === 'android' || process.env.EXPO_OS === 'ios')
+) {
+  const NativeJSLogger = requireOptionalNativeModule('ExpoModulesCoreJSLogger');
+  if (NativeJSLogger) {
+    const onNewException: LogListener = {
+      eventName: 'ExpoModulesCoreJSLogger.onNewError',
+      action: console.error,
+    };
 
-  const onNewWarning: LogListener = {
-    eventName: 'ExpoModulesCoreJSLogger.onNewWarning',
-    action: console.warn,
-  };
+    const onNewWarning: LogListener = {
+      eventName: 'ExpoModulesCoreJSLogger.onNewWarning',
+      action: console.warn,
+    };
 
-  const onNewDebug: LogListener = {
-    eventName: 'ExpoModulesCoreJSLogger.onNewDebug',
-    action: console.debug,
-  };
+    const onNewDebug: LogListener = {
+      eventName: 'ExpoModulesCoreJSLogger.onNewDebug',
+      action: console.debug,
+    };
 
-  const onNewInfo: LogListener = {
-    eventName: 'ExpoModulesCoreJSLogger.onNewInfo',
-    action: console.info,
-  };
+    const onNewInfo: LogListener = {
+      eventName: 'ExpoModulesCoreJSLogger.onNewInfo',
+      action: console.info,
+    };
 
-  const onNewTrace: LogListener = {
-    eventName: 'ExpoModulesCoreJSLogger.onNewTrace',
-    action: console.trace,
-  };
+    const onNewTrace: LogListener = {
+      eventName: 'ExpoModulesCoreJSLogger.onNewTrace',
+      action: console.trace,
+    };
 
-  const listeners: LogListener[] = [
-    onNewException,
-    onNewWarning,
-    onNewDebug,
-    onNewInfo,
-    onNewTrace,
-  ];
+    const listeners: LogListener[] = [
+      onNewException,
+      onNewWarning,
+      onNewDebug,
+      onNewInfo,
+      onNewTrace,
+    ];
 
-  for (const listener of listeners) {
-    NativeJSLogger.addListener(listener.eventName, ({ message }: { message: string }) => {
-      listener.action(message);
-    });
+    for (const listener of listeners) {
+      NativeJSLogger.addListener(listener.eventName, ({ message }: { message: string }) => {
+        listener.action(message);
+      });
+    }
   }
 }
 


### PR DESCRIPTION
# Why

- The RSC code paths are special because they run native code in server mode (e.g. `typeof window === 'undefined'`). When we add new code to core, it's easy to create subtle issues where we create a module that's only available in native clients but not native servers. 
- These issues are subtle but can add up, and only get caught in the tests of other packages such as expo-linking. So this PR adds a basic and fast test to check if any warnings or errors are logged when importing expo modules core in a native server environment.
- fix regression from https://github.com/expo/expo/pull/39726

# Test Plan

- Add `yarn test:rsc` which should run in check-packages to ensure any changes to core will not break RSC for native.
