### PR TITLE
[docs] Added information about the --no-ssg flag

### DIFF
--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -283,7 +283,7 @@ The following options are provided:
 - `-c, --clear`: Clear the bundler cache before exporting.
 - `--no-minify`: Skip minifying JavaScript and CSS assets.
 - `--no-bytecode`: Skip generating Hermes bytecode for native platforms. Only use this for analyzing bundle sizes and never ship UTF-8 bundles to native platforms as this will lead to drastically longer startup times.
-- `--no-ssg`: Skip exporting static HTML files for web routes
+- `--no-ssg`: Skip exporting static HTML files for web routes. This option only generates server code inside the **dist** directory. Useful for [API routes](/router/reference/api-routes).
 
 #### Hosting with sub-paths
 

--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -283,6 +283,7 @@ The following options are provided:
 - `-c, --clear`: Clear the bundler cache before exporting.
 - `--no-minify`: Skip minifying JavaScript and CSS assets.
 - `--no-bytecode`: Skip generating Hermes bytecode for native platforms. Only use this for analyzing bundle sizes and never ship UTF-8 bundles to native platforms as this will lead to drastically longer startup times.
+- `--no-ssg`: Skip exporting static HTML files for web routes
 
 #### Hosting with sub-paths
 

--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -220,6 +220,8 @@ Route handlers are executed in a sandboxed environment that is isolated from the
 When you're ready to deploy to production, run [`npx expo export --platform web`](/more/expo-cli#exporting) to create the server bundle in the **dist** directory. This server can be tested locally with `npx expo serve` (available in Expo SDK 52 and later), visit the URL in a web browser or create a native build with the `origin` set to the local server URL.
 You can deploy the server for production using [EAS Hosting](/eas/hosting/get-started) or another third-party service.
 
+If you don't want a website version of your app and only want to export your API Routes, you can set the `--no-ssg` flag when running `npx expo export --platform web`. This will generate a dist folder containing only your server code.
+
 <BoxLink
   title="Deploy instantly with EAS"
   description="EAS Hosting is the best way to deploy your Expo API routes and servers."

--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -220,7 +220,9 @@ Route handlers are executed in a sandboxed environment that is isolated from the
 When you're ready to deploy to production, run [`npx expo export --platform web`](/more/expo-cli#exporting) to create the server bundle in the **dist** directory. This server can be tested locally with `npx expo serve` (available in Expo SDK 52 and later), visit the URL in a web browser or create a native build with the `origin` set to the local server URL.
 You can deploy the server for production using [EAS Hosting](/eas/hosting/get-started) or another third-party service.
 
-If you don't want a website version of your app and only want to export your API Routes, you can set the `--no-ssg` flag when running `npx expo export --platform web`. This will generate a dist folder containing only your server code.
+If you want to export API routes and skip generating a website version of your app, you can use the following command, which will generate a **dist** directory containing only the server code of your project.
+
+<Terminal cmd={['$ npx expo export --platform web --no-ssg']} />
 
 <BoxLink
   title="Deploy instantly with EAS"

--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -217,7 +217,11 @@ Route handlers are executed in a sandboxed environment that is isolated from the
 
 ## Deployment
 
-When you're ready to deploy to production, run [`npx expo export --platform web`](/more/expo-cli#exporting) to create the server bundle in the **dist** directory. This server can be tested locally with `npx expo serve` (available in Expo SDK 52 and later), visit the URL in a web browser or create a native build with the `origin` set to the local server URL.
+When you're ready to deploy to production, run the following command to create the server bundle in the **dist** directory (see the [Expo CLI documentation](/more/expo-cli#exporting) for more details):
+
+<Terminal cmd={['$ npx expo export --platform web']} />
+
+This server can be tested locally with `npx expo serve` (available in Expo SDK 52 and later), visit the URL in a web browser or create a native build with the `origin` set to the local server URL.
 You can deploy the server for production using [EAS Hosting](/eas/hosting/get-started) or another third-party service.
 
 If you want to export API routes and skip generating a website version of your app, you can use the following command, which will generate a **dist** directory containing only the server code of your project.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The other day I was asked how to export and deploy only the API Routes without generating a full website version of the app. I realized this isn't currently mentioned in the docs, so this update aims to add clarification for that case.

# How

<!--
How did you build this feature or fix this bug and why?
-->

### API Routes
Added short text about `--no-ssg` flag to: https://docs.expo.dev/router/reference/api-routes/#deployment

<img width="1171" height="225" alt="image" src="https://github.com/user-attachments/assets/132e63a7-96c3-42de-8a2b-833d96824a1b" />

### expo-cli/#exporting

Also updated the reference to https://docs.expo.dev/more/expo-cli/#exporting from API Routes docs to include a reference to `--no-ssg`.
<img width="1156" height="406" alt="image" src="https://github.com/user-attachments/assets/98b49d71-6dde-4aaa-bd9f-4f6ebbc34ad7" />


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
