### PR TITLE
[go][Android] Fix flavor configuration

### DIFF
--- a/apps/expo-go/android/expoview/build.gradle
+++ b/apps/expo-go/android/expoview/build.gradle
@@ -12,10 +12,10 @@ buildscript {
 }
 
 plugins {
-   alias libs.plugins.android.library
-   alias libs.plugins.kotlin.android
-   alias libs.plugins.download
-   id("org.jetbrains.kotlin.plugin.compose") version "2.0.0"
+  alias libs.plugins.android.library
+  alias libs.plugins.kotlin.android
+  alias libs.plugins.download
+  id("org.jetbrains.kotlin.plugin.compose") version "2.0.0"
 }
 apply plugin: 'kotlin-kapt'
 apply from: new File(rootDir, "versioning_linking.gradle")
@@ -69,6 +69,12 @@ android {
     ndkVersion rootProject.ext.ndkVersion
   }
 
+  flavorDimensions += "device"
+  productFlavors {
+    quest { dimension "device" }
+    mobile { dimension "device" }
+  }
+
   buildFeatures {
     viewBinding true
     compose true
@@ -84,7 +90,7 @@ android {
 
     // WHEN_VERSIONING_REMOVE_FROM_HERE
     manifestPlaceholders = [
-        'appAuthRedirectScheme': 'host.exp.exponent'
+      'appAuthRedirectScheme': 'host.exp.exponent'
     ]
 
     buildConfigField("boolean", "IS_INTERNAL_BUILD", "false")
@@ -154,7 +160,7 @@ dependencies {
   api project(':packages:react-native:ReactAndroid')
 
   implementation(project(':packages:react-native:ReactAndroid:hermes-engine')) {
-    exclude(group:'com.facebook.fbjni', module: 'fbjni')
+    exclude(group: 'com.facebook.fbjni', module: 'fbjni')
   }
 
   // Expo modules

--- a/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
+++ b/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
@@ -80,6 +80,10 @@ ext.useExpoPublishing = {
     apply plugin: 'maven-publish'
   }
 
+  if (components.findByName("release") == null) {
+    return
+  }
+
   project.android {
     publishing {
       singleVariant("release") {


### PR DESCRIPTION
# Why

Fixes:
<img width="2024" height="940" alt="image" src="https://github.com/user-attachments/assets/441ca955-ae00-45f4-afd1-97a10ae9ef54" />


# How

Fixes the misconfiguration of flavors in Expo Go. We want to depend on the expo package inside the ExpoView. However, the expoview subproject doesn't follow the same configuration as the main application - it doesn't have flavors configured. To ensure that information about the current flavor is passed down to all expo modules, we need to replicate this configuration.

# Test Plan

- expo go ✅ 