### PR TITLE
test(cli): Fix bun isolated monorepo E2E tests and `moduleMapper.test.ts`

### DIFF
--- a/packages/@expo/cli/e2e/__tests__/customize-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/customize-test.ts
@@ -89,7 +89,6 @@ it('runs `npx expo customize tsconfig.json`', async () => {
     'with-router',
     {
       reuseExisting: false,
-      sdkVersion: '52.0.0',
     }
   );
 
@@ -110,7 +109,6 @@ it('runs `npx expo customize tsconfig.json` on a partially setup project', async
     'with-router',
     {
       reuseExisting: false,
-      sdkVersion: '52.0.0',
     }
   );
 

--- a/packages/@expo/cli/e2e/__tests__/install-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/install-test.ts
@@ -235,7 +235,6 @@ describe('expo-router integration', () => {
       'with-router',
       {
         reuseExisting: false,
-        sdkVersion: '52.0.0',
         linkExpoPackages: ['expo-router'],
       }
     );

--- a/packages/@expo/cli/e2e/__tests__/utils.ts
+++ b/packages/@expo/cli/e2e/__tests__/utils.ts
@@ -189,11 +189,9 @@ export async function setupTestProjectWithOptionsAsync(
   fixtureName: string,
   {
     reuseExisting = testingLocally,
-    sdkVersion = '52.0.0',
     linkExpoPackages,
     linkExpoPackagesDev,
   }: {
-    sdkVersion?: string;
     reuseExisting?: boolean;
     linkExpoPackages?: string[];
     linkExpoPackagesDev?: string[];
@@ -207,15 +205,6 @@ export async function setupTestProjectWithOptionsAsync(
     linkExpoPackages,
     linkExpoPackagesDev,
   });
-
-  // Many of the factors in this test are based on the expected SDK version that we're testing against.
-  const { exp } = getConfig(projectRoot, { skipPlugins: true });
-  if (!linkExpoPackages?.includes('expo')) {
-    assert(
-      exp.sdkVersion === sdkVersion,
-      `Expected exp.sdkVersion to be ${sdkVersion}, but it is set to ${exp.sdkVersion} for ${projectRoot} project.`
-    );
-  }
   return projectRoot;
 }
 

--- a/packages/@expo/metro-config/src/transform-worker/utils/__tests__/moduleMapper.test.ts
+++ b/packages/@expo/metro-config/src/transform-worker/utils/__tests__/moduleMapper.test.ts
@@ -5,7 +5,13 @@ describe(createModuleMapper, () => {
     const moduleMapper = createModuleMapper();
 
     expect(moduleMapper('@expo/metro-config')).toBe(require.resolve('@expo/metro-config'));
-    expect(moduleMapper('metro')).toBe(require.resolve('metro'));
+
+    expect(moduleMapper('metro')).toBe(
+      require.resolve('metro', {
+        paths: [require.resolve('@expo/metro/package.json')],
+      })
+    );
+
     // Leaves unrelated modules alone
     expect(moduleMapper('@expo/cli')).toBe(null);
   });


### PR DESCRIPTION
Bun switched to 1.3, which defaults to isolated installations which then fails our monorepo install tests. Basing a removal of the affected `getConfig` onto #40386 should fix the remaining E2E issue.