### PR TITLE
Fix NPE in updateOrScheduleJob in task manager

### DIFF
--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 14.0.8 - 2025-10-15
+
+- [Android] Fix NPE in updateOrScheduleJob in task manager ([#40396](https://github.com/expo/expo/pull/40396) by [@SamuelBrucksch](https://github.com/SamuelBrucksch))
+
 ## 14.0.7 — 2025-09-11
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
@@ -124,7 +124,7 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
 
     List<JobInfo> pendingJobs = jobScheduler.getAllPendingJobs();
     if (pendingJobs == null) {
-      // There is a mismatch between documentation and implementation. In the reference implementation they return null in case of RemoteException:
+      // There is a mismatch between documentation and implementation. In the reference implementation null is returned in case of RemoteException:
       // https://android.googlesource.com/platform//frameworks/base/+/980636f0a5440a12f5d8896d8738c6fcf2430553/apex/jobscheduler/framework/java/android/app/JobSchedulerImpl.java#137
       pendingJobs = new ArrayList<>();
     }

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
@@ -124,7 +124,8 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
 
     List<JobInfo> pendingJobs = jobScheduler.getAllPendingJobs();
     if (pendingJobs == null) {
-      // In some cases, pendingJobs can be null. Collections.sort will crash, if it is not set to an empty list here.
+      // There is a mismatch between documentation and implementation. In the reference implementation they return null in case of RemoteException:
+      // https://android.googlesource.com/platform//frameworks/base/+/980636f0a5440a12f5d8896d8738c6fcf2430553/apex/jobscheduler/framework/java/android/app/JobSchedulerImpl.java#137
       pendingJobs = new ArrayList<>();
     }
 

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
@@ -123,6 +123,10 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
     }
 
     List<JobInfo> pendingJobs = jobScheduler.getAllPendingJobs();
+    if (pendingJobs == null) {
+      // In some cases, pendingJobs can be null. Collections.sort will crash, if it is not set to an empty list here.
+      pendingJobs = new ArrayList<>();
+    }
 
     Collections.sort(pendingJobs, new Comparator<JobInfo>() {
       @Override


### PR DESCRIPTION
# Why

We often saw logs on sentry like
```
java.lang.RuntimeException: Unable to start receiver expo.modules.taskManager.TaskBroadcastReceiver: java.lang.NullPointerException: Attempt to invoke interface method 'void java.util.List.sort(java.util.Comparator)' on a null object reference
    at android.app.ActivityThread.handleReceiver(ActivityThread.java:5672)
    at android.app.ActivityThread.-$$Nest$mhandleReceiver
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2904)
    at android.os.Handler.dispatchMessage(Handler.java:110)
    at android.os.Looper.loopOnce(Looper.java:273)
    at android.os.Looper.loop(Looper.java:363)
    at android.app.ActivityThread.main(ActivityThread.java:10060)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:632)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:975)
java.lang.NullPointerException: Attempt to invoke interface method 'void java.util.List.sort(java.util.Comparator)' on a null object reference
    at java.util.Collections.sort(Collections.java:207)
    at expo.modules.taskManager.TaskManagerUtils.updateOrScheduleJob(TaskManagerUtils.java:127)
    at expo.modules.taskManager.TaskManagerUtils.scheduleJob(TaskManagerUtils.java:66)
    at expo.modules.location.taskConsumers.LocationTaskConsumer.maybeReportDeferredLocations(LocationTaskConsumer.kt:266)
    at expo.modules.location.taskConsumers.LocationTaskConsumer.didReceiveBroadcast(LocationTaskConsumer.kt:87)
    at expo.modules.taskManager.TaskService.handleIntent(TaskService.java:315)
    at expo.modules.taskManager.TaskBroadcastReceiver.onReceive(TaskBroadcastReceiver.java:15)
    at android.app.ActivityThread.handleReceiver(ActivityThread.java:5663)
    at android.app.ActivityThread.-$$Nest$mhandleReceiver
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2904)
    at android.os.Handler.dispatchMessage(Handler.java:110)
    at android.os.Looper.loopOnce(Looper.java:273)
    at android.os.Looper.loop(Looper.java:363)
    at android.app.ActivityThread.main(ActivityThread.java:10060)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:632)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:975) 
```

According to the open source android project, getAllPendingJobs can indeed be null:
https://android.googlesource.com/platform//frameworks/base/+/980636f0a5440a12f5d8896d8738c6fcf2430553/apex/jobscheduler/framework/java/android/app/JobSchedulerImpl.java#137

This however happens in case of RemoteException. So everything migth be broken anyways. I think it still makes sense to try it, as in the code below we catch failed job scheduling anyways, if there is a bigge rproblem with the curren tjob scheduler.
