### PR TITLE
fix(expo-file-system): Correct TypeScript definition for File.write to return Promise<void>

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix recursive file deletion. ([#40248](https://github.com/expo/expo/pull/40248) by [@aleqsio](https://github.com/aleqsio))
+- fix(expo-file-system): Correct TypeScript definition for File.write to return Promise<void> ([#40400](https://github.com/expo/expo/pull/40400) by [@nihar777](https://github.com/nihar777))
+
 
 ### 💡 Others
 
@@ -22,6 +24,7 @@
 
 - Fix typedoc in the File class. ([#40064](https://github.com/expo/expo/pull/40064) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Fix getContentUri. ([#40001](https://github.com/expo/expo/pull/40001) by [@aleqsio](https://github.com/aleqsio))
+
 
 ## 19.0.15 - 2025-09-22
 

--- a/packages/expo-file-system/src/ExpoFileSystem.types.ts
+++ b/packages/expo-file-system/src/ExpoFileSystem.types.ts
@@ -231,7 +231,7 @@ export declare class File {
    * Writes content to the file.
    * @param content The content to write into the file.
    */
-  write(content: string | Uint8Array, options?: FileWriteOptions): void;
+  write(content: string | Uint8Array, options?: FileWriteOptions): Promise<void>;
 
   /**
    * Deletes a file.


### PR DESCRIPTION
**Fixes #40285**

### Summary

This Pull Request updates the TypeScript definition for the `File.write` method within `expo-file-system` to accurately reflect its asynchronous nature by changing its return type from `void` to `Promise<void>`. This resolves the type-checking error reported in the linked issue.

### Test Plan

Confirmed fix by running `yarn workspace expo-file-system tsc --noEmit` locally, which passed successfully, verifying type consistency within the package.