### PR TITLE
[docs] expo-router example with VectorIcon usage

### DIFF
--- a/docs/pages/router/advanced/native-tabs.mdx
+++ b/docs/pages/router/advanced/native-tabs.mdx
@@ -426,7 +426,7 @@ export default function TabLayout() {
         <Label>Home</Label>
         {Platform.select({
           ios: <Icon sf="house.fill" />,
-          android: <Icon src={<VectorIcon family={MIcons} name="home" />} />,
+          android: <Icon src={<VectorIcon family={MaterialIcons} name="home" />} />,
         })}
       </NativeTabs.Trigger>
     </NativeTabs>


### PR DESCRIPTION
# Why

# How

Pass correct family name for better copy

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
