### PR TITLE
[ui][ios] Merge edge and axis paddings correctly in PaddingModifier

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 - [iOS] Add `buttonStyle` modifier. ([#40119](https://github.com/expo/expo/pull/40119) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] remove empty section header spacing when no title provided ([#40296](https://github.com/expo/expo/pull/40296) by [@dylancom](https://github.com/dylancom))
+- [iOS] Merge edge and axis paddings correctly in PaddingModifier ([#40414](https://github.com/expo/expo/pull/40414) by [@lucabc2000](https://github.com/lucabc2000))
 
 ### 💡 Others
 

--- a/packages/expo-ui/ios/Modifiers/ViewModifierRegistry.swift
+++ b/packages/expo-ui/ios/Modifiers/ViewModifierRegistry.swift
@@ -105,17 +105,19 @@ internal struct PaddingModifier: ViewModifier, Record {
   @Field var trailing: CGFloat?
 
   func body(content: Content) -> some View {
-    if let all {
-      content.padding(all)
-    } else if let horizontal, let vertical {
-      content.padding(EdgeInsets(top: vertical, leading: horizontal, bottom: vertical, trailing: horizontal))
-    } else if let horizontal {
-      content.padding(EdgeInsets(top: 0, leading: horizontal, bottom: 0, trailing: horizontal))
-    } else if let vertical {
-      content.padding(EdgeInsets(top: vertical, leading: 0, bottom: vertical, trailing: 0))
-    } else {
-      content.padding(EdgeInsets(top: top ?? 0, leading: leading ?? 0, bottom: bottom ?? 0, trailing: trailing ?? 0))
-    }
+    let topValue = top ?? vertical ?? all ?? 0
+    let bottomValue = bottom ?? vertical ?? all ?? 0
+    let leadingValue = leading ?? horizontal ?? all ?? 0
+    let trailingValue = trailing ?? horizontal ?? all ?? 0
+
+    content.padding(
+      EdgeInsets(
+        top: topValue,
+        leading: leadingValue,
+        bottom: bottomValue,
+        trailing: trailingValue
+      )
+    )
   }
 }
 


### PR DESCRIPTION
# Why

The previous implementation of PaddingModifier applied padding using mutually exclusive conditions (all, then horizontal/vertical, then individual edges).
This caused explicit edge paddings (top, leading, bottom, trailing) to be ignored whenever an axis-level value (vertical or horizontal) was also set.

As a result, developers couldn’t combine, for example, vertical and leading padding in the same modifier — the leading value would be reset to 0.

This PR fixes that by merging all padding values consistently, ensuring explicit sides always take priority.

# How

Refactored PaddingModifier to compute padding insets by merging all possible inputs.

# Test Plan

```
VStack
  modifiers={[padding({ vertical: 20, leading: 24, trailing: 24 })]}
>
  {/* Verify leading and trailing paddings are correctly applied */}
</VStack>
```

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
