### PR TITLE
chore(config-types): mark `experiments.reactCanary` as deprecated in TypeScript types

### DIFF
--- a/packages/@expo/config-types/build/ExpoConfig.d.ts
+++ b/packages/@expo/config-types/build/ExpoConfig.d.ts
@@ -301,6 +301,7 @@ export interface ExpoConfig {
         turboModules?: boolean;
         /**
          * Experimentally use a vendored canary build of React for testing upcoming features.
+         * @deprecated React 19 is enabled by default. Remove unused experiments.reactCanary flag.
          */
         reactCanary?: boolean;
         /**

--- a/packages/@expo/config-types/src/ExpoConfig.ts
+++ b/packages/@expo/config-types/src/ExpoConfig.ts
@@ -309,6 +309,7 @@ export interface ExpoConfig {
     turboModules?: boolean;
     /**
      * Experimentally use a vendored canary build of React for testing upcoming features.
+     * @deprecated React 19 is enabled by default. Remove unused experiments.reactCanary flag.
      */
     reactCanary?: boolean;
     /**


### PR DESCRIPTION
# Why

Follow-up of https://github.com/expo/expo/pull/40386

# How

Marked `experiments.reactCanary` as deprecated in `@expo/config-types`.

# Test Plan

Doc change only.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
