### PR TITLE
[core][iOS] Make `ConstantDefinition` a sendable struct

### DIFF
--- a/packages/expo-modules-core/ios/Api/Factories/ConstantFactories.swift
+++ b/packages/expo-modules-core/ios/Api/Factories/ConstantFactories.swift
@@ -1,13 +1,9 @@
 /**
- Creates the read-only constant with the given name. The definition is no-op if you don't call `.get(_:)` on it.
- */
-public func Constant<Value: AnyArgument>(_ name: String) -> ConstantDefinition<Value> {
-  return ConstantDefinition(name: name)
-}
-
-/**
  Creates the read-only constant whose getter doesn't take the owner as an argument.
  */
-public func Constant<Value: AnyArgument>(_ name: String, @_implicitSelfCapture get: @escaping () -> Value) -> ConstantDefinition<Value> {
+public func Constant<Value: AnyArgument>(
+  _ name: String,
+  @_implicitSelfCapture _ get: @Sendable @escaping () -> Value
+) -> ConstantDefinition<Value> {
   return ConstantDefinition(name: name, getter: get)
 }

--- a/packages/expo-modules-core/ios/Core/Objects/ConstantDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Objects/ConstantDefinition.swift
@@ -12,8 +12,8 @@ protocol AnyConstantDefinition {
   func buildDescriptor(appContext: AppContext) throws -> JavaScriptObject
 }
 
-public final class ConstantDefinition<ReturnType>: AnyDefinition, AnyConstantDefinition {
-  typealias ClosureType = () throws -> ReturnType
+public struct ConstantDefinition<ReturnType>: AnyDefinition, AnyConstantDefinition, Sendable {
+  typealias ClosureType = @Sendable () throws -> ReturnType
 
   /**
    Name of the constant.
@@ -23,40 +23,20 @@ public final class ConstantDefinition<ReturnType>: AnyDefinition, AnyConstantDef
   /**
    Synchronous function that is called when the property is being accessed.
    */
-  var getter: ClosureType?
-
-  /**
-   Initializes an unowned ConstantDefinition without a getter function.
-   */
-  init(name: String) {
-    self.name = name
-  }
+  let getter: ClosureType
 
   /**
    Initializes an unowned ConstantDefinition with a getter without arguments.
    */
-  init(name: String, getter: @escaping () -> ReturnType) {
+  init(name: String, getter: @Sendable @escaping () -> ReturnType) {
     self.name = name
-
-    // Set the getter right away
-    self.get(getter)
-  }
-
-  // MARK: - Modifiers
-
-  /**
-   Modifier that sets constant getter that has no arguments.
-   */
-  @discardableResult
-  public func get(_ getter: @escaping () -> ReturnType) -> Self {
     self.getter = getter
-    return self
   }
 
   // MARK: - Internals
 
   internal func getValue(appContext: AppContext) throws -> ReturnType? {
-    return try getter?()
+    return try getter()
   }
 
   /**
@@ -64,23 +44,17 @@ public final class ConstantDefinition<ReturnType>: AnyDefinition, AnyConstantDef
    */
   internal func buildGetter(appContext: AppContext) throws -> JavaScriptObject {
     var prevValue: JavaScriptValue?
-    return try appContext.runtime.createSyncFunction(name, argsCount: 0) { [weak appContext, weak self, name] _, _ in
-      guard let prevValue else {
-        guard let appContext else {
-          throw Exceptions.AppContextLost()
-        }
-        guard let self else {
-          throw NativeConstantUnavailableException(name)
-        }
-        guard let getter = self.getter else {
-          throw NativeConstantWithoutGetterException(name)
-        }
-        let result = try getter()
-        let newValue = try appContext.converter.toJS(result, ~ReturnType.self)
-        prevValue = newValue
-        return newValue
+    return try appContext.runtime.createSyncFunction(name, argsCount: 0) { [weak appContext, getter] _, _ in
+      if let prevValue {
+        return prevValue
       }
-      return prevValue
+      guard let appContext else {
+        throw Exceptions.AppContextLost()
+      }
+      let result = try getter()
+      let newValue = try appContext.converter.toJS(result, ~ReturnType.self)
+      prevValue = newValue
+      return newValue
     }
   }
 
@@ -91,24 +65,8 @@ public final class ConstantDefinition<ReturnType>: AnyDefinition, AnyConstantDef
     let descriptor = try appContext.runtime.createObject()
 
     descriptor.setProperty("enumerable", value: true)
+    descriptor.setProperty("get", value: try buildGetter(appContext: appContext))
 
-    if getter != nil {
-      descriptor.setProperty("get", value: try buildGetter(appContext: appContext))
-    }
     return descriptor
-  }
-}
-
-// MARK: - Exceptions
-
-internal final class NativeConstantUnavailableException: GenericException<String>, @unchecked Sendable {
-  override var reason: String {
-    return "Native constant '\(param)' is no longer available in memory"
-  }
-}
-
-internal final class NativeConstantWithoutGetterException: GenericException<String>, @unchecked Sendable {
-  override var reason: String {
-    return "Native constant '\(param)' doesn't have a getter"
   }
 }


### PR DESCRIPTION
# Why

Follow up #40369 
To get rid of `@unchecked` annotation the definitions should become immutable structs instead of class instances. `ConstantDefinition` was relatively easy to migrate.

# How

- Changed `ConstantDefinition` to be a struct that conforms to `Sendable`
- Removed `.get` modifier as I think it's not needed and would make the migration more complex. This getter should be provided directly in `Constant("name", getter)` call, otherwise it's no-op
- It became possible to simplify the JS host function and not having to capture the entire definition but only a getter. Also exceptions are now not necessary

# Test Plan

bare-expo builds and the constants are exposed correctly