### PR TITLE
[core][Android] Add getUndefined helper

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ValueOrUndefined.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ValueOrUndefined.kt
@@ -26,6 +26,6 @@ sealed interface ValueOrUndefined<T> {
     inline fun <reified T> getUndefined() = Undefined<T>()
 
     @Suppress("FunctionName")
-    inline fun <reified  T> Undefined(): ValueOrUndefined<T> = getUndefined<T>()
+    inline fun <reified T> Undefined(): ValueOrUndefined<T> = getUndefined<T>()
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ValueOrUndefined.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ValueOrUndefined.kt
@@ -21,5 +21,11 @@ sealed interface ValueOrUndefined<T> {
     @JvmStatic
     @DoNotStrip
     fun getUndefined(): Any = Undefined
+
+    @Suppress("UNCHECKED_CAST")
+    inline fun <reified T> getUndefined() = Undefined<T>()
+
+    @Suppress("FunctionName")
+    inline fun <reified  T> Undefined(): ValueOrUndefined<T> = getUndefined<T>()
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ValueOrUndefined.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ValueOrUndefined.kt
@@ -23,7 +23,7 @@ sealed interface ValueOrUndefined<T> {
     fun getUndefined(): Any = Undefined
 
     @Suppress("UNCHECKED_CAST")
-    inline fun <reified T> getUndefined() = Undefined<T>()
+    inline fun <reified T> getUndefined() = Undefined as ValueOrUndefined<T>
 
     @Suppress("FunctionName")
     inline fun <reified T> Undefined(): ValueOrUndefined<T> = getUndefined<T>()


### PR DESCRIPTION
# Why

Added `getUndefined` helper

# How

Right now, there's no easy way to obtain `ValueOrUndefined.Undefined` of type `T`. It's needed to provide a default value in records. 

# Test Plan

- bare-expo ✅ 