### PR TITLE
[docs] Fix example code in Native tabs > Icon

### DIFF
--- a/docs/pages/router/advanced/native-tabs.mdx
+++ b/docs/pages/router/advanced/native-tabs.mdx
@@ -147,19 +147,21 @@ export default function TabLayout() {
           dark: 'white',
           light: 'black',
         }),
-        // For the selected icon color
-        tintColor: DynamicColorIOS({
-          dark: 'white',
-          light: 'black',
-        }),
-      }}>
+      }}
+      // For the selected icon color
+      tintColor={DynamicColorIOS({
+        dark: 'white',
+        light: 'black',
+      })}>
       <NativeTabs.Trigger name="index">
         <Icon sf={{ default: 'house', selected: 'house.fill' }} drawable="custom_home_drawable" />
       </NativeTabs.Trigger>
       <NativeTabs.Trigger name="settings">
         <Icon
-          src={require('../../../assets/setting_icon.png')}
-          selectedSrc={require('../../../assets/selected_setting_icon.png')}
+          src={{
+            default: require('../../../assets/setting_icon.png'),
+            selected: require('../../../assets/selected_setting_icon.png'),
+          }}
         />
       </NativeTabs.Trigger>
     </NativeTabs>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Found that the example code under Icon section in the Native tabs guide is incorrect:

<img width="2476" height="1502" alt="CleanShot 2025-10-16 at 18 22 14@2x" src="https://github.com/user-attachments/assets/faba5c52-1bd6-4673-b7ad-8ddf97b30f37" />

- The `selectedSrc` is not a valid prop.
- The `tintColor` is a separate prop and not part of `labelStyle`.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix example code in Native tabs > Icon section.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
