### PR TITLE
[docs] Improve title and description in Pre-packaged jobs

### DIFF
--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1,6 +1,7 @@
 ---
-title: Pre-packaged jobs
-description: Learn how to set up and use pre-packaged jobs.
+title: Pre-packaged jobs in EAS Workflows
+sidebar_title: Pre-packaged jobs
+description: Learn how to set up and use pre-packaged jobs in EAS Workflows.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Under the search term "eas workflows", the pre-packaged jobs page does not show up.

<img width="2262" height="2124" alt="CleanShot 2025-10-16 at 18 40 01@2x" src="https://github.com/user-attachments/assets/6918069a-2262-4b59-9427-d47e687c03de" />

<img width="2086" height="2016" alt="CleanShot 2025-10-16 at 18 39 57@2x" src="https://github.com/user-attachments/assets/dd3bb51f-d148-4655-b9e5-ac01ad597ad0" />


# How

<!--
How did you build this feature or fix this bug and why?
-->

Improve title and description in Pre-packaged jobs and use the keyword EAS Workflows in both.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
