### PR TITLE
[ios][contacts] Add ContactSerializationException for error handling

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Added contact image uri validation. ([#39658](https://github.com/expo/expo/pull/39658) by [@hryhoriiK97](https://github.com/hryhoriiK97))
 - [Android] Removed unused `androidx.annotation:annotation` dependency ([#39761](https://github.com/expo/expo/pull/39761) by [@lukmccall](https://github.com/lukmccall))
+- Added ContactSerializationException for error handling. ([#40426](https://github.com/expo/expo/pull/40426) by [@hryhoriiK97](https://github.com/hryhoriiK97))
 
 ## 15.0.9 - 2025-10-01
 

--- a/packages/expo-contacts/ios/ContactsExceptions.swift
+++ b/packages/expo-contacts/ios/ContactsExceptions.swift
@@ -126,3 +126,9 @@ internal final class RemoteImageUriException: Exception {
     "Only file:// URIs are supported for contact images. Provided URI: '\(providedUri)'. Download the image first using File.downloadFileAsync from expo-file-system and provide a local file URI."
   }
 }
+
+internal final class ContactSerializationException: GenericException<String> {
+  override var reason: String {
+    "Failed to serialize contact data: \(param)"
+  }
+}

--- a/packages/expo-contacts/ios/ContactsModule.swift
+++ b/packages/expo-contacts/ios/ContactsModule.swift
@@ -412,8 +412,9 @@ public class ContactsModule: Module, OnContactPickingResultHandler {
   }
 
   private func serializeContactPayload(payload: [String: Any], keys: [String], options: ContactsQuery) throws -> [String: Any]? {
-    if payload["error"] != nil {
-      return nil
+    if let error = payload["error"] {
+      let errorMessage = String(describing: error)
+      throw ContactSerializationException(errorMessage)
     }
     var mutablePayload = payload
     var response = [[String: Any]]()

--- a/packages/expo-contacts/ios/ContactsModule.swift
+++ b/packages/expo-contacts/ios/ContactsModule.swift
@@ -419,7 +419,8 @@ public class ContactsModule: Module, OnContactPickingResultHandler {
     var mutablePayload = payload
     var response = [[String: Any]]()
     guard let contacts = payload["data"] as? [CNContact] else {
-      return nil
+      mutablePayload["data"] = response
+      return mutablePayload
     }
 
     let directory = appContext?.config.cacheDirectory?.appendingPathComponent("Contacts")


### PR DESCRIPTION
# Why
The current implementation of contact serialization in expo-contacts iOS module silently fails by returning nil when encountering errors during contact payload processing. This makes it difficult for developers to debug issues when contact serialization fails, as they receive no information about what went wrong. This improvement adds proper error handling to provide clear feedback about serialization failures.

# How
Added ContactSerializationException to properly handle serialization failures


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
