### PR TITLE
[ncl] reduce linking duplication

### DIFF
--- a/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
@@ -2,7 +2,6 @@ import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useTheme } from 'ThemeProvider';
 import * as React from 'react';
-import { getScreenIdForLinking } from 'test-suite/screens/getScreenIdForLinking';
 
 import { optionalRequire } from './routeBuilder';
 import { TabBackground } from '../components/TabBackground';
@@ -11,11 +10,12 @@ import getStackNavWithConfig from '../navigation/StackConfig';
 import { AudioScreens } from '../screens/Audio/AudioScreen';
 import { BlobScreens } from '../screens/Blob/BlobScreen';
 import { CalendarsScreens } from '../screens/CalendarsScreen';
+import { apiScreensToListElements } from '../screens/ComponentListScreen';
 import { ContactsScreens } from '../screens/Contacts/ContactsScreen';
 import ExpoApis from '../screens/ExpoApisScreen';
 import { MediaLibraryScreens } from '../screens/MediaLibrary@Next/MediaLibraryScreens';
 import { ModulesCoreScreens } from '../screens/ModulesCore/ModulesCoreScreen';
-import { type ScreenApiItem, type ScreenConfig } from '../types/ScreenConfig';
+import { type ScreenConfig } from '../types/ScreenConfig';
 
 const Stack = createNativeStackNavigator();
 
@@ -461,11 +461,7 @@ export const Screens: ScreenConfig[] = [
   ...CalendarsScreens,
 ];
 
-export const screenApiItems: ScreenApiItem[] = ScreensList.map((config) => ({
-  name: config.name,
-  route: '/apis/' + getScreenIdForLinking(config),
-  isAvailable: true,
-}));
+export const screenApiItems = apiScreensToListElements(ScreensList);
 
 function ExpoApisStackNavigator(props: { navigation: BottomTabNavigationProp<any> }) {
   const { theme } = useTheme();

--- a/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
@@ -2,7 +2,6 @@ import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useTheme } from 'ThemeProvider';
 import * as React from 'react';
-import { getScreenIdForLinking } from 'test-suite/screens/getScreenIdForLinking';
 
 import getStackNavWithConfig from './StackConfig';
 import { optionalRequire } from './routeBuilder';
@@ -10,6 +9,7 @@ import { TabBackground } from '../components/TabBackground';
 import TabIcon from '../components/TabIcon';
 import { Layout } from '../constants';
 import { CameraScreens } from '../screens/Camera/CameraScreen';
+import { componentScreensToListElements } from '../screens/ComponentListScreen';
 import ExpoComponents from '../screens/ExpoComponentsScreen';
 import { MapsScreens } from '../screens/ExpoMaps/MapsScreen';
 import { GLScreens } from '../screens/GL/GLScreen';
@@ -17,7 +17,7 @@ import { ImageScreens } from '../screens/Image/ImageScreen';
 import { SVGScreens } from '../screens/SVG/SVGScreen';
 import { UIScreens } from '../screens/UI/UIScreen';
 import { VideoScreens } from '../screens/Video/VideoScreen';
-import { type ScreenApiItem, type ScreenConfig } from '../types/ScreenConfig';
+import { type ScreenConfig } from '../types/ScreenConfig';
 
 const Stack = createNativeStackNavigator();
 
@@ -312,11 +312,7 @@ export const Screens: ScreenConfig[] = [
   ...MapsScreens,
 ];
 
-export const screenApiItems: ScreenApiItem[] = ScreensList.map((config) => ({
-  name: config.name,
-  route: '/components/' + getScreenIdForLinking(config),
-  isAvailable: true,
-}));
+export const screenApiItems = componentScreensToListElements(ScreensList);
 
 function ExpoComponentsStackNavigator(props: { navigation: BottomTabNavigationProp<any> }) {
   const { theme } = useTheme();

--- a/apps/native-component-list/src/screens/Audio/AudioScreen.tsx
+++ b/apps/native-component-list/src/screens/Audio/AudioScreen.tsx
@@ -1,5 +1,5 @@
 import { optionalRequire } from '../../navigation/routeBuilder';
-import ComponentListScreen, { ListElement } from '../ComponentListScreen';
+import ComponentListScreen, { apiScreensToListElements } from '../ComponentListScreen';
 
 export const AudioScreens = [
   {
@@ -54,12 +54,6 @@ export const AudioScreens = [
 ];
 
 export default function AudioScreen() {
-  const apis: ListElement[] = AudioScreens.map((screen) => {
-    return {
-      name: screen.name,
-      isAvailable: true,
-      route: `/apis/${screen.route}`,
-    };
-  });
+  const apis = apiScreensToListElements(AudioScreens);
   return <ComponentListScreen apis={apis} sort={false} />;
 }

--- a/apps/native-component-list/src/screens/Blob/BlobScreen.tsx
+++ b/apps/native-component-list/src/screens/Blob/BlobScreen.tsx
@@ -1,5 +1,5 @@
 import { optionalRequire } from '../../navigation/routeBuilder';
-import ComponentListScreen, { ListElement } from '../ComponentListScreen';
+import ComponentListScreen, { apiScreensToListElements } from '../ComponentListScreen';
 
 export const BlobScreens = [
   {
@@ -61,12 +61,6 @@ export const BlobScreens = [
 ];
 
 export default function BlobScreen() {
-  const apis: ListElement[] = BlobScreens.map((screen) => {
-    return {
-      name: screen.name,
-      isAvailable: true,
-      route: `/apis/${screen.route}`,
-    };
-  });
+  const apis = apiScreensToListElements(BlobScreens);
   return <ComponentListScreen apis={apis} sort={false} />;
 }

--- a/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreen.tsx
@@ -1,5 +1,5 @@
 import { optionalRequire } from '../../navigation/routeBuilder';
-import ComponentListScreen, { ListElement } from '../ComponentListScreen';
+import ComponentListScreen, { componentScreensToListElements } from '../ComponentListScreen';
 
 export const CameraScreens = [
   {
@@ -47,12 +47,6 @@ export const CameraScreens = [
 ];
 
 export default function CameraScreen() {
-  const apis: ListElement[] = CameraScreens.map((screen) => {
-    return {
-      name: screen.name,
-      isAvailable: true,
-      route: `/components/${screen.route}`,
-    };
-  });
+  const apis = componentScreensToListElements(CameraScreens);
   return <ComponentListScreen apis={apis} sort={false} />;
 }

--- a/apps/native-component-list/src/screens/ComponentListScreen.tsx
+++ b/apps/native-component-list/src/screens/ComponentListScreen.tsx
@@ -15,12 +15,38 @@ import {
   useWindowDimensions,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { ScreenConfig } from 'src/types/ScreenConfig';
+import { getScreenIdForLinking } from 'test-suite/screens/getScreenIdForLinking';
 
 export interface ListElement {
   screenName?: string;
   name: string;
-  route?: string;
-  isAvailable?: boolean;
+  route: string;
+  isAvailable: boolean;
+}
+
+/**
+ * Converts component screen configs to ListElements with '/components/' prefix.
+ * @param screens - Array of screen configurations
+ */
+export function componentScreensToListElements(screens: ScreenConfig[]): ListElement[] {
+  return screens.map((screen) => ({
+    name: screen.name,
+    isAvailable: true,
+    route: `/components/${getScreenIdForLinking(screen)}`,
+  }));
+}
+
+/**
+ * Converts API screen configs to ListElements with '/apis/' prefix.
+ * @param screens - Array of screen configurations
+ */
+export function apiScreensToListElements(screens: ScreenConfig[]): ListElement[] {
+  return screens.map((screen) => ({
+    name: screen.name,
+    isAvailable: true,
+    route: `/apis/${getScreenIdForLinking(screen)}`,
+  }));
 }
 
 interface Props {

--- a/apps/native-component-list/src/screens/ExpoApisScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoApisScreen.tsx
@@ -1,9 +1,8 @@
 import { memo } from 'react';
 import { Platform } from 'react-native';
 
-import ComponentListScreen from './ComponentListScreen';
+import ComponentListScreen, { type ListElement } from './ComponentListScreen';
 import ExpoAPIIcon from '../components/ExpoAPIIcon';
-import { type ScreenApiItem } from '../types/ScreenConfig';
 
 if (Platform.OS !== 'web') {
   // Optionally require expo-notifications as we cannot assume that the module is linked.
@@ -26,7 +25,7 @@ if (Platform.OS !== 'web') {
   });
 }
 
-export default memo(function ExpoApisScreen({ apis }: { apis: ScreenApiItem[] }) {
+export default memo(function ExpoApisScreen({ apis }: { apis: ListElement[] }) {
   return (
     <ComponentListScreen
       renderItemRight={({ name }: { name: string }) => (

--- a/apps/native-component-list/src/screens/ExpoComponentsScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoComponentsScreen.tsx
@@ -1,10 +1,9 @@
 import { memo } from 'react';
 
-import ComponentListScreen from './ComponentListScreen';
+import ComponentListScreen, { type ListElement } from './ComponentListScreen';
 import ExpoAPIIcon from '../components/ExpoAPIIcon';
-import { type ScreenApiItem } from '../types/ScreenConfig';
 
-export default memo(function ExpoComponentsScreen({ apis }: { apis: ScreenApiItem[] }) {
+export default memo(function ExpoComponentsScreen({ apis }: { apis: ListElement[] }) {
   return (
     <ComponentListScreen
       renderItemRight={({ name }: { name: string }) => (

--- a/apps/native-component-list/src/screens/ExpoMaps/MapsScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoMaps/MapsScreen.tsx
@@ -1,7 +1,7 @@
 import { Platform } from 'react-native';
 
 import { optionalRequire } from '../../navigation/routeBuilder';
-import ComponentListScreen, { ListElement } from '../ComponentListScreen';
+import ComponentListScreen, { componentScreensToListElements } from '../ComponentListScreen';
 
 export const MapsScreens = Platform.select({
   android: [
@@ -260,12 +260,6 @@ export const MapsScreens = Platform.select({
 });
 
 export default function ImageScreen() {
-  const apis: ListElement[] = MapsScreens.map((screen) => {
-    return {
-      name: screen.name,
-      isAvailable: true,
-      route: `/components/${screen.route}`,
-    };
-  });
+  const apis = componentScreensToListElements(MapsScreens);
   return <ComponentListScreen apis={apis} sort={false} />;
 }

--- a/apps/native-component-list/src/screens/GL/GLScreen.tsx
+++ b/apps/native-component-list/src/screens/GL/GLScreen.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { optionalRequire } from '../../navigation/routeBuilder';
-import ComponentListScreen, { ListElement } from '../ComponentListScreen';
+import ComponentListScreen, { componentScreensToListElements } from '../ComponentListScreen';
 
 export const GLScreens = [
   {
@@ -151,12 +151,6 @@ export const GLScreens = [
 ];
 
 export default function GLScreen() {
-  const apis: ListElement[] = GLScreens.map((screen) => {
-    return {
-      name: screen.name,
-      isAvailable: true,
-      route: `/components/${screen.route}`,
-    };
-  });
+  const apis = componentScreensToListElements(GLScreens);
   return <ComponentListScreen apis={apis} />;
 }

--- a/apps/native-component-list/src/screens/Image/ImageScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageScreen.tsx
@@ -1,7 +1,7 @@
 import { Platform } from 'expo-modules-core';
 
 import { optionalRequire } from '../../navigation/routeBuilder';
-import ComponentListScreen, { ListElement } from '../ComponentListScreen';
+import ComponentListScreen, { componentScreensToListElements } from '../ComponentListScreen';
 
 export const ImageScreens = [
   {
@@ -183,12 +183,6 @@ if (Platform.OS === 'ios') {
 }
 
 export default function ImageScreen() {
-  const apis: ListElement[] = ImageScreens.map((screen) => {
-    return {
-      name: screen.name,
-      isAvailable: true,
-      route: `/components/${screen.route}`,
-    };
-  });
+  const apis = componentScreensToListElements(ImageScreens);
   return <ComponentListScreen apis={apis} sort={false} />;
 }

--- a/apps/native-component-list/src/screens/MediaLibrary@Next/MediaLibraryScreens.tsx
+++ b/apps/native-component-list/src/screens/MediaLibrary@Next/MediaLibraryScreens.tsx
@@ -1,5 +1,5 @@
 import { optionalRequire } from '../../navigation/routeBuilder';
-import ComponentListScreen, { ListElement } from '../ComponentListScreen';
+import ComponentListScreen, { apiScreensToListElements } from '../ComponentListScreen';
 
 export const MediaLibraryScreens = [
   {
@@ -26,13 +26,6 @@ export const MediaLibraryScreens = [
 ];
 
 export default function MediaLibraryScreen() {
-  const apis: ListElement[] = MediaLibraryScreens.map((screen) => {
-    return {
-      name: screen.name,
-      isAvailable: true,
-      route: `/apis/${screen.route}`,
-    };
-  });
-
+  const apis = apiScreensToListElements(MediaLibraryScreens);
   return <ComponentListScreen apis={apis} sort={false} />;
 }

--- a/apps/native-component-list/src/screens/ModulesCore/ModulesCoreScreen.tsx
+++ b/apps/native-component-list/src/screens/ModulesCore/ModulesCoreScreen.tsx
@@ -1,7 +1,7 @@
 import { isRunningInExpoGo } from 'expo';
 
 import { optionalRequire } from '../../navigation/routeBuilder';
-import ComponentListScreen, { ListElement } from '../ComponentListScreen';
+import ComponentListScreen, { apiScreensToListElements } from '../ComponentListScreen';
 
 export const ModulesCoreScreens = [
   {
@@ -31,12 +31,6 @@ if (!isRunningInExpoGo()) {
 }
 
 export default function ModulesCoreScreen() {
-  const apis: ListElement[] = ModulesCoreScreens.map((screen) => {
-    return {
-      name: screen.name,
-      isAvailable: true,
-      route: `/apis/${screen.route}`,
-    };
-  });
+  const apis = apiScreensToListElements(ModulesCoreScreens);
   return <ComponentListScreen apis={apis} sort={false} />;
 }

--- a/apps/native-component-list/src/screens/UI/UIScreen.android.tsx
+++ b/apps/native-component-list/src/screens/UI/UIScreen.android.tsx
@@ -1,5 +1,5 @@
 import { optionalRequire } from '../../navigation/routeBuilder';
-import ComponentListScreen, { ListElement } from '../ComponentListScreen';
+import ComponentListScreen, { componentScreensToListElements } from '../ComponentListScreen';
 
 export const UIScreens = [
   {
@@ -141,13 +141,7 @@ export const UIScreens = [
 ];
 
 export default function UIScreen() {
-  const apis: ListElement[] = UIScreens.map((screen) => {
-    return {
-      name: screen.name,
-      isAvailable: true,
-      route: `/components/${screen.route}`,
-    };
-  });
+  const apis = componentScreensToListElements(UIScreens);
   return <ComponentListScreen apis={apis} />;
 }
 

--- a/apps/native-component-list/src/screens/UI/UIScreen.ios.tsx
+++ b/apps/native-component-list/src/screens/UI/UIScreen.ios.tsx
@@ -1,5 +1,5 @@
 import { optionalRequire } from '../../navigation/routeBuilder';
-import ComponentListScreen, { ListElement } from '../ComponentListScreen';
+import ComponentListScreen, { componentScreensToListElements } from '../ComponentListScreen';
 
 export const UIScreens = [
   {
@@ -197,13 +197,7 @@ export const UIScreens = [
 ];
 
 export default function UIScreen() {
-  const apis: ListElement[] = UIScreens.map((screen) => {
-    return {
-      name: screen.name,
-      isAvailable: true,
-      route: `/components/${screen.route}`,
-    };
-  });
+  const apis = componentScreensToListElements(UIScreens);
   return <ComponentListScreen apis={apis} sort />;
 }
 

--- a/apps/native-component-list/src/screens/Video/VideoScreen.tsx
+++ b/apps/native-component-list/src/screens/Video/VideoScreen.tsx
@@ -1,7 +1,7 @@
 import { Platform } from 'react-native';
 
 import { optionalRequire } from '../../navigation/routeBuilder';
-import ComponentListScreen, { ListElement } from '../ComponentListScreen';
+import ComponentListScreen, { componentScreensToListElements } from '../ComponentListScreen';
 
 export const VideoScreens = [
   {
@@ -143,12 +143,6 @@ if (Platform.OS === 'android') {
 }
 
 export default function VideoScreen() {
-  const apis: ListElement[] = VideoScreens.map((screen) => {
-    return {
-      name: screen.name,
-      isAvailable: true,
-      route: `/components/${screen.route}`,
-    };
-  });
+  const apis = componentScreensToListElements(VideoScreens);
   return <ComponentListScreen apis={apis} sort={false} />;
 }

--- a/apps/native-component-list/src/types/ScreenConfig.ts
+++ b/apps/native-component-list/src/types/ScreenConfig.ts
@@ -6,9 +6,3 @@ export type ScreenConfig = {
   route?: string;
   options?: object;
 };
-
-export type ScreenApiItem = {
-  name: string;
-  route: string;
-  isAvailable: boolean;
-};


### PR DESCRIPTION
# Why

Refactored screen list element creation in native-component-list to reduce code duplication and improve maintainability by introducing utility functions for converting screen configurations to list elements.

# How

- Replaced repetitive mapping code in various screen components with these utility functions
- Removed the redundant `ScreenApiItem` type since it was functionally identical to `ListElement`
- ...


# Test Plan

the following work okay:

- `xcrun simctl openurl booted  bareexpo://apis/alert`
- `xcrun simctl openurl booted  bareexpo://components/expo-ui`
- `xcrun simctl openurl booted bareexpo://test-suite/run?tests=brightness-device-only,blur`

- `adb shell am start -W -a android.intent.action.VIEW -d "bareexpo://test-suite/run?tests=basic,blur" dev.expo.payments`
- `adb shell am start -W -a android.intent.action.VIEW -d "bareexpo://components/expo-ui" dev.expo.payments`


# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)