### PR TITLE
[docs] Fix chat message refresh after context switch in SDK Ask AI

### DIFF
--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -47,7 +47,7 @@ const buildDisplayContextLabel = (label: string, shouldPrefixExpo: boolean) => {
     return trimmed;
   }
   const lower = trimmed.toLowerCase();
-  if (lower === 'expo' || lower.startsWith('expo ')) {
+  if (lower === 'expo') {
     return trimmed;
   }
   return `Expo ${trimmed}`;

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -10,6 +10,8 @@ import {
   useState,
 } from 'react';
 
+import { usePageMetadata } from '~/providers/page-metadata';
+
 import { FOOTNOTE } from '../Text';
 import type {
   ContextMarker,
@@ -34,6 +36,22 @@ type AskPageAIChatProps = {
 
 const FALLBACK_TEMPLATE = (label: string) =>
   `I can only answer questions about the current ${label} documentation.`;
+const DEFAULT_CONTEXT_LABEL = 'This page';
+
+const buildDisplayContextLabel = (label: string, shouldPrefixExpo: boolean) => {
+  const trimmed = label.trim();
+  if (!trimmed) {
+    return DEFAULT_CONTEXT_LABEL;
+  }
+  if (!shouldPrefixExpo) {
+    return trimmed;
+  }
+  const lower = trimmed.toLowerCase();
+  if (lower === 'expo' || lower.startsWith('expo ')) {
+    return trimmed;
+  }
+  return `Expo ${trimmed}`;
+};
 
 export function AskPageAIChat({
   onClose,
@@ -44,6 +62,7 @@ export function AskPageAIChat({
   isExpoSdkPage = false,
 }: AskPageAIChatProps) {
   const router = useRouter();
+  const pageMetadata = usePageMetadata();
   const {
     conversation,
     submitQuery,
@@ -55,18 +74,21 @@ export function AskPageAIChat({
     addFeedback,
   } = useChat();
 
-  const contextLabel = pageTitle?.trim() ? pageTitle : 'This page';
-  const displayContextLabel = useMemo(() => {
-    const label = contextLabel.trim();
-    if (!isExpoSdkPage) {
-      return label;
-    }
-    const lower = label.toLowerCase();
-    if (lower === 'expo' || lower.startsWith('expo ')) {
-      return label;
-    }
-    return `Expo ${label}`;
-  }, [contextLabel, isExpoSdkPage]);
+  const basePath = (router?.asPath ?? '').split('#')[0];
+  const providedTitle = pageTitle?.trim() ?? '';
+  const metadataTitle = pageMetadata?.title?.trim() ?? '';
+  const contextLabel =
+    (providedTitle || metadataTitle || DEFAULT_CONTEXT_LABEL).trim() || DEFAULT_CONTEXT_LABEL;
+
+  const shouldPrefixExpo =
+    typeof isExpoSdkPage === 'boolean'
+      ? isExpoSdkPage
+      : basePath.startsWith('/versions/latest/sdk/');
+
+  const displayContextLabel = useMemo(
+    () => buildDisplayContextLabel(contextLabel, shouldPrefixExpo),
+    [contextLabel, shouldPrefixExpo]
+  );
 
   const fallbackResponse = useMemo(
     () => FALLBACK_TEMPLATE(displayContextLabel),
@@ -147,7 +169,6 @@ export function AskPageAIChat({
 
   const prevDisplayContextRef = useRef<string>(displayContextLabel);
   const prevBasePathRef = useRef<string | null>(null);
-  const basePath = (router?.asPath ?? '').split('#')[0];
 
   useEffect(() => {
     const prevPath = prevBasePathRef.current;


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Identified an issue with chat message not being refreshed after navigating to another page. 

<img width="1348" height="2440" alt="CleanShot 2025-10-16 at 21 11 36@2x" src="https://github.com/user-attachments/assets/46f5ee75-7213-492a-9817-16d27507dc0c" />


# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix chat message refresh after context switch in SDK Ask AI by using page meta data.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally.

## Preview

<img width="1376" height="2422" alt="CleanShot 2025-10-17 at 00 21 11@2x" src="https://github.com/user-attachments/assets/3c8e1110-6fc5-4044-abf0-0600dfc67709" />

<img width="1282" height="2388" alt="CleanShot 2025-10-17 at 00 21 21@2x" src="https://github.com/user-attachments/assets/a93b719a-335e-474e-8e6f-e489d0b4c57b" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
