### PR TITLE
[ios][camera] Allow opt out of barcode scanning deps

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -3630,7 +3630,7 @@ SPEC CHECKSUMS:
   ExpoBlur: b5b7a26572b3c33a11f0b2aa2f95c17c4c393b76
   ExpoBrightness: 7c3c86da46b847aadf44401bd28fb6d67050f324
   ExpoCalendar: 46ad51c48d2cb1a95439c2215b182428919a0c3d
-  ExpoCamera: 6d0c5bc68bc8de669f1ecd4242284de0827c4431
+  ExpoCamera: 442bbbbd75d73d17f3a972b269efe7595b9b6933
   ExpoCellular: 539c6092e755f7b2c37d80f18d9c1f3d7f09e4ab
   ExpoClipboard: 99109306a2d9ed2fbd16f6b856e6267b2afa8472
   ExpoContacts: 82f80ddc812c85548b8edab4153fbc3e8a39212e

--- a/packages/expo-camera/ios/CameraViewModule.swift
+++ b/packages/expo-camera/ios/CameraViewModule.swift
@@ -148,6 +148,7 @@ public final class CameraViewModule: Module, ScannerResultHandler {
       }
 
       Prop("barcodeScannerEnabled") { (view, scanBarcodes: Bool?) in
+#if canImport(ZXingObjC)
         if let scanBarcodes, view.isScanningBarcodes != scanBarcodes {
           view.isScanningBarcodes = scanBarcodes
           return
@@ -155,12 +156,17 @@ public final class CameraViewModule: Module, ScannerResultHandler {
         if scanBarcodes == nil && view.isScanningBarcodes != false {
           view.isScanningBarcodes = false
         }
+#endif
       }
 
       Prop("barcodeScannerSettings") { (view, settings: BarcodeSettings?) in
+#if canImport(ZXingObjC)
         if let settings {
           view.setBarcodeScannerSettings(settings: settings)
         }
+#else
+        self.appContext?.jsLogger.warn("Barcode scanning has been disabled")
+#endif
       }
 
       Prop("mute") { (view, muted: Bool?) in

--- a/packages/expo-camera/ios/Current/BarcodeScanner.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScanner.swift
@@ -1,7 +1,9 @@
-import ZXingObjC
 import AVFoundation
 
 let BARCODE_TYPES_KEY = "barcodeTypes"
+
+#if canImport(ZXingObjC)
+import ZXingObjC
 
 class BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
   private var onBarcodeScanned: (([String: Any]?) -> Void)?
@@ -159,3 +161,4 @@ class BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
     self.onBarcodeScanned?(result)
   }
 }
+#endif

--- a/packages/expo-camera/ios/Current/BarcodeScannerUnavailable.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScannerUnavailable.swift
@@ -1,0 +1,40 @@
+#if !canImport(ZXingObjC)
+import AVFoundation
+
+class BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
+  private var onBarcodeScanned: (([String: Any]?) -> Void)?
+  var isScanningBarcodes = false
+
+  init(session: AVCaptureSession, sessionQueue: DispatchQueue) {}
+
+  func setSettings(_ newSettings: [String: [AVMetadataObject.ObjectType]]) {}
+
+  func setPreviewLayer(layer: AVCaptureVideoPreviewLayer) {}
+
+  func setIsEnabled(_ enabled: Bool) {
+    isScanningBarcodes = enabled
+    if enabled {
+      onBarcodeScanned?(nil)
+    }
+  }
+
+  func setConnection(enabled: Bool) {}
+
+  func setOnBarcodeScanned(_ onBarcodeScanned: @escaping ([String: Any]?) -> Void) {
+    self.onBarcodeScanned = onBarcodeScanned
+  }
+
+  func maybeStartBarcodeScanning() {}
+
+  func stopBarcodeScanning() {
+    if isScanningBarcodes {
+      isScanningBarcodes = false
+      onBarcodeScanned?(nil)
+    }
+  }
+
+  func onScanningResult(_ result: [String: Any]) {
+    onBarcodeScanned?(result)
+  }
+}
+#endif

--- a/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
@@ -1,5 +1,7 @@
 import AVFoundation
+#if canImport(ZXingObjC)
 import ZXingObjC
+#endif
 import VisionKit
 import Vision
 
@@ -103,6 +105,7 @@ class BarcodeScannerUtils {
     ]
   }
 
+  #if canImport(ZXingObjC)
   static func zxResultToDictionary(_ barcodeScannerResult: ZXResult) -> [String: Any] {
     var result = [String: Any]()
     result["type"] = BarcodeScannerUtils.zxingFormatToString(barcodeScannerResult.barcodeFormat)
@@ -134,4 +137,5 @@ class BarcodeScannerUtils {
       return "unknown"
     }
   }
+  #endif
 }

--- a/packages/expo-camera/ios/Current/BarcodeScanningResponseHandler.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScanningResponseHandler.swift
@@ -1,0 +1,3 @@
+protocol BarcodeScanningResponseHandler {
+  func onScanningResult(_ result: [String: Any])
+}

--- a/packages/expo-camera/ios/Current/MetaDataDelegate.swift
+++ b/packages/expo-camera/ios/Current/MetaDataDelegate.swift
@@ -1,8 +1,6 @@
+#if canImport(ZXingObjC)
+import AVFoundation
 import ZXingObjC
-
-protocol BarcodeScanningResponseHandler {
-  func onScanningResult(_ result: [String: Any])
-}
 
 class MetaDataDelegate: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCaptureVideoDataOutputSampleBufferDelegate {
   private var settings: [String: [AVMetadataObject.ObjectType]]
@@ -106,3 +104,4 @@ class MetaDataDelegate: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCapt
     }
   }
 }
+#endif

--- a/packages/expo-camera/plugin/build/withCamera.d.ts
+++ b/packages/expo-camera/plugin/build/withCamera.d.ts
@@ -3,5 +3,6 @@ declare const _default: ConfigPlugin<void | {
     cameraPermission?: string | false;
     microphonePermission?: string | false;
     recordAudioAndroid?: boolean;
+    barcodeScannerEnabled?: boolean;
 }>;
 export default _default;

--- a/packages/expo-camera/plugin/build/withCamera.js
+++ b/packages/expo-camera/plugin/build/withCamera.js
@@ -4,13 +4,23 @@ const config_plugins_1 = require("expo/config-plugins");
 const pkg = require('expo-camera/package.json');
 const CAMERA_USAGE = 'Allow $(PRODUCT_NAME) to access your camera';
 const MICROPHONE_USAGE = 'Allow $(PRODUCT_NAME) to access your microphone';
-const withCamera = (config, { cameraPermission, microphonePermission, recordAudioAndroid = true } = {}) => {
+const BARCODE_SCANNER_PODFILE_KEY = 'expo-camera.barcode-scanner-enabled';
+const withCamera = (config, { cameraPermission, microphonePermission, recordAudioAndroid = true, barcodeScannerEnabled = true, } = {}) => {
     config_plugins_1.IOSConfig.Permissions.createPermissionsPlugin({
         NSCameraUsageDescription: CAMERA_USAGE,
         NSMicrophoneUsageDescription: MICROPHONE_USAGE,
     })(config, {
         NSCameraUsageDescription: cameraPermission,
         NSMicrophoneUsageDescription: microphonePermission,
+    });
+    config = (0, config_plugins_1.withPodfileProperties)(config, (config) => {
+        if (barcodeScannerEnabled === false) {
+            config.modResults[BARCODE_SCANNER_PODFILE_KEY] = 'false';
+        }
+        else {
+            delete config.modResults[BARCODE_SCANNER_PODFILE_KEY];
+        }
+        return config;
     });
     config = config_plugins_1.AndroidConfig.Permissions.withPermissions(config, [
         'android.permission.CAMERA',

--- a/packages/expo-camera/plugin/src/withCamera.ts
+++ b/packages/expo-camera/plugin/src/withCamera.ts
@@ -3,26 +3,46 @@ import {
   type ConfigPlugin,
   createRunOncePlugin,
   IOSConfig,
+  withPodfileProperties,
 } from 'expo/config-plugins';
 
 const pkg = require('expo-camera/package.json');
 
 const CAMERA_USAGE = 'Allow $(PRODUCT_NAME) to access your camera';
 const MICROPHONE_USAGE = 'Allow $(PRODUCT_NAME) to access your microphone';
+const BARCODE_SCANNER_PODFILE_KEY = 'expo-camera.barcode-scanner-enabled';
 
 const withCamera: ConfigPlugin<
   {
     cameraPermission?: string | false;
     microphonePermission?: string | false;
     recordAudioAndroid?: boolean;
+    barcodeScannerEnabled?: boolean;
   } | void
-> = (config, { cameraPermission, microphonePermission, recordAudioAndroid = true } = {}) => {
+> = (
+  config,
+  {
+    cameraPermission,
+    microphonePermission,
+    recordAudioAndroid = true,
+    barcodeScannerEnabled = true,
+  } = {}
+) => {
   IOSConfig.Permissions.createPermissionsPlugin({
     NSCameraUsageDescription: CAMERA_USAGE,
     NSMicrophoneUsageDescription: MICROPHONE_USAGE,
   })(config, {
     NSCameraUsageDescription: cameraPermission,
     NSMicrophoneUsageDescription: microphonePermission,
+  });
+
+  config = withPodfileProperties(config, (config) => {
+    if (barcodeScannerEnabled === false) {
+      config.modResults[BARCODE_SCANNER_PODFILE_KEY] = 'false';
+    } else {
+      delete config.modResults[BARCODE_SCANNER_PODFILE_KEY];
+    }
+    return config;
   });
 
   config = AndroidConfig.Permissions.withPermissions(


### PR DESCRIPTION
# Why
Barcode scanning can add size to the final ipa which is not necessary if the user is not using the functionality. I'm providing a way to opt out of including the scanning dependencies. 

# How
Added `barcodeScannerEnabled` to the config plugin. We provide a stub module for barcode scanning when it is disabled which no-ops all the scanning functionality.

# Test Plan
Sandbox. Enabling and disabling works as expected.

