### PR TITLE
[android][camera] Allow opt out of barcode scanning deps

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Allow disabling the barcode scanner functionality via config plugin. ([#40444](https://github.com/expo/expo/pull/40444) by [@alanjhughes](https://github.com/alanjhughes))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-camera/android/build.gradle
+++ b/packages/expo-camera/android/build.gradle
@@ -6,6 +6,9 @@ plugins {
 group = 'host.exp.exponent'
 version = '17.0.8'
 
+def barcodeScannerEnabled = findProperty('expo.camera.barcode-scanner-enabled')
+def isBarcodeScannerEnabled = (barcodeScannerEnabled ?: "true").toString() != "false"
+
 android {
   namespace "expo.modules.camera"
   defaultConfig {
@@ -15,7 +18,7 @@ android {
 }
 
 dependencies {
-  def camerax_version = "1.5.0-rc01"
+  def camerax_version = "1.5.1"
 
   api "androidx.exifinterface:exifinterface:1.4.1"
   api "androidx.appcompat:appcompat:1.7.1"
@@ -24,10 +27,12 @@ dependencies {
   implementation "androidx.camera:camera-camera2:${camerax_version}"
   implementation "androidx.camera:camera-lifecycle:${camerax_version}"
   implementation "androidx.camera:camera-video:${camerax_version}"
-  implementation "com.google.android.gms:play-services-code-scanner:16.1.0"
 
   implementation "androidx.camera:camera-view:${camerax_version}"
   implementation "androidx.camera:camera-extensions:${camerax_version}"
-  implementation "com.google.mlkit:barcode-scanning:17.3.0"
-  implementation "androidx.camera:camera-mlkit-vision:${camerax_version}"
+
+  def barcodeDependencyConfiguration = isBarcodeScannerEnabled ? "implementation" : "compileOnly"
+  add(barcodeDependencyConfiguration, "com.google.android.gms:play-services-code-scanner:16.1.0")
+  add(barcodeDependencyConfiguration, "com.google.mlkit:barcode-scanning:17.3.0")
+  add(barcodeDependencyConfiguration, "androidx.camera:camera-mlkit-vision:${camerax_version}")
 }

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
@@ -148,6 +148,11 @@ class CameraViewModule : Module() {
     }
 
     AsyncFunction("launchScanner") { settings: BarcodeSettings, promise: Promise ->
+      if (!CameraUtils.isMLKitBarcodeScannerAvailable()) {
+        promise.reject(CameraExceptions.MLKitUnavailableException())
+        return@AsyncFunction
+      }
+
       if (!CameraUtils.hasGooglePlayServices(appContext.reactContext)) {
         promise.reject(CameraExceptions.GooglePlayServicesUnavailableException())
         return@AsyncFunction
@@ -328,12 +333,20 @@ class CameraViewModule : Module() {
       }
 
       Prop("barcodeScannerSettings") { view, settings: BarcodeSettings? ->
+        if (!CameraUtils.isMLKitBarcodeScannerAvailable()) {
+          appContext.jsLogger?.warn("Barcode scanning has been disabled")
+          return@Prop
+        }
         settings?.let {
           view.setBarcodeScannerSettings(it)
         }
       }
 
       Prop("barcodeScannerEnabled") { view, enabled: Boolean? ->
+        if (!CameraUtils.isMLKitBarcodeScannerAvailable()) {
+          view.setShouldScanBarcodes(false)
+          return@Prop
+        }
         enabled?.let {
           view.setShouldScanBarcodes(enabled)
         }

--- a/packages/expo-camera/plugin/build/withCamera.js
+++ b/packages/expo-camera/plugin/build/withCamera.js
@@ -4,7 +4,7 @@ const config_plugins_1 = require("expo/config-plugins");
 const pkg = require('expo-camera/package.json');
 const CAMERA_USAGE = 'Allow $(PRODUCT_NAME) to access your camera';
 const MICROPHONE_USAGE = 'Allow $(PRODUCT_NAME) to access your microphone';
-const BARCODE_SCANNER_PODFILE_KEY = 'expo-camera.barcode-scanner-enabled';
+const BARCODE_SCANNER_KEY = 'expo.camera.barcode-scanner-enabled';
 const withCamera = (config, { cameraPermission, microphonePermission, recordAudioAndroid = true, barcodeScannerEnabled = true, } = {}) => {
     config_plugins_1.IOSConfig.Permissions.createPermissionsPlugin({
         NSCameraUsageDescription: CAMERA_USAGE,
@@ -15,11 +15,15 @@ const withCamera = (config, { cameraPermission, microphonePermission, recordAudi
     });
     config = (0, config_plugins_1.withPodfileProperties)(config, (config) => {
         if (barcodeScannerEnabled === false) {
-            config.modResults[BARCODE_SCANNER_PODFILE_KEY] = 'false';
+            config.modResults[BARCODE_SCANNER_KEY] = 'false';
         }
         else {
-            delete config.modResults[BARCODE_SCANNER_PODFILE_KEY];
+            delete config.modResults[BARCODE_SCANNER_KEY];
         }
+        return config;
+    });
+    config = (0, config_plugins_1.withGradleProperties)(config, (config) => {
+        config.modResults = config_plugins_1.AndroidConfig.BuildProperties.updateAndroidBuildProperty(config.modResults, BARCODE_SCANNER_KEY, barcodeScannerEnabled === false ? 'false' : null, { removePropWhenValueIsNull: true });
         return config;
     });
     config = config_plugins_1.AndroidConfig.Permissions.withPermissions(config, [

--- a/packages/expo-camera/plugin/src/withCamera.ts
+++ b/packages/expo-camera/plugin/src/withCamera.ts
@@ -3,6 +3,7 @@ import {
   type ConfigPlugin,
   createRunOncePlugin,
   IOSConfig,
+  withGradleProperties,
   withPodfileProperties,
 } from 'expo/config-plugins';
 
@@ -10,7 +11,7 @@ const pkg = require('expo-camera/package.json');
 
 const CAMERA_USAGE = 'Allow $(PRODUCT_NAME) to access your camera';
 const MICROPHONE_USAGE = 'Allow $(PRODUCT_NAME) to access your microphone';
-const BARCODE_SCANNER_PODFILE_KEY = 'expo-camera.barcode-scanner-enabled';
+const BARCODE_SCANNER_KEY = 'expo.camera.barcode-scanner-enabled';
 
 const withCamera: ConfigPlugin<
   {
@@ -38,10 +39,20 @@ const withCamera: ConfigPlugin<
 
   config = withPodfileProperties(config, (config) => {
     if (barcodeScannerEnabled === false) {
-      config.modResults[BARCODE_SCANNER_PODFILE_KEY] = 'false';
+      config.modResults[BARCODE_SCANNER_KEY] = 'false';
     } else {
-      delete config.modResults[BARCODE_SCANNER_PODFILE_KEY];
+      delete config.modResults[BARCODE_SCANNER_KEY];
     }
+    return config;
+  });
+
+  config = withGradleProperties(config, (config) => {
+    config.modResults = AndroidConfig.BuildProperties.updateAndroidBuildProperty(
+      config.modResults,
+      BARCODE_SCANNER_KEY,
+      barcodeScannerEnabled === false ? 'false' : null,
+      { removePropWhenValueIsNull: true }
+    );
     return config;
   });
 


### PR DESCRIPTION
# Why
MLKit adds significant size to the apk which is not necessary when you are not using it. 

# How
Switch the barcode scanning dependencies to `compile-only` which will cause them to not be included in the apk. In debug builds there is about a 10mb size difference when MLKit is excluded in the sandbox app. Couldn't check release because I ran into some expo-router issues. I wouldn't expect as large a difference but there will be a decrease 

# Test Plan
Sandbox

