### PR TITLE
[on-hold] Upgrade react-native-screens to 4.17.1

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2809,7 +2809,7 @@ PODS:
     - ReactNativeDependencies
     - RNWorklets
     - Yoga
-  - RNScreens (4.16.0):
+  - RNScreens (4.17.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2831,9 +2831,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNScreens/common (= 4.16.0)
+    - RNScreens/common (= 4.17.1)
     - Yoga
-  - RNScreens/common (4.16.0):
+  - RNScreens/common (4.17.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3775,7 +3775,7 @@ SPEC CHECKSUMS:
   RNDateTimePicker: 6fdd63f5d1e0f21faf4cc8674957c52958a7efae
   RNGestureHandler: 811910565ec11984124c509763477bb53ab445d3
   RNReanimated: f365c13045d09b5a84487029490d0fa15281d6ec
-  RNScreens: dd61bc3a3e6f6901ad833efa411917d44827cf51
+  RNScreens: 323681ad7305fab21bc2594275f1dc89de82ac2b
   RNSVG: 602379e4d59935e26ecc05dd9d04832eefb20dac
   RNWorklets: c181ebc224265a35743abc490e54a5cf66eb2add
   SDWebImage: f29024626962457f3470184232766516dee8dfea

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -73,7 +73,7 @@
     "react-native-pager-view": "6.9.1",
     "react-native-reanimated": "4.1.3",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.16.0",
+    "react-native-screens": "4.17.1",
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.15.0",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3426,7 +3426,7 @@ PODS:
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNScreens (4.16.0):
+  - RNScreens (4.17.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -3453,10 +3453,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.16.0)
+    - RNScreens/common (= 4.17.1)
     - SocketRocket
     - Yoga
-  - RNScreens/common (4.16.0):
+  - RNScreens/common (4.17.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -4321,7 +4321,7 @@ SPEC CHECKSUMS:
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
   EXManifests: 7469efed75d694ce3c43a6da9c6f3886f66d3c26
   EXNotifications: a9eb811deeb51fb8e50ef45569be6ffab3994648
-  Expo: 76227c1085c9eb5fd79d2e55508fea627f272490
+  Expo: b49d6f57d85cbbd1c74ff97237153846dc67a319
   ExpoAppleAuthentication: 414e4316f8e25a2afbc3943cf725579c910f24b8
   ExpoAsset: 4375a46b45b12bbfcf6efac8c8a33aebdb8ba12b
   ExpoAudio: 80c3cce8e252081c24837ef4c7bedda78f3ce8de
@@ -4331,7 +4331,7 @@ SPEC CHECKSUMS:
   ExpoBlur: b5b7a26572b3c33a11f0b2aa2f95c17c4c393b76
   ExpoBrightness: 7c3c86da46b847aadf44401bd28fb6d67050f324
   ExpoCalendar: 46ad51c48d2cb1a95439c2215b182428919a0c3d
-  ExpoCamera: 6d0c5bc68bc8de669f1ecd4242284de0827c4431
+  ExpoCamera: 442bbbbd75d73d17f3a972b269efe7595b9b6933
   ExpoCellular: 539c6092e755f7b2c37d80f18d9c1f3d7f09e4ab
   ExpoClipboard: 99109306a2d9ed2fbd16f6b856e6267b2afa8472
   ExpoContacts: 82f80ddc812c85548b8edab4153fbc3e8a39212e
@@ -4345,7 +4345,7 @@ SPEC CHECKSUMS:
   ExpoGlassEffect: 02d9577dfe05a6b6c9856fd71514120e96792052
   ExpoHaptics: b48d913e7e5f23816c6f130e525c9a6501b160b5
   ExpoHead: bd3ceefbd93f64ff8298e07711bb67605ffb646c
-  ExpoImage: 306dd755c842dba9f3ee654c51834a9cc657e6ca
+  ExpoImage: 0fc185a4a4e462fedfe877ae66204a7c541dfee0
   ExpoImageManipulator: dbf5b8fc805b55463811cb3da96ab60c532faae8
   ExpoImagePicker: bd0a5c81d7734548f6908a480609257e85d19ea8
   ExpoKeepAwake: 3f5e3ac53627849174f3603271df8e08f174ed4a
@@ -4358,7 +4358,7 @@ SPEC CHECKSUMS:
   ExpoMailComposer: 8771121c8d5e6e0e194537fab79360d0f443f70d
   ExpoMediaLibrary: 648cee3f5dcba13410ec9cc8ac9a426e89a61a31
   ExpoMeshGradient: 763087d3b1e6e9a0974e9700ea24cb598816d93c
-  ExpoModulesCore: 598d08a2b60fed6d60a5ded1a1aeb83760718e80
+  ExpoModulesCore: 0e7c7b65c56452e6a1832dc755676d79689cadd8
   ExpoModulesTestCore: e65555b75a4ed7dd3bcf421ad01d7748bd372c88
   ExpoNetwork: 97073786edfe405aba5d0987a544617ed0671ad1
   ExpoPrint: ad836bb90da10793509651c0ea1f39e120db001e
@@ -4398,7 +4398,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 351b8142817eebf7c51b666b43f2fecdd8d5d8bc
+  hermes-engine: 230e9a70c91129baaa785d79840e1ca9efb8584a
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -4493,7 +4493,7 @@ SPEC CHECKSUMS:
   RNDateTimePicker: c4a42c6a77d474f05162d61a4ab4253d13008277
   RNGestureHandler: 310fefa1b72004d0b0a6a361b537a74724f45d5b
   RNReanimated: 451f6574c6913b15ea3e3a33f2d0a95f68f83081
-  RNScreens: 74985ca8e102294a60cec7513fa84c936fa0b20b
+  RNScreens: d3b832c50356686916d18e28d3c5b9107382191c
   RNSVG: 42c67442bd1f7568e8a4abbd42a093d00e1e2dde
   RNWorklets: 089683f4a4564f30393d32352d41d9e92c3e5a55
   SDWebImage: f29024626962457f3470184232766516dee8dfea

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -80,7 +80,7 @@
     "react-native-paper": "^5.12.5",
     "react-native-reanimated": "4.1.3",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.16.0",
+    "react-native-screens": "4.17.1",
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.15.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -150,7 +150,7 @@
     "react-native-worklets": "0.6.1",
     "react-native-reanimated": "4.1.3",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.16.0",
+    "react-native-screens": "4.17.1",
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-web": "~0.21.0",

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -33,7 +33,7 @@
     "react": "19.1.1",
     "react-native": "0.82.0",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.16.0"
+    "react-native-screens": "4.17.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/apps/router-e2e/__e2e__/native-tabs/app/index.tsx
+++ b/apps/router-e2e/__e2e__/native-tabs/app/index.tsx
@@ -1,7 +1,8 @@
 import { useTheme } from '@react-navigation/native';
 import { Link } from 'expo-router';
 import { use } from 'react';
-import { Pressable, ScrollView, Switch, Text, View } from 'react-native';
+import { Platform, Pressable, ScrollView, Switch, Text, View } from 'react-native';
+import { SafeAreaView as RNSSafeAreaView } from 'react-native-screens/experimental';
 
 import { Post } from '../components/Post';
 import { Faces } from '../components/faces';
@@ -9,106 +10,117 @@ import { ActiveTabsContext } from '../utils/active-tabs-context';
 
 const availableTabs = ['tab-1', 'tab-2', 'tab-3', 'tab-4', 'tab-5', 'tab-6'];
 
+const SafeAreaView: typeof RNSSafeAreaView = (props) => {
+  if (Platform.OS === 'android') {
+    return <RNSSafeAreaView {...props} />;
+  }
+  return props.children;
+};
+
 export default function Index() {
   const { colors } = useTheme();
   const { activeTabs, setActiveTabs } = use(ActiveTabsContext);
   return (
-    <ScrollView
-      contentInsetAdjustmentBehavior="automatic"
-      style={{ flex: 1, backgroundColor: colors.background }}
-      contentContainerStyle={{
-        justifyContent: 'center',
-        // alignItems: 'center',
-        padding: 32,
-        gap: 16,
-      }}>
-      <Text style={{ color: colors.text, fontSize: 32, fontWeight: 'bold', textAlign: 'center' }}>
-        Good Afternoon
-      </Text>
-      <Text style={{ color: colors.text, fontSize: 24, marginBottom: 16, textAlign: 'center' }}>
-        If you have a watch, this is an app for you!
-      </Text>
-      <Text style={{ color: colors.text, fontSize: 24, fontWeight: 'bold' }}>Best faces</Text>
-      <Faces numberOfFaces={3} />
-      <Link href="/faces" style={{ color: colors.text, fontSize: 18 }}>
-        <Link.Trigger>See all faces</Link.Trigger>
-        <Link.Preview />
-      </Link>
+    <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }} edges={{ bottom: true }}>
+      <ScrollView
+        contentInsetAdjustmentBehavior="automatic"
+        style={{ flex: 1, backgroundColor: colors.background }}
+        contentContainerStyle={{
+          justifyContent: 'center',
+          // alignItems: 'center',
+          padding: 32,
+          gap: 16,
+        }}>
+        <Text style={{ color: colors.text, fontSize: 32, fontWeight: 'bold', textAlign: 'center' }}>
+          Good Afternoon
+        </Text>
+        <Text style={{ color: colors.text, fontSize: 24, marginBottom: 16, textAlign: 'center' }}>
+          If you have a watch, this is an app for you!
+        </Text>
+        <Text style={{ color: colors.text, fontSize: 24, fontWeight: 'bold' }}>Best faces</Text>
+        <Faces numberOfFaces={3} />
+        <Link href="/faces" style={{ color: colors.text, fontSize: 18 }}>
+          <Link.Trigger>See all faces</Link.Trigger>
+          <Link.Preview />
+        </Link>
 
-      <Text style={{ color: colors.text, fontSize: 24, fontWeight: 'bold' }}>Latest news</Text>
-      <Post title="New watches in August" href="/explore/news/new-watches-august" />
-      <Link href="/explore" style={{ color: colors.text, fontSize: 18 }}>
-        <Link.Trigger>See all news</Link.Trigger>
-        <Link.Preview />
-      </Link>
+        <Text style={{ color: colors.text, fontSize: 24, fontWeight: 'bold' }}>Latest news</Text>
+        <Post title="New watches in August" href="/explore/news/new-watches-august" />
+        <Link href="/explore" style={{ color: colors.text, fontSize: 18 }}>
+          <Link.Trigger>See all news</Link.Trigger>
+          <Link.Preview />
+        </Link>
 
-      <Text style={{ color: colors.text, fontSize: 24, fontWeight: 'bold' }}>History</Text>
-      <Link href="/explore/news/new-watches-august" asChild>
-        <Link.Trigger>
-          <Pressable style={{ borderRadius: 16 }}>
-            <View style={{ flexDirection: 'row', gap: 12, alignItems: 'center' }}>
-              <Text style={{ color: colors.text, fontSize: 48, fontWeight: 600 }}>08</Text>
-              <Link href="/explore/news/new-watches-august" asChild>
-                <Link.Trigger>
-                  <Pressable style={{ flex: 1, borderRadius: 16, overflow: 'hidden' }}>
-                    <View
-                      style={{
-                        flex: 1,
-                        aspectRatio: 1,
-                        backgroundColor: '#9ca3af',
-                      }}
-                    />
-                  </Pressable>
-                </Link.Trigger>
-                <Link.Preview />
-              </Link>
+        <Text style={{ color: colors.text, fontSize: 24, fontWeight: 'bold' }}>History</Text>
+        <Link href="/explore/news/new-watches-august" asChild>
+          <Link.Trigger>
+            <Pressable style={{ borderRadius: 16 }}>
+              <View style={{ flexDirection: 'row', gap: 12, alignItems: 'center' }}>
+                <Text style={{ color: colors.text, fontSize: 48, fontWeight: 600 }}>08</Text>
+                <Link href="/explore/news/new-watches-august" asChild>
+                  <Link.Trigger>
+                    <Pressable style={{ flex: 1, borderRadius: 16, overflow: 'hidden' }}>
+                      <View
+                        style={{
+                          flex: 1,
+                          aspectRatio: 1,
+                          backgroundColor: '#9ca3af',
+                        }}
+                      />
+                    </Pressable>
+                  </Link.Trigger>
+                  <Link.Preview />
+                </Link>
+              </View>
+            </Pressable>
+          </Link.Trigger>
+          <Link.Preview />
+        </Link>
+
+        <Link href="/explore" style={{ color: colors.text, fontSize: 18 }}>
+          <Link.Trigger>See all</Link.Trigger>
+          <Link.Preview />
+        </Link>
+
+        <Text style={{ color: colors.text, fontSize: 24, fontWeight: 'bold' }}>
+          Additional links
+        </Text>
+        <Link href="/dynamic" style={{ color: colors.text, fontSize: 18 }}>
+          <Link.Trigger>Dynamic</Link.Trigger>
+          <Link.Preview />
+        </Link>
+        <Link href="/404" style={{ color: colors.text, fontSize: 18 }}>
+          Try and go to 404
+        </Link>
+        <Link href="/tab-1" style={{ color: colors.text, fontSize: 18 }}>
+          Try and go to Tab 1
+        </Link>
+        <Link href="/tab-2" style={{ color: colors.text, fontSize: 18 }}>
+          Try and go to Tab 2
+        </Link>
+        <Link href="/faces" style={{ color: colors.text, fontSize: 18 }}>
+          Try and go to Faces
+        </Link>
+        <Link href="/_sitemap" style={{ color: colors.text, fontSize: 18 }}>
+          Sitemap is here
+        </Link>
+        <View style={{ marginTop: 16 }}>
+          <Text style={{ color: colors.text, fontSize: 18 }}>Additional Tabs:</Text>
+          {availableTabs.map((tab) => (
+            <View
+              key={tab}
+              style={{ flexDirection: 'row', alignItems: 'center', marginVertical: 4, gap: 24 }}>
+              <Switch
+                value={activeTabs.includes(tab)}
+                onValueChange={(value) => {
+                  setActiveTabs((prev) => (value ? [...prev, tab] : prev.filter((t) => t !== tab)));
+                }}
+              />
+              <Text style={{ color: colors.text }}>{tab}</Text>
             </View>
-          </Pressable>
-        </Link.Trigger>
-        <Link.Preview />
-      </Link>
-
-      <Link href="/explore" style={{ color: colors.text, fontSize: 18 }}>
-        <Link.Trigger>See all</Link.Trigger>
-        <Link.Preview />
-      </Link>
-
-      <Text style={{ color: colors.text, fontSize: 24, fontWeight: 'bold' }}>Additional links</Text>
-      <Link href="/dynamic" style={{ color: colors.text, fontSize: 18 }}>
-        <Link.Trigger>Dynamic</Link.Trigger>
-        <Link.Preview />
-      </Link>
-      <Link href="/404" style={{ color: colors.text, fontSize: 18 }}>
-        Try and go to 404
-      </Link>
-      <Link href="/tab-1" style={{ color: colors.text, fontSize: 18 }}>
-        Try and go to Tab 1
-      </Link>
-      <Link href="/tab-2" style={{ color: colors.text, fontSize: 18 }}>
-        Try and go to Tab 2
-      </Link>
-      <Link href="/faces" style={{ color: colors.text, fontSize: 18 }}>
-        Try and go to Faces
-      </Link>
-      <Link href="/_sitemap" style={{ color: colors.text, fontSize: 18 }}>
-        Sitemap is here
-      </Link>
-      <View style={{ marginTop: 16 }}>
-        <Text style={{ color: colors.text, fontSize: 18 }}>Additional Tabs:</Text>
-        {availableTabs.map((tab) => (
-          <View
-            key={tab}
-            style={{ flexDirection: 'row', alignItems: 'center', marginVertical: 4, gap: 24 }}>
-            <Switch
-              value={activeTabs.includes(tab)}
-              onValueChange={(value) => {
-                setActiveTabs((prev) => (value ? [...prev, tab] : prev.filter((t) => t !== tab)));
-              }}
-            />
-            <Text style={{ color: colors.text }}>{tab}</Text>
-          </View>
-        ))}
-      </View>
-    </ScrollView>
+          ))}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
   );
 }

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -51,7 +51,7 @@
     "react": "19.1.1",
     "react-native": "0.82.0",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.16.0",
+    "react-native-screens": "4.17.1",
     "react-native-webview": "13.15.0"
   },
   "devDependencies": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -102,7 +102,7 @@
   "react-native-pager-view": "6.9.1",
   "react-native-worklets": "0.6.1",
   "react-native-reanimated": "~4.1.1",
-  "react-native-screens": "~4.16.0",
+  "react-native-screens": "~4.17.1",
   "react-native-safe-area-context": "~5.6.0",
   "react-native-svg": "15.12.1",
   "react-native-view-shot": "4.0.3",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -35,7 +35,7 @@
     "react-native-worklets": "0.6.1",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
-    "react-native-screens": "~4.16.0",
+    "react-native-screens": "~4.17.1",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -27,7 +27,7 @@
     "react-native-worklets": "0.6.1",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
-    "react-native-screens": "~4.16.0",
+    "react-native-screens": "~4.17.1",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13500,13 +13500,12 @@ react-native-screens@4.11.1-nightly-20250611-8b82e081e:
     react-native-is-edge-to-edge "^1.1.7"
     warn-once "^0.1.0"
 
-react-native-screens@4.16.0:
-  version "4.16.0"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.16.0.tgz#efa42e77a092aa0b5277c9ae41391ea0240e0870"
-  integrity sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==
+react-native-screens@4.17.1:
+  version "4.17.1"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.17.1.tgz#fad2588c73b063d3156543cfa673ca60ed5b8008"
+  integrity sha512-hGArs1kzsokvwxq98vluGlprUw3Q95zEjvZ3U2q28FmvLy25e6jxMclEkgxNtJ0GVJ2gWcFRTXON0EIVvUEd+A==
   dependencies:
     react-freeze "^1.0.0"
-    react-native-is-edge-to-edge "^1.2.1"
     warn-once "^0.1.0"
 
 react-native-scrollable-mixin@^1.0.0:


### PR DESCRIPTION
# Why

New version of react-native-screens was released, with fixes to iOS 26 header and support for SafeAreaView with Native Bottom Tabs on Android.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

1. Build Bare Expo
2. Build Expo Go
3. Test all the Apps
4. Test router and native tabs

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
