### PR TITLE
Deprecate SafeAreaView in documentation

### DIFF
--- a/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
@@ -14,7 +14,7 @@ import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
 import { APIBoxSectionHeader } from '~/components/plugins/api/components/APIBoxSectionHeader';
 import { CALLOUT } from '~/ui/components/Text';
 
-`react-native-safe-area-context` provides a flexible API for accessing device safe area inset information. This allows you to position your content appropriately around notches, status bars, home indicators, and other such device and operating system interface elements. It also provides a `SafeAreaView` component that you can use in place of `View` to automatically inset your views to account for safe areas.
+`react-native-safe-area-context` provides a flexible API for accessing device safe area inset information. This allows you to position your content appropriately around notches, status bars, home indicators, and other such device and operating system interface elements. `SafeAreaView` is being depricated, it is suggested to `useSafeAreaInsets` and `insets.direction`.
 
 ## Installation
 


### PR DESCRIPTION
Updated the documentation to indicate that `SafeAreaView` is deprecated and recommends using `useSafeAreaInsets` and `insets.direction` instead.

# Why

The latest release blog says SAV is being deprecated but the docs are saying the opposite. This adds a message at the top indicating so.

# How

Edited the docs
