### PR TITLE
[updates][Android] Add 16 KB support

### DIFF
--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -101,7 +101,8 @@ android {
 
     externalNativeBuild {
       cmake {
-        arguments "-DANDROID_STL=c++_shared"
+        arguments "-DANDROID_STL=c++_shared",
+          "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
       }
     }
   }


### PR DESCRIPTION
# Why

Adds 16 KB support
Fixes:
<img width="372" height="224" alt="Screenshot 2025-10-17 at 17 35 04" src="https://github.com/user-attachments/assets/3c22bc4c-2e1c-4a03-aea4-c7ef6d6e98e4" />


# How

Followed official documentation for NDK 27 - https://developer.android.com/guide/practices/page-sizes#compile-r27

# Test Plan

<img width="1124" height="96" alt="Screenshot 2025-10-19 at 10 15 31" src="https://github.com/user-attachments/assets/63732770-fa22-462d-a39b-1ba10a28a4c0" />

