### PR TITLE
[ios][core] Use `runtimeScheduler` for scheduling js tasks

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -30,7 +30,7 @@
 - [iOS] Add explicit CallInvoker and CallbackWrapper imports to EXJSIUtils ([#39818](https://github.com/expo/expo/pull/39818) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Refactor getDelayLoadAppHandler to use ReactHost ([#40084](https://github.com/expo/expo/pull/40084) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Use module name from `expo-module.config.json`. ([#39985](https://github.com/expo/expo/pull/39985), [#40241](https://github.com/expo/expo/pull/40241) by [@jakex7](https://github.com/jakex7))
-- [iOS] Use the `RuntimeScheduler` to schedule tasks on the JS thread.
+- [iOS] Use the `RuntimeScheduler` to schedule tasks on the JS thread. ([#40473](https://github.com/expo/expo/pull/40473) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 3.0.19 - 2025-10-01
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [iOS] Add explicit CallInvoker and CallbackWrapper imports to EXJSIUtils ([#39818](https://github.com/expo/expo/pull/39818) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Refactor getDelayLoadAppHandler to use ReactHost ([#40084](https://github.com/expo/expo/pull/40084) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Use module name from `expo-module.config.json`. ([#39985](https://github.com/expo/expo/pull/39985), [#40241](https://github.com/expo/expo/pull/40241) by [@jakex7](https://github.com/jakex7))
+- [iOS] Use the `RuntimeScheduler` to schedule tasks on the JS thread.
 
 ## 3.0.19 - 2025-10-01
 

--- a/packages/expo-modules-core/ios/JSI/EXJSIInstaller.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIInstaller.mm
@@ -53,8 +53,8 @@ static NSString *modulesHostObjectPropertyName = @"modules";
   }
 
   return [[EXRuntime alloc] initWithRuntime:jsiRuntime
-                                  callInvoker:bridge.jsCallInvoker
-                             runtimeScheduler:[self runtimeSchedulerFromRuntime:jsiRuntime]];
+                                callInvoker:bridge.jsCallInvoker
+                           runtimeScheduler:[self runtimeSchedulerFromRuntime:jsiRuntime]];
 }
 
 #if __has_include(<ReactCommon/RCTRuntimeExecutor.h>)
@@ -79,8 +79,8 @@ static NSString *modulesHostObjectPropertyName = @"modules";
   }
 
   return [[EXRuntime alloc] initWithRuntime:jsiRuntime
-                                  callInvoker:callInvoker
-                             runtimeScheduler:[self runtimeSchedulerFromRuntime:jsiRuntime]];
+                                callInvoker:callInvoker
+                           runtimeScheduler:[self runtimeSchedulerFromRuntime:jsiRuntime]];
 }
 #endif // React Native >=0.74
 

--- a/packages/expo-modules-core/ios/JSI/EXJSIInstaller.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIInstaller.mm
@@ -34,6 +34,17 @@ static NSString *modulesHostObjectPropertyName = @"modules";
 
 @implementation EXJavaScriptRuntimeManager
 
++ (std::shared_ptr<facebook::react::RuntimeScheduler>)runtimeSchedulerFromRuntime:(jsi::Runtime *)jsiRuntime
+{
+  if (jsiRuntime == nullptr) {
+    return nullptr;
+  }
+  if (auto binding = facebook::react::RuntimeSchedulerBinding::getBinding(*jsiRuntime)) {
+    return binding->getRuntimeScheduler();
+  }
+  return nullptr;
+}
+
 + (nullable EXRuntime *)runtimeFromBridge:(nonnull RCTBridge *)bridge
 {
   jsi::Runtime *jsiRuntime = reinterpret_cast<jsi::Runtime *>(bridge.runtime);
@@ -41,13 +52,9 @@ static NSString *modulesHostObjectPropertyName = @"modules";
     return nil;
   }
 
-  std::shared_ptr<facebook::react::RuntimeScheduler> runtimeScheduler = nullptr;
-  if (auto binding = facebook::react::RuntimeSchedulerBinding::getBinding(*jsiRuntime)) {
-    runtimeScheduler = binding->getRuntimeScheduler();
-  }
   return [[EXRuntime alloc] initWithRuntime:jsiRuntime
                                   callInvoker:bridge.jsCallInvoker
-                             runtimeScheduler:runtimeScheduler];
+                             runtimeScheduler:[self runtimeSchedulerFromRuntime:jsiRuntime]];
 }
 
 #if __has_include(<ReactCommon/RCTRuntimeExecutor.h>)
@@ -71,13 +78,9 @@ static NSString *modulesHostObjectPropertyName = @"modules";
     return nil;
   }
 
-  std::shared_ptr<facebook::react::RuntimeScheduler> runtimeScheduler = nullptr;
-  if (auto binding = facebook::react::RuntimeSchedulerBinding::getBinding(*jsiRuntime)) {
-    runtimeScheduler = binding->getRuntimeScheduler();
-  }
   return [[EXRuntime alloc] initWithRuntime:jsiRuntime
                                   callInvoker:callInvoker
-                             runtimeScheduler:runtimeScheduler];
+                             runtimeScheduler:[self runtimeSchedulerFromRuntime:jsiRuntime]];
 }
 #endif // React Native >=0.74
 

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
@@ -9,6 +9,10 @@
 
 #ifdef __cplusplus
 
+namespace facebook::react {
+class RuntimeScheduler;
+}
+
 namespace jsi = facebook::jsi;
 namespace react = facebook::react;
 #endif // __cplusplus
@@ -47,6 +51,9 @@ NS_SWIFT_NAME(JavaScriptRuntime)
 
 - (nonnull instancetype)initWithRuntime:(nonnull jsi::Runtime *)runtime
                             callInvoker:(std::shared_ptr<react::CallInvoker>)callInvoker;
+- (nonnull instancetype)initWithRuntime:(nonnull jsi::Runtime *)runtime
+                            callInvoker:(std::shared_ptr<react::CallInvoker>)callInvoker
+                       runtimeScheduler:(std::shared_ptr<facebook::react::RuntimeScheduler>)runtimeScheduler;
 
 /**
  Returns the underlying runtime object.

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -266,13 +266,9 @@ typedef jsi::Function (^InstanceFactory)(jsi::Runtime& runtime, NSString * name,
     _runtimeScheduler->scheduleTask(schedulerPriority, std::move(callback));
     return;
   }
-#if REACT_NATIVE_TARGET_VERSION >= 75
   _jsCallInvoker->invokeAsync(SchedulerPriority(priority), [block = std::move(block)](jsi::Runtime&) {
     block();
   });
-#else
-  _jsCallInvoker->invokeAsync(SchedulerPriority(priority), block);
-#endif
 }
 
 #pragma mark - Private


### PR DESCRIPTION
# Why
Currently on bridgeless, if the `RCTRuntimeExecutor` is available we use our own `BridgelessJSCallInvoker` to run tasks directly on the  raw `RuntimeExecutor`. This bypasses the scheduler and prioritises our events over everything else.

# How
We should use the scheduler so our events are scheduled appropriately like all RN core modules. 

# Test Plan
Bare-expo. Events now use `_runtimeScheduler->scheduleTask` 

