### PR TITLE
[autolinking][Android] Fix `library projects cannot set applicationIdSuffix`

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -14,7 +14,7 @@
 - [iOS] Added build phase script for a workaround to autolinking-generated react-native-config output not being used in ReactCodegen script phase due to temp output directory. ([#40219](https://github.com/expo/expo/pull/40219) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Fix passing exclude options. ([#40014](https://github.com/expo/expo/pull/40014) by [@jakex7](https://github.com/jakex7))
 - Ignore missing `package.json` name property when scanning dependencies ([#40367](https://github.com/expo/expo/pull/40367) by [@kitten](https://github.com/kitten))
-- [Android] Fixed `library projects cannot set applicationIdSuffix`.
+- [Android] Fixed `library projects cannot set applicationIdSuffix`. ([#40477](https://github.com/expo/expo/pull/40477) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [iOS] Added build phase script for a workaround to autolinking-generated react-native-config output not being used in ReactCodegen script phase due to temp output directory. ([#40219](https://github.com/expo/expo/pull/40219) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Fix passing exclude options. ([#40014](https://github.com/expo/expo/pull/40014) by [@jakex7](https://github.com/jakex7))
 - Ignore missing `package.json` name property when scanning dependencies ([#40367](https://github.com/expo/expo/pull/40367) by [@kitten](https://github.com/kitten))
+- [Android] Fixed `library projects cannot set applicationIdSuffix`.
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingPlugin.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingPlugin.kt
@@ -156,11 +156,6 @@ open class ExpoAutolinkingPlugin : Plugin<Project> {
 
         consumerFlavors.create(appFlavor.name).apply {
           this.dimension = dimension
-          appFlavor.applicationIdSuffix?.let { this.applicationIdSuffix = it }
-          appFlavor.versionNameSuffix?.let { this.versionNameSuffix = it }
-          if (appFlavor.manifestPlaceholders.isNotEmpty()) {
-            this.manifestPlaceholders.putAll(appFlavor.manifestPlaceholders)
-          }
         }
 
         project.logger.quiet("  -> Created flavor '${appFlavor.name}' (dimension='$dimension') in :${project.path}")


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/pull/40238#issuecomment-3411713396.

# How

Stop applying application specific flavor configuration to the Expo package. 

# Test Plan

- bare-expo ✅ 