### PR TITLE
[filesystem][Android] Add downloadFileAsync to SAF

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- [Android] Add downloadFileAsync to SAF.
+- [Android] Add downloadFileAsync to SAF. ([#40487](https://github.com/expo/expo/pull/40487) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [Android] Add downloadFileAsync to SAF.
+
 ### 🐛 Bug fixes
 
 - [Android] Fix recursive file deletion. ([#40248](https://github.com/expo/expo/pull/40248) by [@aleqsio](https://github.com/aleqsio))

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/SAFDocumentFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/SAFDocumentFile.kt
@@ -72,7 +72,7 @@ class SAFDocumentFile(private val context: Context, override val uri: Uri) : Uni
 
   override fun inputStream(): InputStream {
     return context.contentResolver.openInputStream(uri)
-      ?: throw IllegalStateException("Unable to open output stream for URI: $uri")
+      ?: throw IllegalStateException("Unable to open input stream for URI: $uri")
   }
 
   override fun length(): Long {


### PR DESCRIPTION
# Why

https://github.com/expo/expo/issues/40312#issuecomment-3389930349
`downloadFileAsync` works only with Java File. 

# How

Add ability to handle SAF directories/files. 
_* downloadFileAsync ignores `idempotent` option when destination is `SAFDocumentFile`, because SAF auto-resolves filename conflicts by appending a number, so we don't want to interfere with that._

# Test Plan

```tsx
<Button
  title="Create and download SAF"
  onPress={async () => {
    const dir = await Directory.pickDirectoryAsync();
    const dest = dir.createFile('test.pdf', 'application/pdf');
    const res = await File.downloadFileAsync('https://pdfobject.com/pdf/sample.pdf', dest);
    console.log(res);
  }}
/>
<Button
  title="Download SAF"
  onPress={async () => {
    const dir = await Directory.pickDirectoryAsync();
    const res = await File.downloadFileAsync('https://pdfobject.com/pdf/sample.pdf', dir);
    console.log(res);
  }}
/>
<Button
  title="Create and download documents"
  onPress={async () => {
    const dir = Paths.document;
    const dest = new File(dir.uri, 'test.pdf');
    const res = await File.downloadFileAsync('https://pdfobject.com/pdf/sample.pdf', dest, {
      idempotent: true,
    });
    console.log(res);
  }}
/>
<Button
  title="Download documents"
  onPress={async () => {
    const dir = Paths.document;
    const res = await File.downloadFileAsync('https://pdfobject.com/pdf/sample.pdf', dir, {
      idempotent: true,
    });
    console.log(res);
  }}
/>
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
