### PR TITLE
chore(babel-preset-expo): Update snapshot replacement for worklets version

### DIFF
--- a/packages/babel-preset-expo/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/babel-preset-expo/src/__tests__/__snapshots__/index.test.ts.snap
@@ -264,7 +264,7 @@ exports[`metro supports reanimated worklets 1`] = `
 function someWorklet_workletJs1Factory(_ref){var _worklet_14307677064221_init_data=_ref._worklet_14307677064221_init_data;var _e=[new global.Error(),1,-27];var someWorklet=function someWorklet(greeting){
 
 console.log("Hey I'm running on the UI thread");
-};someWorklet.__closure={};someWorklet.__workletHash=14307677064221;someWorklet.__pluginVersion="0.6.1";someWorklet.__initData=_worklet_14307677064221_init_data;someWorklet.__stackDetails=_e;return someWorklet;}({_worklet_14307677064221_init_data:_worklet_14307677064221_init_data});"
+};someWorklet.__closure={};someWorklet.__workletHash=14307677064221;someWorklet.__pluginVersion="[GLOBAL]";someWorklet.__initData=_worklet_14307677064221_init_data;someWorklet.__stackDetails=_e;return someWorklet;}({_worklet_14307677064221_init_data:_worklet_14307677064221_init_data});"
 `;
 
 exports[`metro transpiles non-standard exports 1`] = `
@@ -296,7 +296,7 @@ exports[`metro+hermes supports reanimated worklets 1`] = `
 function someWorklet_workletJs1Factory(_ref){var _worklet_14307677064221_init_data=_ref._worklet_14307677064221_init_data;var _e=[new global.Error(),1,-27];var someWorklet=function(greeting){
 
 console.log("Hey I'm running on the UI thread");
-};someWorklet.__closure={};someWorklet.__workletHash=14307677064221;someWorklet.__pluginVersion="0.6.1";someWorklet.__initData=_worklet_14307677064221_init_data;someWorklet.__stackDetails=_e;return someWorklet;}({_worklet_14307677064221_init_data});"
+};someWorklet.__closure={};someWorklet.__workletHash=14307677064221;someWorklet.__pluginVersion="[GLOBAL]";someWorklet.__initData=_worklet_14307677064221_init_data;someWorklet.__stackDetails=_e;return someWorklet;}({_worklet_14307677064221_init_data});"
 `;
 
 exports[`metro+hermes transpiles non-standard exports 1`] = `
@@ -328,7 +328,7 @@ exports[`webpack supports reanimated worklets 1`] = `
 function someWorklet_workletJs1Factory({_worklet_14307677064221_init_data}){const _e=[new global.Error(),1,-27];const someWorklet=function(greeting){
 
 console.log("Hey I'm running on the UI thread");
-};someWorklet.__closure={};someWorklet.__workletHash=14307677064221;someWorklet.__pluginVersion="0.6.1";someWorklet.__initData=_worklet_14307677064221_init_data;someWorklet.__stackDetails=_e;return someWorklet;}({_worklet_14307677064221_init_data});"
+};someWorklet.__closure={};someWorklet.__workletHash=14307677064221;someWorklet.__pluginVersion="[GLOBAL]";someWorklet.__initData=_worklet_14307677064221_init_data;someWorklet.__stackDetails=_e;return someWorklet;}({_worklet_14307677064221_init_data});"
 `;
 
 exports[`webpack transpiles non-standard exports 1`] = `

--- a/packages/babel-preset-expo/src/__tests__/index.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/index.test.ts
@@ -264,7 +264,7 @@ export * as default from './Animated';
       caller,
     };
 
-    const code = babel.transformFileSync(samplesPath, options)!.code;
+    const code = babel.transformFileSync(samplesPath, options)!.code || '';
     expect(code).toContain("'worklet';");
     expect(code).toMatchSnapshot();
   });
@@ -285,7 +285,7 @@ export * as default from './Animated';
     function stablePaths(src) {
       return src
         .replace(new RegExp(samplesPath, 'g'), '[mock]/worklet.js')
-        .replace(/version:".*"/, 'version:"[GLOBAL]"');
+        .replace(/__pluginVersion="\d+(?:\.\d+){2}"/, '__pluginVersion="[GLOBAL]"');
     }
 
     const code = stablePaths(babel.transformFileSync(samplesPath, options)!.code);


### PR DESCRIPTION
# Why

We frequently forget to update this, since there's no version to bump in `babel-preset-expo` directly, which allows us to update worklets in the monorepo without updating this test.

# How

- Update replacement regex

# Test Plan

- PR updates tests itself

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
