### PR TITLE
[core][Android] Add `WorkletJSCallInvoker`

### DIFF
--- a/packages/expo-modules-core/android/CMakeLists.txt
+++ b/packages/expo-modules-core/android/CMakeLists.txt
@@ -20,7 +20,8 @@ set(COMMON_DIR ${CMAKE_SOURCE_DIR}/../common/cpp)
 file(GLOB sources_android "${SRC_DIR}/main/cpp/*.cpp")
 file(GLOB sources_android_types "${SRC_DIR}/main/cpp/types/*.cpp")
 file(GLOB sources_android_javaclasses "${SRC_DIR}/main/cpp/javaclasses/*.cpp")
-file(GLOB sources_android_javaclasses "${SRC_DIR}/main/cpp/decorators/*.cpp")
+file(GLOB sources_android_decorators "${SRC_DIR}/main/cpp/decorators/*.cpp")
+file(GLOB sources_android_worklets "${SRC_DIR}/main/cpp/worklets/*.cpp")
 file(GLOB common_sources "${COMMON_DIR}/*.cpp")
 
 # shared
@@ -42,6 +43,8 @@ add_library(
   ${sources_android}
   ${sources_android_types}
   ${sources_android_javaclasses}
+  ${sources_android_decorators}
+  ${sources_android_worklets}
 )
 
 target_precompile_headers(${PACKAGE_NAME} PRIVATE ${SRC_DIR}/main/cpp/ExpoHeader.pch)
@@ -53,6 +56,12 @@ if(IS_NEW_ARCHITECTURE_ENABLED)
 else()
   set(NEW_ARCHITECTURE_DEPENDENCIES "")
   set(NEW_ARCHITECTURE_COMPILE_OPTIONS "")
+endif()
+
+if (REACT_NATIVE_WORKLETS_DIR)
+  set(WORKLETS_INTEGRATION_COMPILE_OPTIONS "-DWORKLETS_ENABLED=1")
+else()
+  set(WORKLETS_INTEGRATION_COMPILE_OPTIONS "")
 endif()
 
 createVarAsBoolToInt("USE_HERMES_INT" ${USE_HERMES})
@@ -67,6 +76,7 @@ target_compile_options(CommonSettings INTERFACE
   -DUSE_HERMES=${USE_HERMES_INT}
   -DUNIT_TEST=${UNIT_TEST_INT}
   ${NEW_ARCHITECTURE_COMPILE_OPTIONS}
+  ${WORKLETS_INTEGRATION_COMPILE_OPTIONS}
 )
 
 # tests
@@ -113,6 +123,8 @@ if (REACT_NATIVE_WORKLETS_DIR)
   target_include_directories(
     ${PACKAGE_NAME}
     PRIVATE
+    "${REACT_NATIVE_DIR}/ReactCommon"
+    "${REACT_NATIVE_DIR}/ReactCommon/jsiexecutor"
     "${REACT_NATIVE_WORKLETS_DIR}/Common/cpp"
     "${REACT_NATIVE_WORKLETS_DIR}/android/src/main/cpp"
   )
@@ -147,6 +159,12 @@ target_link_libraries(
 
 if (REACT_NATIVE_WORKLETS_DIR)
   add_library(worklets SHARED IMPORTED)
+
+  if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
+    set(BUILD_TYPE "debug")
+  else()
+    set(BUILD_TYPE "release")
+  endif()
 
   set_target_properties(
     worklets

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -311,16 +311,7 @@ tasks.register("prepareKotlinBuildScriptModel") {
 
 if (workletsProject != null) {
   afterEvaluate {
-    tasks.named("externalNativeBuildDebug") { externalNativeBuildTask ->
-      workletsProject.tasks.named("externalNativeBuildDebug") { workletsExternalNativeBuildTask ->
-        externalNativeBuildTask.dependsOn(workletsExternalNativeBuildTask)
-      }
-    }
-
-    tasks.named("externalNativeBuildRelease") { externalNativeBuildTask ->
-      workletsProject.tasks.named("externalNativeBuildRelease") { workletsExternalNativeBuildTask ->
-        externalNativeBuildTask.dependsOn(workletsExternalNativeBuildTask)
-      }
-    }
+    tasks.getByName("externalNativeBuildDebug").dependsOn(findProject(":react-native-worklets").tasks.getByName("externalNativeBuildDebug"))
+    tasks.getByName("externalNativeBuildRelease").dependsOn(findProject(":react-native-worklets").tasks.getByName("externalNativeBuildRelease"))
   }
 }

--- a/packages/expo-modules-core/android/src/main/cpp/worklets/WorkletJSCallInvoker.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/worklets/WorkletJSCallInvoker.cpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#if WORKLETS_ENABLED
+
+#include "WorkletJSCallInvoker.h"
+
+namespace expo {
+
+  WorkletJSCallInvoker::WorkletJSCallInvoker(
+    std::weak_ptr<worklets::WorkletRuntime> &workletRuntimeHolder
+  ) : workletRuntimeHolder_(workletRuntimeHolder) {}
+
+  void WorkletJSCallInvoker::invokeAsync(react::CallFunc &&func) noexcept {
+    auto workletRuntime = workletRuntimeHolder_.lock();
+    if (!workletRuntime) {
+      return;
+    }
+
+    workletRuntime->executeAsync(std::move(func));
+  }
+
+
+  void WorkletJSCallInvoker::invokeSync(react::CallFunc &&func) {
+    auto workletRuntime = workletRuntimeHolder_.lock();
+    if (!workletRuntime) {
+      return;
+    }
+
+    workletRuntime->executeSync([func = std::move(func)](jsi::Runtime &rt) -> jsi::Value {
+      func(rt);
+      return jsi::Value::undefined();
+    });
+  }
+} // namespace expo
+
+#endif

--- a/packages/expo-modules-core/android/src/main/cpp/worklets/WorkletJSCallInvoker.h
+++ b/packages/expo-modules-core/android/src/main/cpp/worklets/WorkletJSCallInvoker.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#if WORKLETS_ENABLED
+
+#include <ReactCommon/CallInvoker.h>
+#include <ReactCommon/RuntimeExecutor.h>
+
+#include <worklets/WorkletRuntime/WorkletRuntime.h>
+
+#include <memory>
+
+
+namespace jsi = facebook::jsi;
+namespace react = facebook::react;
+
+namespace expo {
+
+class WorkletJSCallInvoker : public react::CallInvoker {
+public:
+  explicit WorkletJSCallInvoker(std::weak_ptr<worklets::WorkletRuntime> &workletRuntimeHolder);
+
+  void invokeAsync(react::CallFunc &&func) noexcept override;
+
+  void invokeSync(react::CallFunc &&func) override;
+private:
+  std::weak_ptr<worklets::WorkletRuntime> workletRuntimeHolder_;
+};
+
+} // namespace expo
+
+#endif


### PR DESCRIPTION
# Why

Adds a `WorkletJSCallInvoker` that dispatches function on the thread connected with given runtime. Used to dispatched promises on the correct thread.

# How

Uses interface provided by `react-native-worklet` to dispatche function on the correct thread. 

> [!NOTE]
This PR needs some upstream changes inorder to work:
	- https://github.com/software-mansion/react-native-reanimated/pull/8426
	- https://github.com/software-mansion/react-native-reanimated/pull/8425

# Test Plan

- bare-expo ✅ 