### PR TITLE
[docs] update `expo-splash-screen` example

### DIFF
--- a/docs/pages/versions/unversioned/sdk/splash-screen.mdx
+++ b/docs/pages/versions/unversioned/sdk/splash-screen.mdx
@@ -16,7 +16,7 @@ import {
 } from '~/ui/components/ConfigSection';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
-The `SplashScreen` module from the `expo-splash-screen` library is used to tell the splash screen to remain visible until it has been explicitly told to hide. This is useful to do tasks that will happen behind the scenes such as making API calls, pre-loading fonts, animating the splash screen and so on.
+The `SplashScreen` module from the `expo-splash-screen` library provides control over the native splash screen behavior. By default, the splash screen will automatically hide when your app is ready, but you can also manually control its visibility for advanced use cases.
 
 > From **SDK 52**, due to changes supporting the latest Android splash screen API, Expo Go and development builds cannot fully replicate the splash screen experience your users will see in your [standalone app](/more/glossary-of-terms/#standalone-app). Expo Go will show your app icon instead of the splash screen, and the splash screen on development builds will not reflect all properties set in the config plugin. **It is highly recommended that you test your splash screen on a release build to ensure it looks as expected.**
 
@@ -28,7 +28,59 @@ Also, see the guide on [creating a splash screen image](/develop/user-interface/
 
 ## Usage
 
-This example shows how to keep the splash screen visible while loading app resources and then hide the splash screen when the app has rendered some initial content.
+For most apps, you don't need to do anything special with the splash screen. It will automatically hide when your app is ready. You can optionally configure animation options:
+
+<Tabs>
+
+<Tab label="With Expo Router">
+
+```jsx app/_layout.tsx
+import { Stack } from 'expo-router';
+import * as SplashScreen from 'expo-splash-screen';
+
+// Set the animation options. This is optional.
+SplashScreen.setOptions({
+  duration: 1000,
+  fade: true,
+});
+
+export default function RootLayout() {
+  return <Stack />;
+}
+```
+
+</Tab>
+
+<Tab label="Without Expo Router">
+
+```jsx App.js
+import { Text, View } from 'react-native';
+import Entypo from '@expo/vector-icons/Entypo';
+import * as SplashScreen from 'expo-splash-screen';
+
+// Set the animation options. This is optional.
+SplashScreen.setOptions({
+  duration: 1000,
+  fade: true,
+});
+
+export default function App() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>SplashScreen Demo! 👋</Text>
+      <Entypo name="rocket" size={30} />
+    </View>
+  );
+}
+```
+
+</Tab>
+
+</Tabs>
+
+### Delay hiding the splash screen
+
+In some cases, it may be necessary to delay hiding the splash screen until certain resources are loaded. For example, if you need to load fonts or API data before displaying the app content, you can use `preventAutoHideAsync()` to manually control when the splash screen hides. The goal should be to hide the splash screen as soon as possible.
 
 <Tabs>
 
@@ -40,12 +92,7 @@ import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { useEffect } from 'react';
 
-// Set the animation options. This is optional.
-SplashScreen.setOptions({
-  duration: 1000,
-  fade: true,
-});
-
+// Keep the splash screen visible while we fetch resources
 SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
@@ -80,12 +127,6 @@ import * as Font from 'expo-font';
 
 // Keep the splash screen visible while we fetch resources
 SplashScreen.preventAutoHideAsync();
-
-// Set the animation options. This is optional.
-SplashScreen.setOptions({
-  duration: 1000,
-  fade: true,
-});
 
 export default function App() {
   const [loaded] = useFonts({

--- a/docs/pages/versions/unversioned/sdk/splash-screen.mdx
+++ b/docs/pages/versions/unversioned/sdk/splash-screen.mdx
@@ -34,7 +34,7 @@ For most apps, you don't need to do anything special with the splash screen. It 
 
 <Tab label="With Expo Router">
 
-```jsx app/_layout.tsx
+```tsx app/_layout.tsx
 import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 
@@ -53,7 +53,7 @@ export default function RootLayout() {
 
 <Tab label="Without Expo Router">
 
-```jsx App.js
+```tsx App.tsx
 import { Text, View } from 'react-native';
 import Entypo from '@expo/vector-icons/Entypo';
 import * as SplashScreen from 'expo-splash-screen';
@@ -86,7 +86,7 @@ In some cases, it may be necessary to delay hiding the splash screen until certa
 
 <Tab label="With Expo Router">
 
-```jsx app/_layout.tsx
+```tsx app/_layout.tsx
 import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { useEffect } from 'react';
@@ -129,7 +129,7 @@ export default function RootLayout() {
 
 <Tab label="Without Expo Router">
 
-```jsx App.js
+```tsx App.tsx
 import { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
 import Entypo from '@expo/vector-icons/Entypo';
@@ -273,7 +273,7 @@ See how to configure the native projects in the [installation instructions in th
 
 `SplashScreen` provides an out-of-the-box fade animation. It can be configured using the `setOptions` method.
 
-```js
+```tsx
 SplashScreen.setOptions({
   duration: 1000,
   fade: true,
@@ -284,7 +284,7 @@ If you prefer to use custom animation, see the [`with-splash-screen`](https://gi
 
 ## API
 
-```js
+```tsx
 import * as SplashScreen from 'expo-splash-screen';
 ```
 

--- a/docs/pages/versions/unversioned/sdk/splash-screen.mdx
+++ b/docs/pages/versions/unversioned/sdk/splash-screen.mdx
@@ -158,7 +158,7 @@ export default function App() {
 
 ## Configuration
 
-You can configure `expo-splash-screen` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect. If your app does **not** use EAS Build, then you'll need to manually configure the package.
+You can configure `expo-splash-screen` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([Continuous Native Generation (CNG)](/workflow/continuous-native-generation/)). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect. If your app does **not** use CNG, then you'll need to manually configure the package.
 
 **Using the config plugin, as shown below, is the recommended method for configuring the splash screen.** The other methods are now considered legacy and will be removed in the future.
 

--- a/docs/pages/versions/unversioned/sdk/splash-screen.mdx
+++ b/docs/pages/versions/unversioned/sdk/splash-screen.mdx
@@ -80,14 +80,13 @@ export default function App() {
 
 ### Delay hiding the splash screen
 
-In some cases, it may be necessary to delay hiding the splash screen until certain resources are loaded. For example, if you need to load fonts or API data before displaying the app content, you can use `preventAutoHideAsync()` to manually control when the splash screen hides. The goal should be to hide the splash screen as soon as possible.
+In some cases, it may be necessary to delay hiding the splash screen until certain resources are loaded. For example, if you need to load API data before displaying the app content, you can use `preventAutoHideAsync()` to manually control when the splash screen hides. The goal should be to hide the splash screen as soon as possible.
 
 <Tabs>
 
 <Tab label="With Expo Router">
 
 ```jsx app/_layout.tsx
-import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { useEffect } from 'react';
@@ -96,9 +95,21 @@ import { useEffect } from 'react';
 SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
-  const [loaded] = useFonts({
-    SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
-  });
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    async function doAsyncStuff() {
+      try {
+        // do something async here
+      } catch (e) {
+        console.warn(e);
+      } finally {
+        setIsReady(true);
+      }
+    }
+
+    doAsyncStuff();
+  }, []);
 
   useEffect(() => {
     if (loaded) {
@@ -123,23 +134,34 @@ import { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
 import Entypo from '@expo/vector-icons/Entypo';
 import * as SplashScreen from 'expo-splash-screen';
-import * as Font from 'expo-font';
 
 // Keep the splash screen visible while we fetch resources
 SplashScreen.preventAutoHideAsync();
 
 export default function App() {
-  const [loaded] = useFonts({
-    SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
-  });
+  const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {
-    if (loaded) {
+    async function doAsyncStuff() {
+      try {
+        // do something async here
+      } catch (e) {
+        console.warn(e);
+      } finally {
+        setIsReady(true);
+      }
+    }
+
+    doAsyncStuff();
+  }, []);
+
+  useEffect(() => {
+    if (isReady) {
       SplashScreen.hideAsync();
     }
-  }, [loaded]);
+  }, [isReady]);
 
-  if (!loaded) {
+  if (!isReady) {
     return null;
   }
 

--- a/docs/pages/versions/v54.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/splash-screen.mdx
@@ -16,7 +16,7 @@ import {
 } from '~/ui/components/ConfigSection';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
-The `SplashScreen` module from the `expo-splash-screen` library is used to tell the splash screen to remain visible until it has been explicitly told to hide. This is useful to do tasks that will happen behind the scenes such as making API calls, pre-loading fonts, animating the splash screen and so on.
+The `SplashScreen` module from the `expo-splash-screen` library provides control over the native splash screen behavior. By default, the splash screen will automatically hide when your app is ready, but you can also manually control its visibility for advanced use cases.
 
 > From **SDK 52**, due to changes supporting the latest Android splash screen API, Expo Go and development builds cannot fully replicate the splash screen experience your users will see in your [standalone app](/more/glossary-of-terms/#standalone-app). Expo Go will show your app icon instead of the splash screen, and the splash screen on development builds will not reflect all properties set in the config plugin. **It is highly recommended that you test your splash screen on a release build to ensure it looks as expected.**
 
@@ -28,7 +28,59 @@ Also, see the guide on [creating a splash screen image](/develop/user-interface/
 
 ## Usage
 
-This example shows how to keep the splash screen visible while loading app resources and then hide the splash screen when the app has rendered some initial content.
+For most apps, you don't need to do anything special with the splash screen. It will automatically hide when your app is ready. You can optionally configure animation options:
+
+<Tabs>
+
+<Tab label="With Expo Router">
+
+```jsx app/_layout.tsx
+import { Stack } from 'expo-router';
+import * as SplashScreen from 'expo-splash-screen';
+
+// Set the animation options. This is optional.
+SplashScreen.setOptions({
+  duration: 1000,
+  fade: true,
+});
+
+export default function RootLayout() {
+  return <Stack />;
+}
+```
+
+</Tab>
+
+<Tab label="Without Expo Router">
+
+```jsx App.js
+import { Text, View } from 'react-native';
+import Entypo from '@expo/vector-icons/Entypo';
+import * as SplashScreen from 'expo-splash-screen';
+
+// Set the animation options. This is optional.
+SplashScreen.setOptions({
+  duration: 1000,
+  fade: true,
+});
+
+export default function App() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>SplashScreen Demo! 👋</Text>
+      <Entypo name="rocket" size={30} />
+    </View>
+  );
+}
+```
+
+</Tab>
+
+</Tabs>
+
+### Delay hiding the splash screen
+
+In some cases, it may be necessary to delay hiding the splash screen until certain resources are loaded. For example, if you need to load fonts or API data before displaying the app content, you can use `preventAutoHideAsync()` to manually control when the splash screen hides. The goal should be to hide the splash screen as soon as possible.
 
 <Tabs>
 
@@ -40,12 +92,7 @@ import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { useEffect } from 'react';
 
-// Set the animation options. This is optional.
-SplashScreen.setOptions({
-  duration: 1000,
-  fade: true,
-});
-
+// Keep the splash screen visible while we fetch resources
 SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
@@ -80,12 +127,6 @@ import * as Font from 'expo-font';
 
 // Keep the splash screen visible while we fetch resources
 SplashScreen.preventAutoHideAsync();
-
-// Set the animation options. This is optional.
-SplashScreen.setOptions({
-  duration: 1000,
-  fade: true,
-});
 
 export default function App() {
   const [loaded] = useFonts({

--- a/docs/pages/versions/v54.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/splash-screen.mdx
@@ -34,7 +34,7 @@ For most apps, you don't need to do anything special with the splash screen. It 
 
 <Tab label="With Expo Router">
 
-```jsx app/_layout.tsx
+```tsx app/_layout.tsx
 import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 
@@ -53,7 +53,7 @@ export default function RootLayout() {
 
 <Tab label="Without Expo Router">
 
-```jsx App.js
+```tsx App.tsx
 import { Text, View } from 'react-native';
 import Entypo from '@expo/vector-icons/Entypo';
 import * as SplashScreen from 'expo-splash-screen';
@@ -86,7 +86,7 @@ In some cases, it may be necessary to delay hiding the splash screen until certa
 
 <Tab label="With Expo Router">
 
-```jsx app/_layout.tsx
+```tsx app/_layout.tsx
 import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { useEffect } from 'react';
@@ -129,7 +129,7 @@ export default function RootLayout() {
 
 <Tab label="Without Expo Router">
 
-```jsx App.js
+```tsx App.tsx
 import { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
 import Entypo from '@expo/vector-icons/Entypo';
@@ -273,7 +273,7 @@ See how to configure the native projects in the [installation instructions in th
 
 `SplashScreen` provides an out-of-the-box fade animation. It can be configured using the `setOptions` method.
 
-```js
+```tsx
 SplashScreen.setOptions({
   duration: 1000,
   fade: true,
@@ -284,7 +284,7 @@ If you prefer to use custom animation, see the [`with-splash-screen`](https://gi
 
 ## API
 
-```js
+```tsx
 import * as SplashScreen from 'expo-splash-screen';
 ```
 

--- a/docs/pages/versions/v54.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/splash-screen.mdx
@@ -158,7 +158,7 @@ export default function App() {
 
 ## Configuration
 
-You can configure `expo-splash-screen` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect. If your app does **not** use EAS Build, then you'll need to manually configure the package.
+You can configure `expo-splash-screen` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([Continuous Native Generation (CNG)](/workflow/continuous-native-generation/)). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect. If your app does **not** use CNG, then you'll need to manually configure the package.
 
 **Using the config plugin, as shown below, is the recommended method for configuring the splash screen.** The other methods are now considered legacy and will be removed in the future.
 

--- a/docs/pages/versions/v54.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/splash-screen.mdx
@@ -80,14 +80,13 @@ export default function App() {
 
 ### Delay hiding the splash screen
 
-In some cases, it may be necessary to delay hiding the splash screen until certain resources are loaded. For example, if you need to load fonts or API data before displaying the app content, you can use `preventAutoHideAsync()` to manually control when the splash screen hides. The goal should be to hide the splash screen as soon as possible.
+In some cases, it may be necessary to delay hiding the splash screen until certain resources are loaded. For example, if you need to load API data before displaying the app content, you can use `preventAutoHideAsync()` to manually control when the splash screen hides. The goal should be to hide the splash screen as soon as possible.
 
 <Tabs>
 
 <Tab label="With Expo Router">
 
 ```jsx app/_layout.tsx
-import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { useEffect } from 'react';
@@ -96,17 +95,29 @@ import { useEffect } from 'react';
 SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
-  const [loaded] = useFonts({
-    SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
-  });
+  const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {
-    if (loaded) {
+    async function doAsyncStuff() {
+      try {
+        // do something async here
+      } catch (e) {
+        console.warn(e);
+      } finally {
+        setIsReady(true);
+      }
+    }
+
+    doAsyncStuff();
+  }, []);
+
+  useEffect(() => {
+    if (isReady) {
       SplashScreen.hide();
     }
-  }, [loaded]);
+  }, [isReady]);
 
-  if (!loaded) {
+  if (!isReady) {
     return null;
   }
 
@@ -123,23 +134,34 @@ import { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
 import Entypo from '@expo/vector-icons/Entypo';
 import * as SplashScreen from 'expo-splash-screen';
-import * as Font from 'expo-font';
 
 // Keep the splash screen visible while we fetch resources
 SplashScreen.preventAutoHideAsync();
 
 export default function App() {
-  const [loaded] = useFonts({
-    SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
-  });
+  const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {
-    if (loaded) {
+    async function doAsyncStuff() {
+      try {
+        // do something async here
+      } catch (e) {
+        console.warn(e);
+      } finally {
+        setIsReady(true);
+      }
+    }
+
+    doAsyncStuff();
+  }, []);
+
+  useEffect(() => {
+    if (isReady) {
       SplashScreen.hideAsync();
     }
-  }, [loaded]);
+  }, [isReady]);
 
-  if (!loaded) {
+  if (!isReady) {
     return null;
   }
 


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C1QP38NQ5/p1761118097783159

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- [x] separate the `preventAutoHideAsync` example to a separate section and highlight it should be done only when really needed
- [x] fix typo that refers to EAS Build instead of CNG
- [x] use a generic `doAsyncStuff` example instead of loading fonts (for most non-Expo Go projects, fonts should be included in the app via a config plugin. 

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested locally

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
