### PR TITLE
[android] - fix edge-to-edge when `enableMinifyInReleaseBuilds` is true

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix edge-to-edge when `enableMinifyInReleaseBuilds` is `true` by ([#40515](https://github.com/expo/expo/pull/40515) by [@nishan](https://github.com/intergalacticspacehighway))
+
 ### 💡 Others
 
 - [android] Add getDefaultReactHost to ExpoReactHostFactory ([#40086](https://github.com/expo/expo/pull/40086) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo/android/proguard-rules.pro
+++ b/packages/expo/android/proguard-rules.pro
@@ -25,12 +25,6 @@
 -keepnames class * extends expo.modules.core.BasePackage
 -keepnames class * implements expo.modules.core.interfaces.Package
 
-# Keep edge-to-edge methods in WindowUtilKt
--keep class com.facebook.react.views.view.WindowUtilKt {
-    *** enableEdgeToEdge(...);
-    *** isEdgeToEdgeFeatureFlagOn(...);
-}
-
 # For React Native WindowUtilKt edge-to-edge support
 -keep class com.facebook.react.views.view.WindowUtilKt {
   *;

--- a/packages/expo/android/proguard-rules.pro
+++ b/packages/expo/android/proguard-rules.pro
@@ -24,3 +24,14 @@
 
 -keepnames class * extends expo.modules.core.BasePackage
 -keepnames class * implements expo.modules.core.interfaces.Package
+
+# Keep edge-to-edge methods in WindowUtilKt
+-keep class com.facebook.react.views.view.WindowUtilKt {
+    *** enableEdgeToEdge(...);
+    *** isEdgeToEdgeFeatureFlagOn(...);
+}
+
+# For React Native WindowUtilKt edge-to-edge support
+-keep class com.facebook.react.views.view.WindowUtilKt {
+  *;
+}


### PR DESCRIPTION
# Why

Fixes - https://github.com/expo/expo/pull/38627#issuecomment-3360264248

[ENG-17762](https://linear.app/expo/issue/ENG-17762/debug-enableminifyinreleasebuilds-breaking-edge-to-edge-on-android)

Edge to edge on API level < 36 is broken when `enableMinifyInReleaseBuilds` is set to true. 

We're using RN's [WindowUtils](https://github.com/expo/expo/blob/766a9f82822b79e266f177e78ec143f3683b0688/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt#L161) API to enable edge-to-edge but calling it's methods using string `"enableEdgeToEdge"` and `"isEdgeToEdgeFeatureFlagOn"` as this [API](https://github.com/facebook/react-native/blob/93c17cd0c43ba7fe3bc09f547b64771984992fbb/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/WindowUtil.kt#L106) internally extends the `Window` in RN. This throws error when `enableMinifyInReleaseBuilds` is `true`, as proguard minifies/renames RN's APIs.

```
 Failed to invoke 'isEdgeToEdgeFeatureFlagOn' on com.facebook.react.views.view.WindowUtilKt
                                                                                                    java.lang.NoSuchMethodException: isEdgeToEdgeFeatureFlagOn []
                                                                                                    	at java.lang.Class.getMethod(Class.java:1981)
                                                                                                    	at java.lang.Class.getDeclaredMethod(Class.java:1960)
                                                                                                    	at w2.m$h.q(SourceFile:129)
                                                                                                    	at w2.m$h.u(SourceFile:9)
                                                                                                    	at w2.m$h.w(SourceFile:5)
                                                                                                    	at w2.m$c.q(SourceFile:90)
                                                                                                    	at w2.m$c.u(SourceFile:9)
                                                                                                    	at w2.m$c.w(SourceFile:5)
                                                                                                    	at b5.b.a(SourceFile:21)
                                                                                                    	at Y4.J.h(SourceFile:28)
                                                                                     
```


# Repro
Repo: https://github.com/brentvatne/unendingblue

Run `bun install` then `bun expo run:android --variant release`

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

I am not very happy with the solution in this PR. But `WindowUtils` in RN does not provide a public API (we can potentially copy code from RN though). If someone has an alternate solution please lmk! Tagging @zoontek 🙏 

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Add the patch from this PR and run the above mentioned repro after cleaning the build. 

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
