### PR TITLE
[docs] Update runtime docs for EAS Hosting

### DIFF
--- a/docs/pages/eas/hosting/reference/responses-and-headers.mdx
+++ b/docs/pages/eas/hosting/reference/responses-and-headers.mdx
@@ -42,17 +42,9 @@ Its default value is set to `max-age=31536000; includeSubDomains; preload`.
 
 For more information on why this header is a good default, improves security, and performance, [read this article on `web.dev`](https://web.dev/blog/bbc-hsts) and read more about [Strict-Transport-Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) header in the MDN documentation.
 
-## Common version headers
+## Common headers
 
 By default, EAS Hosting will remove and not forward any `X-Powered-By` and `X-Aspnet-Version` headers. With API routes, this header does not serve much of a purpose and we don't recommend you add alternative headers like `X-Powered-By` to your API routes as it unnecessarily exposes internal information on the code you're running.
-
-## Frame Content-Security Policy (CSP)
-
-By default, browsers allow any webpage to render in an iframe. Unfortunately, this allows phishing attacks such as clickjacking which is used by malicious actors to overlay a page with their own controls and inputs, to steal credentials or coerce users to perform certain actions.
-
-To prevent this, EAS Hosting adds a `frame-ancestors 'self'` directive by default, telling browsers to not embed EAS Hosting in iframes on other domains that you don't control.
-
-This is equivalent to setting the (older) `X-Frame-Options` header to `SAMEORIGIN`.This default directive is only applied to responses with `text/html` content types, so it will only be applied to HTML pages.
 
 If your API routes respond with custom `X-Frame-Options` headers, these headers will automatically be converted to `Content-Security-Policy` directives in your response.
 

--- a/docs/pages/eas/hosting/reference/worker-runtime.mdx
+++ b/docs/pages/eas/hosting/reference/worker-runtime.mdx
@@ -30,12 +30,11 @@ This means, many Node.js APIs that you might be used to or some dependencies you
 | `node:constants`           | <YesIcon />   |                                                                                    |
 | `node:diagnostics_channel` | <YesIcon />   | Select deprecated algorithms are not implemented                                   |
 | `node:dns`                 | <YesIcon />   | `Resolver` is unimplemented, all DNS requests are sent to Cloudflare               |
-| `node:dns/promises`        | <YesIcon />   | All DNS requests are sent to Cloudflare                                            |
 | `node:events`              | <YesIcon />   |                                                                                    |
-| `node:fs`                  | <NoIcon />    | Provided as JS stubs, since workers have no file system                            |
-| `node:fs/promises`         | <NoIcon />    | Provided as JS stubs, since workers have no file system                            |
-| `node:http`                | <AlertIcon /> | Provided as partially functional JS shims based on `fetch`                         |
-| `node:https`               | <AlertIcon /> | Provided as partially functional JS shims based on `fetch`                         |
+| `node:fs`                  | <YesIcon />   | Supported, with in-memory filesystem                                               |
+| `node:http`                | <YesIcon />   | Supported, except for server functionality                                         |
+| `node:http2`               | <AlertIcon /> | Partially supported. Server functionality unsupported                              |
+| `node:https`               | <YesIcon />   | Supported, except for server functionality                                         |
 | `node:module`              | <AlertIcon /> | `SourceMap` is unimplemented, partially supported otherwise                        |
 | `node:net`                 | <AlertIcon /> | `Server` and `BlockList` are unimplemented, client sockets are partially supported |
 | `node:os`                  | <YesIcon />   | Provided as JS stubs that provide mock values matching Node.js on Linux            |
@@ -46,15 +45,13 @@ This means, many Node.js APIs that you might be used to or some dependencies you
 | `node:punycode`            | <NoIcon />    |                                                                                    |
 | `node:querystring`         | <YesIcon />   |                                                                                    |
 | `node:readline`            | <NoIcon />    | Provided as non-functional JS stubs, since workers have no `stdin`                 |
-| `node:readline/promises`   | <NoIcon />    | Provided as non-functional JS stubs, since workers have no `stdin`                 |
 | `node:stream`              | <YesIcon />   |                                                                                    |
 | `node:stream/consumers`    | <YesIcon />   |                                                                                    |
-| `node:stream/promises`     | <YesIcon />   |                                                                                    |
 | `node:stream/web`          | <YesIcon />   |                                                                                    |
 | `node:string_decoder`      | <YesIcon />   |                                                                                    |
+| `node:test`                | <YesIcon />   |                                                                                    |
 | `node:timers`              | <YesIcon />   |                                                                                    |
-| `node:timers/promises`     | <YesIcon />   |                                                                                    |
-| `node:tls`                 | <AlertIcon /> | `Server` is unimplemented, client sockets are partially supported                  |
+| `node:tls`                 | <YesIcon />   | Supported, except for server functionality                                         |
 | `node:trace_events`        | <AlertIcon /> | Provided as non-functional JS stubs                                                |
 | `node:tty`                 | <YesIcon />   | Provided as JS shims redirecting output to the Console API                         |
 | `node:url`                 | <YesIcon />   |                                                                                    |
@@ -64,7 +61,7 @@ This means, many Node.js APIs that you might be used to or some dependencies you
 | `node:zlib`                | <YesIcon />   |                                                                                    |
 
 These modules generally provide a lower-accuracy polyfill or approximation of their Node.js counterparts.
-For example, the `http` and `https` modules only provide thin Node.js compatibility wrappers around the `fetch` API and cannot be used to make arbitrary HTTP requests.
+For example, the `fs`, `http`, and `https` modules have additional restrictions in place and are Node.js compatibility layers, which aren't equivalent to running them in a Node.js process.
 
 Any of the above listed Node.js modules can be used in API routes or dependencies of your API routes as usual and will use appropriate compatibility modules. However, some of these modules may not provide any practical functionality and only exist to shim APIs to prevent runtime crashes.
 


### PR DESCRIPTION
## Summary

This updates us to some changes to `workerd` and the EAS Hosting runtime.

## Set of changes

- Remove `/promises` entries from Node.js modules list since they're redundant
- Add new `fs`, `http`, `https`, `http2` notes
- Add `node:test`
- Remove outdated CSP (Content-Security-Policy) section