### PR TITLE
[ci] fix test-suite android failure

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -254,7 +254,7 @@ jobs:
           working-directory: apps/bare-expo
           build-command: |
             ./scripts/start-android-e2e-test.ts --build
-          build-output: apps/bare-expo/android/app/build/outputs/apk
+          build-output: apps/bare-expo/android/app/build/outputs/apk/release
           artifact-name: bare-expo-android-builds
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -288,7 +288,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: bare-expo-android-builds
-          path: apps/bare-expo/android/app/build/outputs/apk
+          path: apps/bare-expo/android/app/build/outputs/apk/release
       - name: 🍺 Install Maestro
         run: |
           curl -Ls "https://get.maestro.mobile.dev" | bash


### PR DESCRIPTION
# Why

fixed the failure: https://github.com/expo/expo/actions/runs/18717471619/job/53381435758?pr=40524

# How

fix the artifact path

# Test Plan

test-suite android should pass

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
