### PR TITLE
[dev-menu][iOS] set DevMenu windowScene to support SwiftUI apps

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Add support to SwiftUI apps ([#40542](https://github.com/expo/expo/pull/40542) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -267,7 +267,14 @@ open class DevMenuManager: NSObject {
     }
     if visible {
       setCurrentScreen(screen)
-      DispatchQueue.main.async { self.window?.makeKeyAndVisible() }
+      DispatchQueue.main.async {
+        if self.window?.windowScene == nil {
+          let windowScene = UIApplication.shared.connectedScenes
+            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
+          self.window?.windowScene = windowScene
+        }
+        self.window?.makeKeyAndVisible()
+      }
     } else {
       DispatchQueue.main.async { self.window?.closeBottomSheet(nil) }
     }


### PR DESCRIPTION
# Why

In SwiftUI apps, when `DevMenuManager` calls `makeKeyAndVisible()` in the `DevMenuWindow`, the system doesn't know which of the app scenes to present the window, leading to the menu not showing up.

# How

Check if windowScene is null before making the menu visible, and attach it to the connected scene with the `foregroundActive` state

# Test Plan

Brownfield tester app for iOS (https://github.com/expo/expo/pull/40541) 
<img width="568" height="1084" alt="image" src="https://github.com/user-attachments/assets/9fda08cc-5a90-4743-a95a-9034d2a5f3c2" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
