### PR TITLE
[android][calendar] Fix parsing recurrence rules

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed retrieving recurrence rules information. ([#40549](https://github.com/expo/expo/pull/40549) by [@barthap](https://github.com/barthap))
+
 ### 💡 Others
 
 - [Android] Refactored module native code. ([#40548](https://github.com/expo/expo/pull/40548) by [@barthap](https://github.com/barthap))

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarUtils.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarUtils.kt
@@ -13,6 +13,17 @@ internal object CalendarUtils {
 
   /**
    * [SimpleDateFormat] used in native recurrence rule string.
+   * The format corresponds to the 'date-time' type defined by RFC-5455 section 3.3.5.
    */
-  val recurrenceRuleSDF = SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'")
+  val recurrenceRuleSDF = SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'").apply {
+    timeZone = TimeZone.getTimeZone("GMT")
+  }
+
+  /**
+   * [SimpleDateFormat] used in native recurrence rule string for all-day events.
+   * The format corresponds to the 'date' type defined by RFC-5455 section 3.3.4.
+   */
+  val allDayRecurrenceSDF = SimpleDateFormat("yyyyMMdd").apply {
+    timeZone = TimeZone.getTimeZone("GMT")
+  }
 }

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/event/records/input/RecurrenceRuleInput.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/event/records/input/RecurrenceRuleInput.kt
@@ -24,6 +24,9 @@ data class RecurrenceRuleInput(
     return recurrenceRuleSDF.format(calendar.time)
   }
 
+  /**
+   * @return A string defined by RFC 5455 section 3.3.10
+   */
   fun toRuleString(): String {
     var rrule: String = when (frequency) {
       "daily" -> "FREQ=DAILY"

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/EventRecurrenceTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/EventRecurrenceTest.kt
@@ -94,6 +94,30 @@ class EventRecurrenceUtilsTest {
     assertEquals(recurrence.endDate, null)
     assertEquals(recurrence.occurrence, null)
   }
+
+  @Test
+  fun testParseRecurrenceRule_withAllDayDate() {
+    val rrule = "FREQ=DAILY;INTERVAL=1;UNTIL=20251024"
+
+    val recurrence = RecurrenceRuleEntity.fromRuleString(rrule)
+
+    assertEquals(recurrence.frequency, "daily")
+    assertEquals(recurrence.interval, 1)
+    assertEquals(recurrence.endDate, "2025-10-24T00:00:00.000Z")
+    assertEquals(recurrence.occurrence, null)
+  }
+
+  @Test
+  fun testParseRecurrenceRule_withCustomOrderAndUnknownFields() {
+    val rrule = "FREQ=DAILY;UNTIL=20251024;INTERVAL=1;WKST=SU"
+
+    val recurrence = RecurrenceRuleEntity.fromRuleString(rrule)
+
+    assertEquals(recurrence.frequency, "daily")
+    assertEquals(recurrence.interval, 1)
+    assertEquals(recurrence.endDate, "2025-10-24T00:00:00.000Z")
+    assertEquals(recurrence.occurrence, null)
+  }
 }
 
 @OptIn(EitherType::class)


### PR DESCRIPTION
# Why

When testing #40548 I noticed that retrieving recurrence rules info in e.g. `Calendar.getEventAsync()` is broken on Android. There are 3 main issues:
- `endDate` format parsing was broken in #13527 and was always `null` - compare [**before**](https://github.com/expo/expo/blob/09cfa47b77a4391c20c46385d508ffaeaf50c590/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.java#L1251) and [**after**](https://github.com/expo/expo/blob/f2a23adf43c71e42baeea89cd0938fef5945f959/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.kt#L689). Wrong `sdf` was used to parse it.
- Separately, `endDate` was still broken for all-day events. Looking into [RFC-5545 section 3.3.10](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.10), the `UNTIL / enddate` can be either `date` _(section 3.3.4 of the RFC)_ or `date-time` _(section 3.3.5)_. For all-day events, Android content resolver returns a value in the `date` format. However, in Expo Calendar, only the `datetime` was supported.
- The RFC (section 3.3.10) says 
  > The rule parts are not ordered in any particular sequence.

  But we expected them to be present in strict order. Values returned by the content resolver sometimes were in a different order than we expected. 

# How

- The fix is applied to the refactored code from #40548
- In addition to the existing `SimpleDateFormat` for "date-time" type _([RFC 5545 section 3.3.5](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.5))_, added a format for the "date" type _([section 3.3.4](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.4))_. Created a helper function to attempt parsing both formats.
- Reworked rrule string parsing logic to not expect parts being present in specific order, and thus comply with the RFC.
- Added appropriate unit tests

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Test Suite
- NCL:
  - Created two recurring events: one all-day and the other not
  - Used the "Get Events" to verify that the returned JSON contains valid `endDate` for both.
- Unit tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
