### PR TITLE
[docs][expo-server] Fix typo in isStaging variable name

### DIFF
--- a/docs/pages/versions/unversioned/sdk/server.mdx
+++ b/docs/pages/versions/unversioned/sdk/server.mdx
@@ -40,7 +40,7 @@ import { origin, environment } from 'expo-server';
 export async function GET() {
   return Response.json({
     isProduction: environment() == null,
-    isStating: environment() === 'staging',
+    isStaging: environment() === 'staging',
     origin: origin(),
   });
 }


### PR DESCRIPTION
This fixes a possible typo in the expo-server docs from "isStating" to "isStaging"

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
I was going through the expo-server docs and I saw a code example:
import { origin, environment } from 'expo-server';

export async function GET() {
  return Response.json({
    isProduction: environment() == null,
    isStating: environment() === 'staging', // I think isStaging was meant to be written not isStating
    origin: origin(),
  });
}



# How

<!--
How did you build this feature or fix this bug and why?
-->

I just corrected the typo

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
