### PR TITLE
[test-suite] do not stop app in between test suites

### DIFF
--- a/apps/bare-expo/scripts/lib/e2e-common.ts
+++ b/apps/bare-expo/scripts/lib/e2e-common.ts
@@ -44,20 +44,21 @@ appId: ${appId}
 - tapOn:
     text: "Open"
     optional: true
-- stopApp
 `);
   }
 
   for (const testCase of testCases) {
     contents.push(`\
 - openLink: bareexpo://test-suite/run?tests=${testCase}
+# make sure we're running the right test
+- assertVisible:
+    text: "${testCase}"
 - extendedWaitUntil:
     visible:
       id: "test_suite_text_results"
     timeout: 120000
 - assertVisible:
     text: "Success!"
-- stopApp
 `);
   }
 

--- a/apps/test-suite/components/DoneText.js
+++ b/apps/test-suite/components/DoneText.js
@@ -3,9 +3,10 @@ import { StyleSheet, Text, View, ActivityIndicator } from 'react-native';
 
 import Colors from '../constants/Colors';
 
-export default function DoneText({ done, numFailed, results }) {
+export default function DoneText({ done, numFailed, results, selectionQuery }) {
   return (
     <View testID="test_suite_results" style={styles.container}>
+      <Text style={styles.doneMessage}>{selectionQuery}</Text>
       {!done && (
         <View style={styles.messageContainer}>
           <ActivityIndicator />

--- a/apps/test-suite/components/Suites.js
+++ b/apps/test-suite/components/Suites.js
@@ -6,13 +6,11 @@ import DoneText from './DoneText';
 import SuiteResult from './SuiteResult';
 import { useTheme } from '../../common/ThemeProvider';
 
-export default function Suites({ suites, done, numFailed, results }) {
-  const ref = React.useRef(null);
+export default function Suites({ suites, done, numFailed, results, selectionQuery }) {
   const { theme } = useTheme();
 
   return (
     <FlatList
-      ref={ref}
       style={styles.list}
       contentContainerStyle={styles.contentContainerStyle}
       data={[...suites]}
@@ -27,7 +25,12 @@ export default function Suites({ suites, done, numFailed, results }) {
               borderBottomColor: theme.border.secondary,
             },
           ]}>
-          <DoneText done={done} numFailed={numFailed} results={results} />
+          <DoneText
+            done={done}
+            numFailed={numFailed}
+            results={results}
+            selectionQuery={selectionQuery}
+          />
         </View>
       )}
       stickyHeaderIndices={[0]}

--- a/apps/test-suite/screens/TestScreen.js
+++ b/apps/test-suite/screens/TestScreen.js
@@ -28,9 +28,26 @@ export default class TestScreen extends React.Component {
   _results = '';
   _failures = '';
 
-  componentDidMount() {
-    const selectionQuery = this.props.route.params?.tests ?? '';
+  getSelectionQuery = () => {
+    return this.props.route.params?.tests ?? '';
+  };
 
+  componentDidMount() {
+    this._isMounted = true;
+    this._handleTestsParam(this.getSelectionQuery());
+  }
+
+  componentDidUpdate(prevProps) {
+    const currentTestsParam = this.getSelectionQuery();
+    const previousTestsParam = prevProps.route.params?.tests ?? '';
+
+    // Re-run tests if the tests param has changed
+    if (currentTestsParam !== previousTestsParam) {
+      this._handleTestsParam(currentTestsParam);
+    }
+  }
+
+  _handleTestsParam(selectionQuery) {
     const selectedTestNames = getSelectedTestNames(selectionQuery);
     // We get test modules here to make sure that React Native will reload this component when tests were changed.
     const selectedModules = getTestModules().filter((m) =>
@@ -47,7 +64,6 @@ export default class TestScreen extends React.Component {
     }
 
     this._runTests(selectedModules);
-    this._isMounted = true;
   }
 
   componentWillUnmount() {
@@ -290,7 +306,13 @@ export default class TestScreen extends React.Component {
     }
     return (
       <View testID="test_suite_container" style={styles.container}>
-        <Suites numFailed={numFailed} results={results} done={done} suites={state.get('suites')} />
+        <Suites
+          numFailed={numFailed}
+          results={results}
+          done={done}
+          suites={state.get('suites')}
+          selectionQuery={this.getSelectionQuery()}
+        />
         <Portal isVisible={portalChildShouldBeVisible}>{testPortal}</Portal>
       </View>
     );


### PR DESCRIPTION
# Why

Improve the E2E test reliability and speed by adding test name verification and removing unnecessary app stops between test cases.

# How

- Added an assertion to verify the expected test link is visible before proceeding with the test to make sure we don't check "succeeded" status on a different test suite
- Removed `stopApp` commands between test cases to maintain app state between tests
- Enhanced the TestScreen component to handle test parameter changes and re-run tests when parameters change

# Test Plan

- green CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)