### PR TITLE
[android][expo-audio] removed use of setShowActionsInCompactView when using custom layouts

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Removed call to setShowActionsInCompactView when using custom layout in notification.
 - [Android] Fixed race-condition when creating the notification before the actions has been added. ([#40518](https://github.com/expo/expo/pull/40518) by [@chrfalch](https://github.com/chrfalch))
 - [iOS/Android] Aligned Android and iOS pitch correction by changing the default quality on iOS to match Android. `shouldCorrectPitch` now defaults to `true`. ([#40176](https://github.com/expo/expo/pull/40176) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Fix issue where after replacing the media source, events are emitted twice. ([#40133](https://github.com/expo/expo/pull/40133) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Removed call to setShowActionsInCompactView when using custom layout in notification.
+- [Android] Removed call to setShowActionsInCompactView when using custom layout in notification. ([#40557](https://github.com/expo/expo/pull/40557) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Fixed race-condition when creating the notification before the actions has been added. ([#40518](https://github.com/expo/expo/pull/40518) by [@chrfalch](https://github.com/chrfalch))
 - [iOS/Android] Aligned Android and iOS pitch correction by changing the default quality on iOS to match Android. `shouldCorrectPitch` now defaults to `true`. ([#40176](https://github.com/expo/expo/pull/40176) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Fix issue where after replacing the media source, events are emitted twice. ([#40133](https://github.com/expo/expo/pull/40133) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
@@ -106,25 +106,6 @@ class AudioControlsService : MediaSessionService() {
   private fun buildNotification(): Notification? {
     val session = mediaSession ?: return null
 
-    // Calculate which action indices should be shown in compact view
-    // This must match the order of buttons in the custom layout
-    val compactViewIndices = mutableListOf<Int>()
-    var actionCount = 0
-
-    // Count actions in the same order as updateSessionCustomLayout
-    if (currentOptions?.showSeekBackward == true) {
-      compactViewIndices.add(actionCount)
-      actionCount++
-    }
-    // Play/pause is always shown in compact view
-    compactViewIndices.add(actionCount)
-    actionCount++
-
-    if (currentOptions?.showSeekForward == true) {
-      compactViewIndices.add(actionCount)
-      actionCount++
-    }
-
     val builder = NotificationCompat.Builder(this, CHANNEL_ID)
       .setSmallIcon(androidx.media3.session.R.drawable.media3_icon_circular_play)
       .setContentTitle(currentMetadata?.title ?: "\u200E")
@@ -135,13 +116,9 @@ class AudioControlsService : MediaSessionService() {
       .setAutoCancel(false)
       .setCategory(NotificationCompat.CATEGORY_TRANSPORT)
 
-    // Only set compact view indices if they're within valid range
-    // MediaStyle pulls actions from the session's custom layout
-    val style = MediaStyleNotificationHelper.MediaStyle(session)
-    if (compactViewIndices.isNotEmpty() && compactViewIndices.all { it < actionCount }) {
-      style.setShowActionsInCompactView(*compactViewIndices.toIntArray())
-    }
-    builder.setStyle(style)
+    // Using only session custom layout: do NOT call setShowActionsInCompactView.
+    // The compact layout will follow the order of the custom layout provided to the session.
+    builder.setStyle(MediaStyleNotificationHelper.MediaStyle(session))
 
     return builder.build()
   }
@@ -182,9 +159,9 @@ class AudioControlsService : MediaSessionService() {
     }
 
     session.setCustomLayout(customLayout)
-  }
+ }
 
-  private fun postOrStartForegroundNotification(startInForeground: Boolean) {
+ private fun postOrStartForegroundNotification(startInForeground: Boolean) {
     val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
     val notification = buildNotification() ?: return
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
@@ -159,9 +159,9 @@ class AudioControlsService : MediaSessionService() {
     }
 
     session.setCustomLayout(customLayout)
- }
+  }
 
- private fun postOrStartForegroundNotification(startInForeground: Boolean) {
+  private fun postOrStartForegroundNotification(startInForeground: Boolean) {
     val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
     val notification = buildNotification() ?: return
 


### PR DESCRIPTION
# Why

When using custom layouts to build the media lock screen notifcation, we don't need to call the `setShowActionsInCompactView` when building the notification, since it will use the order in the custom layout anyway.

# How

This commit fixes this by removing the call to setShowActionsInCompactView. This was previously causing errors in Sentry like the following:

```
Couldn't inflate contentViewsjava.lang.IllegalArgumentException: setShowActionsInCompactView: action 0 out of bounds (max -1)
```

# Test Plan

✅ Tested in client app and BareExpo

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
