### PR TITLE
[docs] Lock `typescript` dependency

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -121,7 +121,7 @@
     "sitefetch": "^0.0.17",
     "sitemap": "^8.0.1",
     "tailwindcss": "^3.4.18",
-    "typescript": "^5.8.3",
+    "typescript": "~5.8.3",
     "unist-builder": "^4.0.0",
     "unist-util-visit": "^5.0.0",
     "user-agent-data-types": "^0.4.2"

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -7002,7 +7002,7 @@ __metadata:
     sitemap: "npm:^8.0.1"
     tailwindcss: "npm:^3.4.18"
     tippy.js: "npm:^6.3.7"
-    typescript: "npm:^5.8.3"
+    typescript: "npm:~5.8.3"
     unist-builder: "npm:^4.0.0"
     unist-util-visit: "npm:^5.0.0"
     user-agent-data-types: "npm:^0.4.2"
@@ -13843,23 +13843,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.8.3":
-  version: 5.9.3
-  resolution: "typescript@npm:5.9.3"
+"typescript@npm:~5.8.3":
+  version: 5.8.3
+  resolution: "typescript@npm:5.8.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
+  checksum: 10c0/5f8bb01196e542e64d44db3d16ee0e4063ce4f3e3966df6005f2588e86d91c03e1fb131c2581baf0fb65ee79669eea6e161cd448178986587e9f6844446dbb48
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.8.3#optional!builtin<compat/typescript>":
-  version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+"typescript@patch:typescript@npm%3A~5.8.3#optional!builtin<compat/typescript>":
+  version: 5.8.3
+  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
+  checksum: 10c0/39117e346ff8ebd87ae1510b3a77d5d92dae5a89bde588c747d25da5c146603a99c8ee588c7ef80faaf123d89ed46f6dbd918d534d641083177d5fac38b8a1cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Getting the following warning (when running `yarn run lint`) because running `yarn install` installs `5.9.3` version of TypeScript:

<img width="732" height="344" alt="CleanShot 2025-10-23 at 17 58 26" src="https://github.com/user-attachments/assets/15b11ca3-aa47-45dd-ab79-f43571f32f2d" />


# How

<!--
How did you build this feature or fix this bug and why?
-->

Use `~` to only install `5.8.x` version of TypeScript.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

In docs app locally, run `yarn install` and then run `yarn lint` and there should be no warnings.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
