### PR TITLE
[core][Android] Added `ReactNativeHostHandler.onDidCreateReactHost`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Add StaticFunction and StaticAsyncFunction to Class in modules API. ([#39228](https://github.com/expo/expo/pull/39228), [#38754](https://github.com/expo/expo/pull/38754) by [@jakex7](https://github.com/jakex7))
 - [iOS] Add `applicationDidReceiveMemoryWarning` subscribing to ExpoAppDelegateSubscriberManager ([#40504](https://github.com/expo/expo/pull/40504) by [@szydlovsky](https://github.com/szydlovsky))
 - [Android] Added `ReactActivityHandler.onDidCreateReactActivityDelegateNotification`. ([#40537](https://github.com/expo/expo/pull/40537) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Added `ReactNativeHostHandler.onDidCreateReactHost`.
+- [Android] Added `ReactNativeHostHandler.onDidCreateReactHost`. ([#40561](https://github.com/expo/expo/pull/40561) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add StaticFunction and StaticAsyncFunction to Class in modules API. ([#39228](https://github.com/expo/expo/pull/39228), [#38754](https://github.com/expo/expo/pull/38754) by [@jakex7](https://github.com/jakex7))
 - [iOS] Add `applicationDidReceiveMemoryWarning` subscribing to ExpoAppDelegateSubscriberManager ([#40504](https://github.com/expo/expo/pull/40504) by [@szydlovsky](https://github.com/szydlovsky))
 - [Android] Added `ReactActivityHandler.onDidCreateReactActivityDelegateNotification`. ([#40537](https://github.com/expo/expo/pull/40537) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Added `ReactNativeHostHandler.onDidCreateReactHost`.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactNativeHostHandler.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactNativeHostHandler.java
@@ -1,8 +1,11 @@
 package expo.modules.core.interfaces;
 
+import android.content.Context;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.facebook.react.ReactHost;
 import com.facebook.react.bridge.JavaScriptExecutorFactory;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
@@ -71,6 +74,11 @@ public interface ReactNativeHostHandler {
    * Callback before react instance creation
    */
   default void onWillCreateReactInstance(boolean useDeveloperSupport) {}
+
+  /**
+   * Callback when the {@link ReactHost} is created
+   */
+  default void onDidCreateReactHost(@NonNull Context context, @NonNull ReactHost reactNativeHost) {}
 
   /**
    * Callback when the {@link DevSupportManager} is available


### PR DESCRIPTION
# Why

Addes `ReactNativeHostHandler.onDidCreateReactHost` needed by `expo-dev-menu`.

# How

Similarly to https://github.com/expo/expo/pull/40537, I exposed another method that can be used by `expo-dev-menu` to simplify integration.

# Test Plan

- bare-expo ✅ 