### PR TITLE
[ci] Add release branch cut off workflow

### DIFF
--- a/.github/workflows/sdk-cutoff.yml
+++ b/.github/workflows/sdk-cutoff.yml
@@ -1,0 +1,27 @@
+name: Cut off release branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      sdkVersion:
+        description: 'Enter the SDK version'
+        required: true
+
+jobs:
+  cut-release:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v4
+      - name: Cut release branch
+        run: |
+          git checkout -b sdk-${{ github.event.inputs.sdkVersion }}
+          git push origin sdk-${{ github.event.inputs.sdkVersion }}
+          echo "Created new SDK branch: https://github.com/${{ github.repository }}/tree/sdk-${{ github.event.inputs.sdkVersion }}"
+      - name: Create SDK cherry-pick labels
+        run: |
+          echo "Creating labels for SDK ${{ github.event.inputs.sdkVersion }}"
+          gh label create "SDK ${{ github.event.inputs.sdkVersion }}" --color "f39c12" --description "Pull request needs cherry-pick to sdk-${{ github.event.inputs.sdkVersion }} branch"
+          gh label create "SDK ${{ github.event.inputs.sdkVersion }} cherry-picked" --color "2ecc71" --description "Pull request was cherry-picked to sdk-${{ github.event.inputs.sdkVersion }} branch"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
# Why

After cutting a release branch now we need to create a cherry-pick labels which can be automated.

# How

Created action to cut sdk-xx branch from main and create cherry-pick labels.

_TODO: Update release process doc on notion_

<img height="300" alt="image" src="https://github.com/user-attachments/assets/81eef0de-dbc8-44c5-acf7-ca6b2885f2b6" />

<img width="643" height="122" alt="image" src="https://github.com/user-attachments/assets/0e80d1ca-e456-4c3b-9e4a-b7a496316dba" />

# Test Plan

Manually with xx branch number (can be reversed manually by deleting branch and created labels).
