### PR TITLE
fix(cli): allow relative `export:embed` flags for Windows and monorepos

### DIFF
--- a/apps/router-e2e/index.js
+++ b/apps/router-e2e/index.js
@@ -1,0 +1,3 @@
+// This entry point is used to test relative command flags on Windows Android builds, triggered through Gradle.
+// See: https://github.com/facebook/react-native/commit/bb02ccf13f76f46b8572e2a85d578fd8d4fd9467
+import 'expo-router/entry';

--- a/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
@@ -48,7 +48,7 @@ it('runs `npx expo export:embed --help`', async () => {
 
       Options
         <dir>                                  Directory of the Expo project. Default: Current working directory
-        --entry-file <path>                    Path to the root JS file, either absolute or relative to JS root
+        --entry-file <path>                    Path to the root JS file, either absolute or relative to current working directory
         --platform <string>                    Either "ios" or "android" (default: "ios")
         --transformer <string>                 Specify a custom transformer to be used
         --dev [boolean]                        If false, warnings are disabled and the bundle is minified (default: true)

--- a/packages/@expo/cli/src/export/embed/index.ts
+++ b/packages/@expo/cli/src/export/embed/index.ts
@@ -51,7 +51,7 @@ export const expoExportEmbed: Command = async (argv) => {
       chalk`npx expo export:embed {dim <dir>}`,
       [
         chalk`<dir>                                  Directory of the Expo project. {dim Default: Current working directory}`,
-        `--entry-file <path>                    Path to the root JS file, either absolute or relative to JS root`,
+        `--entry-file <path>                    Path to the root JS file, either absolute or relative to current working directory`,
         `--platform <string>                    Either "ios" or "android" (default: "ios")`,
         `--transformer <string>                 Specify a custom transformer to be used`,
         `--dev [boolean]                        If false, warnings are disabled and the bundle is minified (default: true)`,


### PR DESCRIPTION
# Why

Resolves #39738
Resolves #40837

# How

It seems that from `react-native@0.72-rc.0` the default parameters passed to `expo export:embed` are all relative, due to this change: https://github.com/facebook/react-native/commit/bb02ccf13f76f46b8572e2a85d578fd8d4fd9467.

That means that when running `cd ./android && ./gradlew bundleRelease` does not do the right thing, but there are some caveats:

1. This is only an issue for monorepos, as we resolve relative entry files [from server root here](https://github.com/expo/expo/blob/ec50639e76ded456d150c1e44ecc2d8ba9736cf6/packages/%40expo/metro-config/src/rewriteRequestUrl.ts#L124-L126)
2. Server root in monorepos is not identical to the project root, it's `<monorepoRoot>` vs `<monorepoRoot>/apps/awesome-app`.
3. This is only an issue on Windows, as Meta uses relative paths when for [the bundle command here](https://github.com/facebook/react-native/blob/b8463053d4cac0c36d6bd54359280be827250aed/packages/gradle-plugin/shared/src/main/kotlin/com/facebook/react/utils/Os.kt#L39-L44)
4. This is an issue for workspace relative entry points (in `main` from **package.json**)
5. This is not an issue for module-relative entry points (like `expo-router/entry` in `main` from **package.json**), except:
    - When using isolated modules, as the server root won't have access to the right package in `<monorepoRoot>`
    - When using non-isolated modules, but the entry point package is not hoisted to the server root


# Test Plan

The added test mimics both the Windows `expo export:embed` flags, as well as using a workspace-relative entry point.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
