### PR TITLE
[et][verify-cherrypicks] New command to cherry-pick important commits

### DIFF
--- a/tools/src/Git.ts
+++ b/tools/src/Git.ts
@@ -161,14 +161,14 @@ export class GitDirectory {
   }
 
   /**
-   * Returns name of remote branch that the current local branch is tracking.
+   * Returns name of remote branch that the local branch is tracking (defaults to the current branch).
    */
-  async getTrackingBranchNameAsync(): Promise<string> {
+  async getTrackingBranchNameAsync(localBranch = ''): Promise<string> {
     const { stdout } = await this.runAsync([
       'rev-parse',
       '--abbrev-ref',
       '--symbolic-full-name',
-      '@{u}',
+      `${localBranch}@{u}`,
     ]);
     return stdout.trim();
   }

--- a/tools/src/commands/VerifyCherrypicks.ts
+++ b/tools/src/commands/VerifyCherrypicks.ts
@@ -1,0 +1,84 @@
+import { Command } from '@expo/commander';
+import chalk from 'chalk';
+
+import { Task, TaskRunner } from '../TasksRunner';
+import { checkRepositoryStatus } from '../verify-cherrypicks/tasks/checkRepositoryStatus';
+import { fixCherrypicks } from '../verify-cherrypicks/tasks/fixCherrypicks';
+import { fixCherrypicksContinue } from '../verify-cherrypicks/tasks/fixCherrypicksContinue';
+import { fixLabels } from '../verify-cherrypicks/tasks/fixLabels';
+import { verifyCherrypicks } from '../verify-cherrypicks/tasks/verifyCherrypicks';
+import { CommandOptions, TaskArgs } from '../verify-cherrypicks/types';
+
+export default (program: Command) => {
+  program
+    .command('verify-cherrypicks')
+    .alias('vcp')
+    .option('-t, --tag <tag>', 'Limit verify to one branch only.')
+    .option(
+      '--fix',
+      'Automatically cherry-pick all commits that are not on the target branch and update labels.',
+      false
+    )
+    .option(
+      '--continue',
+      'Continue --fix cherry-picking without verifying local sdk branches.',
+      false
+    )
+    .option(
+      '--fix-labels',
+      'Automatically fix labels on all PRs that are already cherry-picked.',
+      false
+    )
+    .option('--merged-by <user>', 'Filter PRs merged by a specific user (GitHub login).', false)
+    .option(
+      '-D, --dry',
+      'Print git commands instead of executing them. Skips updating labels.',
+      false
+    )
+    .description(`Verify cherry-picks for all PRs with SDK labels.`)
+    .usage(
+      `
+
+To list all PRs that need to be cherry-picked or need label updates:
+${chalk.gray('>')} ${chalk.italic.cyan('et verify-cherrypicks')}
+
+To fix labels on all PRs that are already cherry-picked:
+${chalk.gray('>')} ${chalk.italic.cyan('et verify-cherrypicks --fix-labels')}
+
+To cherry-pick all commits that are not on the target branch and update labels:
+${chalk.gray('>')} ${chalk.italic.cyan('et verify-cherrypicks --fix')}`
+    )
+    .asyncAction(async (options: CommandOptions) => {
+      const taskRunner = new TaskRunner<TaskArgs>({
+        tasks: tasksForOptions(options),
+      });
+
+      await taskRunner.runAndExitAsync(
+        {
+          labels: [],
+          pullRequests: {
+            toCherrypick: [],
+            toUpdateLabel: [],
+            toVerify: [],
+          },
+        },
+        options
+      );
+    });
+};
+
+/**
+ * Returns target task instances based on provided command options.
+ */
+function tasksForOptions(options: CommandOptions): Task<TaskArgs>[] {
+  if (options.fixLabels) {
+    return [checkRepositoryStatus, verifyCherrypicks, fixLabels];
+  }
+  if (options.fix) {
+    if (options.continue) {
+      return [fixCherrypicksContinue, fixLabels];
+    }
+    return [fixCherrypicks, fixLabels];
+  }
+  return [verifyCherrypicks];
+}

--- a/tools/src/verify-cherrypicks/helpers.ts
+++ b/tools/src/verify-cherrypicks/helpers.ts
@@ -1,0 +1,55 @@
+import chalk from 'chalk';
+
+import { link } from '../Formatter';
+import Git from '../Git';
+import * as GitHub from '../GitHub';
+
+const { green, blue, bold } = chalk;
+
+/**
+ * Returns SDK branch name (sdk-<version>) based on the label name (SDK <version>).
+ */
+export const branchNameFromLabel = (label: string) => {
+  return label.replace(' ', '-').toLowerCase();
+};
+
+// TODO: Very naive implementation, needs to be improved based on CherryPickCommand.ts
+export const isCherrypicked = async (hash: string, targetBranch: string) => {
+  const mergeBase = await Git.mergeBaseAsync('main', targetBranch);
+  const commitsOnDestinationBranch = await Git.logAsync({
+    fromCommit: mergeBase,
+    toCommit: targetBranch,
+  });
+
+  const commits = (
+    await Git.logAsync({
+      fromCommit: 'main',
+      toCommit: targetBranch,
+      cherryPick: 'left',
+      symmetricDifference: true,
+    })
+  ).filter((srcCommit) => {
+    const hasAlreadyBeenCherryPicked = commitsOnDestinationBranch.some(
+      (destCommit) =>
+        srcCommit.authorDate === destCommit.authorDate &&
+        srcCommit.authorName === destCommit.authorName &&
+        srcCommit.title === destCommit.title
+    );
+    return !hasAlreadyBeenCherryPicked;
+  });
+
+  return !commits.find((commit) => commit.hash.startsWith(hash));
+};
+
+function linkToPullRequest(pr: GitHub.PullRequestWithMerge): string {
+  return link(blue('#' + pr.number), pr.url);
+}
+
+function linkToMerger(pr: GitHub.PullRequestWithMerge): string {
+  const { mergedBy } = pr;
+  return mergedBy ? link(green('@' + mergedBy.login), mergedBy.url) : 'anonymous';
+}
+
+export function formatPullRequest(pr: GitHub.PullRequestWithMerge): string {
+  return `${linkToPullRequest(pr)}: ${bold(pr.title)} (merged by ${linkToMerger(pr)})`;
+}

--- a/tools/src/verify-cherrypicks/tasks/checkRepositoryStatus.ts
+++ b/tools/src/verify-cherrypicks/tasks/checkRepositoryStatus.ts
@@ -1,0 +1,53 @@
+import chalk from 'chalk';
+
+import logger from '../../Logger';
+import { Task } from '../../TasksRunner';
+import { TaskArgs } from '../types';
+import { getPullRequests } from './getPullRequests';
+import Git from '../../Git';
+import { branchNameFromLabel } from '../helpers';
+
+const { cyan } = chalk;
+
+/**
+ * Checks whether the current branch is correct and working dir is not dirty.
+ */
+export const checkRepositoryStatus = new Task<TaskArgs>(
+  {
+    name: 'checkRepositoryStatus',
+    required: true,
+    dependsOn: [getPullRequests],
+  },
+  async (state, options): Promise<void | symbol> => {
+    logger.info(`\n🕵️‍♂️  Checking repository status...`);
+
+    if (await Git.hasUnstagedChangesAsync()) {
+      logger.error(`🚫 Repository contains unstaged changes, please make sure to have it clear.`);
+      logger.error(`🚫 If you want to include them, they must be committed.`);
+      return Task.STOP;
+    }
+
+    const localBranch = 'main';
+    const trackingBranch = await Git.getTrackingBranchNameAsync(localBranch);
+    await Git.fetchAsync();
+    const stats = await Git.compareBranchesAsync(localBranch, trackingBranch);
+    if (stats.ahead + stats.behind > 0) {
+      logger.error(`🚫 Your local ${cyan(localBranch)} branch is out of sync with remote branch.`);
+      return Task.STOP;
+    }
+
+    await Promise.all(
+      state.labels.map(async (label): Promise<void | symbol> => {
+        const localBranch = branchNameFromLabel(label.name);
+        const trackingBranch = await Git.getTrackingBranchNameAsync(localBranch);
+        const stats = await Git.compareBranchesAsync(localBranch, trackingBranch);
+        if (stats.ahead > 0 || (!options.continue && stats.behind > 0)) {
+          logger.error(
+            `🚫 Your local branch ${cyan(localBranch)} is out of sync with remote branch.`
+          );
+          return Task.STOP;
+        }
+      })
+    );
+  }
+);

--- a/tools/src/verify-cherrypicks/tasks/fixCherrypicks.ts
+++ b/tools/src/verify-cherrypicks/tasks/fixCherrypicks.ts
@@ -1,0 +1,16 @@
+import { Task } from '../../TasksRunner';
+import { TaskArgs } from '../types';
+import { checkRepositoryStatus } from './checkRepositoryStatus';
+import { fixCherrypicksContinue } from './fixCherrypicksContinue';
+import { pushSdkBranches } from './pushSdkBranches';
+
+/**
+ * Performs fix cherrypicks with additional repository status check.
+ */
+export const fixCherrypicks = new Task<TaskArgs>(
+  {
+    name: 'fixCherrypicks',
+    dependsOn: [checkRepositoryStatus, fixCherrypicksContinue, pushSdkBranches],
+  },
+  async () => {}
+);

--- a/tools/src/verify-cherrypicks/tasks/fixCherrypicks.ts
+++ b/tools/src/verify-cherrypicks/tasks/fixCherrypicks.ts
@@ -2,7 +2,6 @@ import { Task } from '../../TasksRunner';
 import { TaskArgs } from '../types';
 import { checkRepositoryStatus } from './checkRepositoryStatus';
 import { fixCherrypicksContinue } from './fixCherrypicksContinue';
-import { pushSdkBranches } from './pushSdkBranches';
 
 /**
  * Performs fix cherrypicks with additional repository status check.
@@ -10,7 +9,7 @@ import { pushSdkBranches } from './pushSdkBranches';
 export const fixCherrypicks = new Task<TaskArgs>(
   {
     name: 'fixCherrypicks',
-    dependsOn: [checkRepositoryStatus, fixCherrypicksContinue, pushSdkBranches],
+    dependsOn: [checkRepositoryStatus, fixCherrypicksContinue],
   },
   async () => {}
 );

--- a/tools/src/verify-cherrypicks/tasks/fixCherrypicksContinue.ts
+++ b/tools/src/verify-cherrypicks/tasks/fixCherrypicksContinue.ts
@@ -4,6 +4,7 @@ import Git from '../../Git';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { TaskArgs } from '../types';
+import { pushSdkBranches } from './pushSdkBranches';
 import { updateState } from './updateState';
 import { verifyCherrypicks } from './verifyCherrypicks';
 
@@ -15,7 +16,7 @@ const { yellow, bold, blue } = chalk;
 export const fixCherrypicksContinue = new Task<TaskArgs>(
   {
     name: 'fixCherrypicksContinue',
-    dependsOn: [verifyCherrypicks, updateState],
+    dependsOn: [verifyCherrypicks, updateState, pushSdkBranches],
   },
   async (state, options): Promise<void | symbol> => {
     const toCherrypick = [...state.pullRequests.toCherrypick];

--- a/tools/src/verify-cherrypicks/tasks/fixCherrypicksContinue.ts
+++ b/tools/src/verify-cherrypicks/tasks/fixCherrypicksContinue.ts
@@ -1,0 +1,54 @@
+import chalk from 'chalk';
+
+import Git from '../../Git';
+import logger from '../../Logger';
+import { Task } from '../../TasksRunner';
+import { TaskArgs } from '../types';
+import { updateState } from './updateState';
+import { verifyCherrypicks } from './verifyCherrypicks';
+
+const { yellow, bold, blue } = chalk;
+
+/**
+ * Continues fix cherrypicks after resolving conflicts (without checking repository status).
+ */
+export const fixCherrypicksContinue = new Task<TaskArgs>(
+  {
+    name: 'fixCherrypicksContinue',
+    dependsOn: [verifyCherrypicks, updateState],
+  },
+  async (state, options): Promise<void | symbol> => {
+    const toCherrypick = [...state.pullRequests.toCherrypick];
+    if (toCherrypick.length === 0) {
+      logger.info('\n✅ Did not found any PRs that needs to be cherry-picked.');
+      return;
+    }
+    logger.info(`\nCherry-picking ${toCherrypick.length} PRs...`);
+
+    for (const pr of toCherrypick) {
+      if (pr.sdkBranch !== (await Git.getCurrentBranchNameAsync())) {
+        if (options.dry) {
+          logger.log(bold(yellow(`git checkout ${pr.sdkBranch}`)));
+        } else {
+          logger.debug(`Checking out ${bold(blue(pr.sdkBranch))} branch...`);
+          await Git.checkoutAsync({ ref: pr.sdkBranch });
+        }
+      }
+      if (options.dry) {
+        logger.log(bold(yellow(`git cherry-pick ${pr.mergeCommit.sha}`)));
+      } else {
+        logger.debug(`Running ${yellow(`git cherry-pick ${pr.mergeCommit.sha}`)}`);
+        try {
+          // pipe output to current process stdio to emulate user running this command directly
+          await Git.cherryPickAsync([pr.mergeCommit.sha], { inheritStdio: true });
+        } catch {
+          logger.error(
+            `Expotools: could not complete cherry-pick. Resolve the conflicts and continue as instructed by git above.`
+          );
+          return Task.STOP;
+        }
+      }
+      state.pullRequests.toUpdateLabel.push(pr);
+    }
+  }
+);

--- a/tools/src/verify-cherrypicks/tasks/fixLabels.ts
+++ b/tools/src/verify-cherrypicks/tasks/fixLabels.ts
@@ -1,0 +1,42 @@
+import chalk from 'chalk';
+
+import { addIssueLabelsAsync, removeIssueLabelAsync } from '../../GitHub';
+import logger from '../../Logger';
+import { Task } from '../../TasksRunner';
+import { TaskArgs } from '../types';
+import { getPullRequests } from './getPullRequests';
+import { updateState } from './updateState';
+
+const { green, red } = chalk;
+
+/**
+ * Fixes labels on all PRs that are already cherry-picked.
+ */
+export const fixLabels = new Task<TaskArgs>(
+  {
+    name: 'fixLabels',
+    dependsOn: [getPullRequests, updateState],
+  },
+  async (state, options) => {
+    const toUpdateLabel = [...state.pullRequests.toUpdateLabel];
+
+    if (toUpdateLabel.length === 0) {
+      logger.info('\n✅ Did not found any PRs that needs label updates.');
+      return;
+    }
+
+    logger.info(`\nUpdating ${toUpdateLabel.length} labels...`);
+
+    for (const pr of toUpdateLabel) {
+      logger.log(`    Updating #${pr.number} (${pr.title}) labels:`);
+      if (!options.dry) {
+        await removeIssueLabelAsync(pr.number, pr.label.name);
+      }
+      logger.debug(`        ${red('-')} ${pr.label.name}`);
+      if (!options.dry) {
+        await addIssueLabelsAsync(pr.number, [`${pr.label.name} cherry-picked`]);
+      }
+      logger.debug(`        ${green('+')} ${pr.label.name} cherry-picked`);
+    }
+  }
+);

--- a/tools/src/verify-cherrypicks/tasks/getPullRequests.ts
+++ b/tools/src/verify-cherrypicks/tasks/getPullRequests.ts
@@ -1,0 +1,50 @@
+import { getAllMergedPullRequestsByLabelAsync, getAllSdkLabelsAsync } from '../../GitHub';
+import logger from '../../Logger';
+import { Task } from '../../TasksRunner';
+import { branchNameFromLabel } from '../helpers';
+import { TaskArgs } from '../types';
+
+/**
+ * Fetches all PRs with SDK labels and prepares initial state for further tasks.
+ */
+export const getPullRequests = new Task<TaskArgs>(
+  {
+    name: 'getPullRequests',
+    dependsOn: [],
+  },
+  async (state, options): Promise<void | symbol> => {
+    let labels = await getAllSdkLabelsAsync();
+
+    if (options.tag) {
+      const filteredLabels = labels.filter((label) => label.name === options.tag);
+      if (filteredLabels.length === 0) {
+        logger.error(`Label with name "${options.tag}" not found.`);
+        return Task.STOP;
+      }
+      labels = filteredLabels;
+    }
+
+    state.labels = labels;
+
+    await Promise.all(
+      labels.map(async (label) => {
+        let pullRequests = await getAllMergedPullRequestsByLabelAsync(label.name);
+        if (options.mergedBy) {
+          pullRequests = pullRequests.filter((pr) => pr.mergedBy?.login === options.mergedBy);
+        }
+        pullRequests.forEach((pr) => {
+          state.pullRequests.toVerify.push({
+            ...pr,
+            label,
+            sdkBranch: branchNameFromLabel(label.name),
+          });
+        });
+      })
+    );
+    state.pullRequests.toVerify.sort(
+      (a, b) =>
+        new Date(a.mergeCommit.committedDate).getTime() -
+        new Date(b.mergeCommit.committedDate).getTime()
+    );
+  }
+);

--- a/tools/src/verify-cherrypicks/tasks/pushSdkBranches.ts
+++ b/tools/src/verify-cherrypicks/tasks/pushSdkBranches.ts
@@ -1,0 +1,52 @@
+import chalk from 'chalk';
+
+import Git from '../../Git';
+import logger from '../../Logger';
+import { Task } from '../../TasksRunner';
+import { branchNameFromLabel } from '../helpers';
+import { TaskArgs } from '../types';
+import { getPullRequests } from './getPullRequests';
+
+const { cyan, bold, yellow } = chalk;
+
+/**
+ * Pushes the SDK branches after cherry-picks.
+ */
+export const pushSdkBranches = new Task<TaskArgs>(
+  {
+    name: 'pushSdkBranches',
+    dependsOn: [getPullRequests],
+  },
+  async (state, options): Promise<void | symbol> => {
+    const labelsToPush = state.labels.filter((label) =>
+      state.pullRequests.toUpdateLabel.some((pr) => pr.label.name === label.name)
+    );
+
+    if (labelsToPush.length === 0) {
+      logger.info('\n✅ Did not found any SDK branches that needs to be pushed.');
+      return;
+    }
+
+    logger.info(`\nPushing SDK branches...`);
+
+    for (const label of labelsToPush) {
+      const localBranch = branchNameFromLabel(label.name);
+      const trackingBranch = await Git.getTrackingBranchNameAsync(localBranch);
+      const stats = await Git.compareBranchesAsync(localBranch, trackingBranch);
+
+      logger.log(
+        `    Branch ${cyan(localBranch)} is ${stats.ahead} commits ahead of remote branch...`
+      );
+      if (stats.ahead > 0) {
+        if (options.dry) {
+          logger.log(bold(yellow(`git push ${localBranch}`)));
+        } else {
+          await Git.pushAsync({
+            track: localBranch,
+          });
+        }
+        logger.log(`    Branch ${cyan(localBranch)} pushed to remote.`);
+      }
+    }
+  }
+);

--- a/tools/src/verify-cherrypicks/tasks/updateState.ts
+++ b/tools/src/verify-cherrypicks/tasks/updateState.ts
@@ -1,0 +1,43 @@
+import { formatCommitHash } from '../../Formatter';
+import logger from '../../Logger';
+import { Task } from '../../TasksRunner';
+import { branchNameFromLabel, formatPullRequest, isCherrypicked } from '../helpers';
+import { TaskArgs } from '../types';
+import { getPullRequests } from './getPullRequests';
+
+/**
+ * Updates the state based on cherry-pick status.
+ */
+export const updateState = new Task<TaskArgs>(
+  {
+    name: 'updateState',
+    dependsOn: [getPullRequests],
+  },
+  async (state) => {
+    if (state.pullRequests.toVerify.length === 0) {
+      return;
+    }
+
+    const toVerify = [...state.pullRequests.toVerify];
+    logger.info(`\nVerifying ${toVerify.length} PRs...`);
+
+    for (const pr of toVerify) {
+      const branch = branchNameFromLabel(pr.label.name);
+      const alreadyCherrypicked = await isCherrypicked(pr.mergeCommit.sha, branch);
+
+      state.pullRequests.toVerify = state.pullRequests.toVerify.filter(
+        (p) => p.number !== pr.number
+      );
+
+      if (alreadyCherrypicked) {
+        logger.debug(`    ${formatPullRequest(pr)} is already cherry-picked to ${branch}.`);
+        state.pullRequests.toUpdateLabel.push(pr);
+      } else {
+        state.pullRequests.toCherrypick.push(pr);
+        logger.debug(
+          `    ${formatPullRequest(pr)} needs cherry-pick to ${branch}... ${formatCommitHash(pr.mergeCommit.sha)}`
+        );
+      }
+    }
+  }
+);

--- a/tools/src/verify-cherrypicks/tasks/verifyCherrypicks.ts
+++ b/tools/src/verify-cherrypicks/tasks/verifyCherrypicks.ts
@@ -1,0 +1,29 @@
+import chalk from 'chalk';
+
+import logger from '../../Logger';
+import { Task } from '../../TasksRunner';
+import { formatPullRequest } from '../helpers';
+import { TaskArgs } from '../types';
+import { getPullRequests } from './getPullRequests';
+
+const { green, bold } = chalk;
+
+/**
+ * Print all PRs that needs to be verified.
+ */
+export const verifyCherrypicks = new Task<TaskArgs>(
+  {
+    name: 'verifyCherrypicks',
+    dependsOn: [getPullRequests],
+  },
+  async (state, options) => {
+    if (state.pullRequests.toVerify.length === 0) {
+      logger.info('✅ Did not found any PRs that needs to be to be verified.');
+      return;
+    }
+    logger.info(`\nFound ${state.pullRequests.toVerify.length} entries that needs to be verified:`);
+    state.pullRequests.toVerify.forEach((pr) => {
+      logger.log(`    ${formatPullRequest(pr)} with ${green(bold(pr.label.name))} tag`);
+    });
+  }
+);

--- a/tools/src/verify-cherrypicks/types.ts
+++ b/tools/src/verify-cherrypicks/types.ts
@@ -1,0 +1,32 @@
+import { LabelsSearch, PullRequestWithMerge } from '../GitHub';
+
+/**
+ * Command's options.
+ */
+export type CommandOptions = {
+  continue: boolean;
+  fix: boolean;
+  dry: boolean;
+  fixLabels: boolean;
+  mergedBy?: string;
+  tag?: string;
+};
+
+type PullRequest = PullRequestWithMerge & {
+  label: LabelsSearch[number];
+  sdkBranch?: string;
+};
+
+export type CommandState = {
+  pullRequests: {
+    toUpdateLabel: PullRequest[];
+    toCherrypick: PullRequest[];
+    toVerify: PullRequest[];
+  };
+  labels: LabelsSearch;
+};
+
+/**
+ * Array type representing arguments passed to the tasks.
+ */
+export type TaskArgs = [CommandState, CommandOptions];


### PR DESCRIPTION
# Why

Sometimes it's hard to remember to cherry-pick some commits to SDK branch. This new command should make it easier for us to cherry-pick stuff by labeling it on GitHub. 

# How

Adds new command that can 
* list PRs with pending cherry-pick tag
* fix labels on commits that were already cherry-picked manually
* cherry-pick all PRs with pending cherry-pick label

```text
❯ et verify-cherrypicks --help

Description:

  Verify cherry-picks for all PRs with SDK labels.

Usage: verify-cherrypicks | vcp

To list all PRs that need to be cherry-picked or need label updates:
> et verify-cherrypicks

To fix labels on all PRs that are already cherry-picked:
> et verify-cherrypicks --fix-labels

To cherry-pick all commits that are not on the target branch and update labels:
> et verify-cherrypicks --fix

Options:
  -t, --tag <tag>
    Limit verify to one branch only.

  --fix
    Automatically cherry-pick all commits that are not on the target branch and update labels.

  --continue
    Continue --fix cherry-picking without verifying local sdk branches.

  --fix-labels
    Automatically fix labels on all PRs that are already cherry-picked.

  --merged-by <user> (default: undefined)
    Filter PRs merged by a specific user (GitHub login).

  -D, --dry
    Print git commands instead of executing them. Skips updating labels.

  -h, --help
    Outputs usage information.
```

# Test Plan

## Example outputs

<details>
<summary>et verify-cherrypicks</summary>

```
❯ et verify-cherrypicks

Found 1 entries that needs to be verified:
    #3: Test3 (merged by @jakex7) with SDK 54 tag
```

</details>


<details>
<summary>et verify-cherrypicks --fix</summary>

```
❯ et verify-cherrypicks --fix

🕵️‍♂️  Checking repository status...

Found 4 entries that needs to be verified:
    #3: Test3 (merged by @jakex7) with SDK 54 tag
    #5: Bump version from 1.4.3 to 1.4.5 (merged by @jakex7) with SDK 54 tag
    #4: Bump version from 1.4.3 to 1.4.4 (merged by @jakex7) with SDK 54 tag
    #6: Bump version from 1.4.3 to 1.4.6 (merged by @jakex7) with SDK 54 tag

Verifying 4 PRs...
    #3: Test3 (merged by @jakex7) needs cherry-pick to sdk-54... (8b20cf)
    #5: Bump version from 1.4.3 to 1.4.5 (merged by @jakex7) needs cherry-pick to sdk-54... (7970c2)
    #4: Bump version from 1.4.3 to 1.4.4 (merged by @jakex7) is already cherry-picked to sdk-54.
    #6: Bump version from 1.4.3 to 1.4.6 (merged by @jakex7) needs cherry-pick to sdk-54... (5e34a7)

Cherry-picking 3 PRs...
Checking out sdk-54 branch...
Running git cherry-pick 8b20cf242d69530a1e9d6f8af27d604b5c5d0fea
Auto-merging package.json
[sdk-54 254ac2fceaa] Test3 (#3)
 Author: Jakub Grzywacz <kontakt@jakubgrzywacz.pl>
 Date: Wed Oct 22 15:13:37 2025 +0200
 1 file changed, 1 insertion(+), 1 deletion(-)
Running git cherry-pick 7970c28bbd0a5cf4da27f7d8e2e6bd9b45bd398d
Auto-merging package.json
[sdk-54 254af26ce4a] Bump version from 1.4.3 to 1.4.5 (#5)
 Author: Jakub Grzywacz <kontakt@jakubgrzywacz.pl>
 Date: Wed Oct 22 15:13:37 2025 +0200
 1 file changed, 1 insertion(+), 1 deletion(-)
Running git cherry-pick 5e34a7be03d820f976529e905d35943be32f2f52
Auto-merging package.json
[sdk-54 5a61eac4592] Bump version from 1.4.3 to 1.4.6 (#6)
 Author: Jakub Grzywacz <kontakt@jakubgrzywacz.pl>
 Date: Wed Oct 22 15:15:26 2025 +0200
 1 file changed, 1 insertion(+), 1 deletion(-)

Pushing SDK branches...
    Branch sdk-54 is 0 commits ahead of remote branch...

Updating 4 labels...
    Updating #4 (Bump version from 1.4.3 to 1.4.4) labels:
        - SDK 54
        + SDK 54 cherry-picked
    Updating #3 (Test3) labels:
        - SDK 54
        + SDK 54 cherry-picked
    Updating #5 (Bump version from 1.4.3 to 1.4.5) labels:
        - SDK 54
        + SDK 54 cherry-picked
    Updating #6 (Bump version from 1.4.3 to 1.4.6) labels:
        - SDK 54
        + SDK 54 cherry-picked
```

</details>


<details>
<summary>et verify-cherrypicks --fix-labels</summary>

```diff
❯ et verify-cherrypicks --fix-labels

Verifying 4 PRs...
    #3: Test3 (merged by @jakex7) needs cherry-pick to sdk-54... (8b20cf)
    #5: Bump version from 1.4.3 to 1.4.5 (merged by @jakex7) needs cherry-pick to sdk-54... (7970c2)
    #4: Bump version from 1.4.3 to 1.4.4 (merged by @jakex7) is already cherry-picked to sdk-54.
    #6: Bump version from 1.4.3 to 1.4.6 (merged by @jakex7) needs cherry-pick to sdk-54... (5e34a7)

Updating 2 labels...
    Updating #4 (Bump version from 1.4.3 to 1.4.4) labels:
        - SDK 54
        + SDK 54 cherry-picked
    Updating #3 (Test3) labels:
        - SDK 54
        + SDK 54 cherry-picked
```

</details>