### PR TITLE
chore(eslint-config-universe): enforce type-only imports are marked as such

### DIFF
--- a/packages/eslint-config-universe/flat/shared/typescript.js
+++ b/packages/eslint-config-universe/flat/shared/typescript.js
@@ -97,6 +97,13 @@ module.exports = defineConfig([
 
       'no-useless-constructor': 'off',
       '@typescript-eslint/no-useless-constructor': 'warn',
+      '@typescript-eslint/consistent-type-imports': [
+        'warn',
+        {
+          disallowTypeAnnotations: false,
+          fixStyle: 'inline-type-imports',
+        },
+      ],
       'no-undef': 'off',
 
       // TODO (Kadi): Enable this. Disabling for now because import/recommended adds it, but we didn't use to have it enabled

--- a/packages/eslint-config-universe/shared/typescript.js
+++ b/packages/eslint-config-universe/shared/typescript.js
@@ -51,7 +51,13 @@ module.exports = {
 
         'no-useless-constructor': 'off',
         '@typescript-eslint/no-useless-constructor': 'warn',
-
+        '@typescript-eslint/consistent-type-imports': [
+          'warn',
+          {
+            disallowTypeAnnotations: false,
+            fixStyle: 'inline-type-imports',
+          },
+        ],
         // The typescript-eslint FAQ recommends turning off "no-undef" in favor of letting tsc check for
         // undefined variables, including types
         'no-undef': 'off',


### PR DESCRIPTION
# Why

Makes it easier to see at a glance which imports are type-only across the codebase.

# How

Added `@typescript-eslint/consistent-type-imports` to `shared/typescript.js` and `flat/shared/typescript.js`

# Test Plan

CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
