### PR TITLE
ci: add missing `expo-server` and `@expo/router-server` packages to `cli` and `router-e2e` workflows

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -14,11 +14,12 @@ on:
       - packages/@expo/json-file/src/**
       - packages/@expo/package-manager/src/**
       - packages/@expo/prebuild-config/src/**
-      - packages/@expo/server/src/**
+      - packages/@expo/router-server/**
       - packages/create-expo/**
       - packages/eslint-config-expo/**
       - packages/eslint-plugin-expo/**
       - packages/expo-router/**
+      - packages/expo-server/**
       - yarn.lock
       - '!**.md'
   pull_request:
@@ -33,11 +34,12 @@ on:
       - packages/@expo/json-file/src/**
       - packages/@expo/package-manager/src/**
       - packages/@expo/prebuild-config/src/**
-      - packages/@expo/server/src/**
+      - packages/@expo/router-server/**
       - packages/create-expo/**
       - packages/eslint-config-expo/**
       - packages/eslint-plugin-expo/**
       - packages/expo-router/**
+      - packages/expo-server/**
       - yarn.lock
       - '!**.md'
   schedule:

--- a/.github/workflows/router-e2e.yml
+++ b/.github/workflows/router-e2e.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - .github/workflows/router-e2e.yml
       - packages/@expo/cli/**
+      - packages/@expo/router-server/**
       - packages/expo-router/**
 
 jobs:


### PR DESCRIPTION
# Why

Ensure that some of our newer packages are picked up correctly by our GitHub workflows.

# How

Added missing packages to workflow path whitelists.

# Test Plan

CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
