### PR TITLE
[glass-effect] - add non uniform border support in glass view

### DIFF
--- a/apps/native-component-list/src/screens/GlassView/GlassViewScreen.ios.tsx
+++ b/apps/native-component-list/src/screens/GlassView/GlassViewScreen.ios.tsx
@@ -183,6 +183,7 @@ const styles = StyleSheet.create({
     width: 150,
     height: 100,
     borderRadius: 12,
+    borderTopLeftRadius: 100,
   },
   glassContent: {
     flex: 1,

--- a/packages/expo-glass-effect/CHANGELOG.md
+++ b/packages/expo-glass-effect/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add non-uniform border radius support to `GlassView` ([#40570](https://github.com/expo/expo/pull/40570) by [@nishan](https://github.com/intergalacticspacehighway))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-glass-effect/ios/GlassEffectModule.swift
+++ b/packages/expo-glass-effect/ios/GlassEffectModule.swift
@@ -1,6 +1,7 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
 import ExpoModulesCore
+import React
 
 public final class GlassEffectModule: Module {
   public func definition() -> ModuleDefinition {
@@ -51,6 +52,43 @@ public final class GlassEffectModule: Module {
 
       Prop("borderTopRightRadius") { (view, radius: CGFloat?) in
         view.setBorderTopRightRadius(radius)
+      }
+
+      // Start/End alternatives that respect RTL layout
+      Prop("borderTopStartRadius") { (view, radius: CGFloat?) in
+        let isRTL = RCTI18nUtil.sharedInstance()?.isRTL() ?? false
+        if isRTL {
+          view.setBorderTopRightRadius(radius)
+        } else {
+          view.setBorderTopLeftRadius(radius)
+        }
+      }
+
+      Prop("borderTopEndRadius") { (view, radius: CGFloat?) in
+        let isRTL = RCTI18nUtil.sharedInstance()?.isRTL() ?? false
+        if isRTL {
+          view.setBorderTopLeftRadius(radius)
+        } else {
+          view.setBorderTopRightRadius(radius)
+        }
+      }
+
+      Prop("borderBottomStartRadius") { (view, radius: CGFloat?) in
+        let isRTL = RCTI18nUtil.sharedInstance()?.isRTL() ?? false
+        if isRTL {
+          view.setBorderBottomRightRadius(radius)
+        } else {
+          view.setBorderBottomLeftRadius(radius)
+        }
+      }
+
+      Prop("borderBottomEndRadius") { (view, radius: CGFloat?) in
+        let isRTL = RCTI18nUtil.sharedInstance()?.isRTL() ?? false
+        if isRTL {
+          view.setBorderBottomLeftRadius(radius)
+        } else {
+          view.setBorderBottomRightRadius(radius)
+        }
       }
 
       Prop("borderCurve") { (view, curve: String?) in

--- a/packages/expo-glass-effect/ios/GlassEffectModule.swift
+++ b/packages/expo-glass-effect/ios/GlassEffectModule.swift
@@ -37,6 +37,22 @@ public final class GlassEffectModule: Module {
         view.setBorderRadius(border)
       }
 
+      Prop("borderBottomLeftRadius") { (view, radius: CGFloat?) in
+        view.setBorderBottomLeftRadius(radius)
+      }
+
+      Prop("borderBottomRightRadius") { (view, radius: CGFloat?) in
+        view.setBorderBottomRightRadius(radius)
+      }
+
+      Prop("borderTopLeftRadius") { (view, radius: CGFloat?) in
+        view.setBorderTopLeftRadius(radius)
+      }
+
+      Prop("borderTopRightRadius") { (view, radius: CGFloat?) in
+        view.setBorderTopRightRadius(radius)
+      }
+
       Prop("borderCurve") { (view, curve: String?) in
         view.setBorderCurve(curve)
       }

--- a/packages/expo-glass-effect/ios/GlassView.swift
+++ b/packages/expo-glass-effect/ios/GlassView.swift
@@ -9,6 +9,12 @@ public final class GlassView: ExpoView {
   private var glassStyle: GlassStyle?
   private var glassTintColor: UIColor?
   private var glassIsInteractive: Bool?
+  
+  private var radius: CGFloat?
+  private var bottomLeftRadius: CGFloat?
+  private var bottomRightRadius: CGFloat?
+  private var topLeftRadius: CGFloat?
+  private var topRightRadius: CGFloat?
 
   public required init(appContext: AppContext? = nil) {
     super.init(appContext: appContext)
@@ -16,6 +22,23 @@ public final class GlassView: ExpoView {
     glassEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
 
     addSubview(glassEffectView)
+  }
+
+  public func updateBorderRadius() {
+    if #available(iOS 26.0, *) {
+      
+      let topLeft = UICornerRadius(floatLiteral: topLeftRadius ?? radius ?? 0)
+      let topRight = UICornerRadius(floatLiteral: topRightRadius ?? radius ?? 0)
+      let bottomLeft = UICornerRadius(floatLiteral: bottomLeftRadius ?? radius ?? 0)
+      let bottomRight = UICornerRadius(floatLiteral: bottomRightRadius ?? radius ?? 0)
+      
+      glassEffectView.cornerConfiguration = .corners(
+        topLeftRadius: topLeft,
+        topRightRadius: topRight,
+        bottomLeftRadius: bottomLeft,
+        bottomRightRadius: bottomRight
+      )
+    }
   }
 
   public func setGlassStyle(_ style: GlassStyle) {
@@ -32,14 +55,43 @@ public final class GlassView: ExpoView {
     }
   }
 
-  // When GlassView is a child of a GlassContainer, it does not respect parent layer corner properties, so we copy it here
-  // Non uniform borders also do not work as GlassView does not respect mask property when nested in a GlassContainer
   // TODO: support UIVisualEffectView with ExpoFabricView?
-  public func setBorderRadius(_: CGFloat?) {
-    glassEffectView.layer.cornerRadius = self.layer.cornerRadius
+  public func setBorderRadius(_ _radius: CGFloat?) {
+    if _radius != radius {
+      radius = _radius
+      updateBorderRadius()
+    }
   }
   public func setBorderCurve(_: String?) {
     glassEffectView.layer.cornerCurve = self.layer.cornerCurve
+  }
+
+  public func setBorderBottomLeftRadius(_ radius: CGFloat?) {
+    if radius != bottomLeftRadius {
+      bottomLeftRadius = radius
+      updateBorderRadius()
+    }
+  }
+
+  public func setBorderBottomRightRadius(_ radius: CGFloat?) {
+    if radius != bottomRightRadius {
+      bottomRightRadius = radius
+      updateBorderRadius()
+    }
+  }
+
+  public func setBorderTopLeftRadius(_ radius: CGFloat?) {
+    if radius != topLeftRadius {
+      topLeftRadius = radius
+      updateBorderRadius()
+    }
+  }
+
+  public func setBorderTopRightRadius(_ radius: CGFloat?) {
+    if radius != topRightRadius {
+      topRightRadius = radius
+      updateBorderRadius()
+    }
   }
 
   public func setTintColor(_ color: UIColor?) {
@@ -64,7 +116,7 @@ public final class GlassView: ExpoView {
         effect.isInteractive = glassIsInteractive ?? false
         // we need to set the effect again or it has no effect!
         glassEffectView.effect = effect
-        setBorderRadius(nil)
+        updateBorderRadius()
         setBorderCurve(nil)
       }
       #endif


### PR DESCRIPTION
# Why

Currently we lack non-uniform border support with Glass View (borderTopLeftRadius, borderTopRightRadius etc).  


Also shoutout to @okwasniewski for finding the cool API - https://x.com/o_kwasniewski/status/1981343093573013587 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

iOS 26 has a new API [UICornerConfiguration](https://developer.apple.com/documentation/uikit/uicornerconfiguration-swift.struct) to add non-uniform border.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Added `borderTopRightRadius` in example.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
