### PR TITLE
[ios][pods] fixed issue with unstable ids in pod manipulator

### DIFF
--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
@@ -159,9 +159,9 @@ class AudioControlsService : MediaSessionService() {
     }
 
     session.setCustomLayout(customLayout)
- }
+  }
 
- private fun postOrStartForegroundNotification(startInForeground: Boolean) {
+  private fun postOrStartForegroundNotification(startInForeground: Boolean) {
     val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
     val notification = buildNotification() ?: return
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
@@ -159,9 +159,9 @@ class AudioControlsService : MediaSessionService() {
     }
 
     session.setCustomLayout(customLayout)
-  }
+ }
 
-  private fun postOrStartForegroundNotification(startInForeground: Boolean) {
+ private fun postOrStartForegroundNotification(startInForeground: Boolean) {
     val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
     val notification = buildNotification() ?: return
 

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Moved our special build phase script initialization from run_podfile_post_install_hooks -> perform_post_install_actions to fix issue with wrong UUIDs in Pods.pbproj file.
 - fix globMatchFunctorAllAsync to check if globbed path is a file to prevent errors ([#40437](https://github.com/expo/expo/pull/40437) by [@artus9033](https://github.com/artus9033)) ([#40501](https://github.com/expo/expo/pull/40501) by [@kitten](https://github.com/kitten))
 - [iOS] Added build phase script for a workaround to autolinking-generated react-native-config output not being used in ReactCodegen script phase due to temp output directory. ([#40219](https://github.com/expo/expo/pull/40219) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Fix passing exclude options. ([#40014](https://github.com/expo/expo/pull/40014) by [@jakex7](https://github.com/jakex7))

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Moved our special build phase script initialization from run_podfile_post_install_hooks -> perform_post_install_actions to fix issue with wrong UUIDs in Pods.pbproj file.
+- [iOS] Moved our special build phase script initialization from run_podfile_post_install_hooks -> perform_post_install_actions to fix issue with wrong UUIDs in Pods.pbproj file. ([#40572](https://github.com/expo/expo/pull/40572) by [@chrfalch](https://github.com/chrfalch))
 - fix globMatchFunctorAllAsync to check if globbed path is a file to prevent errors ([#40437](https://github.com/expo/expo/pull/40437) by [@artus9033](https://github.com/artus9033)) ([#40501](https://github.com/expo/expo/pull/40501) by [@kitten](https://github.com/kitten))
 - [iOS] Added build phase script for a workaround to autolinking-generated react-native-config output not being used in ReactCodegen script phase due to temp output directory. ([#40219](https://github.com/expo/expo/pull/40219) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Fix passing exclude options. ([#40014](https://github.com/expo/expo/pull/40014) by [@jakex7](https://github.com/jakex7))

--- a/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
@@ -22,15 +22,16 @@ module Pod
   class Installer
     private
 
-    _original_run_podfile_post_install_hooks = instance_method(:run_podfile_post_install_hooks)
+    _original_perform_post_install_actions = instance_method(:perform_post_install_actions)
     _original_run_podfile_pre_install_hooks = instance_method(:run_podfile_pre_install_hooks)
     _script_phase_name = '[Expo Autolinking] Run Codegen with autolinking'
 
     public
 
-    define_method(:run_podfile_post_install_hooks) do
+    define_method(:perform_post_install_actions) do
+
       # Call original implementation first
-      _original_run_podfile_post_install_hooks.bind(self).()
+      _original_perform_post_install_actions.bind(self).()
 
       # Next we'll perform an Expo workaround for Codegen in React Native where it uses the wrong output path for
       # the generated files. This can be remove when the following PR is merged and released upstream:


### PR DESCRIPTION
# Why

We previously added a fix to make sure React codegen is ran correctly while waiting for a fix in React Native to be released.

This temporary fix can be found here:
https://github.com/expo/expo/pull/40219

In a very rare situation this script caused some UUIDs to clash in the produced Pods.pbxproj file.

This could be reproduced by:

```bash
npx create-expo-app@latest --template blank
....
npx expo add expo-audio
```

Try to run and observe it fails. Open the Workspace in Xcode and observe that it is unable to open the Pods project (you can also try opening the pods project directly - it will fail).

Xcode fingerprints a PBX object from stable inputs that include the build-phase index. When you delete/insert to move the phase before “Compile Sources,” you change that index; after adding a new pod the whole object graph shifts, and your phase’s hash can (deterministically) collide with the Pods project’s rootObject UUID.

# How

The problem was that the script we injected was injected at the wrong time in the Cocoapods installer timeline.

This commit fixes this by moving it from `run_podfile_post_install_hooks` -> `perform_post_install_actions`.

# Testing

  Do the same as the reproduction, now expect the Pods project to load correctly.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
