### PR TITLE
[android][updates] Add patch content negotiation headers

### DIFF
--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/loader/FileDownloaderAssetDiffTest.kt
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/loader/FileDownloaderAssetDiffTest.kt
@@ -22,6 +22,7 @@ import org.junit.After
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Rule
@@ -118,8 +119,9 @@ class FileDownloaderAssetDiffTest {
 
     server.enqueue(
       MockResponse()
-        .setResponseCode(200)
-        .setHeader("Content-Type", "application/vnd.bsdiff")
+        .setResponseCode(226)
+        .setHeader("Content-Type", "application/javascript")
+        .setHeader("im", "bsdiff")
         .setBody("diff")
     )
 
@@ -154,9 +156,86 @@ class FileDownloaderAssetDiffTest {
     assertArrayEquals(fallback, destination.readBytes())
 
     val firstRequest = server.takeRequest()
-    assertEquals("application/vnd.bsdiff,*/*", firstRequest.getHeader("Accept"))
+    assertEquals("bsdiff", firstRequest.getHeader("A-IM"))
     val secondRequest = server.takeRequest()
     assertEquals("*/*", secondRequest.getHeader("Accept"))
+    assertNull(secondRequest.getHeader("A-IM"))
+  }
+
+  @Test
+  fun downloadAssetAndVerifyHashAndWriteToPath_missingPatchHeadersFallsBackToFullAsset() = runTest {
+    val fallbackBytes = loadFixture("new.hbc")
+    val expectedFile = temporaryFolder.newFile("expected.hbc").apply {
+      writeBytes(fallbackBytes)
+    }
+    val expectedHashBytes = UpdatesUtils.sha256(expectedFile)
+    val expectedHash = UpdatesUtils.toBase64Url(expectedHashBytes)
+
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(226)
+        .setHeader("Content-Type", "application/javascript")
+        .setHeader("im", "bsdiff")
+        .setBody("diff")
+    )
+
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .setHeader("Content-Type", "*/*")
+        .setBody(Buffer().write(fallbackBytes))
+    )
+
+    val asset = AssetEntity("bundle", "hbc").apply {
+      url = Uri.parse(server.url("/bundle.hbc").toString())
+      isLaunchAsset = true
+    }
+
+    val launchedUpdate = createUpdate(UUID.randomUUID())
+    val requestedUpdate = createUpdate(UUID.randomUUID())
+    val extraHeaders = FileDownloader.getExtraHeadersForRemoteAssetRequest(
+      launchedUpdate = launchedUpdate,
+      embeddedUpdate = null,
+      requestedUpdate = requestedUpdate
+    )
+
+    val downloader = FileDownloader(
+      filesDirectory,
+      "test-eas-client",
+      configuration,
+      logger,
+      defaultDatabase,
+      OkHttpClient()
+    )
+    val request = downloader.createRequestForAsset(
+      asset,
+      extraHeaders,
+      configuration,
+      allowPatch = true
+    )
+    val destination = File(updatesDirectory, "missing-headers.hbc")
+
+    val result = downloader.downloadAssetAndVerifyHashAndWriteToPath(
+      asset = asset,
+      extraHeaders = extraHeaders,
+      request = request,
+      expectedBase64URLEncodedSHA256Hash = expectedHash,
+      destination = destination,
+      updatesDirectory = updatesDirectory,
+      progressListener = null,
+      allowPatch = true,
+      launchedUpdate = launchedUpdate,
+      requestedUpdate = requestedUpdate
+    )
+
+    assertArrayEquals(expectedHashBytes, result.hash)
+    assertArrayEquals(fallbackBytes, destination.readBytes())
+
+    val firstRequest = server.takeRequest()
+    assertEquals("bsdiff", firstRequest.getHeader("A-IM"))
+
+    val secondRequest = server.takeRequest()
+    assertNull(secondRequest.getHeader("A-IM"))
   }
 
   @Test

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/loader/FileDownloaderTest.kt
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/loader/FileDownloaderTest.kt
@@ -133,7 +133,7 @@ class FileDownloaderTest {
     val actual = fileDownloader.createRequestForAsset(assetEntity, JSONObject("{}"), config)
     Assert.assertEquals("android", actual.header("expo-platform"))
     Assert.assertEquals("custom", actual.header("expo-updates-environment"))
-    Assert.assertEquals("application/vnd.bsdiff,*/*", actual.header("Accept"))
+    Assert.assertEquals("*/*", actual.header("Accept"))
   }
 
   @Test
@@ -165,7 +165,7 @@ class FileDownloaderTest {
     Assert.assertEquals("47.5", actual.header("expo-number"))
     Assert.assertEquals("true", actual.header("expo-boolean"))
     Assert.assertEquals("null", actual.header("expo-null"))
-    Assert.assertEquals("application/vnd.bsdiff,*/*", actual.header("Accept"))
+    Assert.assertEquals("*/*", actual.header("Accept"))
   }
 
   @Test
@@ -302,6 +302,39 @@ class FileDownloaderTest {
 
     // cleanup
     unmockkObject(ManifestMetadata)
+  }
+
+  @Test
+  fun testGetExtraHeadersForRemoteAssetRequest_includesPatchNegotiationHeaders() {
+    val launchedUpdateUUIDString = "7c1d2bd0-f88b-454d-998c-7fa92a924dbf"
+    val requestedUpdateUUIDString = "9433b1ed-4006-46b8-8aa7-fdc7eeb203fd"
+    val launchedUpdate = UpdateEntity(
+      UUID.fromString(launchedUpdateUUIDString),
+      Date(),
+      "1.0",
+      "test",
+      JSONObject("{}"),
+      Uri.parse("https://u.expo.dev/00000000-0000-0000-0000-000000000000"),
+      null
+    )
+    val requestedUpdate = UpdateEntity(
+      UUID.fromString(requestedUpdateUUIDString),
+      Date(),
+      "1.0",
+      "test",
+      JSONObject("{}"),
+      Uri.parse("https://u.expo.dev/00000000-0000-0000-0000-000000000000"),
+      null
+    )
+
+    val headers = FileDownloader.getExtraHeadersForRemoteAssetRequest(
+      launchedUpdate,
+      null,
+      requestedUpdate
+    )
+
+    Assert.assertEquals(launchedUpdateUUIDString, headers.get("Expo-Current-Update-ID"))
+    Assert.assertEquals(requestedUpdateUUIDString, headers.get("Expo-Requested-Update-ID"))
   }
 
   @Test

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/updates-server/server.ts
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/updates-server/server.ts
@@ -101,10 +101,17 @@ function consumeRequestedStaticFiles() {
 }
 
 app.use(express.json());
-app.use('/static', (req: { url: string }, res: any, next: () => void) => {
-  requestedStaticFiles.push(path.basename(req.url));
-  next();
-});
+app.use(
+  '/static',
+  (
+    req: { url: string; headers: Record<string, string | undefined> },
+    res: any,
+    next: () => void
+  ) => {
+    requestedStaticFiles.push(path.basename(req.url));
+    next();
+  }
+);
 app.use('/static', express.static(path.resolve(__dirname, '..', '.static')));
 
 app.get(


### PR DESCRIPTION
# Why

Adds content negotiation headers for patches.

# How

Update the requests for patches to be [RFC 3229](https://www.rfc-editor.org/rfc/rfc3229.html) compliant

# Test Plan

Using the custom updates server with Quins changes.