### PR TITLE
[ios][updates] Add patch content negotiation headers

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Remove `ExpoAppDelegate` inheritance requirement ([#39417](https://github.com/expo/expo/pull/39417) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add patch content negotiation headers. ([#40583](https://github.com/expo/expo/pull/40583) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 


### PR DESCRIPTION
# Why
Adds content negotiation headers for patches.

# How
Update the requests for patches to be [RFC 3229](https://www.rfc-editor.org/rfc/rfc3229.html) compliant

# Test Plan
Using the custom updates server with Quins changes. 

