### PR TITLE
[docs] Fix code example and verbiage issues in Expo Router's authentication guides

### DIFF
--- a/docs/pages/router/advanced/authentication-rewrites.mdx
+++ b/docs/pages/router/advanced/authentication-rewrites.mdx
@@ -5,7 +5,7 @@ description: How to implement authentication and protect routes with Expo Router
 hasVideoLink: true
 ---
 
-> SDK 53 introduced [Protected routes](/router/advanced/protected/), a more powerful method of handling authentication. Please follow this guide if using SDK >53.
+> **info** SDK 53 introduced [Protected routes](/router/advanced/protected/), a more powerful method of handling authentication. Please follow this guide if you are using SDK 52 and earlier.
 
 import { Lock01Icon } from '@expo/styleguide-icons/outline/Lock01Icon';
 import { LockUnlocked01Icon } from '@expo/styleguide-icons/outline/LockUnlocked01Icon';
@@ -56,7 +56,7 @@ To follow the above example, set up a [React Context provider](https://react.dev
 This provider uses a mock implementation. You can replace it with your own [authentication provider](/guides/authentication/).
 
 ```tsx ctx.tsx
-import { use, createContext, type PropsWithChildren } from 'react';
+import { useContext, createContext, type PropsWithChildren } from 'react';
 import { useStorageState } from './useStorageState';
 
 const AuthContext = createContext<{
@@ -73,7 +73,7 @@ const AuthContext = createContext<{
 
 // This hook can be used to access the user info.
 export function useSession() {
-  const value = use(AuthContext);
+  const value = useContext(AuthContext);
   if (!value) {
     throw new Error('useSession must be wrapped in a <SessionProvider />');
   }
@@ -85,7 +85,7 @@ export function SessionProvider({ children }: PropsWithChildren) {
   const [[isLoading, session], setSession] = useStorageState('session');
 
   return (
-    <AuthContext
+    <AuthContext.Provider
       value={{
         signIn: () => {
           // Perform sign-in logic here
@@ -98,7 +98,7 @@ export function SessionProvider({ children }: PropsWithChildren) {
         isLoading,
       }}>
       {children}
-    </AuthContext>
+    </AuthContext.Provider>
   );
 }
 ```
@@ -153,7 +153,7 @@ export function useStorageState(key: string): UseStateHook<string> {
         console.error('Local storage is unavailable:', e);
       }
     } else {
-      SecureStore.getItemAsync(key).then(value => {
+      SecureStore.getItemAsync(key).then((value: string | null) => {
         setState(value);
       });
     }

--- a/docs/pages/router/advanced/authentication.mdx
+++ b/docs/pages/router/advanced/authentication.mdx
@@ -5,7 +5,7 @@ description: How to implement authentication and protect routes with Expo Router
 hasVideoLink: true
 ---
 
-> **info** **Note:** This guide requires SDK 53. For the previous version of this guide see [Authentication (redirects)](/router/advanced/authentication-rewrites/).
+> **info** **Note:** This guide requires SDK 53 and later. For the previous version of this guide see [Authentication (redirects)](/router/advanced/authentication-rewrites/).
 
 import { Lock01Icon } from '@expo/styleguide-icons/outline/Lock01Icon';
 import { LockUnlocked01Icon } from '@expo/styleguide-icons/outline/LockUnlocked01Icon';
@@ -79,7 +79,7 @@ export function SessionProvider({ children }: PropsWithChildren) {
   const [[isLoading, session], setSession] = useStorageState('session');
 
   return (
-    <AuthContext
+    <AuthContext.Provider
       value={{
         signIn: () => {
           // Perform sign-in logic here
@@ -92,7 +92,7 @@ export function SessionProvider({ children }: PropsWithChildren) {
         isLoading,
       }}>
       {children}
-    </AuthContext>
+    </AuthContext.Provider>
   );
 }
 ```
@@ -151,7 +151,7 @@ export function useStorageState(key: string): UseStateHook<string> {
         console.error('Local storage is unavailable:', e);
       }
     } else {
-      SecureStore.getItemAsync(key).then(value => {
+      SecureStore.getItemAsync(key).then((value: string | null) => {
         setState(value);
       });
     }
@@ -260,7 +260,7 @@ Now modify the `RootNavigator` to protect routes based on your `SessionProvider`
 
 ```tsx app/_layout.tsx|collapseHeight=400
 // All import statements remain the same except you need to import `useSession` from your `ctx.tsx` file.
-import { SessionProvider } from '../ctx';
+import { SessionProvider, useSession } from '../ctx';
 
 // All of the above code remains unchanged. Update the `RootNavigator` to protect routes based on your `SessionProvider` below.
 
@@ -298,7 +298,7 @@ export default function Index() {
     <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
       <Text
         onPress={() => {
-          // The `app/(app)/_layout.tsx` redirects to the sign-in screen.
+          // The guard in `RootNavigator` redirects back to the sign-in screen.
           signOut();
         }}>
         Sign Out
@@ -374,8 +374,8 @@ For more information, read the [Protected routes documentation](/router/advanced
 
 <VideoBoxLink
   videoId="XCTaMu0qnFY"
-  title="How to use Protected Routes in Expo Router V5 and higher for smooth authentication"
-  description="Learn how to use Protected Routes in Expo Router V5 and higher to create an authentication flow."
+  title="How to use Protected Routes in Expo Router version 5 and later for smooth authentication"
+  description="Learn how to use Protected Routes in Expo Router version 5 and later to create an authentication flow."
 />
 
 ## Middleware


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-10798 ENG-17898

# How

<!--
How did you build this feature or fix this bug and why?
-->

- The "Protected routes" guide now specifies it is for SDK 53 and later, while the "Authentication (redirects)" guide is for SDK 52 and earlier.
- Improved video titles and descriptions to refer to "Expo Router version 5 and later" for consistency and clarity.
- Fixed incorrect usage of `AuthContext` by replacing `<AuthContext>` with `<AuthContext.Provider>` in both authentication guides. 
- Updated the import and usage of React context hooks, replacing `use` with `useContext` for proper context consumption in the redirects guide.
- Added explicit type annotation for the value returned by `SecureStore.getItemAsync` to improve type safety. 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally and proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
