### PR TITLE
[docs] Add a usage section to clarify `Host` requirement in SwiftUI reference

### DIFF
--- a/docs/pages/guides/expo-ui-swift-ui.mdx
+++ b/docs/pages/guides/expo-ui-swift-ui.mdx
@@ -43,7 +43,7 @@ You'll need to install the `@expo/ui` package in your Expo project. Run the foll
 
 ## Usage
 
-Expo UI has several SwiftUI components available. You can use them in your app by importing them from `@expo/ui/swift-ui`. However, to cross the boundary from React Native (UIKit) to SwiftUI, you need to use the [`<Host>`](/versions/latest/sdk/ui/#host) component. The [`<Host>`](/versions/latest/sdk/ui/#host) is the container for SwiftUI views. You can think of it like [`<svg>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/svg) in the DOM or [`<Canvas>`](https://shopify.github.io/react-native-skia/docs/canvas/overview/) in [`react-native-skia`](https://shopify.github.io/react-native-skia/). Under the hood, it uses [`UIHostingController`](https://developer.apple.com/documentation/swiftui/uihostingcontroller) to render SwiftUI views in UIKit.
+Expo UI has several SwiftUI components available. You can use them in your app by importing them from `@expo/ui/swift-ui`. However, to cross the boundary from React Native (UIKit) to SwiftUI, you need to use the [`Host`](/versions/latest/sdk/ui/#host) component. The [`Host`](/versions/latest/sdk/ui/#host) is the container for SwiftUI views. You can think of it like [`<svg>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/svg) in the DOM or [`<Canvas>`](https://shopify.github.io/react-native-skia/docs/canvas/overview/) in [`react-native-skia`](https://shopify.github.io/react-native-skia/). Under the hood, it uses [`UIHostingController`](https://developer.apple.com/documentation/swiftui/uihostingcontroller) to render SwiftUI views in UIKit.
 
 ### Basic usage with `Host`
 
@@ -263,13 +263,13 @@ Combining the Expo UI components and modifiers, you can build a UI like iOS Sett
 
 <Collapsible summary="Can I use flexbox or other styles in SwiftUI components?">
 
-Flexbox styles can be applied to the `<Host>` component itself. Once you're inside the SwiftUI context, however, [`Yoga`](https://www.yogalayout.dev/) is not available &mdash; layouts should be defined using `<HStack>` and `<VStack>` instead.
+Flexbox styles can be applied to the `Host` component itself. Once you're inside the SwiftUI context, however, [`Yoga`](https://www.yogalayout.dev/) is not available &mdash; layouts should be defined using `<HStack>` and `<VStack>` instead.
 
 </Collapsible>
 
 <Collapsible summary={<>What's the <CODE>Host</CODE> component?</>}>
 
-`<Host>` is the container for SwiftUI views. You can think of it like [`<svg>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/svg) in the DOM or [`<Canvas>`](https://shopify.github.io/react-native-skia/docs/canvas/overview/) in [`react-native-skia`](https://shopify.github.io/react-native-skia/). Under the hood, it uses [`UIHostingController`](https://developer.apple.com/documentation/swiftui/uihostingcontroller) to render SwiftUI views in UIKit.
+`Host` is the container for SwiftUI views. You can think of it like [`<svg>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/svg) in the DOM or [`<Canvas>`](https://shopify.github.io/react-native-skia/docs/canvas/overview/) in [`react-native-skia`](https://shopify.github.io/react-native-skia/). Under the hood, it uses [`UIHostingController`](https://developer.apple.com/documentation/swiftui/uihostingcontroller) to render SwiftUI views in UIKit.
 
 </Collapsible>
 
@@ -290,9 +290,9 @@ The first milestone for Expo UI is achieving a 1-to-1 mapping from SwiftUI to Ex
 Yes, you can place React Native components as JSX children of Expo UI components. Expo UI automatically creates a [`UIViewRepresentable`](https://developer.apple.com/documentation/swiftui/uiviewrepresentable) wrapper for you.
 However, keep in mind that the SwiftUI layout system works differently from UIKit and has some limitations. According to Apple's documentation:
 
-> **Warning** SwiftUI fully controls the layout of the UIKit view's [`center`](https://developer.apple.com/documentation/UIKit/UIView/center), [`bounds`](https://developer.apple.com/documentation/UIKit/UIView/bounds), [`frame`](https://developer.apple.com/documentation/UIKit/UIView/frame), and [`transform`](https://developer.apple.com/documentation/UIKit/UIView/transform) properties. Don't directly set these layout-related properties on the view managed by a [`UIViewRepresentable`](https://developer.apple.com/documentation/swiftui/uiviewrepresentable) instance from your own code because that conflicts with SwiftUI and results in undefined behavior.
+> **Warning** SwiftUI fully controls the layout of the UIKit view's [`center`](https://developer.apple.com/documentation/UIKit/UIView/center), [`bounds`](https://developer.apple.com/documentation/UIKit/UIView/bounds), [`frame`](https://developer.apple.com/documentation/UIKit/UIView/frame), and [`transform`](https://developer.apple.com/documentation/UIKit/UIView/transform) properties. Don't directly set these layout-related properties on the view managed by a [`UIViewRepresentable`](https://developer.apple.com/documentation/swiftui/uiviewrepresentable) instance from your own code because that conflicts with SwiftUI and results in undefined behavior.
 
-Also note that once you render React Native components, you're leaving the SwiftUI context. If you want to add Expo UI components again, you'll need to reintroduce a `<Host>` wrapper.
+Also note that once you render React Native components, you're leaving the SwiftUI context. If you want to add Expo UI components again, you'll need to reintroduce a `Host` wrapper.
 
 We recommend keeping SwiftUI layouts self-contained. Interop is possible, but it works best when boundaries are clearly defined.
 

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/index.mdx
@@ -26,7 +26,7 @@ The SwiftUI components in `@expo/ui/swift-ui` allow you to build fully native iO
 
 ## Usage
 
-Using a component from `@expo/ui/swift-ui` requires wrapping it in a [`<Host>`](./host) component. The `<Host>` is a container for SwiftUI views.
+Using a component from `@expo/ui/swift-ui` requires wrapping it in a [`Host`](./host) component. The `Host` is a container for SwiftUI views.
 
 ```tsx
 import { Host, Button } from '@expo/ui/swift-ui';
@@ -40,7 +40,7 @@ export function SaveButton() {
 }
 ```
 
-For an in-depth explanation of how `<Host>` works, see the following resources:
+For an in-depth explanation of how `Host` works, see the following resources:
 
 <BoxLink
   title="Expo UI guide for Swift UI"

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/index.mdx
@@ -20,6 +20,28 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 The SwiftUI components in `@expo/ui/swift-ui` allow you to build fully native iOS interfaces using SwiftUI from React Native.
 
+## Installation
+
+<APIInstallSection />
+
+## Usage
+
+Using a component from `@expo/ui/swift-ui` requires wrapping it in a [`<Host>`](./host) component. The `<Host>` is a container for SwiftUI views.
+
+```tsx
+import { Host, Button } from '@expo/ui/swift-ui';
+
+export function SaveButton() {
+  return (
+    <Host style={{ flex: 1 }}>
+      <Button variant="default">Save changes</Button>
+    </Host>
+  );
+}
+```
+
+For an in-depth explanation of how `<Host>` works, see the following resources:
+
 <BoxLink
   title="Expo UI guide for Swift UI"
   description={
@@ -36,7 +58,3 @@ The SwiftUI components in `@expo/ui/swift-ui` allow you to build fully native iO
   title="Expo UI iOS Liquid Glass Tutorial"
   description="Learn how to build real SwiftUI views in your React Native app with the new Expo UI."
 />
-
-## Installation
-
-<APIInstallSection />

--- a/docs/pages/versions/v54.0.0/sdk/ui/swift-ui.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/ui/swift-ui.mdx
@@ -42,7 +42,7 @@ export function SaveButton() {
 }
 ```
 
-For a in-depth explanation of how `<Host>` works, see the following resources:
+For an in-depth explanation of how `<Host>` works, see the following resources:
 
 <BoxLink
   title="Expo UI guide for Swift UI"

--- a/docs/pages/versions/v54.0.0/sdk/ui/swift-ui.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/ui/swift-ui.mdx
@@ -28,7 +28,7 @@ The SwiftUI components in `@expo/ui/swift-ui` allow you to build fully native iO
 
 ## Usage
 
-Render every SwiftUI component inside the `<Host>` component from `@expo/ui/swift-ui`. `<Host>` bridges React Native and SwiftUI, and views rendered outside it will not appear.
+Using a component from `@expo/ui/swift-ui` requires wrapping it in a [`<Host>`](#host) component. The `<Host>` is a container for SwiftUI views.
 
 ```tsx
 import { Host, Button } from '@expo/ui/swift-ui';

--- a/docs/pages/versions/v54.0.0/sdk/ui/swift-ui.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/ui/swift-ui.mdx
@@ -28,7 +28,7 @@ The SwiftUI components in `@expo/ui/swift-ui` allow you to build fully native iO
 
 ## Usage
 
-Using a component from `@expo/ui/swift-ui` requires wrapping it in a [`<Host>`](#host) component. The `<Host>` is a container for SwiftUI views.
+Using a component from `@expo/ui/swift-ui` requires wrapping it in a [`Host>`](#host) component. The `Host` is a container for SwiftUI views.
 
 ```tsx
 import { Host, Button } from '@expo/ui/swift-ui';
@@ -42,7 +42,7 @@ export function SaveButton() {
 }
 ```
 
-For an in-depth explanation of how `<Host>` works, see the following resources:
+For an in-depth explanation of how `Host` works, see the following resources:
 
 <BoxLink
   title="Expo UI guide for Swift UI"

--- a/docs/pages/versions/v54.0.0/sdk/ui/swift-ui.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/ui/swift-ui.mdx
@@ -22,6 +22,28 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 The SwiftUI components in `@expo/ui/swift-ui` allow you to build fully native iOS interfaces using SwiftUI from React Native.
 
+## Installation
+
+<APIInstallSection />
+
+## Usage
+
+Render every SwiftUI component inside the `<Host>` component from `@expo/ui/swift-ui`. `<Host>` bridges React Native and SwiftUI, and views rendered outside it will not appear.
+
+```tsx
+import { Host, Button } from '@expo/ui/swift-ui';
+
+export function SaveButton() {
+  return (
+    <Host style={{ flex: 1 }}>
+      <Button variant="default">Save changes</Button>
+    </Host>
+  );
+}
+```
+
+For a in-depth explanation of how `<Host>` works, see the following resources:
+
 <BoxLink
   title="Expo UI guide for Swift UI"
   description={
@@ -38,10 +60,6 @@ The SwiftUI components in `@expo/ui/swift-ui` allow you to build fully native iO
   title="Expo UI iOS Liquid Glass Tutorial"
   description="Learn how to build real SwiftUI views in your React Native app with the new Expo UI."
 />
-
-## Installation
-
-<APIInstallSection />
 
 ## Components
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-17867

Also, the `<Host>` is referenced sometimes, however, we only use `<Component>` pattern for React Native components.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add a usage section to clarify `Host` requirement in SwiftUI reference in SDK 54 and unversioned
- Normalize Host component references

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally.

## Preview

<img width="944" height="943" alt="CleanShot 2025-10-24 at 19 38 42" src="https://github.com/user-attachments/assets/dad5108b-1e08-4afd-b204-8f275adc15ba" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
