### PR TITLE
[core][Android] Add `map` to `ValueOrUndefined`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Add `map` to `ValueOrUndefined`. ([#40593](https://github.com/expo/expo/pull/40593) by [@Wenszel](https://github.com/Wenszel))
 - Add types for `process.env.EXPO_DOM_HOST_OS`. ([#40382](https://github.com/expo/expo/pull/40382) by [@EvanBacon](https://github.com/EvanBacon))
 - [Android] Add `ComposableScope` for compose Content functions. ([#39155](https://github.com/expo/expo/pull/39155) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Adds support for `ArrayBuffer`. ([#39943](https://github.com/expo/expo/pull/39943) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ValueOrUndefined.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ValueOrUndefined.kt
@@ -1,6 +1,9 @@
 package expo.modules.kotlin.types
 
 import expo.modules.core.interfaces.DoNotStrip
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 @DoNotStrip
 sealed interface ValueOrUndefined<T> {
@@ -30,8 +33,14 @@ sealed interface ValueOrUndefined<T> {
   }
 }
 
-inline fun <T, reified R> ValueOrUndefined<T>.flatMap(transform: (T) -> ValueOrUndefined<R>): ValueOrUndefined<R> =
-  when (this) {
-    is ValueOrUndefined.Value -> transform(value)
-    is ValueOrUndefined.Undefined -> ValueOrUndefined.Undefined()
+@OptIn(ExperimentalContracts::class)
+inline fun <T, reified R> ValueOrUndefined<T>.map(transform: (T) -> R): ValueOrUndefined<R> {
+  contract {
+    callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
   }
+  return when (this) {
+    is ValueOrUndefined.Value -> ValueOrUndefined.Value(transform(value))
+    is ValueOrUndefined.Undefined -> ValueOrUndefined.getUndefined<R>()
+  }
+}
+

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ValueOrUndefined.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ValueOrUndefined.kt
@@ -43,4 +43,3 @@ inline fun <T, reified R> ValueOrUndefined<T>.map(transform: (T) -> R): ValueOrU
     is ValueOrUndefined.Undefined -> ValueOrUndefined.getUndefined<R>()
   }
 }
-

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ValueOrUndefined.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ValueOrUndefined.kt
@@ -1,6 +1,7 @@
 package expo.modules.kotlin.types
 
 import expo.modules.core.interfaces.DoNotStrip
+import expo.modules.kotlin.types.ValueOrUndefined.Companion.getUndefined
 
 @DoNotStrip
 sealed interface ValueOrUndefined<T> {
@@ -29,3 +30,10 @@ sealed interface ValueOrUndefined<T> {
     inline fun <reified T> Undefined(): ValueOrUndefined<T> = getUndefined<T>()
   }
 }
+
+inline fun <T, reified R> ValueOrUndefined<T>.flatMap(transform: (T) -> ValueOrUndefined<R>): ValueOrUndefined<R> =
+  when (this) {
+    is ValueOrUndefined.Value -> transform(value)
+    is ValueOrUndefined.Undefined -> getUndefined<R>()
+  }
+

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ValueOrUndefined.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ValueOrUndefined.kt
@@ -1,7 +1,6 @@
 package expo.modules.kotlin.types
 
 import expo.modules.core.interfaces.DoNotStrip
-import expo.modules.kotlin.types.ValueOrUndefined.Companion.getUndefined
 
 @DoNotStrip
 sealed interface ValueOrUndefined<T> {
@@ -34,6 +33,5 @@ sealed interface ValueOrUndefined<T> {
 inline fun <T, reified R> ValueOrUndefined<T>.flatMap(transform: (T) -> ValueOrUndefined<R>): ValueOrUndefined<R> =
   when (this) {
     is ValueOrUndefined.Value -> transform(value)
-    is ValueOrUndefined.Undefined -> getUndefined<R>()
+    is ValueOrUndefined.Undefined -> ValueOrUndefined.Undefined()
   }
-


### PR DESCRIPTION
# Why
Depends on [#40418](https://github.com/expo/expo/pull/40418)

This change allows us to perform transformations on a wrapped value.
# How

Added `map` extension to `ValueOrUndefined`

# Test Plan

Tested on bare-expo
