### PR TITLE
[menu][Android] Add missing `devmenu.fab` package

### DIFF
--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/fab/FloatingActionButtonContent.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/fab/FloatingActionButtonContent.kt
@@ -1,3 +1,5 @@
+package expo.modules.devmenu.fab
+
 import android.annotation.SuppressLint
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/fab/MovableFloatingActionButton.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/fab/MovableFloatingActionButton.kt
@@ -1,6 +1,5 @@
 package expo.modules.devmenu.fab
 
-import FloatingActionButtonContent
 import android.annotation.SuppressLint
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Animatable


### PR DESCRIPTION
# Why

Adds `missing `devmenu.fab` package.

# Test Plan

- bare-expo ✅ 