### PR TITLE
[bare-expo] ignore log-box dist for fingerprint

### DIFF
--- a/apps/bare-expo/.fingerprintignore
+++ b/apps/bare-expo/.fingerprintignore
@@ -1,0 +1,1 @@
+../../packages/@expo/log-box/dist/**/*


### PR DESCRIPTION
# Why

fix unstable fingerprint like https://github.com/expo/expo/pull/40333#issuecomment-3443916470

```
[
  {
    "op": "changed",
    "beforeSource": {
      "type": "dir",
      "filePath": "../../packages/@expo/log-box",
      "reasons": [
        "expoAutolinkingIos",
        "expoAutolinkingAndroid"
      ],
      "hash": "6468a8c54b76ca42d70e15a206adb90b148b6b8c"
    },
    "afterSource": {
      "type": "dir",
      "filePath": "../../packages/@expo/log-box",
      "reasons": [
        "expoAutolinkingIos",
        "expoAutolinkingAndroid"
      ],
      "hash": "2d6af577c3effaeed9381ee036948db4925f7f63"
    }
  }
]
```

# How

because the log-box/dist is building on-the-fly when yarn install now, the bundle output is not stable. let's add the log-box/dist to the ignore list

# Test Plan

this pr should be fingerprint compatible after mering the pr.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
