### PR TITLE
[docs] Add bottom tab navigation screen options from React Navigation

### DIFF
--- a/docs/pages/router/advanced/stack.mdx
+++ b/docs/pages/router/advanced/stack.mdx
@@ -169,6 +169,8 @@ The `Stack` navigator supports comprehensive header configuration options. Below
 
 <ReactNavigationOptions category="header" />
 
+For additional details and navigator-specific examples, see [React Navigation's Native Stack Navigator documentation](https://reactnavigation.org/docs/native-stack-navigator).
+
 ### Set screen options dynamically
 
 To configure a route's option dynamically, you can always use the `<Stack.Screen>` component in that route's file.
@@ -253,6 +255,8 @@ const styles = StyleSheet.create({
 For a complete list of all available other screen options including animations, gestures, and other configurations:
 
 <ReactNavigationOptions excludeCategories={['header']} />
+
+For additional details and navigator-specific examples, see [React Navigation's Native Stack Navigator documentation](https://reactnavigation.org/docs/native-stack-navigator).
 
 ## Custom push behavior
 

--- a/docs/pages/router/advanced/tabs.mdx
+++ b/docs/pages/router/advanced/tabs.mdx
@@ -9,6 +9,7 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { FileTree } from '~/ui/components/FileTree';
+import { ReactNavigationOptions } from '~/ui/components/ReactNavigationOptions';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 <VideoBoxLink
@@ -135,7 +136,11 @@ The tab file named **index.tsx** is the default tab when the app loads. The seco
 
 ## Screen options
 
-The tabs layout wraps the [Bottom Tabs Navigator](https://reactnavigation.org/docs/bottom-tab-navigator) from React Navigation. You can use the [options presented in the React Navigation documentation](https://reactnavigation.org/docs/bottom-tab-navigator/#options) to customize the tab bar or each tab.
+The tabs layout wraps the [Bottom Tabs Navigator](https://reactnavigation.org/docs/bottom-tab-navigator) from React Navigation. Expo Router extends those APIs, so you can use the same configuration props to customize the tab bar or each tab. The supported tab bar options are listed below and sourced directly from the React Navigation documentation.
+
+<ReactNavigationOptions category="tabBar" />
+
+For additional details and navigator-specific examples, refer to the [React Navigation bottom tabs guide](https://reactnavigation.org/docs/bottom-tab-navigator/#options).
 
 ## Advanced
 

--- a/docs/pages/router/advanced/tabs.mdx
+++ b/docs/pages/router/advanced/tabs.mdx
@@ -136,7 +136,7 @@ The tab file named **index.tsx** is the default tab when the app loads. The seco
 
 ## Tab bar options
 
-The JavaScript tabs wraps the [**Bottom Tabs Navigator v7**](https://reactnavigation.org/docs/bottom-tab-navigator) from React Navigation. **Expo Router v6 and later** extends those APIs, so you can use the same configuration props to customize the bottom tab bar or each tab. For example, using customization options, a tab navigator in your project can look like:
+The JavaScript tabs in Expo Router extend the [Bottom Tabs Navigator](https://reactnavigation.org/docs/bottom-tab-navigator) from React Navigation. The specific APIs available depend on your versions. For example, Expo Router v6 extends Bottom Tabs Navigator v7. Check your versions to ensure compatibility, then you can use the same configuration props to customize the bottom tab bar and individual tabs. For example:
 
 ```tsx app/(tabs)/_layout.tsx
 import { Tabs } from 'expo-router';

--- a/docs/pages/router/advanced/tabs.mdx
+++ b/docs/pages/router/advanced/tabs.mdx
@@ -136,7 +136,7 @@ The tab file named **index.tsx** is the default tab when the app loads. The seco
 
 ## Tab bar options
 
-The JavaScript tabs wraps the [Bottom Tabs Navigator](https://reactnavigation.org/docs/bottom-tab-navigator) from React Navigation. Expo Router extends those APIs, so you can use the same configuration props to customize the bottom tab bar or each tab. For example, using customization options, a tab navigator in your project can look like:
+The JavaScript tabs wraps the [**Bottom Tabs Navigator v7**](https://reactnavigation.org/docs/bottom-tab-navigator) from React Navigation. **Expo Router v6 and later** extends those APIs, so you can use the same configuration props to customize the bottom tab bar or each tab. For example, using customization options, a tab navigator in your project can look like:
 
 ```tsx app/(tabs)/_layout.tsx
 import { Tabs } from 'expo-router';

--- a/docs/pages/router/advanced/tabs.mdx
+++ b/docs/pages/router/advanced/tabs.mdx
@@ -136,11 +136,11 @@ The tab file named **index.tsx** is the default tab when the app loads. The seco
 
 ## Screen options
 
-The tabs layout wraps the [Bottom Tabs Navigator](https://reactnavigation.org/docs/bottom-tab-navigator) from React Navigation. Expo Router extends those APIs, so you can use the same configuration props to customize the tab bar or each tab. The supported tab bar options are listed below and sourced directly from the React Navigation documentation.
+The JavaScript tabs wraps the [Bottom Tabs Navigator](https://reactnavigation.org/docs/bottom-tab-navigator) from React Navigation. Expo Router extends those APIs, so you can use the same configuration props to customize the bottom tab bar or each tab. The supported tab bar options are listed below:
 
 <ReactNavigationOptions category="tabBar" />
 
-For additional details and navigator-specific examples, refer to the [React Navigation bottom tabs guide](https://reactnavigation.org/docs/bottom-tab-navigator/#options).
+For additional details and navigator-specific examples, see [React Navigation's Bottom Tabs Navigator documentation](https://reactnavigation.org/docs/bottom-tab-navigator/#options).
 
 ## Advanced
 

--- a/docs/pages/router/advanced/tabs.mdx
+++ b/docs/pages/router/advanced/tabs.mdx
@@ -134,9 +134,35 @@ const styles = StyleSheet.create({
 
 The tab file named **index.tsx** is the default tab when the app loads. The second tab file **settings.tsx** shows how you can add more tabs to the tab bar.
 
-## Screen options
+## Tab bar options
 
-The JavaScript tabs wraps the [Bottom Tabs Navigator](https://reactnavigation.org/docs/bottom-tab-navigator) from React Navigation. Expo Router extends those APIs, so you can use the same configuration props to customize the bottom tab bar or each tab. The supported tab bar options are listed below:
+The JavaScript tabs wraps the [Bottom Tabs Navigator](https://reactnavigation.org/docs/bottom-tab-navigator) from React Navigation. Expo Router extends those APIs, so you can use the same configuration props to customize the bottom tab bar or each tab. For example, using customization options, a tab navigator in your project can look like:
+
+```tsx app/(tabs)/_layout.tsx
+import { Tabs } from 'expo-router';
+
+export default function TabLayout() {
+  return (
+    <Tabs
+      screenOptions={
+        {
+          // Here to apply for all tabs
+        }
+      }>
+      <Tabs.Screen
+        name="index"
+        options={
+          {
+            // Or here to apply for one tab
+          }
+        }
+      />
+    </Tabs>
+  );
+}
+```
+
+The supported tab bar options are listed below:
 
 <ReactNavigationOptions category="tabBar" />
 

--- a/docs/public/data/react-navigation-options.json
+++ b/docs/public/data/react-navigation-options.json
@@ -1,324 +1,548 @@
 {
-  "source": "React Navigation Documentation (Markdown)",
-  "sourceUrl": "https://raw.githubusercontent.com/react-navigation/react-navigation.github.io/main/versioned_docs/version-7.x/native-stack-navigator.md",
-  "fetchedAt": "2025-05-27T18:58:23.643Z",
-  "totalOptions": 52,
+  "sources": [
+    {
+      "id": "native-stack-navigator",
+      "name": "Native Stack Navigator",
+      "url": "https://raw.githubusercontent.com/react-navigation/react-navigation.github.io/main/versioned_docs/version-7.x/native-stack-navigator.md"
+    },
+    {
+      "id": "bottom-tab-navigator",
+      "name": "Bottom Tab Navigator",
+      "url": "https://raw.githubusercontent.com/react-navigation/react-navigation.github.io/main/versioned_docs/version-7.x/bottom-tab-navigator.md"
+    }
+  ],
+  "fetchedAt": "2025-10-24T13:42:11.994Z",
+  "totalOptions": 75,
   "categories": {
-    "header": 25,
-    "other": 27
+    "header": 27,
+    "other": 27,
+    "tabBar": 21
   },
   "options": [
     {
       "name": "title",
       "description": "String that can be used as a fallback for `headerTitle`.",
       "platform": "Both",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "headerBackButtonMenuEnabled",
       "description": "Boolean indicating whether to show the menu on longPress of iOS >= 14 back button. Defaults to `true`.",
       "platform": "iOS only",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "headerBackVisible",
       "description": "Whether the back button is visible in the header. You can use it to show a back button alongside `headerLeft` if you have specified it.\n\nThis will have no effect on the first screen in the stack.",
       "platform": "Both",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "headerBackTitle",
       "description": "Title string used by the back button on iOS. Defaults to the previous scene's title, \"Back\" or arrow icon depending on the available space. See `headerBackButtonDisplayMode` to read about limitations and customize the behavior.\n\nUse `headerBackButtonDisplayMode: \"minimal\"` to hide it.",
       "platform": "iOS only",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "headerBackButtonDisplayMode",
       "description": "How the back button displays icon and title.\n\nSupported values:\n\n- \"default\" - Displays one of the following depending on the available space: previous screen's title, generic title (e.g. 'Back') or no title (only icon).\n- \"generic\" – Displays one of the following depending on the available space: generic title (e.g. 'Back') or no title (only icon).\n- \"minimal\" – Always displays only the icon without a title.\n\nThe space-aware behavior is disabled when:\n\n- The iOS version is 13 or lower\n- Custom font family or size is set (e.g. with `headerBackTitleStyle`)\n- Back button menu is disabled (e.g. with `headerBackButtonMenuEnabled`)\n\nIn such cases, a static title and icon are always displayed.",
       "platform": "iOS only",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "headerBackTitleStyle",
       "description": "Style object for header back title. Supported properties:\n\n- `fontFamily`\n- `fontSize`",
       "platform": "iOS only",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "headerBackImageSource",
       "description": "Image to display in the header as the icon in the back button. Defaults to back icon image for the platform\n\n- A chevron on iOS\n- An arrow on Android",
       "platform": "Both",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "headerLargeStyle",
       "description": "Style of the header when a large title is shown. The large title is shown if `headerLargeTitle` is `true` and the edge of any scrollable content reaches the matching edge of the header.\n\nSupported properties:\n\n- backgroundColor",
       "platform": "iOS only",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "headerLargeTitle",
       "description": "Whether to enable header with large title which collapses to regular header on scroll.\nDefaults to `false`.\n\nFor large title to collapse on scroll, the content of the screen should be wrapped in a scrollable view such as `ScrollView` or `FlatList`. If the scrollable area doesn't fill the screen, the large title won't collapse on scroll. You also need to specify `contentInsetAdjustmentBehavior=\"automatic\"` in your `ScrollView`, `FlatList` etc.",
       "platform": "iOS only",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "headerLargeTitleShadowVisible",
       "description": "Whether drop shadow of header is visible when a large title is shown.",
       "platform": "Both",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "headerLargeTitleStyle",
       "description": "Style object for large title in header. Supported properties:\n\n- `fontFamily`\n- `fontSize`\n- `fontWeight`\n- `color`",
       "platform": "iOS only",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "headerShown",
       "description": "Whether to show the header. The header is shown by default. Setting this to `false` hides the header.",
       "platform": "Both",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "headerStyle",
       "description": "Style object for header. Supported properties:\n\n- `backgroundColor`",
       "platform": "Both",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "headerShadowVisible",
       "description": "Whether to hide the elevation shadow (Android) or the bottom border (iOS) on the header.",
       "platform": "Both",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "headerTransparent",
       "description": "Boolean indicating whether the navigation bar is translucent.\n\nDefaults to `false`. Setting this to `true` makes the header absolutely positioned - so that the header floats over the screen so that it overlaps the content underneath, and changes the background color to `transparent` unless specified in `headerStyle`.\n\nThis is useful if you want to render a semi-transparent header or a blurred background.\n\nNote that if you don't want your content to appear under the header, you need to manually add a top margin to your content. React Navigation won't do it automatically.\n\nTo get the height of the header, you can use `HeaderHeightContext` with React's Context API or `useHeaderHeight`.",
       "platform": "Both",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "headerBlurEffect",
       "description": "Blur effect for the translucent header. The `headerTransparent` option needs to be set to `true` for this to work.\n\nSupported values: `extraLight`, `light`, `dark`, `regular`, `prominent`, `systemUltraThinMaterial`, `systemThinMaterial`, `systemMaterial`, `systemThickMaterial`, `systemChromeMaterial`, `systemUltraThinMaterialLight`, `systemThinMaterialLight`, `systemMaterialLight`, `systemThickMaterialLight`, `systemChromeMaterialLight`, `systemUltraThinMaterialDark`, `systemThinMaterialDark`, `systemMaterialDark`, `systemThickMaterialDark`, `systemChromeMaterialDark`",
       "platform": "iOS only",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "headerBackground",
       "description": "Function which returns a React Element to render as the background of the header. This is useful for using backgrounds such as an image or a gradient.",
       "platform": "Both",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "headerTintColor",
       "description": "Tint color for the header. Changes the color of back button and title.",
       "platform": "Both",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "headerLeft",
-      "description": "Function which returns a React Element to display on the left side of the header. This replaces the back button. See `headerBackVisible` to show the back button along side left element.",
+      "description": "Function which returns a React Element to display on the left side of the header. This replaces the back button. See `headerBackVisible` to show the back button along side left element. It receives the following properties in the arguments:\n\n- `tintColor` - The tint color to apply. Defaults to the theme's primary color.\n- `canGoBack` - Boolean indicating whether there is a screen to go back to.\n- `label` - Label text for the button. Usually the title of the previous screen.\n- `href` - The `href` to use for the anchor tag on web",
       "platform": "Both",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
+    },
+    {
+      "name": "unstable_headerLeftItems",
+      "description": "This option is experimental and may change in a minor release.\n\nFunction which returns an array of items to display as on the left side of the header. This will override `headerLeft` if both are specified. It receives the following properties in the arguments:\n\n- `tintColor` - The tint color to apply. Defaults to the theme's primary color.\n- `canGoBack` - Boolean indicating whether there is a screen to go back to.\n\nSee Header items for more information.",
+      "platform": "iOS only",
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "headerRight",
-      "description": "Function which returns a React Element to display on the right side of the header.",
+      "description": "Function which returns a React Element to display on the right side of the header. It receives the following properties in the arguments:\n\n- `tintColor` - The tint color to apply. Defaults to the theme's primary color.\n- `canGoBack` - Boolean indicating whether there is a screen to go back to.",
       "platform": "Both",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
+    },
+    {
+      "name": "unstable_headerRightItems",
+      "description": "This option is experimental and may change in a minor release.\n\nFunction which returns an array of items to display as on the right side of the header. This will override `headerRight` if both are specified. It receives the following properties in the arguments:\n\n- `tintColor` - The tint color to apply. Defaults to the theme's primary color.\n- `canGoBack` - Boolean indicating whether there is a screen to go back to.\n\nSee Header items for more information.",
+      "platform": "iOS only",
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "headerTitle",
       "description": "String or a function that returns a React Element to be used by the header. Defaults to `title` or name of the screen.\n\nWhen a function is passed, it receives `tintColor` and`children` in the options object as an argument. The title string is passed in `children`.\n\nNote that if you render a custom element by passing a function, animations for the title won't work.",
       "platform": "Both",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "headerTitleAlign",
       "description": "How to align the header title. Possible values:\n\n- `left`\n  \n\n- `center`\n  \n\nDefaults to `left` on platforms other than iOS.\n\nNot supported on iOS. It's always `center` on iOS and cannot be changed.",
       "platform": "Both",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "headerTitleStyle",
       "description": "Style object for header title. Supported properties:\n\n- `fontFamily`\n- `fontSize`\n- `fontWeight`\n- `color`",
       "platform": "Both",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "headerSearchBarOptions",
       "description": "Options to render a native search bar on iOS. Search bars are rarely static so normally it is controlled by passing an object to `headerSearchBarOptions` navigation option in the component's body.\n\nYou also need to specify `contentInsetAdjustmentBehavior=\"automatic\"` in your `ScrollView`, `FlatList` etc. If you don't have a `ScrollView`, specify `headerTransparent: false`.\n\nSupported properties are:\n\n**ref**\n\nRef to manipulate the search input imperatively. It contains the following methods:\n\n- `focus` - focuses the search bar\n- `blur` - removes focus from the search bar\n- `setText` - sets the search bar's content to given value\n- `clearText` - removes any text present in the search bar input field\n- `cancelSearch` - cancel the search and close the search bar\n\n**autoCapitalize**\n\nControls whether the text is automatically auto-capitalized as it is entered by the user.\nPossible values:\n\n- `none`\n- `words`\n- `sentences`\n- `characters`\n\nDefaults to `sentences`.\n\n**autoFocus**\n\nWhether to automatically focus search bar when it's shown. Defaults to `false`.\n\n**barTintColor**\n\nThe search field background color. By default bar tint color is translucent.\n\n**tintColor**\n\nThe color for the cursor caret and cancel button text.\n\n**cancelButtonText**\n\nThe text to be used instead of default `Cancel` button text.\n\n**disableBackButtonOverride**\n\nWhether the back button should close search bar's text input or not. Defaults to `false`.\n\n**hideNavigationBar**\n\nBoolean indicating whether to hide the navigation bar during searching. Defaults to `true`.\n\n**hideWhenScrolling**\n\nBoolean indicating whether to hide the search bar when scrolling. Defaults to `true`.\n\n**inputType**\n\nThe type of the input. Defaults to `\"text\"`.\n\nSupported values: `\"text\"`, `\"phone\"`, `\"number\"`, `\"email\"`\n\n**obscureBackground**\n\nBoolean indicating whether to obscure the underlying content with semi-transparent overlay. Defaults to `true`.\n\n**placeholder**\n\nText displayed when search field is empty.\n\n**textColor**\n\nThe color of the text in the search field.\n\n**hintTextColor**\n\nThe color of the hint text in the search field.\n\n**headerIconColor**\n\nThe color of the search and close icons shown in the header\n\n**shouldShowHintSearchIcon**\n\nWhether to show the search hint icon when search bar is focused. Defaults to `true`.\n\n**onBlur**\n\nA callback that gets called when search bar has lost focus.\n\n**onCancelButtonPress**\n\nA callback that gets called when the cancel button is pressed.\n\n**onChangeText**\n\nA callback that gets called when the text changes. It receives the current text value of the search bar.",
       "platform": "iOS only",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "header",
       "description": "Custom header to use instead of the default header.\n\nThis accepts a function that returns a React Element to display as a header. The function receives an object containing the following properties as the argument:\n\n- `navigation` - The navigation object for the current screen.\n- `route` - The route object for the current screen.\n- `options` - The options for the current screen\n- `back` - Options for the back button, contains an object with a `title` property to use for back button label.\n\nTo set a custom header for all the screens in the navigator, you can specify this option in the `screenOptions` prop of the navigator.\n\nNote that if you specify a custom header, the native functionality such as large title, search bar etc. won't work.",
       "platform": "Both",
-      "category": "header"
+      "category": "header",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "statusBarAnimation",
       "description": "Sets the status bar animation (similar to the `StatusBar` component). Defaults to `fade` on iOS and `none` on Android.\n\nSupported values: `\"fade\"`, `\"none\"`, `\"slide\"`\n\nOn Android, setting either `fade` or `slide` will set the transition of status bar color. On iOS, this option applies to appereance animation of the status bar.\n\nRequires setting `View controller-based status bar appearance -> YES` (or removing the config) in your `Info.plist` file.",
       "platform": "Android only",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "statusBarHidden",
       "description": "Whether the status bar should be hidden on this screen.\n\nRequires setting `View controller-based status bar appearance -> YES` (or removing the config) in your `Info.plist` file.",
       "platform": "Android only",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "statusBarStyle",
-      "description": "Sets the status bar color (similar to the `StatusBar` component). Defaults to `auto`.\n\nSupported values: `\"auto\"`, `\"inverted\"`, `\"dark\"`, `\"light\"`\n\nRequires setting `View controller-based status bar appearance -> YES` (or removing the config) in your `Info.plist` file.",
+      "description": "Sets the status bar color (similar to the `StatusBar` component).\n\nSupported values: `\"auto\"`, `\"inverted\"`, `\"dark\"`, `\"light\"`\n\nDefaults to `auto` on iOS and `light` on Android.\n\nRequires setting `View controller-based status bar appearance -> YES` (or removing the config) in your `Info.plist` file.",
       "platform": "Android only",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "statusBarBackgroundColor",
       "description": "This option is deprecated and will be removed in a future release (for apps targeting Android SDK 35 or above edge-to-edge mode is enabled by default\nand it is expected that the edge-to-edge will be enforced in future SDKs, see here for more information).\n\nSets the background color of the status bar (similar to the `StatusBar` component).",
       "platform": "Android only",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "statusBarTranslucent",
       "description": "This option is deprecated and will be removed in a future release (for apps targeting Android SDK 35 or above edge-to-edge mode is enabled by default\nand it is expected that the edge-to-edge will be enforced in future SDKs, see here for more information).\n\nSets the translucency of the status bar (similar to the `StatusBar` component). Defaults to `false`.",
       "platform": "Android only",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "contentStyle",
       "description": "Style object for the scene content.",
       "platform": "Both",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "animationMatchesGesture",
       "description": "Whether the gesture to dismiss should use animation provided to `animation` prop. Defaults to `false`.\n\nDoesn't affect the behavior of screens presented modally.",
       "platform": "iOS only",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "fullScreenGestureEnabled",
       "description": "Whether the gesture to dismiss should work on the whole screen. Using gesture to dismiss with this option results in the same transition animation as `simple_push`. This behavior can be changed by setting `customAnimationOnGesture` prop. Achieving the default iOS animation isn't possible due to platform limitations. Defaults to `false`.\n\nDoesn't affect the behavior of screens presented modally.",
       "platform": "iOS only",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "fullScreenGestureShadowEnabled",
       "description": "Whether the full screen dismiss gesture has shadow under view during transition. Defaults to `true`.\n\nThis does not affect the behavior of transitions that don't use gestures enabled by `fullScreenGestureEnabled` prop.",
       "platform": "Both",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "gestureEnabled",
       "description": "Whether you can use gestures to dismiss this screen. Defaults to `true`.",
       "platform": "iOS only",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "animationTypeForReplace",
       "description": "The type of animation to use when this screen replaces another screen. Defaults to `push`.\n\nSupported values: `push`, `pop`",
       "platform": "Both",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "animation",
       "description": "How the screen should animate when pushed or popped.\n\nSupported values: `default`, `fade`, `fade_from_bottom`, `flip`, `simple_push`, `slide_from_bottom`, `slide_from_right`, `slide_from_left`, `none`",
       "platform": "Android only",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "presentation",
       "description": "How should the screen be presented.\n\nSupported values: `card`, `modal`, `transparentModal`, `containedModal`, `containedTransparentModal`, `fullScreenModal`, `formSheet`",
       "platform": "Android only",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "sheetAllowedDetents",
       "description": "Works only when `presentation` is set to `formSheet`.\n\nDescribes heights where a sheet can rest.\n\nSupported values: `fitToContents`\n\nDefaults to `[1.0]`.",
       "platform": "Android only",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "sheetElevation",
       "description": "Works only when `presentation` is set to `formSheet`.\n\nInteger value describing elevation of the sheet, impacting shadow on the top edge of the sheet.\n\nNot dynamic - changing it after the component is rendered won't have an effect.\n\nDefaults to `24`.",
       "platform": "Android only",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "sheetExpandsWhenScrolledToEdge",
       "description": "Works only when `presentation` is set to `formSheet`.\n\nWhether the sheet should expand to larger detent when scrolling.\n\nDefaults to `true`.\n\nPlease note that for this interaction to work, the ScrollView must be \"first-subview-chain\" descendant of the Screen component. This restriction is due to platform requirements.",
       "platform": "iOS only",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "sheetCornerRadius",
       "description": "Works only when `presentation` is set to `formSheet`.\n\nThe corner radius that the sheet will try to render with.\n\nIf set to non-negative value it will try to render sheet with provided radius, else it will apply system default.\n\nIf left unset, system default is used.",
       "platform": "Android only",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "sheetInitialDetentIndex",
       "description": "Works only when `presentation` is set to `formSheet`.\n\n**Index** of the detent the sheet should expand to after being opened.\n\nIf the specified index is out of bounds of `sheetAllowedDetents` array, in dev environment more errors will be thrown, in production the value will be reset to default value.\n\nAdditionaly there is `last` value available, when set the sheet will expand initially to last (largest) detent.\n\nDefaults to `0` - which represents first detent in the detents array.",
       "platform": "Android only",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "sheetGrabberVisible",
       "description": "Works only when `presentation` is set to `formSheet`.\n\nBoolean indicating whether the sheet shows a grabber at the top.\n\nDefaults to `false`.",
       "platform": "iOS only",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "sheetLargestUndimmedDetentIndex",
       "description": "Works only when `presentation` is set to `formSheet`.\n\nThe largest sheet detent for which a view underneath won't be dimmed.\n\nThis prop can be set to an number, which indicates index of detent in `sheetAllowedDetents` array for which there won't be a dimming view beneath the sheet.\n\nAdditionaly there are following options available:\n\n- `none` - there will be dimming view for all detents levels,\n- `last` - there won't be a dimming view for any detent level.\n\nDefaults to `none`, indicating that the dimming view should be always present.",
       "platform": "Android only",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "orientation",
       "description": "The display orientation to use for the screen.\n\nSupported values: `default`, `all`, `portrait`, `portrait_up`, `portrait_down`, `landscape`, `landscape_left`, `landscape_right`",
       "platform": "Android only",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "autoHideHomeIndicator",
       "description": "Boolean indicating whether the home indicator should prefer to stay hidden. Defaults to `false`.",
       "platform": "iOS only",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "gestureDirection",
       "description": "Sets the direction in which you should swipe to dismiss the screen.\n\nSupported values: `vertical`, `horizontal`\n\nWhen using `vertical` option, options `fullScreenGestureEnabled: true`, `customAnimationOnGesture: true` and `animation: 'slide_from_bottom'` are set by default.",
       "platform": "iOS only",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "animationDuration",
       "description": "Changes the duration (in milliseconds) of `slide_from_bottom`, `fade_from_bottom`, `fade` and `simple_push` transitions on iOS. Defaults to `350`.\n\nThe duration of `default` and `flip` transitions isn't customizable.",
       "platform": "iOS only",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "navigationBarColor",
       "description": "This option is deprecated and will be removed in a future release (for apps targeting Android SDK 35 or above edge-to-edge mode is enabled by default\nand it is expected that the edge-to-edge will be enforced in future SDKs, see here for more information).\n\nSets the navigation bar color. Defaults to initial status bar color.",
       "platform": "Android only",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "navigationBarHidden",
       "description": "Boolean indicating whether the navigation bar should be hidden. Defaults to `false`.",
       "platform": "Android only",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
     },
     {
       "name": "freezeOnBlur",
       "description": "Boolean indicating whether to prevent inactive screens from re-rendering. Defaults to `false`.\nDefaults to `true` when `enableFreeze()` from `react-native-screens` package is run at the top of the application.\n\nOnly supported on iOS and Android.",
       "platform": "iOS only",
-      "category": "other"
+      "category": "other",
+      "origin": "native-stack-navigator"
+    },
+    {
+      "name": "tabBarLabel",
+      "description": "Title string of a tab displayed in the tab bar or a function that given `{ focused: boolean, color: string }` returns a React.Node, to display in tab bar. When undefined, scene `title` is used. To hide, see `tabBarShowLabel`.",
+      "platform": "Both",
+      "category": "tabBar",
+      "origin": "bottom-tab-navigator"
+    },
+    {
+      "name": "tabBarShowLabel",
+      "description": "Whether the tab label should be visible. Defaults to `true`.",
+      "platform": "Both",
+      "category": "tabBar",
+      "origin": "bottom-tab-navigator"
+    },
+    {
+      "name": "tabBarLabelPosition",
+      "description": "Whether the label is shown below the icon or beside the icon.\n\nBy default, the position is chosen automatically based on device width.\n\n- `below-icon`: the label is shown below the icon (typical for iPhones)\n  \n\n- `beside-icon` the label is shown next to the icon (typical for iPad)",
+      "platform": "Both",
+      "category": "tabBar",
+      "origin": "bottom-tab-navigator"
+    },
+    {
+      "name": "tabBarLabelStyle",
+      "description": "Style object for the tab label.",
+      "platform": "Both",
+      "category": "tabBar",
+      "origin": "bottom-tab-navigator"
+    },
+    {
+      "name": "tabBarIcon",
+      "description": "Function that given `{ focused: boolean, color: string, size: number }` returns a React.Node, to display in the tab bar.",
+      "platform": "Both",
+      "category": "tabBar",
+      "origin": "bottom-tab-navigator"
+    },
+    {
+      "name": "tabBarIconStyle",
+      "description": "Style object for the tab icon.",
+      "platform": "Both",
+      "category": "tabBar",
+      "origin": "bottom-tab-navigator"
+    },
+    {
+      "name": "tabBarBadge",
+      "description": "Text to show in a badge on the tab icon. Accepts a `string` or a `number`.",
+      "platform": "Both",
+      "category": "tabBar",
+      "origin": "bottom-tab-navigator"
+    },
+    {
+      "name": "tabBarBadgeStyle",
+      "description": "Style for the badge on the tab icon. You can specify a background color or text color here.",
+      "platform": "Both",
+      "category": "tabBar",
+      "origin": "bottom-tab-navigator"
+    },
+    {
+      "name": "tabBarAccessibilityLabel",
+      "description": "Accessibility label for the tab button. This is read by the screen reader when the user taps the tab. It's recommended to set this if you don't have a label for the tab.",
+      "platform": "Both",
+      "category": "tabBar",
+      "origin": "bottom-tab-navigator"
+    },
+    {
+      "name": "tabBarButton",
+      "description": "Function which returns a React element to render as the tab bar button. It wraps the icon and label. Renders `Pressable` by default.\n\nYou can specify a custom implementation here:\n\n```js\ntabBarButton: (props) => <TouchableOpacity {...props} />;\n```",
+      "platform": "Both",
+      "category": "tabBar",
+      "origin": "bottom-tab-navigator"
+    },
+    {
+      "name": "tabBarButtonTestID",
+      "description": "ID to locate this tab button in tests.",
+      "platform": "Both",
+      "category": "tabBar",
+      "origin": "bottom-tab-navigator"
+    },
+    {
+      "name": "tabBarActiveTintColor",
+      "description": "Color for the icon and label in the active tab.",
+      "platform": "Both",
+      "category": "tabBar",
+      "origin": "bottom-tab-navigator"
+    },
+    {
+      "name": "tabBarInactiveTintColor",
+      "description": "Color for the icon and label in the inactive tabs.",
+      "platform": "Both",
+      "category": "tabBar",
+      "origin": "bottom-tab-navigator"
+    },
+    {
+      "name": "tabBarActiveBackgroundColor",
+      "description": "Background color for the active tab.",
+      "platform": "Both",
+      "category": "tabBar",
+      "origin": "bottom-tab-navigator"
+    },
+    {
+      "name": "tabBarInactiveBackgroundColor",
+      "description": "Background color for the inactive tabs.",
+      "platform": "Both",
+      "category": "tabBar",
+      "origin": "bottom-tab-navigator"
+    },
+    {
+      "name": "tabBarHideOnKeyboard",
+      "description": "Whether the tab bar is hidden when the keyboard opens. Defaults to `false`.",
+      "platform": "Both",
+      "category": "tabBar",
+      "origin": "bottom-tab-navigator"
+    },
+    {
+      "name": "tabBarItemStyle",
+      "description": "Style object for the tab item container.",
+      "platform": "Both",
+      "category": "tabBar",
+      "origin": "bottom-tab-navigator"
+    },
+    {
+      "name": "tabBarStyle",
+      "description": "Style object for the tab bar. You can configure styles such as background color here.\n\nTo show your screen under the tab bar, you can set the `position` style to absolute:\n\n```js\n<Tab.Navigator\n  screenOptions={{\n    tabBarStyle: { position: 'absolute' },\n  }}\n>\n```\n\nYou also might need to add a bottom margin to your content if you have an absolutely positioned tab bar. React Navigation won't do it automatically. See `useBottomTabBarHeight` for more details.",
+      "platform": "Both",
+      "category": "tabBar",
+      "origin": "bottom-tab-navigator"
+    },
+    {
+      "name": "tabBarBackground",
+      "description": "Function which returns a React Element to use as background for the tab bar. You could render an image, a gradient, blur view etc.:\n\n```js\nimport { BlurView } from 'expo-blur';\n\n// ...\n\n<Tab.Navigator\n  screenOptions={{\n    tabBarStyle: { position: 'absolute' },\n    tabBarBackground: () => (\n      <BlurView tint=\"light\" intensity={100} style={StyleSheet.absoluteFill} />\n    ),\n  }}\n>\n```\n\nWhen using `BlurView`, make sure to set `position: 'absolute'` in `tabBarStyle` as well. You'd also need to use `useBottomTabBarHeight` to add bottom padding to your content.",
+      "platform": "Both",
+      "category": "tabBar",
+      "origin": "bottom-tab-navigator"
+    },
+    {
+      "name": "tabBarPosition",
+      "description": "Position of the tab bar. Available values are:\n\n- `bottom` (Default)\n- `top`\n- `left`\n- `right`\n\nWhen the tab bar is positioned on the `left` or `right`, it is styled as a sidebar. This can be useful when you want to show a sidebar on larger screens and a bottom tab bar on smaller screens:\n\n```js\n<Tab.Navigator\n  screenOptions={{\n    tabBarPosition: dimensions.width < 600 ? 'bottom' : 'left',\n    tabBarLabelPosition: 'below-icon',\n  }}\n>\n```",
+      "platform": "Both",
+      "category": "tabBar",
+      "origin": "bottom-tab-navigator"
+    },
+    {
+      "name": "tabBarVariant",
+      "description": "Variant of the tab bar. Available values are:\n\n- `uikit` (Default) - The tab bar will be styled according to the iOS UIKit guidelines.\n- `material` - The tab bar will be styled according to the Material Design guidelines.\n\nThe `material` variant is currently only supported when the `tabBarPosition` is set to `left` or `right`.",
+      "platform": "Both",
+      "category": "tabBar",
+      "origin": "bottom-tab-navigator"
     }
   ]
 }

--- a/docs/ui/components/ReactNavigationOptions/index.tsx
+++ b/docs/ui/components/ReactNavigationOptions/index.tsx
@@ -11,18 +11,15 @@ type ReactNavigationOption = {
   name: string;
   description: string;
   platform: 'Both' | 'iOS only' | 'Android only';
-  category: 'header' | 'other';
+  category: 'header' | 'other' | 'tabBar';
+  origin: string;
 };
 
 type ReactNavigationOptionsData = {
-  source: string;
-  sourceUrl: string;
+  sources: { id: string; name: string; url: string }[];
   fetchedAt: string;
   totalOptions: number;
-  categories: {
-    header: number;
-    other: number;
-  };
+  categories: Record<string, number>;
   options: ReactNavigationOption[];
 };
 
@@ -89,7 +86,12 @@ export const ReactNavigationOptions = ({
     return <div className="text-sm text-secondary">No options found for category: {category}</div>;
   }
 
-  const defaultTitle = category ? 'Header options' : 'Screen options';
+  const categoryTitles: Record<string, string> = {
+    header: 'Header options',
+    tabBar: 'Tab bar options',
+  };
+
+  const defaultTitle = category ? (categoryTitles[category] ?? 'Options') : 'Screen options';
 
   return (
     <div>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-17899

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add bottom tab navigation screen options from React Navigation in JavaScript tabs guide.
- Also sync header/screen options changes for Stack navigation in React Navigation version 7.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

<img width="1525" height="1150" alt="CleanShot 2025-10-25 at 00 08 27" src="https://github.com/user-attachments/assets/3766a823-684e-42e8-b0eb-6c8544a54f7c" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
