### PR TITLE
[app-integrity][docs] Fix missing inline syntax highlights

### DIFF
--- a/docs/pages/versions/unversioned/sdk/app-integrity.mdx
+++ b/docs/pages/versions/unversioned/sdk/app-integrity.mdx
@@ -51,9 +51,9 @@ const requestHash = '2cp24z...';
 const result = await AppIntegrity.requestIntegrityCheckAsync(requestHash);
 ```
 
-Before calling [requestIntegrityCheckAsync](#appintegrityrequestintegritycheckasyncrequesthash), ensure that [prepareIntegrityTokenProviderAsync](#appintegrityprepareintegritytokenproviderasynccloudprojectnumber) was called successfully.
+Before calling [`requestIntegrityCheckAsync`](#appintegrityrequestintegritycheckasyncrequesthash), ensure that [`prepareIntegrityTokenProviderAsync`](#appintegrityprepareintegritytokenproviderasynccloudprojectnumber) was called successfully.
 
-In this example, `requestHash` is a hash unique to the specific user action being verified. You can call [requestIntegrityCheckAsync](#appintegrityprepareintegritytokenproviderasynccloudprojectnumber) multiple times with different hashes for different user actions.
+In this example, `requestHash` is a hash unique to the specific user action being verified. You can call [`requestIntegrityCheckAsync`](#appintegrityprepareintegritytokenproviderasynccloudprojectnumber) multiple times with different hashes for different user actions.
 
 On success, send the result to your server for verification.
 

--- a/docs/pages/versions/v54.0.0/sdk/app-integrity.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/app-integrity.mdx
@@ -51,9 +51,9 @@ const requestHash = '2cp24z...';
 const result = await AppIntegrity.requestIntegrityCheckAsync(requestHash);
 ```
 
-Before calling [requestIntegrityCheckAsync](#appintegrityrequestintegritycheckasyncrequesthash), ensure that [prepareIntegrityTokenProviderAsync](#appintegrityprepareintegritytokenproviderasynccloudprojectnumber) was called successfully.
+Before calling [`requestIntegrityCheckAsync`](#appintegrityrequestintegritycheckasyncrequesthash), ensure that [`prepareIntegrityTokenProviderAsync`](#appintegrityprepareintegritytokenproviderasynccloudprojectnumber) was called successfully.
 
-In this example, `requestHash` is a hash unique to the specific user action being verified. You can call [requestIntegrityCheckAsync](#appintegrityprepareintegritytokenproviderasynccloudprojectnumber) multiple times with different hashes for different user actions.
+In this example, `requestHash` is a hash unique to the specific user action being verified. You can call [`requestIntegrityCheckAsync`](#appintegrityprepareintegritytokenproviderasynccloudprojectnumber) multiple times with different hashes for different user actions.
 
 On success, send the result to your server for verification.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix missing inline syntax highlights for multiple methods in App Integrity reference.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
