### PR TITLE
[sqlite][Web] Check navigator.storage availability

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- Add explicit secure context error for `web/wa-sqlite/AccessHandlePoolVFS.js` ([#40605](https://github.com/expo/expo/pull/40605) by [@BDav24](https://github.com/BDav24))
+
 ### 💡 Others
 
 - Session changesets now use native `ArrayBuffer`s. ([#42638](https://github.com/expo/expo/pull/42638) by [@barthap](https://github.com/barthap))

--- a/packages/expo-sqlite/web/wa-sqlite/AccessHandlePoolVFS.js
+++ b/packages/expo-sqlite/web/wa-sqlite/AccessHandlePoolVFS.js
@@ -217,6 +217,9 @@ export class AccessHandlePoolVFS extends FacadeVFS {
 
   async isReady() {
     if (!this.#directoryHandle) {
+      if (!navigator.storage) {
+        throw new Error('navigator.storage not available (not supported by your browser or context is not secure)');
+      }
       // All files are stored in a single directory.
       let handle = await navigator.storage.getDirectory();
       for (const d of this.#directoryPath.split('/')) {


### PR DESCRIPTION
# Why

When using `expo-sqlite` in an unsupported browser or outside of a secure context (during development if you don't use localhost for example), you get the foloowing error:

```
Error: TypeError: Cannot read properties of undefined (reading 'getDirectory')
  workerMessageHandler node_modules/expo-sqlite/web/WorkerChannel.ts:64:25
  worker.addEventListener$argument_1 node_modules/expo-sqlite/web/SQLiteModule.ts:30:27
```

https://developer.mozilla.org/en-US/docs/Web/API/Navigator/storage
> navigator.storage is available only in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS), in some or all [supporting browsers](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/storage#browser_compatibility).

# How

Raise an error if `navigator.storage` is not defined.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
