### PR TITLE
[ios][audio] Fix expo-audio iOS delay when alternating between playing and recording audio

### DIFF
--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -41,9 +41,9 @@ public class AudioModule: Module {
         usingRequesterClass: AudioRecordingRequester.self,
         resolve: promise.resolver,
         reject: promise.legacyRejecter
-        )
+      )
       #else
-        promise.reject(Exception.init(name: "UnsupportedOperation", description: "Audio recording is not supported on this platform."))
+      promise.reject(Exception.init(name: "UnsupportedOperation", description: "Audio recording is not supported on this platform."))
       #endif
     }
 
@@ -55,7 +55,7 @@ public class AudioModule: Module {
         reject: promise.legacyRejecter
       )
       #else
-        promise.reject(Exception.init(name: "UnsupportedOperation", description: "Audio recording is not supported on this platform."))
+      promise.reject(Exception.init(name: "UnsupportedOperation", description: "Audio recording is not supported on this platform."))
       #endif
     }
 
@@ -222,7 +222,7 @@ public class AudioModule: Module {
         }
       }
 
-      AsyncFunction("seekTo") { ( player: AudioPlayer, seconds: Double, toleranceMillisBefore: Double?, toleranceMillisAfter: Double?) in
+      AsyncFunction("seekTo") { (player: AudioPlayer, seconds: Double, toleranceMillisBefore: Double?, toleranceMillisAfter: Double?) in
         await player.seekTo(
           seconds: seconds,
           toleranceMillisBefore: toleranceMillisBefore,
@@ -265,67 +265,67 @@ public class AudioModule: Module {
         try recorder.prepare(options: options, sessionOptions: sessionOptions)
       }
 
-        Function("record") { (recorder: AudioRecorder, options: RecordOptions?) in
-          try checkPermissions()
+      Function("record") { (recorder: AudioRecorder, options: RecordOptions?) in
+        try checkPermissions()
 
-          switch (options?.atTime, options?.forDuration) {
-          case let (atTime?, forDuration?):
-            // Convert relative delay to absolute device time
-            let absoluteTime = recorder.ref.deviceCurrentTime + TimeInterval(atTime)
-            recorder.ref.record(atTime: absoluteTime, forDuration: TimeInterval(forDuration))
-            recorder.updateStateForDirectRecording()
-            return recorder.getRecordingStatus()
-          case let (atTime?, nil):
-            // Convert relative delay to absolute device time
-            let absoluteTime = recorder.ref.deviceCurrentTime + TimeInterval(atTime)
-            recorder.ref.record(atTime: absoluteTime)
-            recorder.updateStateForDirectRecording()
-            return recorder.getRecordingStatus()
-          case let (nil, forDuration?):
-            recorder.ref.record(forDuration: TimeInterval(forDuration))
-            recorder.updateStateForDirectRecording()
-            return recorder.getRecordingStatus()
-          case (nil, nil):
-            return try recorder.startRecording()
-          }
-        }
-
-        Function("pause") { recorder in
-          try checkPermissions()
-          recorder.pauseRecording()
-        }
-
-        AsyncFunction("stop") { recorder in
-          try checkPermissions()
-          recorder.stopRecording()
-        }
-
-        Function("getStatus") { recorder -> [String: Any] in
-          recorder.getRecordingStatus()
-        }
-
-        Function("startRecordingAtTime") { (recorder, seconds: Double) in
-          try checkPermissions()
-          recorder.ref.record(atTime: TimeInterval(seconds))
-        }
-
-        Function("recordForDuration") { (recorder, seconds: Double) in
-          try checkPermissions()
-          recorder.ref.record(forDuration: TimeInterval(seconds))
-        }
-
-        Function("getAvailableInputs") {
-          RecordingUtils.getAvailableInputs()
-        }
-
-        Function("getCurrentInput") { () -> [String: Any] in
-          try RecordingUtils.getCurrentInput()
-        }
-
-        Function("setInput") { (input: String) in
-          try RecordingUtils.setInput(input)
+        switch (options?.atTime, options?.forDuration) {
+        case let (atTime?, forDuration?):
+          // Convert relative delay to absolute device time
+          let absoluteTime = recorder.ref.deviceCurrentTime + TimeInterval(atTime)
+          recorder.ref.record(atTime: absoluteTime, forDuration: TimeInterval(forDuration))
+          recorder.updateStateForDirectRecording()
+          return recorder.getRecordingStatus()
+        case let (atTime?, nil):
+          // Convert relative delay to absolute device time
+          let absoluteTime = recorder.ref.deviceCurrentTime + TimeInterval(atTime)
+          recorder.ref.record(atTime: absoluteTime)
+          recorder.updateStateForDirectRecording()
+          return recorder.getRecordingStatus()
+        case let (nil, forDuration?):
+          recorder.ref.record(forDuration: TimeInterval(forDuration))
+          recorder.updateStateForDirectRecording()
+          return recorder.getRecordingStatus()
+        case (nil, nil):
+          return try recorder.startRecording()
         }
       }
+
+      Function("pause") { recorder in
+        try checkPermissions()
+        recorder.pauseRecording()
+      }
+
+      AsyncFunction("stop") { recorder in
+        try checkPermissions()
+        recorder.stopRecording()
+      }
+
+      Function("getStatus") { recorder -> [String: Any] in
+        recorder.getRecordingStatus()
+      }
+
+      Function("startRecordingAtTime") { (recorder, seconds: Double) in
+        try checkPermissions()
+        recorder.ref.record(atTime: TimeInterval(seconds))
+      }
+
+      Function("recordForDuration") { (recorder, seconds: Double) in
+        try checkPermissions()
+        recorder.ref.record(forDuration: TimeInterval(seconds))
+      }
+
+      Function("getAvailableInputs") {
+        RecordingUtils.getAvailableInputs()
+      }
+
+      Function("getCurrentInput") { () -> [String: Any] in
+        try RecordingUtils.getCurrentInput()
+      }
+
+      Function("setInput") { (input: String) in
+        try RecordingUtils.setInput(input)
+      }
+    }
     #endif
   }
 
@@ -412,13 +412,13 @@ public class AudioModule: Module {
       }
     }
 
-    #if os(iOS)
-      registry.allRecorders.values.forEach { recorder in
-        if recorder.isRecording {
-          recorder.pauseRecording()
-        }
+  #if os(iOS)
+    registry.allRecorders.values.forEach { recorder in
+      if recorder.isRecording {
+        recorder.pauseRecording()
       }
-    #endif
+    }
+#endif
   }
 
   private func handleInterruptionEnded(with options: AVAudioSession.InterruptionOptions) {
@@ -435,8 +435,7 @@ public class AudioModule: Module {
   @objc private func handleAudioSessionRouteChange(_ notification: Notification) {
     guard let userInfo = notification.userInfo,
       let reasonRaw = userInfo[AVAudioSessionRouteChangeReasonKey] as? UInt,
-      let reason = AVAudioSession.RouteChangeReason(rawValue: reasonRaw)
-    else {
+      let reason = AVAudioSession.RouteChangeReason(rawValue: reasonRaw) else {
       return
     }
 
@@ -462,13 +461,13 @@ public class AudioModule: Module {
       }
     }
 
-    #if os(iOS)
-      registry.allRecorders.values.forEach { recorder in
-        if recorder.allowsRecording && !recorder.isRecording {
-          _ = try? recorder.startRecording()
-        }
+  #if os(iOS)
+    registry.allRecorders.values.forEach { recorder in
+      if recorder.allowsRecording && !recorder.isRecording {
+        _ = try? recorder.startRecording()
       }
-    #endif
+    }
+  #endif
 
     interruptedPlayers.removeAll()
     playerVolumes.removeAll()
@@ -505,8 +504,7 @@ public class AudioModule: Module {
     }
 
     do {
-      try AVAudioSession.sharedInstance().setActive(
-        isActive, options: [.notifyOthersOnDeactivation])
+      try AVAudioSession.sharedInstance().setActive(isActive, options: [.notifyOthersOnDeactivation])
       sessionIsActive = isActive
     } catch {
       throw AudioStateException(error.localizedDescription)
@@ -526,16 +524,16 @@ public class AudioModule: Module {
     self.allowsRecording = mode.allowsRecording
 
     #if os(iOS)
-      if !mode.allowsRecording {
-        registry.allRecorders.values.forEach { recorder in
-          if recorder.isRecording {
-            recorder.ref.stop()
-          }
-          recorder.allowsRecording = false
+    if !mode.allowsRecording {
+      registry.allRecorders.values.forEach { recorder in
+        if recorder.isRecording {
+          recorder.ref.stop()
         }
-      } else {
-        registry.allRecorders.values.forEach { recorder in
-          recorder.allowsRecording = true
+        recorder.allowsRecording = false
+      }
+    } else {
+      registry.allRecorders.values.forEach { recorder in
+        recorder.allowsRecording = true
         }
       }
     #endif
@@ -564,17 +562,17 @@ public class AudioModule: Module {
       case .mixWithOthers:
         categoryOptions.insert(.mixWithOthers)
       }
-    
-      #if !os(tvOS)
-        if category == .playAndRecord {
-          #if compiler(>=6.2)  // Xcode 26
-            categoryOptions.insert(.allowBluetoothHFP)
-          #else
-            categoryOptions.insert(.allowBluetooth)
-          #endif
-        }
-      #endif
-    
+ 
+#if !os(tvOS)
+      if category == .playAndRecord {
+#if compiler(>=6.2)  // Xcode 26
+        categoryOptions.insert(.allowBluetoothHFP)
+#else
+        categoryOptions.insert(.allowBluetooth)
+#endif
+      }
+#endif
+
       sessionOptions = categoryOptions
     }
     
@@ -625,21 +623,21 @@ public class AudioModule: Module {
 
   private func checkPermissions() throws {
     #if os(iOS)
-      if #available(iOS 17.0, *) {
-        switch AVAudioApplication.shared.recordPermission {
-        case .denied, .undetermined:
-          throw AudioPermissionsException()
-        default:
-          break
-        }
-      } else {
-        switch AVAudioSession.sharedInstance().recordPermission {
-        case .denied, .undetermined:
-          throw AudioPermissionsException()
-        default:
-          break
-        }
+    if #available(iOS 17.0, *) {
+      switch AVAudioApplication.shared.recordPermission {
+      case .denied, .undetermined:
+        throw AudioPermissionsException()
+      default:
+        break
       }
+    } else {
+      switch AVAudioSession.sharedInstance().recordPermission {
+      case .denied, .undetermined:
+        throw AudioPermissionsException()
+      default:
+        break
+      }
+    }
     #endif
   }
 }

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -333,8 +333,6 @@ public class AudioModule: Module {
     // Set audio session category once at initialization to avoid blocking delays later.
     // Using .playAndRecord with .mixWithOthers allows both playback and recording
     // without needing to change categories, which eliminates 3+ second blocking delays.
-    // See: https://github.com/expo/expo/issues/15873
-    // See: https://github.com/expo/expo/issues/40531
     let session = AVAudioSession.sharedInstance()
     do {
       var options: AVAudioSession.CategoryOptions = [.mixWithOthers]
@@ -515,8 +513,6 @@ public class AudioModule: Module {
     // Commenting out category changes to avoid 3+ second blocking delays.
     // The audio session category is set once at initialization and remains as .playAndRecord.
     // This allows both playback and recording without delays when switching between modes.
-    // See: https://github.com/expo/expo/issues/15873
-    // See: https://github.com/expo/expo/issues/40531
 
     self.shouldPlayInBackground = mode.shouldPlayInBackground
     self.interruptionMode = mode.interruptionMode

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -339,7 +339,7 @@ public class AudioModule: Module {
     do {
       var options: AVAudioSession.CategoryOptions = [.mixWithOthers]
       #if !os(tvOS)
-        #if compiler(>=6.2)  // Xcode 26
+        #if compiler(>=6.2) // Xcode 26
           options.insert(.allowBluetoothHFP)
         #else
           options.insert(.allowBluetooth)
@@ -533,8 +533,8 @@ public class AudioModule: Module {
     } else {
       registry.allRecorders.values.forEach { recorder in
         recorder.allowsRecording = true
-        }
       }
+    }
     #endif
 
     // Original category-changing code commented out to prevent blocking delays:
@@ -551,7 +551,7 @@ public class AudioModule: Module {
       sessionOptions = []
     } else {
       category = mode.allowsRecording ? .playAndRecord : .playback
-    
+ 
       var categoryOptions: AVAudioSession.CategoryOptions = []
       switch mode.interruptionMode {
       case .doNotMix:
@@ -574,7 +574,7 @@ public class AudioModule: Module {
 
       sessionOptions = categoryOptions
     }
-    
+
     if sessionOptions.isEmpty {
       try session.setCategory(category, mode: .default)
     } else {

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -551,7 +551,7 @@ public class AudioModule: Module {
       sessionOptions = []
     } else {
       category = mode.allowsRecording ? .playAndRecord : .playback
- 
+
       var categoryOptions: AVAudioSession.CategoryOptions = []
       switch mode.interruptionMode {
       case .doNotMix:
@@ -561,10 +561,10 @@ public class AudioModule: Module {
       case .mixWithOthers:
         categoryOptions.insert(.mixWithOthers)
       }
- 
+
 #if !os(tvOS)
       if category == .playAndRecord {
-#if compiler(>=6.2)  // Xcode 26
+#if compiler(>=6.2) // Xcode 26
         categoryOptions.insert(.allowBluetoothHFP)
 #else
         categoryOptions.insert(.allowBluetooth)
@@ -588,15 +588,11 @@ public class AudioModule: Module {
   }
 
   private func deactivateSession() {
-    // After ample discussion, testing and consideration, it makes no sense to constantly
-    // disable AVAudioSession as it is a synchronous and blocking process. This was causing
+    // Don't disable AVAudioSession as it is a synchronous and blocking process. This was causing
     // 3+ second delays when switching between playing and recording audio on iOS.
     // With this change, transitions between play/record modes are effectively instant
     // without frame drops. To avoid triggering unnecessary setActive(true) calls, we update
     // the internal sessionIsActive flag without actually disabling the session.
-    // This matches the approach used in expo-av that resolved a similar issue.
-    // See: https://github.com/expo/expo/issues/15873
-    // See: https://github.com/expo/expo/issues/40531
 
     // We need to give isPlaying time to update before running this
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -373,8 +373,7 @@ public class AudioModule: Module {
   @objc private func handleAudioSessionInterruption(_ notification: Notification) {
     guard let userInfo = notification.userInfo,
       let interruptionTypeRaw = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
-      let interruptionType = AVAudioSession.InterruptionType(rawValue: interruptionTypeRaw)
-    else {
+      let interruptionType = AVAudioSession.InterruptionType(rawValue: interruptionTypeRaw) else {
       return
     }
 
@@ -412,7 +411,7 @@ public class AudioModule: Module {
       }
     }
 
-  #if os(iOS)
+#if os(iOS)
     registry.allRecorders.values.forEach { recorder in
       if recorder.isRecording {
         recorder.pauseRecording()
@@ -461,13 +460,13 @@ public class AudioModule: Module {
       }
     }
 
-  #if os(iOS)
+#if os(iOS)
     registry.allRecorders.values.forEach { recorder in
       if recorder.allowsRecording && !recorder.isRecording {
         _ = try? recorder.startRecording()
       }
     }
-  #endif
+#endif
 
     interruptedPlayers.removeAll()
     playerVolumes.removeAll()

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -18,9 +18,9 @@ public class AudioModule: Module {
 
     OnCreate {
       #if os(iOS)
-        self.appContext?.permissions?.register([
-          AudioRecordingRequester()
-        ])
+      self.appContext?.permissions?.register([
+        AudioRecordingRequester()
+      ])
       #endif
 
       setupInterruptionHandling()
@@ -31,37 +31,31 @@ public class AudioModule: Module {
       try setAudioMode(mode: mode)
     }
 
-    AsyncFunction("setIsAudioActiveAsync") { (isActive: Bool) in
+    AsyncFunction("setIsAudioActiveAsync") { (isActive: Bool)  in
       try setIsAudioActive(isActive)
     }
 
     AsyncFunction("requestRecordingPermissionsAsync") { (promise: Promise) in
       #if os(iOS)
-        appContext?.permissions?.askForPermission(
-          usingRequesterClass: AudioRecordingRequester.self,
-          resolve: promise.resolver,
-          reject: promise.legacyRejecter
+      appContext?.permissions?.askForPermission(
+        usingRequesterClass: AudioRecordingRequester.self,
+        resolve: promise.resolver,
+        reject: promise.legacyRejecter
         )
       #else
-        promise.reject(
-          Exception.init(
-            name: "UnsupportedOperation",
-            description: "Audio recording is not supported on this platform."))
+        promise.reject(Exception.init(name: "UnsupportedOperation", description: "Audio recording is not supported on this platform."))
       #endif
     }
 
     AsyncFunction("getRecordingPermissionsAsync") { (promise: Promise) in
       #if os(iOS)
-        appContext?.permissions?.getPermissionUsingRequesterClass(
-          AudioRecordingRequester.self,
-          resolve: promise.resolver,
-          reject: promise.legacyRejecter
-        )
+      appContext?.permissions?.getPermissionUsingRequesterClass(
+        AudioRecordingRequester.self,
+        resolve: promise.resolver,
+        reject: promise.legacyRejecter
+      )
       #else
-        promise.reject(
-          Exception.init(
-            name: "UnsupportedOperation",
-            description: "Audio recording is not supported on this platform."))
+        promise.reject(Exception.init(name: "UnsupportedOperation", description: "Audio recording is not supported on this platform."))
       #endif
     }
 
@@ -84,9 +78,7 @@ public class AudioModule: Module {
 
     // swiftlint:disable:next closure_body_length
     Class(AudioPlayer.self) {
-      Constructor {
-        (source: AudioSource?, updateInterval: Double, keepAudioSessionActive: Bool) -> AudioPlayer
-        in
+      Constructor { (source: AudioSource?, updateInterval: Double, keepAudioSessionActive: Bool) -> AudioPlayer in
         let avPlayer = AudioUtils.createAVPlayer(from: source)
         let player = AudioPlayer(avPlayer, interval: updateInterval)
         player.owningRegistry = self.registry
@@ -174,8 +166,7 @@ public class AudioModule: Module {
         player.play(at: rate)
       }
 
-      Function("setPlaybackRate") {
-        (player, rate: Double, pitchCorrectionQuality: PitchCorrectionQuality?) in
+      Function("setPlaybackRate") { (player, rate: Double, pitchCorrectionQuality: PitchCorrectionQuality?) in
         let playerRate = rate < 0 ? 0.0 : Float(min(rate, 2.0))
         player.currentRate = playerRate
 
@@ -212,8 +203,7 @@ public class AudioModule: Module {
         }
       }
 
-      Function("setActiveForLockScreen") {
-        (player: AudioPlayer, active: Bool, metadata: Metadata?, options: LockScreenOptions?) in
+      Function("setActiveForLockScreen") { (player: AudioPlayer, active: Bool, metadata: Metadata?, options: LockScreenOptions?) in
         player.setActiveForLockScreen(active, metadata: metadata, options: options)
       }
 
@@ -232,11 +222,7 @@ public class AudioModule: Module {
         }
       }
 
-      AsyncFunction("seekTo") {
-        (
-          player: AudioPlayer, seconds: Double, toleranceMillisBefore: Double?,
-          toleranceMillisAfter: Double?
-        ) in
+      AsyncFunction("seekTo") { ( player: AudioPlayer, seconds: Double, toleranceMillisBefore: Double?, toleranceMillisAfter: Double?) in
         await player.seekTo(
           seconds: seconds,
           toleranceMillisBefore: toleranceMillisBefore,
@@ -246,38 +232,38 @@ public class AudioModule: Module {
     }
 
     #if os(iOS)
-      // swiftlint:disable:next closure_body_length
-      Class(AudioRecorder.self) {
-        Constructor { (options: RecordingOptions) -> AudioRecorder in
-          let recordingDir = try recordingDirectory()
-          let avRecorder = AudioUtils.createRecorder(directory: recordingDir, with: options)
-          let recorder = AudioRecorder(avRecorder)
-          recorder.owningRegistry = self.registry
-          recorder.allowsRecording = allowsRecording
-          self.registry.add(recorder)
+    // swiftlint:disable:next closure_body_length
+    Class(AudioRecorder.self) {
+      Constructor { (options: RecordingOptions) -> AudioRecorder in
+        let recordingDir = try recordingDirectory()
+        let avRecorder = AudioUtils.createRecorder(directory: recordingDir, with: options)
+        let recorder = AudioRecorder(avRecorder)
+        recorder.owningRegistry = self.registry
+        recorder.allowsRecording = allowsRecording
+        self.registry.add(recorder)
 
-          return recorder
-        }
+        return recorder
+      }
 
-        Property("id") { recorder in
-          recorder.id
-        }
+      Property("id") { recorder in
+        recorder.id
+      }
 
-        Property("isRecording") { recorder in
-          recorder.isRecording
-        }
+      Property("isRecording") { recorder in
+        recorder.isRecording
+      }
 
-        Property("currentTime") { recorder in
-          recorder.ref.currentTime
-        }
+      Property("currentTime") { recorder in
+        recorder.ref.currentTime
+      }
 
-        Property("uri") { recorder in
-          recorder.uri
-        }
+      Property("uri") { recorder in
+        recorder.uri
+      }
 
-        AsyncFunction("prepareToRecordAsync") { (recorder, options: RecordingOptions?) in
-          try recorder.prepare(options: options, sessionOptions: sessionOptions)
-        }
+      AsyncFunction("prepareToRecordAsync") { (recorder, options: RecordingOptions?) in
+        try recorder.prepare(options: options, sessionOptions: sessionOptions)
+      }
 
         Function("record") { (recorder: AudioRecorder, options: RecordOptions?) in
           try checkPermissions()

--- a/packages/expo-audio/ios/AudioRecorder.swift
+++ b/packages/expo-audio/ios/AudioRecorder.swift
@@ -65,7 +65,9 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
     }
   }
 
-  func prepare(options: RecordingOptions?, sessionOptions: AVAudioSession.CategoryOptions = []) throws {
+  func prepare(options: RecordingOptions?, sessionOptions: AVAudioSession.CategoryOptions = [])
+    throws
+  {
     if currentState == .recording {
       ref.stop()
     }
@@ -73,10 +75,15 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
     let session = AVAudioSession.sharedInstance()
     do {
       try session.setCategory(.playAndRecord, mode: .default, options: sessionOptions)
-      try session.setActive(true)
+      // Commenting out setActive(true) to avoid 3+ second blocking delay when switching modes.
+      // The audio session is managed by AudioModule and should remain active.
+      // See: https://github.com/expo/expo/issues/15873
+      // See: https://github.com/expo/expo/issues/40531
+      // try session.setActive(true)
     } catch {
       currentState = .error
-      throw AudioRecordingException("Failed to configure audio session: \(error.localizedDescription)")
+      throw AudioRecordingException(
+        "Failed to configure audio session: \(error.localizedDescription)")
     }
 
     if let options {
@@ -155,7 +162,7 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
       "isRecording": currentState == .recording,
       "durationMillis": totalDuration,
       "mediaServicesDidReset": false,
-      "url": ref.url.absoluteString
+      "url": ref.url.absoluteString,
     ]
 
     if ref.isMeteringEnabled {
@@ -171,13 +178,15 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
     currentState = .stopped
     resetDurationTracking()
 
-    emit(event: recordingStatus, arguments: [
-      "id": id,
-      "isFinished": true,
-      "hasError": false,
-      "error": nil,
-      "url": recorder.url.absoluteString
-    ])
+    emit(
+      event: recordingStatus,
+      arguments: [
+        "id": id,
+        "isFinished": true,
+        "hasError": false,
+        "error": nil,
+        "url": recorder.url.absoluteString,
+      ])
   }
 
   func encodeErrorDidOccur(_ recorder: AVAudioRecorder, error: Error?) {
@@ -185,13 +194,15 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
     currentState = .error
     resetDurationTracking()
 
-    emit(event: recordingStatus, arguments: [
-      "id": id,
-      "isFinished": true,
-      "hasError": true,
-      "error": error?.localizedDescription,
-      "url": nil
-    ])
+    emit(
+      event: recordingStatus,
+      arguments: [
+        "id": id,
+        "isFinished": true,
+        "hasError": true,
+        "error": error?.localizedDescription,
+        "url": nil,
+      ])
   }
 
   private var recordingDirectory: URL? {

--- a/packages/expo-audio/ios/AudioRecorder.swift
+++ b/packages/expo-audio/ios/AudioRecorder.swift
@@ -80,7 +80,7 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
       // try session.setActive(true)
     } catch {
       currentState = .error
-      throw AudioRecordingException( "Failed to configure audio session: \(error.localizedDescription)")
+      throw AudioRecordingException("Failed to configure audio session: \(error.localizedDescription)")
     }
 
     if let options {
@@ -180,7 +180,7 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
       "isFinished": true,
       "hasError": false,
       "error": nil,
-      "url": recorder.url.absoluteString,
+      "url": recorder.url.absoluteString
     ])
   }
 
@@ -194,7 +194,7 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
       "isFinished": true,
       "hasError": true,
       "error": error?.localizedDescription,
-      "url": nil,
+      "url": nil
     ])
   }
 

--- a/packages/expo-audio/ios/AudioRecorder.swift
+++ b/packages/expo-audio/ios/AudioRecorder.swift
@@ -75,8 +75,6 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
       try session.setCategory(.playAndRecord, mode: .default, options: sessionOptions)
       // Commenting out setActive(true) to avoid 3+ second blocking delay when switching modes.
       // The audio session is managed by AudioModule and should remain active.
-      // See: https://github.com/expo/expo/issues/15873
-      // See: https://github.com/expo/expo/issues/40531
       // try session.setActive(true)
     } catch {
       currentState = .error

--- a/packages/expo-audio/ios/AudioRecorder.swift
+++ b/packages/expo-audio/ios/AudioRecorder.swift
@@ -65,9 +65,7 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
     }
   }
 
-  func prepare(options: RecordingOptions?, sessionOptions: AVAudioSession.CategoryOptions = [])
-    throws
-  {
+  func prepare(options: RecordingOptions?, sessionOptions: AVAudioSession.CategoryOptions = []) throws {
     if currentState == .recording {
       ref.stop()
     }
@@ -82,8 +80,7 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
       // try session.setActive(true)
     } catch {
       currentState = .error
-      throw AudioRecordingException(
-        "Failed to configure audio session: \(error.localizedDescription)")
+      throw AudioRecordingException( "Failed to configure audio session: \(error.localizedDescription)")
     }
 
     if let options {
@@ -162,7 +159,7 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
       "isRecording": currentState == .recording,
       "durationMillis": totalDuration,
       "mediaServicesDidReset": false,
-      "url": ref.url.absoluteString,
+      "url": ref.url.absoluteString
     ]
 
     if ref.isMeteringEnabled {
@@ -178,15 +175,13 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
     currentState = .stopped
     resetDurationTracking()
 
-    emit(
-      event: recordingStatus,
-      arguments: [
-        "id": id,
-        "isFinished": true,
-        "hasError": false,
-        "error": nil,
-        "url": recorder.url.absoluteString,
-      ])
+    emit(event: recordingStatus, arguments: [
+      "id": id,
+      "isFinished": true,
+      "hasError": false,
+      "error": nil,
+      "url": recorder.url.absoluteString,
+    ])
   }
 
   func encodeErrorDidOccur(_ recorder: AVAudioRecorder, error: Error?) {
@@ -194,15 +189,13 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
     currentState = .error
     resetDurationTracking()
 
-    emit(
-      event: recordingStatus,
-      arguments: [
-        "id": id,
-        "isFinished": true,
-        "hasError": true,
-        "error": error?.localizedDescription,
-        "url": nil,
-      ])
+    emit(event: recordingStatus, arguments: [
+      "id": id,
+      "isFinished": true,
+      "hasError": true,
+      "error": error?.localizedDescription,
+      "url": nil,
+    ])
   }
 
   private var recordingDirectory: URL? {


### PR DESCRIPTION
# Why

Fixes bug: https://github.com/expo/expo/issues/40531

On iOS, when alternating between playing and recording audio, there is a 3+ second delay with expo-audio. Did not happen with expo-av.

# How

The bug report mentioned 3+ second delays. These were caused by these synchronous blocking iOS system calls: AVAudioSession.setActive(false), AVAudioSession.setActive(true), and AVAudioSession.setCategory(). The fix initializes the audio session once at app startup with .playAndRecord category and .mixWithOthers option. The audio session now remains permanently active in a mode that supports both playback and recording. No TypeScript or API changes required.

# Test Plan

I manually tested the minimal reproducible bug in the above bug report: https://github.com/expo/expo/issues/40531

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
