### PR TITLE
[core][iOS] Remove some runtime type checks for dynamic types

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -17,7 +17,7 @@
 - [iOS] Add `applicationDidReceiveMemoryWarning` subscribing to ExpoAppDelegateSubscriberManager ([#40504](https://github.com/expo/expo/pull/40504) by [@szydlovsky](https://github.com/szydlovsky))
 - [Android] Added `ReactActivityHandler.onDidCreateReactActivityDelegateNotification`. ([#40537](https://github.com/expo/expo/pull/40537) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Added `ReactNativeHostHandler.onDidCreateReactHost`. ([#40561](https://github.com/expo/expo/pull/40561) by [@lukmccall](https://github.com/lukmccall))
-- [iOS] Removed some runtime type checks for dynamic types.
+- [iOS] Removed some runtime type checks for dynamic types. ([#40611](https://github.com/expo/expo/pull/40611) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [iOS] Add `applicationDidReceiveMemoryWarning` subscribing to ExpoAppDelegateSubscriberManager ([#40504](https://github.com/expo/expo/pull/40504) by [@szydlovsky](https://github.com/szydlovsky))
 - [Android] Added `ReactActivityHandler.onDidCreateReactActivityDelegateNotification`. ([#40537](https://github.com/expo/expo/pull/40537) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Added `ReactNativeHostHandler.onDidCreateReactHost`. ([#40561](https://github.com/expo/expo/pull/40561) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Removed some runtime type checks for dynamic types.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicType.swift
@@ -7,54 +7,17 @@
 /**
  Factory creating an instance of the dynamic type wrapper conforming to `AnyDynamicType`.
  Depending on the given type, it may return one of `DynamicArrayType`, `DynamicOptionalType`, `DynamicConvertibleType`, etc.
- Note that this goes through many type checks, thus it might be a bit more expensive than using generic type constraints,
- see the `~` prefix operator below that handles types conforming to `AnyArgument` in a faster way.
+ It does some type checks in runtime when the type's conformance/inheritance is unknown for the compiler.
+ See the `~` prefix operator overloads that are used for types known for the compiler.
+ You can add more type checks for types that don't conform to `AnyArgument`, but are allowed to be used as return types.
+ `Void` is a good example as it cannot conform to anything or language protocols that cannot be extended to implement `AnyArgument`.
  */
 private func DynamicType<T>(_ type: T.Type) -> AnyDynamicType {
-  if type is any Numeric.Type {
-    return DynamicNumberType(numberType: T.self)
-  }
-  if type is String.Type {
-    return DynamicStringType.shared
-  }
-  if let ArrayType = T.self as? AnyArray.Type {
-    return DynamicArrayType(elementType: ArrayType.getElementDynamicType())
-  }
-  if let DictionaryType = T.self as? AnyDictionary.Type {
-    return DynamicDictionaryType(valueType: DictionaryType.getValueDynamicType())
-  }
-  if let OptionalType = T.self as? any AnyOptional.Type {
-    return DynamicOptionalType(wrappedType: OptionalType.getWrappedDynamicType())
-  }
-  if let ConvertibleType = T.self as? Convertible.Type {
-    return DynamicConvertibleType(innerType: ConvertibleType)
-  }
-  if let EnumType = T.self as? any Enumerable.Type {
-    return DynamicEnumType(innerType: EnumType)
-  }
-  if let ViewType = T.self as? UIView.Type {
-    return DynamicViewType(innerType: ViewType)
-  }
-  if let SharedObjectType = T.self as? SharedObject.Type {
-    return DynamicSharedObjectType(innerType: SharedObjectType)
-  }
-  if let TypedArrayType = T.self as? AnyTypedArray.Type {
-    return DynamicTypedArrayType(innerType: TypedArrayType)
-  }
-  if T.self is Data.Type {
-    return DynamicDataType.shared
-  }
-  if let JavaScriptValueType = T.self as? any AnyJavaScriptValue.Type {
-    return DynamicJavaScriptType(innerType: JavaScriptValueType)
+  if let AnyArgumentType = T.self as? AnyArgument.Type {
+    return AnyArgumentType.getDynamicType()
   }
   if T.self == Void.self {
     return DynamicVoidType.shared
-  }
-  if let AnyEitherType = T.self as? AnyEither.Type {
-    return AnyEitherType.getDynamicType()
-  }
-  if let AnyValueOrUndefinedType = T.self as? AnyValueOrUndefined.Type {
-    return AnyValueOrUndefinedType.getDynamicType()
   }
   return DynamicRawType(innerType: T.self)
 }


### PR DESCRIPTION
# Why

I was going to add another dynamic type for types conforming to `Encodable` and noticed that we don't really need to do so many runtime type checks in `DynamicType` function. Types that already conform to `AnyArgument` can just return the result of `.getDynamicType()` which should be slightly faster, easier to maintain and add new supported types.

# Test Plan

Checked many test-suite tests, on modules with different kind of types. Native iOS tests are also passing.
I also measured time difference – it's only up to 10ms faster in bare-expo, but it seems worth it as it runs on the main thread on app startup.