### PR TITLE
[docs] Use `DiffBlock` component in CNG guide

### DIFF
--- a/docs/pages/workflow/continuous-native-generation.mdx
+++ b/docs/pages/workflow/continuous-native-generation.mdx
@@ -5,7 +5,7 @@ sidebar_title: Continuous Native Generation
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
-import { Terminal } from '~/ui/components/Snippet';
+import { Terminal, DiffBlock } from '~/ui/components/Snippet';
 
 A single native project on its own is complicated to maintain, scale, and update. In a cross-platform app, you have multiple native projects that you must maintain and keep up to date with the latest operating system releases to avoid falling too far behind in any third-party dependencies.
 
@@ -46,10 +46,15 @@ For a project that has **android** and **ios** directories, EAS Build will not r
 
 If you troubleshoot your app by [compiling it locally](/guides/local-app-development/#local-app-compilation) (running `npx expo prebuild`, or `npx expo run:android` or `npx expo run:ios`), you can still use Prebuild with EAS Build to generate fresh native directories during the build process. The **android** and **ios** directories are automatically added to **.gitignore** when you create a new project, but if you need to add them manually, you can add them to **.gitignore** or [**.easignore**](/build-reference/easignore/) files:
 
-```diff .gitignore
-+ /android
-+ /ios
-```
+<DiffBlock
+  raw={`diff --git a/.gitignore b/.gitignore
+--- a/.gitignore
++++ b/.gitignore
+@@ -0,0 +1,2 @@
++/android
++/ios
+`}
+/>
 
 ### Usage with Expo CLI run commands
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-17907

# How

<!--
How did you build this feature or fix this bug and why?
-->

Use `DiffBlock` component for the code block.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

<img width="1790" height="660" alt="CleanShot 2025-10-25 at 22 21 58@2x" src="https://github.com/user-attachments/assets/6df82299-b770-48e9-a1fb-2623204704e6" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
