### PR TITLE
[docs] Fix typo of import statement tip in documentation

### DIFF
--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -461,7 +461,7 @@ const styles = StyleSheet.create({
 });
 ```
 
-> **info** **Tip**: If you created a new module, make sure to update the import statement to: `import { ExpoRadialChartView } from expo-radial-chart';`
+> **info** **Tip**: If you created a new module, make sure to update the import statement to: `import { ExpoRadialChartView } from 'expo-radial-chart';`
 
 </Step>
 


### PR DESCRIPTION
# Why

Fix typo of import statement tip in documentation.
Lack of single quote (`'`).

# How

<img width="666" height="90" alt="image" src="https://github.com/user-attachments/assets/3894a28b-acdf-43ba-aef2-1f7210ff8979" />

Just add the missing single quote (`'`).

# Test Plan

N/A.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
