### PR TITLE
[core][iOS] Support for converting `Encodable` types to JS values

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -17,7 +17,7 @@
 - [iOS] Add `applicationDidReceiveMemoryWarning` subscribing to ExpoAppDelegateSubscriberManager ([#40504](https://github.com/expo/expo/pull/40504) by [@szydlovsky](https://github.com/szydlovsky))
 - [Android] Added `ReactActivityHandler.onDidCreateReactActivityDelegateNotification`. ([#40537](https://github.com/expo/expo/pull/40537) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Added `ReactNativeHostHandler.onDidCreateReactHost`. ([#40561](https://github.com/expo/expo/pull/40561) by [@lukmccall](https://github.com/lukmccall))
-- [iOS] Removed some runtime type checks for dynamic types. ([#40611](https://github.com/expo/expo/pull/40611) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Swift's `Encodable` types can now be converted to JavaScript values.
 
 ### 🐛 Bug fixes
 
@@ -35,6 +35,7 @@
 - [Android] Use module name from `expo-module.config.json`. ([#39985](https://github.com/expo/expo/pull/39985), [#40241](https://github.com/expo/expo/pull/40241) by [@jakex7](https://github.com/jakex7))
 - [iOS] Use the `RuntimeScheduler` to schedule tasks on the JS thread. ([#40473](https://github.com/expo/expo/pull/40473) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Added base props support for SwiftUI integration. ([#40492](https://github.com/expo/expo/pull/40492) by [@kudo](https://github.com/kudo))
+- [iOS] Removed some runtime type checks for dynamic types. ([#40611](https://github.com/expo/expo/pull/40611) by [@tsapeta](https://github.com/tsapeta))
 
 ## 3.0.22 - 2025-10-20
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -17,7 +17,7 @@
 - [iOS] Add `applicationDidReceiveMemoryWarning` subscribing to ExpoAppDelegateSubscriberManager ([#40504](https://github.com/expo/expo/pull/40504) by [@szydlovsky](https://github.com/szydlovsky))
 - [Android] Added `ReactActivityHandler.onDidCreateReactActivityDelegateNotification`. ([#40537](https://github.com/expo/expo/pull/40537) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Added `ReactNativeHostHandler.onDidCreateReactHost`. ([#40561](https://github.com/expo/expo/pull/40561) by [@lukmccall](https://github.com/lukmccall))
-- [iOS] Swift's `Encodable` types can now be converted to JavaScript values.
+- [iOS] Swift's `Encodable` types can now be converted to JavaScript values. ([#40621](https://github.com/expo/expo/pull/40621) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEncodableType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEncodableType.swift
@@ -22,6 +22,9 @@ internal struct DynamicEncodableType: AnyDynamicType {
   }
 
   func castToJS<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue {
+    if let value = value as? JavaScriptValue {
+      return value
+    }
     if let value = value as? Encodable {
       let runtime = try appContext.runtime
       let encoder = JSValueEncoder(runtime: runtime)

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEncodableType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEncodableType.swift
@@ -1,0 +1,44 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+/**
+ Dynamic type for values conforming to `Encodable` protocol.
+ Note that currently it can only encode from native to JavaScript values, thus cannot be used for arguments.
+ */
+internal struct DynamicEncodableType: AnyDynamicType {
+  static let shared = DynamicEncodableType()
+
+  func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
+    return type is Encodable
+  }
+
+  func equals(_ type: any AnyDynamicType) -> Bool {
+    // Just mocking it here as we don't really need this function and we rather want to keep it a singleton
+    return false
+  }
+
+  func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
+    // TODO: Create DynamicDecodableType and reuse it here – that would work perfectly with Codable types
+    fatalError("DynamicEncodableType can only cast to JavaScript, not from")
+  }
+
+  func castToJS<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue {
+    if let value = value as? Encodable {
+      let runtime = try appContext.runtime
+      let encoder = JSValueEncoder(runtime: runtime)
+
+      try value.encode(to: encoder)
+
+      return encoder.value
+    }
+    throw Conversions.ConversionToJSFailedException((kind: .object, nativeType: ValueType.self))
+  }
+
+  func convertResult<ResultType>(_ result: ResultType, appContext: AppContext) throws -> Any {
+    // TODO: We should get rid of this function, but it seems it's still used in some places
+    return try castToJS(result, appContext: appContext)
+  }
+
+  var description: String {
+    "Encodable"
+  }
+}

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicType.swift
@@ -19,6 +19,11 @@ private func DynamicType<T>(_ type: T.Type) -> AnyDynamicType {
   if T.self == Void.self {
     return DynamicVoidType.shared
   }
+  if T.self is Encodable.Type {
+    // There is no dedicated `~` operator overload for encodables to avoid ambiguity
+    // when the type is both `AnyArgument` and `Encodable` (e.g. strings, numeric types).
+    return DynamicEncodableType.shared
+  }
   return DynamicRawType(innerType: T.self)
 }
 

--- a/packages/expo-modules-core/ios/Core/JSValueEncoder.swift
+++ b/packages/expo-modules-core/ios/Core/JSValueEncoder.swift
@@ -1,0 +1,185 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+/**
+ Encodes `Encodable` objects or values to `JavaScriptValue`. This implementation is incomplete,
+ but it supports basic use cases with structs defined by the user and when the default `Encodable` implementation is used.
+ */
+internal final class JSValueEncoder: Encoder {
+  private let runtime: JavaScriptRuntime
+  private let valueHolder = JSValueHolder()
+
+  /**
+   The result of encoding to `JavaScriptValue`. Use this property after running `encode(to:)` on the encodable.
+   */
+  var value: JavaScriptValue {
+    return valueHolder.value
+  }
+
+  /**
+   Initializes the encoder with the given runtime in which the value will be created.
+   */
+  init(runtime: JavaScriptRuntime) {
+    self.runtime = runtime
+  }
+
+  // MARK: - Encoder
+
+  // We don't use `codingPath` and `userInfo`, but they are required by the protocol.
+  let codingPath: [any CodingKey] = []
+  let userInfo: [CodingUserInfoKey: Any] = [:]
+
+  func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key: CodingKey {
+    let container = JSObjectEncodingContainer<Key>(to: valueHolder, runtime: runtime)
+    return KeyedEncodingContainer(container)
+  }
+
+  func unkeyedContainer() -> any UnkeyedEncodingContainer {
+    return JSArrayEncodingContainer(to: valueHolder, runtime: runtime)
+  }
+
+  func singleValueContainer() -> any SingleValueEncodingContainer {
+    return JSValueEncodingContainer(to: valueHolder, runtime: runtime)
+  }
+}
+
+/**
+ An object that holds a JS value that could be overriden by the encoding container.
+ */
+private final class JSValueHolder {
+  var value: JavaScriptValue = .undefined
+}
+
+/**
+ Single value container used to encode to primitive JS values.
+ */
+private struct JSValueEncodingContainer: SingleValueEncodingContainer {
+  private weak var runtime: JavaScriptRuntime?
+  private let valueHolder: JSValueHolder
+
+  init(to valueHolder: JSValueHolder, runtime: JavaScriptRuntime?) {
+    self.runtime = runtime
+    self.valueHolder = valueHolder
+  }
+
+  // MARK: - SingleValueEncodingContainer
+
+  // Unused, but required by the protocol.
+  let codingPath: [any CodingKey] = []
+
+  mutating func encodeNil() throws {
+    self.valueHolder.value = .null
+  }
+
+  mutating func encode<ValueType>(_ value: ValueType) throws {
+    guard let runtime else {
+      // Do nothing when the runtime is already deallocated
+      return
+    }
+    self.valueHolder.value = JavaScriptValue.from(value, runtime: runtime)
+  }
+}
+
+/**
+ Keyed container that encodes to a JavaScript object.
+ */
+private struct JSObjectEncodingContainer<Key: CodingKey>: KeyedEncodingContainerProtocol {
+  private weak var runtime: JavaScriptRuntime?
+  private let valueHolder: JSValueHolder
+  private var object: JavaScriptObject
+
+  init(to valueHolder: JSValueHolder, runtime: JavaScriptRuntime) {
+    let object = runtime.createObject()
+    valueHolder.value = JavaScriptValue.from(object, runtime: runtime)
+
+    self.runtime = runtime
+    self.object = object
+    self.valueHolder = valueHolder
+  }
+
+  // MARK: - KeyedEncodingContainerProtocol
+
+  // Unused, but required by the protocol.
+  var codingPath: [any CodingKey] = []
+
+  mutating func encodeNil(forKey key: Key) throws {
+    object.setProperty(key.stringValue, value: JavaScriptValue.null)
+  }
+
+  mutating func encode<ValueType>(_ value: ValueType, forKey key: Key) throws {
+    object.setProperty(key.stringValue, value: value)
+  }
+
+  mutating func encode<T: Encodable>(_ value: T, forKey key: Key) throws {
+    guard let runtime else {
+      // Do nothing when the runtime is already deallocated
+      return
+    }
+    let encoder = JSValueEncoder(runtime: runtime)
+    try value.encode(to: encoder)
+    object.setProperty(key.stringValue, value: encoder.value)
+  }
+
+  mutating func nestedContainer<NestedKey: CodingKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
+    fatalError("JSValueEncoder does not support nested containers")
+  }
+
+  mutating func nestedUnkeyedContainer(forKey key: Key) -> any UnkeyedEncodingContainer {
+    fatalError("JSValueEncoder does not support nested containers")
+  }
+
+  mutating func superEncoder() -> any Encoder {
+    fatalError("superEncoder() is not implemented in JSValueEncoder")
+  }
+
+  mutating func superEncoder(forKey key: Key) -> any Encoder {
+    return self.superEncoder()
+  }
+}
+
+/**
+ Unkeyed container that encodes values to a JavaScript array.
+ */
+private struct JSArrayEncodingContainer: UnkeyedEncodingContainer {
+  private weak var runtime: JavaScriptRuntime?
+  private let valueHolder: JSValueHolder
+  private var items: [JavaScriptValue] = []
+
+  init(to valueHolder: JSValueHolder, runtime: JavaScriptRuntime) {
+    self.runtime = runtime
+    self.valueHolder = valueHolder
+  }
+
+  // MARK: - UnkeyedEncodingContainer
+
+  // Unused, but required by the protocol.
+  var codingPath: [any CodingKey] = []
+  var count: Int = 0
+
+  mutating func encodeNil() throws {
+    items.append(.null)
+  }
+
+  mutating func encode<T: Encodable>(_ value: T) throws {
+    guard let runtime else {
+      // Do nothing when the runtime is already deallocated
+      return
+    }
+    let encoder = JSValueEncoder(runtime: runtime)
+    try value.encode(to: encoder)
+
+    items.append(encoder.value)
+    valueHolder.value = .from(items, runtime: runtime)
+  }
+
+  mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+    fatalError("JSValueEncoder does not support nested containers")
+  }
+
+  mutating func nestedUnkeyedContainer() -> any UnkeyedEncodingContainer {
+    fatalError("JSValueEncoder does not support nested containers")
+  }
+
+  mutating func superEncoder() -> any Encoder {
+    fatalError("superEncoder() is not implemented in JSValueEncoder")
+  }
+}

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.h
@@ -60,6 +60,7 @@ NS_SWIFT_NAME(JavaScriptValue)
 #pragma mark - Statics
 
 @property (class, nonatomic, assign, readonly, nonnull) EXJavaScriptValue *undefined;
+@property (class, nonatomic, assign, readonly, nonnull) EXJavaScriptValue *null;
 
 + (nonnull EXJavaScriptValue *)number:(double)value;
 

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
@@ -170,8 +170,12 @@
 
 + (nonnull EXJavaScriptValue *)undefined
 {
-  auto undefined = std::make_shared<jsi::Value>();
   return [[EXJavaScriptValue alloc] initWithRuntime:nil value:jsi::Value::undefined()];
+}
+
++ (nonnull EXJavaScriptValue *)null
+{
+  return [[EXJavaScriptValue alloc] initWithRuntime:nil value:jsi::Value::null()];
 }
 
 + (nonnull EXJavaScriptValue *)number:(double)value

--- a/packages/expo-modules-core/ios/Tests/DynamicTypeSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/DynamicTypeSpec.swift
@@ -408,7 +408,7 @@ final class DynamicTypeSpec: ExpoSpec {
 
     // MARK: - DynamicEncodableType
 
-    fdescribe("DynamicEncodableType") {
+    describe("DynamicEncodableType") {
       struct TestEncodable: Encodable {
         let string: String
         let number: Int

--- a/packages/expo-modules-core/ios/Tests/DynamicTypeSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/DynamicTypeSpec.swift
@@ -405,5 +405,75 @@ final class DynamicTypeSpec: ExpoSpec {
         }
       }
     }
+
+    // MARK: - DynamicEncodableType
+
+    fdescribe("DynamicEncodableType") {
+      struct TestEncodable: Encodable {
+        let string: String
+        let number: Int
+        let bool: Bool
+        var object: TestEncodableChild? = nil
+        var array: [Int]? = nil
+      }
+      struct TestEncodableChild: Encodable {
+        let name: String
+      }
+
+      it("is created") {
+        expect(~TestEncodable.self).to(beAKindOf(DynamicEncodableType.self))
+      }
+      it("casts to JS object") {
+        let encodable = TestEncodable(string: "test", number: -5, bool: true)
+        let result = try (~TestEncodable.self).castToJS(encodable, appContext: appContext)
+
+        expect(result.kind) == .object
+      }
+      it("has proper property names") {
+        let encodable = TestEncodable(string: "test", number: -5, bool: true)
+        let result = try (~TestEncodable.self).castToJS(encodable, appContext: appContext)
+        let propertyNames = result.getObject().getPropertyNames()
+
+        expect(propertyNames.count) == 3
+        expect(propertyNames).to(contain(["string", "number", "bool"]))
+      }
+      it("has correct values") {
+        let encodable = TestEncodable(string: "test", number: -5, bool: true)
+        let result = try (~TestEncodable.self).castToJS(encodable, appContext: appContext)
+        let object = result.getObject()
+
+        expect(try object.getProperty("string").asString()) == encodable.string
+        expect(try object.getProperty("number").asInt()) == encodable.number
+        expect(try object.getProperty("bool").asBool()) == encodable.bool
+        expect(object.getProperty("object").isUndefined()) == true
+        expect(object.getProperty("array").isUndefined()) == true
+      }
+      it("casts nested objects") {
+        let encodable = TestEncodable(
+          string: "test",
+          number: -5,
+          bool: true,
+          object: TestEncodableChild(name: "expo")
+        )
+        let result = try (~TestEncodable.self).castToJS(encodable, appContext: appContext)
+        let nestedValue = result.getObject().getProperty("object")
+
+        expect(nestedValue.kind) == .object
+        expect(try nestedValue.getObject().getProperty("name").asString()) == encodable.object?.name
+      }
+      it("casts arrays") {
+        let encodable = TestEncodable(
+          string: "test",
+          number: -5,
+          bool: true,
+          array: [1, 2, 3]
+        )
+        let result = try (~TestEncodable.self).castToJS(encodable, appContext: appContext)
+        let array = result.getObject().getProperty("array").getArray()
+
+        expect(array.count) == encodable.array?.count
+        expect(array.map({ $0.getInt() })) == encodable.array
+      }
+    }
   }
 }

--- a/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
@@ -257,6 +257,11 @@ class FunctionSpec: ExpoSpec {
         @Field var b: ValueOrUndefined<Double> = .undefined
       }
 
+      struct TestEncodable: Encodable {
+        let name: String
+        let version: Int
+      }
+
       afterEach {
         try runtime.eval("globalThis.result = undefined")
       }
@@ -316,6 +321,10 @@ class FunctionSpec: ExpoSpec {
 
           Function("withOptionalRecord") { (f: TestRecord?) in
             return "\(f?.property ?? "no value")"
+          }
+
+          Function("returnEncodable") {
+            return TestEncodable(name: "Expo SDK", version: 55)
           }
 
           Function("withSharedObject") {
@@ -399,6 +408,14 @@ class FunctionSpec: ExpoSpec {
 
       it("accepts optional record") {
         expect(try runtime.eval("expo.modules.TestModule.withOptionalRecord({property: \"123\"})").asString()) == "123"
+      }
+
+      it("returns encodable struct") {
+        let result = try runtime.eval("expo.modules.TestModule.returnEncodable()")
+        expect(result.kind) == .object
+        expect(result.getObject().getPropertyNames()).to(contain(["name", "version"]))
+        expect(try result.getObject().getProperty("name").asString()) == "Expo SDK"
+        expect(try result.getObject().getProperty("version").asInt()) == 55
       }
 
       it("returns URL (sync)") {


### PR DESCRIPTION
# Why

Currently when we want to return an object from a function or property, we can do it in three ways, depending on the needs: shared object, record or dictionary.
If we use dictionaries, it's often just a mapping from native structures which sometimes results in unnecessary and typo-prone boilerplate code, especially when we map properties one-to-one from a struct. We can use records instead, but it's just another but clearer way to do the same thing.

I'm proposing something even simpler. Imagine that we have some struct, it could be from our module's code or 3rd-party lib and we want to return all of its non-private properties.

```swift
struct SomeStruct {
  let id: Int
  let name: String
}

Function("someFunction") {
  let someStruct: SomeStruct = createMyStruct()
  return [
    "id": someStruct.id,
    "name": someStruct.name
  ]
}
```

What if we make it as simple as this 👇? Notice how `SomeStruct` became an [`Encodable`](https://developer.apple.com/documentation/Swift/Encodable).

```swift
struct SomeStruct: Encodable {
  let id: Int
  let name: String
}

Function("someFunction") {
  return createMyStruct()
}
```

If it turns out working well, I would go even further and do the same for `Decodable` types to let us use it for arguments as well. Can we then deprecate records? 🤔 

# How

Introduced a new dynamic type for types conforming to `Encodable` and the `JSValueEncoder` whose role is to encode a value into `JavaScriptValue`. This encoder works pretty well for simple structures and the default implementation of `Encodable`, however it's incomplete and may crash in some scenarios that I'm not aware of 😅 

# Test Plan

Added new native unit tests that covers implemented functionality. I'm also using this in a new module that I'm working on.