### PR TITLE
[docs] Add missing subscription cleanup call in Keyboard guide

### DIFF
--- a/docs/pages/guides/keyboard-handling.mdx
+++ b/docs/pages/guides/keyboard-handling.mdx
@@ -96,6 +96,7 @@ export default function HomeScreen() {
 
     return () => {
       showSubscription.remove();
+      hideSubscription.remove();
     };
   }, []);
 


### PR DESCRIPTION
# Why

This pull request makes a small improvement to the keyboard event cleanup logic in the Keyboard Handling guide docs. Only the show keyboard subscription was getting cleaned up in the `useEffect`.

# How

Add additional line cleaning up the hide keyboard subscription in the example.  


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
