### PR TITLE
fix test-suite package import error in NCL

### DIFF
--- a/apps/native-component-list/metro.config.js
+++ b/apps/native-component-list/metro.config.js
@@ -16,6 +16,7 @@ config.watchFolders = [
   path.join(monorepoRoot, 'node_modules'), // Allow Metro to resolve "shared" `node_modules` of the monorepo
   path.join(monorepoRoot, 'apps/common'), // Allow Metro to resolve common ThemeProvider
   path.join(monorepoRoot, 'apps/bare-expo/modules/benchmarking'), // Allow Metro to resolve benchmarking folder
+  path.join(monorepoRoot, 'apps/test-suite'), // Allow Metro to resolve test-suite app
 ];
 
 config.resolver.assetExts.push(


### PR DESCRIPTION
# Why

We get bundler error on running NCL app. It was missing metro watch folder config. 
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
