### PR TITLE
Addresses a potential crash where `[NSString UTF8String]` could return `nil` for certain string inputs (non-english).

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### 🐛 Bug fixes
 
+- [core] [iOS] Addresses a potential crash where `[NSString UTF8String]` could return `nil` for certain string inputs (non-English), leading to an attempt to dereference a null pointer during `jsi::String` creation. ([#40639](https://github.com/expo/expo/pull/40639) by [@mohammadamin16](https://github.com/mohammadamin16))
 - [RSC] Fix server components asserting from missing native modules. ([#40388](https://github.com/expo/expo/pull/40388) by [@EvanBacon](https://github.com/EvanBacon))
 - [Android] Restore `register` overload in `ModuleRegistry`. ([#40149](https://github.com/expo/expo/pull/40149) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Add `invalidate` callback to SwiftUIVirtualView. ([#40237](https://github.com/expo/expo/pull/40237) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))

--- a/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
@@ -31,7 +31,8 @@ jsi::String convertNSStringToJSIString(jsi::Runtime &runtime, NSString *value)
 #if !TARGET_OS_OSX
   const uint8_t *utf8 = (const uint8_t *)[value UTF8String];
   const size_t length = [value length];
-  if (expo::isAllASCIIAndNotNull(utf8, utf8 + length)) {
+
+  if (utf8 != nullptr && expo::isAllASCIIAndNotNull(utf8, utf8 + length)) {
     return jsi::String::createFromAscii(runtime, (const char *)utf8, length);
   }
   // Using cStringUsingEncoding should be fine as long as we provide the length.


### PR DESCRIPTION
 Addresses a potential crash where `[NSString UTF8String]` could return `nil` for certain string inputs (non-english), leading to an attempt to dereference a null pointer during `jsi::String` creation.

This change introduces a `nullptr` check for the `utf8` pointer obtained from `[value UTF8String]`. If `nil`, a warning is logged, and the conversion gracefully falls back to using `jsi::String::createFromUtf16` with `NSUTF16StringEncoding`.
This change introduces a `nullptr` check for the `utf8` pointer obtained from `[value UTF8String]`. If `nil`, a warning is logged, and the conversion gracefully falls back to using `jsi::String::createFromUtf16` with `NSUTF16StringEncoding`.

# Why
We encountered a bug in our iOS app where certain very large strings (around 40,000 characters) containing many non-ASCII characters would cause a crash within the isAllASCIIAndNotNull function. After a ton of debugging, We discovered that the begin parameter, the first argument passed to that function, was NULL, leading to the crash.

To prevent this, I've added an if statement. If the initial conversion using UTF8String returns NULL, the code now gracefully falls back to using createFromUtf16. While this UTF-16 conversion might be less performant in some cases, it successfully prevents the application from crashing.
I didn't put a lot of time exploring and testing it, but it worked on my app and fixed the crash, so I'm putting it here in case anyone else had the same problem
# How
