### PR TITLE
[docs] Fix typo in SwiftUI reference

### DIFF
--- a/docs/pages/versions/v54.0.0/sdk/ui/swift-ui.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/ui/swift-ui.mdx
@@ -28,7 +28,7 @@ The SwiftUI components in `@expo/ui/swift-ui` allow you to build fully native iO
 
 ## Usage
 
-Using a component from `@expo/ui/swift-ui` requires wrapping it in a [`Host>`](#host) component. The `Host` is a container for SwiftUI views.
+Using a component from `@expo/ui/swift-ui` requires wrapping it in a [`Host`](#host) component. The `Host` is a container for SwiftUI views.
 
 ```tsx
 import { Host, Button } from '@expo/ui/swift-ui';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix typo in SwiftUI reference page under Expo UI in SDK 54.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
