### PR TITLE
[expo-image][iOS] Fix disk cache not working when `uri` is empty

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix disk cache not working when `uri` is empty ([#40644](https://github.com/expo/expo/pull/40644) by [@kosmydel](https://github.com/kosmydel))
+
 ### 💡 Others
 
 ## 3.0.10 - 2025-10-20

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -179,8 +179,15 @@ public final class ImageView: ExpoView {
 
     onLoadStart([:])
 
+    var uri = source.uri
+    // If there is a valid cacheKey but no URI, provide a dummy URL
+    // so the image loader attempts to resolve the image from cache using the cacheKey.
+    if uri == nil, let cacheKey = source.cacheKey, !cacheKey.isEmpty {
+      uri = URL("")
+    }
+
     pendingOperation = imageManager.loadImage(
-      with: source.uri,
+      with: uri,
       options: loadingOptions,
       context: context,
       progress: imageLoadProgress(_:_:_:),


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR addresses https://github.com/expo/expo/issues/40442 issue.

# How

<!--
How did you build this feature or fix this bug and why?
-->

If the provided `uri` is empty, the `SDWebImageManager` won’t attempt to access the cache. However, if a cache key is available, we can force it to load from the cache by supplying a dummy uri.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

**Described Repro**
1. Use a `Image` with a custom cache key:
```typescript
      <Image
        style={{ width: 300, height: 300 }}
        cachePolicy="disk"
        source={{
          uri: 'https://images.unsplash.com/photo-1759399703184-11a722ec0706?ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&q=80&w=1364',
          cacheKey: 'my-image-key',
        }}
      />
```
2. Run the app.
3. Turn off the internet connection and remove the `uri` from the `source` prop.
4. Restart the app.
5. Verify that the image is still displayed (even when `uri` is undefined and there is no internet connection).

**Verify Old Behavior**
1. Change the `cacheKey` to one that doesn’t exist.
2. Remove the `uri`.
3. Run the app both online and offline, and verify that the image does not load.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
