### PR TITLE
docs: replace deprecated listeners methods

### DIFF
--- a/docs/pages/push-notifications/receiving-notifications.mdx
+++ b/docs/pages/push-notifications/receiving-notifications.mdx
@@ -19,20 +19,20 @@ useEffect(() => {
   registerForPushNotificationsAsync().then(token => setExpoPushToken(token));
 
   /* @info This listener is fired whenever a notification is received while the app is foregrounded. */
-  notificationListener.current = Notifications.addNotificationReceivedListener(notification => {
-    setNotification(notification);
+  const notificationListener = Notifications.addNotificationReceivedListener(notification => {
+    console.log(notification);
   });
   /* @end */
 
   /* @info This listener is fired whenever a user taps on or interacts with a notification (works when an app is foregrounded, backgrounded, or killed). */
-  responseListener.current = Notifications.addNotificationResponseReceivedListener(response => {
+  const responseListener = Notifications.addNotificationResponseReceivedListener(response => {
     console.log(response);
   });
   /* @end */
 
   return () => {
-    Notifications.removeNotificationSubscription(notificationListener.current);
-    Notifications.removeNotificationSubscription(responseListener.current);
+    notificationListener.remove();
+    responseListener.remove();
   };
 }, []);
 ```


### PR DESCRIPTION
# Why

This page description doesn't match latest changes of removed deprecated listeners methods (`removeNotificationSubscription`). It should use same code as on https://docs.expo.dev/versions/latest/sdk/notifications/ usage example
Current https://docs.expo.dev/push-notifications/receiving-notifications/#notification-event-listeners code example is misleading as it uses removed deprecated methods

# How

Updated docs

# Test Plan

No test plan as it is just documentation update

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
