### PR TITLE
[core][Android] Remove `pragma once` in `WorkletJSCallInvoker.cpp`

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/worklets/WorkletJSCallInvoker.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/worklets/WorkletJSCallInvoker.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #if WORKLETS_ENABLED
 
 #include "WorkletJSCallInvoker.h"


### PR DESCRIPTION
# Why

Fixes: 
```
C/C++: ninja: Entering directory `/Users/lukasz/work/expo/packages/expo-modules-core/android/.cxx/Debug/681p253q/arm64-v8a'
C/C++: /Users/lukasz/work/expo/packages/expo-modules-core/android/src/main/cpp/worklets/WorkletJSCallInvoker.cpp:1:9: warning: #pragma once in main file [-Wpragma-once-outside-header]
C/C++:     1 | #pragma once
C/C++:       |         ^
C/C++: 1 warning generated.
```

# Test Plan

- bare-expo ✅ 