### PR TITLE
[expo-modules-core] Rework compose integration.

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -179,6 +179,7 @@ _This version does not introduce any user-facing changes._
 
 ### 🎉 New features
 
+- [Android] Rework compose integration. ([#40653](https://github.com/expo/expo/pull/40653) by [@aleqsio](https://github.com/aleqsio))
 - Added support for expo modules written using TurboModules ([#36996](https://github.com/expo/expo/pull/36996) by [@acoates-ms](https://github.com/acoates-ms))
 - [Android] Add Array converter and handle nullable values. ([#37220](https://github.com/expo/expo/pull/37220) by [@jakex7](https://github.com/jakex7))
 - [Android] Support object arrays in type converters. ([#37276](https://github.com/expo/expo/pull/37276) by [@jakex7](https://github.com/jakex7))

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeViewProp.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeViewProp.kt
@@ -8,7 +8,11 @@ import expo.modules.kotlin.exception.PropSetException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.logger
 import expo.modules.kotlin.types.AnyType
+import kotlin.reflect.KMutableProperty1
 import kotlin.reflect.KProperty1
+import kotlin.reflect.full.instanceParameter
+import kotlin.reflect.full.memberFunctions
+import kotlin.reflect.full.memberProperties
 
 class ComposeViewProp(
   name: String,
@@ -22,6 +26,25 @@ class ComposeViewProp(
       PropSetException(name, onView::class, it)
     }) {
       val props = (onView as ExpoComposeView<*>).props ?: return
+
+      if (onView is ComposeFunctionHolder<*>) {
+        val props = onView.props ?: return
+        val copy = props::class.memberFunctions.firstOrNull { it.name == "copy" }
+        if (copy == null) {
+          logger.warn("⚠️ Props are not a data class with default values for all properties, cannot set prop $name dynamically.")
+          return
+        }
+        val instanceParam = copy.instanceParameter!!
+        val newPropParam = copy.parameters.firstOrNull { it.name == name } ?: return
+        val result = copy.callBy(mapOf(instanceParam to props, newPropParam to type.convert(prop, appContext)))
+        // Set the new props instance back to the onView
+        val memberProperty = onView::class.memberProperties
+          .firstOrNull { it.name == "props" } as? KMutableProperty1<Any, Any?> ?: return
+        memberProperty.set(onView, result)
+        // trigger recomposition
+        onView.recompose()
+        return
+      }
       val mutableState = property.getter.call(props)
       if (mutableState is MutableState<*>) {
         (mutableState as MutableState<Any?>).value = type.convert(prop, appContext)

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeViewProp.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeViewProp.kt
@@ -8,11 +8,9 @@ import expo.modules.kotlin.exception.PropSetException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.logger
 import expo.modules.kotlin.types.AnyType
-import kotlin.reflect.KMutableProperty1
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.instanceParameter
 import kotlin.reflect.full.memberFunctions
-import kotlin.reflect.full.memberProperties
 
 class ComposeViewProp(
   name: String,
@@ -28,7 +26,6 @@ class ComposeViewProp(
       val props = (onView as ExpoComposeView<*>).props ?: return
 
       if (onView is ComposeFunctionHolder<*>) {
-        val props = onView.props ?: return
         val copy = props::class.memberFunctions.firstOrNull { it.name == "copy" }
         if (copy == null) {
           logger.warn("⚠️ Props are not a data class with default values for all properties, cannot set prop $name dynamically.")
@@ -38,13 +35,10 @@ class ComposeViewProp(
         val newPropParam = copy.parameters.firstOrNull { it.name == name } ?: return
         val result = copy.callBy(mapOf(instanceParam to props, newPropParam to type.convert(prop, appContext)))
         // Set the new props instance back to the onView
-        val memberProperty = onView::class.memberProperties
-          .firstOrNull { it.name == "props" } as? KMutableProperty1<Any, Any?> ?: return
-        memberProperty.set(onView, result)
-        // trigger recomposition
-        onView.recompose()
+        (onView.propsMutableState as MutableState<Any?>).value = result
         return
       }
+
       val mutableState = property.getter.call(props)
       if (mutableState is MutableState<*>) {
         (mutableState as MutableState<Any?>).value = type.convert(prop, appContext)

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -152,21 +153,16 @@ class ComposeFunctionHolder<P : ComposeProps>(
   context: Context,
   appContext: AppContext,
   private val composableContent: @Composable ExpoViewComposableScope.(props: P) -> Unit,
-  props: P
+  override val props: P
 ) : ExpoComposeView<P>(context, appContext) {
-  override var props: P? = props
-  private var key by mutableIntStateOf(0)
+  val propsMutableState = mutableStateOf(props)
   val scope = ExpoViewComposableScope(this)
-
-  fun recompose() {
-    key++
-  }
 
   @Composable
   override fun ComposableScope.Content() {
-    LaunchedEffect(key) {}
+    val props by propsMutableState
     with(scope) {
-      composableContent(props ?: return)
+      composableContent(props)
     }
   }
 }

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -7,9 +7,7 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.ComposeView
@@ -149,12 +147,12 @@ class ExpoViewComposableScope(val view: ComposeFunctionHolder<*>) {
   }
 }
 
-class ComposeFunctionHolder<P : ComposeProps>(
+class ComposeFunctionHolder<Props : ComposeProps>(
   context: Context,
   appContext: AppContext,
-  private val composableContent: @Composable ExpoViewComposableScope.(props: P) -> Unit,
-  override val props: P
-) : ExpoComposeView<P>(context, appContext) {
+  private val composableContent: @Composable ExpoViewComposableScope.(props: Props) -> Unit,
+  override val props: Props
+) : ExpoComposeView<Props>(context, appContext) {
   val propsMutableState = mutableStateOf(props)
   val scope = ExpoViewComposableScope(this)
 

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ModuleDefinitionBuilderComposeExtension.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ModuleDefinitionBuilderComposeExtension.kt
@@ -37,18 +37,22 @@ open class ModuleDefinitionBuilderWithCompose(
   }
 
   @JvmName("ComposeView")
-  inline fun <reified P : ComposeProps> View(name: String, events: ComposeViewFunctionDefinitionBuilder<P>.() -> Unit = {}, noinline viewFunction: @Composable ExpoViewComposableScope.(props: P) -> Unit) {
-    val definitionBuilder = ComposeViewFunctionDefinitionBuilder(name, P::class, viewFunction)
+  inline fun <reified Props : ComposeProps> View(
+    name: String,
+    events: ComposeViewFunctionDefinitionBuilder<Props>.() -> Unit = {},
+    noinline viewFunction: @Composable ExpoViewComposableScope.(props: Props) -> Unit
+  ) {
+    val definitionBuilder = ComposeViewFunctionDefinitionBuilder(name, Props::class, viewFunction)
     events.invoke(definitionBuilder)
     registerViewDefinition(definitionBuilder.build())
   }
 }
 
 @DefinitionMarker
-class ComposeViewFunctionDefinitionBuilder<P : ComposeProps>(
+class ComposeViewFunctionDefinitionBuilder<Props : ComposeProps>(
   val name: String,
-  val propsClass: KClass<P>,
-  val viewFunction: @Composable ExpoViewComposableScope.(props: P) -> Unit
+  val propsClass: KClass<Props>,
+  val viewFunction: @Composable ExpoViewComposableScope.(props: Props) -> Unit
 ) {
   private var callbacksDefinition: CallbacksDefinition? = null
 
@@ -56,7 +60,7 @@ class ComposeViewFunctionDefinitionBuilder<P : ComposeProps>(
     return ViewManagerDefinition(
       name = name,
       viewFactory = { context, appContext ->
-        val instance: P = try {
+        val instance: Props = try {
           propsClass.createInstance()
         } catch (e: Exception) {
           throw IllegalStateException("Could not instantiate props instance of $name compose component.", e)

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ModuleDefinitionBuilderComposeExtension.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ModuleDefinitionBuilderComposeExtension.kt
@@ -2,12 +2,15 @@
 
 package expo.modules.kotlin.views
 
+import androidx.compose.runtime.Composable
+import expo.modules.kotlin.modules.DefinitionMarker
 import expo.modules.kotlin.modules.InternalModuleDefinitionBuilder
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.types.AnyType
 import expo.modules.kotlin.types.LazyKType
 import expo.modules.kotlin.views.decorators.UseCSSProps
 import kotlin.reflect.KClass
+import kotlin.reflect.full.createInstance
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.typeOf
 
@@ -31,5 +34,56 @@ open class ModuleDefinitionBuilderWithCompose(
     viewDefinitionBuilder.UseCSSProps()
     body.invoke(viewDefinitionBuilder)
     registerViewDefinition(viewDefinitionBuilder.build())
+  }
+
+  @JvmName("ComposeView")
+  inline fun <reified P : ComposeProps> View(name: String, events: ComposeViewFunctionDefinitionBuilder<P>.() -> Unit = {}, noinline viewFunction: @Composable ExpoViewComposableScope.(props: P) -> Unit) {
+    val definitionBuilder = ComposeViewFunctionDefinitionBuilder(name, P::class, viewFunction)
+    events.invoke(definitionBuilder)
+    registerViewDefinition(definitionBuilder.build())
+  }
+}
+
+@DefinitionMarker
+class ComposeViewFunctionDefinitionBuilder<P : ComposeProps>(
+  val name: String,
+  val propsClass: KClass<P>,
+  val viewFunction: @Composable ExpoViewComposableScope.(props: P) -> Unit
+) {
+  private var callbacksDefinition: CallbacksDefinition? = null
+
+  fun build(): ViewManagerDefinition {
+    return ViewManagerDefinition(
+      name = name,
+      viewFactory = { context, appContext ->
+        val instance: P = try {
+          propsClass.createInstance()
+        } catch (e: Exception) {
+          throw IllegalStateException("Could not instantiate props instance of $name compose component.", e)
+        }
+        ComposeFunctionHolder(context, appContext, viewFunction, instance)
+      },
+      callbacksDefinition = callbacksDefinition,
+      viewType = ComposeFunctionHolder::class.java,
+      props = propsClass.memberProperties.associate { prop ->
+        val kType = prop.returnType
+        prop.name to ComposeViewProp(prop.name, AnyType(kType), prop)
+      }
+    )
+  }
+
+  /**
+   * Defines prop names that should be treated as callbacks.
+   */
+  fun Events(vararg callbacks: String) {
+    callbacksDefinition = CallbacksDefinition(callbacks)
+  }
+
+  /**
+   * Defines prop names that should be treated as callbacks.
+   */
+  @JvmName("EventsWithArray")
+  fun Events(callbacks: Array<String>) {
+    callbacksDefinition = CallbacksDefinition(callbacks)
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEventDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEventDelegate.kt
@@ -12,12 +12,19 @@ class ViewEventDelegate<T>(
 ) {
   private val viewHolder = WeakReference(view)
 
-  operator fun getValue(thisRef: View, property: KProperty<*>): ViewEventCallback<T> {
+  fun getValue(property: KProperty<*>): ViewEventCallback<T> {
     val view = viewHolder.get()
       ?: throw IllegalStateException("Can't send the '${property.name}' event from the view that is deallocated")
     return ViewEvent(property.name, view, coalescingKey)
   }
+
+  operator fun getValue(thisRef: View, property: KProperty<*>): ViewEventCallback<T> {
+    return getValue(property)
+  }
 }
+
+@Suppress("NOTHING_TO_INLINE")
+inline operator fun <T> ViewEventDelegate<T>.getValue(thisObj: Any?, property: KProperty<*>): ViewEventCallback<T> = getValue(property)
 
 /**
  * Creates a reference to the js callback.

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/BottomSheetView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/BottomSheetView.kt
@@ -1,32 +1,23 @@
 package expo.modules.ui
 
-import android.content.Context
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
-import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
-import expo.modules.kotlin.views.ExpoComposeView
+import expo.modules.kotlin.views.ExpoViewComposableScope
 import java.io.Serializable
 
 open class IsOpenedChangeEvent(
   @Field open val isOpened: Boolean = false
 ) : Record, Serializable
-
-data class BottomSheetProps(
-  val isOpened: MutableState<Boolean> = mutableStateOf(false),
-  val skipPartiallyExpanded: MutableState<Boolean> = mutableStateOf(false)
-) : ComposeProps
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -44,23 +35,24 @@ fun BottomSheetComposable(skipPartiallyExpanded: Boolean, isOpened: Boolean, onI
   }
 }
 
-class BottomSheetView(context: Context, appContext: AppContext) :
-  ExpoComposeView<BottomSheetProps>(context, appContext) {
-  override val props = BottomSheetProps()
-  private val onIsOpenedChange by EventDispatcher<IsOpenedChangeEvent>()
+data class BottomSheetProps(
+  val isOpened: Boolean = false,
+  val skipPartiallyExpanded: Boolean = false
+) : ComposeProps
 
-  @Composable
-  override fun ComposableScope.Content() {
-    val (isOpened) = props.isOpened
-    val (skipPartiallyExpanded) = props.skipPartiallyExpanded
-
-    Box {
-      BottomSheetComposable(
-        skipPartiallyExpanded,
-        isOpened,
-        onIsOpenedChange = { value -> onIsOpenedChange(IsOpenedChangeEvent(value)) }
+@Composable
+fun ExpoViewComposableScope.BottomSheetContent(props: BottomSheetProps, onIsOpenedChange: (IsOpenedChangeEvent) -> Unit) {
+  Box {
+    BottomSheetComposable(
+      props.skipPartiallyExpanded,
+      props.isOpened,
+      onIsOpenedChange = { value -> onIsOpenedChange(IsOpenedChangeEvent(value)) }
+    ) {
+      Children(ComposableScope())
+      Button(
+        onClick = { onIsOpenedChange(IsOpenedChangeEvent(false)) }
       ) {
-        Children(ComposableScope())
+        androidx.compose.material3.Text("Close Bottom Sheet")
       }
     }
   }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/BottomSheetView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/BottomSheetView.kt
@@ -49,11 +49,6 @@ fun ExpoViewComposableScope.BottomSheetContent(props: BottomSheetProps, onIsOpen
       onIsOpenedChange = { value -> onIsOpenedChange(IsOpenedChangeEvent(value)) }
     ) {
       Children(ComposableScope())
-      Button(
-        onClick = { onIsOpenedChange(IsOpenedChangeEvent(false)) }
-      ) {
-        androidx.compose.material3.Text("Close Bottom Sheet")
-      }
     }
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ExpoUIModule.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ExpoUIModule.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
@@ -23,8 +24,17 @@ import androidx.compose.ui.zIndex
 import expo.modules.kotlin.jni.JavaScriptFunction
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
+import expo.modules.kotlin.viewevent.EventDispatcher
+import expo.modules.kotlin.viewevent.getValue
 import expo.modules.ui.button.Button
 import expo.modules.ui.menu.ContextMenu
+import kotlin.reflect.KProperty
+
+class ExampleDelegate {
+  operator fun getValue(thisRef: Any?, property: KProperty<*>): String {
+    return "Hello from delegate!"
+  }
+}
 
 class ExpoUIModule : Module() {
   override fun definition() = ModuleDefinition {
@@ -42,8 +52,11 @@ class ExpoUIModule : Module() {
       }
     }
 
-    View(BottomSheetView::class) {
+    View("BottomSheetView", events = {
       Events("onIsOpenedChange")
+    }) { props: BottomSheetProps ->
+      val onIsOpenedChange by remember { EventDispatcher<IsOpenedChangeEvent>() }
+      BottomSheetContent(props) { onIsOpenedChange(it) }
     }
 
     // Defines a single view for now – a single choice segmented control

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ExpoUIModule.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ExpoUIModule.kt
@@ -30,12 +30,6 @@ import expo.modules.ui.button.Button
 import expo.modules.ui.menu.ContextMenu
 import kotlin.reflect.KProperty
 
-class ExampleDelegate {
-  operator fun getValue(thisRef: Any?, property: KProperty<*>): String {
-    return "Hello from delegate!"
-  }
-}
-
 class ExpoUIModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("ExpoUI")


### PR DESCRIPTION
# Why

@lukmccall Suggested to move the compose integration to a more compose-like approach:

From: 

`View(BottomSheetView::class)`

To:

`View("BottomSheetView") { props ->`

# How
Introduced a new `ComposeFunctionHolder` that is used for all compose views that only have composables, no custom classes. Also handles setting props by copying data classes.

For now requires DSL for events to whitelist them in RN, we should drop that requirement soon.

# Test Plan

Tested in BareExpo.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
