### PR TITLE
[e-m-c] convert Either types in Swift Records

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -22,11 +22,12 @@
 ### 🐛 Bug fixes
 
 - [core] [iOS] Addresses a potential crash where `[NSString UTF8String]` could return `nil` for certain string inputs (non-English), leading to an attempt to dereference a null pointer during `jsi::String` creation. ([#40639](https://github.com/expo/expo/pull/40639) by [@mohammadamin16](https://github.com/mohammadamin16))
+- [iOS] Fix `Either` conversion in `Record` ([#40655](https://github.com/expo/expo/pull/40655) by [@vonovak](https://github.com/vonovak))
 - [RSC] Fix server components asserting from missing native modules. ([#40388](https://github.com/expo/expo/pull/40388) by [@EvanBacon](https://github.com/EvanBacon))
 - [Android] Restore `register` overload in `ModuleRegistry`. ([#40149](https://github.com/expo/expo/pull/40149) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Add `invalidate` callback to SwiftUIVirtualView. ([#40237](https://github.com/expo/expo/pull/40237) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [Android] Fix `androidNavigationBar.enforceContrast` app config property not working. ([#40263](https://github.com/expo/expo/pull/40263) by [@behenate](https://github.com/behenate))
-- [iOS] Fix `ValueOrUndefined` conversion in record. ([#40289](https://github.com/expo/expo/pull/40289) by [@jakex7](https://github.com/jakex7))
+- [iOS] Fix `ValueOrUndefined` conversion in `Record`. ([#40289](https://github.com/expo/expo/pull/40289) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Core/Arguments/Either.swift
+++ b/packages/expo-modules-core/ios/Core/Arguments/Either.swift
@@ -15,6 +15,11 @@ protocol AnyEither: AnyArgument {
    A dynamic either type for the current either type.
    */
   static func getDynamicType() -> any AnyDynamicType
+
+  /**
+   The underlying type-erased value.
+   */
+  var value: Any? { get }
 }
 
 /*

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEitherType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEitherType.swift
@@ -40,6 +40,23 @@ internal struct DynamicEitherType<EitherType: AnyEither>: AnyDynamicType {
     throw NeitherTypeException(types)
   }
 
+  func convertResult<ResultType>(_ result: ResultType, appContext: AppContext) throws -> Any {
+    guard let either = result as? EitherType else {
+      throw Conversions.CastingException<EitherType>(result)
+    }
+
+    let types = eitherType.dynamicTypes()
+
+    // Try each type - one should succeed
+    for type in types {
+      if let converted = try? type.convertResult(either.value, appContext: appContext) {
+        return converted
+      }
+    }
+
+    throw NeitherTypeException(types)
+  }
+
   var description: String {
     let types = eitherType.dynamicTypes()
     return "Either<\(types.map(\.description).joined(separator: ", "))>"

--- a/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
@@ -343,6 +343,10 @@ class FunctionSpec: ExpoSpec {
             p.resolve(SharedString("Test with Promise"))
           }
 
+          Function("withEither") { (either: Either<Bool, String>) in
+            return either
+          }
+
           AsyncFunction("withURLAsync") {
             return TestURLRecord.defaultURL
           }
@@ -544,7 +548,17 @@ class FunctionSpec: ExpoSpec {
         expect(result.kind) == .string
         expect(result.getString()) == "Test with Promise"
       }
-      
+
+      it("accepts and returns Either value") {
+        let stringResult = try runtime.eval("expo.modules.TestModule.withEither('test string')")
+        expect(stringResult.kind) == .string
+        expect(stringResult.getString()) == "test string"
+
+        let boolResult = try runtime.eval("expo.modules.TestModule.withEither(true)")
+        expect(boolResult.kind) == .bool
+        expect(boolResult.getBool()) == true
+      }
+
       // For async tests, this is a safe way to repeatedly evaluate JS
       // and catch both Swift and ObjC exceptions
       func safeBoolEval(_ js: String) -> Bool {

--- a/packages/expo-modules-core/ios/Tests/RecordSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/RecordSpec.swift
@@ -60,6 +60,31 @@ class RecordSpec: ExpoSpec {
       expect((asDict["b"] as? JavaScriptValue)?.kind).to(equal(.undefined))
     }
 
+    it("works back and forth with Either") {
+      struct TestRecord: Record {
+        @Field var stringValue: Either<Bool, String>?
+        @Field var boolValue: Either<Bool, String>?
+        @Field var intValue: Either<Int, String>?
+        @Field var nilValue: Either<Int, String>?
+      }
+      let dict: [String: Any] = [
+        "stringValue": "custom",
+        "boolValue": true,
+        "intValue": 42,
+      ]
+      let record = try TestRecord(from: dict, appContext: appContext)
+      expect(record.stringValue?.get() as String?).to(equal("custom"))
+      expect(record.boolValue?.get() as Bool?).to(equal(true))
+      expect(record.intValue?.get() as Int?).to(equal(42))
+      expect(record.nilValue).to(beNil())
+
+      let asDict = record.toDictionary(appContext: appContext)
+      expect(asDict["stringValue"] as? String).to(equal("custom"))
+      expect(asDict["boolValue"] as? Bool).to(equal(true))
+      expect(asDict["intValue"] as? Int).to(equal(42))
+      expect(asDict["nilValue"] as? Int).to(beNil())
+    }
+
     it("works back and forth with a keyed field") {
       struct TestRecord: Record {
         @Field("key") var a: String?


### PR DESCRIPTION
# Why

This PR adds support for returning `Either` type values inside of Records from native module functions to JavaScript.

# How

- Implemented `convertResult` method in `DynamicEitherType` to convert `Either` values when returning them from functions
- Added tests to verify that `Either` values can be properly passed back and forth between Swift and JavaScript

# Test Plan

- tests pass in CI

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)