### PR TITLE
Update documentation to use fetchUpdateAsync method

### DIFF
--- a/docs/pages/eas-update/download-updates.mdx
+++ b/docs/pages/eas-update/download-updates.mdx
@@ -31,7 +31,7 @@ You can disable the default behavior by setting the [`checkAutomatically`](/vers
 
 You can use `Updates.checkForUpdateAsync()` to check for updates while the app is running. This will return a promise that resolves to a [`UpdateCheckResult` object](/versions/latest/sdk/updates/#updatecheckresult), with `isAvailable` set to `true` if an update is available, and information about the update in the [`manifest`](/versions/latest/sdk/manifests/#expoupdatesmanifest) property.
 
-If an update is available, you can use the `Updates.downloadAsync()` method to download the update. This will return a promise that resolves when the download is complete. Finally, you can use the `Updates.reloadAsync()` method to reload the app with the new version. The `useUpdates()` hook can also be used to monitor the state of the `expo-updates` library from a React component.
+If an update is available, you can use the `Updates.fetchUpdateAsync()` method to download the update. This will return a promise that resolves when the download is complete. Finally, you can use the `Updates.reloadAsync()` method to reload the app with the new version. The `useUpdates()` hook can also be used to monitor the state of the `expo-updates` library from a React component.
 
 <Collapsible summary="What are common patterns for checking for updates while the app is running?">
 
@@ -42,7 +42,7 @@ If an update is available, you can use the `Updates.downloadAsync()` method to d
 
 ## Checking for updates while the app is backgrounded
 
-You can use [`expo-background-task`](/versions/latest/sdk/background-task/) to check for updates while the app is backgrounded. To do this, use the same `Updates.checkForUpdateAsync()` and `Updates.downloadAsync()` methods as you would in the foreground, but execute them inside of a background task. This is a great way to ensure that the user always has the latest version of the app, even if they have not opened the app in a while.
+You can use [`expo-background-task`](/versions/latest/sdk/background-task/) to check for updates while the app is backgrounded. To do this, use the same `Updates.checkForUpdateAsync()` and `Updates.fetchUpdateAsync()` methods as you would in the foreground, but execute them inside of a background task. This is a great way to ensure that the user always has the latest version of the app, even if they have not opened the app in a while.
 
 It's worth considering whether you want to reload the app after an update is downloaded in the background, or wait for the user to close and reopen it. If you choose to only download it in the background and not apply it, this should still be useful to ensure that the next boot will immediately have the latest version, and it will lead to a faster adoption rate for updates compared to the default behavior.
 


### PR DESCRIPTION
Fixed the expo-updates API documentation to use fetchUpdateAsync instead of downloadAsync. The documentation uses wrong method that is not supported by expo-updates API.