### PR TITLE
[cli] integrate mcp-tunnel handshaking and graceful shutdown

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Migrate typed routes logic from `expo-router` to `@expo/router-server` ([#40576](https://github.com/expo/expo/pull/40576) by [@hassankhan](https://github.com/hassankhan))
 - Deduplicate shared types across `@expo/cli`, `@expo/router-server`, `expo-server` ([#40614](https://github.com/expo/expo/pull/40614) by [@hassankhan](https://github.com/hassankhan))
 - Alias `transformer.asyncRequireModulePath` via Node resolution, when provided ([#40584](https://github.com/expo/expo/pull/40584) by [@kitten](https://github.com/kitten))
+- Added MCP server handshaking and graceful shutdown. ([#40660](https://github.com/expo/expo/pull/40660) by [@kudo](https://github.com/kudo))
 
 ### ⚠️ Notices
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -49,7 +49,7 @@
     "@expo/env": "~2.0.7",
     "@expo/image-utils": "^0.8.7",
     "@expo/json-file": "^10.0.7",
-    "@expo/mcp-tunnel": "~0.0.7",
+    "@expo/mcp-tunnel": "~0.1.0",
     "@expo/metro": "~54.1.0",
     "@expo/metro-config": "~54.0.3",
     "@expo/osascript": "^2.3.7",

--- a/packages/@expo/cli/src/start/interface/commandsTable.ts
+++ b/packages/@expo/cli/src/start/interface/commandsTable.ts
@@ -4,6 +4,7 @@ import qrcode from 'qrcode-terminal';
 import wrapAnsi from 'wrap-ansi';
 
 import * as Log from '../../log';
+import type { McpServer } from '../server/MCP';
 
 export const BLT = '\u203A';
 
@@ -14,6 +15,7 @@ export type StartOptions = {
   nonPersistent?: boolean;
   maxWorkers?: number;
   platforms?: ExpoConfig['platforms'];
+  mcpServer?: McpServer;
 };
 
 export const printHelp = (): void => {

--- a/packages/@expo/cli/src/start/interface/startInterface.ts
+++ b/packages/@expo/cli/src/start/interface/startInterface.ts
@@ -1,4 +1,3 @@
-import type { McpServerProxy } from '@expo/mcp-tunnel' with { 'resolution-mode': 'import' };
 import chalk from 'chalk';
 
 import { KeyPressHandler } from './KeyPressHandler';
@@ -37,10 +36,9 @@ const PLATFORM_SETTINGS: Record<
 
 export async function startInterfaceAsync(
   devServerManager: DevServerManager,
-  options: Pick<StartOptions, 'devClient' | 'platforms'> & { mcpServer: McpServerProxy | null }
+  options: Pick<StartOptions, 'devClient' | 'platforms' | 'mcpServer'>
 ) {
   const actions = new DevServerManagerActions(devServerManager, options);
-  const { mcpServer } = options;
 
   const isWebSocketsEnabled = devServerManager.getDefaultDevServer()?.isTargetingNative();
 
@@ -75,8 +73,8 @@ export async function startInterfaceAsync(
         const spinner = ora({ text: 'Stopping server', color: 'white' }).start();
         try {
           await devServerManager.stopAsync();
-          if (mcpServer) {
-            await mcpServer.close();
+          if (options.mcpServer) {
+            await options.mcpServer.closeAsync();
           }
           spinner.stopAndPersist({ text: 'Stopped server', symbol: `\u203A` });
           // @ts-ignore: Argument of type '"SIGINT"' is not assignable to parameter of type '"disconnect"'.

--- a/packages/@expo/cli/src/start/interface/startInterface.ts
+++ b/packages/@expo/cli/src/start/interface/startInterface.ts
@@ -1,3 +1,4 @@
+import type { McpServerProxy } from '@expo/mcp-tunnel' with { 'resolution-mode': 'import' };
 import chalk from 'chalk';
 
 import { KeyPressHandler } from './KeyPressHandler';
@@ -36,9 +37,10 @@ const PLATFORM_SETTINGS: Record<
 
 export async function startInterfaceAsync(
   devServerManager: DevServerManager,
-  options: Pick<StartOptions, 'devClient' | 'platforms'>
+  options: Pick<StartOptions, 'devClient' | 'platforms'> & { mcpServer: McpServerProxy | null }
 ) {
   const actions = new DevServerManagerActions(devServerManager, options);
+  const { mcpServer } = options;
 
   const isWebSocketsEnabled = devServerManager.getDefaultDevServer()?.isTargetingNative();
 
@@ -73,6 +75,9 @@ export async function startInterfaceAsync(
         const spinner = ora({ text: 'Stopping server', color: 'white' }).start();
         try {
           await devServerManager.stopAsync();
+          if (mcpServer) {
+            await mcpServer.close();
+          }
           spinner.stopAndPersist({ text: 'Stopped server', symbol: `\u203A` });
           // @ts-ignore: Argument of type '"SIGINT"' is not assignable to parameter of type '"disconnect"'.
           process.emit('SIGINT');

--- a/packages/@expo/cli/src/start/server/__tests__/MCP-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/MCP-test.ts
@@ -2,6 +2,7 @@
 import resolveFrom from 'resolve-from';
 
 import { Log } from '../../../log';
+import * as ExitHooks from '../../../utils/exit';
 import { maybeCreateMCPServerAsync } from '../MCP';
 
 jest.mock('@expo/mcp-tunnel', () => ({
@@ -13,12 +14,15 @@ jest.mock('@expo/cli/add-module', () =>
     TunnelMcpServerProxy: jest.fn().mockImplementation((mcpServerUrl: string) => ({
       // Adding a mock property that allows checking the server URL
       mockServerUrl: mcpServerUrl,
+      start: jest.fn(),
+      close: jest.fn(),
     })),
     addMcpCapabilities: jest.fn(),
   })
 );
 jest.mock('resolve-from');
 jest.mock('../../../log');
+jest.mock('../../../utils/exit');
 
 describe(maybeCreateMCPServerAsync, () => {
   const mockResolveFromSilent = resolveFrom.silent as jest.MockedFunction<
@@ -29,6 +33,7 @@ describe(maybeCreateMCPServerAsync, () => {
   beforeEach(() => {
     delete process.env.EXPO_STAGING;
     delete process.env.EXPO_UNSTABLE_MCP_SERVER;
+    mockResolveFromSilent.mockReturnValue('/app/node_modules/expo-mcp');
   });
 
   afterEach(() => {
@@ -40,21 +45,30 @@ describe(maybeCreateMCPServerAsync, () => {
   });
 
   it('should return null if the MCP server is not enabled', async () => {
-    const server = await maybeCreateMCPServerAsync('/app');
+    const server = await maybeCreateMCPServerAsync({
+      projectRoot: '/app',
+      devServerUrl: 'http://localhost:8081',
+    });
     expect(server).toBeNull();
   });
 
   it('should return non-null value if the MCP server is enabled', async () => {
     process.env.EXPO_UNSTABLE_MCP_SERVER = '1';
-    mockResolveFromSilent.mockReturnValue('/app/node_modules/expo-mcp');
-    const server = await maybeCreateMCPServerAsync('/app');
+    const server = await maybeCreateMCPServerAsync({
+      projectRoot: '/app',
+      devServerUrl: 'http://localhost:8081',
+    });
     expect(server).not.toBeNull();
   });
 
   it('should return null and log an error if the MCP server is enabled but the expo-mcp package is not installed', async () => {
     process.env.EXPO_UNSTABLE_MCP_SERVER = '1';
     const spyLogError = jest.spyOn(Log, 'error');
-    const server = await maybeCreateMCPServerAsync('/app');
+    mockResolveFromSilent.mockReturnValue(undefined);
+    const server = await maybeCreateMCPServerAsync({
+      projectRoot: '/app',
+      devServerUrl: 'http://localhost:8081',
+    });
     expect(spyLogError).toHaveBeenCalledWith(
       'Missing the `expo-mcp` package in the project. To enable the MCP integration, add the `expo-mcp` package to your project.'
     );
@@ -63,8 +77,10 @@ describe(maybeCreateMCPServerAsync, () => {
 
   it('should use production MCP server by default', async () => {
     process.env.EXPO_UNSTABLE_MCP_SERVER = '1';
-    mockResolveFromSilent.mockReturnValue('/app/node_modules/expo-mcp');
-    const server = await maybeCreateMCPServerAsync('/app');
+    const server = await maybeCreateMCPServerAsync({
+      projectRoot: '/app',
+      devServerUrl: 'http://localhost:8081',
+    });
     // @ts-expect-error
     expect(server?.mockServerUrl).toBe('wss://mcp.expo.dev');
   });
@@ -72,17 +88,44 @@ describe(maybeCreateMCPServerAsync, () => {
   it('should use staging MCP server if the EXPO_STAGING environment variable is set', async () => {
     process.env.EXPO_UNSTABLE_MCP_SERVER = '1';
     process.env.EXPO_STAGING = '1';
-    mockResolveFromSilent.mockReturnValue('/app/node_modules/expo-mcp');
-    const server = await maybeCreateMCPServerAsync('/app');
+    const server = await maybeCreateMCPServerAsync({
+      projectRoot: '/app',
+      devServerUrl: 'http://localhost:8081',
+    });
     // @ts-expect-error
     expect(server?.mockServerUrl).toBe('wss://staging-mcp.expo.dev');
   });
 
   it('should allow specifying custom MCP server URL', async () => {
     process.env.EXPO_UNSTABLE_MCP_SERVER = 'ws://localhost:8787';
-    mockResolveFromSilent.mockReturnValue('/app/node_modules/expo-mcp');
-    const server = await maybeCreateMCPServerAsync('/app');
+    const server = await maybeCreateMCPServerAsync({
+      projectRoot: '/app',
+      devServerUrl: 'http://localhost:8081',
+    });
     // @ts-expect-error
     expect(server?.mockServerUrl).toBe('ws://localhost:8787');
+  });
+
+  it('should install the exit hook', async () => {
+    process.env.EXPO_UNSTABLE_MCP_SERVER = '1';
+    const spyInstallExitHooks = jest.spyOn(ExitHooks, 'installExitHooks');
+    await maybeCreateMCPServerAsync({
+      projectRoot: '/app',
+      devServerUrl: 'http://localhost:8081',
+    });
+    expect(spyInstallExitHooks).toHaveBeenCalledTimes(1);
+  });
+
+  it('should cleanup the registered exit hook when explicitly closing the server', async () => {
+    process.env.EXPO_UNSTABLE_MCP_SERVER = '1';
+    const spyInstallExitHooks = jest.spyOn(ExitHooks, 'installExitHooks');
+    const mockRemoveExitHook = jest.fn();
+    spyInstallExitHooks.mockReturnValue(mockRemoveExitHook);
+    const server = await maybeCreateMCPServerAsync({
+      projectRoot: '/app',
+      devServerUrl: 'http://localhost:8081',
+    });
+    await server.closeAsync();
+    expect(mockRemoveExitHook).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -116,10 +116,11 @@ export async function startAsync(
   const defaultServerUrl = devServerManager.getDefaultDevServer()?.getDevServerUrl() ?? '';
   // Present the Terminal UI.
   if (isInteractive()) {
-    const mcpServer = await profile(maybeCreateMCPServerAsync)({
-      projectRoot,
-      devServerUrl: defaultServerUrl,
-    });
+    const mcpServer =
+      (await profile(maybeCreateMCPServerAsync)({
+        projectRoot,
+        devServerUrl: defaultServerUrl,
+      })) ?? undefined;
 
     await profile(startInterfaceAsync)(devServerManager, {
       platforms: exp.platforms ?? ['ios', 'android', 'web'],

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -113,24 +113,28 @@ export async function startAsync(
   // Open project on devices.
   await profile(openPlatformsAsync)(devServerManager, options);
 
+  const defaultServerUrl = devServerManager.getDefaultDevServer()?.getDevServerUrl() ?? '';
   // Present the Terminal UI.
   if (isInteractive()) {
-    const mcpServer = await profile(maybeCreateMCPServerAsync)(projectRoot);
+    const mcpServer = await profile(maybeCreateMCPServerAsync)({
+      projectRoot,
+      devServerUrl: defaultServerUrl,
+    });
 
     await profile(startInterfaceAsync)(devServerManager, {
       platforms: exp.platforms ?? ['ios', 'android', 'web'],
+      mcpServer,
     });
 
     mcpServer?.start();
   } else {
     // Display the server location in CI...
-    const url = devServerManager.getDefaultDevServer()?.getDevServerUrl();
-    if (url) {
+    if (defaultServerUrl) {
       if (env.__EXPO_E2E_TEST) {
         // Print the URL to stdout for tests
-        console.info(`[__EXPO_E2E_TEST:server] ${JSON.stringify({ url })}`);
+        console.info(`[__EXPO_E2E_TEST:server] ${JSON.stringify({ url: defaultServerUrl })}`);
       }
-      Log.log(chalk`Waiting on {underline ${url}}`);
+      Log.log(chalk`Waiting on {underline ${defaultServerUrl}}`);
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1580,10 +1580,10 @@
     debug "^3.1.0"
     glob "^10.4.2"
 
-"@expo/mcp-tunnel@~0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@expo/mcp-tunnel/-/mcp-tunnel-0.0.7.tgz#16850d5e7b5b3961bf06be0111ae4689de959aeb"
-  integrity sha512-ht8Q1nKtiHobZqkUqt/7awwjW2D59ardP6XDVmGceGjQtoZELVaJDHyMIX+aVG9SZ9aj8+uGlhQYeBi57SZPMA==
+"@expo/mcp-tunnel@~0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@expo/mcp-tunnel/-/mcp-tunnel-0.1.0.tgz#ae4ce4320b2f97a9891783c2316f9936c912d126"
+  integrity sha512-rJ6hl0GnIZj9+ssaJvFsC7fwyrmndcGz+RGFzu+0gnlm78X01957yjtHgjcmnQAgL5hWEOR6pkT0ijY5nU5AWw==
   dependencies:
     ws "^8.18.3"
     zod "^3.25.76"


### PR DESCRIPTION
# Why

improve mcp integration

# How

- add McpServer graceful shutdown
- pass `projectRoot` and `devServerUrl` for handshaking

# Test Plan

test local patch from https://github.com/expo/expo-mcp/pull/2

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
