### PR TITLE
[constants][android] Read projectRoot from expo-autolinking

### DIFF
--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [android] Read projectRoot from expo-autolinking ([#40666](https://github.com/expo/expo/pull/40666) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-constants/scripts/get-app-config-android.gradle
+++ b/packages/expo-constants/scripts/get-app-config-android.gradle
@@ -12,7 +12,9 @@ def config = project.hasProperty("react") ? project.react : [];
 def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]
 
 afterEvaluate {
-  def projectRoot = file("${rootProject.projectDir}")
+  def expoGradleExtension = gradle.extensions.findByName("expoGradle")
+  def customProjectRoot = expoGradleExtension?.projectRoot
+  def projectRoot = file("${customProjectRoot ?: rootProject.projectDir}")
   def assetsDir = file("$buildDir/generated/assets/expo-constants")
 
   def currentCreateConfigTask = tasks.register('createExpoConfig', Exec) {


### PR DESCRIPTION
# Why

When integrating a brownfield app in a complex monorepo structure expo-constants doesn't always find the correct package json to write the app.config. Instead of assuming paths in brownfield, we should just read the expoAutolinking  projectRoot config

# How

Read expoAutolinking projectRoot to determine the root path of the JS code

# Test Plan

Run MinimalTester and BrownfieldTester

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
