### PR TITLE
[dev-menu] Decouple dev-menu from dev-launcher

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Remove `ExpoAppDelegate` inheritance requirement ([#39417](https://github.com/expo/expo/pull/39417) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Add brownfield support ([#40463](https://github.com/expo/expo/pull/40463) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Decouple menu from dev-launcher ([#40669](https://github.com/expo/expo/pull/40669) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/ios/DevLauncherDevMenuDelegate.swift
+++ b/packages/expo-dev-launcher/ios/DevLauncherDevMenuDelegate.swift
@@ -1,0 +1,18 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+import EXDevMenuInterface
+
+@objcMembers
+public class DevLauncherDevMenuDelegate: NSObject, DevMenuHostDelegate {
+  public weak var controller: EXDevLauncherController?
+
+  public init(controller: EXDevLauncherController) {
+    self.controller = controller
+    super.init()
+  }
+
+  public func devMenuNavigateHome() {
+    controller?.navigateToLauncher()
+  }
+}

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -56,6 +56,7 @@
 @property (nonatomic, strong) EXDevLauncherReactNativeFactory *reactNativeFactory;
 @property (nonatomic, strong) DevLauncherViewController *devLauncherViewController;
 @property (nonatomic, strong) NSURL *lastOpenedAppUrl;
+@property (nonatomic, strong) DevLauncherDevMenuDelegate *devMenuDelegate;
 
 @end
 
@@ -84,6 +85,8 @@
 
     self.dependencyProvider = [RCTAppDependencyProvider new];
     self.reactNativeFactory = [[EXDevLauncherReactNativeFactory alloc] initWithDelegate:self releaseLevel:[self getReactNativeReleaseLevel]];
+    self.devMenuDelegate = [[DevLauncherDevMenuDelegate alloc] initWithController:self];
+    [[DevMenuManager shared] setDelegate:self.devMenuDelegate];
   }
   return self;
 }
@@ -631,20 +634,20 @@
 - (void)setDevMenuAppBridge
 {
   DevMenuManager *manager = [DevMenuManager shared];
-  manager.currentBridge = self.appBridge.parentBridge;
+  [manager updateCurrentBridge:self.appBridge.parentBridge];
 
   if (self.manifest != nil) {
-    manager.currentManifest = self.manifest;
-    manager.currentManifestURL = self.manifestURL;
+    [manager updateCurrentManifest:self.manifest manifestURL:self.manifestURL];
+  } else {
+    [manager updateCurrentManifest:nil manifestURL:nil];
   }
 }
 
 - (void)invalidateDevMenuApp
 {
   DevMenuManager *manager = [DevMenuManager shared];
-  manager.currentBridge = nil;
-  manager.currentManifest = nil;
-  manager.currentManifestURL = nil;
+  [manager updateCurrentBridge:nil];
+  [manager updateCurrentManifest:nil manifestURL:nil];
 }
 
 -(NSDictionary *)getUpdatesConfig: (nullable NSDictionary *) constants

--- a/packages/expo-dev-menu-interface/ios/DevMenuHostDelegate.swift
+++ b/packages/expo-dev-menu-interface/ios/DevMenuHostDelegate.swift
@@ -1,0 +1,11 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+
+@objc
+public protocol DevMenuHostDelegate: NSObjectProtocol {
+  /**
+   Optional function to navigate the host application to its home screen.
+   */
+  @objc optional func devMenuNavigateHome()
+}

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - [iOS] Add support to SwiftUI apps ([#40542](https://github.com/expo/expo/pull/40542) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- [iOS] Decouple dev menu from dev launcher.
+- [iOS] Decouple dev menu from dev launcher. ([#40669](https://github.com/expo/expo/pull/40669) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - [iOS] Add support to SwiftUI apps ([#40542](https://github.com/expo/expo/pull/40542) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Decouple dev menu from dev launcher.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -283,12 +283,12 @@ open class DevMenuManager: NSObject {
   func shouldShowOnboarding() -> Bool {
     return !isOnboardingFinished
   }
-  
+
   @objc
   public var isOnboardingFinished: Bool {
     return DevMenuPreferences.isOnboardingFinished
   }
-  
+
   @objc
   public func setOnboardingFinished(_ finished: Bool) {
     DevMenuPreferences.isOnboardingFinished = finished

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -69,15 +69,10 @@ open class DevMenuManager: NSObject {
 
   var currentScreen: String?
 
-  /**
-   For backwards compatibility in projects that call this method from AppDelegate
-   */
-  @available(*, deprecated, message: "Manual setup of DevMenuManager in AppDelegate is deprecated in favor of automatic setup with Expo Modules")
-  @objc
-  public static func configure(withBridge bridge: AnyObject) { }
+  weak var hostDelegate: DevMenuHostDelegate?
 
   @objc
-  public var currentBridge: RCTBridge? {
+  public private(set) var currentBridge: RCTBridge? {
     didSet {
       updateAutoLaunchObserver()
 
@@ -88,10 +83,33 @@ open class DevMenuManager: NSObject {
   }
 
   @objc
-  public var currentManifest: Manifest?
+  public private(set) var currentManifest: Manifest?
 
   @objc
-  public var currentManifestURL: URL?
+  public private(set) var currentManifestURL: URL?
+
+  /**
+   For backwards compatibility in projects that call this method from AppDelegate
+   */
+  @available(*, deprecated, message: "Manual setup of DevMenuManager in AppDelegate is deprecated in favor of automatic setup with Expo Modules")
+  @objc
+  public static func configure(withBridge bridge: AnyObject) { }
+
+  @objc
+  public func setDelegate(_ delegate: DevMenuHostDelegate?) {
+    hostDelegate = delegate
+  }
+
+  @objc
+  public func updateCurrentBridge(_ bridge: RCTBridge?) {
+    currentBridge = bridge
+  }
+
+  @objc
+  public func updateCurrentManifest(_ manifest: Manifest?, manifestURL: URL?) {
+    currentManifest = manifest
+    currentManifestURL = manifestURL
+  }
 
   @objc
   public func autoLaunch(_ shouldRemoveObserver: Bool = true) {
@@ -208,6 +226,32 @@ open class DevMenuManager: NSObject {
   }
 
   @objc
+  public var canNavigateHome: Bool {
+    guard let delegate = hostDelegate else {
+      return false
+    }
+    return delegate.responds(to: #selector(DevMenuHostDelegate.devMenuNavigateHome))
+  }
+
+  @objc
+  public func navigateHome() {
+    guard let delegate = hostDelegate,
+      delegate.responds(to: #selector(DevMenuHostDelegate.devMenuNavigateHome)) else {
+      return
+    }
+
+    let action: () -> Void = {
+      delegate.devMenuNavigateHome?()
+    }
+
+    if Thread.isMainThread {
+      action()
+    } else {
+      DispatchQueue.main.async(execute: action)
+    }
+  }
+
+  @objc
   public func setCurrentScreen(_ screenName: String?) {
     currentScreen = screenName
   }
@@ -244,7 +288,17 @@ open class DevMenuManager: NSObject {
    Returns bool value whether the onboarding view should be displayed by the dev menu view.
    */
   func shouldShowOnboarding() -> Bool {
-    return !DevMenuPreferences.isOnboardingFinished
+    return !isOnboardingFinished
+  }
+  
+  @objc
+  public var isOnboardingFinished: Bool {
+    return DevMenuPreferences.isOnboardingFinished
+  }
+  
+  @objc
+  public func setOnboardingFinished(_ finished: Bool) {
+    DevMenuPreferences.isOnboardingFinished = finished
   }
 
   func readAutoLaunchDisabledState() {

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -88,13 +88,6 @@ open class DevMenuManager: NSObject {
   @objc
   public private(set) var currentManifestURL: URL?
 
-  /**
-   For backwards compatibility in projects that call this method from AppDelegate
-   */
-  @available(*, deprecated, message: "Manual setup of DevMenuManager in AppDelegate is deprecated in favor of automatic setup with Expo Modules")
-  @objc
-  public static func configure(withBridge bridge: AnyObject) { }
-
   @objc
   public func setDelegate(_ delegate: DevMenuHostDelegate?) {
     hostDelegate = delegate

--- a/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.swift
@@ -36,7 +36,7 @@ public class DevMenuInternalModule: Module {
     }
 
     AsyncFunction("setOnboardingFinished") { (finished: Bool) in
-      DevMenuPreferences.isOnboardingFinished = finished
+      DevMenuManager.shared.setOnboardingFinished(finished)
     }
 
     AsyncFunction("openDevMenuFromReactNative") {

--- a/packages/expo-dev-menu/ios/ReactDelegateHandler/ExpoDevMenuReactDelegateHandler.swift
+++ b/packages/expo-dev-menu/ios/ReactDelegateHandler/ExpoDevMenuReactDelegateHandler.swift
@@ -12,7 +12,7 @@ public class ExpoDevMenuReactDelegateHandler: ExpoReactDelegateHandler {
     launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> UIView? {
     if EXAppDefines.APP_DEBUG {
-      DevMenuManager.shared.currentBridge = RCTBridge.current()
+      DevMenuManager.shared.updateCurrentBridge(RCTBridge.current())
     }
     return nil
   }

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuActions.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuActions.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct DevMenuActions: View {
-  let isDevLauncherInstalled: Bool
+  let canNavigateHome: Bool
   let onReload: () -> Void
   let onGoHome: () -> Void
 
@@ -14,7 +14,7 @@ struct DevMenuActions: View {
       )
       .cornerRadius(18)
 
-      if isDevLauncherInstalled {
+      if canNavigateHome {
         DevMenuActionButton(
           title: "Go home",
           icon: "house.fill",

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuMainView.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuMainView.swift
@@ -16,7 +16,7 @@ struct DevMenuMainView: View {
           }
 
           DevMenuActions(
-            isDevLauncherInstalled: viewModel.isDevLauncherInstalled,
+            canNavigateHome: viewModel.canNavigateHome,
             onReload: viewModel.reload,
             onGoHome: viewModel.goHome
           )

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
@@ -68,11 +68,12 @@ class DevMenuViewModel: ObservableObject {
   }
 
   func goHome() {
-    devMenuManager.closeMenu()
-    if let devLauncherClass = NSClassFromString("EXDevLauncherController") as? NSObject.Type {
-      let sharedInstance = devLauncherClass.perform(Selector(("sharedInstance")))?.takeUnretainedValue()
-      _ = sharedInstance?.perform(Selector(("navigateToLauncher")))
+    guard devMenuManager.canNavigateHome else {
+      return
     }
+
+    devMenuManager.closeMenu()
+    devMenuManager.navigateHome()
   }
 
   func togglePerformanceMonitor() {
@@ -159,16 +160,16 @@ class DevMenuViewModel: ObservableObject {
     }
   }
 
-  var isDevLauncherInstalled: Bool {
-    return NSClassFromString("EXDevLauncherController") != nil
+  var canNavigateHome: Bool {
+    return devMenuManager.canNavigateHome
   }
 
   private func checkOnboardingStatus() {
-    isOnboardingFinished = UserDefaults.standard.bool(forKey: "EXDevMenuIsOnboardingFinished")
+    isOnboardingFinished = devMenuManager.isOnboardingFinished
   }
 
   func finishOnboarding() {
-    UserDefaults.standard.set(true, forKey: "EXDevMenuIsOnboardingFinished")
+    devMenuManager.setOnboardingFinished(true)
     isOnboardingFinished = true
   }
 


### PR DESCRIPTION
# Why
Initial work to decouple dev menu from dev launcher.  

# How
On iOS, there is not much interaction between the two packages. We just need to provide functionality for navigating to home and updating the current bridge and manifest. Added a `DevMenuHostDelegate` protocol the host can conform to. I will follow up with making the integration easier in brownfield.

# Test Plan
Bare-expo 

