### PR TITLE
chore: add missing codemention for `@expo/router-server`

### DIFF
--- a/.github/codemention.yml
+++ b/.github/codemention.yml
@@ -42,6 +42,8 @@ rules:
     mentions: ['EvanBacon', 'bycedric']
   - patterns: ['packages/@expo/prebuild-config/**']
     mentions: ['EvanBacon']
+  - patterns: ['packages/@expo/router-server/**']
+    mentions: ['EvanBacon', 'hassankhan', 'kitten']
   - patterns: ['packages/@expo/schemer/**']
     mentions: ['bycedric', 'kitten']
   - patterns: ['packages/@expo/schema-utils/**']


### PR DESCRIPTION
# Why

So relevant developers are notified when changes are made to the `@expo/router-server` package.
