### PR TITLE
fix(expo-log-box): Use yarn to spawn expo CLI on Windows

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -15,6 +15,7 @@ on:
       - packages/@expo/package-manager/src/**
       - packages/@expo/prebuild-config/src/**
       - packages/@expo/router-server/**
+      - packages/@expo/log-box/**
       - packages/create-expo/**
       - packages/eslint-config-expo/**
       - packages/eslint-plugin-expo/**
@@ -35,6 +36,7 @@ on:
       - packages/@expo/package-manager/src/**
       - packages/@expo/prebuild-config/src/**
       - packages/@expo/router-server/**
+      - packages/@expo/log-box/**
       - packages/create-expo/**
       - packages/eslint-config-expo/**
       - packages/eslint-plugin-expo/**

--- a/packages/@expo/log-box/scripts/build-bundle.mjs
+++ b/packages/@expo/log-box/scripts/build-bundle.mjs
@@ -23,14 +23,14 @@ const indexHtmlPath = join(outputDir, defaultDomComponentsBundle, 'index.html');
 
 await rm(outputDir, { recursive: true, force: true });
 
-// We use path to the binary to avoid issue with the package managers when building in Android Studio or Xcode.
-const executable = process.platform === 'win32' ? 'yarn' : nodePath;
-const expo = process.platform === 'win32' ? 'expo' : join(__dirname, '../node_modules/.bin/expo');
+const expoCliJs = import.meta
+  .resolve('expo/bin/cli', join(__dirname, '..'))
+  .slice('file://'.length);
 
 const result = await spawn(
-  executable,
+  nodePath,
   [
-    expo,
+    expoCliJs,
     'export:embed',
     '--platform',
     'android',

--- a/packages/@expo/log-box/scripts/build-bundle.mjs
+++ b/packages/@expo/log-box/scripts/build-bundle.mjs
@@ -6,6 +6,7 @@
 import spawn from '@expo/spawn-async';
 import { globSync } from 'glob';
 import { rm, rename } from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import { join, dirname } from 'path';
 import { argv } from 'process';
 import { fileURLToPath } from 'url';
@@ -23,9 +24,7 @@ const indexHtmlPath = join(outputDir, defaultDomComponentsBundle, 'index.html');
 
 await rm(outputDir, { recursive: true, force: true });
 
-const expoCliJs = import.meta
-  .resolve('expo/bin/cli', join(__dirname, '..'))
-  .slice('file://'.length);
+const expoCliJs = createRequire(__dirname).resolve('expo/bin/cli');
 
 const result = await spawn(
   nodePath,

--- a/packages/@expo/log-box/scripts/build-bundle.mjs
+++ b/packages/@expo/log-box/scripts/build-bundle.mjs
@@ -23,10 +23,14 @@ const indexHtmlPath = join(outputDir, defaultDomComponentsBundle, 'index.html');
 
 await rm(outputDir, { recursive: true, force: true });
 
+// We use path to the binary to avoid issue with the package managers when building in Android Studio or Xcode.
+const executable = process.platform === 'win32' ? 'yarn' : nodePath;
+const expo = process.platform === 'win32' ? 'expo' : join(__dirname, '../node_modules/.bin/expo');
+
 const result = await spawn(
-  nodePath,
+  executable,
   [
-    join(__dirname, '../node_modules/.bin/expo'),
+    expo,
     'export:embed',
     '--platform',
     'android',


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

After
- https://github.com/expo/expo/pull/40594

Windows CI is not happy.

Fails on `node_modules/.bin/expo` not being a JS file. 

# How

<!--
How did you build this feature or fix this bug and why?
-->

When bundling on windows, use `yarn expo` else use `node .bin/expo` to avoid issues in Android Studio and Xcode.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

CI passes.
