### PR TITLE
[core][android] Remove hermesEnabled property requirement

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -19,7 +19,7 @@
 - [Android] Added `ReactNativeHostHandler.onDidCreateReactHost`. ([#40561](https://github.com/expo/expo/pull/40561) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Swift's `Encodable` types can now be converted to JavaScript values. ([#40621](https://github.com/expo/expo/pull/40621) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Added `subscriberDidRegister` function to AppDelegate subscribers. ([#40684](https://github.com/expo/expo/pull/40684) by [@tsapeta](https://github.com/tsapeta))
-- [Android] Remove hermesEnabled property requirement ([#40678](https://github.com/expo/expo/pull/40678) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [Android] Remove `hermesEnabled` property requirement for internal testing ([#40678](https://github.com/expo/expo/pull/40678) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [Android] Added `ReactNativeHostHandler.onDidCreateReactHost`. ([#40561](https://github.com/expo/expo/pull/40561) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Swift's `Encodable` types can now be converted to JavaScript values. ([#40621](https://github.com/expo/expo/pull/40621) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Added `subscriberDidRegister` function to AppDelegate subscribers. ([#40684](https://github.com/expo/expo/pull/40684) by [@tsapeta](https://github.com/tsapeta))
+- [Android] Remove hermesEnabled property requirement ([#40678](https://github.com/expo/expo/pull/40678) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -52,7 +52,11 @@ def reactNativeArchitectures() {
 def USE_HERMES = true
 if (findProject(":app")) {
   def appProject = project(":app")
-  USE_HERMES = appProject?.hermesEnabled?.toBoolean() || appProject?.ext?.react?.enableHermes?.toBoolean()
+  def hermesProp = appProject.findProperty("hermesEnabled")
+  def enableHermes = appProject?.ext?.react?.enableHermes
+  if (hermesProp != null || enableHermes != null) {
+    USE_HERMES = hermesProp?.toBoolean() || enableHermes?.toBoolean()
+  }
 }
 
 // Currently the needs for hermes/jsc are only for androidTest, so we turn on this flag only when `isExpoModulesCoreTests` is true

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -49,15 +49,7 @@ def reactNativeArchitectures() {
 }
 
 // HERMES
-def USE_HERMES = true
-if (findProject(":app")) {
-  def appProject = project(":app")
-  def hermesProp = appProject.findProperty("hermesEnabled")
-  def enableHermes = appProject?.ext?.react?.enableHermes
-  if (hermesProp != null || enableHermes != null) {
-    USE_HERMES = hermesProp?.toBoolean() || enableHermes?.toBoolean()
-  }
-}
+def USE_HERMES = findProperty("hermesEnabled") ?: true
 
 // Currently the needs for hermes/jsc are only for androidTest, so we turn on this flag only when `isExpoModulesCoreTests` is true
 USE_HERMES = USE_HERMES && isExpoModulesCoreTests


### PR DESCRIPTION
# Why

Now that the JSC integration has been removed from core and Hermes is no longer removable without third-party libs, we shouldn't require the configuration of `hermesEnabled` inside `gradle.properties`. This also facilitate the setup for brownfield users, given that this is one less variable to config

# How

Use `findProperty` to get `hermesEnabled` in expo modules core to prevent syncing from failing when the variable is not present 

# Test Plan

BareExpo and BrownfieldTester

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
