### PR TITLE
[core][iOS] Add `subscriberDidRegister` function to AppDelegate subscribers

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [Android] Added `ReactActivityHandler.onDidCreateReactActivityDelegateNotification`. ([#40537](https://github.com/expo/expo/pull/40537) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Added `ReactNativeHostHandler.onDidCreateReactHost`. ([#40561](https://github.com/expo/expo/pull/40561) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Swift's `Encodable` types can now be converted to JavaScript values. ([#40621](https://github.com/expo/expo/pull/40621) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Added `subscriberDidRegister` function to AppDelegate subscribers.
 
 ### 🐛 Bug fixes
 
@@ -39,7 +40,6 @@
 - [iOS] Added base props support for SwiftUI integration. ([#40492](https://github.com/expo/expo/pull/40492) by [@kudo](https://github.com/kudo))
 - [iOS] Removed some runtime type checks for dynamic types. ([#40611](https://github.com/expo/expo/pull/40611) by [@tsapeta](https://github.com/tsapeta))
 - Remove tests related files from the published package content. ([#39551](https://github.com/expo/expo/pull/39551) by [@Simek](https://github.com/Simek))
-
 
 ## 3.0.22 - 2025-10-20
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -18,7 +18,7 @@
 - [Android] Added `ReactActivityHandler.onDidCreateReactActivityDelegateNotification`. ([#40537](https://github.com/expo/expo/pull/40537) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Added `ReactNativeHostHandler.onDidCreateReactHost`. ([#40561](https://github.com/expo/expo/pull/40561) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Swift's `Encodable` types can now be converted to JavaScript values. ([#40621](https://github.com/expo/expo/pull/40621) by [@tsapeta](https://github.com/tsapeta))
-- [iOS] Added `subscriberDidRegister` function to AppDelegate subscribers.
+- [iOS] Added `subscriberDidRegister` function to AppDelegate subscribers. ([#40684](https://github.com/expo/expo/pull/40684) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriber.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriber.swift
@@ -24,6 +24,14 @@ open class BaseExpoAppDelegateSubscriber: UIResponder {
 @objc(EXAppDelegateSubscriberProtocol)
 public protocol ExpoAppDelegateSubscriberProtocol: UIApplicationDelegate {
   @objc optional func customizeRootView(_ rootView: UIView)
+
+  /**
+   Function that is called automatically by the `ExpoAppDelegate` once the subscriber is successfully registered.
+   If the subscriber is loaded from the modules provider, it is executed just before the main code of the app,
+   thus even before any other `UIApplicationDelegate` function. Use it if your subscriber needs to run some code as early as possible,
+   but keep in mind that this affects the application loading time.
+   */
+  @objc optional func subscriberDidRegister()
 }
 
 /**

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriberRepository.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriberRepository.swift
@@ -34,6 +34,7 @@ public class ExpoAppDelegateSubscriberRepository: NSObject {
       fatalError("Given app delegate subscriber `\(String(describing: subscriber))` is already registered.")
     }
     _subscribers.append(subscriber)
+    subscriber.subscriberDidRegister?()
   }
 
   @objc

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [iOS] Add `applicationDidReceiveMemoryWarning` subscribing to ExpoAppDelegate ([#40504](https://github.com/expo/expo/pull/40504) by [@szydlovsky](https://github.com/szydlovsky))
 - Fork default RN `HMRClient` to enable custom HMR Errors handling and UI ([#40449](https://github.com/expo/expo/pull/40449) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Add support for a new error overlay UI from `@expo/log-box` ([#39958](https://github.com/expo/expo/pull/39958) by [@krystofwoldrich](https://github.com/krystofwoldrich))
+- [iOS] Added `subscriberDidRegister` function to AppDelegate subscribers.
 
 ### 🐛 Bug fixes
 
@@ -26,7 +27,7 @@
 - [android] Add getDefaultReactHost to ExpoReactHostFactory ([#40086](https://github.com/expo/expo/pull/40086) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Remove edge-to-edge logic from `ReactActivityDelegateWrapper`. ([#40263](https://github.com/expo/expo/pull/40263) by [@behenate](https://github.com/behenate))
 - [expo/dom] Add `overrideUri` to `DOMProps` to enable pre-bundled DOM Components. ([#40397](https://github.com/expo/expo/pull/40397) by [@krystofwoldrich](https://github.com/krystofwoldrich))
-- Add `internal/async-require-module` for `@expo/metro-config`'s `asyncRequireModulePath`([#40584](https://github.com/expo/expo/pull/40584) by [@kitten](https://github.com/kitten)) 
+- Add `internal/async-require-module` for `@expo/metro-config`'s `asyncRequireModulePath`([#40584](https://github.com/expo/expo/pull/40584) by [@kitten](https://github.com/kitten))
 
 ### ⚠️ Notices
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [iOS] Add `applicationDidReceiveMemoryWarning` subscribing to ExpoAppDelegate ([#40504](https://github.com/expo/expo/pull/40504) by [@szydlovsky](https://github.com/szydlovsky))
 - Fork default RN `HMRClient` to enable custom HMR Errors handling and UI ([#40449](https://github.com/expo/expo/pull/40449) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Add support for a new error overlay UI from `@expo/log-box` ([#39958](https://github.com/expo/expo/pull/39958) by [@krystofwoldrich](https://github.com/krystofwoldrich))
-- [iOS] Added `subscriberDidRegister` function to AppDelegate subscribers.
+- [iOS] Added `subscriberDidRegister` function to AppDelegate subscribers. ([#40684](https://github.com/expo/expo/pull/40684) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 


### PR DESCRIPTION
# Why

There are cases when the module needs to invoke some code as early as possible (something like `+load` in Objective-C). Currently it is possible by overriding `init()` in the AppDelegate subscriber, but I think it's not the best way to do it. I'm rather in favor of having something dedicated for this use case.

# How

Added optional `subscriberDidRegister()` function to AppDelegate subscribers that is called automatically when the subscriber is successfully registered to receive events from the AppDelegate.

# Test Plan

Tested by implementing this function in one of the subscribers and confirming that it gets called before `AppDelegate.main()`.
