### PR TITLE
[ci] xcode 16.4 compilation

### DIFF
--- a/packages/expo-glass-effect/CHANGELOG.md
+++ b/packages/expo-glass-effect/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Fixed XCode 16.4 compilation ([#40686](https://github.com/expo/expo/pull/40686) by [@nishan](https://github.com/intergalacticspacehighway))
+
 ## 0.1.4 - 2025-09-17
 
 ### 🐛 Bug fixes

--- a/packages/expo-glass-effect/ios/GlassView.swift
+++ b/packages/expo-glass-effect/ios/GlassView.swift
@@ -26,7 +26,7 @@ public final class GlassView: ExpoView {
 
   public func updateBorderRadius() {
     if #available(iOS 26.0, *) {
-      
+      #if compiler(>=6.2) // Xcode 26
       let topLeft = UICornerRadius(floatLiteral: topLeftRadius ?? radius ?? 0)
       let topRight = UICornerRadius(floatLiteral: topRightRadius ?? radius ?? 0)
       let bottomLeft = UICornerRadius(floatLiteral: bottomLeftRadius ?? radius ?? 0)
@@ -38,6 +38,7 @@ public final class GlassView: ExpoView {
         bottomLeftRadius: bottomLeft,
         bottomRightRadius: bottomRight
       )
+      #endif
     }
   }
 


### PR DESCRIPTION
# Why

Fixes build failing on XCode 16.4 due to missing check for XCode 26. Code that caused the issue - https://github.com/expo/expo/pull/40570

https://github.com/expo/expo/actions/runs/18883957590/job/53894325619
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Add XCode 26 check for incompatible API
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

CI passes

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
](https://github.com/expo/expo/actions/runs/18883957590/job/53894325619)