### PR TITLE
[ios][image] Add plugin to disable libdav1d

### DIFF
--- a/docs/pages/versions/unversioned/sdk/image.mdx
+++ b/docs/pages/versions/unversioned/sdk/image.mdx
@@ -10,13 +10,13 @@ searchRank: 10
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
-import { Terminal } from '~/ui/components/Snippet';
 import {
   ConfigPluginExample,
   ConfigPluginProperties,
   ConfigReactNative,
 } from '~/ui/components/ConfigSection';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+import { Terminal } from '~/ui/components/Snippet';
 
 `expo-image` is a cross-platform React component that loads and renders images.
 

--- a/docs/pages/versions/unversioned/sdk/image.mdx
+++ b/docs/pages/versions/unversioned/sdk/image.mdx
@@ -12,6 +12,11 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { Terminal } from '~/ui/components/Snippet';
+import {
+  ConfigPluginExample,
+  ConfigPluginProperties,
+  ConfigReactNative,
+} from '~/ui/components/ConfigSection';
 
 `expo-image` is a cross-platform React component that loads and renders images.
 
@@ -43,9 +48,11 @@ import { Terminal } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-### Config plugin (optional)
+## Configuration in app config
 
 You can configure build-time settings for `expo-image` using its [config plugin](/config-plugins/introduction/). Add the plugin to the `plugins` array in your **app.json** or **app.config.js** and rebuild the native project.
+
+<ConfigPluginExample>
 
 ```json app.json
 {
@@ -62,9 +69,27 @@ You can configure build-time settings for `expo-image` using its [config plugin]
 }
 ```
 
-- **disableLibdav1d** (_boolean_, iOS only) — When `true`, skips adding the bundled `libavif/libdav1d` Pod. Use this when another dependency (such as FFmpegKit) already links `libdav1d`. Disabling the Pod removes AVIF image support on iOS unless another decoder is available.
+</ConfigPluginExample>
 
-If you are not running config plugins (for example, in a plain React Native workflow), set the shell environment variable `EXPO_IMAGE_DISABLE_LIBDAV1D=1` before running `pod install` to achieve the same effect.
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'disableLibdav1d',
+      platform: 'ios',
+      description:
+        'When true, skips adding the bundled `libavif/libdav1d` Pod. Use this when another dependency (such as FFmpegKit) already links `libdav1d`. Disabling the Pod removes AVIF image support on iOS unless another decoder is available.',
+      default: 'false',
+    },
+  ]}
+/>
+
+<ConfigReactNative>
+  If you are not using Continuous Native Generation ([CNG](/workflow/continuous-native-generation/))
+  or you're using native **ios** project manually, then set the shell environment variable
+  `EXPO_IMAGE_DISABLE_LIBDAV1D=1` before running `pod install` to achieve the same effect.
+  Alternatively, you can add `ENV['EXPO_IMAGE_DISABLE_LIBDAV1D'] ||= '0'` to the top of your
+  `Podfile`.
+</ConfigReactNative>
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/image.mdx
+++ b/docs/pages/versions/unversioned/sdk/image.mdx
@@ -43,6 +43,29 @@ import { Terminal } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
+### Config plugin (optional)
+
+You can configure build-time settings for `expo-image` using its [config plugin](/config-plugins/introduction/). Add the plugin to the `plugins` array in your **app.json** or **app.config.js** and rebuild the native project.
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-image",
+        {
+          "disableLibdav1d": true
+        }
+      ]
+    ]
+  }
+}
+```
+
+- **disableLibdav1d** (_boolean_, iOS only) — When `true`, skips adding the bundled `libavif/libdav1d` Pod. Use this when another dependency (such as FFmpegKit) already links `libdav1d`. Disabling the Pod removes AVIF image support on iOS unless another decoder is available.
+
+If you are not running config plugins (for example, in a plain React Native workflow), set the shell environment variable `EXPO_IMAGE_DISABLE_LIBDAV1D=1` before running `pod install` to achieve the same effect.
+
 ## Usage
 
 ```jsx

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -9,7 +9,7 @@
 - [Android] Upgrades Glide to `5.0.5`. ([#39713](https://github.com/expo/expo/pull/39713) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Added support for HDR images ([#40242](https://github.com/expo/expo/pull/40242) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Adopted Swift 6 ([#40369](https://github.com/expo/expo/pull/40369) by [@tsapeta](https://github.com/tsapeta))
-- [iOS] Provide plugin to disable `libdav1d`.
+- [iOS] Provide plugin to disable `libdav1d`. ([#40691](https://github.com/expo/expo/pull/40691) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [Android] Upgrades Glide to `5.0.5`. ([#39713](https://github.com/expo/expo/pull/39713) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Added support for HDR images ([#40242](https://github.com/expo/expo/pull/40242) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Adopted Swift 6 ([#40369](https://github.com/expo/expo/pull/40369) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Provide plugin to disable `libdav1d`.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-image/app.plugin.js
+++ b/packages/expo-image/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./plugin/build/withExpoImage');

--- a/packages/expo-image/ios/ExpoImage.podspec
+++ b/packages/expo-image/ios/ExpoImage.podspec
@@ -1,6 +1,15 @@
 require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
+podfile_properties = JSON.parse(File.read("#{Pod::Config.instance.installation_root}/Podfile.properties.json")) rescue {}
+property_override = podfile_properties['expo-image.disable-libdav1d']
+env_override = ENV['EXPO_IMAGE_DISABLE_LIBDAV1D']
+disable_libdav1d =
+  if property_override.nil?
+    env_override == '1' || env_override == 'true'
+  else
+    property_override == 'true'
+  end
 
 Pod::Spec.new do |s|
   s.name           = 'ExpoImage'
@@ -23,7 +32,7 @@ Pod::Spec.new do |s|
   s.dependency 'SDWebImageAVIFCoder', '~> 0.11.0'
   s.dependency 'SDWebImageSVGCoder', '~> 1.7.0'
   s.dependency 'SDWebImageWebPCoder', '~> 0.14.6'
-  s.dependency 'libavif/libdav1d'
+  s.dependency 'libavif/libdav1d' unless disable_libdav1d
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {

--- a/packages/expo-image/package.json
+++ b/packages/expo-image/package.json
@@ -8,6 +8,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "expo-module build",
+    "build:plugin": "expo-module build plugin",
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "expo-module test",

--- a/packages/expo-image/plugin/build/withExpoImage.d.ts
+++ b/packages/expo-image/plugin/build/withExpoImage.d.ts
@@ -1,0 +1,7 @@
+import { ConfigPlugin } from 'expo/config-plugins';
+type Props = {
+    /** Disable linking the included libdav1d decoder. Useful when another dependency already provides it. */
+    disableLibdav1d?: boolean;
+};
+declare const _default: ConfigPlugin<void | Props>;
+export default _default;

--- a/packages/expo-image/plugin/build/withExpoImage.js
+++ b/packages/expo-image/plugin/build/withExpoImage.js
@@ -1,0 +1,12 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const config_plugins_1 = require("expo/config-plugins");
+const pkg = require('../../package.json');
+const withExpoImage = (config, props) => {
+    const disableLibdav1d = props?.disableLibdav1d ?? false;
+    return (0, config_plugins_1.withPodfileProperties)(config, (config) => {
+        config.modResults['expo-image.disable-libdav1d'] = disableLibdav1d ? 'true' : 'false';
+        return config;
+    });
+};
+exports.default = (0, config_plugins_1.createRunOncePlugin)(withExpoImage, pkg.name, pkg.version);

--- a/packages/expo-image/plugin/src/withExpoImage.ts
+++ b/packages/expo-image/plugin/src/withExpoImage.ts
@@ -1,0 +1,19 @@
+import { ConfigPlugin, createRunOncePlugin, withPodfileProperties } from 'expo/config-plugins';
+
+const pkg = require('../../package.json');
+
+type Props = {
+  /** Disable linking the included libdav1d decoder. Useful when another dependency already provides it. */
+  disableLibdav1d?: boolean;
+};
+
+const withExpoImage: ConfigPlugin<Props | void> = (config, props) => {
+  const disableLibdav1d = props?.disableLibdav1d ?? false;
+
+  return withPodfileProperties(config, (config) => {
+    config.modResults['expo-image.disable-libdav1d'] = disableLibdav1d ? 'true' : 'false';
+    return config;
+  });
+};
+
+export default createRunOncePlugin(withExpoImage, pkg.name, pkg.version);

--- a/packages/expo-image/plugin/tsconfig.json
+++ b/packages/expo-image/plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "expo-module-scripts/tsconfig.plugin",
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src"
+  },
+  "include": ["./src"],
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+}


### PR DESCRIPTION
# Why
Closes #40632
 
# How
Provide a config plugin to disable `libdav1d`. We also support using an environment variable for projects not using prebuild. 

I've added docs for the plugin.

# Test Plan
Sandbox app