### PR TITLE
[core][ios] - Fix sizing glitch when using RN components with Expo UI

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [iOS] Add `invalidate` callback to SwiftUIVirtualView. ([#40237](https://github.com/expo/expo/pull/40237) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [Android] Fix `androidNavigationBar.enforceContrast` app config property not working. ([#40263](https://github.com/expo/expo/pull/40263) by [@behenate](https://github.com/behenate))
 - [iOS] Fix `ValueOrUndefined` conversion in `Record`. ([#40289](https://github.com/expo/expo/pull/40289) by [@jakex7](https://github.com/jakex7))
+- [iOS] Fix sizing glitch when React Native components are used as child in Expo UI components ([#40693](https://github.com/expo/expo/pull/40693) by [@nishan](https://github.com/intergalacticspacehighway))
 
 ### 💡 Others
 
@@ -39,7 +40,6 @@
 - [iOS] Added base props support for SwiftUI integration. ([#40492](https://github.com/expo/expo/pull/40492) by [@kudo](https://github.com/kudo))
 - [iOS] Removed some runtime type checks for dynamic types. ([#40611](https://github.com/expo/expo/pull/40611) by [@tsapeta](https://github.com/tsapeta))
 - Remove tests related files from the published package content. ([#39551](https://github.com/expo/expo/pull/39551) by [@Simek](https://github.com/Simek))
-
 
 ## 3.0.22 - 2025-10-20
 

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewHost.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewHost.swift
@@ -29,6 +29,14 @@ extension ExpoSwiftUI {
       // Nothing to do here
     }
 
+    static func dismantleUIView(_ uiView: UIView, coordinator: ()) {
+      // https://github.com/expo/expo/issues/40604
+      // UIViewRepresentable attaches autoresizingMask w+h to the hosted UIView
+      // This causes issues for RN views when they are recycled.
+      // So we clean up the autoresizingMask to avoid issues.
+      uiView.autoresizingMask = []
+    }
+
     // MARK: - AnyChild implementations
 
     var childView: some SwiftUI.View {

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewHost.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewHost.swift
@@ -13,6 +13,7 @@ extension ExpoSwiftUI {
 
     #if os(macOS)
     func makeNSView(context: Context) -> NSView {
+      context.coordinator.originalAutoresizingMask = view.autoresizingMask
       return view
     }
 
@@ -22,6 +23,7 @@ extension ExpoSwiftUI {
     #endif
 
     func makeUIView(context: Context) -> UIView {
+      context.coordinator.originalAutoresizingMask = view.autoresizingMask
       return view
     }
 
@@ -29,12 +31,20 @@ extension ExpoSwiftUI {
       // Nothing to do here
     }
 
-    static func dismantleUIView(_ uiView: UIView, coordinator: ()) {
+    static func dismantleUIView(_ uiView: UIView, coordinator: Coordinator) {
       // https://github.com/expo/expo/issues/40604
       // UIViewRepresentable attaches autoresizingMask w+h to the hosted UIView
       // This causes issues for RN views when they are recycled.
-      // So we clean up the autoresizingMask to avoid issues.
-      uiView.autoresizingMask = []
+      // So we restore the original autoresizingMask to avoid issues.
+      uiView.autoresizingMask = coordinator.originalAutoresizingMask
+    }
+
+    func makeCoordinator() -> Coordinator {
+      Coordinator()
+    }
+
+    class Coordinator {
+      var originalAutoresizingMask: UIView.AutoresizingMask = []
     }
 
     // MARK: - AnyChild implementations

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -35,7 +35,6 @@
 
 - [iOS] remove empty section header spacing when no title provided ([#40296](https://github.com/expo/expo/pull/40296) by [@dylancom](https://github.com/dylancom))
 - [iOS] Merge edge and axis paddings correctly in PaddingModifier ([#40414](https://github.com/expo/expo/pull/40414) by [@lucabc2000](https://github.com/lucabc2000))
-- [iOS] Fix sizing glitch when React Native components are used as child in Expo UI components ([#40693](https://github.com/expo/expo/pull/40693) by [@nishan](https://github.com/intergalacticspacehighway))
 
 ### 💡 Others
 

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 - [iOS] remove empty section header spacing when no title provided ([#40296](https://github.com/expo/expo/pull/40296) by [@dylancom](https://github.com/dylancom))
 - [iOS] Merge edge and axis paddings correctly in PaddingModifier ([#40414](https://github.com/expo/expo/pull/40414) by [@lucabc2000](https://github.com/lucabc2000))
+- [iOS] Fix sizing glitch when React Native components are used as child in Expo UI components ([#40693](https://github.com/expo/expo/pull/40693) by [@nishan](https://github.com/intergalacticspacehighway))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

Fixes - https://github.com/expo/expo/issues/40604

On recycling, RN components face sizing issues when used with Expo UI. It can lead to sizing glitches in unrelated part of the app.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

As shown in the layout hierarchy, the `RCTViewComponent` gets attached `autoresizing w+h` modes. This is done internally by `UIViewPresentable` so `UIView` can respond to SwiftUI sizing changes. But it creates issues when the same `RCTViewComponent` unmounts and gets mounted to other part of the app due to view recycling. Fix is to clean up the autoresizing masks when SwiftUI releases the `RCTViewComponent`

<img width="400" height="auto" alt="Screenshot 2025-10-29 at 3 56 07 PM" src="https://github.com/user-attachments/assets/af0cec47-bcb5-4454-b7ef-e09170b2bfdc" />


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested the patch in repro provided in https://github.com/expo/expo/issues/40604

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
