### PR TITLE
[go][quest] Add auth workaround for Meta Quest

### DIFF
--- a/apps/expo-go/src/screens/AccountModal/LoggedOutAccountView.tsx
+++ b/apps/expo-go/src/screens/AccountModal/LoggedOutAccountView.tsx
@@ -17,6 +17,8 @@ import { useDispatch, useSelector } from '../../redux/Hooks';
 import SessionActions from '../../redux/SessionActions';
 import { useAccountName } from '../../utils/AccountNameContext';
 import hasSessionSecret from '../../utils/hasSessionSecret';
+import { isQuest } from '../../utils/isQuest';
+import { openQuestAuthSessionAsync } from '../../utils/questAuthSessionPolyfill';
 
 type Props = {
   refetch: () => Promise<void>;
@@ -88,7 +90,12 @@ export function LoggedOutAccountView({ refetch }: Props) {
       const authSessionURL = `${
         Config.website.origin
       }/${urlPath}?confirm_account=1&app_redirect_uri=${encodeURIComponent(redirectBase)}`;
-      const result = await WebBrowser.openAuthSessionAsync(authSessionURL, redirectBase, {
+
+      // Use a custom auth session opener for Meta Quest devices (see note in `openQuestAuthSessionAsync`)
+      const openAuthSessionAsync = isQuest()
+        ? openQuestAuthSessionAsync
+        : WebBrowser.openAuthSessionAsync;
+      const result = await openAuthSessionAsync(authSessionURL, redirectBase, {
         /** note(brentvatne): We should disable the showInRecents option when
          * https://github.com/expo/expo/issues/8072 is resolved. This workaround
          * prevents the Chrome Custom Tabs activity from closing when the user

--- a/apps/expo-go/src/utils/isQuest.ts
+++ b/apps/expo-go/src/utils/isQuest.ts
@@ -1,0 +1,12 @@
+import * as Device from 'expo-device';
+
+export function isQuest() {
+  const manufacturer = Device.manufacturer || '';
+  const modelName = Device.modelName || '';
+
+  const isQuestModel = modelName.toLowerCase().includes('quest');
+  const isOculusOrMeta =
+    manufacturer.toLowerCase() === 'oculus' || manufacturer.toLowerCase() === 'meta';
+
+  return isOculusOrMeta && isQuestModel;
+}

--- a/apps/expo-go/src/utils/questAuthSessionPolyfill.ts
+++ b/apps/expo-go/src/utils/questAuthSessionPolyfill.ts
@@ -1,0 +1,101 @@
+/**
+ * This is the android auth polyfill from `expo-web-browser` for modified for Meta Quest. It opens the auth request
+ * in the default system browser instead of a custom tab, due to redirect issues encountered on Meta Quest.
+ * This is a workaround until the underlying issue is resolved. It's not optimal as the web browser is not
+ * auto-closed after the redirect.
+ *
+ * TODO: @behenate - Use regular `expo-web-browser` Android implementation once the redirect issue is resolved.
+ */
+
+import {
+  WebBrowserAuthSessionResult,
+  WebBrowserRedirectResult,
+  WebBrowserResult,
+  WebBrowserResultType,
+} from 'expo-web-browser';
+import { RedirectEvent } from 'expo-web-browser/build/WebBrowser.types';
+import { AppState, AppStateStatus, Linking, EmitterSubscription } from 'react-native';
+
+export async function openQuestAuthSessionAsync(
+  url: string,
+  redirectUrl?: string | null
+): Promise<WebBrowserAuthSessionResult> {
+  if (_redirectSubscription) {
+    throw new Error(
+      `The WebBrowser's auth session is in an invalid state with a redirect handler set when it should not be`
+    );
+  }
+
+  if (_onWebBrowserCloseQuest) {
+    throw new Error(`WebBrowser is already open, only one can be open at a time`);
+  }
+
+  try {
+    return await Promise.race([
+      _openBrowserAndWaitQuestAsync(url),
+      _waitForRedirectAsync(redirectUrl),
+    ]);
+  } finally {
+    _stopWaitingForRedirect();
+  }
+}
+let _redirectSubscription: EmitterSubscription | null = null;
+let _onWebBrowserCloseQuest: null | (() => void) = null;
+let _isAppStateAvailable: boolean = AppState.currentState !== null;
+
+function _onAppStateChangeQuest(state: AppStateStatus) {
+  if (!_isAppStateAvailable) {
+    _isAppStateAvailable = true;
+    return;
+  }
+
+  if (state === 'active' && _onWebBrowserCloseQuest) {
+    _onWebBrowserCloseQuest();
+  }
+}
+
+async function _openBrowserAndWaitQuestAsync(startUrl: string): Promise<WebBrowserResult> {
+  const appStateChangedToActive = new Promise<void>((resolve) => {
+    _onWebBrowserCloseQuest = resolve;
+  });
+  const stateChangeSubscription = AppState.addEventListener('change', _onAppStateChangeQuest);
+
+  let result: WebBrowserResult = { type: WebBrowserResultType.CANCEL };
+
+  try {
+    await Linking.openURL(startUrl);
+    await appStateChangedToActive;
+    result = { type: WebBrowserResultType.DISMISS }; // User returned to the app
+  } catch (e) {
+    stateChangeSubscription.remove();
+    _onWebBrowserCloseQuest = null;
+    throw e;
+  }
+
+  stateChangeSubscription.remove();
+  _onWebBrowserCloseQuest = null;
+  return result;
+}
+
+function _stopWaitingForRedirect() {
+  if (!_redirectSubscription) {
+    throw new Error(
+      `The WebBrowser auth session is in an invalid state with no redirect handler when one should be set`
+    );
+  }
+
+  _redirectSubscription.remove();
+  _redirectSubscription = null;
+}
+
+function _waitForRedirectAsync(returnUrl?: string | null): Promise<WebBrowserRedirectResult> {
+  return new Promise((resolve) => {
+    const redirectHandler = (event: RedirectEvent) => {
+      if (returnUrl && event.url.startsWith(returnUrl)) {
+        resolve({ url: event.url, type: 'success' });
+      }
+    };
+
+    _redirectSubscription = Linking.addEventListener('url', redirectHandler);
+  });
+}


### PR DESCRIPTION
# Why

We use `expo-web-browser` custom tabs for auth in Expo Go. Redirects back into the app seem to be broken in custom tabs on quest, which prevents login.

It's likely a regression, before the login used to work.

# How

As a workaround I have created a modified quest-specific version of the auth polyfill that uses a regular browser instead of custom tabs. This makes the login work but has the downside of the browser not closing after the login is fulfilled.

This is not ideal, but until we get a solution from Meta it's probably the best we can do.

# Test Plan

Tested in Expo Go on the SDK-54 branch (main is not building for me)

