### PR TITLE
[core][iOS] Make the Class definition for shared objects optional

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -20,7 +20,7 @@
 - [iOS] Swift's `Encodable` types can now be converted to JavaScript values. ([#40621](https://github.com/expo/expo/pull/40621) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Added `subscriberDidRegister` function to AppDelegate subscribers. ([#40684](https://github.com/expo/expo/pull/40684) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Remove `hermesEnabled` property requirement for internal testing ([#40678](https://github.com/expo/expo/pull/40678) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- [iOS] `Class` definition for shared objects is now optional.
+- [iOS] `Class` definition for shared objects is now optional. ([#40708](https://github.com/expo/expo/pull/40708) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [iOS] Swift's `Encodable` types can now be converted to JavaScript values. ([#40621](https://github.com/expo/expo/pull/40621) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Added `subscriberDidRegister` function to AppDelegate subscribers. ([#40684](https://github.com/expo/expo/pull/40684) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Remove `hermesEnabled` property requirement for internal testing ([#40678](https://github.com/expo/expo/pull/40678) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] `Class` definition for shared objects is now optional.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -195,8 +195,7 @@ public final class AppContext: NSObject, @unchecked Sendable {
    */
   internal func newObject(nativeClassId: ObjectIdentifier) throws -> JavaScriptObject? {
     guard let jsClass = classRegistry.getJavaScriptClass(nativeClassId: nativeClassId) else {
-      // TODO: Define a JS class for SharedRef in the CoreModule and then use it here instead of a raw object (?)
-      return try runtime.createObject()
+      throw JavaScriptClassNotFoundException()
     }
     let prototype = try jsClass.getProperty("prototype").asObject()
     let object = try runtime.createObject(withPrototype: prototype)
@@ -512,6 +511,12 @@ public final class AppContext: NSObject, @unchecked Sendable {
 }
 
 // MARK: - Public exceptions
+
+public class JavaScriptClassNotFoundException: Exception, @unchecked Sendable {
+  public override var reason: String {
+    "Unable to find a JavaScript class in the class registry"
+  }
+}
 
 // Deprecated since v1.0.0
 @available(*, deprecated, renamed: "Exceptions.AppContextLost")

--- a/packages/expo-modules-core/ios/Core/ExpoRuntime.swift
+++ b/packages/expo-modules-core/ios/Core/ExpoRuntime.swift
@@ -1,6 +1,24 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+/**
+ Class that extends the standard JavaScript runtime with some Expo-specific features.
+ For instance, the global `expo` object is available only in Expo runtimes.
+ */
 @objc(EXRuntime)
 public final class ExpoRuntime: JavaScriptRuntime {
   internal func initializeCoreObject(_ coreObject: JavaScriptObject) throws {
     global().defineProperty(EXGlobalCoreObjectPropertyName, value: coreObject, options: .enumerable)
+  }
+
+  internal func getCoreObject() throws -> JavaScriptObject {
+    return try global().getProperty(EXGlobalCoreObjectPropertyName).asObject()
+  }
+
+  internal func getSharedObjectClass() throws -> JavaScriptObject {
+    return try getCoreObject().getProperty("SharedObject").asObject()
+  }
+
+  internal func getSharedRefClass() throws -> JavaScriptObject {
+    return try getCoreObject().getProperty("SharedRef").asObject()
   }
 }

--- a/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
@@ -343,6 +343,10 @@ class FunctionSpec: ExpoSpec {
             p.resolve(SharedString("Test with Promise"))
           }
 
+          Function("returnBaseSharedRef") {
+            return BaseSharedRef(1.2)
+          }
+
           Function("withEither") { (either: Either<Bool, String>) in
             return either
           }
@@ -549,6 +553,15 @@ class FunctionSpec: ExpoSpec {
         expect(result.getString()) == "Test with Promise"
       }
 
+      it("returns shared ref without the Class definition") {
+        // In this case the native shared ref type is not defined as a class in the module's definition.
+        // Nevertheless, it should be converted to JS object that is an instance of the base `SharedRef` class.
+        let isSharedRef = try runtime.eval("expo.modules.TestModule.returnBaseSharedRef() instanceof expo.SharedRef")
+
+        expect(isSharedRef.kind) == .bool
+        expect(isSharedRef.getBool()) == true
+      }
+
       it("accepts and returns Either value") {
         let stringResult = try runtime.eval("expo.modules.TestModule.withEither('test string')")
         expect(stringResult.kind) == .string
@@ -582,5 +595,11 @@ class FunctionSpec: ExpoSpec {
 private class SharedString: SharedRef<String> {
   override var nativeRefType: String {
     "string"
+  }
+}
+
+private class BaseSharedRef: SharedRef<Double> {
+  override var nativeRefType: String {
+    "none"
   }
 }

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fork default RN `HMRClient` to enable custom HMR Errors handling and UI ([#40449](https://github.com/expo/expo/pull/40449) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Add support for a new error overlay UI from `@expo/log-box` ([#39958](https://github.com/expo/expo/pull/39958) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - [iOS] Added `subscriberDidRegister` function to AppDelegate subscribers. ([#40684](https://github.com/expo/expo/pull/40684) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] `Class` definition for shared objects is now optional.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Fork default RN `HMRClient` to enable custom HMR Errors handling and UI ([#40449](https://github.com/expo/expo/pull/40449) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Add support for a new error overlay UI from `@expo/log-box` ([#39958](https://github.com/expo/expo/pull/39958) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - [iOS] Added `subscriberDidRegister` function to AppDelegate subscribers. ([#40684](https://github.com/expo/expo/pull/40684) by [@tsapeta](https://github.com/tsapeta))
-- [iOS] `Class` definition for shared objects is now optional.
+- [iOS] `Class` definition for shared objects is now optional. ([#40708](https://github.com/expo/expo/pull/40708) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 


### PR DESCRIPTION
# Why

Currently, if the module's function returns a shared object of a class that is not defined in the module's definition, a plain object is being returned. In theory this is ok as the object doesn't have any JS properties anyway. However, it doesn't work well if this object is later passed somewhere else (e.g. to another function) – the association with the native object is being lost, i.e. the JS object doesn't have the shared object id in its native state.

# How

In short, I made the `Class` definition optional. Instead of returning a plain object, it will be creating an instance of the base `SharedObject` or `SharedRef` JS class.

# Test Plan

Added new native unit tests