### PR TITLE
[video][android] Fix `player` prop not working when re-assigned a previous player.

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fix `FOREGROUND_SERVICE_MEDIA_PLAYBACK` being always present in the manifest. ([#40074](https://github.com/expo/expo/pull/40074) by [@behenate](https://github.com/behenate))
 - [iOS] Fix crashes when rapidly replacing HLS sources. ([#40265](https://github.com/expo/expo/pull/40265) by [@behenate](https://github.com/behenate))
+- [Android] Fix the `player` prop of the `VideoView` not working when a player is re-assigned after being replaced by a different player earlier. ([#40709](https://github.com/expo/expo/pull/40709) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
@@ -114,6 +114,7 @@ open class VideoView(context: Context, appContext: AppContext, useTextureView: B
         VideoManager.onVideoPlayerDetachedFromView(it, this)
       }
       videoPlayer?.removeListener(this)
+      videoPlayer?.changePlayerView(null)
       newPlayer?.addListener(this)
       field = newPlayer
       shouldHideSurfaceView = true


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/40512

When doing player assignment loop to the same view like playerA -> playerB -> playerA. 
The last assignment will do nothing, this is because when we switch to playerB, we don't inform the playerA that it's view has been changed. Because of this upon re-assignment (playerB -> playerA) nothing happens, as playerA thinks it's already mounted in the video view.


# How

When changing the player of a video view call `player. changePlayerView(null)` on the old player to let it know it's not connected to a view.

# Test Plan

Tested in BareExpo on Android
