### PR TITLE
[dev-launcher][android] Fix launching apps in brownfield

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix launching apps in brownfield ([#40711](https://github.com/expo/expo/pull/40711) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 - [Android] Migrated from `kotlinOptions` to `compilerOptions` DSL. ([#39794](https://github.com/expo/expo/pull/39794) by [@huextrat](https://github.com/huextrat))

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -483,6 +483,10 @@ class DevLauncherController private constructor() :
 
     @JvmStatic
     fun wrapReactActivityDelegate(activity: ReactActivity, devLauncherReactActivityDelegateSupplier: DevLauncherReactActivityDelegateSupplier): ReactActivityDelegate {
+      // Set activity class as launcher for createBasicAppIntent() to correctly identify the React Native Intent when launching,
+      // otherwise it will just use the main app intent, which is not always true in brownfield.
+      sLauncherClass = activity::class.java
+
       devLauncherKoin()
         .get<DevLauncherLifecycle>()
         .delegateWillBeCreated(activity)


### PR DESCRIPTION
# Why

When using dev-client in a brownfield app with multiple activities, dec-launcher does not have a reference to react native activity causing it to just launch the main activity when opening an app from the server list

https://github.com/user-attachments/assets/426d32f7-3b0d-4687-9cbe-a1f4cae675aa



# How

Set activity class as launcher class to allow brownfield apps to launch the correct intent

# Test Plan

BareExpo and BrownfieldTester

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
