### PR TITLE
Change .envrc to allow multiple Ruby versions

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -32,10 +32,15 @@ install_git_hooks() {
 }
 
 use_ruby() {
-  local required_version=$1
-
-  if ! ruby -v | grep -q "ruby $required_version"; then
-    log_error "Ruby $required_version is required. Please install it using your Ruby version manager like rbenv or rvm."
+  local allowed_versions=$@
+  local pass=0
+  for version in $allowed_versions; do
+    if ruby -v | grep -q "ruby $version"; then
+      pass=1
+    fi
+  done
+  if [[ "$pass" == "0" ]]; then
+    log_error "Ruby version must be one of $allowed_versions. Please install it using your Ruby version manager like rbenv or rvm."
     exit 1
   fi
 
@@ -45,4 +50,4 @@ use_ruby() {
 source_secrets secrets/expotools.env
 source_local
 install_git_hooks
-use_ruby "3.3"
+use_ruby "3.3" "3.4"


### PR DESCRIPTION
# Why

Ruby 3.3 is enforced by direnv, but I (and probably others) have already moved to 3.4.

# How

Modify `.envrc` to allow multiple versions of Ruby (currently 3.3 and 3.4).

# Test Plan

CI should pass