### PR TITLE
[docs] Add information about recommended repo x Workflows setup

### DIFF
--- a/docs/pages/build-reference/build-with-monorepos.mdx
+++ b/docs/pages/build-reference/build-with-monorepos.mdx
@@ -7,7 +7,7 @@ description: Learn how to set up EAS Build with a monorepo.
 To set up EAS Build with a monorepo, you need to follow the standard process as described below:
 
 - Run all EAS CLI commands from the root of the app directory. For example, if your project exists inside your git repository at **apps/my-app**, then run `eas build` from there.
-- All files related to EAS Build, such as **eas.json** and **credentials.json**, should be in the root of the app directory. If you have multiple apps that use EAS Build in your monorepo, each app directory will have its own copy of these files.
+- All files related to EAS, such as **eas.json**, **credentials.json**, and the **.eas/workflows** directory, should be in the root of the app directory. If you have multiple apps in your monorepo, each app directory will have its own copy of these files.
 - **If you are building a managed project in a monorepo**, see [Working with Monorepos](/guides/monorepos) guide.
 - If your project needs additional setup beyond what is provided, add a `postinstall` step to **package.json** in your project that builds all necessary dependencies in other workspaces. For example:
 
@@ -18,3 +18,11 @@ To set up EAS Build with a monorepo, you need to follow the standard process as 
   }
 }
 ```
+
+## Using EAS Workflows with monorepos
+
+When you connect a GitHub repository to your Expo project, you can set a base directory that points to your app directory (for example, **apps/my-app**). This allows [EAS Workflows](/eas/workflows/introduction/) to trigger builds and other automated tasks for that specific app.
+
+The **.eas/workflows** directory lives in the same directory as **eas.json**, so each app in your monorepo can have its own workflows.
+
+> Learn more about [setting up EAS Workflows with monorepos](/eas/workflows/get-started/#monorepo-setup).

--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -123,14 +123,14 @@ For example, if your monorepo structure looks like this:
 
 <FileTree
   files={[
-    ['monorepo/apps/mobile-app/.eas/workflows/build-production.yml', ''],
-    ['monorepo/apps/mobile-app/eas.json', ''],
-    ['monorepo/apps/mobile-app/package.json', ''],
-    ['monorepo/apps/admin-app/.eas/workflows/deploy.yml', ''],
-    ['monorepo/apps/admin-app/eas.json', ''],
-    ['monorepo/apps/admin-app/package.json', ''],
-    ['monorepo/packages/shared/', ''],
-    ['monorepo/package.json', ''],
+    ['apps/mobile-app/.eas/workflows/build-production.yml', ''],
+    ['apps/mobile-app/eas.json', ''],
+    ['apps/mobile-app/package.json', ''],
+    ['apps/admin-app/.eas/workflows/deploy.yml', ''],
+    ['apps/admin-app/eas.json', ''],
+    ['apps/admin-app/package.json', ''],
+    ['packages/shared/', ''],
+    ['package.json', ''],
   ]}
 />
 

--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -115,6 +115,39 @@ Once you do, you can see your workflow running on your project's [workflows page
 
 </Step>
 
+## Monorepo setup
+
+The **.eas/workflows** directory lives in the same directory as **eas.json**. This allows you to have multiple Expo apps in the same monorepo, each with its own workflows.
+
+For example, if your monorepo structure looks like this:
+
+<FileTree
+  files={[
+    ['monorepo/apps/mobile-app/.eas/workflows/build-production.yml', ''],
+    ['monorepo/apps/mobile-app/eas.json', ''],
+    ['monorepo/apps/mobile-app/package.json', ''],
+    ['monorepo/apps/admin-app/.eas/workflows/deploy.yml', ''],
+    ['monorepo/apps/admin-app/eas.json', ''],
+    ['monorepo/apps/admin-app/package.json', ''],
+    ['monorepo/packages/shared/', ''],
+    ['monorepo/package.json', ''],
+  ]}
+/>
+
+Each app directory (**apps/mobile-app** and **apps/admin-app**) has its own **eas.json** and **.eas/workflows** directory.
+
+### Connect GitHub repository to a project
+
+When you connect a GitHub repository to your Expo project, you can set a base directory that points to the directory containing both **eas.json** and the **.eas** directory.
+
+To set the base directory:
+
+- Navigate to your project's [GitHub settings](https://expo.dev/accounts/%5Baccount%5D/projects/%5BprojectName%5D/github).
+- Connect your GitHub repository (if not already connected).
+- Set the base directory to the app directory. For example, **apps/mobile-app**.
+
+After setting the base directory, workflows in that app directory will trigger based on the events you configure in your workflow files. For example, you can set up a workflow to build **mobile-app** when changes are pushed to **apps/mobile-app/\*\***.
+
 ## More
 
 ### Automate workflows with GitHub events

--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -4,6 +4,7 @@ description: Learn about setting up Expo projects in a monorepo with workspaces.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
 import { Tab, Tabs } from '~/ui/components/Tabs';
 
@@ -238,10 +239,14 @@ The **.eas/workflows** directory lives in the same directory as **eas.json**. If
 
 For example:
 
-- **apps/cool-app/.eas/workflows/build.yml**
-- **apps/cool-app/eas.json**
-- **apps/another-app/.eas/workflows/deploy.yml**
-- **apps/another-app/eas.json**
+<FileTree
+  files={[
+    ['apps/cool-app/.eas/workflows/build.yml', ''],
+    ['apps/cool-app/eas.json', ''],
+    ['apps/another-app/.eas/workflows/deploy.yml', ''],
+    ['apps/another-app/eas.json', ''],
+  ]}
+/>
 
 ### Connect GitHub repository
 

--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -230,6 +230,48 @@ export default function App() {
 }
 ```
 
+## Using EAS Workflows with monorepos
+
+[EAS Workflows](/eas/workflows/introduction/) automate your CI/CD processes, such as creating builds, publishing updates, and running tests. When working with monorepos, each app can have its own workflows.
+
+The **.eas/workflows** directory lives in the same directory as **eas.json**. If you have multiple Expo apps in your monorepo, each app directory will have its own **eas.json** and **.eas/workflows** directory.
+
+For example:
+
+- **apps/cool-app/.eas/workflows/build.yml**
+- **apps/cool-app/eas.json**
+- **apps/another-app/.eas/workflows/deploy.yml**
+- **apps/another-app/eas.json**
+
+### Connect GitHub repository
+
+When you connect a GitHub repository to your Expo project on [expo.dev](https://expo.dev/), you can set a base directory. The base directory points to the directory containing both **eas.json** and the **.eas** directory.
+
+For example, if your app is in **apps/cool-app**, set the base directory to **apps/cool-app** in your project's [GitHub settings](https://expo.dev/accounts/%5Baccount%5D/projects/%5BprojectName%5D/github). Workflows in that directory will then trigger based on the events you configure.
+
+You can use the `on.push.paths` trigger to run workflows only when specific files change:
+
+```yaml .eas/workflows/build.yml
+name: Build on app changes
+
+on:
+  push:
+    branches: ['main']
+    paths:
+      - 'apps/cool-app/**'
+      - 'packages/shared/**'
+
+jobs:
+  build_android:
+    type: build
+    params:
+      platform: android
+```
+
+This workflow runs only when files in **apps/cool-app** or **packages/shared** change.
+
+> Learn more about [setting up EAS Workflows with monorepos](/eas/workflows/get-started/#monorepo-setup).
+
 ## Common issues
 
 Monorepos may cause resolution and dependency issues that a regular project won't. They require more in-depth knowledge and require specific tooling configuration. You take on increased complexity and will need to solve issues you wouldn't run into without workspaces. Here are a couple of common issues you might encounter.


### PR DESCRIPTION
# Why

https://discord.com/channels/695411232856997968/1431764277852770536

# How

Asked Claude to review our monorepo support docs and add workflows-specific information.

Is information about multiple Expo apps in the same repo helpful? Maybe that's too much (I mentioned it in the prompt)?

# Test Plan

<img width="1014" height="1126" alt="Zrzut ekranu 2025-10-30 o 11 12 16" src="https://github.com/user-attachments/assets/1df0b6d1-56dd-4e2b-b6a9-a5f627ea615c" />
<img width="1276" height="362" alt="Zrzut ekranu 2025-10-30 o 11 11 25" src="https://github.com/user-attachments/assets/180e628e-a471-4f43-a64a-a927a13dcc45" />
<img width="1268" height="1119" alt="Zrzut ekranu 2025-10-30 o 11 10 50" src="https://github.com/user-attachments/assets/dde1bc61-8925-44cc-a51f-9cd168923592" />
