### PR TITLE
[docs] Add infos about `fingerprint`'s `environment`

### DIFF
--- a/docs/pages/eas/workflows/examples/deploy-to-production.mdx
+++ b/docs/pages/eas/workflows/examples/deploy-to-production.mdx
@@ -83,6 +83,9 @@ jobs:
   fingerprint:
     name: Fingerprint
     type: fingerprint
+    # @info Use the same environment as your build profile #
+    environment: production
+    # @end #
   get_android_build:
     name: Check for existing android build
     needs: [fingerprint]

--- a/docs/pages/eas/workflows/examples/deploy-to-production.mdx
+++ b/docs/pages/eas/workflows/examples/deploy-to-production.mdx
@@ -83,9 +83,7 @@ jobs:
   fingerprint:
     name: Fingerprint
     type: fingerprint
-    # @info Use the same environment as your build profile #
     environment: production
-    # @end #
   get_android_build:
     name: Check for existing android build
     needs: [fingerprint]

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -264,12 +264,15 @@ Calculates a fingerprint of your project.
 
 > **Note:** This job type only supports [CNG (managed)](/workflow/continuous-native-generation/) workflows. If you commit your **android** or **ios** directories, the fingerprint job won't work.
 
+> **Note:** To ensure fingerprints match your builds, use the same `environment` setting as your build profile. For environment variables, we recommend using [EAS environment variables](/eas/environment-variables/) rather than the `env` field for better consistency.
+
 ### Syntax
 
 ```yaml
 jobs:
   fingerprint:
     type: fingerprint
+    environment: production # Should match your build profile
 ```
 
 #### Outputs
@@ -287,7 +290,7 @@ Here are some practical examples of using the fingerprint job:
 
 <Collapsible summary="Basic fingerprint calculation">
 
-This workflow calculates fingerprints for both Android and iOS builds in the production environment.
+This workflow calculates fingerprints for both Android and iOS builds. The `environment` should match your build profile for accurate fingerprint matching.
 
 ```yaml .eas/workflows/fingerprint-basic.yml
 name: Basic Fingerprint
@@ -296,14 +299,16 @@ jobs:
   fingerprint:
     name: Calculate Fingerprint
     type: fingerprint
+    # @info Match your build profile's environment #
     environment: production
+    # @end #
 ```
 
 </Collapsible>
 
-<Collapsible summary="Fingerprint with environment variables">
+<Collapsible summary="Fingerprint with inline environment variables">
 
-This workflow calculates fingerprints with custom environment variables that can affect the build configuration.
+If you need to pass environment variables inline, you can use the `env` field. However, we recommend using [EAS environment variables](/eas/environment-variables/) for better consistency.
 
 ```yaml .eas/workflows/fingerprint-with-env.yml
 name: Fingerprint with Environment Variables
@@ -1570,6 +1575,9 @@ jobs:
   fingerprint:
     id: fingerprint
     type: fingerprint
+    # @info Match your build profile's environment #
+    environment: production
+    # @end #
 
   android_get_build:
     needs: [fingerprint]

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -308,7 +308,7 @@ jobs:
 
 <Collapsible summary="Fingerprint with inline environment variables">
 
-> **Note:** This possible, but generally not recommended. If you depend on inline environment variables, you will need to always make sure to set the right set of environment variables to the right values in every place (build profile, fingerprint job, update job, etc.) for fingerprints to match. Instead, consider using [EAS Environment Variables](/eas/environment-variables/) instead, where you can group sets of variables into environments and reference them in the build profile and workflow jobs.
+> **Note:** If you depend on inline environment variables, you will need to always make sure to set the right set of environment variables to the right values in every place (build profile, fingerprint job, update job, and so on) for fingerprints to match. **We recommend using [EAS Environment Variables](/eas/environment-variables/) instead**, where you can group sets of variables into environments and reference them in the build profile and workflow jobs.
 
 ```yaml .eas/workflows/fingerprint-with-env.yml
 name: Fingerprint with Environment Variables

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -264,7 +264,7 @@ Calculates a fingerprint of your project.
 
 > **Note:** This job type only supports [CNG (managed)](/workflow/continuous-native-generation/) workflows. If you commit your **android** or **ios** directories, the fingerprint job won't work.
 
-> **Note:** To ensure fingerprints match your builds, use the same `environment` setting as your build profile. For environment variables, we recommend using [EAS environment variables](/eas/environment-variables/) rather than the `env` field for better consistency.
+> **Note:** To ensure fingerprints match your builds, use the same `environment` setting as your build profile. For environment variables, we recommend using [EAS environment variables](/eas/environment-variables/) rather than the [`env`](/eas/workflows/syntax/#jobsjob_idenv) field for better consistency.
 
 ### Syntax
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -308,7 +308,7 @@ jobs:
 
 <Collapsible summary="Fingerprint with inline environment variables">
 
-If you need to pass environment variables inline, you can use the `env` field. However, we recommend using [EAS environment variables](/eas/environment-variables/) for better consistency.
+> **Note:** This possible, but generally not recommended. If you depend on inline environment variables, you will need to always make sure to set the right set of environment variables to the right values in every place (build profile, fingerprint job, update job, etc.) for fingerprints to match. Instead, consider using [EAS Environment Variables](/eas/environment-variables/) instead, where you can group sets of variables into environments and reference them in the build profile and workflow jobs.
 
 ```yaml .eas/workflows/fingerprint-with-env.yml
 name: Fingerprint with Environment Variables
@@ -318,6 +318,8 @@ jobs:
     name: Calculate Fingerprint
     type: fingerprint
     environment: production
+    # Resulting environment will be a union of the "production" environment and the inline environment variables.
+    # `env` variables override environment variables of the same name from the "production" environment.
     env:
       APP_VARIANT: staging
       API_URL: https://api.staging.example.com

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -899,6 +899,7 @@ jobs:
     # @info #
     type: fingerprint
     # @end #
+    environment: production # Should match your build profile
 ```
 
 This job outputs the following properties:
@@ -909,6 +910,8 @@ This job outputs the following properties:
   "ios_fingerprint_hash": string,
 }
 ```
+
+> **Note:** For accurate fingerprint matching, ensure the fingerprint job's `environment` matches your build profile. Consider using [EAS environment variables](/eas/environment-variables/) instead of `env` for better consistency across jobs.
 
 #### `get-build`
 


### PR DESCRIPTION
# Why

Make ability / requirement to pass `environment` to `fingerprint` job more clear.

# How

Asked Claude to review all mentions of Fingerprint job and adjust the information / add a note..

# Test Plan

<img width="1267" height="594" alt="Zrzut ekranu 2025-10-30 o 22 21 47" src="https://github.com/user-attachments/assets/cc8f9337-427a-446d-b07b-6dfc1e44b369" />
<img width="989" height="1103" alt="Zrzut ekranu 2025-10-30 o 22 22 31" src="https://github.com/user-attachments/assets/d26270ed-6577-4c64-a440-e157d60d88a0" />
