### PR TITLE
[menu][Android] Start removing `DevMenuManager`

### DIFF
--- a/apps/bare-expo/App.tsx
+++ b/apps/bare-expo/App.tsx
@@ -1,6 +1,7 @@
 import { ThemeProvider } from 'ThemeProvider';
 import * as Splashscreen from 'expo-splash-screen';
 import React from 'react';
+import * as DevMenu from 'expo-dev-menu';
 
 import MainNavigator, { optionalRequire } from './MainNavigator';
 
@@ -10,6 +11,23 @@ try {
 } catch {
   // do nothing
 }
+
+DevMenu.registerDevMenuItems([
+  {
+    name: 'Action 1',
+    callback: () => {
+      console.log('Action 1 executed');
+    },
+    shouldCollapse: true,
+  },
+  {
+    name: 'Action 2',
+    callback: () => {
+      console.log('Action 2 executed');
+    },
+    shouldCollapse: false,
+  },
+]);
 
 Splashscreen.setOptions({ fade: true, duration: 800 });
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/helpers/DevLauncherReactUtils.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/helpers/DevLauncherReactUtils.kt
@@ -49,10 +49,6 @@ fun injectReactInterceptor(
 
 private fun injectDevSupportManager(reactHost: ReactHost) {
   DevLauncherDevSupportManagerSwapper().swapDevSupportManagerImpl(reactHost)
-
-  // Swapping dev support manager overrides dev menu setup.
-  // We need to reinitialize it.
-  DevMenuManager.initializeWithReactHost(reactHost)
 }
 
 fun injectDebugServerHost(

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -1,29 +1,12 @@
 package expo.modules.devmenu
 
-import android.app.Activity
-import android.util.Log
-import com.facebook.react.ReactHost
-import com.facebook.react.ReactInstanceEventListener
-import com.facebook.react.bridge.LifecycleEventListener
-import com.facebook.react.bridge.ReactContext
-import com.facebook.react.modules.core.DeviceEventManagerModule
-import expo.modules.devmenu.compose.DevMenuFragment
-import expo.modules.devmenu.compose.DevMenuAction
 import expo.modules.manifests.core.Manifest
-import java.lang.ref.WeakReference
 
 const val DEV_MENU_TAG = "ExpoDevMenu"
 
-object DevMenuManager : LifecycleEventListener {
-  data class KeyCommand(val code: Int, val withShift: Boolean = false)
-
-  data class Callback(val name: String, val shouldCollapse: Boolean)
-
-  private var preferences: DevMenuPreferencesHandle? = null
-  internal var delegate: DevMenuDefaultDelegate? = null
-  private var shouldLaunchDevMenuOnStart: Boolean = false
-  private var currentReactInstance: WeakReference<ReactHost?> = WeakReference(null)
-  private var canLaunchDevMenuOnStart = true
+object DevMenuManager {
+  var canLaunchDevMenuOnStart = true
+    private set
 
   private var goToHomeAction: () -> Unit = {}
 
@@ -31,170 +14,25 @@ object DevMenuManager : LifecycleEventListener {
   var currentManifestURL: String? = null
   var launchUrl: String? = null
 
-  //region helpers
-
-  fun getReactHost(): ReactHost? {
-    return delegate?.reactHost()
-  }
-
-  private val delegateReactContext: ReactContext?
-    get() = delegate?.reactHost()?.currentReactContext
-
-  private val delegateActivity: Activity?
-    get() = delegateReactContext?.currentActivity
-
-  //endregion
-
-  //region init
-
-  private fun setUpReactInstance(reactHost: ReactHost) {
-    currentReactInstance = WeakReference(reactHost)
-
-    if (reactHost.currentReactContext == null) {
-      reactHost.addReactInstanceEventListener(object : ReactInstanceEventListener {
-        override fun onReactContextInitialized(context: ReactContext) {
-          if (currentReactInstance.get() === reactHost) {
-            handleLoadedDelegateContext(context)
-          }
-          reactHost.removeReactInstanceEventListener(this)
-        }
-      })
-    } else {
-      handleLoadedDelegateContext(reactHost.currentReactContext!!)
-    }
-  }
-
   private fun hasDisableOnboardingQueryParam(urlString: String): Boolean {
     return urlString.contains("disableOnboarding=1")
   }
 
-  /**
-   * Starts dev menu if wasn't initialized, prepares for opening menu at launch if needed and gets [DevMenuPreferencesHandler].
-   * We can't open dev menu here, cause then the app will crash - two react instance try to render.
-   * So we wait until the [reactContext] activity will be ready.
-   */
-  private fun handleLoadedDelegateContext(reactContext: ReactContext) {
-    Log.i(DEV_MENU_TAG, "Delegate's context was loaded.")
-
-    preferences = DevMenuPreferencesHandle.also {
-      if (hasDisableOnboardingQueryParam(currentManifestURL.orEmpty()) ||
-        hasDisableOnboardingQueryParam(launchUrl.orEmpty())
-      ) {
-        it.isOnboardingFinished = true
-      }
-    }.also {
-      shouldLaunchDevMenuOnStart =
-        canLaunchDevMenuOnStart && (it.showsAtLaunch || !it.isOnboardingFinished)
-      if (shouldLaunchDevMenuOnStart) {
-        reactContext.addLifecycleEventListener(this)
-      }
-    }
-  }
-
-  // captures any callbacks that are registered via the `registerDevMenuItems` module method
-  // it is set and unset by the public facing `DevMenuModule`
-  // when the DevMenuModule instance is unloaded (e.g between app loads) the callback list is reset to an empty list
-  var registeredCallbacks = mutableListOf<Callback>()
-
-  //endregion
-
-  //region delegate's LifecycleEventListener
-
-  override fun onHostResume() {
-    delegateReactContext?.removeLifecycleEventListener(this)
-
-    if (shouldLaunchDevMenuOnStart) {
-      shouldLaunchDevMenuOnStart = false
-      delegateActivity?.let { activity ->
-        activity.runOnUiThread {
-          openMenu(activity)
-        }
-      }
-    }
-  }
-
-  override fun onHostPause() = Unit
-
-  override fun onHostDestroy() = Unit
-
-  //endregion
-
-  fun updateStateIfNeeded(devMenuFragment: DevMenuFragment) {
-    val currentReactInstance = currentReactInstance.get() ?: return
-    val appInfo = AppInfo.getAppInfo(currentReactInstance)
-    devMenuFragment.viewModel.updateAppInfo(appInfo)
-    devMenuFragment.viewModel.updateCustomItems(registeredCallbacks)
-  }
-
-  inline fun withBindingView(
-    activity: Activity,
-    crossinline action: (DevMenuFragment) -> Unit
-  ) {
-    activity.runOnUiThread {
-      val fragment = DevMenuFragment.fragment { activity }.value
-      if (fragment == null) {
-        Log.e(DEV_MENU_TAG, "BindingView not found in the activity hierarchy.")
-        return@runOnUiThread
-      }
-
-      updateStateIfNeeded(fragment)
-      action(fragment)
-    }
+  fun shouldDisableOnboarding(): Boolean {
+    return hasDisableOnboardingQueryParam(currentManifestURL.orEmpty()) ||
+      hasDisableOnboardingQueryParam(launchUrl.orEmpty())
   }
 
   fun goToHome() {
     goToHomeAction()
   }
 
-  fun openMenu(activity: Activity) =
-    withBindingView(activity) { bindingView ->
-      bindingView.viewModel.onAction(DevMenuAction.Open)
-    }
-
-  fun setDelegate(newDelegate: DevMenuDefaultDelegate) {
-    Log.i(DEV_MENU_TAG, "Set new dev-menu delegate: ${newDelegate.javaClass}")
-    // removes event listener for old delegate
-    delegateReactContext?.removeLifecycleEventListener(this)
-
-    delegate = newDelegate.apply {
-      setUpReactInstance(this.reactHost())
-    }
-  }
-
   fun setGoToHomeAction(action: () -> Unit) {
     goToHomeAction = action
-  }
-
-  fun initializeWithReactHost(reactHost: ReactHost) {
-    setDelegate(DevMenuDefaultDelegate(reactHost))
-  }
-
-  fun sendEventToDelegateBridge(eventName: String, eventData: Any?) {
-    delegateReactContext
-      ?.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
-      ?.emit(eventName, eventData)
-  }
-
-  fun isInitialized(): Boolean {
-    return delegate !== null
   }
 
   fun setCanLaunchDevMenuOnStart(canLaunchDevMenuOnStart: Boolean) {
     this.canLaunchDevMenuOnStart = canLaunchDevMenuOnStart
   }
-
-  fun synchronizeDelegate() {
-    val newReactInstance = requireNotNull(delegate).reactHost()
-    if (newReactInstance != currentReactInstance.get()) {
-      setUpReactInstance(newReactInstance)
-    }
-  }
-
-  fun refreshCustomItems() {
-    delegateActivity?.let { activity ->
-      withBindingView(activity) { bindingView ->
-        bindingView.viewModel.updateCustomItems(registeredCallbacks)
-      }
-    }
-  }
 }
+

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -35,4 +35,3 @@ object DevMenuManager {
     this.canLaunchDevMenuOnStart = canLaunchDevMenuOnStart
   }
 }
-

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuPackage.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuPackage.kt
@@ -3,19 +3,16 @@ package expo.modules.devmenu
 import android.app.Activity
 import android.app.Application
 import android.content.Context
-import android.os.Bundle
 import android.view.KeyEvent
 import android.view.ViewGroup
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
-import com.facebook.react.ReactApplication
 import com.facebook.react.ReactHost
 import com.facebook.react.devsupport.DevSupportManagerBase
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import expo.modules.core.interfaces.ApplicationLifecycleListener
 import expo.modules.core.interfaces.Package
 import expo.modules.core.interfaces.ReactActivityHandler
-import expo.modules.core.interfaces.ReactActivityLifecycleListener
 import expo.modules.core.interfaces.ReactNativeHostHandler
 import expo.modules.devmenu.compose.DevMenuFragment
 import expo.modules.devmenu.react.DevMenuInstaller
@@ -46,28 +43,6 @@ class DevMenuPackage : Package {
           }
 
           DevMenuInstaller.install(devSupportManager)
-        }
-      }
-    )
-  }
-
-  override fun createReactActivityLifecycleListeners(activityContext: Context?): List<ReactActivityLifecycleListener> {
-    if (!BuildConfig.DEBUG) {
-      return emptyList()
-    }
-
-    return listOf(
-      object : ReactActivityLifecycleListener {
-        override fun onCreate(activity: Activity, savedInstanceState: Bundle?) {
-          if (!DevMenuManager.isInitialized()) {
-            val reactHost = (activity.application as ReactApplication).reactHost
-            checkNotNull(reactHost) {
-              "DevMenuManager.initializeWithReactHost() was called before reactHost was initialized"
-            }
-            DevMenuManager.initializeWithReactHost(reactHost)
-          } else {
-            DevMenuManager.synchronizeDelegate()
-          }
         }
       }
     )

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/DevMenuAction.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/DevMenuAction.kt
@@ -14,9 +14,8 @@ sealed class DevMenuAction(val shouldCloseMenu: Boolean = false) {
   object OpenReactNativeDevMenu : DevMenuAction(shouldCloseMenu = true)
   object FinishOnboarding : DevMenuAction(shouldCloseMenu = false)
   data class TriggerCustomCallback(
-    val name: String,
-    val shouldCollapse: Boolean
-  ) : DevMenuAction(shouldCloseMenu = shouldCollapse)
+    val item: DevMenuState.CustomItem
+  ) : DevMenuAction(shouldCloseMenu = item.shouldCollapse)
 }
 
 typealias DevMenuActionHandler = (DevMenuAction) -> Unit

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/DevMenuFragment.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/DevMenuFragment.kt
@@ -18,6 +18,8 @@ import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
 import com.facebook.react.ReactHost
+import com.facebook.react.ReactInstanceEventListener
+import com.facebook.react.bridge.ReactContext
 import expo.modules.devmenu.AppInfo
 import expo.modules.devmenu.DevMenuManager
 import expo.modules.devmenu.DevMenuPreferencesHandle
@@ -42,13 +44,40 @@ class DevMenuFragment(
   private val threeFingerLongPressDetector = ThreeFingerLongPressDetector(::onThreeFingerLongPressDetected)
   private val shakeDetector = ShakeDetector(this::onShakeDetected)
 
+  private val reactHost: ReactHost?
+    get() = reactHostHolder.get()
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    if (DevMenuManager.shouldDisableOnboarding()) {
+      DevMenuPreferencesHandle.isOnboardingFinished = true
+    }
+
+    val shouldShowAtLaunch = DevMenuManager.canLaunchDevMenuOnStart &&
+      (DevMenuPreferencesHandle.showsAtLaunch || !DevMenuPreferencesHandle.isOnboardingFinished)
+    if (shouldShowAtLaunch) {
+      val onReactContext = object : ReactInstanceEventListener {
+        override fun onReactContextInitialized(context: ReactContext) {
+          val boundedContext = reactHost?.currentReactContext
+          // We check if that listener is called for the same context that is currently set in the host.
+          if (boundedContext != null && boundedContext == context) {
+            viewModel.onAction(DevMenuAction.Open)
+          }
+          reactHost?.removeReactInstanceEventListener(this)
+        }
+      }
+
+      reactHost?.addReactInstanceEventListener(onReactContext)
+    }
+  }
+
   override fun onStart() {
     super.onStart()
 
-    val reactHost = reactHostHolder.get()
-    if (reactHost != null) {
+    reactHost?.let {
       viewModel.updateAppInfo(
-        AppInfo.getAppInfo(reactHost)
+        AppInfo.getAppInfo(it)
       )
     }
 
@@ -98,12 +127,12 @@ class DevMenuFragment(
       return false
     }
 
-    val keyCommand = DevMenuManager.KeyCommand(
+    val keyCommand = KeyCommand(
       code = keyCode,
       withShift = event.modifiers and KeyEvent.META_SHIFT_MASK > 0
     )
 
-    if (keyCommand == DevMenuManager.KeyCommand(KeyEvent.KEYCODE_MENU)) {
+    if (keyCommand == KeyCommand(KeyEvent.KEYCODE_MENU)) {
       viewModel.onAction(DevMenuAction.Toggle)
       return true
     }
@@ -117,9 +146,9 @@ class DevMenuFragment(
     )
 
     when (keyCommand) {
-      DevMenuManager.KeyCommand(KeyEvent.KEYCODE_R) -> devToolsDelegate.reload()
-      DevMenuManager.KeyCommand(KeyEvent.KEYCODE_P) -> devToolsDelegate.togglePerformanceMonitor()
-      DevMenuManager.KeyCommand(KeyEvent.KEYCODE_I) -> devToolsDelegate.toggleElementInspector()
+      KeyCommand(KeyEvent.KEYCODE_R) -> devToolsDelegate.reload()
+      KeyCommand(KeyEvent.KEYCODE_P) -> devToolsDelegate.togglePerformanceMonitor()
+      KeyCommand(KeyEvent.KEYCODE_I) -> devToolsDelegate.toggleElementInspector()
       else -> return false
     }
 
@@ -222,5 +251,7 @@ class DevMenuFragment(
 
       operator fun getValue(thisRef: Any?, property: KProperty<*>): T? = value
     }
+
+    private  data class KeyCommand(val code: Int, val withShift: Boolean = false)
   }
 }

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/DevMenuState.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/DevMenuState.kt
@@ -15,7 +15,8 @@ data class DevMenuState(
 ) {
   data class CustomItem(
     val name: String,
-    val shouldCollapse: Boolean
+    val shouldCollapse: Boolean,
+    internal val fn: () -> Unit
   )
 
   data class AppInfo(

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/DevMenuViewModel.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/DevMenuViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.ViewModelProvider
 import com.facebook.react.ReactHost
 import expo.modules.devmenu.DevMenuDevSettings
 import expo.modules.devmenu.DevMenuManager
-import expo.modules.devmenu.DevMenuManager.getReactHost
 import expo.modules.devmenu.DevMenuPreferencesHandle
 import expo.modules.devmenu.DevToolsSettings
 import expo.modules.devmenu.devtools.DevMenuDevToolsDelegate
@@ -109,7 +108,7 @@ class DevMenuViewModel(
       DevMenuAction.GoHome -> DevMenuManager.goToHome()
       DevMenuAction.TogglePerformanceMonitor -> devToolsDelegate?.togglePerformanceMonitor()
       DevMenuAction.OpenJSDebugger -> devToolsDelegate?.openJSInspector()
-      DevMenuAction.OpenReactNativeDevMenu -> getReactHost()?.devSupportManager?.showDevOptionsDialog()
+      DevMenuAction.OpenReactNativeDevMenu -> reactHost?.devSupportManager?.showDevOptionsDialog()
       DevMenuAction.ToggleElementInspector -> devToolsDelegate?.toggleElementInspector()
       is DevMenuAction.ToggleFastRefresh -> toggleFastRefresh()
       is DevMenuAction.ToggleFab -> toggleFab()

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/ui/CustomItemsSection.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/ui/CustomItemsSection.kt
@@ -1,11 +1,13 @@
 package expo.modules.devmenu.compose.ui
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
 import expo.modules.devmenu.compose.DevMenuState
 import expo.modules.devmenu.compose.newtheme.NewAppTheme
+import expo.modules.devmenu.compose.primitives.Divider
 import expo.modules.devmenu.compose.primitives.NewText
+import expo.modules.devmenu.compose.primitives.RoundedSurface
 import expo.modules.devmenu.compose.primitives.Spacer
 
 @Composable
@@ -17,14 +19,21 @@ fun CustomItemsSection(
 
   Spacer(NewAppTheme.spacing.`3`)
 
-  Column(verticalArrangement = Arrangement.spacedBy(NewAppTheme.spacing.`2`)) {
-    items.forEach { item ->
-      NewMenuButton(
-        content = {
-          NewText(text = item.name)
-        },
-        onClick = { onItemClick(item) }
-      )
+  RoundedSurface {
+    Column {
+      items.withIndex().forEach { (index, item) ->
+        NewMenuButton(
+          withSurface = false,
+          content = {
+            NewText(text = item.name)
+          },
+          onClick = { onItemClick(item) }
+        )
+
+        if (index < items.size - 1) {
+          Divider(thickness = 0.5.dp)
+        }
+      }
     }
   }
 }

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/ui/DevMenuScreen.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/ui/DevMenuScreen.kt
@@ -66,7 +66,7 @@ fun DevMenuScreen(
       CustomItemsSection(
         items = customItems,
         onItemClick = { item ->
-          onAction(DevMenuAction.TriggerCustomCallback(item.name, item.shouldCollapse))
+          onAction(DevMenuAction.TriggerCustomCallback(item))
         }
       )
 

--- a/packages/expo-dev-menu/android/src/release/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/release/java/expo/modules/devmenu/DevMenuManager.kt
@@ -1,95 +1,26 @@
 package expo.modules.devmenu
 
-import android.app.Activity
-import android.content.Context
-import android.os.Bundle
-import com.facebook.react.ReactHost
-import expo.modules.devmenu.api.DevMenuMetroClient
 import expo.modules.manifests.core.Manifest
-import kotlinx.coroutines.CoroutineScope
 
 const val DEV_MENU_TAG = "[disabled] ExpoDevMenu"
 
 private const val DEV_MENU_IS_NOT_AVAILABLE = "DevMenu isn't available in release builds"
 
 object DevMenuManager {
-  data class KeyCommand(val code: Int, val withShift: Boolean = false)
+  var canLaunchDevMenuOnStart = true
+    private set
 
-  internal var delegate: DevMenuDefaultDelegate? = null
+  private var goToHomeAction: () -> Unit = {}
 
   var currentManifest: Manifest? = null
   var currentManifestURL: String? = null
+  var launchUrl: String? = null
 
-  data class Callback(val name: String, val shouldCollapse: Boolean)
-
-  var registeredCallbacks = arrayListOf<Callback>()
-
-  fun getReactHost(): ReactHost? {
-    return null
-  }
-
-  fun getAppInfo(): Bundle {
+  private fun hasDisableOnboardingQueryParam(urlString: String): Boolean {
     throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
   }
 
-  fun getDevSettings(): DevToolsSettings {
-    throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
-  }
-
-  val metroClient: DevMenuMetroClient by lazy {
-    throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
-  }
-
-  fun openMenu(activity: Activity) {
-    throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
-  }
-
-  fun closeMenu() {
-    throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
-  }
-
-  fun hideMenu() {
-    throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
-  }
-
-  fun toggleMenu(activity: Activity) {
-    throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
-  }
-
-  fun setDelegate(newDelegate: DevMenuDefaultDelegate) = Unit
-
-  fun initializeWithReactHost(reactHost: ReactHost) = Unit
-
-  fun getSettings(): DevMenuPreferencesHandle? {
-    throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
-  }
-
-  fun getMenuPreferences(): Bundle {
-    throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
-  }
-
-  fun synchronizeDelegate() = Unit
-
-  fun setCanLaunchDevMenuOnStart(canLaunchDevMenuOnStart: Boolean) {
-    throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
-  }
-
-  fun sendEventToDelegateBridge(eventName: String, eventData: Any?) {
-    throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
-  }
-
-  fun isInitialized(): Boolean {
-    throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
-  }
-
-  fun loadFonts(context: Context) {
-    throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
-  }
-
-  val coroutineScope: CoroutineScope
-    get() = throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
-
-  fun reload() {
+  fun shouldDisableOnboarding(): Boolean {
     throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
   }
 
@@ -97,27 +28,11 @@ object DevMenuManager {
     throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
   }
 
-  fun togglePerformanceMonitor() {
+  fun setGoToHomeAction(action: () -> Unit) {
     throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
   }
 
-  fun toggleInspector() {
-    throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
-  }
-
-  fun openJSInspector() {
-    throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
-  }
-
-  fun toggleFastRefresh() {
-    throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
-  }
-
-  fun toggleFab() {
-    throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
-  }
-
-  fun refreshCustomItems() {
+  fun setCanLaunchDevMenuOnStart(canLaunchDevMenuOnStart: Boolean) {
     throw IllegalStateException(DEV_MENU_IS_NOT_AVAILABLE)
   }
 }


### PR DESCRIPTION
# Why

Starts removing `DevMenuManager` to simplify integration between `dev-menu` and the application.
I want to remove all usages of singletons, making the API surface predictable and minimal. 

# How

- Moved "on start" logic to the fragment
- Handled custom menu items without passing them via the manager 


# Test Plan

- bare-expo ✅ 
