### PR TITLE
[android][video] Fix remote media controls

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [Android] Fix the `player` prop of the `VideoView` not working when a player is re-assigned after being replaced by a different player earlier. ([#40709](https://github.com/expo/expo/pull/40709) by [@behenate](https://github.com/behenate))
 - [Android] Fix surface view not showing when changing the `player` prop. ([#40817](https://github.com/expo/expo/pull/40817) by [@behenate](https://github.com/behenate))
 - [Android] Emit `onFirstFrameRender` when player is moved to a new `VideoView` and renders a frame. ([#40854](https://github.com/expo/expo/pull/40854) by [@behenate](https://github.com/behenate))
+- [Android] Fix media controls (e.g. bluetooth) not working when `ExpoVideoPlaybackService` is not registered. ([#40728](https://github.com/expo/expo/pull/40728) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/playbackService/ExpoVideoPlaybackService.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/playbackService/ExpoVideoPlaybackService.kt
@@ -85,6 +85,10 @@ class ExpoVideoPlaybackService : MediaSessionService() {
         .setCustomLayout(ImmutableList.of(seekBackwardButton, seekForwardButton))
         .build()
 
+      // Replace the basic media session with a session connected to our playback service.
+      videoPlayer.mediaSession.release()
+      videoPlayer.mediaSession = mediaSession
+
       mediaSessions[player] = mediaSession
       addSession(mediaSession)
       setShowNotification(videoPlayer.showNowPlayingNotification, player)

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
@@ -21,6 +21,7 @@ import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
+import androidx.media3.session.MediaSession
 import androidx.media3.ui.PlayerView
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.Exceptions
@@ -44,6 +45,7 @@ import expo.modules.video.records.TimeUpdate
 import expo.modules.video.records.VideoSource
 import expo.modules.video.utils.MutableWeakReference
 import expo.modules.video.records.VideoTrack
+import expo.modules.video.utils.buildBasicMediaSession
 import kotlinx.coroutines.launch
 import java.io.FileInputStream
 import java.lang.ref.WeakReference
@@ -73,6 +75,7 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
 
   internal lateinit var firstFrameEventGenerator: FirstFrameEventGenerator
   val serviceConnection = PlaybackServiceConnection(WeakReference(this), appContext)
+  var mediaSession: MediaSession = buildBasicMediaSession(context, player)
   val intervalUpdateClock = IntervalUpdateClock(this)
 
   var playing by IgnoreSameSet(false) { new, old ->
@@ -337,6 +340,8 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
       appContext?.reactContext?.unbindService(serviceConnection)
     }
     serviceConnection.playbackServiceBinder?.service?.unregisterPlayer(player)
+    mediaSession.release()
+
     VideoManager.unregisterVideoPlayer(this@VideoPlayer)
 
     appContext?.mainQueue?.launch {

--- a/packages/expo-video/android/src/main/java/expo/modules/video/utils/MediaSessionUtils.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/utils/MediaSessionUtils.kt
@@ -1,0 +1,14 @@
+package expo.modules.video.utils
+
+import android.content.Context
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.session.MediaSession
+
+/**
+ * Creates a basic foreground media session, for receiving commands like play/pause from bluetooth devices.
+ */
+internal fun buildBasicMediaSession(context: Context, player: ExoPlayer): MediaSession {
+  return MediaSession.Builder(context, player)
+    .setId("ExpoVideoBasicMediaSession_${player.hashCode()}")
+    .build()
+}


### PR DESCRIPTION
# Why

fixes https://github.com/expo/expo/issues/39450

With changes to `ExpoVideoPlaybackService` registration introduced in SDK 54, the media controls (e.g. bluetooth play/pause) have stopped working when the player is not bound to the service.

# How

Added a basic MediaSession to every player so that it handles media controls events.

# Test Plan

Tested in BareExpo on Android.

