### PR TITLE
fix(doctor): Invoke Expo CLI without `npx`

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix dependecy check failure when using EXPO_DEBUG=1 ([#39929](https://github.com/expo/expo/pull/39929) by [@betomoedano](https://github.com/betomoedano))
+- Circumvent `npx expo` Expo CLI invocation to avoid debug warnings from npm polluting standard output ([#40731](https://github.com/expo/expo/pull/40731) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/expo-doctor/src/checks/InstalledDependencyVersionCheck.ts
+++ b/packages/expo-doctor/src/checks/InstalledDependencyVersionCheck.ts
@@ -1,4 +1,5 @@
 import spawnAsync, { SpawnResult } from '@expo/spawn-async';
+import resolveFrom from 'resolve-from';
 import semver from 'semver';
 
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
@@ -7,6 +8,25 @@ import { parseInstallCheckOutput } from '../utils/parseInstallCheckOutput';
 
 function isSpawnResult(result: any): result is SpawnResult {
   return 'stderr' in result && 'stdout' in result && 'status' in result;
+}
+
+async function spawnExpoCLI(
+  projectRoot: string,
+  args: string[],
+  options: Omit<spawnAsync.SpawnOptions, 'cwd'>
+) {
+  const expoCliPath = resolveFrom.silent(projectRoot, 'expo/bin/cli');
+  if (expoCliPath) {
+    return await spawnAsync('node', [expoCliPath, ...args], {
+      cwd: projectRoot,
+      ...options,
+    });
+  } else {
+    return await spawnAsync('npx', ['expo', ...args], {
+      cwd: projectRoot,
+      ...options,
+    });
+  }
 }
 
 export class InstalledDependencyVersionCheck implements DoctorCheck {
@@ -38,9 +58,8 @@ export class InstalledDependencyVersionCheck implements DoctorCheck {
       let commandResult: SpawnResult;
 
       try {
-        commandResult = await spawnAsync('npx', ['expo', 'install', '--check', '--json'], {
+        commandResult = await spawnExpoCLI(projectRoot, ['install', '--check', '--json'], {
           stdio: 'pipe',
-          cwd: projectRoot,
           env: { ...process.env, CI: '1', EXPO_DEBUG: '0' },
         });
       } catch (error: any) {
@@ -59,9 +78,8 @@ export class InstalledDependencyVersionCheck implements DoctorCheck {
       // SDK versions <54 don't support --json output
       // In the future, we should remove this and use the --json output above
       try {
-        await spawnAsync('npx', ['expo', 'install', '--check'], {
+        await spawnExpoCLI(projectRoot, ['install', '--check'], {
           stdio: 'pipe',
-          cwd: projectRoot,
           env: { ...process.env, CI: '1', EXPO_DEBUG: '0' },
         });
       } catch (error: any) {


### PR DESCRIPTION
Resolves #40718
Related #39929

# Why

Invoking `npx expo` works, mostly, but isn't desirable because `npx` (in some versions and circumstances) seems to pollute the standard output with its own debug/warning messages. We rely on the `--json` output being clean, but we also don't need to take the launch time penalty that `npx` introduces.

# How

- Default to `resolveFrom.silent('expo/bin/cli')` invoked with node and fall back to `npx expo` instead

> [!NOTE]
> This is a pattern we probably want to implement in more places where we invoke the Expo CLI programmatically. We're not very consistent about this. This could also rely on `require.resolve` checks or another way of invoking that we could try to extract to a package

# Test Plan

- Doesn't impact testing flow, since it's functionally equivalent
- Manually tested by invoking `expo-doctor` (and logging the resolved script path)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
