### PR TITLE
[e2e] confirm app open on iOS before running tests

### DIFF
--- a/apps/bare-expo/e2e/_nested-flows/confirm-app-open.yaml
+++ b/apps/bare-expo/e2e/_nested-flows/confirm-app-open.yaml
@@ -1,0 +1,9 @@
+appId: dev.expo.Payments
+jsEngine: graaljs
+---
+# Run once to approve the first time deep linking prompt on iOS
+# This runs before all tests (only on iOS), as some tests fail because the prompt is not confirmed
+- openLink: bareexpo://test-suite/run
+- tapOn:
+    text: 'Open'
+    optional: false

--- a/apps/bare-expo/e2e/expo-video/test.yaml
+++ b/apps/bare-expo/e2e/expo-video/test.yaml
@@ -1,4 +1,5 @@
 appId: dev.expo.Payments
+jsEngine: graaljs
 ---
 # when devving, start from different screen so state is reset
 #- openLink: bareexpo://components

--- a/apps/bare-expo/scripts/lib/e2e-common.ts
+++ b/apps/bare-expo/scripts/lib/e2e-common.ts
@@ -8,6 +8,7 @@ const MAESTRO_CLI_NO_ANALYTICS = '1';
 export const MAESTRO_ENV_VARS = {
   MAESTRO_DRIVER_STARTUP_TIMEOUT,
   MAESTRO_CLI_NO_ANALYTICS,
+  MAESTRO_USE_GRAALJS: 'true',
 };
 
 export type StartMode = 'BUILD' | 'TEST' | 'BUILD_AND_TEST';
@@ -45,6 +46,7 @@ export async function createMaestroFlowAsync({
   const contents = [
     `\
 appId: ${appId}
+jsEngine: graaljs
 ---
 - clearState
 `,
@@ -182,6 +184,9 @@ const getCustomMaestroFlowsAsync = async (
     ignore,
   });
 
+  if (platform === 'ios') {
+    yamlFiles.unshift('_nested-flows/confirm-app-open.yaml');
+  }
   console.log(`detected maestro files for ${platform}:`, yamlFiles);
   return yamlFiles;
 };


### PR DESCRIPTION
# Why

Try to improve Maestro E2E testing reliability by adding a flow to handle iOS deep linking prompts. I saw some flows where the button was displayed but not pressed. Also it makes the logs a little more readable, as a lot of logging related to simulator start is hidden in the first ::group::.

# How

- Created a new nested flow `confirm-app-open.yaml` that approves the first-time deep linking prompt on iOS

# Test Plan

- green CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)