### PR TITLE
fix(log-box): restore backdrop blur on Web

### DIFF
--- a/packages/@expo/log-box/CHANGELOG.md
+++ b/packages/@expo/log-box/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix missing backdrop blur on Web
+
 ### 💡 Others
 
 ### ⚠️ Notices

--- a/packages/@expo/log-box/CHANGELOG.md
+++ b/packages/@expo/log-box/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix missing backdrop blur on Web
+- Fix missing backdrop blur on Web ([#40737](https://github.com/expo/expo/pull/40737) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 
 ### 💡 Others
 

--- a/packages/@expo/log-box/src/overlay/Overlay.tsx
+++ b/packages/@expo/log-box/src/overlay/Overlay.tsx
@@ -67,7 +67,7 @@ function LogBoxInspector({
 
   const onMinimize = useCallback(
     (cb?: () => void): void => {
-      if (['ios', 'android'].includes(process.env.EXPO_DOM_HOST_OS)) {
+      if (['ios', 'android'].includes(process.env.EXPO_DOM_HOST_OS ?? '')) {
         onMinimizeAction?.();
         cb?.();
       } else {
@@ -86,14 +86,14 @@ function LogBoxInspector({
         styles.overlay,
         process.env.EXPO_DOM_HOST_OS === 'ios' ? styles.overlayIos : null,
         process.env.EXPO_DOM_HOST_OS === 'android' ? styles.overlayAndroid : null,
-        process.env.EXPO_DOM_HOST_OS === 'web' ? styles.overlayWeb : null,
+        process.env.EXPO_DOM_HOST_OS === undefined ? styles.overlayWeb : null,
       ]
         .filter(Boolean)
         .join(' ')}>
       <div
         data-expo-log-backdrop="true"
         className={
-          process.env.EXPO_DOM_HOST_OS === 'web'
+          process.env.EXPO_DOM_HOST_OS === undefined
             ? `${styles.bg} ${closing ? styles.bgExit : ''}`
             : undefined
         }


### PR DESCRIPTION
# Before

<img height="412" alt="Screenshot 2025-10-30 at 19 48 15" src="https://github.com/user-attachments/assets/cd8fa12c-2e9f-4c0a-9391-fa54a0f31992" />

# After

<img height="412" alt="Screenshot 2025-10-30 at 19 48 02" src="https://github.com/user-attachments/assets/a09ceb56-b351-4d8e-9b16-c3258e10f551" />


# How

<!--
How did you build this feature or fix this bug and why?
-->

`EXPO_DOM_HOST_OS === undefined` means we are not in Dom Component as we don't have a host os, we are directly on the web.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
