### PR TITLE
SDK 53 - Set AppContext runtime on JS thread, not main thread

### DIFF
--- a/packages/expo-modules-core/ios/Core/ExpoBridgeModule.mm
+++ b/packages/expo-modules-core/ios/Core/ExpoBridgeModule.mm
@@ -46,7 +46,9 @@ RCT_EXPORT_MODULE(ExpoModulesCore);
   _appContext.reactBridge = bridge;
 
 #if !__has_include(<ReactCommon/RCTRuntimeExecutor.h>)
-  _appContext._runtime = [EXJavaScriptRuntimeManager runtimeFromBridge:bridge];
+  [bridge dispatchBlock:^{
+      _appContext._runtime = [EXJavaScriptRuntimeManager runtimeFromBridge:bridge];
+    } queue:RCTJSThread];
 #endif // React Native <0.74
 }
 


### PR DESCRIPTION
Related to https://github.com/expo/expo/issues/40736

This was deferred to the JS thread previously (At least Expo 50), but was lost along the way.  

We began noticing crashes on both the main thread and JS thread with a recent ugrade.

The common code path for the crash was ExpoBridgeModule initializing the AppContext runtime on the main thread as the JS thread was also mutating state.  

Moving this back to the JS thread should prevent any multithreading issues again.