### PR TITLE
[docs] [eas-update] Fix code signing certificate .gitignore issue that causes build failures

### DIFF
--- a/docs/pages/eas-update/code-signing.mdx
+++ b/docs/pages/eas-update/code-signing.mdx
@@ -36,6 +36,34 @@ This command generated a key pair along with a code signing certificate to be in
 - `../keys/public-key.pem`: the public key of the key pair.
 - `certs/certificate.pem`: the code signing certificate configured to be valid for 10 years. This file should be added to source control (if applicable).
 
+<Collapsible summary="Important: File handling and .gitignore configuration">
+
+**Certificate vs Private Key Handling:**
+
+- **Certificate file (`certs/certificate.pem`)**: **MUST** be committed to source control and included in your app builds. This file is not sensitive and is required for signature verification.
+
+- **Private key file (`../keys/private-key.pem`)**: **MUST NOT** be committed to source control. Keep this file secure and private (use KMS, password manager, etc.).
+
+**Common .gitignore Issue:**
+
+Projects created with `create-expo-app` include `*.pem` in `.gitignore` by default, which will prevent the certificate from being included in builds. This causes build errors like:
+
+```
+Error: File not found at `updates.codeSigningCertificate` path: /path/to/certs/certificate.pem
+```
+
+**Solution:** Update your `.gitignore` to allow the certificate while still protecting private keys:
+
+```gitignore
+# Ignore all .pem files except certificates
+*.pem
+!certs/certificate.pem
+```
+
+If you encounter build issues, see the [troubleshooting section](#troubleshooting) for detailed solutions.
+
+</Collapsible>
+
 - The generated private key must be kept private and secure. The command above suggests generating and storing these keys in a directory outside of your source control to ensure they are not accidentally checked into source control. We recommend storing the private key in the same way you would store other sensitive information (KMS, password manager, and so on), and how you store it will vary the steps needed to publish an update in step (3).
 - The public key may be stored alongside the private key, but isn't sensitive.
 - The certificate should be included in the project (checked into source control). It contains the public key and a method for verifying code signatures. When a signed update is downloaded, the update's signature is verified using this certificate.
@@ -79,6 +107,8 @@ After running the above command, your **app.json** will include additional confi
   }
 }
 ```
+
+> **warning** Make sure that `certs/certificate.pem` is not ignored by your `.gitignore` file. If you encounter build errors about the certificate file not being found, check the [troubleshooting section](#troubleshooting) for solutions.
 
 </Collapsible>
 
@@ -195,3 +225,53 @@ The process of removing code signing from an app is similar to [key rotation](#k
 1. Backup the old key and certificate that were generated in step (1) above.
 2. Remove the `updates.codeSigningMetadata` field from your app config (**app.json**).
 3. The new certificate-less app is a new distinct runtime, so a new runtime version should be set for builds to ensure that only unsigned updates run in the new build.
+
+## Troubleshooting
+
+### Certificate file not found during build
+
+If you encounter an error like:
+
+```
+Error: [android.manifest]: withAndroidManifestBaseMod: File not found at `updates.codeSigningCertificate` path: /path/to/certs/certificate.pem
+```
+
+This typically occurs when the certificate file is being ignored by `.gitignore`. 
+
+**Common causes:**
+- Projects created with `create-expo-app` include `*.pem` in `.gitignore` by default
+- Custom `.gitignore` rules that exclude certificate files
+- Certificate file not committed to source control
+
+**Solutions:**
+1. **Check your `.gitignore` file** and ensure `certs/certificate.pem` is not being ignored. If you have a rule like `*.pem`, you can add an exception:
+   ```gitignore
+   # Ignore all .pem files except certificates
+   *.pem
+   !certs/certificate.pem
+   ```
+
+2. **Verify the file exists** in your repository by running:
+   ```bash
+   git ls-files | grep certificate.pem
+   ```
+   If the command returns no results, the file is not tracked by git.
+
+3. **Force add the certificate** if it's being ignored:
+   ```bash
+   git add -f certs/certificate.pem
+   git commit -m "Add code signing certificate"
+   ```
+
+4. **Check the file path** in your **app.json** matches the actual file location:
+   ```json
+   {
+     "expo": {
+       "updates": {
+         "codeSigningCertificate": "./certs/certificate.pem"
+       }
+     }
+   }
+   ```
+
+Remember: Only the certificate file (`certs/certificate.pem`) should be committed to source control. The private key files should remain secure and outside of your repository.


### PR DESCRIPTION
This PR addresses a confusing build error I encountered when setting up EAS Update code signing, which appears to affect other developers as well.

## Why

While setting up EAS Update code signing for local builds using `eas build --platform android --local`, I encountered this error:

```
Error: [android.manifest]: withAndroidManifestBaseMod: File not found at `updates.codeSigningCertificate` path: /private/var/folders/5f/bl1njk5n0b53w3246_r9cx3r0000gp/T/eas-build-local-nodejs/42240c31-46b3-4396-831f-a8c0286a52e6/build/certs/certificate.pem
```
The error only manifests during build time, not during local development. I searched through existing issues and found that other developers have encountered the same problem. #35060 However, these issues were either closed without resolution or marked as incomplete due to missing reproduction examples. I tried several approaches to fix this issue,All of these approaches failed:

1. **Verified my app.json configuration** - The certificate path was correctly specified:
   ```json
   "updates": {
     "codeSigningCertificate": "certs/certificate.pem",
   ```

2. **Changed to absolute paths** - Tried using absolute paths for the certificate location, but this didn't help

3. **Cleared build cache and recreated project / add `--clear-cache` argument** - Neither clearing cache nor starting with a fresh project resolved the issue

4. **Added certificate to assetBundlePatterns** - Attempted to force include the certificate file in the build assets


## How

I eventually discovered that the issue was caused by `.gitignore` configuration. Projects created with `create-expo-app` automatically include `*.pem` in `.gitignore`, which prevents the certificate file from being included in builds. **Even when specifying absolute paths, files ignored by git are not copied to the build directory.**

This issue is particularly confusing because current documentation mentions moving `private_key.pem` outside the project or add to `.gitignore` file (which is correct) , but doesn't clarify that `certificates.pem` need special `.gitignore` handling. Projects created with create-expo-app automatically include *.pem in .gitignore, so developers naturally assume ALL `.pem` files should be ignored for security, not realizing certificates (unlike private keys) must be committed.

## Test Plan

To prevent other developers from experiencing this confusion, I've added:

- **Collapsible warning section** in Step 1 explaining the crucial difference between certificate files (must commit) and private key files (must not commit)
- **Specific `.gitignore` configuration** showing how to exclude private keys while including certificates
- **Warning in Step 2** reminding developers about `.gitignore` requirements
- **Comprehensive troubleshooting section** with the exact error message and step-by-step solutions

<img width="50%" height="50%" alt="image" src="https://github.com/user-attachments/assets/eb695284-d733-4092-9931-34d169c7aac6" />

<img width="50%" height="50%" alt="image" src="https://github.com/user-attachments/assets/9ad5423f-4b10-4e10-8c10-381723c0bb97" />

<img width="50%" height="50%"  alt="image" src="https://github.com/user-attachments/assets/f825a9e0-165b-4697-b625-6da64e5d94a8" />

These changes provide upfront guidance instead of leaving developers to discover this issue through trial and error.

### Link to the related documentation page

https://docs.expo.dev/eas-update/code-signing/#configure-your-project-to-use-code-signing

## Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

