### PR TITLE
Fixed typing and text visibility on Gyroscope and Accelerometer examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,6 +278,7 @@ Package-specific changes not released in any SDK will be added here just before 
   - [iOS] Change Constants to Constant/Property. ([#38926](https://github.com/expo/expo/pull/38926) by [@jakex7](https://github.com/jakex7))
 - **`expo-sensors`**
   - Change Constants to Constant/Property. ([#38926](https://github.com/expo/expo/pull/38926) by [@jakex7](https://github.com/jakex7))
+  - [docs] Fixed Subscription typing warnings text visiblity in Gyroscope and Accelerometer examples by [@RobViren](https://github.com/RobViren)
 - **`expo-screen-capture`**
   - Remove "Please" from warnings and errors ([#36862](https://github.com/expo/expo/pull/36862) by [@brentvatne](https://github.com/brentvatne))
   - [iOS] Replaced deprecated keyWindow usage. ([#38207](https://github.com/expo/expo/pull/38207) by [@hryhoriiK97](https://github.com/hryhoriiK97))

--- a/docs/pages/versions/v53.0.0/sdk/accelerometer.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/accelerometer.mdx
@@ -22,9 +22,10 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label="Basic Accelerometer usage" dependencies={['expo-sensors']}>
 
 ```jsx
-import { useState, useEffect } from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Accelerometer } from 'expo-sensors';
+import { Subscription } from 'expo-sensors/src/DeviceSensor';
+import { useEffect, useState } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 export default function App() {
   const [{ x, y, z }, setData] = useState({
@@ -32,7 +33,7 @@ export default function App() {
     y: 0,
     z: 0,
   });
-  const [subscription, setSubscription] = useState(null);
+  const [subscription, setSubscription] = useState<Subscription | null>(null);
 
   const _slow = () => Accelerometer.setUpdateInterval(1000);
   const _fast = () => Accelerometer.setUpdateInterval(16);
@@ -76,7 +77,8 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
-    paddingHorizontal: 20,
+    paddingHorizontal: 10,
+    backgroundColor: '#eee',
   },
   text: {
     textAlign: 'center',
@@ -90,13 +92,13 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: '#eee',
+    backgroundColor: '#ccc',
     padding: 10,
   },
   middleButton: {
     borderLeftWidth: 1,
     borderRightWidth: 1,
-    borderColor: '#ccc',
+    borderColor: '#999',
   },
 });
 ```

--- a/docs/pages/versions/v53.0.0/sdk/gyroscope.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/gyroscope.mdx
@@ -22,9 +22,10 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Basic Gyroscope usage' dependencies={['expo-sensors']}>
 
 ```jsx
-import { useState, useEffect } from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Gyroscope } from 'expo-sensors';
+import { Subscription } from 'expo-sensors/src/DeviceSensor';
+import { useEffect, useState } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 export default function App() {
   const [{ x, y, z }, setData] = useState({
@@ -32,17 +33,13 @@ export default function App() {
     y: 0,
     z: 0,
   });
-  const [subscription, setSubscription] = useState(null);
+  const [subscription, setSubscription] = useState<Subscription | null>(null);
 
   const _slow = () => Gyroscope.setUpdateInterval(1000);
   const _fast = () => Gyroscope.setUpdateInterval(16);
 
   const _subscribe = () => {
-    setSubscription(
-      Gyroscope.addListener(gyroscopeData => {
-        setData(gyroscopeData);
-      })
-    );
+    setSubscription(Gyroscope.addListener(setData));
   };
 
   const _unsubscribe = () => {
@@ -81,6 +78,7 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     paddingHorizontal: 10,
+    backgroundColor: '#eee',
   },
   text: {
     textAlign: 'center',
@@ -94,13 +92,13 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: '#eee',
+    backgroundColor: '#ccc',
     padding: 10,
   },
   middleButton: {
     borderLeftWidth: 1,
     borderRightWidth: 1,
-    borderColor: '#ccc',
+    borderColor: '#999',
   },
 });
 ```

--- a/docs/pages/versions/v54.0.0/sdk/accelerometer.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/accelerometer.mdx
@@ -22,9 +22,10 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label="Basic Accelerometer usage" dependencies={['expo-sensors']}>
 
 ```jsx
-import { useState, useEffect } from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Accelerometer } from 'expo-sensors';
+import { Subscription } from 'expo-sensors/src/DeviceSensor';
+import { useEffect, useState } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 export default function App() {
   const [{ x, y, z }, setData] = useState({
@@ -32,7 +33,7 @@ export default function App() {
     y: 0,
     z: 0,
   });
-  const [subscription, setSubscription] = useState(null);
+  const [subscription, setSubscription] = useState<Subscription | null>(null);
 
   const _slow = () => Accelerometer.setUpdateInterval(1000);
   const _fast = () => Accelerometer.setUpdateInterval(16);
@@ -76,7 +77,8 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
-    paddingHorizontal: 20,
+    paddingHorizontal: 10,
+    backgroundColor: '#eee',
   },
   text: {
     textAlign: 'center',
@@ -90,13 +92,13 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: '#eee',
+    backgroundColor: '#ccc',
     padding: 10,
   },
   middleButton: {
     borderLeftWidth: 1,
     borderRightWidth: 1,
-    borderColor: '#ccc',
+    borderColor: '#999',
   },
 });
 ```

--- a/docs/pages/versions/v54.0.0/sdk/gyroscope.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/gyroscope.mdx
@@ -22,9 +22,10 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Basic Gyroscope usage' dependencies={['expo-sensors']}>
 
 ```jsx
-import { useState, useEffect } from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Gyroscope } from 'expo-sensors';
+import { Subscription } from 'expo-sensors/src/DeviceSensor';
+import { useEffect, useState } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 export default function App() {
   const [{ x, y, z }, setData] = useState({
@@ -32,17 +33,13 @@ export default function App() {
     y: 0,
     z: 0,
   });
-  const [subscription, setSubscription] = useState(null);
+  const [subscription, setSubscription] = useState<Subscription | null>(null);
 
   const _slow = () => Gyroscope.setUpdateInterval(1000);
   const _fast = () => Gyroscope.setUpdateInterval(16);
 
   const _subscribe = () => {
-    setSubscription(
-      Gyroscope.addListener(gyroscopeData => {
-        setData(gyroscopeData);
-      })
-    );
+    setSubscription(Gyroscope.addListener(setData));
   };
 
   const _unsubscribe = () => {
@@ -81,6 +78,7 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     paddingHorizontal: 10,
+    backgroundColor: '#eee',
   },
   text: {
     textAlign: 'center',
@@ -94,13 +92,13 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: '#eee',
+    backgroundColor: '#ccc',
     padding: 10,
   },
   middleButton: {
     borderLeftWidth: 1,
     borderRightWidth: 1,
-    borderColor: '#ccc',
+    borderColor: '#999',
   },
 });
 ```


### PR DESCRIPTION
# Why

Dropping the examples into the initially created templates showed completely black text on a black background on my Pixel 8a using a default system theme of "dark" meaning I could not see the data at all.

My editor also showed the following errors:

- Argument of type 'EventSubscription' is not assignable to parameter of type 'SetStateAction<null>'.
  Type 'EventSubscription' provides no match for the signature '(prevState: null): null'.
- Property 'remove' does not exist on type 'never'.

The code worked but it would be better to add the typing expected by Typescript as an example.

# How

I added the proper typing, was explicit in background color contrasting with text assuming others will have similarly dark themed Android. The typing changes eliminated the typing errors and the background color changes made the text visible on my Android system. Explicit background colors should work across platforms independent of theme making the example more applicable.

# Test Plan

I ran the code using my system and text is now visible. I am not certain what other doc tests could be performed.

# Checklist

- [ x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
