### PR TITLE
fix(cli): Fix `[...rsc]+api.ts` template path resolution

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - fix launching apps on Android emulators where `hw.keyboard = no` ([#34677](https://github.com/expo/expo/pull/34677) by [@DimitarNestorov](https://github.com/DimitarNestorov))
 - only skip dependency validation for `EXPO_NO_DEPENDENCY_VALIDATION=1` ([#40043](https://github.com/expo/expo/pull/40043) by [@kitten](https://github.com/kitten))
+- Fix RSC `[...rsc]+api.ts` template path resolution ([#40760](https://github.com/expo/expo/pull/40760) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -284,7 +284,10 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       debug('Adding RSC route to the manifest:', rscPath);
       // NOTE: This might need to be sorted to the correct spot in the future.
       manifest.apiRoutes.push({
-        file: resolveFrom(this.projectRoot, '@expo/cli/static/template/[...rsc]+api.ts'),
+        // TODO(@kitten): This isn't great, we shouldn't be needing to rely on files like this
+        // It might even be better to make templating strings since that'd be type-checked, but currently,
+        // we rely on this being an entrypoint for Metro
+        file: require.resolve('@expo/cli/static/template/[...rsc]+api.ts'),
         page: rscPath,
         namedRegex: '^/_flight(?:/(?<rsc>.+?))?(?:/)?$',
         routeKeys: { rsc: 'rsc' },


### PR DESCRIPTION
# Why

Reported on Discord. Not crucial that we fix it, but it's an easy change. The resolution here re-enters `@expo/cli` via `resolve-from`, which means this isn't safe for isolated installation or mis-hoisted CLI paths.

# How

- Replace `resolveFrom` with `require.resolve` to get to template path

# Test Plan

- E2E CI covers this
- Manually checked against `yarn start:01-rsc` and `yarn export:01-rsc`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
