### PR TITLE
docs: replace "anon key" with "publishable key" in Supabase guide

### DIFF
--- a/docs/pages/guides/using-supabase.mdx
+++ b/docs/pages/guides/using-supabase.mdx
@@ -41,7 +41,7 @@ After you have created your [Expo project](/get-started/create-a-project/), inst
 
 <Step label="2">
 
-Create a helper file to initialize the Supabase client (`@supabase/supabase-js`). You need the API URL and the `anon` key copied [earlier](#get-the-api-keys). These variables are safe to expose in your Expo app since Supabase has [Row Level Security](https://supabase.com/docs/guides/auth/row-level-security?utm_source=expo&utm_medium=referral&utm_term=expo-react-native) enabled in the Database.
+Create a helper file to initialize the Supabase client (`@supabase/supabase-js`). You need the API URL and the `Publishable` key copied [earlier](#get-the-api-keys). These variables are safe to expose in your Expo app since Supabase has [Row Level Security](https://supabase.com/docs/guides/auth/row-level-security?utm_source=expo&utm_medium=referral&utm_term=expo-react-native) enabled in the Database.
 
 ```ts utils/supabase.ts
 import 'expo-sqlite/localStorage/install';

--- a/docs/pages/guides/using-supabase.mdx
+++ b/docs/pages/guides/using-supabase.mdx
@@ -19,10 +19,12 @@ Head over to [database.new](https://database.new?utm_source=expo&utm_medium=refe
 
 ### Get the API Keys
 
-Get the Project URL and `anon` key from the API settings.
+Get the `Project URL` from the API settings and `Publishable key` from the API Keys.
 
 1. Go to the [API Settings](https://supabase.com/dashboard/project/_/settings/api) page in the Dashboard.
-1. Find your Project `URL`, `anon`, and `service_role` keys on this page.
+2. Find your Project `URL` and `service_role` keys on this page.
+3. Then go to the [API Keys](https://supabase.com/dashboard/project/_/settings/api-keys)
+4. Find your Project `Publishable key` on this page under API Keys tab.
 
 ## Using the Supabase TypeScript SDK
 
@@ -46,9 +48,9 @@ import 'expo-sqlite/localStorage/install';
 import { createClient } from '@supabase/supabase-js';
 
 const supabaseUrl = YOUR_REACT_NATIVE_SUPABASE_URL;
-const supabaseAnonKey = YOUR_REACT_NATIVE_SUPABASE_ANON_KEY;
+const supabasePublishableKey = YOUR_REACT_NATIVE_SUPABASE_PUBLISHABLE_KEY;
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+export const supabase = createClient(supabaseUrl, supabasePublishableKey, {
   auth: {
     storage: localStorage,
     autoRefreshToken: true,

--- a/docs/pages/guides/using-supabase.mdx
+++ b/docs/pages/guides/using-supabase.mdx
@@ -19,12 +19,12 @@ Head over to [database.new](https://database.new?utm_source=expo&utm_medium=refe
 
 ### Get the API Keys
 
-Get the `Project URL` from the API settings and `Publishable key` from the API Keys.
+Get the **Project URL** from the API settings and **Publishable key** from the API Keys:
 
 1. Go to the [API Settings](https://supabase.com/dashboard/project/_/settings/api) page in the Dashboard.
 2. Find your Project `URL` and `service_role` keys on this page.
 3. Then go to the [API Keys](https://supabase.com/dashboard/project/_/settings/api-keys)
-4. Find your Project `Publishable key` on this page under API Keys tab.
+4. Find your Project **Publishable key** on this page under the API Keys tab.
 
 ## Using the Supabase TypeScript SDK
 


### PR DESCRIPTION
# Why
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Supabase has officially renamed the "anon key" to "publishable key" across their platform and documentation. This PR updates the Expo documentation to reflect this change and maintain consistency with current Supabase naming conventions.

The term "publishable key" more clearly communicates that this key is safe to use in client-side applications, similar to naming conventions used by other services like Stripe. This change improves clarity for developers following the integration guide and ensures they see consistent terminology across both Expo and Supabase documentation.

# How
<!--
How did you build this feature or fix this bug and why?
-->

Updated all references to "anon key" throughout the Supabase integration documentation:
- Changed text references from `anon` to `publishable` in the "Get the API Keys" section
- Updated code example variable name from `supabaseAnonKey` to `supabasePublishableKey`
- Updated placeholder constant from `YOUR_REACT_NATIVE_SUPABASE_ANON_KEY` to `YOUR_REACT_NATIVE_SUPABASE_PUBLISHABLE_KEY`

The underlying functionality remains unchanged - this is purely a terminology update.

# Test Plan
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

**To verify this change:**
1. Review the documentation changes in the Files Changed tab
2. Verify that all instances of "anon key" have been replaced with "publishable key"
3. Confirm that the code example uses consistent variable naming (`supabasePublishableKey`)
4. Check that the changes align with current Supabase documentation at https://supabase.com/docs/guides/api/api-keys

**Manual verification:**
- Reviewed the Supabase docs guide at the modified file path
- Confirmed all code snippets use the updated terminology
- Verified markdown formatting is correct

# Checklist
<!--
Please check the appropriate items below if they apply to your diff.
-->
- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)