### PR TITLE
Fix command syntax for installing ESLint plugin

### DIFF
--- a/docs/pages/guides/react-compiler.mdx
+++ b/docs/pages/guides/react-compiler.mdx
@@ -69,7 +69,7 @@ Additionally, you should use the ESLint plugin to continuously enforce the rules
 
 Run [`npx expo lint`](/guides/using-eslint/#eslint) to ensure ESLint is setup in your app, then install the ESLint plugin for React Compiler:
 
-<Terminal cmd={['$ npx expo install eslint-plugin-react-compiler -D']} />
+<Terminal cmd={['$ npx expo install eslint-plugin-react-compiler -- -D']} />
 
 </Step>
 


### PR DESCRIPTION
# Why

The `--` is required to pass the -D option. Otherwise, it will throw an error.

<img width="691" height="51" alt="image" src="https://github.com/user-attachments/assets/4c5be921-cc6b-46f9-9910-b5f1a389fcc4" />
