### PR TITLE
test(@expo/prebuild-config): remove `/build/reports/problems/problems-report.html` from test

### DIFF
--- a/packages/@expo/prebuild-config/src/plugins/__tests__/withDefaultPlugins-test.ts
+++ b/packages/@expo/prebuild-config/src/plugins/__tests__/withDefaultPlugins-test.ts
@@ -371,7 +371,6 @@ describe('built-in plugins', () => {
         'android/app/src/debug/AndroidManifest.xml',
         'android/app/src/debugOptimized/AndroidManifest.xml',
         'android/app/src/main/AndroidManifest.xml',
-        'android/build/reports/problems/problems-report.html',
         'android/app/src/main/java/com/bacon/todo/MainActivity.kt',
         'android/app/src/main/java/com/bacon/todo/MainApplication.kt',
         'android/app/src/main/res/drawable/ic_launcher_background.xml',


### PR DESCRIPTION
# Why

The test update was overlooked in a243aff02432bcdc5c5c2eb65b0cc0ceebe483df.

# How

Removed the file from test expectations.

# Test Plan

CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
