### PR TITLE
[web-browser][android] Fix app destroying all Activities on initial launch when using `experimentalLauncherActivity`

### DIFF
--- a/apps/bare-expo/android/app/src/main/java/dev/expo/payments/BrowserLauncherActivity.kt
+++ b/apps/bare-expo/android/app/src/main/java/dev/expo/payments/BrowserLauncherActivity.kt
@@ -8,7 +8,9 @@ class BrowserLauncherActivity : Activity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     val application = application as MainApplication
-    if (!application.isActivityInBackStack(MainActivity::class.java)) {
+    val isLeavingDevLauncher = intent.extras?.getBoolean("isLeavingDevLauncher") ?: false
+
+    if (!application.isActivityInBackStack(MainActivity::class.java) || isLeavingDevLauncher) {
       val intent = Intent(this, MainActivity::class.java)
       startActivity(intent)
     }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -399,7 +399,10 @@ class DevLauncherController private constructor() :
       ) { "Couldn't find the launcher class." }
     } else {
       Intent(context, sLauncherClass!!)
-    }.apply { addFlags(NEW_ACTIVITY_FLAGS) }
+    }.apply {
+      addFlags(NEW_ACTIVITY_FLAGS)
+      putExtra("isLeavingDevLauncher", true)
+    }
 
   companion object {
     private var sErrorHandlerWasInitialized = false

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix app destroying all Activities on initial launch when using `experimentalLauncherActivity`.
+
 ### 💡 Others
 
 ## 15.0.8 - 2025-10-01

--- a/packages/expo-web-browser/plugin/build/withWebBrowserAndroid.js
+++ b/packages/expo-web-browser/plugin/build/withWebBrowserAndroid.js
@@ -63,7 +63,9 @@ class BrowserLauncherActivity : Activity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     val application = application as MainApplication
-    if (!application.isActivityInBackStack(MainActivity::class.java)) {
+    val isLeavingDevLauncher = intent.extras?.getBoolean("isLeavingDevLauncher") ?: false
+
+    if (!application.isActivityInBackStack(MainActivity::class.java) || isLeavingDevLauncher) {
       val intent = Intent(this, MainActivity::class.java)
       startActivity(intent)
     }

--- a/packages/expo-web-browser/plugin/src/withWebBrowserAndroid.ts
+++ b/packages/expo-web-browser/plugin/src/withWebBrowserAndroid.ts
@@ -82,7 +82,9 @@ class BrowserLauncherActivity : Activity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     val application = application as MainApplication
-    if (!application.isActivityInBackStack(MainActivity::class.java)) {
+    val isLeavingDevLauncher = intent.extras?.getBoolean("isLeavingDevLauncher") ?: false
+
+    if (!application.isActivityInBackStack(MainActivity::class.java) || isLeavingDevLauncher) {
       val intent = Intent(this, MainActivity::class.java)
       startActivity(intent)
     }


### PR DESCRIPTION
# Why

Since march we had the issue with BareExpo 'crashing' when opening the app from the dev server by pressing `a`. 
This was due to changes introduced in https://github.com/expo/expo/pull/34160

Turns out, the app is not actually crashing, instead it closes all it's activities. 
When launching straight into the experience the `application.isActivityInBackStack(MainActivity::class.java)` will return `true`, but the activity is about to be closed which means that we don't start a new `MainActivity`. 

# How

Added a flag to inform the `BrowserLauncherActivity` that the launch is coming from the DevLauncher. When flag is `true` start a new instance of `MainActivity` anyways since we know that the previous one will be destroyed.

This is NOT an optimal solution, but I'm just putting it out there, so hopefully someone with more knowledge of DevLauncher suggests something better.

# Test Plan

Tested in BareExpo on Android
