### PR TITLE
[glass-effect] - Fix border(Left|Right|Start|End)Radius

### DIFF
--- a/packages/expo-glass-effect/CHANGELOG.md
+++ b/packages/expo-glass-effect/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `border(Left|Right|Start|End)Radius` ([#40780](https://github.com/expo/expo/pull/40780) by [@nishan](https://github.com/intergalacticspacehighway))
+
 ### 💡 Others
 
 - Fixed XCode 16.4 compilation ([#40686](https://github.com/expo/expo/pull/40686) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-glass-effect/ios/GlassEffectModule.swift
+++ b/packages/expo-glass-effect/ios/GlassEffectModule.swift
@@ -1,7 +1,6 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
 import ExpoModulesCore
-import React
 
 public final class GlassEffectModule: Module {
   public func definition() -> ModuleDefinition {
@@ -54,41 +53,20 @@ public final class GlassEffectModule: Module {
         view.setBorderTopRightRadius(radius)
       }
 
-      // Start/End alternatives that respect RTL layout
       Prop("borderTopStartRadius") { (view, radius: CGFloat?) in
-        let isRTL = RCTI18nUtil.sharedInstance()?.isRTL() ?? false
-        if isRTL {
-          view.setBorderTopRightRadius(radius)
-        } else {
-          view.setBorderTopLeftRadius(radius)
-        }
+        view.setBorderTopStartRadius(radius)
       }
 
       Prop("borderTopEndRadius") { (view, radius: CGFloat?) in
-        let isRTL = RCTI18nUtil.sharedInstance()?.isRTL() ?? false
-        if isRTL {
-          view.setBorderTopLeftRadius(radius)
-        } else {
-          view.setBorderTopRightRadius(radius)
-        }
+        view.setBorderTopEndRadius(radius)
       }
 
       Prop("borderBottomStartRadius") { (view, radius: CGFloat?) in
-        let isRTL = RCTI18nUtil.sharedInstance()?.isRTL() ?? false
-        if isRTL {
-          view.setBorderBottomRightRadius(radius)
-        } else {
-          view.setBorderBottomLeftRadius(radius)
-        }
+        view.setBorderBottomStartRadius(radius)
       }
 
       Prop("borderBottomEndRadius") { (view, radius: CGFloat?) in
-        let isRTL = RCTI18nUtil.sharedInstance()?.isRTL() ?? false
-        if isRTL {
-          view.setBorderBottomLeftRadius(radius)
-        } else {
-          view.setBorderBottomRightRadius(radius)
-        }
+        view.setBorderBottomEndRadius(radius)
       }
 
       Prop("borderCurve") { (view, curve: String?) in

--- a/packages/expo-glass-effect/ios/GlassView.swift
+++ b/packages/expo-glass-effect/ios/GlassView.swift
@@ -1,6 +1,7 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
 import ExpoModulesCore
+import React
 
 public final class GlassView: ExpoView {
   private var glassEffect: Any?
@@ -15,6 +16,11 @@ public final class GlassView: ExpoView {
   private var bottomRightRadius: CGFloat?
   private var topLeftRadius: CGFloat?
   private var topRightRadius: CGFloat?
+  
+  private var bottomStartRadius: CGFloat?
+  private var bottomEndRadius: CGFloat?
+  private var topStartRadius: CGFloat?
+  private var topEndRadius: CGFloat?
 
   public required init(appContext: AppContext? = nil) {
     super.init(appContext: appContext)
@@ -27,11 +33,30 @@ public final class GlassView: ExpoView {
   public func updateBorderRadius() {
     if #available(iOS 26.0, *) {
       #if compiler(>=6.2) // Xcode 26
-      let topLeft = UICornerRadius(floatLiteral: topLeftRadius ?? radius ?? 0)
-      let topRight = UICornerRadius(floatLiteral: topRightRadius ?? radius ?? 0)
-      let bottomLeft = UICornerRadius(floatLiteral: bottomLeftRadius ?? radius ?? 0)
-      let bottomRight = UICornerRadius(floatLiteral: bottomRightRadius ?? radius ?? 0)
-      
+      let isRTL = RCTI18nUtil.sharedInstance()?.isRTL() ?? false
+
+      let finalTopLeft: CGFloat
+      let finalTopRight: CGFloat
+      let finalBottomLeft: CGFloat
+      let finalBottomRight: CGFloat
+
+      if isRTL {
+        finalTopLeft = topLeftRadius ?? topEndRadius ?? radius ?? 0
+        finalTopRight = topRightRadius ?? topStartRadius ?? radius ?? 0
+        finalBottomLeft = bottomLeftRadius ?? bottomEndRadius ?? radius ?? 0
+        finalBottomRight = bottomRightRadius ?? bottomStartRadius ?? radius ?? 0
+      } else {
+        finalTopLeft = topLeftRadius ?? topStartRadius ?? radius ?? 0
+        finalTopRight = topRightRadius ?? topEndRadius ?? radius ?? 0
+        finalBottomLeft = bottomLeftRadius ?? bottomStartRadius ?? radius ?? 0
+        finalBottomRight = bottomRightRadius ?? bottomEndRadius ?? radius ?? 0
+      }
+
+      let topLeft = UICornerRadius(floatLiteral: finalTopLeft)
+      let topRight = UICornerRadius(floatLiteral: finalTopRight)
+      let bottomLeft = UICornerRadius(floatLiteral: finalBottomLeft)
+      let bottomRight = UICornerRadius(floatLiteral: finalBottomRight)
+
       glassEffectView.cornerConfiguration = .corners(
         topLeftRadius: topLeft,
         topRightRadius: topRight,
@@ -91,6 +116,34 @@ public final class GlassView: ExpoView {
   public func setBorderTopRightRadius(_ radius: CGFloat?) {
     if radius != topRightRadius {
       topRightRadius = radius
+      updateBorderRadius()
+    }
+  }
+
+  public func setBorderBottomStartRadius(_ radius: CGFloat?) {
+    if radius != bottomStartRadius {
+      bottomStartRadius = radius
+      updateBorderRadius()
+    }
+  }
+
+  public func setBorderBottomEndRadius(_ radius: CGFloat?) {
+    if radius != bottomEndRadius {
+      bottomEndRadius = radius
+      updateBorderRadius()
+    }
+  }
+
+  public func setBorderTopStartRadius(_ radius: CGFloat?) {
+    if radius != topStartRadius {
+      topStartRadius = radius
+      updateBorderRadius()
+    }
+  }
+
+  public func setBorderTopEndRadius(_ radius: CGFloat?) {
+    if radius != topEndRadius {
+      topEndRadius = radius
       updateBorderRadius()
     }
   }


### PR DESCRIPTION
# Why

Fixes - https://github.com/expo/expo/issues/40778

`border(Left|Right|Start|End)Radius` have undefined behaviour

This is somewhat related to https://github.com/expo/expo/pull/39331. The setters of `border(Start|End)Radius` were overriding `border(Left|Right)Radius` with nil values, because currently we [call](https://github.com/expo/expo/blob/8e708a7b217cdecb028741d9d582b4f1142c23be/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift#L80) all the defined setter functions even if RN does not update a prop, it gets called in different orders so it was having undefined behaviour (it works sometimes)

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Store start/end border alternatives in a separate property.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested the fix in https://github.com/expo/expo/issues/40778 repro and NCL.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
