### PR TITLE
Update OpenSSL dependency version in build.gradle

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Throwing error when `ExpoSQLite.defaultDatabaseDirectory` returns undefined. ([#40680](https://github.com/expo/expo/pull/40680) by [@kudo](https://github.com/kudo))
 - Fixed node runtime bundling error on web. ([#40739](https://github.com/expo/expo/pull/40739) by [@kudo](https://github.com/kudo))
+- Fixed Android 16kb page size issue when enabling `useSQLCipher`. ([#40781](https://github.com/expo/expo/pull/40781) by [@ronickg](https://github.com/ronickg))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/android/build.gradle
+++ b/packages/expo-sqlite/android/build.gradle
@@ -94,7 +94,7 @@ android {
 
 dependencies {
   if (project.ext.USE_SQLCIPHER) {
-    compileOnly 'io.github.ronickg:openssl:3.3.2'
+    compileOnly 'io.github.ronickg:openssl:3.3.2-1'
   }
   compileOnly 'com.facebook.fbjni:fbjni:0.3.0'
 }


### PR DESCRIPTION
Updatde the OpenSSL ndk package version to use the 16kb one

# Why

Android requires 16kb page size enabled in order to release or update apps.

# How

I created an easy way to generate and publish ndk ports like openssl, as google wasn't publishing updates anymore

# Test Plan

I didn't run any tests. But this version is already used in rn quick crypto and works as expected

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
