### PR TITLE
[sqlite] bump openssl to support 16kb page size

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Throwing error when `ExpoSQLite.defaultDatabaseDirectory` returns undefined. ([#40680](https://github.com/expo/expo/pull/40680) by [@kudo](https://github.com/kudo))
 - Fixed node runtime bundling error on web. ([#40739](https://github.com/expo/expo/pull/40739) by [@kudo](https://github.com/kudo))
+- Fixed Android 16kb page size issue when enabling `useSQLCipher`. ([#40783](https://github.com/expo/expo/pull/40783) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/android/build.gradle
+++ b/packages/expo-sqlite/android/build.gradle
@@ -94,7 +94,7 @@ android {
 
 dependencies {
   if (project.ext.USE_SQLCIPHER) {
-    compileOnly 'io.github.ronickg:openssl:3.3.2'
+    compileOnly 'io.github.ronickg:openssl:3.3.2-1'
   }
   compileOnly 'com.facebook.fbjni:fbjni:0.3.0'
 }


### PR DESCRIPTION
# Why

fixes #39792

# How

bump the openssl lib that supports 16kb page size. relevant thread: https://github.com/ronickg/ndkports/issues/3

# Test Plan

tested on blank sdk54 project with `useSQLCipher` expo-sqlite plugin and verify apk by [`check_elf_alignment.sh`](https://github.com/expo/fyi/blob/main/assets/android-16kb-page-sizes/check_elf_alignment.sh

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
