### PR TITLE
[go] Prevents error when OAuth flow cancels

### DIFF
--- a/apps/expo-go/src/screens/AccountModal/LoggedOutAccountView.tsx
+++ b/apps/expo-go/src/screens/AccountModal/LoggedOutAccountView.tsx
@@ -104,6 +104,12 @@ export function LoggedOutAccountView({ refetch }: Props) {
 
       if (result.type === 'success') {
         const resultURL = url.parse(result.url, true);
+
+        if (Object.keys(resultURL.query).length === 0) {
+          setIsAuthenticating(false);
+          return;
+        }
+
         const encodedSessionSecret = resultURL.query['session_secret'] as string;
         if (!encodedSessionSecret) {
           throw new Error('session_secret is missing in auth redirect query');


### PR DESCRIPTION
# Why

There could be situations in which the OAuth flow might "cancel" by redirecting back to the application with no paramaters. This prevents an error from being shown to the user in that case.

# How

Before parsing, the OAuth return flow checks if the URL has no query params and returns if that is the case.

# Test Plan

Tested in Expo Go.
