### PR TITLE
Add `expo/log-box` package to `codemention.yml`

### DIFF
--- a/.github/codemention.yml
+++ b/.github/codemention.yml
@@ -28,6 +28,8 @@ rules:
     mentions: ['bycedric', 'EvanBacon']
   - patterns: ['packages/@expo/json-file/**']
     mentions: ['EvanBacon', 'bycedric']
+  - patterns: ['packages/@expo/log-box/**']
+    mentions: ['EvanBacon', 'krystofwoldrich']
   - patterns: ['packages/@expo/metro-config/**']
     mentions: ['EvanBacon', 'bycedric', 'krystofwoldrich', 'kitten']
   - patterns: ['packages/@expo/metro-runtime/**']


### PR DESCRIPTION
Was not added when the new package was introduced.