### PR TITLE
[expo][web] transitionDuration should support number

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### 💡 Others
 
+- [Types] Fix `transitionDuration` type missing the `number` option for Reanimated V4 compatibility. ([#40793](https://github.com/expo/expo/pull/40793) by [@DelphineBugner](https://github.com/DelphineBugner))
 - [android] Add getDefaultReactHost to ExpoReactHostFactory ([#40086](https://github.com/expo/expo/pull/40086) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Remove edge-to-edge logic from `ReactActivityDelegateWrapper`. ([#40263](https://github.com/expo/expo/pull/40263) by [@behenate](https://github.com/behenate))
 - [expo/dom] Add `overrideUri` to `DOMProps` to enable pre-bundled DOM Components. ([#40397](https://github.com/expo/expo/pull/40397) by [@krystofwoldrich](https://github.com/krystofwoldrich))

--- a/packages/expo/types/react-native-web.d.ts
+++ b/packages/expo/types/react-native-web.d.ts
@@ -93,7 +93,7 @@ declare module 'react-native' {
     /** @platform web */
     transitionDelay?: string | string[];
     /** @platform web */
-    transitionDuration?: string | string[];
+    transitionDuration?: string | string[] | number;
     /** @platform web */
     transitionProperty?: string | string[];
     /** @platform web */


### PR DESCRIPTION
# Why

@MArtytraM99 opened an excellent issue: https://github.com/software-mansion/react-native-reanimated/issues/8305

TL;DR: on a View, `transitionDuration` doesn't accept a number type despite [Reanimates documentation stating it should](https://docs.swmansion.com/react-native-reanimated/docs/css-transitions/transition-duration/#reference) 

It comes from a conflict with React Native Web types described in Expo ; @marklawlor already extended them for compatibility with Reanimated V4 in https://github.com/expo/expo/pull/37024

But `transitionDuration` param still misses the number option

# How

- Add "number" to  `transitionDuration` style View  

# Test Plan

- Types are OK on CI ⏳ 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- ~[ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).~
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
