### PR TITLE
[docs] fix status usage in send_slack_message

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -1293,7 +1293,7 @@ jobs:
 
 Sends a specified message to a configured [Slack webhook URL](https://api.slack.com/messaging/webhooks), which then posts it in the related Slack channel. The message can be specified as plaintext or as a [Slack Block Kit](https://api.slack.com/block-kit) message.
 
-With both cases, you can reference build job properties and [use other steps outputs](#jobsjob_idoutputs) in the message for dynamic evaluation. For example, `Build URL: https://expo.dev/builds/${{ needs.build_ios.outputs.build_id }}`, `Build finished with status: ${{ after.build_android.outputs.status }}`.
+With both cases, you can reference build job properties and [use other steps outputs](#jobsjob_idoutputs) in the message for dynamic evaluation. For example, `Build URL: https://expo.dev/builds/${{ needs.build_ios.outputs.build_id }}`, `Build finished with status: ${{ after.build_android.status }}`.
 
 Either `message` or `payload` has to be specified, but not both.
 


### PR DESCRIPTION
# Why

Fixed a typo in the EAS Workflows syntax documentation where the example for referencing build job properties incorrectly used `after.build_android.outputs.status` instead of `after.build_android.status`.

# How

Updated the example 

# Test Plan

Verified that the corrected syntax matches the actual structure of the `after` context object in EAS Workflows.

# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)