### PR TITLE
Set AppContext runtime on JS thread, not main thread

### DIFF
--- a/packages/expo-modules-core/ios/Core/ExpoBridgeModule.mm
+++ b/packages/expo-modules-core/ios/Core/ExpoBridgeModule.mm
@@ -46,7 +46,9 @@ RCT_EXPORT_MODULE(ExpoModulesCore);
   _appContext.reactBridge = bridge;
 
 #if !__has_include(<ReactCommon/RCTRuntimeExecutor.h>)
-  _appContext._runtime = [EXJavaScriptRuntimeManager runtimeFromBridge:bridge];
+  [bridge dispatchBlock:^{
+      _appContext._runtime = [EXJavaScriptRuntimeManager runtimeFromBridge:bridge];
+    } queue:RCTJSThread];
 #endif // React Native <0.74
 }
 


### PR DESCRIPTION
# Why

See https://github.com/expo/expo/pull/40742 for the out-dated patch to SDK 53, which is where it was originally discovered.

The runtime is expected to be set on the JS thread, but it is executing on the main thread.  

The React Native 0.74 preprocessor gate in this file is actually executing again for React Native >= 0.77, because the file was once again removed.

# How

Noticed an elevated crash rate post-upgrade from Expo 50 to 53.  All stack traces pointed to this flow.

Patched expo locally via yarn patch, built locally to verify.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
