### PR TITLE
[ios][web-browser] Fix issue with `dismissBrowser`

### DIFF
--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `dismissBrowser` hanging when called with no browser open.
+
 ### 💡 Others
 
 ## 15.0.8 - 2025-10-01

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix `dismissBrowser` hanging when called with no browser open.
+- [iOS] Fix `dismissBrowser` hanging when called with no browser open. ([#40799](https://github.com/expo/expo/pull/40799) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-web-browser/ios/WebBrowserExceptions.swift
+++ b/packages/expo-web-browser/ios/WebBrowserExceptions.swift
@@ -13,3 +13,10 @@ final class WebBrowserInvalidURLException: Exception {
     return "The provided URL is not valid."
   }
 }
+
+final class WebBrowserNotOpenException: Exception {
+  override var reason: String {
+    "There is no web browser to dismiss"
+  }
+}
+

--- a/packages/expo-web-browser/ios/WebBrowserModule.swift
+++ b/packages/expo-web-browser/ios/WebBrowserModule.swift
@@ -43,6 +43,10 @@ final public class WebBrowserModule: Module {
     .runOnQueue(.main)
 
     AsyncFunction("dismissBrowser") { (promise: Promise) in
+      if (currentWebBrowserSession == nil) {
+        throw WebBrowserNotOpenException()
+      }
+      
       currentWebBrowserSession?.dismiss { type in
         self.currentWebBrowserSession = nil
         promise.resolve(["type": type])


### PR DESCRIPTION
# Why
Closes #40710

# How
When `dismissBrowser` is called without an open browser, the function will hang without resolving.  We should check if we have a `currentWebBrowserSession` and throw if we don't. 

# Test Plan
Bare-expo
