### PR TITLE
[ios][expo-updates-interface] New interface for metrics

### DIFF
--- a/packages/expo-updates-interface/ios/EXUpdatesInterface/UpdatesControllerRegistry.swift
+++ b/packages/expo-updates-interface/ios/EXUpdatesInterface/UpdatesControllerRegistry.swift
@@ -6,6 +6,7 @@ import Foundation
 @objcMembers
 public final class UpdatesControllerRegistry: NSObject {
   public weak var controller: UpdatesExternalInterface?
+  public weak var metricsController: UpdatesExternalMetricsInterface?
 
   public static let sharedInstance = UpdatesControllerRegistry()
 }

--- a/packages/expo-updates-interface/ios/EXUpdatesInterface/UpdatesExternalInterface.swift
+++ b/packages/expo-updates-interface/ios/EXUpdatesInterface/UpdatesExternalInterface.swift
@@ -54,6 +54,6 @@ public protocol UpdatesExternalInterfaceDelegate {
 public protocol UpdatesExternalMetricsInterface {
   @objc var runtimeVersion: String? { get }
   @objc var updateURL: URL? { get }
-  @objc var launchedUpdateId: String { get }
-  @objc var embeddedUpdateId: String { get }
+  @objc var launchedUpdateId: String? { get }
+  @objc var embeddedUpdateId: String? { get }
 }

--- a/packages/expo-updates-interface/ios/EXUpdatesInterface/UpdatesExternalInterface.swift
+++ b/packages/expo-updates-interface/ios/EXUpdatesInterface/UpdatesExternalInterface.swift
@@ -54,6 +54,6 @@ public protocol UpdatesExternalInterfaceDelegate {
 public protocol UpdatesExternalMetricsInterface {
   @objc var runtimeVersion: String? { get }
   @objc var updateURL: URL? { get }
-  @objc var launchedUpdateId: String? { get }
-  @objc var embeddedUpdateId: String? { get }
+  @objc var launchedUpdateId: UUID? { get }
+  @objc var embeddedUpdateId: UUID? { get }
 }

--- a/packages/expo-updates-interface/ios/EXUpdatesInterface/UpdatesExternalInterface.swift
+++ b/packages/expo-updates-interface/ios/EXUpdatesInterface/UpdatesExternalInterface.swift
@@ -46,3 +46,14 @@ public protocol UpdatesExternalInterface {
 public protocol UpdatesExternalInterfaceDelegate {
   @objc func updatesExternalInterfaceDidRequestRelaunch(_ updatesExternalInterface: UpdatesExternalInterface)
 }
+
+/**
+ * Protocol for use by the expo-app-metrics library
+ */
+@objc(EXUpdatesExternalMetricsInterface)
+public protocol UpdatesExternalMetricsInterface {
+  @objc var runtimeVersion: String? { get }
+  @objc var updateURL: URL? { get }
+  @objc var launchedUpdateId: String { get }
+  @objc var embeddedUpdateId: String { get }
+}

--- a/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
@@ -169,12 +169,12 @@ public class EnabledAppController: InternalAppControllerInterface, UpdatesExtern
     return config.updateUrl
   }
 
-  public var launchedUpdateId: String? {
-    return startupProcedure.launchedUpdate()?.updateId.uuidString
+  public var launchedUpdateId: UUID? {
+    return startupProcedure.launchedUpdate()?.updateId
   }
 
-  public var embeddedUpdateId: String? {
-    return getEmbeddedUpdate()?.updateId.uuidString
+  public var embeddedUpdateId: UUID? {
+    return getEmbeddedUpdate()?.updateId
   }
 
   // MARK: - Internal

--- a/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
@@ -2,11 +2,12 @@
 
 import SwiftUI
 import ExpoModulesCore
+import EXUpdatesInterface
 
 /**
  * Updates controller for applications that have updates enabled and properly-configured.
  */
-public class EnabledAppController: InternalAppControllerInterface, StartupProcedureDelegate {
+public class EnabledAppController: InternalAppControllerInterface, UpdatesExternalMetricsInterface, StartupProcedureDelegate {
   public weak var delegate: AppControllerDelegate?
   public var reloadScreenManager: Reloadable? = ReloadScreenManager()
 
@@ -58,6 +59,7 @@ public class EnabledAppController: InternalAppControllerInterface, StartupProced
     self.logger.info(message: "AppController sharedInstance created")
     self.eventManager = QueueUpdatesEventManager(logger: logger)
     self.stateMachine = UpdatesStateMachine(logger: self.logger, eventManager: self.eventManager, validUpdatesStateValues: Set(UpdatesStateValue.allCases))
+    UpdatesControllerRegistry.sharedInstance.metricsController = self
   }
 
   public func start() {
@@ -156,6 +158,30 @@ public class EnabledAppController: InternalAppControllerInterface, StartupProced
 
     stateMachine.queueExecution(stateMachineProcedure: procedure)
   }
+
+  // MARK: - UpdatesExternalMetricsInterface
+
+  // swiftlint:disable implicit_getter
+  public var runtimeVersion: String? {
+    get {
+      return getConstantsForModule().runtimeVersion
+    }
+  }
+
+  public var updateURL: URL? {
+    get {
+      return config.updateUrl
+    }
+  }
+
+  public var launchedUpdateId: String {
+    return getConstantsForModule().launchedUpdate?.updateId.uuidString ?? ""
+  }
+
+  public var embeddedUpdateId: String {
+    return getConstantsForModule().embeddedUpdate?.updateId.uuidString ?? ""
+  }
+  // swiftlint:enable implicit_getter
 
   // MARK: - Internal
 

--- a/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
@@ -164,7 +164,7 @@ public class EnabledAppController: InternalAppControllerInterface, UpdatesExtern
   // swiftlint:disable implicit_getter
   public var runtimeVersion: String? {
     get {
-      return getConstantsForModule().runtimeVersion
+      return config.runtimeVersion
     }
   }
 

--- a/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
@@ -174,12 +174,12 @@ public class EnabledAppController: InternalAppControllerInterface, UpdatesExtern
     }
   }
 
-  public var launchedUpdateId: String {
-    return getConstantsForModule().launchedUpdate?.updateId.uuidString ?? ""
+  public var launchedUpdateId: String? {
+    return getConstantsForModule().launchedUpdate?.updateId.uuidString
   }
 
-  public var embeddedUpdateId: String {
-    return getConstantsForModule().embeddedUpdate?.updateId.uuidString ?? ""
+  public var embeddedUpdateId: String? {
+    return getConstantsForModule().embeddedUpdate?.updateId.uuidString
   }
   // swiftlint:enable implicit_getter
 

--- a/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
@@ -161,27 +161,21 @@ public class EnabledAppController: InternalAppControllerInterface, UpdatesExtern
 
   // MARK: - UpdatesExternalMetricsInterface
 
-  // swiftlint:disable implicit_getter
   public var runtimeVersion: String? {
-    get {
-      return config.runtimeVersion
-    }
+    return config.runtimeVersion
   }
 
   public var updateURL: URL? {
-    get {
-      return config.updateUrl
-    }
+    return config.updateUrl
   }
 
   public var launchedUpdateId: String? {
-    return getConstantsForModule().launchedUpdate?.updateId.uuidString
+    return startupProcedure.launchedUpdate()?.updateId.uuidString
   }
 
   public var embeddedUpdateId: String? {
-    return getConstantsForModule().embeddedUpdate?.updateId.uuidString
+    return getEmbeddedUpdate()?.updateId.uuidString
   }
-  // swiftlint:enable implicit_getter
 
   // MARK: - Internal
 


### PR DESCRIPTION
# Why

Expose a limited set of data on the currently running update, etc., to native code, without requiring an `expo-updates` dependency.

# How

Instead of using the existing protocol (designed for the needs of `expo-dev-launcher`), add a new smaller protocol specifically for this use case. Only the enabled updates controller implements this protocol.

# Test Plan

- CI should pass
- Use a test app to verify that updates data can be read through the interface