### PR TITLE
[docs] Fix section heading casing in Expo CLI reference

### DIFF
--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -498,7 +498,7 @@ From here, you can choose to generate basic project files like:
 - **metro.config.js** -- The default Metro config for universal development. This is required for usage with `npx react-native`.
 - **tsconfig.json** -- Create a TypeScript config file and install the required dependencies.
 
-## Environment Variables
+## Environment variables
 
 | Name                                 | Type        | Description                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | ------------------------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix section heading casing in the Expo CLI reference as per the writing style guide by updating "Environment Variables" to "Environment variables".

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
