### PR TITLE
[docs] Apply inline syntax highlight in config plugin properties in Expo Image reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/image.mdx
+++ b/docs/pages/versions/unversioned/sdk/image.mdx
@@ -77,7 +77,7 @@ You can configure build-time settings for `expo-image` using its [config plugin]
       name: 'disableLibdav1d',
       platform: 'ios',
       description:
-        'When true, skips adding the bundled `libavif/libdav1d` Pod. Use this when another dependency (such as FFmpegKit) already links `libdav1d`. Disabling the Pod removes AVIF image support on iOS unless another decoder is available.',
+        'When `true`, skips adding the bundled `libavif/libdav1d` Pod. Use this when another dependency (such as `FFmpegKit`) already links `libdav1d`. Disabling the Pod removes AVIF image support on iOS unless another decoder is available.',
       default: 'false',
     },
   ]}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

In Expo Image reference (unversioned), the description for `disableLibdav1d` config plugin property is missing some inline code syntax highlights. This PR applies it to the value and package name.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
