### PR TITLE
[docs] Fix formatting issues in AgeRange reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/age-range.mdx
+++ b/docs/pages/versions/unversioned/sdk/age-range.mdx
@@ -12,7 +12,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ConfigReactNative } from '~/ui/components/ConfigSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-> **important** This library is currently in alpha and will frequently experience breaking changes.
+> **important** **This library is currently in alpha and will frequently experience breaking changes.**
 
 `expo-age-range` provides access to user age range information. It uses Google's [Play Age Signals API](https://developer.android.com/google/play/age-signals/use-age-signals-api) on Android and Apple's [Declared Age Range framework](https://developer.apple.com/documentation/declaredagerange/) on iOS.
 
@@ -124,11 +124,10 @@ import * as AgeRange from 'expo-age-range';
 
 ## Error codes
 
-Available in the `code` property of any error thrown by the native module.
-For Android-specific error codes, see "Handle API error codes" in [Use Play Age Signals API docs](https://developer.android.com/google/play/age-signals/use-age-signals-api#handle-api-errors)
+Available in the `code` property of any error thrown by the native module. For Android-specific error codes, see "Handle API error codes" in [Use Play Age Signals API docs](https://developer.android.com/google/play/age-signals/use-age-signals-api#handle-api-errors).
 
 | Code                            | Description                                                                                                                      |
 | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `ERR_AGE_RANGE_USER_DECLINED`   | **iOS Only.** User declined to shar their age range.                                                                             |
+| `ERR_AGE_RANGE_USER_DECLINED`   | **iOS Only.** User declined to share their age range.                                                                            |
 | `ERR_AGE_RANGE_NOT_AVAILABLE`   | **iOS Only.** Age range not available. The most likely cause is that user is not signed in to their Apple account on the device. |
 | `ERR_AGE_RANGE_INVALID_REQUEST` | **iOS Only.** The provided params were invalid. The age ranges need to be minimum 2 years apart.                                 |

--- a/docs/pages/versions/unversioned/sdk/age-range.mdx
+++ b/docs/pages/versions/unversioned/sdk/age-range.mdx
@@ -12,6 +12,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ConfigReactNative } from '~/ui/components/ConfigSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
+> **important** This library is currently in alpha and will frequently experience breaking changes.
+
 `expo-age-range` provides access to user age range information. It uses Google's [Play Age Signals API](https://developer.android.com/google/play/age-signals/use-age-signals-api) on Android and Apple's [Declared Age Range framework](https://developer.apple.com/documentation/declaredagerange/) on iOS.
 
 This API allows you to request age range information from users to help you comply with age-appropriate content regulations (such as in [Texas](https://developer.apple.com/news/?id=btkirlj8)) and provide age-appropriate experiences in your app.
@@ -93,8 +95,15 @@ export default function App() {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: 'center', padding: 20 },
-  result: { marginTop: 20, fontSize: 16 },
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 20,
+  },
+  result: {
+    marginTop: 20,
+    fontSize: 16,
+  },
 });
 ```
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
While going through the Expo AgeRange reference, found some formatting issues, typos, and missing callout for a package marked as Alpha. This PR fixes them.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
