### PR TITLE
[docs] Fix SnackInline language lookup to prefer App.tsx for `tsx` code blocks

### DIFF
--- a/docs/common/code-utilities.ts
+++ b/docs/common/code-utilities.ts
@@ -171,30 +171,31 @@ export function findNodeByPropInChildren<T>(
   element: ReactElement,
   propToFind: string
 ): PropsWithChildren<{ [propToFind]: T }> | T | null {
-  if (!element || typeof element !== 'object') {
+  if (!isValidElement<PropsWithChildren>(element)) {
     return null;
   }
 
-  if (isValidElement<PropsWithChildren<{ [propToFind]: T }>>(element)) {
-    return element.props;
+  const props = element.props as PropsWithChildren<{ [propToFind]: T }>;
+  if (props && Object.prototype.hasOwnProperty.call(props, propToFind)) {
+    return props;
   }
 
-  if (isValidElement<PropsWithChildren>(element)) {
-    const children = element.props.children;
+  const { children } = props;
+  if (!children) {
+    return null;
+  }
 
-    if (Array.isArray(children)) {
-      for (const child of Children.toArray(children)) {
-        const allProps = findNodeByPropInChildren<T>(child as ReactElement, propToFind);
-        if (allProps) {
-          return allProps;
-        }
+  if (Array.isArray(children)) {
+    for (const child of Children.toArray(children)) {
+      const found = findNodeByPropInChildren<T>(child as ReactElement, propToFind);
+      if (found) {
+        return found;
       }
-    } else {
-      return findNodeByPropInChildren<T>(children as ReactElement, propToFind);
     }
+    return null;
   }
 
-  return null;
+  return findNodeByPropInChildren<T>(children as ReactElement, propToFind);
 }
 
 export function getCodeBlockDataFromChildren(children?: ReactNode, className?: string) {


### PR DESCRIPTION
# Why
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

While going through some SDK references, I noticed that code blocks that are explicitly using `tsx` language and wrapped by `SnackInline` component, are not respecting `App.tsx` support (that is, when they open in Snack, they are still using `App.js` file name, as opposed to `App.tsx`). We introduced support for `App.tsx` in https://github.com/expo/expo/issues/29052.

Discovered that the problem was caused by `findNodeByPropInChildren`, a utility function, which immediately returns the props of the first React child, even if that child doesn't have the specific prop being queried. The first child is always a `<pre>` tag, so it never reaches the language syntax to identify whether the code block uses `jsx` or `tsx` language format.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Refactor `findNodeByPropInChildren` so it keeps traversing until it finds a node that actually owns the requested prop. This allows `getCodeBlockDataFromChildren` to pick up `tsx` language fenced code blocks, so SnackInline uses `App.tsx` when appropriate.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Run the docs app locally and visit: http://localhost:3002/versions/unversioned/sdk/checkbox/#usage
- Under "Usage" click "Open in Snack" button
- The Snack should open and should use `App.tsx` file.

<img width="237" height="349" alt="CleanShot 2025-11-04 at 01 05 53" src="https://github.com/user-attachments/assets/87577de2-40eb-4fa3-831a-bd87a114c861" />

**For examples that use `jsx` like http://localhost:3002/versions/latest/sdk/blur-view/**, it should open the Snack and use `App.js` file:

<img width="240" height="254" alt="CleanShot 2025-11-04 at 01 20 10" src="https://github.com/user-attachments/assets/2ec9d08d-8283-4628-8398-2e6384299b3c" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
