### PR TITLE
[video-thumbnails][android] - fix Android 9 regression

### DIFF
--- a/packages/expo-video-thumbnails/CHANGELOG.md
+++ b/packages/expo-video-thumbnails/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed broken thumbnail generation on Android 9 and lower. ([#3854081613](https://github.com/expo/expo/pull/40816) by [@andrejpavlovic](https://github.com/andrejpavlovic))
+
 ### 💡 Others
 
 - [Android] Remove unused `androidx.annotation:annotation` dependency. ([#39755](https://github.com/expo/expo/pull/39755) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-video-thumbnails/android/src/main/java/expo/modules/videothumbnails/VideoThumbnailsModule.kt
+++ b/packages/expo-video-thumbnails/android/src/main/java/expo/modules/videothumbnails/VideoThumbnailsModule.kt
@@ -76,8 +76,9 @@ class VideoThumbnailsModule : Module() {
     private val videoOptions: VideoThumbnailOptions,
     private val context: Context
   ) {
-    fun execute(): Bitmap? = MediaMetadataRetriever()
-      .use { retriever ->
+    fun execute(): Bitmap? {
+      val retriever = MediaMetadataRetriever()
+      try {
         try {
           if (URLUtil.isFileUrl(sourceFilename)) {
             retriever.setDataSource(Uri.decode(sourceFilename).replace("file://", ""))
@@ -100,7 +101,15 @@ class VideoThumbnailsModule : Module() {
           Log.e(ERROR_TAG, "Unable to retrieve source file")
           return null
         }
+      } finally {
+        try {
+          retriever.release()
+        } catch (e: Exception) {
+          Log.e(ERROR_TAG, "Error releasing MediaMetadataRetriever for source file")
+          return null
+        }
       }
+    }
   }
 
   private fun isAllowedToRead(url: String): Boolean {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Regression caused by #29015 - it uses `MediaMetadataRetriever().use` syntax, not supported on Android 9 or lower causing thumbnail generation to no longer work.

Fixes #34780

# How

<!--
How did you build this feature or fix this bug and why?
-->
Replace `MediaMetadataRetriever().use` with `try/catch`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Tried Android 9 and Android 16 and it works well.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
