### PR TITLE
[video][android] Fix surface view not showing when changing the `player` prop

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix `FOREGROUND_SERVICE_MEDIA_PLAYBACK` being always present in the manifest. ([#40074](https://github.com/expo/expo/pull/40074) by [@behenate](https://github.com/behenate))
 - [iOS] Fix crashes when rapidly replacing HLS sources. ([#40265](https://github.com/expo/expo/pull/40265) by [@behenate](https://github.com/behenate))
 - [Android] Fix the `player` prop of the `VideoView` not working when a player is re-assigned after being replaced by a different player earlier. ([#40709](https://github.com/expo/expo/pull/40709) by [@behenate](https://github.com/behenate))
+- [Android] Fix surface view not showing when changing the `player` prop. ([#40817](https://github.com/expo/expo/pull/40817) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
@@ -113,14 +113,18 @@ open class VideoView(context: Context, appContext: AppContext, useTextureView: B
       field?.let {
         VideoManager.onVideoPlayerDetachedFromView(it, this)
       }
-      videoPlayer?.removeListener(this)
-      videoPlayer?.changePlayerView(null)
+      val oldPlayer = videoPlayer
+      oldPlayer?.removeListener(this)
       newPlayer?.addListener(this)
       field = newPlayer
-      shouldHideSurfaceView = true
+      shouldHideSurfaceView = !(newPlayer?.hasRenderedAFrameOfVideoSource ?: false)
+      applySurfaceViewVisibility()
       attachPlayer()
       newPlayer?.let {
         VideoManager.onVideoPlayerAttachedToView(it, this)
+      }
+      if (oldPlayer != newPlayer) {
+        oldPlayer?.hasBeenDisconnectedFromPlayerView()
       }
     }
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
@@ -71,6 +71,7 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
   val serviceConnection = PlaybackServiceConnection(WeakReference(this), appContext)
   val intervalUpdateClock = IntervalUpdateClock(this)
 
+  var hasRenderedAFrameOfVideoSource = false
   var playing by IgnoreSameSet(false) { new, old ->
     sendEvent(PlayerEvent.IsPlayingChanged(new, old))
   }
@@ -272,6 +273,7 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
         resetPlaybackInfo()
       }
       subtitles.setSubtitlesEnabled(false)
+      hasRenderedAFrameOfVideoSource = false
       super.onMediaItemTransition(mediaItem, reason)
     }
 
@@ -347,6 +349,16 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
   override fun deallocate() {
     super.deallocate()
     close()
+  }
+
+  /**
+   * Used to notify the player that is has been disconnected from the player view by another player.
+   */
+  fun hasBeenDisconnectedFromPlayerView() {
+    if (currentPlayerView.get()?.player == this.player) {
+      throw IllegalStateException("The player has been notified of disconnection from the player view, even though it's still connected.")
+    }
+    currentPlayerView.set(null)
   }
 
   fun changePlayerView(playerView: PlayerView?) {
@@ -472,6 +484,7 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
 
   private fun createFirstFrameEventGenerator(): FirstFrameEventGenerator {
     return FirstFrameEventGenerator(player, currentPlayerView) {
+      hasRenderedAFrameOfVideoSource = true
       sendEvent(PlayerEvent.RenderedFirstFrame())
     }
   }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/38426

On Android there is an issue with the surface view getting hidden for already playing players when they are placed into a fresh `VideoView`

# How

This happens because when the player is already playing the `onFirstFrameRendered` event is not emitted, therefore we don't update the visibility.

Check if the player has already rendered a frame. In that case we can just display it in the surface view.

# Test Plan

Tested in BareExpo on Android and iOS on a new testing screen (will add it in a separate PR since I'll be backporting this one to SDK 54)

