### PR TITLE
Rename deviceToken to fcmToken in notification function

### DIFF
--- a/docs/pages/push-notifications/sending-notifications-custom.mdx
+++ b/docs/pages/push-notifications/sending-notifications-custom.mdx
@@ -71,11 +71,11 @@ The example code below calls `getAccessTokenAsync()` above to get the Oauth 2.0 
 async function sendFCMv1Notification() {
   const key = require(process.env.FCM_SERVER_KEY);
   const firebaseAccessToken = await getAccessTokenAsync(key);
-  const deviceToken = process.env.FCM_DEVICE_TOKEN;
+  const fcmToken = process.env.FCM_DEVICE_TOKEN;
 
   const messageBody = {
     message: {
-      token: deviceToken,
+      token: fcmToken,
       data: {
         channelId: 'default',
         message: 'Testing',


### PR DESCRIPTION
Renamed `deviceToken` to `fcmToken` to clarify that FCM registration tokens are required, not raw device tokens from `getDevicePushTokenAsync()`. This prevents confusion about which token type should be used with the FCM v1 API.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
