### PR TITLE
[ios][dev-launcher] Add activity indicator when loading dev server URL

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Remove `ExpoAppDelegate` inheritance requirement ([#39417](https://github.com/expo/expo/pull/39417) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Add brownfield support ([#40463](https://github.com/expo/expo/pull/40463) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Decouple menu from dev-launcher ([#40669](https://github.com/expo/expo/pull/40669) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Add activity indicator when loading dev server URL.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Remove `ExpoAppDelegate` inheritance requirement ([#39417](https://github.com/expo/expo/pull/39417) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Add brownfield support ([#40463](https://github.com/expo/expo/pull/40463) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Decouple menu from dev-launcher ([#40669](https://github.com/expo/expo/pull/40669) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Add activity indicator when loading dev server URL.
+- [iOS] Add activity indicator when loading dev server URL. ([#40825](https://github.com/expo/expo/pull/40825) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
@@ -40,6 +40,7 @@ class DevLauncherViewModel: ObservableObject {
   @Published var isAuthenticating = false
   @Published var user: User?
   @Published var selectedAccountId: String?
+  @Published var loadingServerUrl: String?
 
   #if !os(tvOS)
   private let presentationContext = DevLauncherAuthPresentationContext()
@@ -98,12 +99,17 @@ class DevLauncherViewModel: ObservableObject {
       return
     }
 
+    loadingServerUrl = url
+
     EXDevLauncherController.sharedInstance().loadApp(
       bundleUrl,
-      onSuccess: nil,
+      onSuccess: { [weak self] in
+        self?.loadingServerUrl = nil
+      },
       onError: { [weak self] _ in
         let message = "Failed to connect to \(url)"
         DispatchQueue.main.async {
+          self?.loadingServerUrl = nil
           self?.showErrorAlert(message)
         }
       })

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
@@ -40,7 +40,7 @@ class DevLauncherViewModel: ObservableObject {
   @Published var isAuthenticating = false
   @Published var user: User?
   @Published var selectedAccountId: String?
-  @Published var loadingServerUrl: String?
+  @Published var isLoadingServer: Bool = false
 
   #if !os(tvOS)
   private let presentationContext = DevLauncherAuthPresentationContext()
@@ -99,17 +99,19 @@ class DevLauncherViewModel: ObservableObject {
       return
     }
 
-    loadingServerUrl = url
+    isLoadingServer = true
 
     EXDevLauncherController.sharedInstance().loadApp(
       bundleUrl,
       onSuccess: { [weak self] in
-        self?.loadingServerUrl = nil
+        DispatchQueue.main.async {
+          self?.isLoadingServer = false
+        }
       },
       onError: { [weak self] _ in
         let message = "Failed to connect to \(url)"
         DispatchQueue.main.async {
-          self?.loadingServerUrl = nil
+          self?.isLoadingServer = false
           self?.showErrorAlert(message)
         }
       })

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
@@ -172,10 +172,6 @@ struct DevServerRow: View {
   let server: DevServer
   let onTap: () -> Void
 
-  private var isLoading: Bool {
-    viewModel.loadingServerUrl == server.url
-  }
-
   var body: some View {
     Button {
       onTap()
@@ -191,11 +187,8 @@ struct DevServerRow: View {
 
         Spacer()
 
-        if isLoading {
+        if viewModel.isLoadingServer {
           ProgressView()
-            #if os(tvOS)
-            .scaleEffect(1.5)
-            #endif
         } else {
           Image(systemName: "chevron.right")
             .font(.caption)

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
@@ -168,8 +168,13 @@ struct DevServersView: View {
 }
 
 struct DevServerRow: View {
+  @EnvironmentObject var viewModel: DevLauncherViewModel
   let server: DevServer
   let onTap: () -> Void
+
+  private var isLoading: Bool {
+    viewModel.loadingServerUrl == server.url
+  }
 
   var body: some View {
     Button {
@@ -185,9 +190,17 @@ struct DevServerRow: View {
           .foregroundColor(.primary)
 
         Spacer()
-        Image(systemName: "chevron.right")
-          .font(.caption)
-          .foregroundColor(.secondary)
+
+        if isLoading {
+          ProgressView()
+            #if os(tvOS)
+            .scaleEffect(1.5)
+            #endif
+        } else {
+          Image(systemName: "chevron.right")
+            .font(.caption)
+            .foregroundColor(.secondary)
+        }
       }
       .padding()
       .background(Color.expoSecondarySystemBackground)


### PR DESCRIPTION
# Why
Adds an activity indicator to the dev server row when the app is loading

# Test Plan
<img width="450" height="978" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-04 at 09 28 29" src="https://github.com/user-attachments/assets/9d71708a-5a27-4703-9f6c-c435b10bed13" />
