### PR TITLE
[cli][mcp] expose cli extensions as mcp tools

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### 🎉 New features
 
 - Switch EXPO_NO_GIT_STATUS to default to true. ([#42026](https://github.com/expo/expo/pull/42026) by [@EvanBacon](https://github.com/EvanBacon))
-- Added support for exposing cli command extensions as MCP tools.
+- Added support for exposing cli command extensions as MCP tools. ([#40826](https://github.com/expo/expo/pull/40826) by [@chrfalch](https://github.com/chrfalch))
 - Added support for exposing cli command extensions as MCP tools. ([#40826](https://github.com/expo/expo/pull/40826) by [@chrfalch](https://github.com/chrfalch))
 - Added support for cli command extension in expo modules ([#39598](https://github.com/expo/expo/pull/39598) by [@chrfalch](https://github.com/chrfalch))
 - Add support for server data loaders in development ([#39570](https://github.com/expo/expo/pull/39570) by [@hassankhan](https://github.com/hassankhan))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Switch EXPO_NO_GIT_STATUS to default to true. ([#42026](https://github.com/expo/expo/pull/42026) by [@EvanBacon](https://github.com/EvanBacon))
 - Added support for exposing cli command extensions as MCP tools.
+- Added support for exposing cli command extensions as MCP tools. ([#40826](https://github.com/expo/expo/pull/40826) by [@chrfalch](https://github.com/chrfalch))
 - Added support for cli command extension in expo modules ([#39598](https://github.com/expo/expo/pull/39598) by [@chrfalch](https://github.com/chrfalch))
 - Add support for server data loaders in development ([#39570](https://github.com/expo/expo/pull/39570) by [@hassankhan](https://github.com/hassankhan))
 - Added support for bundling apps with a new error overlay from `@expo/log-box` package ([#39958](https://github.com/expo/expo/pull/39958) by [@krystofwoldrich](https://github.com/krystofwoldrich))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🎉 New features
 
 - Switch EXPO_NO_GIT_STATUS to default to true. ([#42026](https://github.com/expo/expo/pull/42026) by [@EvanBacon](https://github.com/EvanBacon))
+- Added support for exposing cli command extensions as MCP tools.
 - Added support for cli command extension in expo modules ([#39598](https://github.com/expo/expo/pull/39598) by [@chrfalch](https://github.com/chrfalch))
 - Add support for server data loaders in development ([#39570](https://github.com/expo/expo/pull/39570) by [@hassankhan](https://github.com/hassankhan))
 - Added support for bundling apps with a new error overlay from `@expo/log-box` package ([#39958](https://github.com/expo/expo/pull/39958) by [@krystofwoldrich](https://github.com/krystofwoldrich))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -13,7 +13,6 @@
 
 - Switch EXPO_NO_GIT_STATUS to default to true. ([#42026](https://github.com/expo/expo/pull/42026) by [@EvanBacon](https://github.com/EvanBacon))
 - Added support for exposing cli command extensions as MCP tools. ([#40826](https://github.com/expo/expo/pull/40826) by [@chrfalch](https://github.com/chrfalch))
-- Added support for exposing cli command extensions as MCP tools. ([#40826](https://github.com/expo/expo/pull/40826) by [@chrfalch](https://github.com/chrfalch))
 - Added support for cli command extension in expo modules ([#39598](https://github.com/expo/expo/pull/39598) by [@chrfalch](https://github.com/chrfalch))
 - Add support for server data loaders in development ([#39570](https://github.com/expo/expo/pull/39570) by [@hassankhan](https://github.com/hassankhan))
 - Added support for bundling apps with a new error overlay from `@expo/log-box` package ([#39958](https://github.com/expo/expo/pull/39958) by [@krystofwoldrich](https://github.com/krystofwoldrich))

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -49,6 +49,7 @@
     "@expo/env": "~2.0.7",
     "@expo/image-utils": "^0.8.7",
     "@expo/json-file": "^10.0.7",
+    "@expo/mcp-tunnel": "~0.2.3",
     "@expo/metro": "~54.2.0",
     "@expo/metro-config": "~54.0.3",
     "@expo/osascript": "^2.3.7",

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -49,7 +49,6 @@
     "@expo/env": "~2.0.7",
     "@expo/image-utils": "^0.8.7",
     "@expo/json-file": "^10.0.7",
-    "@expo/mcp-tunnel": "~0.2.3",
     "@expo/metro": "~54.2.0",
     "@expo/metro-config": "~54.0.3",
     "@expo/osascript": "^2.3.7",
@@ -126,7 +125,7 @@
     }
   },
   "devDependencies": {
-    "@expo/mcp-tunnel": "~0.2.1",
+    "@expo/mcp-tunnel": "~0.2.3",
     "@expo/multipart-body-parser": "^1.0.0",
     "@expo/ngrok": "4.1.3",
     "@graphql-codegen/cli": "^2.16.3",

--- a/packages/@expo/cli/src/start/interface/interactiveActions.ts
+++ b/packages/@expo/cli/src/start/interface/interactiveActions.ts
@@ -148,7 +148,7 @@ export class DevServerManagerActions {
 
       const metroServerOrigin = this.devServerManager.getDefaultDevServer().getJsInspectorBaseUrl();
       const plugins = await this.devServerManager.devtoolsPluginManager.queryPluginsAsync();
-      Log.log();
+
       const menuItems = [
         ...defaultMenuItems,
         ...createDevToolsMenuItems(plugins, defaultServerUrl, metroServerOrigin),

--- a/packages/@expo/cli/src/start/server/DevToolsPluginCliExtensionExecutor.ts
+++ b/packages/@expo/cli/src/start/server/DevToolsPluginCliExtensionExecutor.ts
@@ -83,7 +83,7 @@ export class DevToolsPluginCliExtensionExecutor {
       const tool = path.join(this.plugin.packageRoot, this.plugin.cliExtensions!.entryPoint);
       const child = this.spawnFunc(
         'node',
-        [tool, command, `${JSON.stringify(args)}`, `'${metroServerOrigin}'`],
+        [tool, command, `${JSON.stringify(args)}`, `${metroServerOrigin}`],
         {
           cwd: this.projectRoot,
           env: { ...process.env },

--- a/packages/@expo/cli/src/start/server/DevToolsPluginCliExtensionExecutor.ts
+++ b/packages/@expo/cli/src/start/server/DevToolsPluginCliExtensionExecutor.ts
@@ -83,7 +83,7 @@ export class DevToolsPluginCliExtensionExecutor {
       const tool = path.join(this.plugin.packageRoot, this.plugin.cliExtensions!.entryPoint);
       const child = this.spawnFunc(
         'node',
-        [tool, command, `'${JSON.stringify(args)}'`, `'${metroServerOrigin}'`],
+        [tool, command, `${JSON.stringify(args)}`, `'${metroServerOrigin}'`],
         {
           cwd: this.projectRoot,
           env: { ...process.env },

--- a/packages/@expo/cli/src/start/server/MCPDevToolsPluginCLIExtensions.ts
+++ b/packages/@expo/cli/src/start/server/MCPDevToolsPluginCLIExtensions.ts
@@ -1,0 +1,139 @@
+import { z } from 'zod';
+
+import { DevServerManager } from './DevServerManager';
+import { DevToolsPlugin } from './DevToolsPlugin';
+import { DevToolsPluginCommand, DevToolsPluginOutputSchema } from './DevToolsPlugin.schema';
+import { DevToolsPluginCliExtensionExecutor } from './DevToolsPluginCliExtensionExecutor';
+import { McpServer } from './MCP';
+import { Log } from '../../log';
+
+const debug = require('debug')('expo:start:server:devtools:mcp');
+
+export async function addMcpCapabilities(mcpServer: McpServer, devServerManager: DevServerManager) {
+  const plugins = await devServerManager.devtoolsPluginManager.queryPluginsAsync();
+
+  for (const plugin of plugins) {
+    if (plugin.cliExtensions) {
+      const commands = (plugin.cliExtensions.commands ?? []).filter((p) =>
+        p.environments?.includes('mcp')
+      );
+      if (commands.length === 0) {
+        continue;
+      }
+
+      const inputSchema = createSchema(plugin);
+
+      debug(
+        `Installing MCP CLI extension for plugin: ${plugin.packageName} - found ${commands.length} commands`
+      );
+      const devServerManagerRef = new WeakRef(devServerManager);
+
+      mcpServer.registerTool(
+        plugin.packageName,
+        { title: plugin.packageName, description: plugin.description, inputSchema },
+        async (cliCommandArgs) => {
+          try {
+            if (!('parameters' in cliCommandArgs)) {
+              throw new Error(`No parameters provided : ${JSON.stringify(cliCommandArgs)}`);
+            }
+            const parameters = cliCommandArgs['parameters'];
+            if (!('command' in parameters)) {
+              throw new Error('No command provided');
+            }
+            const devServerManager = devServerManagerRef.deref();
+            if (!devServerManager) {
+              throw new Error('DevServerManager has been garbage collected');
+            }
+            const { command, ...args } = parameters;
+
+            const metroServerOrigin = devServerManager
+              .getDefaultDevServer()
+              .getJsInspectorBaseUrl();
+
+            const results = await new DevToolsPluginCliExtensionExecutor(
+              plugin,
+              devServerManager.projectRoot
+            ).execute({ command, args, metroServerOrigin });
+
+            const parsedResults = DevToolsPluginOutputSchema.safeParse(results);
+            if (parsedResults.success === false) {
+              throw new Error(
+                `Invalid output from CLI command: ${parsedResults.error.issues
+                  .map((issue) => issue.message)
+                  .join(', ')}`
+              );
+            }
+            return {
+              content: parsedResults.data
+                .map((line) => {
+                  const { type } = line;
+                  if (type === 'text') {
+                    return { type, text: line.text, level: line.level, url: line.url };
+                  } else if (line.type === 'image' || line.type === 'audio') {
+                    // We could present this as a resource_link, but it seems not to be well supported in MCP clients,
+                    // so we'll return a text with the link instead.
+                    return {
+                      type: 'text',
+                      text: `${type} resource: ${line.url}${line.text ? ' (' + line.text + ')' : ''}`,
+                    } as const;
+                  }
+                  return null;
+                })
+                .filter((line): line is Exclude<typeof line, null> => line !== null),
+            };
+          } catch (e: any) {
+            Log.error('Error executing MCP CLI command:', e);
+            return {
+              content: [
+                { type: 'text', text: `Error executing command: ${e.toString()}`, error: true },
+              ],
+            };
+          }
+        }
+      );
+    }
+  }
+}
+
+function createSchema(plugin: DevToolsPlugin) {
+  if (plugin.cliExtensions == null || plugin.cliExtensions?.commands.length === 0) {
+    throw new Error(
+      `Plugin ${plugin.packageName} has no commands defined. Please define at least one command.`
+    );
+  }
+
+  const createCommandSchema = (c: DevToolsPluginCommand) =>
+    z.object({
+      command: z.literal(c.name).describe(c.title),
+      ...((c.parameters?.length ?? 0) > 0
+        ? {
+            // If the command has parameters, extend schema for them
+            ...c.parameters!.reduce(
+              (acc, param) => ({
+                ...acc,
+                [param.name]: z.string().describe(param.description || ''),
+              }),
+              {} as Record<string, z.ZodTypeAny>
+            ),
+          }
+        : {}),
+    });
+
+  // If we only have a single command, we can return the schema directly.
+  const commandSchemas = plugin.cliExtensions.commands.map((c) => createCommandSchema(c));
+  if (commandSchemas.length === 1) {
+    return {
+      parameters: commandSchemas[0],
+    };
+  }
+
+  // The union type expects an array with at least two elements, so we need to create the type based
+  // on the actual command schemas.
+  type First = (typeof commandSchemas)[0];
+  type Second = (typeof commandSchemas)[1];
+  type Schema = [First, Second, ...z.ZodTypeAny[]];
+
+  return {
+    parameters: commandSchemas.length === 1 ? commandSchemas[0] : z.union(commandSchemas as Schema),
+  };
+}

--- a/packages/@expo/cli/src/start/server/MCPDevToolsPluginCLIExtensions.ts
+++ b/packages/@expo/cli/src/start/server/MCPDevToolsPluginCLIExtensions.ts
@@ -1,10 +1,8 @@
-import { z } from 'zod';
-
 import { DevServerManager } from './DevServerManager';
-import { DevToolsPlugin } from './DevToolsPlugin';
-import { DevToolsPluginCommand, DevToolsPluginOutputSchema } from './DevToolsPlugin.schema';
+import { DevToolsPluginOutputSchema } from './DevToolsPlugin.schema';
 import { DevToolsPluginCliExtensionExecutor } from './DevToolsPluginCliExtensionExecutor';
 import { McpServer } from './MCP';
+import { createMCPDevToolsExtensionSchema } from './createMCPDevToolsExtensionSchema';
 import { Log } from '../../log';
 
 const debug = require('debug')('expo:start:server:devtools:mcp');
@@ -21,7 +19,7 @@ export async function addMcpCapabilities(mcpServer: McpServer, devServerManager:
         continue;
       }
 
-      const inputSchema = createSchema(plugin);
+      const inputSchema = createMCPDevToolsExtensionSchema(plugin);
 
       debug(
         `Installing MCP CLI extension for plugin: ${plugin.packageName} - found ${commands.length} commands`
@@ -93,47 +91,4 @@ export async function addMcpCapabilities(mcpServer: McpServer, devServerManager:
       );
     }
   }
-}
-
-function createSchema(plugin: DevToolsPlugin) {
-  if (plugin.cliExtensions == null || plugin.cliExtensions?.commands.length === 0) {
-    throw new Error(
-      `Plugin ${plugin.packageName} has no commands defined. Please define at least one command.`
-    );
-  }
-
-  const createCommandSchema = (c: DevToolsPluginCommand) =>
-    z.object({
-      command: z.literal(c.name).describe(c.title),
-      ...((c.parameters?.length ?? 0) > 0
-        ? {
-            // If the command has parameters, extend schema for them
-            ...c.parameters!.reduce(
-              (acc, param) => ({
-                ...acc,
-                [param.name]: z.string().describe(param.description || ''),
-              }),
-              {} as Record<string, z.ZodTypeAny>
-            ),
-          }
-        : {}),
-    });
-
-  // If we only have a single command, we can return the schema directly.
-  const commandSchemas = plugin.cliExtensions.commands.map((c) => createCommandSchema(c));
-  if (commandSchemas.length === 1) {
-    return {
-      parameters: commandSchemas[0],
-    };
-  }
-
-  // The union type expects an array with at least two elements, so we need to create the type based
-  // on the actual command schemas.
-  type First = (typeof commandSchemas)[0];
-  type Second = (typeof commandSchemas)[1];
-  type Schema = [First, Second, ...z.ZodTypeAny[]];
-
-  return {
-    parameters: commandSchemas.length === 1 ? commandSchemas[0] : z.union(commandSchemas as Schema),
-  };
 }

--- a/packages/@expo/cli/src/start/server/MCPDevToolsPluginCLIExtensions.ts
+++ b/packages/@expo/cli/src/start/server/MCPDevToolsPluginCLIExtensions.ts
@@ -82,9 +82,8 @@ export async function addMcpCapabilities(mcpServer: McpServer, devServerManager:
           } catch (e: any) {
             Log.error('Error executing MCP CLI command:', e);
             return {
-              content: [
-                { type: 'text', text: `Error executing command: ${e.toString()}`, error: true },
-              ],
+              content: [{ type: 'text', text: `Error executing command: ${e.toString()}` }],
+              isError: true,
             };
           }
         }

--- a/packages/@expo/cli/src/start/server/MCPDevToolsPluginCLIExtensions.ts
+++ b/packages/@expo/cli/src/start/server/MCPDevToolsPluginCLIExtensions.ts
@@ -28,15 +28,8 @@ export async function addMcpCapabilities(mcpServer: McpServer, devServerManager:
       mcpServer.registerTool(
         plugin.packageName,
         { title: plugin.packageName, description: plugin.description, inputSchema },
-        async (cliCommandArgs) => {
+        async ({ parameters }) => {
           try {
-            if (!('parameters' in cliCommandArgs)) {
-              throw new Error(`No parameters provided : ${JSON.stringify(cliCommandArgs)}`);
-            }
-            const parameters = cliCommandArgs['parameters'];
-            if (!('command' in parameters)) {
-              throw new Error('No command provided');
-            }
             const { command, ...args } = parameters;
 
             const metroServerOrigin = devServerManager

--- a/packages/@expo/cli/src/start/server/MCPDevToolsPluginCLIExtensions.ts
+++ b/packages/@expo/cli/src/start/server/MCPDevToolsPluginCLIExtensions.ts
@@ -24,7 +24,6 @@ export async function addMcpCapabilities(mcpServer: McpServer, devServerManager:
       debug(
         `Installing MCP CLI extension for plugin: ${plugin.packageName} - found ${commands.length} commands`
       );
-      const devServerManagerRef = new WeakRef(devServerManager);
 
       mcpServer.registerTool(
         plugin.packageName,
@@ -37,10 +36,6 @@ export async function addMcpCapabilities(mcpServer: McpServer, devServerManager:
             const parameters = cliCommandArgs['parameters'];
             if (!('command' in parameters)) {
               throw new Error('No command provided');
-            }
-            const devServerManager = devServerManagerRef.deref();
-            if (!devServerManager) {
-              throw new Error('DevServerManager has been garbage collected');
             }
             const { command, ...args } = parameters;
 

--- a/packages/@expo/cli/src/start/server/MCPDevToolsPluginCLIExtensions.ts
+++ b/packages/@expo/cli/src/start/server/MCPDevToolsPluginCLIExtensions.ts
@@ -19,7 +19,7 @@ export async function addMcpCapabilities(mcpServer: McpServer, devServerManager:
         continue;
       }
 
-      const inputSchema = createMCPDevToolsExtensionSchema(plugin);
+      const schema = createMCPDevToolsExtensionSchema(plugin);
 
       debug(
         `Installing MCP CLI extension for plugin: ${plugin.packageName} - found ${commands.length} commands`
@@ -27,7 +27,11 @@ export async function addMcpCapabilities(mcpServer: McpServer, devServerManager:
 
       mcpServer.registerTool(
         plugin.packageName,
-        { title: plugin.packageName, description: plugin.description, inputSchema },
+        {
+          title: plugin.packageName,
+          description: plugin.description,
+          inputSchema: { parameters: schema },
+        },
         async ({ parameters }) => {
           try {
             const { command, ...args } = parameters;

--- a/packages/@expo/cli/src/start/server/__tests__/MCPDevToolsPluginCLIExtensions-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/MCPDevToolsPluginCLIExtensions-test.ts
@@ -1,0 +1,239 @@
+import { Log } from '../../../log';
+import { DevServerManager } from '../DevServerManager';
+import { DevToolsPlugin } from '../DevToolsPlugin';
+import { DevToolsPluginCommand } from '../DevToolsPlugin.schema';
+import { DevToolsPluginCliExtensionExecutor } from '../DevToolsPluginCliExtensionExecutor';
+import { McpServer } from '../MCP';
+import { addMcpCapabilities } from '../MCPDevToolsPluginCLIExtensions';
+
+jest.mock('../DevToolsPluginCliExtensionExecutor');
+jest.mock('../../../log', () => ({
+  Log: {
+    error: jest.fn(),
+    log: jest.fn(),
+  },
+}));
+
+const MockedExecutor = DevToolsPluginCliExtensionExecutor as jest.MockedClass<
+  typeof DevToolsPluginCliExtensionExecutor
+>;
+
+const PROJECT_ROOT = '/tmp/project';
+
+let executeMock: jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  executeMock = jest.fn();
+  MockedExecutor.mockImplementation(
+    () =>
+      ({
+        execute: executeMock,
+      }) as unknown as InstanceType<typeof DevToolsPluginCliExtensionExecutor>
+  );
+});
+
+describe(addMcpCapabilities, () => {
+  it('registers MCP CLI commands as tools on the MCP server', async () => {
+    const mcpCommands: DevToolsPluginCommand[] = [
+      createCommand({
+        name: 'first-command',
+        parameters: [{ name: 'foo', type: 'text', description: 'Foo parameter' }],
+      }),
+      createCommand({ name: 'second-command' }),
+    ];
+    const plugin = createPlugin('test-plugin', 'Test MCP plugin', mcpCommands);
+
+    const { devServerManager, queryPluginsAsync } = createDevServerManager([plugin]);
+    const registerTool = jest.fn();
+    const mcpServer = { registerTool } as unknown as McpServer;
+
+    await addMcpCapabilities(mcpServer, devServerManager);
+
+    expect(queryPluginsAsync).toHaveBeenCalledTimes(1);
+    expect(registerTool).toHaveBeenCalledTimes(1);
+
+    const [toolName, toolDefinition, toolHandler] = registerTool.mock.calls[0];
+    expect(toolName).toBe('test-plugin');
+    expect(toolDefinition.title).toBe('test-plugin');
+    expect(toolDefinition.description).toBe('Test MCP plugin');
+    expect(typeof toolHandler).toBe('function');
+
+    const schema = toolDefinition.inputSchema.parameters;
+    expect(schema.safeParse({ command: 'first-command', foo: 'bar' }).success).toBe(true);
+    expect(schema.safeParse({ command: 'second-command' }).success).toBe(true);
+    expect(schema.safeParse({ command: 'first-command' }).success).toBe(false);
+    expect(MockedExecutor).not.toHaveBeenCalled();
+  });
+
+  it('executes registered command and formats output lines', async () => {
+    const command = createCommand({
+      name: 'run-analysis',
+      parameters: [{ name: 'path', type: 'text', description: 'Target path' }],
+    });
+    const plugin = createPlugin('analysis-plugin', 'Analysis Plugin', [command]);
+    const { devServerManager, getJsInspectorBaseUrl } = createDevServerManager(
+      [plugin],
+      'http://localhost:19000'
+    );
+    const registerTool = jest.fn();
+    const mcpServer = { registerTool } as unknown as McpServer;
+
+    const pluginOutput = [
+      { type: 'text', text: 'Run complete', level: 'info', url: 'https://example.com' },
+      { type: 'image', url: 'https://example.com/image.png', text: 'Screenshot' },
+      { type: 'audio', url: 'https://example.com/sound.mp3' },
+    ] as const;
+    executeMock.mockResolvedValue(pluginOutput);
+
+    await addMcpCapabilities(mcpServer, devServerManager);
+
+    const [, , handler] = registerTool.mock.calls[0];
+    const result = await handler({
+      parameters: {
+        command: 'run-analysis',
+        path: '/tmp/data',
+      },
+    });
+
+    expect(MockedExecutor).toHaveBeenCalledTimes(1);
+    expect(MockedExecutor).toHaveBeenLastCalledWith(plugin, PROJECT_ROOT);
+    expect(executeMock).toHaveBeenCalledWith({
+      command: 'run-analysis',
+      args: { path: '/tmp/data' },
+      metroServerOrigin: 'http://localhost:19000',
+    });
+    expect(getJsInspectorBaseUrl).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: 'Run complete',
+          level: 'info',
+          url: 'https://example.com',
+        },
+        {
+          type: 'text',
+          text: 'image resource: https://example.com/image.png (Screenshot)',
+        },
+        {
+          type: 'text',
+          text: 'audio resource: https://example.com/sound.mp3',
+        },
+      ],
+    });
+  });
+
+  it('returns error output when command execution fails', async () => {
+    const command = createCommand({ name: 'failing-command' });
+    const plugin = createPlugin('broken-plugin', 'Broken Plugin', [command]);
+    const { devServerManager } = createDevServerManager([plugin]);
+    const registerTool = jest.fn();
+    const mcpServer = { registerTool } as unknown as McpServer;
+    const error = new Error('Execution exploded');
+    executeMock.mockRejectedValue(error);
+
+    await addMcpCapabilities(mcpServer, devServerManager);
+    const [, , handler] = registerTool.mock.calls[0];
+    const response = await handler({
+      parameters: { command: 'failing-command' },
+    });
+
+    const logError = Log.error as jest.Mock;
+    expect(logError).toHaveBeenCalledWith('Error executing MCP CLI command:', error);
+    expect(response).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: 'Error executing command: Error: Execution exploded',
+          error: true,
+        },
+      ],
+    });
+  });
+
+  it('skips plugins without MCP-compatible commands', async () => {
+    const cliOnlyCommand: DevToolsPluginCommand = {
+      name: 'local-only',
+      title: 'Local only',
+      environments: ['cli'],
+      parameters: [],
+    };
+    const plugin = createPlugin('cli-plugin', 'CLI Plugin', [cliOnlyCommand]);
+    const pluginWithoutCliExtensions = new DevToolsPlugin(
+      {
+        packageName: 'ui-plugin',
+        packageRoot: '/packages/ui-plugin',
+      },
+      PROJECT_ROOT
+    );
+
+    const { devServerManager, queryPluginsAsync } = createDevServerManager([
+      plugin,
+      pluginWithoutCliExtensions,
+    ]);
+    const registerTool = jest.fn();
+    const mcpServer = { registerTool } as unknown as McpServer;
+
+    await addMcpCapabilities(mcpServer, devServerManager);
+
+    expect(queryPluginsAsync).toHaveBeenCalledTimes(1);
+    expect(registerTool).not.toHaveBeenCalled();
+  });
+});
+
+function createPlugin(
+  packageName: string,
+  description: string,
+  commands: DevToolsPluginCommand[]
+): DevToolsPlugin {
+  return new DevToolsPlugin(
+    {
+      packageName,
+      packageRoot: `/packages/${packageName}`,
+      cliExtensions: {
+        description,
+        entryPoint: 'dist/cli.js',
+        commands,
+      },
+    },
+    PROJECT_ROOT
+  );
+}
+
+function createCommand({
+  name,
+  title = name,
+  parameters = [],
+}: {
+  name: string;
+  title?: string;
+  parameters?: DevToolsPluginCommand['parameters'];
+}): DevToolsPluginCommand {
+  return {
+    name,
+    title,
+    environments: ['mcp'],
+    parameters,
+  };
+}
+
+function createDevServerManager(
+  plugins: DevToolsPlugin[],
+  metroServerOrigin: string = 'http://localhost:8081'
+): {
+  devServerManager: DevServerManager;
+  queryPluginsAsync: jest.Mock<Promise<DevToolsPlugin[]>>;
+  getJsInspectorBaseUrl: jest.Mock<string, []>;
+} {
+  const queryPluginsAsync = jest.fn().mockResolvedValue(plugins);
+  const getJsInspectorBaseUrl = jest.fn().mockReturnValue(metroServerOrigin);
+  const defaultDevServer = { getJsInspectorBaseUrl };
+  const devServerManager = {
+    projectRoot: PROJECT_ROOT,
+    devtoolsPluginManager: { queryPluginsAsync },
+    getDefaultDevServer: jest.fn(() => defaultDevServer),
+  } as unknown as DevServerManager;
+
+  return { devServerManager, queryPluginsAsync, getJsInspectorBaseUrl };
+}

--- a/packages/@expo/cli/src/start/server/__tests__/MCPDevToolsPluginCLIExtensions-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/MCPDevToolsPluginCLIExtensions-test.ts
@@ -62,7 +62,6 @@ describe(addMcpCapabilities, () => {
     const schema = toolDefinition.inputSchema.parameters;
     expect(schema.safeParse({ command: 'first-command', foo: 'bar' }).success).toBe(true);
     expect(schema.safeParse({ command: 'second-command' }).success).toBe(true);
-    expect(schema.safeParse({ command: 'first-command' }).success).toBe(false);
     expect(MockedExecutor).not.toHaveBeenCalled();
   });
 
@@ -146,9 +145,9 @@ describe(addMcpCapabilities, () => {
         {
           type: 'text',
           text: 'Error executing command: Error: Execution exploded',
-          error: true,
         },
       ],
+      isError: true,
     });
   });
 

--- a/packages/@expo/cli/src/start/server/__tests__/createMCPDevToolsExtensionSchema-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/createMCPDevToolsExtensionSchema-test.ts
@@ -1,0 +1,57 @@
+import { DevToolsPlugin } from '../DevToolsPlugin';
+import { DevToolsPluginInfo } from '../DevToolsPlugin.schema';
+import { createMCPDevToolsExtensionSchema } from '../createMCPDevToolsExtensionSchema';
+
+describe(createMCPDevToolsExtensionSchema, () => {
+  const mockPlugin: DevToolsPluginInfo = {
+    packageName: 'mock-plugin',
+    packageRoot: '/path/to/mock-plugin',
+    cliExtensions: {
+      description: 'Expo: manage background tasks',
+      commands: [
+        { name: 'list', title: 'List registered background tasks', environments: ['cli', 'mcp'] },
+        {
+          name: 'task',
+          title: 'Show information about a registered background task',
+          environments: ['cli', 'mcp'],
+          parameters: [{ name: 'name', type: 'text', required: true }],
+        },
+        {
+          name: 'trigger-test',
+          title: 'Trigger a test background task',
+          environments: ['cli', 'mcp'],
+        },
+      ],
+      entryPoint: 'cli/build/index.js',
+    },
+  } as DevToolsPluginInfo;
+
+  it('generates correct schema for plugin with commands and parameters', () => {
+    const schema = createMCPDevToolsExtensionSchema(new DevToolsPlugin(mockPlugin, ''));
+    const parameters = {
+      command: 'task',
+      name: 'task 1',
+    };
+    expect(schema.parse(parameters)).toEqual({
+      command: 'task',
+      name: 'task 1',
+    });
+  });
+
+  it('throws error if plugin has no commands', () => {
+    const pluginWithoutCommands: DevToolsPlugin = {
+      packageName: 'no-commands-plugin',
+      packageRoot: '/path/to/no-commands-plugin',
+      cliExtensions: {
+        entryPoint: 'cli-extension.js',
+        commands: [],
+      },
+    } as DevToolsPlugin;
+
+    expect(() => {
+      createMCPDevToolsExtensionSchema(pluginWithoutCommands);
+    }).toThrow(
+      'Plugin no-commands-plugin has no commands defined. Please define at least one command.'
+    );
+  });
+});

--- a/packages/@expo/cli/src/start/server/createMCPDevToolsExtensionSchema.ts
+++ b/packages/@expo/cli/src/start/server/createMCPDevToolsExtensionSchema.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+
+import { DevToolsPlugin } from './DevToolsPlugin';
+import { DevToolsPluginCommand } from './DevToolsPlugin.schema';
+
+export function createMCPDevToolsExtensionSchema(plugin: DevToolsPlugin) {
+  if (plugin.cliExtensions == null || plugin.cliExtensions?.commands.length === 0) {
+    throw new Error(
+      `Plugin ${plugin.packageName} has no commands defined. Please define at least one command.`
+    );
+  }
+
+  const createCommandSchema = (c: DevToolsPluginCommand) =>
+    z.object({
+      command: z.literal(c.name).describe(c.title),
+      ...((c.parameters?.length ?? 0) > 0
+        ? {
+            // If the command has parameters, extend schema for them
+            ...c.parameters!.reduce(
+              (acc, param) => ({
+                ...acc,
+                [param.name]: z.string().describe(param.description || ''),
+              }),
+              {} as Record<string, z.ZodTypeAny>
+            ),
+          }
+        : {}),
+    });
+
+  // If we only have a single command, we can return the schema directly.
+  const commandSchemas = plugin.cliExtensions.commands.map((c) => createCommandSchema(c));
+  if (commandSchemas.length === 1) {
+    return {
+      parameters: commandSchemas[0],
+    };
+  }
+
+  // The union type expects an array with at least two elements, so we need to create the type based
+  // on the actual command schemas.
+  type First = (typeof commandSchemas)[0];
+  type Second = (typeof commandSchemas)[1];
+  type Schema = [First, Second, ...z.ZodTypeAny[]];
+
+  return {
+    parameters: commandSchemas.length === 1 ? commandSchemas[0] : z.union(commandSchemas as Schema),
+  };
+}

--- a/packages/@expo/cli/src/start/server/createMCPDevToolsExtensionSchema.ts
+++ b/packages/@expo/cli/src/start/server/createMCPDevToolsExtensionSchema.ts
@@ -3,6 +3,38 @@ import { z } from 'zod';
 import { DevToolsPlugin } from './DevToolsPlugin';
 import { DevToolsPluginCommand } from './DevToolsPlugin.schema';
 
+/**
+ * Creates an MCP-compatible JSON schema for a DevTools plugin's CLI extensions.
+ *
+ * LLM agents have varying support for complex JSON schema features like `anyOf`/`oneOf`
+ * discriminated unions. This implementation uses a flat schema with an enum for the
+ * command name, which provides the best compatibility across different LLM providers:
+ *
+ * - OpenAI: Supports `anyOf` but requires `additionalProperties: false` and all fields `required`
+ * - Claude/Anthropic: Works best with simple flat schemas with enums
+ * - Other providers: Generally have limited or inconsistent support for discriminated unions
+ *
+ * To compensate for the lack of discriminated unions, parameter descriptions include
+ * which command(s) they belong to, and command descriptions include their parameters.
+ *
+ * The resulting schema structure is:
+ * ```json
+ * {
+ *   "type": "object",
+ *   "properties": {
+ *     "command": {
+ *       "type": "string",
+ *       "enum": ["cmd1", "cmd2", ...],
+ *       "description": "The command to execute. Available commands: \"cmd1\" - Title 1 (params: foo); ..."
+ *     },
+ *     "foo": { "type": "string", "description": "Foo description (Used by: \"cmd1\")" },
+ *     ...
+ *   },
+ *   "required": ["command"],
+ *   "additionalProperties": false
+ * }
+ * ```
+ */
 export function createMCPDevToolsExtensionSchema(plugin: DevToolsPlugin) {
   if (plugin.cliExtensions == null || plugin.cliExtensions?.commands.length === 0) {
     throw new Error(
@@ -10,38 +42,71 @@ export function createMCPDevToolsExtensionSchema(plugin: DevToolsPlugin) {
     );
   }
 
-  const createCommandSchema = (c: DevToolsPluginCommand) =>
-    z.object({
-      command: z.literal(c.name).describe(c.title),
-      ...((c.parameters?.length ?? 0) > 0
-        ? {
-            // If the command has parameters, extend schema for them
-            ...c.parameters!.reduce(
-              (acc, param) => ({
-                ...acc,
-                [param.name]: z.string().describe(param.description || ''),
-              }),
-              {} as Record<string, z.ZodTypeAny>
-            ),
-          }
-        : {}),
-    });
+  const commands = plugin.cliExtensions.commands;
 
-  // If we only have a single command, we can return the schema directly.
-  const commandSchemas = plugin.cliExtensions.commands.map((c) => createCommandSchema(c));
-  if (commandSchemas.length === 1) {
-    return {
-      parameters: commandSchemas[0],
-    };
+  // Build a rich description that explains each command and its parameters
+  const commandDescriptions = commands
+    .map((c) => {
+      const params = c.parameters?.map((p) => p.name).join(', ');
+      return params ? `"${c.name}": ${c.title} (params: ${params})` : `"${c.name}": ${c.title}`;
+    })
+    .join('. ');
+
+  // Create enum of command names for clear LLM selection
+  const commandNames = commands.map((c) => c.name) as [string, ...string[]];
+
+  // Collect all unique parameters across all commands
+  // Track which commands use each parameter for documentation
+  const parameterCommandMap: Record<string, string[]> = {};
+  const parameterDescriptions: Record<string, string> = {};
+
+  for (const command of commands) {
+    if (command.parameters && command.parameters.length > 0) {
+      for (const param of command.parameters) {
+        if (!parameterCommandMap[param.name]) {
+          parameterCommandMap[param.name] = [];
+          parameterDescriptions[param.name] = param.description || '';
+        }
+        parameterCommandMap[param.name].push(command.name);
+      }
+    }
   }
 
-  // The union type expects an array with at least two elements, so we need to create the type based
-  // on the actual command schemas.
-  type First = (typeof commandSchemas)[0];
-  type Second = (typeof commandSchemas)[1];
-  type Schema = [First, Second, ...z.ZodTypeAny[]];
+  // Build parameters with descriptions that indicate which command(s) they belong to
+  const allParameters: Record<string, z.ZodTypeAny> = {};
+  for (const [paramName, commandList] of Object.entries(parameterCommandMap)) {
+    const baseDescription = parameterDescriptions[paramName];
+    const commandsUsingParam =
+      commandList.length === commands.length
+        ? 'all commands'
+        : commandList.map((c) => `"${c}"`).join(', ');
+
+    // Include command context in the description so LLMs know when to use each parameter
+    const fullDescription = baseDescription
+      ? `${baseDescription} (Used by: ${commandsUsingParam})`
+      : `Parameter for: ${commandsUsingParam}`;
+
+    allParameters[paramName] = z.string().optional().describe(fullDescription);
+  }
+
+  // Build the command description with clear instructions for the LLM
+  const hasParameters = Object.keys(allParameters).length > 0;
+  const commandDescription = hasParameters
+    ? `Required. The command to execute. You must select exactly one command from the enum values. ` +
+      `Each command may require specific parameters - only include parameters that belong to the selected command. ` +
+      `Commands: ${commandDescriptions}.`
+    : `Required. The command to execute. Select exactly one from the available options. ` +
+      `Commands: ${commandDescriptions}.`;
+
+  // Build the flat schema with additionalProperties: false for LLM compatibility
+  const schema = z
+    .object({
+      command: z.enum(commandNames).describe(commandDescription),
+      ...allParameters,
+    })
+    .strict(); // .strict() adds additionalProperties: false
 
   return {
-    parameters: commandSchemas.length === 1 ? commandSchemas[0] : z.union(commandSchemas as Schema),
+    parameters: schema,
   };
 }

--- a/packages/@expo/cli/src/start/server/createMCPDevToolsExtensionSchema.ts
+++ b/packages/@expo/cli/src/start/server/createMCPDevToolsExtensionSchema.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 
 import { DevToolsPlugin } from './DevToolsPlugin';
-import { DevToolsPluginCommand } from './DevToolsPlugin.schema';
 
 /**
  * Creates an MCP-compatible JSON schema for a DevTools plugin's CLI extensions.

--- a/packages/@expo/cli/src/start/server/createMCPDevToolsExtensionSchema.ts
+++ b/packages/@expo/cli/src/start/server/createMCPDevToolsExtensionSchema.ts
@@ -105,7 +105,5 @@ export function createMCPDevToolsExtensionSchema(plugin: DevToolsPlugin) {
     })
     .strict(); // .strict() adds additionalProperties: false
 
-  return {
-    parameters: schema,
-  };
+  return schema;
 }

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -16,6 +16,9 @@ import { env } from '../utils/env';
 import { isInteractive } from '../utils/interactive';
 import { profile } from '../utils/profile';
 import { maybeCreateMCPServerAsync } from './server/MCP';
+import { addMcpCapabilities } from './server/MCPDevToolsPluginCLIExtensions';
+
+const debug = require('debug')('expo:start');
 
 async function getMultiBundlerStartOptions(
   projectRoot: string,

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -139,7 +139,11 @@ export async function startAsync(
       Log.log(chalk`Waiting on {underline ${defaultServerUrl}}`);
     }
   }
-  mcpServer?.start();
+
+  if (mcpServer) {
+    addMcpCapabilities(mcpServer, devServerManager);
+    mcpServer.start();
+  }
 
   // Final note about closing the server.
   const logLocation = settings.webOnly ? 'in the browser console' : 'below';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3806,7 +3806,7 @@
     invariant "^2.2.4"
     nullthrows "^1.1.1"
 
-"@react-navigation/bottom-tabs@^7.3.10", "@react-navigation/bottom-tabs@^7.7.3":
+"@react-navigation/bottom-tabs@7.7.3", "@react-navigation/bottom-tabs@^7.3.10", "@react-navigation/bottom-tabs@^7.7.3":
   version "7.7.3"
   resolved "https://registry.yarnpkg.com/@react-navigation/bottom-tabs/-/bottom-tabs-7.7.3.tgz#b5f25f013b531e69e68bc6cb356d6b36953b3805"
   integrity sha512-aqsutx8auVaPySf8p165Cqj8K2s8e96uXYViU01sEGrBHdOg/pdR7XPiLoqmpsYcRifwZJlZwLAENhzyqdL/DQ==
@@ -3815,7 +3815,7 @@
     color "^4.2.3"
     sf-symbols-typescript "^2.1.0"
 
-"@react-navigation/core@^7.13.2":
+"@react-navigation/core@7.13.2", "@react-navigation/core@^7.13.2":
   version "7.13.2"
   resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-7.13.2.tgz#25c67bf578eb4329b8bf6c4ed9ef348871964f95"
   integrity sha512-A0pFeZlKp+FJob2lVr7otDt3M4rsSJrnAfXWoWR9JVeFtfEXsH/C0s7xtpDCMRUO58kzSBoTF1GYzoMC5DLD4g==
@@ -3829,7 +3829,7 @@
     use-latest-callback "^0.2.4"
     use-sync-external-store "^1.5.0"
 
-"@react-navigation/drawer@^7.7.2":
+"@react-navigation/drawer@7.7.2", "@react-navigation/drawer@^7.7.2":
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/@react-navigation/drawer/-/drawer-7.7.2.tgz#86f0fcf7065d8754d7532bebd4800a8fa17afde2"
   integrity sha512-393VoJLiQe1wMw6FxP+ajCgJRRI3PuEX+OA1YQG1my1BB2AbrbBld6e5uyvU5eoYykIpkQ5D1mxDmZ5MhF4yPA==
@@ -3839,7 +3839,7 @@
     react-native-drawer-layout "^4.2.0"
     use-latest-callback "^0.2.4"
 
-"@react-navigation/elements@^2.8.1", "@react-navigation/elements@^2.8.3":
+"@react-navigation/elements@2.8.3", "@react-navigation/elements@^2.8.1", "@react-navigation/elements@^2.8.3":
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/@react-navigation/elements/-/elements-2.8.3.tgz#d8f15b3d1ed2a1a5c8bf766a97382505e39851be"
   integrity sha512-0c5nSDPP3bUFujgkSVqqMShaAup3XIxNe1KTK9LSmwKgWEneyo6OPIjIdiEwPlZvJZKi7ag5hDjacQLGwO0LGA==
@@ -3848,7 +3848,7 @@
     use-latest-callback "^0.2.4"
     use-sync-external-store "^1.5.0"
 
-"@react-navigation/native-stack@^7.8.0":
+"@react-navigation/native-stack@7.8.0", "@react-navigation/native-stack@^7.8.0":
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/@react-navigation/native-stack/-/native-stack-7.8.0.tgz#6e83e34c9f6aed196a6dcb92929e6443f7298602"
   integrity sha512-iRqQY+IYB610BJY/335/kdNDhXQ8L9nPUlIT+DSk88FA86+C+4/vek8wcKw8IrfwdorT4m+6TY0v7Qnrt+WLKQ==
@@ -3858,7 +3858,7 @@
     sf-symbols-typescript "^2.1.0"
     warn-once "^0.1.1"
 
-"@react-navigation/native@^7.1.21", "@react-navigation/native@^7.1.6":
+"@react-navigation/native@7.1.21", "@react-navigation/native@^7.1.21", "@react-navigation/native@^7.1.6":
   version "7.1.21"
   resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-7.1.21.tgz#77228e0c556a35e5d6aa7e571a17465ae796f789"
   integrity sha512-mhpAewdivBL01ibErr91FUW9bvKhfAF6Xv/yr6UOJtDhv0jU6iUASUcA3i3T8VJCOB/vxmoke7VDp8M+wBFs/Q==
@@ -3869,14 +3869,14 @@
     nanoid "^3.3.11"
     use-latest-callback "^0.2.4"
 
-"@react-navigation/routers@^7.5.2":
-  version "7.5.3"
-  resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-7.5.3.tgz#8002930ef5f62351be2475d0dffde3ffaee174d7"
-  integrity sha512-1tJHg4KKRJuQ1/EvJxatrMef3NZXEPzwUIUZ3n1yJ2t7Q97siwRtbynRpQG9/69ebbtiZ8W3ScOZF/OmhvM4Rg==
+"@react-navigation/routers@7.5.1", "@react-navigation/routers@^7.5.2":
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-7.5.1.tgz#b8f6e9b491fdc1bc7164fdac4fa4faa82f397daf"
+  integrity sha512-pxipMW/iEBSUrjxz2cDD7fNwkqR4xoi0E/PcfTQGCcdJwLoaxzab5kSadBLj1MTJyT0YRrOXL9umHpXtp+Dv4w==
   dependencies:
     nanoid "^3.3.11"
 
-"@react-navigation/stack@^7.6.7":
+"@react-navigation/stack@7.6.7", "@react-navigation/stack@^7.6.7":
   version "7.6.7"
   resolved "https://registry.yarnpkg.com/@react-navigation/stack/-/stack-7.6.7.tgz#8cd599681964ba930a15b70134bcbe38bf96424d"
   integrity sha512-8NZWKTBYRVl8oSvhLKs26C6Dw5a3OhyfRc8ITS9A0kRSYaaX/KcZpObbAxp8kCJfTaJ7ZmghyX2NCGwnKw6V7A==
@@ -4206,14 +4206,14 @@
     "@types/babel__template" "*"
     "@types/babel__traverse" "*"
 
-"@types/babel__generator@*":
+"@types/babel__generator@*", "@types/babel__generator@^7.27.0":
   version "7.27.0"
   resolved "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.27.0.tgz#b5819294c51179957afaec341442f9341e4108a9"
   integrity sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==
   dependencies:
     "@babel/types" "^7.0.0"
 
-"@types/babel__template@*":
+"@types/babel__template@*", "@types/babel__template@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.4.4.tgz#5672513701c1b2199bc6dad636a9d7491586766f"
   integrity sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==
@@ -4221,7 +4221,7 @@
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"
 
-"@types/babel__traverse@*", "@types/babel__traverse@^7.0.6":
+"@types/babel__traverse@*", "@types/babel__traverse@^7.0.6", "@types/babel__traverse@^7.20.7":
   version "7.28.0"
   resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.28.0.tgz#07d713d6cce0d265c9849db0cbe62d3f61f36f74"
   integrity sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==
@@ -5283,17 +5283,7 @@ ajv@^6.12.4, ajv@^6.12.6:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.1.0, ajv@^8.11.0:
-  version "8.12.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
-  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
-    uri-js "^4.2.2"
-
-ajv@^8.17.1:
+ajv@^8.0.0, ajv@^8.1.0, ajv@^8.11.0, ajv@^8.17.1:
   version "8.17.1"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
   integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
@@ -5952,22 +5942,7 @@ body-parser@1.20.3:
     type-is "~1.6.18"
     unpipe "1.0.0"
 
-body-parser@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-2.2.0.tgz#f7a9656de305249a715b549b7b8fd1ab9dfddcfa"
-  integrity sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==
-  dependencies:
-    bytes "^3.1.2"
-    content-type "^1.0.5"
-    debug "^4.4.0"
-    http-errors "^2.0.0"
-    iconv-lite "^0.6.3"
-    on-finished "^2.4.1"
-    qs "^6.14.0"
-    raw-body "^3.0.0"
-    type-is "^2.0.0"
-
-body-parser@^2.2.1:
+body-parser@^2.2.0, body-parser@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-2.2.2.tgz#1a32cdb966beaf68de50a9dfbe5b58f83cb8890c"
   integrity sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==
@@ -7088,10 +7063,10 @@ debug@2, debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.0.tgz#2b3f2aea2ffeb776477460267377dc8710faba8a"
-  integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.4.0, debug@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
   dependencies:
     ms "^2.1.3"
 
@@ -7101,13 +7076,6 @@ debug@^3.1.0, debug@^3.2.6, debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
-
-debug@^4.4.3:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
-  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
-  dependencies:
-    ms "^2.1.3"
 
 decamelize-keys@^1.1.0:
   version "1.1.1"
@@ -8363,7 +8331,7 @@ express@^4.19.2:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
-express@^5.0.1:
+express@^5.0.1, express@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/express/-/express-5.2.1.tgz#8f21d15b6d327f92b4794ecf8cb08a72f956ac04"
   integrity sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==
@@ -8376,39 +8344,6 @@ express@^5.0.1:
     cookie-signature "^1.2.1"
     debug "^4.4.0"
     depd "^2.0.0"
-    encodeurl "^2.0.0"
-    escape-html "^1.0.3"
-    etag "^1.8.1"
-    finalhandler "^2.1.0"
-    fresh "^2.0.0"
-    http-errors "^2.0.0"
-    merge-descriptors "^2.0.0"
-    mime-types "^3.0.0"
-    on-finished "^2.4.1"
-    once "^1.4.0"
-    parseurl "^1.3.3"
-    proxy-addr "^2.0.7"
-    qs "^6.14.0"
-    range-parser "^1.2.1"
-    router "^2.2.0"
-    send "^1.1.0"
-    serve-static "^2.2.0"
-    statuses "^2.0.1"
-    type-is "^2.0.1"
-    vary "^1.1.2"
-
-express@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/express/-/express-5.1.0.tgz#d31beaf715a0016f0d53f47d3b4d7acf28c75cc9"
-  integrity sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==
-  dependencies:
-    accepts "^2.0.0"
-    body-parser "^2.2.0"
-    content-disposition "^1.0.0"
-    content-type "^1.0.5"
-    cookie "^0.7.1"
-    cookie-signature "^1.2.1"
-    debug "^4.4.0"
     encodeurl "^2.0.0"
     escape-html "^1.0.3"
     etag "^1.8.1"
@@ -9486,7 +9421,7 @@ http-cache-semantics@^4.0.0:
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
   integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
 
-http-errors@2.0.0, http-errors@^2.0.0:
+http-errors@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.0.tgz#b7774a1486ef73cf7667ac9ae0858c012c57b9d3"
   integrity sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==
@@ -9497,7 +9432,7 @@ http-errors@2.0.0, http-errors@^2.0.0:
     statuses "2.0.1"
     toidentifier "1.0.1"
 
-http-errors@~2.0.1:
+http-errors@^2.0.0, http-errors@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.1.tgz#36d2f65bc909c8790018dd36fb4d93da6caae06b"
   integrity sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==
@@ -9702,11 +9637,6 @@ inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, i
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-
-inherits@2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
-  integrity sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==
 
 ini@^1.3.4, ini@~1.3.0:
   version "1.3.8"
@@ -13265,14 +13195,7 @@ qs@6.13.0:
   dependencies:
     side-channel "^1.0.6"
 
-qs@^6.14.0:
-  version "6.14.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.0.tgz#c63fa40680d2c5c941412a0e899c89af60c0a930"
-  integrity sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==
-  dependencies:
-    side-channel "^1.1.0"
-
-qs@^6.14.1:
+qs@^6.14.0, qs@^6.14.1:
   version "6.14.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.1.tgz#a41d85b9d3902f31d27861790506294881871159"
   integrity sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==
@@ -13345,17 +13268,7 @@ raw-body@2.5.2:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-raw-body@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-3.0.0.tgz#25b3476f07a51600619dae3fe82ddc28a36e5e0f"
-  integrity sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==
-  dependencies:
-    bytes "3.1.2"
-    http-errors "2.0.0"
-    iconv-lite "0.6.3"
-    unpipe "1.0.0"
-
-raw-body@^3.0.1:
+raw-body@^3.0.0, raw-body@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-3.0.2.tgz#3e3ada5ae5568f9095d84376fd3a49b8fb000a51"
   integrity sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==
@@ -13745,12 +13658,7 @@ react-timer-mixin@^0.13.3:
   resolved "https://registry.yarnpkg.com/react-timer-mixin/-/react-timer-mixin-0.13.4.tgz#75a00c3c94c13abe29b43d63b4c65a88fc8264d3"
   integrity sha512-4+ow23tp/Tv7hBM5Az5/Be/eKKF7DIvJ09voz5LyHGQaqqz9WV8YMs31eFvcYQs7d451LSg7kDJV70XYN/Ug/Q==
 
-react@19.1.1:
-  version "19.1.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.1.1.tgz#06d9149ec5e083a67f9a1e39ce97b06a03b644af"
-  integrity sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==
-
-react@19.2.0:
+react@19.1.1, react@19.2.0:
   version "19.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-19.2.0.tgz#d33dd1721698f4376ae57a54098cb47fc75d93a5"
   integrity sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==
@@ -16043,14 +15951,7 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-util@^0.10.3:
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
-  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
-  dependencies:
-    inherits "2.0.3"
-
-util@^0.12.0:
+util@^0.10.3, util@^0.12.0, util@~0.12.4:
   version "0.12.5"
   resolved "https://registry.yarnpkg.com/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
   integrity sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==
@@ -16972,12 +16873,7 @@ zen-observable@0.8.15:
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
 
-zod-to-json-schema@^3.24.6:
-  version "3.24.6"
-  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz#5920f020c4d2647edfbb954fa036082b92c9e12d"
-  integrity sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==
-
-zod-to-json-schema@^3.25.0:
+zod-to-json-schema@^3.24.6, zod-to-json-schema@^3.25.0:
   version "3.25.1"
   resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz#7f24962101a439ddade2bf1aeab3c3bfec7d84ba"
   integrity sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1575,11 +1575,12 @@
     "@expo/sudo-prompt" "^9.3.1"
     debug "^3.1.0"
 
-"@expo/mcp-tunnel@~0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@expo/mcp-tunnel/-/mcp-tunnel-0.2.1.tgz#ed392d86702e44f9ef22cff653d2cdc0c7c575b3"
-  integrity sha512-2cuTYx4Ewe5UzQgtKd0FZWX8+es9c+y26YmT4fqhgw4q59uLuZjDZlTnJtsq3NMMTMmv+3Xl83IbvcqYoBd3oA==
+"@expo/mcp-tunnel@~0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@expo/mcp-tunnel/-/mcp-tunnel-0.2.3.tgz#349b9da026b172d0b04edede14e982b4deaa437b"
+  integrity sha512-AUyjAFxrDASPZo95BO8iUi8SqDXi97K9toCl/aT1vAU/1Ap5W7K+1IrMWNJivFdT7/XHvXU5LmoRtg5vXpYc1Q==
   dependencies:
+    "@modelcontextprotocol/sdk" "^1.17.5"
     ws "^8.18.3"
     zod "^3.25.76"
     zod-to-json-schema "^3.24.6"
@@ -2652,6 +2653,11 @@
     protobufjs "^6.10.0"
     yargs "^16.2.0"
 
+"@hono/node-server@^1.19.7":
+  version "1.19.7"
+  resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.7.tgz#ecb2d3a7af40d1d378e53ce1fc1219f199fbcd6f"
+  integrity sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw==
+
 "@humanfs/core@^0.19.1":
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@humanfs/core/-/core-0.19.1.tgz#17c55ca7d426733fe3c561906b8173c336b40a77"
@@ -3138,6 +3144,28 @@
   integrity sha512-2FptWtHQ+o7MzdsMKSvNZ1Mz7xtKSYI0WL9HjZ1r+CvsXR3lbLQUDp7Pwx6qhg0Akm4VluQ+8/D1S1fcr1Ao4w==
   dependencies:
     lottie-web "^5.12.2"
+
+"@modelcontextprotocol/sdk@^1.17.5":
+  version "1.25.2"
+  resolved "https://registry.yarnpkg.com/@modelcontextprotocol/sdk/-/sdk-1.25.2.tgz#2284560b4e044b4ce5f328ee180931110cb8c5cf"
+  integrity sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww==
+  dependencies:
+    "@hono/node-server" "^1.19.7"
+    ajv "^8.17.1"
+    ajv-formats "^3.0.1"
+    content-type "^1.0.5"
+    cors "^2.8.5"
+    cross-spawn "^7.0.5"
+    eventsource "^3.0.2"
+    eventsource-parser "^3.0.0"
+    express "^5.0.1"
+    express-rate-limit "^7.5.0"
+    jose "^6.1.1"
+    json-schema-typed "^8.0.2"
+    pkce-challenge "^5.0.0"
+    raw-body "^3.0.0"
+    zod "^3.25 || ^4.0"
+    zod-to-json-schema "^3.25.0"
 
 "@mswjs/interceptors@^0.39.5":
   version "0.39.8"
@@ -3778,7 +3806,7 @@
     invariant "^2.2.4"
     nullthrows "^1.1.1"
 
-"@react-navigation/bottom-tabs@7.7.3", "@react-navigation/bottom-tabs@^7.3.10", "@react-navigation/bottom-tabs@^7.7.3":
+"@react-navigation/bottom-tabs@^7.3.10", "@react-navigation/bottom-tabs@^7.7.3":
   version "7.7.3"
   resolved "https://registry.yarnpkg.com/@react-navigation/bottom-tabs/-/bottom-tabs-7.7.3.tgz#b5f25f013b531e69e68bc6cb356d6b36953b3805"
   integrity sha512-aqsutx8auVaPySf8p165Cqj8K2s8e96uXYViU01sEGrBHdOg/pdR7XPiLoqmpsYcRifwZJlZwLAENhzyqdL/DQ==
@@ -3787,7 +3815,7 @@
     color "^4.2.3"
     sf-symbols-typescript "^2.1.0"
 
-"@react-navigation/core@7.13.2", "@react-navigation/core@^7.13.2":
+"@react-navigation/core@^7.13.2":
   version "7.13.2"
   resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-7.13.2.tgz#25c67bf578eb4329b8bf6c4ed9ef348871964f95"
   integrity sha512-A0pFeZlKp+FJob2lVr7otDt3M4rsSJrnAfXWoWR9JVeFtfEXsH/C0s7xtpDCMRUO58kzSBoTF1GYzoMC5DLD4g==
@@ -3801,7 +3829,7 @@
     use-latest-callback "^0.2.4"
     use-sync-external-store "^1.5.0"
 
-"@react-navigation/drawer@7.7.2", "@react-navigation/drawer@^7.7.2":
+"@react-navigation/drawer@^7.7.2":
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/@react-navigation/drawer/-/drawer-7.7.2.tgz#86f0fcf7065d8754d7532bebd4800a8fa17afde2"
   integrity sha512-393VoJLiQe1wMw6FxP+ajCgJRRI3PuEX+OA1YQG1my1BB2AbrbBld6e5uyvU5eoYykIpkQ5D1mxDmZ5MhF4yPA==
@@ -3811,7 +3839,7 @@
     react-native-drawer-layout "^4.2.0"
     use-latest-callback "^0.2.4"
 
-"@react-navigation/elements@2.8.3", "@react-navigation/elements@^2.8.1", "@react-navigation/elements@^2.8.3":
+"@react-navigation/elements@^2.8.1", "@react-navigation/elements@^2.8.3":
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/@react-navigation/elements/-/elements-2.8.3.tgz#d8f15b3d1ed2a1a5c8bf766a97382505e39851be"
   integrity sha512-0c5nSDPP3bUFujgkSVqqMShaAup3XIxNe1KTK9LSmwKgWEneyo6OPIjIdiEwPlZvJZKi7ag5hDjacQLGwO0LGA==
@@ -3820,7 +3848,7 @@
     use-latest-callback "^0.2.4"
     use-sync-external-store "^1.5.0"
 
-"@react-navigation/native-stack@7.8.0", "@react-navigation/native-stack@^7.8.0":
+"@react-navigation/native-stack@^7.8.0":
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/@react-navigation/native-stack/-/native-stack-7.8.0.tgz#6e83e34c9f6aed196a6dcb92929e6443f7298602"
   integrity sha512-iRqQY+IYB610BJY/335/kdNDhXQ8L9nPUlIT+DSk88FA86+C+4/vek8wcKw8IrfwdorT4m+6TY0v7Qnrt+WLKQ==
@@ -3830,7 +3858,7 @@
     sf-symbols-typescript "^2.1.0"
     warn-once "^0.1.1"
 
-"@react-navigation/native@7.1.21", "@react-navigation/native@^7.1.21", "@react-navigation/native@^7.1.6":
+"@react-navigation/native@^7.1.21", "@react-navigation/native@^7.1.6":
   version "7.1.21"
   resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-7.1.21.tgz#77228e0c556a35e5d6aa7e571a17465ae796f789"
   integrity sha512-mhpAewdivBL01ibErr91FUW9bvKhfAF6Xv/yr6UOJtDhv0jU6iUASUcA3i3T8VJCOB/vxmoke7VDp8M+wBFs/Q==
@@ -3841,14 +3869,14 @@
     nanoid "^3.3.11"
     use-latest-callback "^0.2.4"
 
-"@react-navigation/routers@7.5.1", "@react-navigation/routers@^7.5.2":
-  version "7.5.1"
-  resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-7.5.1.tgz#b8f6e9b491fdc1bc7164fdac4fa4faa82f397daf"
-  integrity sha512-pxipMW/iEBSUrjxz2cDD7fNwkqR4xoi0E/PcfTQGCcdJwLoaxzab5kSadBLj1MTJyT0YRrOXL9umHpXtp+Dv4w==
+"@react-navigation/routers@^7.5.2":
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-7.5.3.tgz#8002930ef5f62351be2475d0dffde3ffaee174d7"
+  integrity sha512-1tJHg4KKRJuQ1/EvJxatrMef3NZXEPzwUIUZ3n1yJ2t7Q97siwRtbynRpQG9/69ebbtiZ8W3ScOZF/OmhvM4Rg==
   dependencies:
     nanoid "^3.3.11"
 
-"@react-navigation/stack@7.6.7", "@react-navigation/stack@^7.6.7":
+"@react-navigation/stack@^7.6.7":
   version "7.6.7"
   resolved "https://registry.yarnpkg.com/@react-navigation/stack/-/stack-7.6.7.tgz#8cd599681964ba930a15b70134bcbe38bf96424d"
   integrity sha512-8NZWKTBYRVl8oSvhLKs26C6Dw5a3OhyfRc8ITS9A0kRSYaaX/KcZpObbAxp8kCJfTaJ7ZmghyX2NCGwnKw6V7A==
@@ -4178,14 +4206,14 @@
     "@types/babel__template" "*"
     "@types/babel__traverse" "*"
 
-"@types/babel__generator@*", "@types/babel__generator@^7.27.0":
+"@types/babel__generator@*":
   version "7.27.0"
   resolved "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.27.0.tgz#b5819294c51179957afaec341442f9341e4108a9"
   integrity sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==
   dependencies:
     "@babel/types" "^7.0.0"
 
-"@types/babel__template@*", "@types/babel__template@^7.4.4":
+"@types/babel__template@*":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.4.4.tgz#5672513701c1b2199bc6dad636a9d7491586766f"
   integrity sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==
@@ -4193,7 +4221,7 @@
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"
 
-"@types/babel__traverse@*", "@types/babel__traverse@^7.0.6", "@types/babel__traverse@^7.20.7":
+"@types/babel__traverse@*", "@types/babel__traverse@^7.0.6":
   version "7.28.0"
   resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.28.0.tgz#07d713d6cce0d265c9849db0cbe62d3f61f36f74"
   integrity sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==
@@ -5238,6 +5266,13 @@ ajv-formats@^2.0.2:
   dependencies:
     ajv "^8.0.0"
 
+ajv-formats@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-3.0.1.tgz#3d5dc762bca17679c3c2ea7e90ad6b7532309578"
+  integrity sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv@^6.12.4, ajv@^6.12.6:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -5257,6 +5292,16 @@ ajv@^8.0.0, ajv@^8.1.0, ajv@^8.11.0:
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
+
+ajv@^8.17.1:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
+  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -5922,6 +5967,21 @@ body-parser@^2.2.0:
     raw-body "^3.0.0"
     type-is "^2.0.0"
 
+body-parser@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-2.2.2.tgz#1a32cdb966beaf68de50a9dfbe5b58f83cb8890c"
+  integrity sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==
+  dependencies:
+    bytes "^3.1.2"
+    content-type "^1.0.5"
+    debug "^4.4.3"
+    http-errors "^2.0.0"
+    iconv-lite "^0.7.0"
+    on-finished "^2.4.1"
+    qs "^6.14.1"
+    raw-body "^3.0.1"
+    type-is "^2.0.1"
+
 boolbase@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
@@ -6040,7 +6100,7 @@ busboy@^1.6.0:
   dependencies:
     streamsearch "^1.1.0"
 
-bytes@3.1.2, bytes@^3.1.2:
+bytes@3.1.2, bytes@^3.1.2, bytes@~3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
@@ -6722,6 +6782,14 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
 cosmiconfig-typescript-loader@^4.3.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.4.0.tgz#f3feae459ea090f131df5474ce4b1222912319f9"
@@ -7033,6 +7101,13 @@ debug@^3.1.0, debug@^3.2.6, debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
 
 decamelize-keys@^1.1.0:
   version "1.1.1"
@@ -8093,6 +8168,18 @@ eventemitter3@^4.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
+eventsource-parser@^3.0.0, eventsource-parser@^3.0.1:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.6.tgz#292e165e34cacbc936c3c92719ef326d4aeb4e90"
+  integrity sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==
+
+eventsource@^3.0.2:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-3.0.7.tgz#1157622e2f5377bb6aef2114372728ba0c156989"
+  integrity sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==
+  dependencies:
+    eventsource-parser "^3.0.1"
+
 exec-async@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/exec-async/-/exec-async-2.2.0.tgz#c7c5ad2eef3478d38390c6dd3acfe8af0efc8301"
@@ -8234,6 +8321,11 @@ exponential-backoff@^3.1.1:
   resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.1.tgz#64ac7526fe341ab18a39016cd22c787d01e00bf6"
   integrity sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==
 
+express-rate-limit@^7.5.0:
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-7.5.1.tgz#8c3a42f69209a3a1c969890070ece9e20a879dec"
+  integrity sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==
+
 express@^4.19.2:
   version "4.21.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.21.1.tgz#9dae5dda832f16b4eec941a4e44aa89ec481b281"
@@ -8270,6 +8362,40 @@ express@^4.19.2:
     type-is "~1.6.18"
     utils-merge "1.0.1"
     vary "~1.1.2"
+
+express@^5.0.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/express/-/express-5.2.1.tgz#8f21d15b6d327f92b4794ecf8cb08a72f956ac04"
+  integrity sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==
+  dependencies:
+    accepts "^2.0.0"
+    body-parser "^2.2.1"
+    content-disposition "^1.0.0"
+    content-type "^1.0.5"
+    cookie "^0.7.1"
+    cookie-signature "^1.2.1"
+    debug "^4.4.0"
+    depd "^2.0.0"
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    etag "^1.8.1"
+    finalhandler "^2.1.0"
+    fresh "^2.0.0"
+    http-errors "^2.0.0"
+    merge-descriptors "^2.0.0"
+    mime-types "^3.0.0"
+    on-finished "^2.4.1"
+    once "^1.4.0"
+    parseurl "^1.3.3"
+    proxy-addr "^2.0.7"
+    qs "^6.14.0"
+    range-parser "^1.2.1"
+    router "^2.2.0"
+    send "^1.1.0"
+    serve-static "^2.2.0"
+    statuses "^2.0.1"
+    type-is "^2.0.1"
+    vary "^1.1.2"
 
 express@^5.1.0:
   version "5.1.0"
@@ -8401,6 +8527,11 @@ fast-querystring@^1.1.1:
   integrity sha512-qR2r+e3HvhEFmpdHMv//U8FnFlnYjaC6QKDuaXALDkw2kvHO8WDjxH+f/rHGR4Me4pnk8p9JAkRNTjYHAKRn2Q==
   dependencies:
     fast-decode-uri-component "^1.0.1"
+
+fast-uri@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
+  integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
 
 fast-url-parser@^1.1.3:
   version "1.1.3"
@@ -9366,6 +9497,17 @@ http-errors@2.0.0, http-errors@^2.0.0:
     statuses "2.0.1"
     toidentifier "1.0.1"
 
+http-errors@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.1.tgz#36d2f65bc909c8790018dd36fb4d93da6caae06b"
+  integrity sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==
+  dependencies:
+    depd "~2.0.0"
+    inherits "~2.0.4"
+    setprototypeof "~1.2.0"
+    statuses "~2.0.2"
+    toidentifier "~1.0.1"
+
 http-parser-js@>=0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.6.tgz#2e02406ab2df8af8a7abfba62e0da01c62b95afd"
@@ -9450,6 +9592,13 @@ iconv-lite@0.6.3, iconv-lite@^0.6.2, iconv-lite@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
+iconv-lite@^0.7.0, iconv-lite@~0.7.0:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.7.1.tgz#d4af1d2092f2bb05aab6296e5e7cd286d2f15432"
+  integrity sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
@@ -9549,10 +9698,15 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+inherits@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+  integrity sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==
 
 ini@^1.3.4, ini@~1.3.0:
   version "1.3.8"
@@ -10666,6 +10820,11 @@ jose@^5:
   resolved "https://registry.yarnpkg.com/jose/-/jose-5.10.0.tgz#c37346a099d6467c401351a9a0c2161e0f52c4be"
   integrity sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==
 
+jose@^6.1.1:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-6.1.3.tgz#8453d7be88af7bb7d64a0481d6a35a0145ba3ea5"
+  integrity sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -10777,6 +10936,11 @@ json-schema-traverse@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
+json-schema-typed@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/json-schema-typed/-/json-schema-typed-8.0.2.tgz#e98ee7b1899ff4a184534d1f167c288c66bbeff4"
+  integrity sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
@@ -12162,7 +12326,7 @@ ob1@0.83.3:
   dependencies:
     flow-enums-runtime "^0.0.6"
 
-object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -12709,6 +12873,11 @@ pixi.js@^4.6.1:
     remove-array-items "^1.0.0"
     resource-loader "^2.2.3"
 
+pkce-challenge@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/pkce-challenge/-/pkce-challenge-5.0.1.tgz#3b4446865b17b1745e9ace2016a31f48ddf6230d"
+  integrity sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==
+
 pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
@@ -13103,6 +13272,13 @@ qs@^6.14.0:
   dependencies:
     side-channel "^1.1.0"
 
+qs@^6.14.1:
+  version "6.14.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.1.tgz#a41d85b9d3902f31d27861790506294881871159"
+  integrity sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==
+  dependencies:
+    side-channel "^1.1.0"
+
 query-string@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.3.tgz#a1cf90e994abb113a325804a972d98276fe02328"
@@ -13178,6 +13354,16 @@ raw-body@^3.0.0:
     http-errors "2.0.0"
     iconv-lite "0.6.3"
     unpipe "1.0.0"
+
+raw-body@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-3.0.2.tgz#3e3ada5ae5568f9095d84376fd3a49b8fb000a51"
+  integrity sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==
+  dependencies:
+    bytes "~3.1.2"
+    http-errors "~2.0.1"
+    iconv-lite "~0.7.0"
+    unpipe "~1.0.0"
 
 rc@^1.0.1, rc@^1.1.6, rc@^1.2.7, rc@~1.2.7:
   version "1.2.8"
@@ -13559,7 +13745,12 @@ react-timer-mixin@^0.13.3:
   resolved "https://registry.yarnpkg.com/react-timer-mixin/-/react-timer-mixin-0.13.4.tgz#75a00c3c94c13abe29b43d63b4c65a88fc8264d3"
   integrity sha512-4+ow23tp/Tv7hBM5Az5/Be/eKKF7DIvJ09voz5LyHGQaqqz9WV8YMs31eFvcYQs7d451LSg7kDJV70XYN/Ug/Q==
 
-react@19.1.1, react@19.2.0:
+react@19.1.1:
+  version "19.1.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-19.1.1.tgz#06d9149ec5e083a67f9a1e39ce97b06a03b644af"
+  integrity sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==
+
+react@19.2.0:
   version "19.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-19.2.0.tgz#d33dd1721698f4376ae57a54098cb47fc75d93a5"
   integrity sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==
@@ -14327,7 +14518,7 @@ setimmediate@^1.0.5:
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
 
-setprototypeof@1.2.0:
+setprototypeof@1.2.0, setprototypeof@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
@@ -14766,7 +14957,7 @@ statuses@2.0.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
-statuses@^2.0.1:
+statuses@^2.0.1, statuses@~2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.2.tgz#8f75eecef765b5e1cfcdc080da59409ed424e382"
   integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
@@ -15330,7 +15521,7 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-toidentifier@1.0.1:
+toidentifier@1.0.1, toidentifier@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
@@ -15852,7 +16043,14 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-util@^0.10.3, util@^0.12.0, util@~0.12.4:
+util@^0.10.3:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
+  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
+  dependencies:
+    inherits "2.0.3"
+
+util@^0.12.0:
   version "0.12.5"
   resolved "https://registry.yarnpkg.com/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
   integrity sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==
@@ -15927,7 +16125,7 @@ value-or-promise@1.0.12, value-or-promise@^1.0.11, value-or-promise@^1.0.12:
   resolved "https://registry.yarnpkg.com/value-or-promise/-/value-or-promise-1.0.12.tgz#0e5abfeec70148c78460a849f6b003ea7986f15c"
   integrity sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==
 
-vary@^1.1.2, vary@~1.1.2:
+vary@^1, vary@^1.1.2, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
@@ -16778,6 +16976,16 @@ zod-to-json-schema@^3.24.6:
   version "3.24.6"
   resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz#5920f020c4d2647edfbb954fa036082b92c9e12d"
   integrity sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==
+
+zod-to-json-schema@^3.25.0:
+  version "3.25.1"
+  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz#7f24962101a439ddade2bf1aeab3c3bfec7d84ba"
+  integrity sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==
+
+"zod@^3.25 || ^4.0":
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.5.tgz#aeb269a6f9fc259b1212c348c7c5432aaa474d2a"
+  integrity sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==
 
 zod@^3.25.76:
   version "3.25.76"


### PR DESCRIPTION
# Why

CLI extensions are already supported by the CLI, where any expo package can expose tools that will be available in the CLI "more tools" menu.

These commands are suitable as MCP tools as well, since they follow a fixed schema for input/output.

# How

This PR implements support for exposing a command in a cli extension as an MCP tool.

An example of a cli extension configuration for the `expo-background-task` package (`expo-modules.config.json`)

```json
{
  ...
  "devtools": {
    "cliExtensions": {
      "description": "Expo: manage background tasks",
      "commands": [
        { "name": "fail", "title": "Show error with regular log", "environments": [ "cli", "mcp" ] },
        { "name": "fail++", "title": "Show error with error log", "environments": [ "cli", "mcp" ] },
        { "name": "fail--", "title": "Throw error", "environments": [ "cli", "mcp" ] },
        { "name": "test", "title": "Succeed with output", "environments": [ "cli", "mcp" ] },
        { "name": "test++", "title": "Succeed with error output", "environments": [ "cli", "mcp" ] },
        { "name": "json", "title": "Succeed with JSON error output", "environments": [ "cli", "mcp" ] },
        { "name": "json--", "title": "Succeed with JSON error output", "environments": [ "cli", "mcp" ] }
      ],
      "entryPoint": "testing.js"
    }
  }
}
```

The file `testing.js` should be placed at the root of the `expo-background-task`:

```js
console.log('Starting to test expo-background-task');
setTimeout(() => {
  if (process.argv[2] === 'fail') {
    console.log('Testing expo-background-task failed');
    process.exit(1);
  } else if (process.argv[2] === 'fail++') {
    console.error('Testing expo-background-task failed');
    process.exit(1);
  } else if (process.argv[2] === 'fail--') {
    throw new Error('Testing expo-background-task failed');
  } else if (process.argv[2] === 'test') {
    console.log('Finished testing expo-background-task');
  } else if (process.argv[2] === 'params') {
    console.log('Params provided:', process.argv[3]);
  } else if (process.argv[2] === 'json') {
    console.log(
      JSON.stringify([
        { type: 'text', text: 'This is an info text', level: 'info' },
        { type: 'text', text: 'This is a warning', level: 'warning' },
        { type: 'text', text: 'This is an error', level: 'error' },
        { type: 'text', text: 'This is a link', level: 'info', url: 'https://example.com' },
        { type: 'image', url: 'https://picsum.photos/200/300', text: 'Example image' },
      ])
    );
  } else if (process.argv[2] === 'json--') {
    console.error(
      JSON.stringify([
        { type: 'text', text: 'This is an info text', level: 'info' },
        { type: 'text', text: 'This is a warning', level: 'warning' },
        { type: 'text', text: 'This is an error', level: 'error' },
        { type: 'image', url: 'https://picsum.photos/200/300', text: 'Example image' },
      ])
    );
    process.exit(1);
  } else {
    console.error('Finished testing expo-background-task');
  }
}, 1250);
```

# Test Plan

- Add the above files to `expo-background-task`
- Install the `expo-mcp` package in BareExpo
- Restart the cli with `EXPO_UNSTABLE_MCP_SERVER=1 nexpo start`
- Start a new agent chat in VSCode
- Run the command `Execute the command "json--" for the mcp tool expo-background-task`
- Verify that the agent asks if it is ok to run the command in a message similar to: "I'll execute the "json--" command for the expo-background-task MCP tool."
- Press "Allow"
- Verify that the output is something like the following:



# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
