### PR TITLE
[cli] fix failing tests

### DIFF
--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -162,7 +162,7 @@
     "jest-runner-tsd": "^6.0.0",
     "klaw-sync": "^6.0.0",
     "memfs": "^3.2.0",
-    "nock": "14.0.0-beta.7",
+    "nock": "^14.0.10",
     "node-html-parser": "^6.1.5",
     "nullthrows": "^1.1.1",
     "playwright": "^1.53.1",

--- a/packages/@expo/cli/src/api/rest/cache/ResponseCache.ts
+++ b/packages/@expo/cli/src/api/rest/cache/ResponseCache.ts
@@ -94,7 +94,7 @@ export function getRequestBodyCacheData(body: RequestInit['body']) {
     return body.path;
   }
 
-  if (body.toString && body.toString() === '[object FormData]') {
+  if (body.constructor.name === 'FormData') {
     return new URLSearchParams(body as any).toString();
   }
 

--- a/packages/@expo/cli/src/api/rest/cache/ResponseCache.ts
+++ b/packages/@expo/cli/src/api/rest/cache/ResponseCache.ts
@@ -19,11 +19,20 @@ export interface ResponseCache {
 }
 
 export function getResponseInfo(response: Response) {
+  // Handle multiple values for the same header key (e.g., set-cookie)
+  const headers: Record<string, string> = {};
+  for (const [key, value] of response.headers.entries()) {
+    if (headers[key]) {
+      headers[key] = headers[key] + ',' + value;
+    } else {
+      headers[key] = value;
+    }
+  }
   return {
     url: response.url,
     status: response.status,
     statusText: response.statusText,
-    headers: Object.fromEntries(response.headers.entries()),
+    headers,
   };
 }
 

--- a/packages/@expo/cli/src/api/rest/cache/ResponseCache.ts
+++ b/packages/@expo/cli/src/api/rest/cache/ResponseCache.ts
@@ -19,15 +19,8 @@ export interface ResponseCache {
 }
 
 export function getResponseInfo(response: Response) {
-  // Handle multiple values for the same header key (e.g., set-cookie)
-  const headers: Record<string, string> = {};
-  for (const [key, value] of response.headers.entries()) {
-    if (headers[key]) {
-      headers[key] = headers[key] + ',' + value;
-    } else {
-      headers[key] = value;
-    }
-  }
+  const headers = Object.fromEntries(response.headers.entries());
+  delete headers['set-cookie'];
   return {
     url: response.url,
     status: response.status,
@@ -94,7 +87,7 @@ export function getRequestBodyCacheData(body: RequestInit['body']) {
     return body.path;
   }
 
-  if (body.constructor.name === 'FormData') {
+  if (body.toString && body.toString() === '[object FormData]') {
     return new URLSearchParams(body as any).toString();
   }
 

--- a/packages/@expo/cli/src/api/rest/cache/__tests__/ResponseCache.test.ts
+++ b/packages/@expo/cli/src/api/rest/cache/__tests__/ResponseCache.test.ts
@@ -23,7 +23,7 @@ describe(getResponseInfo, () => {
       url: expect.any(String), // This is empty for Nock responses
       status: 200,
       statusText: 'OK',
-      headers: { 'content-type': 'application/json', 'set-cookie': 'test=123,test2=456' },
+      headers: { 'content-type': 'application/json' },
     });
 
     scope.done();

--- a/packages/create-expo/package.json
+++ b/packages/create-expo/package.json
@@ -54,7 +54,7 @@
     "expo-module-scripts": "^5.0.7",
     "getenv": "^2.0.0",
     "glob": "^10.4.2",
-    "nock": "^14.0.0-beta.7",
+    "nock": "^14.0.10",
     "ora": "3.4.0",
     "picomatch": "^2.3.1",
     "prompts": "^2.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3142,6 +3142,18 @@
   dependencies:
     lottie-web "^5.12.2"
 
+"@mswjs/interceptors@^0.39.5":
+  version "0.39.8"
+  resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.39.8.tgz#0a2cf4cf26a731214ca4156273121f67dff7ebf8"
+  integrity sha512-2+BzZbjRO7Ct61k8fMNHEtoKjeWI9pIlHFTqBwZ5icHpqszIgEZbjb1MW5Z0+bITTCTl3gk4PDBxs9tA/csXvA==
+  dependencies:
+    "@open-draft/deferred-promise" "^2.2.0"
+    "@open-draft/logger" "^0.3.0"
+    "@open-draft/until" "^2.0.0"
+    is-node-process "^1.2.0"
+    outvariant "^1.4.3"
+    strict-event-emitter "^0.5.1"
+
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3":
   version "2.1.8-no-fsevents.3"
   resolved "https://registry.yarnpkg.com/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz#323d72dd25103d0c4fbdce89dadf574a787b1f9b"
@@ -3214,6 +3226,24 @@
   integrity sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==
   dependencies:
     "@octokit/openapi-types" "^26.0.0"
+
+"@open-draft/deferred-promise@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz#4a822d10f6f0e316be4d67b4d4f8c9a124b073bd"
+  integrity sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==
+
+"@open-draft/logger@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/logger/-/logger-0.3.0.tgz#2b3ab1242b360aa0adb28b85f5d7da1c133a0954"
+  integrity sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==
+  dependencies:
+    is-node-process "^1.2.0"
+    outvariant "^1.4.0"
+
+"@open-draft/until@^2.0.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-2.1.0.tgz#0acf32f470af2ceaf47f095cdecd40d68666efda"
+  integrity sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==
 
 "@parcel/watcher-android-arm64@2.5.1":
   version "2.5.1"
@@ -10150,6 +10180,11 @@ is-nan@^1.2.1:
     call-bind "^1.0.0"
     define-properties "^1.1.3"
 
+is-node-process@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.2.0.tgz#ea02a1b90ddb3934a19aea414e88edef7e11d134"
+  integrity sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==
+
 is-number-object@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.1.1.tgz#144b21e95a1bc148205dcc2814a9134ec41b2541"
@@ -12594,11 +12629,12 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-nock@14.0.0-beta.7, nock@^14.0.0-beta.7:
-  version "14.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-14.0.0-beta.7.tgz#bdb3f3cfa2276659c87412f6dff2aea9ee69a7fc"
-  integrity sha512-+EQMm5W9K8YnBE2Ceg4hnJynaCZmvK8ZlFXQ2fxGwtkOkBUq8GpQLTks2m1jpvse9XDxMDDOHgOWpiznFuh0bA==
+nock@^14.0.10:
+  version "14.0.10"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-14.0.10.tgz#d6f4e73e1c6b4b7aa19d852176e68940e15cd19d"
+  integrity sha512-Q7HjkpyPeLa0ZVZC5qpxBt5EyLczFJ91MEewQiIi9taWuA0KB/MDJlUWtON+7dGouVdADTQsf9RA7TZk6D8VMw==
   dependencies:
+    "@mswjs/interceptors" "^0.39.5"
     json-stringify-safe "^5.0.1"
     propagate "^2.0.0"
 
@@ -13025,6 +13061,11 @@ os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
+
+outvariant@^1.4.0, outvariant@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.4.3.tgz#221c1bfc093e8fec7075497e7799fdbf43d14873"
+  integrity sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==
 
 p-cancelable@^2.0.0:
   version "2.1.1"
@@ -15552,6 +15593,11 @@ streamsearch@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
+
+strict-event-emitter@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz#1602ece81c51574ca39c6815e09f1a3e8550bd93"
+  integrity sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==
 
 strict-uri-encode@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
# Why

- test case `returns cached response for post request formdata body` failed locally for me, realized it was becaues I had node 24. I can also go down to 22 🤷 

# How

- fixed failing test (there's no better matcher than the somewhat clumsy `[object FormData]` afaict)
- upgrade nock from 14.0.0-beta.7 to 14.0.10 to use the stable release version
- changed `getResponseInfo` because otherwise [this](https://github.com/expo/expo/blob/364ee88395203ae2cb54b12baf51ea076936032c/packages/%40expo/cli/src/api/rest/cache/__tests__/ResponseCache.test.ts#L26) failed (only `'set-cookie': 'test2=456'` was reported)

# Test Plan

- green CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)