### PR TITLE
[ios][dev-launcher] Fix hotkeys after reload

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - [Android] Fix launching apps in brownfield ([#40711](https://github.com/expo/expo/pull/40711) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Fix React Native dev menu not showing up in 0.83.x ([#40819](https://github.com/expo/expo/pull/40819) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- [iOS] Fix broken hotkeys after reload.
+- [iOS] Fix broken hotkeys after reload. ([#40829](https://github.com/expo/expo/pull/40829) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -14,7 +14,6 @@
 
 - [Android] Fix launching apps in brownfield ([#40711](https://github.com/expo/expo/pull/40711) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Fix React Native dev menu not showing up in 0.83.x ([#40819](https://github.com/expo/expo/pull/40819) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- [iOS] Fix broken hotkeys after reload. ([#40829](https://github.com/expo/expo/pull/40829) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [Android] Fix launching apps in brownfield ([#40711](https://github.com/expo/expo/pull/40711) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Fix React Native dev menu not showing up in 0.83.x ([#40819](https://github.com/expo/expo/pull/40819) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Fix broken hotkeys after reload.
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix React Native dev menu not showing up in 0.83.x ([#40819](https://github.com/expo/expo/pull/40819) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Fix broken hotkeys after reload. ([#40829](https://github.com/expo/expo/pull/40829) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift
+++ b/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift
@@ -20,7 +20,11 @@ class DevMenuKeyCommandsInterceptor {
     }
   }
 
+  static private var moduleObserver: NSObjectProtocol?
+
   static private func registerKeyCommands() {
+    addModuleObserver()
+
     guard let commands = RCTKeyCommands.sharedInstance() else {
       return
     }
@@ -35,6 +39,14 @@ class DevMenuKeyCommandsInterceptor {
       withInput: "d",
       modifierFlags: .control,
       action: { _ in DevMenuManager.shared.toggleMenu() }
+    )
+
+    commands.registerKeyCommand(
+      withInput: "r",
+      modifierFlags: .command,
+      action: { _ in
+        DevMenuManager.shared.reload()
+      }
     )
 
     commands.registerKeyCommand(
@@ -70,7 +82,45 @@ class DevMenuKeyCommandsInterceptor {
     commands.unregisterKeyCommand(withInput: "d", modifierFlags: .command)
     commands.unregisterKeyCommand(withInput: "d", modifierFlags: .control)
     commands.unregisterKeyCommand(withInput: "r", modifierFlags: [])
+    commands.unregisterKeyCommand(withInput: "r", modifierFlags: .command)
     commands.unregisterKeyCommand(withInput: "i", modifierFlags: .command)
     commands.unregisterKeyCommand(withInput: "p", modifierFlags: .command)
+
+    removeModuleObserver()
+  }
+
+  static private func refreshKeyCommands() {
+    guard isInstalled else {
+      return
+    }
+
+    RCTExecuteOnMainQueue {
+      unregisterKeyCommands()
+      registerKeyCommands()
+    }
+  }
+
+  static private func addModuleObserver() {
+    guard moduleObserver == nil else {
+      return
+    }
+
+    moduleObserver = NotificationCenter.default.addObserver(
+      forName: NSNotification.Name.RCTDidInitializeModule,
+      object: nil,
+      queue: .main
+    ) { notification in
+      if (notification.userInfo?["module"] as? RCTDevMenu) != nil {
+        refreshKeyCommands()
+      }
+    }
+  }
+
+  static private func removeModuleObserver() {
+    let center = NotificationCenter.default
+    if let moduleObserver {
+      center.removeObserver(moduleObserver)
+      self.moduleObserver = nil
+    }
   }
 }


### PR DESCRIPTION
# Why
Fixes https://exponent-internal.slack.com/archives/CNHBN8LNS/p1762207018335769

# How
We need to listen for the dev menu modules registration to install and uninstall the key binding. We were also missing the `command+r` from our command registration

# Test Plan
Bare-expo. Hotkeys with command modifiers continue to work after a reload

