### PR TITLE
[docs] Fix formatting issues and missing installation info in Drawer

### DIFF
--- a/docs/pages/router/advanced/drawer.mdx
+++ b/docs/pages/router/advanced/drawer.mdx
@@ -8,12 +8,12 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 
 A navigation drawer is a common pattern in mobile apps, it allows users to swipe open a menu from a side of their screen to expose navigation options. This menu is also typically toggleable through a button in the app's header.
 
+## Installation
+
 <Tabs>
 <Tab label="SDK 54 and later">
 
 To use [drawer navigator](https://reactnavigation.org/docs/drawer-based-navigation) you'll need to install some additional dependencies if you do not have them already. On Android and iOS, the drawer navigator requires `react-native-reanimated` and `react-native-worklets` to drive its animations. On web, this is handled by CSS animations.
-
-## Installation
 
 <Terminal
   cmd={[
@@ -21,54 +21,19 @@ To use [drawer navigator](https://reactnavigation.org/docs/drawer-based-navigati
   ]}
 />
 
-## Usage
-
-Now you can use the `Drawer` layout to create a drawer navigator
-
-```tsx app/_layout.tsx
-import { Drawer } from 'expo-router/drawer';
-
-export default function Layout() {
-  return <Drawer />;
-}
-```
-
-To edit the drawer navigation menu labels, titles and screen options specific screens are required as follows:
-
-```tsx app/_layout.tsx
-import { Drawer } from 'expo-router/drawer';
-
-export default function Layout() {
-  return (
-    <Drawer>
-      <Drawer.Screen
-        name="index" // This is the name of the page and must match the url from root
-        options={{
-          drawerLabel: 'Home',
-          title: 'overview',
-        }}
-      />
-      <Drawer.Screen
-        name="user/[id]" // This is the name of the page and must match the url from root
-        options={{
-          drawerLabel: 'User',
-          title: 'overview',
-        }}
-      />
-    </Drawer>
-  );
-}
-```
-
 </Tab>
 <Tab label="SDK 53 and earlier">
-## Installation
+
+To use [drawer navigator](https://reactnavigation.org/docs/drawer-based-navigation) you'll need to install some additional dependencies if you do not have them already. On Android and iOS, the drawer navigator requires `react-native-reanimated` and `react-native-gesture-handler` to drive its animations. On web, this is handled by CSS animations.
 
 <Terminal
   cmd={[
     '$ npx expo install @react-navigation/drawer react-native-reanimated react-native-gesture-handler',
   ]}
 />
+
+</Tab>
+</Tabs>
 
 ## Usage
 
@@ -108,6 +73,3 @@ export default function Layout() {
   );
 }
 ```
-
-</Tab>
-</Tabs>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-17992

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix formatting issues and missing installation info in the SDK 53 tab for the Drawer navigator guide.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally.

## Preview

<img width="1303" height="897" alt="CleanShot 2025-11-04 at 17 38 01" src="https://github.com/user-attachments/assets/dcc80dc9-99aa-4dac-81fb-d17ad1b75793" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
