### PR TITLE
[docs] Update type for status in BackgroundFetchScreen to use BackgroundFetch.BackgroundFetchStatus

### DIFF
--- a/docs/pages/versions/unversioned/sdk/background-fetch.mdx
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.mdx
@@ -93,7 +93,7 @@ async function unregisterBackgroundFetchAsync() {
 
 export default function BackgroundFetchScreen() {
   const [isRegistered, setIsRegistered] = useState(false);
-  const [status, setStatus] = useState(null);
+  const [status, setStatus] = useState<BackgroundFetch.BackgroundFetchStatus | null>(null);
 
   useEffect(() => {
     checkStatusAsync();

--- a/docs/pages/versions/v52.0.0/sdk/background-fetch.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/background-fetch.mdx
@@ -90,7 +90,7 @@ async function unregisterBackgroundFetchAsync() {
 
 export default function BackgroundFetchScreen() {
   const [isRegistered, setIsRegistered] = useState(false);
-  const [status, setStatus] = useState(null);
+  const [status, setStatus] = useState<BackgroundFetch.BackgroundFetchStatus | null>(null);
 
   useEffect(() => {
     checkStatusAsync();

--- a/docs/pages/versions/v53.0.0/sdk/background-fetch.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/background-fetch.mdx
@@ -93,7 +93,7 @@ async function unregisterBackgroundFetchAsync() {
 
 export default function BackgroundFetchScreen() {
   const [isRegistered, setIsRegistered] = useState(false);
-  const [status, setStatus] = useState(null);
+  const [status, setStatus] = useState<BackgroundFetch.BackgroundFetchStatus | null>(null);
 
   useEffect(() => {
     checkStatusAsync();

--- a/docs/pages/versions/v54.0.0/sdk/background-fetch.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/background-fetch.mdx
@@ -93,7 +93,7 @@ async function unregisterBackgroundFetchAsync() {
 
 export default function BackgroundFetchScreen() {
   const [isRegistered, setIsRegistered] = useState(false);
-  const [status, setStatus] = useState(null);
+  const [status, setStatus] = useState<BackgroundFetch.BackgroundFetchStatus | null>(null);
 
   useEffect(() => {
     checkStatusAsync();


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

While going through the example, @kadikraman found that the example was missing a type for `status` in the Expo BackgroundFetch reference. This PR fixes it.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
