### PR TITLE
[modules-core] remove old REACT_NATIVE_TARGET_VERSION checks

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -44,6 +44,7 @@
 - [iOS] Added base props support for SwiftUI integration. ([#40492](https://github.com/expo/expo/pull/40492) by [@kudo](https://github.com/kudo))
 - [iOS] Removed some runtime type checks for dynamic types. ([#40611](https://github.com/expo/expo/pull/40611) by [@tsapeta](https://github.com/tsapeta))
 - Remove tests related files from the published package content. ([#39551](https://github.com/expo/expo/pull/39551) by [@Simek](https://github.com/Simek))
+- Remove old REACT_NATIVE_TARGET_VERSION checks ([#40843](https://github.com/expo/expo/pull/40843) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 3.0.22 - 2025-10-20
 

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
@@ -15,15 +15,11 @@ ExpoModulesHostObject::ExpoModulesHostObject(JSIContext *installer)
   : installer(installer) {}
 
 /**
- * Clears jsi references held by JSRegistry and JavaScriptRuntime. 
+ * Clears jsi references held by JSRegistry and JavaScriptRuntime.
  */
 ExpoModulesHostObject::~ExpoModulesHostObject() {
-#if REACT_NATIVE_TARGET_VERSION >= 75
   auto &runtime = installer->runtimeHolder->get();
   facebook::react::LongLivedObjectCollection::get(runtime).clear();
-#else
-  facebook::react::LongLivedObjectCollection::get().clear();
-#endif
   installer->prepareForDeallocation();
 }
 

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
@@ -23,11 +23,7 @@
 
 #endif
 
-#if REACT_NATIVE_TARGET_VERSION >= 73
-
 #include <ReactCommon/NativeMethodCallInvokerHolder.h>
-
-#endif
 
 #include <memory>
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
@@ -17,8 +17,6 @@
 
 namespace expo {
 
-#if REACT_NATIVE_TARGET_VERSION >= 75
-
 JavaCallback::CallbackContext::CallbackContext(
   jsi::Runtime &rt,
   std::weak_ptr<react::CallInvoker> jsCallInvokerHolder,
@@ -29,20 +27,6 @@ JavaCallback::CallbackContext::CallbackContext(
     jsCallInvokerHolder(std::move(jsCallInvokerHolder)),
     resolveHolder(std::move(resolveHolder)),
     rejectHolder(std::move(rejectHolder)) {}
-
-#else
-
-JavaCallback::CallbackContext::CallbackContext(
-  jsi::Runtime &rt,
-  std::weak_ptr<react::CallInvoker> jsCallInvokerHolder,
-  std::optional<jsi::Function> resolveHolder,
-  std::optional<jsi::Function> rejectHolder
-) : rt(rt),
-    jsCallInvokerHolder(std::move(jsCallInvokerHolder)),
-    resolveHolder(std::move(resolveHolder)),
-    rejectHolder(std::move(rejectHolder)) {}
-
-#endif
 
 void JavaCallback::CallbackContext::invalidate() {
   resolveHolder.reset();

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -37,11 +37,7 @@ jni::local_ref<JavaCallback::JavaPart> createJavaCallback(
     std::move(rejectFunction)
   );
 
-#if REACT_NATIVE_TARGET_VERSION >= 75
   facebook::react::LongLivedObjectCollection::get(rt).add(callbackContext);
-#else
-  facebook::react::LongLivedObjectCollection::get().add(callbackContext);
-#endif
 
   return JavaCallback::newInstance(jsiContext, std::move(callbackContext));
 }

--- a/packages/expo-modules-core/common/cpp/BridgelessJSCallInvoker.h
+++ b/packages/expo-modules-core/common/cpp/BridgelessJSCallInvoker.h
@@ -16,7 +16,6 @@ class BridgelessJSCallInvoker : public react::CallInvoker {
 public:
   explicit BridgelessJSCallInvoker(react::RuntimeExecutor runtimeExecutor) : runtimeExecutor_(std::move(runtimeExecutor)) {}
 
-#if REACT_NATIVE_TARGET_VERSION >= 75
   void invokeAsync(react::CallFunc &&func) noexcept override {
     runtimeExecutor_([func = std::move(func)](jsi::Runtime &runtime) { func(runtime); });
   }
@@ -24,15 +23,6 @@ public:
   void invokeSync(react::CallFunc &&func) override {
     throw std::runtime_error("Synchronous native -> JS calls are currently not supported.");
   }
-#else
-  void invokeAsync(std::function<void()> &&func) noexcept override {
-    runtimeExecutor_([func = std::move(func)](jsi::Runtime &runtime) { func(); });
-  }
-
-  void invokeSync(std::function<void()> &&func) override {
-    throw std::runtime_error("Synchronous native -> JS calls are currently not supported.");
-  }
-#endif
 
 private:
   react::RuntimeExecutor runtimeExecutor_;


### PR DESCRIPTION
# Why

In SDK 55, we will only support react-native 0.83, we don't need to keep old REACT_NATIVE_TARGET_VERSION checks

# How

Remove old REACT_NATIVE_TARGET_VERSION checks from modules-core

# Test Plan

BareExpo

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
