### PR TITLE
[ci] remove Gradle prebuild workaround from nightly jobs

### DIFF
--- a/.github/workflows/test-react-native-nightly.yml
+++ b/.github/workflows/test-react-native-nightly.yml
@@ -149,10 +149,6 @@ jobs:
       - name: ⭐️ Create test-nightlies Project (New Architecture)
         run: yarn prepare && bun build/index.js --expo-repo ${{ github.workspace }} --no-install ${{ runner.temp }} --enable-new-architecture true
         working-directory: packages/create-expo-nightly
-      - name: 🤖 Gradle prebuild for Android project (workaround to fix build error)
-        run: |
-          cd android && ./gradlew preBuild
-        working-directory: ${{ runner.temp }}/test-nightlies
       - name: 🤖 Build Android project (New Architecture)
         run: |
           cd android && ./gradlew ":app:assemble$VARIANT"

--- a/.github/workflows/test-react-native-nightly.yml
+++ b/.github/workflows/test-react-native-nightly.yml
@@ -3,7 +3,7 @@ name: Test React Native nightly build for Expo Modules
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 3 * * *' # 03:00 AM UTC everyday
+    - cron: "0 3 * * *" # 03:00 AM UTC everyday
   push:
     branches: [main]
     paths:
@@ -105,7 +105,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_ios }}
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         with:
-          channel: '#expo-ios'
+          channel: "#expo-ios"
           status: ${{ job.status }}
           fields: job,message,ref,eventName,author,took
           author_name: React Native Nightly (iOS)
@@ -118,21 +118,23 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
-      GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx4096m -XX:MaxMetaspaceSize=4096m"
+      GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6096m -XX:MaxMetaspaceSize=6096m"
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
+      - name: 🧹 Cleanup GitHub Linux runner disk space
+        uses: ./.github/actions/cleanup-linux-disk-space
       - name: 🚀 Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - name: 🔨 Use JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: "temurin"
+          java-version: "17"
       - name: ♻️ Restore workspace node modules
         # Use restore only cache here because we don't want to nightly react-native version saving back to the cache
         uses: actions/cache/restore@v3
@@ -163,24 +165,6 @@ jobs:
         with:
           name: android-builds-oldArch-${{ matrix.build-type }}
           path: ${{ runner.temp }}/test-nightlies/android/app/build/outputs/apk/
-      - name: 🤖 Build Android project (Old Architecture)
-        run: |
-          jq '.expo.newArchEnabled = false' app.json > app.json.tmp
-          mv -f app.json.tmp app.json
-          cat app.json
-          npx expo prebuild -p android --no-install --clean --template .expo/expo-template-bare-minimum-*.tgz
-          cd android && ./gradlew ":app:assemble$VARIANT"
-        shell: bash
-        working-directory: ${{ runner.temp }}/test-nightlies
-        env:
-          NODE_ENV: production
-          VARIANT: ${{ matrix.build-type == 'release' && 'Release' || 'Debug' }}
-      - name: 📸 Upload builds
-        uses: actions/upload-artifact@v4
-        if: ${{ github.event_name == 'workflow_dispatch' && matrix.build-type == 'release' }} # Only archive release builds
-        with:
-          name: android-builds-newArch-${{ matrix.build-type }}
-          path: ${{ runner.temp }}/test-nightlies/android/app/build/outputs/apk/
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
         if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main')
@@ -189,7 +173,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_android }}
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         with:
-          channel: '#expo-android'
+          channel: "#expo-android"
           status: ${{ job.status }}
           fields: job,message,ref,eventName,author,took
           author_name: React Native Nightly (Android)

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -3,7 +3,7 @@ name: Test Suite on React Native nightly build
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 10 * * SAT' # 10:00 AM UTC time every Saturday
+    - cron: "0 10 * * SAT" # 10:00 AM UTC time every Saturday
   push:
     branches: [main]
     paths:
@@ -48,7 +48,7 @@ jobs:
         uses: ./.github/actions/expo-caches
         id: expo-caches
         with:
-          yarn-tools: 'true'
+          yarn-tools: "true"
       - name: ⚙️ Setup react-native nightly
         run: et setup-react-native-nightly
       - name: ⚛️ Display React Native config
@@ -78,7 +78,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_ios }}
         with:
-          channel: '#expo-ios'
+          channel: "#expo-ios"
           status: ${{ job.status }}
           fields: job,message,ref,eventName,author,took
           author_name: Test Suite Nightly (iOS)
@@ -121,7 +121,7 @@ jobs:
         uses: ./.github/actions/expo-caches
         id: expo-caches
         with:
-          yarn-workspace: 'true'
+          yarn-workspace: "true"
       - name: 🧶 Install node modules in root dir
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
@@ -144,7 +144,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_ios }}
         with:
-          channel: '#expo-ios'
+          channel: "#expo-ios"
           status: ${{ job.status }}
           fields: job,message,ref,eventName,author,took
           author_name: Test Suite Nightly (iOS)
@@ -153,7 +153,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
-      GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx4096m -XX:MaxMetaspaceSize=4096m"
+      GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=4096m"
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v5
@@ -170,16 +170,16 @@ jobs:
       - name: 🔨 Use JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: "temurin"
+          java-version: "17"
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches
         with:
-          gradle: 'true'
-          yarn-tools: 'true'
+          gradle: "true"
+          yarn-tools: "true"
       - name: ⚙️ Setup react-native nightly
         run: et setup-react-native-nightly
       - name: ⚛️ Display React Native config
@@ -201,7 +201,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_android }}
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         with:
-          channel: '#expo-android'
+          channel: "#expo-android"
           status: ${{ job.status }}
           fields: job,message,ref,eventName,author,took
           author_name: Test Suite Nightly (Android)
@@ -234,7 +234,7 @@ jobs:
         uses: ./.github/actions/expo-caches
         id: expo-caches
         with:
-          yarn-workspace: 'true'
+          yarn-workspace: "true"
       - name: 🧶 Install node modules in root dir
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
@@ -262,7 +262,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_android }}
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         with:
-          channel: '#expo-android'
+          channel: "#expo-android"
           status: ${{ job.status }}
           fields: job,message,ref,eventName,author,took
           author_name: Test Suite Nightly (Android)

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -185,9 +185,6 @@ jobs:
       - name: ⚛️ Display React Native config
         run: yarn expo-modules-autolinking react-native-config --platform android
         working-directory: apps/bare-expo
-      - name: 🤖 Gradle prebuild for Android project (workaround to fix build error)
-        run: ./gradlew preBuild
-        working-directory: apps/bare-expo/android
       - name: 🤖 Build Android project
         run: ./scripts/start-android-e2e-test.ts --build
         working-directory: apps/bare-expo


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
