### PR TITLE
[docs] Fix missing and extra import of useState

### DIFF
--- a/docs/pages/versions/unversioned/sdk/splash-screen.mdx
+++ b/docs/pages/versions/unversioned/sdk/splash-screen.mdx
@@ -89,7 +89,7 @@ In some cases, it may be necessary to delay hiding the splash screen until certa
 ```tsx app/_layout.tsx
 import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 // Keep the splash screen visible while we fetch resources
 SplashScreen.preventAutoHideAsync();

--- a/docs/pages/versions/v53.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/splash-screen.mdx
@@ -72,7 +72,7 @@ export default function RootLayout() {
 <Tab label="Without Expo Router">
 
 ```jsx App.js
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { Text, View } from 'react-native';
 import Entypo from '@expo/vector-icons/Entypo';
 import * as SplashScreen from 'expo-splash-screen';

--- a/docs/pages/versions/v54.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/splash-screen.mdx
@@ -89,7 +89,7 @@ In some cases, it may be necessary to delay hiding the splash screen until certa
 ```tsx app/_layout.tsx
 import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 // Keep the splash screen visible while we fetch resources
 SplashScreen.preventAutoHideAsync();


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

There is a missing import in a example code for the splash-screen

# How

Add the missing import

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
