### PR TITLE
[e2e] open to apis screen

### DIFF
--- a/apps/bare-expo/e2e/_nested-flows/confirm-app-open.yaml
+++ b/apps/bare-expo/e2e/_nested-flows/confirm-app-open.yaml
@@ -3,7 +3,14 @@ jsEngine: graaljs
 ---
 # Run once to approve the first time deep linking prompt on iOS
 # This runs before all tests (only on iOS), as some tests fail because the prompt is not confirmed
-- openLink: bareexpo://test-suite/run
+# The tapOn is optional because the file is executed multiple times in CI, if it fails
+- openLink: bareexpo://apis
 - tapOn:
     text: 'Open'
-    optional: false
+    optional: true
+# for good measure
+- stopApp: dev.expo.Payments
+- openLink: bareexpo://apis
+- tapOn:
+    text: 'Open'
+    optional: true


### PR DESCRIPTION
# Why

I noticed some tests fail on the test-suite/run screen with no query provided. I suppose if we don't link to that screen at the start, this will not be the case

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- green CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
