### PR TITLE
[video][android] Emit `onFirstFrameRender` when player is moved to a new `VideoView`

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [iOS] Fix crashes when rapidly replacing HLS sources. ([#40265](https://github.com/expo/expo/pull/40265) by [@behenate](https://github.com/behenate))
 - [Android] Fix the `player` prop of the `VideoView` not working when a player is re-assigned after being replaced by a different player earlier. ([#40709](https://github.com/expo/expo/pull/40709) by [@behenate](https://github.com/behenate))
 - [Android] Fix surface view not showing when changing the `player` prop. ([#40817](https://github.com/expo/expo/pull/40817) by [@behenate](https://github.com/behenate))
+- [Android] Emit `onFirstFrameRender` when player is moved to a new `VideoView` and renders a frame. ([#40854](https://github.com/expo/expo/pull/40854) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/FullscreenPlayerActivity.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/FullscreenPlayerActivity.kt
@@ -77,7 +77,11 @@ class FullscreenPlayerActivity : Activity() {
     requestedOrientation = options.orientation.toActivityOrientation()
 
     videoPlayer = videoView.videoPlayer
-    videoPlayer?.changePlayerView(playerView)
+    videoPlayer?.player?.let {
+      PlayerView.switchTargetView(it, videoView.playerView, playerView)
+      videoPlayer?.hasBeenDisconnectedFromVideoView() // The video player is disconnected. We are only using the ExoPlayer it contained
+    }
+
     VideoManager.registerFullscreenPlayerActivity(hashCode().toString(), this)
     playerView.player?.let {
       val aspectRatio = calculatePiPAspectRatio(it.videoSize, playerView.width, playerView.height, videoView.contentFit)

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
@@ -114,17 +114,19 @@ open class VideoView(context: Context, appContext: AppContext, useTextureView: B
         VideoManager.onVideoPlayerDetachedFromView(it, this)
       }
       val oldPlayer = videoPlayer
+      val hasEmittedFirstFrame = newPlayer?.firstFrameEventGenerator?.hasSentFirstFrameForCurrentMediaItem
+        ?: false
       oldPlayer?.removeListener(this)
       newPlayer?.addListener(this)
       field = newPlayer
-      shouldHideSurfaceView = !(newPlayer?.hasRenderedAFrameOfVideoSource ?: false)
+      shouldHideSurfaceView = !hasEmittedFirstFrame
       applySurfaceViewVisibility()
       attachPlayer()
       newPlayer?.let {
         VideoManager.onVideoPlayerAttachedToView(it, this)
       }
       if (oldPlayer != newPlayer) {
-        oldPlayer?.hasBeenDisconnectedFromPlayerView()
+        oldPlayer?.hasBeenDisconnectedFromVideoView()
       }
     }
 
@@ -219,7 +221,7 @@ open class VideoView(context: Context, appContext: AppContext, useTextureView: B
   }
 
   fun attachPlayer() {
-    videoPlayer?.changePlayerView(playerView)
+    videoPlayer?.changeVideoView(this)
   }
 
   fun exitFullscreen() {
@@ -306,9 +308,11 @@ open class VideoView(context: Context, appContext: AppContext, useTextureView: B
   }
 
   override fun onRenderedFirstFrame(player: VideoPlayer) {
-    shouldHideSurfaceView = false
-    applySurfaceViewVisibility()
-    onFirstFrameRender(Unit)
+    if (player.currentVideoView == this) {
+      shouldHideSurfaceView = false
+      applySurfaceViewVisibility()
+      onFirstFrameRender(Unit)
+    }
   }
 
   override fun requestLayout() {

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/FirstFrameEventGenerator.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/FirstFrameEventGenerator.kt
@@ -1,11 +1,11 @@
 package expo.modules.video.player
 
+import androidx.annotation.MainThread
 import androidx.annotation.OptIn
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.exoplayer.ExoPlayer
-import androidx.media3.ui.PlayerView
+import expo.modules.video.VideoView
 import expo.modules.video.enums.ContentFit
 import expo.modules.video.utils.MutableWeakReference
 import java.lang.ref.WeakReference
@@ -20,17 +20,27 @@ import kotlin.math.abs
  * https://github.com/google/ExoPlayer/issues/5222
  */
 @OptIn(UnstableApi::class)
+@MainThread
 internal class FirstFrameEventGenerator(
-  player: ExoPlayer,
-  private val currentViewReference: MutableWeakReference<PlayerView?>,
+  videoPlayer: VideoPlayer,
+  private val currentViewReference: MutableWeakReference<VideoView?>,
   private val onFirstFrameRendered: () -> Unit
-) : Player.Listener {
-  val playerReference = WeakReference(player)
+) : Player.Listener, VideoPlayerListener {
+  private val videoPlayerReference = WeakReference(videoPlayer)
   private var hasPendingOnFirstFrame = false
-  private var hasSentFirstFrameForCurrentMediaItem = false
+  internal var hasSentFirstFrameForCurrentMediaItem = false
+    private set
+  internal var hasSentFirstFrameForCurrentVideoView = false
+    private set
 
   init {
-    player.addListener(this)
+    videoPlayer.player.addListener(this)
+    videoPlayer.addListener(this)
+  }
+
+  fun release() {
+    videoPlayerReference.get()?.removeListener(this)
+    videoPlayerReference.get()?.player?.removeListener(this)
   }
 
   override fun onRenderedFirstFrame() {
@@ -52,20 +62,25 @@ internal class FirstFrameEventGenerator(
     }
   }
 
+  override fun onTargetViewChanged(player: VideoPlayer, newTargetView: VideoView?, oldTargetView: VideoView?) {
+    hasSentFirstFrameForCurrentVideoView = false
+  }
+
   // Unlike iOS, android calls `onRenderedFirstFrame` multiple times for the same media item (after seeking).
   // We want to match the behavior across platforms, so we limit the number of event emissions.
   private fun maybeCallOnFirstFrameRendered() {
-    if (!hasSentFirstFrameForCurrentMediaItem) {
+    if (!hasSentFirstFrameForCurrentMediaItem || !hasSentFirstFrameForCurrentVideoView) {
       onFirstFrameRendered()
     }
     hasPendingOnFirstFrame = false
     hasSentFirstFrameForCurrentMediaItem = true
+    hasSentFirstFrameForCurrentVideoView = true
   }
 
   private fun isPlayerSurfaceLayoutValid(): Boolean {
     // Sometimes the video size announced by the track will is 1px off the render size.
     val epsilon = 0.05
-    val player = playerReference.get() ?: run {
+    val player = videoPlayerReference.get()?.player ?: run {
       return false
     }
     val currentPlayerView = currentViewReference.get() ?: run {
@@ -85,7 +100,7 @@ internal class FirstFrameEventGenerator(
     val trackAspectRatio = sourceWidth.toFloat() / sourceHeight * sourcePixelWidthHeightRatio
 
     val videoSizeIsUnknown = sourceWidth == 0 || sourceHeight == 0
-    val hasFillContentFit = currentPlayerView.resizeMode == ContentFit.FILL.toResizeMode()
+    val hasFillContentFit = currentPlayerView.playerView.resizeMode == ContentFit.FILL.toResizeMode()
     val hasCorrectRatio = abs(trackAspectRatio - surfaceAspectRatio) < epsilon
 
     return (hasCorrectRatio || hasFillContentFit || videoSizeIsUnknown)

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/PlayerEvent.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/PlayerEvent.kt
@@ -4,6 +4,7 @@ import androidx.annotation.OptIn
 import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.common.Tracks
 import androidx.media3.common.util.UnstableApi
+import expo.modules.video.VideoView
 import expo.modules.video.enums.AudioMixingMode
 import expo.modules.video.enums.PlayerStatus
 import expo.modules.video.records.AudioTrack
@@ -141,6 +142,11 @@ sealed class PlayerEvent {
     override val name = "playToEnd"
   }
 
+  data class TargetViewChanged(val newTargetView: VideoView?, val oldTargetView: VideoView?) : PlayerEvent() {
+    override val name = "targetViewChange"
+    override val emitToJS = false
+  }
+
   fun emit(player: VideoPlayer, listeners: List<VideoPlayerListener>) {
     when (this) {
       is StatusChanged -> listeners.forEach { it.onStatusChanged(player, status, oldStatus, error) }
@@ -157,6 +163,7 @@ sealed class PlayerEvent {
       is VideoTrackChanged -> listeners.forEach { it.onVideoTrackChanged(player, videoTrack, oldVideoTrack) }
       is RenderedFirstFrame -> listeners.forEach { it.onRenderedFirstFrame(player) }
       is VideoSourceLoaded -> listeners.forEach { it.onVideoSourceLoaded(player, videoSource, duration, availableVideoTracks, availableSubtitleTracks, availableAudioTracks) }
+      is TargetViewChanged -> listeners.forEach { it.onTargetViewChanged(player, newTargetView, oldTargetView) }
       // JS-only events - SubtitleTrackChanged - In the native events the TracksChanged can be used instead
       else -> Unit
     }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
@@ -28,6 +28,7 @@ import expo.modules.kotlin.sharedobjects.SharedObject
 import expo.modules.video.IntervalUpdateClock
 import expo.modules.video.IntervalUpdateEmitter
 import expo.modules.video.VideoManager
+import expo.modules.video.VideoView
 import expo.modules.video.delegates.IgnoreSameSet
 import expo.modules.video.enums.AudioMixingMode
 import expo.modules.video.enums.PlayerStatus
@@ -55,7 +56,10 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
     .forceEnableMediaCodecAsynchronousQueueing()
     .setEnableDecoderFallback(true)
   private var listeners: MutableList<WeakReference<VideoPlayerListener>> = mutableListOf()
-  private var currentPlayerView = MutableWeakReference<PlayerView?>(null)
+  private val currentVideoViewRef = MutableWeakReference<VideoView?>(null) { new, old ->
+    sendEvent(PlayerEvent.TargetViewChanged(new, old))
+  }
+  var currentVideoView by currentVideoViewRef
   val loadControl: VideoPlayerLoadControl = VideoPlayerLoadControl()
   val subtitles: VideoPlayerSubtitles = VideoPlayerSubtitles(this)
   val audioTracks: VideoPlayerAudioTracks = VideoPlayerAudioTracks(this)
@@ -67,11 +71,10 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
     .setLoadControl(loadControl)
     .build()
 
-  private val firstFrameEventGenerator = createFirstFrameEventGenerator()
+  internal lateinit var firstFrameEventGenerator: FirstFrameEventGenerator
   val serviceConnection = PlaybackServiceConnection(WeakReference(this), appContext)
   val intervalUpdateClock = IntervalUpdateClock(this)
 
-  var hasRenderedAFrameOfVideoSource = false
   var playing by IgnoreSameSet(false) { new, old ->
     sendEvent(PlayerEvent.IsPlayingChanged(new, old))
   }
@@ -273,7 +276,6 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
         resetPlaybackInfo()
       }
       subtitles.setSubtitlesEnabled(false)
-      hasRenderedAFrameOfVideoSource = false
       super.onMediaItemTransition(mediaItem, reason)
     }
 
@@ -325,6 +327,7 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
 
     // ExoPlayer will enable subtitles automatically at the start, we want them disabled by default
     appContext.mainQueue.launch {
+      firstFrameEventGenerator = createFirstFrameEventGenerator()
       subtitles.setSubtitlesEnabled(false)
     }
   }
@@ -337,6 +340,7 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
     VideoManager.unregisterVideoPlayer(this@VideoPlayer)
 
     appContext?.mainQueue?.launch {
+      firstFrameEventGenerator.release()
       player.removeListener(playerListener)
       player.release()
     }
@@ -354,16 +358,16 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
   /**
    * Used to notify the player that is has been disconnected from the player view by another player.
    */
-  fun hasBeenDisconnectedFromPlayerView() {
-    if (currentPlayerView.get()?.player == this.player) {
+  fun hasBeenDisconnectedFromVideoView() {
+    if (currentVideoView?.playerView?.player == this.player) {
       throw IllegalStateException("The player has been notified of disconnection from the player view, even though it's still connected.")
     }
-    currentPlayerView.set(null)
+    currentVideoView = null
   }
 
-  fun changePlayerView(playerView: PlayerView?) {
-    PlayerView.switchTargetView(player, currentPlayerView.get(), playerView)
-    currentPlayerView.set(playerView)
+  fun changeVideoView(videoView: VideoView?) {
+    PlayerView.switchTargetView(player, currentVideoView?.playerView, videoView?.playerView)
+    currentVideoView = videoView
   }
 
   fun prepare() {
@@ -483,8 +487,7 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
   }
 
   private fun createFirstFrameEventGenerator(): FirstFrameEventGenerator {
-    return FirstFrameEventGenerator(player, currentPlayerView) {
-      hasRenderedAFrameOfVideoSource = true
+    return FirstFrameEventGenerator(this, currentVideoViewRef) {
       sendEvent(PlayerEvent.RenderedFirstFrame())
     }
   }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayerListener.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayerListener.kt
@@ -4,6 +4,7 @@ import androidx.annotation.OptIn
 import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.common.Tracks
 import androidx.media3.common.util.UnstableApi
+import expo.modules.video.VideoView
 import expo.modules.video.enums.AudioMixingMode
 import expo.modules.video.enums.PlayerStatus
 import expo.modules.video.records.AudioTrack
@@ -28,5 +29,6 @@ interface VideoPlayerListener {
   fun onAudioMixingModeChanged(player: VideoPlayer, audioMixingMode: AudioMixingMode, oldAudioMixingMode: AudioMixingMode?) {}
   fun onVideoTrackChanged(player: VideoPlayer, videoTrack: VideoTrack?, oldVideoTrack: VideoTrack?) {}
   fun onVideoSourceLoaded(player: VideoPlayer, videoSource: VideoSource?, duration: Double?, availableVideoTracks: List<VideoTrack>, availableSubtitleTracks: List<SubtitleTrack>, availableAudioTracks: List<AudioTrack>) {}
+  fun onTargetViewChanged(player: VideoPlayer, newTargetView: VideoView?, oldTargetView: VideoView?) {}
   fun onRenderedFirstFrame(player: VideoPlayer) {}
 }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/utils/MutableWeakReference.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/utils/MutableWeakReference.kt
@@ -1,15 +1,26 @@
 package expo.modules.video.utils
 
 import java.lang.ref.WeakReference
+import kotlin.reflect.KProperty
 
-internal class MutableWeakReference<T>(value: T? = null) {
-  private var ref: WeakReference<T> = WeakReference(value)
+internal class MutableWeakReference<T : Any?>(initialValue: T, val didSet: ((new: T?, old: T?) -> Unit)? = null) {
+  private var ref: WeakReference<T> = WeakReference(initialValue)
+
+  operator fun getValue(thisRef: Any?, property: KProperty<*>): T? {
+    return get()
+  }
+
+  operator fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
+    set(value)
+  }
 
   fun get(): T? {
     return ref.get()
   }
 
   fun set(value: T) {
+    val oldValue = ref.get()
     ref = WeakReference(value)
+    didSet?.invoke(oldValue, value)
   }
 }


### PR DESCRIPTION
# Why

Currently we only emit `onFirstFrameRender` only on the first frame of the current media source of the player. 
If the player has already rendered the first frame and then was moved into a new view, it will not emit the event. This is incorrect as we'd like to emit the event every time the first frame is displayed in the `VideoView`

# How

Update our first frame event emission filter to take into account `VideoView` changes. This required quite a lot of changes, since we now need to keep a closer track of VideoView changes on the player side.

# Test Plan

Tested in BareExpo on Android
