### PR TITLE
[docs] Update nextjs config

### DIFF
--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -39,6 +39,7 @@ const removeConsoleConfig =
     : false;
 
 const nextConfig: NextConfig = {
+  outputFileTracingRoot: join(__dirname, '..'),
   transpilePackages: [
     '@expo/*',
     '@radix-ui/react-dropdown-menu',

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -39,7 +39,7 @@ const removeConsoleConfig =
     : false;
 
 const nextConfig: NextConfig = {
-  outputFileTracingRoot: join(__dirname, '..'),
+  outputFileTracingRoot: join(__dirname),
   transpilePackages: [
     '@expo/*',
     '@radix-ui/react-dropdown-menu',


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

On running `yarn dev` inside `docs/`, the following warning appears because Next.js sees both `expo/yarn.lock` and `expo/docs/yarn.lock`, guesses the monorepo root, and complains about it.

<img width="824" height="399" alt="CleanShot 2025-11-05 at 17 19 48" src="https://github.com/user-attachments/assets/aebfdfe5-b237-40da-bfad-0363aab07a36" />


# How

<!--
How did you build this feature or fix this bug and why?
-->

Add `outputFileTracingRoot` in `next.config.ts` as mentioned in the warning.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn dev` in the docs app and this warning should go away:

<img width="846" height="235" alt="CleanShot 2025-11-05 at 17 19 42" src="https://github.com/user-attachments/assets/98d977cb-2180-4866-aa15-1e82a17eca2b" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
