### PR TITLE
[audio] Separate mic permissions in plugin

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -3762,7 +3762,7 @@ SPEC CHECKSUMS:
   EXUpdates: 83e4d666a085b44149f3b21d5bd057ad37b2c3e5
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   FBLazyVector: b733c6ff598607c9c5a2757669306ca5481fa7a1
-  hermes-engine: b1e5aac33dadd818b62a43c558e35c596336de5c
+  hermes-engine: 2c7c3f3ea699e71a322152fbd4dede6fb6e7fc29
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -3780,7 +3780,7 @@ SPEC CHECKSUMS:
   React: 0d33ae696cce9f29ef4ef9395b677461f819edff
   React-callinvoker: 98827bd8d13282630bd3ac420d9deab3ef9c4404
   React-Core: c53a32ac2fd877b127d678668eacb32ee5b278a2
-  React-Core-prebuilt: 70e42a2d6ebc93c21944b4df1750d306e453adbb
+  React-Core-prebuilt: 84652d896dc2f54edacb498d2d99984bf8b86ff4
   React-CoreModules: 55744f49f098b26e46de697a828f0a22540246cd
   React-cxxreact: 07d452b1ca44cb6bf003b36d8263a1fa772d2cae
   React-debug: 65a8b0304322f0641d4aa5fcd1d9bdeae3f97327
@@ -3849,7 +3849,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: c55bd3998b0b548d2e81f5aae4758096d4321a7a
   ReactCodegen: c63ed13899d192e3ac78b794f4149e950dc86122
   ReactCommon: 558d37855c8b281c4fdfe8f9ba2d7bc102fb55ff
-  ReactNativeDependencies: e5bbb52b99bdc4386c563b1fc2aeaf98e59b18f8
+  ReactNativeDependencies: 0e21bdd14e5112c3663bdfedc68157a52b80c310
   RNCAsyncStorage: e85a99325df9eb0191a6ee2b2a842644c7eb29f4
   RNCMaskedView: 3c9d7586e2b9bbab573591dcb823918bc4668005
   RNCPicker: 38a9deb903d9a8ae18b598bac727e6c84b3cf0fa

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -4492,7 +4492,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 2853aea4922d43f84b721631947e9b25da43eabd
+  hermes-engine: 452f2dd7422b2fd7973ae9ca103898d28d7744f0
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8

--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -49,7 +49,8 @@ You can configure `expo-audio` using its built-in [config plugin](/config-plugin
     {
       name: 'microphonePermission',
       platform: 'ios',
-      description: 'A string to set the `NSMicrophoneUsageDescription` permission message. Setting to `false` will disable the permission.',
+      description:
+        'A string to set the `NSMicrophoneUsageDescription` permission message. Setting to `false` will disable the permission.',
       default: '"Allow $(PRODUCT_NAME) to access your microphone"',
     },
     {

--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -49,8 +49,15 @@ You can configure `expo-audio` using its built-in [config plugin](/config-plugin
     {
       name: 'microphonePermission',
       platform: 'ios',
-      description: 'A string to set the `NSMicrophoneUsageDescription` permission message.',
+      description: 'A string to set the `NSMicrophoneUsageDescription` permission message. Setting to `false` will disable the permission.',
       default: '"Allow $(PRODUCT_NAME) to access your microphone"',
+    },
+    {
+      name: 'recordAudioAndroid',
+      platform: 'android',
+      description:
+        'A boolean that determines whether to enable the `RECORD_AUDIO` permission on Android.',
+      default: 'true',
     },
   ]}
 />

--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -50,7 +50,7 @@ You can configure `expo-audio` using its built-in [config plugin](/config-plugin
       name: 'microphonePermission',
       platform: 'ios',
       description:
-        'A string to set the `NSMicrophoneUsageDescription` permission message. Setting to `false` will disable the permission.',
+        'A string to set the `NSMicrophoneUsageDescription` permission message. Setting it to `false` will disable the permission.',
       default: '"Allow $(PRODUCT_NAME) to access your microphone"',
     },
     {

--- a/docs/pages/versions/v54.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/audio.mdx
@@ -49,7 +49,8 @@ You can configure `expo-audio` using its built-in [config plugin](/config-plugin
     {
       name: 'microphonePermission',
       platform: 'ios',
-      description: 'A string to set the `NSMicrophoneUsageDescription` permission message. Setting to `false` will disable the permission.',
+      description:
+        'A string to set the `NSMicrophoneUsageDescription` permission message. Setting to `false` will disable the permission.',
       default: '"Allow $(PRODUCT_NAME) to access your microphone"',
     },
     {

--- a/docs/pages/versions/v54.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/audio.mdx
@@ -49,8 +49,15 @@ You can configure `expo-audio` using its built-in [config plugin](/config-plugin
     {
       name: 'microphonePermission',
       platform: 'ios',
-      description: 'A string to set the `NSMicrophoneUsageDescription` permission message.',
+      description: 'A string to set the `NSMicrophoneUsageDescription` permission message. Setting to `false` will disable the permission.',
       default: '"Allow $(PRODUCT_NAME) to access your microphone"',
+    },
+    {
+      name: 'recordAudioAndroid',
+      platform: 'android',
+      description:
+        'A boolean that determines whether to enable the `RECORD_AUDIO` permission on Android.',
+      default: 'true',
     },
   ]}
 />

--- a/docs/pages/versions/v54.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/audio.mdx
@@ -50,7 +50,7 @@ You can configure `expo-audio` using its built-in [config plugin](/config-plugin
       name: 'microphonePermission',
       platform: 'ios',
       description:
-        'A string to set the `NSMicrophoneUsageDescription` permission message. Setting to `false` will disable the permission.',
+        'A string to set the `NSMicrophoneUsageDescription` permission message. Setting it to `false` will disable the permission.',
       default: '"Allow $(PRODUCT_NAME) to access your microphone"',
     },
     {

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### 💡 Others
 
 - Removing `Record` from `RecordingPresets` type annotation to improve type safety ([#39391](https://github.com/expo/expo/pull/39391) by [@Shoghy](https://github.com/Shoghy))
+- Separate the conditions to enable and disable microphone permissions.
 
 ## 1.0.13 - 2025-09-18
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -22,7 +22,7 @@
 ### 💡 Others
 
 - Removing `Record` from `RecordingPresets` type annotation to improve type safety ([#39391](https://github.com/expo/expo/pull/39391) by [@Shoghy](https://github.com/Shoghy))
-- Separate the conditions to enable and disable microphone permissions.
+- Separate the conditions to enable and disable microphone permissions. ([#40861](https://github.com/expo/expo/pull/40861) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 1.0.13 - 2025-09-18
 

--- a/packages/expo-audio/plugin/build/withAudio.d.ts
+++ b/packages/expo-audio/plugin/build/withAudio.d.ts
@@ -1,5 +1,6 @@
 import { ConfigPlugin } from 'expo/config-plugins';
 declare const _default: ConfigPlugin<void | {
     microphonePermission?: string | false;
+    recordAudioAndroid?: boolean;
 }>;
 export default _default;

--- a/packages/expo-audio/plugin/build/withAudio.js
+++ b/packages/expo-audio/plugin/build/withAudio.js
@@ -3,14 +3,14 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const config_plugins_1 = require("expo/config-plugins");
 const pkg = require('expo-audio/package.json');
 const MICROPHONE_USAGE = 'Allow $(PRODUCT_NAME) to access your microphone';
-const withAudio = (config, { microphonePermission } = {}) => {
+const withAudio = (config, { microphonePermission, recordAudioAndroid = true } = {}) => {
     config_plugins_1.IOSConfig.Permissions.createPermissionsPlugin({
         NSMicrophoneUsageDescription: MICROPHONE_USAGE,
     })(config, {
         NSMicrophoneUsageDescription: microphonePermission,
     });
     return config_plugins_1.AndroidConfig.Permissions.withPermissions(config, [
-        microphonePermission !== false && 'android.permission.RECORD_AUDIO',
+        recordAudioAndroid !== false && 'android.permission.RECORD_AUDIO',
         'android.permission.MODIFY_AUDIO_SETTINGS',
     ].filter(Boolean));
 };

--- a/packages/expo-audio/plugin/src/withAudio.ts
+++ b/packages/expo-audio/plugin/src/withAudio.ts
@@ -4,10 +4,9 @@ const pkg = require('expo-audio/package.json');
 
 const MICROPHONE_USAGE = 'Allow $(PRODUCT_NAME) to access your microphone';
 
-const withAudio: ConfigPlugin<{ microphonePermission?: string | false } | void> = (
-  config,
-  { microphonePermission } = {}
-) => {
+const withAudio: ConfigPlugin<
+  { microphonePermission?: string | false; recordAudioAndroid?: boolean } | void
+> = (config, { microphonePermission, recordAudioAndroid = true } = {}) => {
   IOSConfig.Permissions.createPermissionsPlugin({
     NSMicrophoneUsageDescription: MICROPHONE_USAGE,
   })(config, {
@@ -17,7 +16,7 @@ const withAudio: ConfigPlugin<{ microphonePermission?: string | false } | void> 
   return AndroidConfig.Permissions.withPermissions(
     config,
     [
-      microphonePermission !== false && 'android.permission.RECORD_AUDIO',
+      recordAudioAndroid !== false && 'android.permission.RECORD_AUDIO',
       'android.permission.MODIFY_AUDIO_SETTINGS',
     ].filter(Boolean) as string[]
   );


### PR DESCRIPTION
# Why
Allows users to enable and disable microphone permissions per platform.

# How
Similar to camera, added the `recordAudioAndroid` key. 

# Test Plan
Sandbox app
