### PR TITLE
Fix bash quoting in expotools

### DIFF
--- a/bin/expotools
+++ b/bin/expotools
@@ -7,4 +7,4 @@ repository_root="${script_dir}/.."
 expotools_dir="`cd ${repository_root}/tools;pwd;`"
 NODE_BINARY=${NODE_BINARY:-node}
 
-$NODE_BINARY "${expotools_dir}/bin/expotools.js" "$@"
+"$NODE_BINARY" "${expotools_dir}/bin/expotools.js" "$@"


### PR DESCRIPTION
# Why

On some systems, e.g. mine, the `node` binary is inside a folder with spaces (`~/Library/Application Support`).

# How

By putting quotes around the variable, it expands to a single path, instead of being interpreted as path + arguments.

# Test Plan

I've tested this by seeing that it fixed my build error.

# Checklist

- [n/a] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [n/a] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
