### PR TITLE
[dev-launcher][iOS] Fix RCTDevMenuConfiguration in release builds

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [Android] Fix launching apps in brownfield ([#40711](https://github.com/expo/expo/pull/40711) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Fix React Native dev menu not showing up in 0.83.x ([#40819](https://github.com/expo/expo/pull/40819) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Fix port scanning on pysical devices. ([#40824](https://github.com/expo/expo/pull/40824) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix RCTDevMenuConfiguration in release builds ([#40870](https://github.com/expo/expo/pull/40870) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -79,12 +79,14 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, EXDe
       self.reactNativeFactory?.rootViewFactory.bridge = nil
     }
 
+    #if RCT_DEV_MENU
     // Set core dev menu configuration to disable shortcuts and shake gesture
     self.reactNativeFactory?.devMenuConfiguration = RCTDevMenuConfiguration(
       devMenuEnabled: true,
       shakeGestureEnabled: false,
       keyboardShortcutsEnabled: false
     )
+    #endif
 
     let rootView = reactDelegate.reactNativeFactory.recreateRootView(
       withBundleURL: developmentClientController.sourceUrl(),


### PR DESCRIPTION
# Why

CI is failing (https://github.com/expo/expo/actions/runs/19113068411/job/54614952441) on iOS release builds because of RCTDevMenuConfiguration

# How

Add `RCT_DEV_MENU` check to fix RCTDevMenuConfiguration in release builds

# Test Plan

Run BareExpo in release mode

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
