### PR TITLE
Load environment first in exportWebAsync

### DIFF
--- a/packages/@expo/cli/src/export/web/exportWebAsync.ts
+++ b/packages/@expo/cli/src/export/web/exportWebAsync.ts
@@ -10,11 +10,12 @@ import { CommandError } from '../../utils/errors';
 import { setNodeEnv } from '../../utils/nodeEnv';
 
 export async function exportWebAsync(projectRoot: string, options: Options) {
+  require('@expo/env').load(projectRoot);
+
   // Ensure webpack is available
   await new WebSupportProjectPrerequisite(projectRoot).assertAsync();
 
   setNodeEnv(options.dev ? 'development' : 'production');
-  require('@expo/env').load(projectRoot);
 
   const { exp } = getConfig(projectRoot);
   const platformBundlers = getPlatformBundlers(projectRoot, exp);


### PR DESCRIPTION
# Why

When digging into dynamic app configurations I want to make sure environment variables are set. 
I followed the approach described by @betomoedano here https://www.youtube.com/watch?v=uKGx3gRrhx0 but ran into issues.

You can see below, that even if I switch to "preview", the first round of my  two debug logs come back as "production" (the fallback).

![expo-env-loading](https://github.com/user-attachments/assets/f92594f7-3f92-4942-88c8-6ef0a58ab2f7)

```ts
// app.config.ts
const Environments = z.enum(['development', 'preview', 'production']);

export default ({ config }: ConfigContext): ExpoConfig => {
  const appEnv = Environments.parse(process.env.EXPO_PUBLIC_APP_ENV ?? 'production');

  debug('Building app for environment:', appEnv);
}
```

After digging into this I realised that loading the env isn't the first thing the exporter does, therefore this call to load the config inside `WebSupportProjectPrerequisite` loads the config without the vars.

https://github.com/expo/expo/blob/main/packages/%40expo/cli/src/start/doctor/web/WebSupportProjectPrerequisite.ts#L37

# How

The env should be consistent, therefore loaded first, I simply moved it up.

# Test Plan

THIS IS A PROPOSAL, I DID ON GITHUBs WEB UI WHILE READING THROUGH THE CODE — I DID NOT TEST IT :) Tell me how and I'm more than happy to take it to the next step, or take over this PR and push it over the line.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
