### PR TITLE
[ios][screen-orientation] fix wrong orientation if AVPictureInPictureController is used

### DIFF
--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [iOS] Remove use of deprecated API `UIApplication.shared.windows`.
+
 ## 9.0.7 — 2025-09-11
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [iOS] Remove use of deprecated API `UIApplication.shared.windows`.
+- [iOS] Remove use of deprecated API `UIApplication.shared.windows`. ([#40877](https://github.com/expo/expo/pull/40877) by [@bwallberg](https://github.com/bwallberg))
 
 ## 9.0.7 — 2025-09-11
 

--- a/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
@@ -57,10 +57,7 @@ public class ScreenOrientationRegistry: NSObject, UIApplicationDelegate {
    Called by ScreenOrientationAppDelegate in order to set initial interface orientation.
    */
   public func updateCurrentScreenOrientation() {
-    let windows = UIApplication.shared.windows
-    if !windows.isEmpty {
-      self.currentScreenOrientation = windows[0].windowScene?.interfaceOrientation ?? .unknown
-    }
+      self.currentScreenOrientation = rootViewController?.view.window?.windowScene?.interfaceOrientation ?? .unknown
   }
 
   deinit {

--- a/packages/expo-screen-orientation/ios/ScreenOrientationViewController.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationViewController.swift
@@ -9,7 +9,7 @@ class ScreenOrientationViewController: UIViewController {
   private var defaultOrientationMask: UIInterfaceOrientationMask
   private var previousInterfaceOrientation: UIInterfaceOrientation = .unknown
   private var windowInterfaceOrientation: UIInterfaceOrientation? {
-    return UIApplication.shared.windows.first?.windowScene?.interfaceOrientation
+    return view.window?.windowScene?.interfaceOrientation
   }
 
   init(defaultOrientationMask: UIInterfaceOrientationMask = doesDeviceHaveNotch ? .allButUpsideDown : .all) {


### PR DESCRIPTION
# Why

Two reasons:

The main reason is that we use the `AVPictureInPictureController` which will create a window ( even if PiP is not started ) this will cause `expo-screen-orientation` to no longer properly identify orientation changes.

The second reason is that `UIApplication.shared.windows` is deprecated



# How

Looking at how the package works and suggested changes from using `windows` ( https://developer.apple.com/forums/thread/682621 ) it seemed to most appropriate to use windowScene that the Registry/ViewController interact with for other things related to orientation.

# Test Plan

The existing unit-tests seems enough to verify that everything that is expected to work still works.
To test the issue connected to `AVPictureInPictureController` is trickier as that involved created a native video module that uses it, I'm not sure how to approach that in this repository, so it might be better to just treat this as a general improvement of not using a deprectaed API.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
