### PR TITLE
[ios][screen-orientation] remove use of deprecated api UIApplication.shared.windows

### DIFF
--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unpublished
 
-- [iOS] Remove use of deprecated API `UIApplication.shared.windows`. ([#40881](https://github.com/expo/expo/pull/40881) by [@bwallberg](https://github.com/bwallberg))
-
 ### 🛠 Breaking changes
 
 ### 🎉 New features
@@ -11,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [web] fix undeclared `listener` reference ([#41441](https://github.com/expo/expo/pull/41441) by [@vonovak](https://github.com/vonovak))
+- [iOS] Remove use of deprecated API `UIApplication.shared.windows`. ([#40881](https://github.com/expo/expo/pull/40881) by [@bwallberg](https://github.com/bwallberg))
 
 ### 💡 Others
 

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unpublished
 
+- [iOS] Remove use of deprecated API `UIApplication.shared.windows`.
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unpublished
 
-- [iOS] Remove use of deprecated API `UIApplication.shared.windows`.
+- [iOS] Remove use of deprecated API `UIApplication.shared.windows`. ([#40881](https://github.com/expo/expo/pull/40881) by [@bwallberg](https://github.com/bwallberg))
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
@@ -57,10 +57,7 @@ public class ScreenOrientationRegistry: NSObject, UIApplicationDelegate {
    Called by ScreenOrientationAppDelegate in order to set initial interface orientation.
    */
   public func updateCurrentScreenOrientation() {
-    let windows = UIApplication.shared.windows
-    if !windows.isEmpty {
-      self.currentScreenOrientation = windows[0].windowScene?.interfaceOrientation ?? .unknown
-    }
+      self.currentScreenOrientation = rootViewController?.view.window?.windowScene?.interfaceOrientation ?? .unknown
   }
 
   deinit {

--- a/packages/expo-screen-orientation/ios/ScreenOrientationViewController.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationViewController.swift
@@ -9,7 +9,13 @@ class ScreenOrientationViewController: UIViewController {
   private var defaultOrientationMask: UIInterfaceOrientationMask
   private var previousInterfaceOrientation: UIInterfaceOrientation = .unknown
   private var windowInterfaceOrientation: UIInterfaceOrientation? {
-    return UIApplication.shared.windows.first?.windowScene?.interfaceOrientation
+    let keyWindow = UIApplication
+      .shared
+      .connectedScenes
+      .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
+      .last { $0.isKeyWindow }
+
+    return keyWindow?.windowScene?.interfaceOrientation
   }
 
   init(defaultOrientationMask: UIInterfaceOrientationMask = doesDeviceHaveNotch ? .allButUpsideDown : .all) {


### PR DESCRIPTION
# Why

Two reasons:

The main reason is that we use the `AVPictureInPictureController` which will create a window ( even if PiP is not started ) this will cause `expo-screen-orientation` to no longer properly identify orientation changes.

The second reason is that `UIApplication.shared.windows` is deprecated

# How

Looking at how the package works and suggested changes from using `windows` it seemed to most appropriate to align on using the same logic to look up the window used by ScreenOrientationRegistry

# Test Plan

The existing unit-tests seems enough to verify that everything that is expected to work still works.
To test the issue connected to `AVPictureInPictureController` is trickier as that involved created a native video module that uses it, I'm not sure how to approach that in this repository, so it might be better to just treat this as a general improvement of not using a deprecated API.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
