### PR TITLE
[docs] Fix typo in Expo MediaLibrary reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/media-library.mdx
+++ b/docs/pages/versions/unversioned/sdk/media-library.mdx
@@ -93,7 +93,7 @@ You can configure `expo-media-library` using its built-in [config plugin](/confi
 
 <ConfigReactNative>
 
-If you're not using Continuous Native Generation ([CNG](/workflow/continuous-native-generation/)) or you're using native **android** **ios** projects manually, then you need to add following permissions and configuration to your native projects:
+If you're not using Continuous Native Generation ([CNG](/workflow/continuous-native-generation/)) or you're using native **android** and **ios** projects manually, then you need to add following permissions and configuration to your native projects:
 
 **Android**
 

--- a/docs/pages/versions/v52.0.0/sdk/media-library.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/media-library.mdx
@@ -78,7 +78,7 @@ You can configure `expo-media-library` using its built-in [config plugin](/confi
 
 <ConfigReactNative>
 
-If you're not using Continuous Native Generation ([CNG](/workflow/continuous-native-generation/)) or you're using native **android** **ios** projects manually, then you need to add following permissions and configuration to your native projects:
+If you're not using Continuous Native Generation ([CNG](/workflow/continuous-native-generation/)) or you're using native **android** and **ios** projects manually, then you need to add following permissions and configuration to your native projects:
 
 **Android**
 

--- a/docs/pages/versions/v53.0.0/sdk/media-library.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/media-library.mdx
@@ -85,7 +85,7 @@ You can configure `expo-media-library` using its built-in [config plugin](/confi
 
 <ConfigReactNative>
 
-If you're not using Continuous Native Generation ([CNG](/workflow/continuous-native-generation/)) or you're using native **android** **ios** projects manually, then you need to add following permissions and configuration to your native projects:
+If you're not using Continuous Native Generation ([CNG](/workflow/continuous-native-generation/)) or you're using native **android** and **ios** projects manually, then you need to add following permissions and configuration to your native projects:
 
 **Android**
 

--- a/docs/pages/versions/v54.0.0/sdk/media-library.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/media-library.mdx
@@ -93,7 +93,7 @@ You can configure `expo-media-library` using its built-in [config plugin](/confi
 
 <ConfigReactNative>
 
-If you're not using Continuous Native Generation ([CNG](/workflow/continuous-native-generation/)) or you're using native **android** **ios** projects manually, then you need to add following permissions and configuration to your native projects:
+If you're not using Continuous Native Generation ([CNG](/workflow/continuous-native-generation/)) or you're using native **android** and **ios** projects manually, then you need to add following permissions and configuration to your native projects:
 
 **Android**
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Found a typo in Expo MediaLibrary reference:

<img width="1048" height="247" alt="CleanShot 2025-11-06 at 18 15 19" src="https://github.com/user-attachments/assets/85c83938-52e9-4f57-8bf0-35b6d6b68656" />

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix typo by adding "and" in between platforms.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
