### PR TITLE
[docs] Fix typo in example code in Web modals guide

### DIFF
--- a/docs/pages/router/advanced/web-modals.mdx
+++ b/docs/pages/router/advanced/web-modals.mdx
@@ -38,7 +38,7 @@ export default function Layout() {
         name="modal"
         options={{
           presentation: 'modal', // Enables modal behavior
-          sheetAllowedDetents: [0.5, 1], // Array of snap positions for screens that have a width less than 786px.
+          sheetAllowedDetents: [0.5, 1], // Array of snap positions for screens that have a width less than 768px.
         }}
       />
     </Stack>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Issue reported here: https://github.com/expo/expo/issues/40868#issuecomment-3495752108.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix typo in example code in Web modals guide.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
