### PR TITLE
jest-expo: Apply the expo-file-system mock to expo-file-system/legacy too

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Move the old expo-file-system mock to expo-file-system/legacy. ([#40916](https://github.com/expo/expo/pull/40916) by [@macksal](https://github.com/macksal))
+
 ### 💡 Others
 
 - Improve local mock lookup. ([#39743](https://github.com/expo/expo/pull/39743) by [@aleqsio](https://github.com/aleqsio))

--- a/packages/jest-expo/src/preset/setup.js
+++ b/packages/jest-expo/src/preset/setup.js
@@ -131,7 +131,7 @@ Object.keys(mockNativeModules.NativeUnimoduleProxy.viewManagersMetadata).forEach
 jest.mock('expo/src/async-require/messageSocket', () => undefined);
 
 try {
-  jest.mock('expo-file-system', () => ({
+  jest.mock('expo-file-system/legacy', () => ({
     downloadAsync: jest.fn(() => Promise.resolve({ md5: 'md5', uri: 'uri' })),
     getInfoAsync: jest.fn(() => Promise.resolve({ exists: true, md5: 'md5', uri: 'uri' })),
     readAsStringAsync: jest.fn(() => Promise.resolve()),


### PR DESCRIPTION
Should fix consumer tests that were importing expo-file-system and moved to expo-file-system/legacy as of SDK 54.

# Why

Expo's filesystem module has been moved to a separate legacy import in favour of the new API. For existing users of `expo-file-system` who just upgraded to expo SDK 54, the naive solution is to change all their imports to `expo-file-system/legacy`. If those users have jest tests that previously imported `expo-file-system`, they would have received a mock from jest-expo. That same mock is not applied to the legacy import because it wasn't changed when the legacy import was added. It's a sneaky breaking change.

This broke my tests after the upgrade, let's save others some time.

# How

Apply the same mock to expo-file-system/legacy.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
