### PR TITLE
[ios][audio] fixed lockscreen controls by setting playback category

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] fixed lockscreen controls by setting playback category ([#40919](https://github.com/expo/expo/pull/40919) by [@Raj1v](https://github.com/Raj1v))
 - [Android] Removed call to setShowActionsInCompactView when using custom layout in notification. ([#40557](https://github.com/expo/expo/pull/40557) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Fixed race-condition when creating the notification before the actions has been added. ([#40518](https://github.com/expo/expo/pull/40518) by [@chrfalch](https://github.com/chrfalch))
 - [iOS/Android] Aligned Android and iOS pitch correction by changing the default quality on iOS to match Android. `shouldCorrectPitch` now defaults to `true`. ([#40176](https://github.com/expo/expo/pull/40176) by [@chrfalch](https://github.com/chrfalch))

--- a/packages/expo-audio/ios/MediaController.swift
+++ b/packages/expo-audio/ios/MediaController.swift
@@ -22,6 +22,13 @@ class MediaController {
 
     DispatchQueue.main.async {
       if let player {
+        let session = AVAudioSession.sharedInstance()
+        do {
+          try session.setCategory(.playback, mode: .default, options: [])
+        } catch {
+          log.warn("Failed to configure audio session for lockscreen controls: \(error.localizedDescription)")
+        }
+        
         self.enableRemoteCommands(options: options)
         self.updateNowPlayingInfo(for: player)
       } else {

--- a/packages/expo-audio/package.json
+++ b/packages/expo-audio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-audio",
   "title": "Expo Audio",
-  "version": "1.0.14",
+  "version": "1.0.12",
   "description": "A cross-platform audio library for React Native and Expo apps.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/expo-audio/package.json
+++ b/packages/expo-audio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-audio",
   "title": "Expo Audio",
-  "version": "1.0.12",
+  "version": "1.0.14",
   "description": "A cross-platform audio library for React Native and Expo apps.",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
# Why

On iOS, the ``MediaController.swift`` that integrates with the lock screen / Now Playing UI was
updating `MPNowPlayingInfoCenter.default().nowPlayingInfo` regularly—after calling `setActiveForLockScreen` (which marks a player as active)—and audio continued to play in the background, but the system still did not show any Now Playing card on the lock screen or in Control Center.

After debugging, it turned out that when this module tried to publish Now Playing metadata, the shared `AVAudioSession` category was not configured as a playback category at that moment. In that state, iOS will still play audio (and can even keep it alive in the background), but it does not treat the app as the active "Now Playing" source, so updates to `MPNowPlayingInfoCenter` never surface in the system UI.

Explicitly configuring the audio session with the `.playback` category in `setActivePlayer` immediately made the Now Playing card appear, without changing any of the existing logic around remote commands or metadata updates.

# How

When a player is marked as active for the lock screen (inside `setActivePlayer`), this module now configures the shared  `AVAudioSession` to use the `.playback` category before:

- Enabling remote commands, and  
- Updating the Now Playing info.

Concretely, the method now:

- Retrieves the shared audio session instance.
- Attempts to set its category to `.playback` with a default mode.
- Logs a warning if setting the category fails.

There is no additional state tracking or guarding in this change — the category is simply configured at the point where the module expects to drive the lock screen / Control Center UI. This is the minimal change that ensures iOS treats this playback as long-form "playback" audio, which is required for Now Playing and lock screen controls to appear and respond.

Before this change:

- Background audio worked.
- The module’s “update Now Playing” logic ran.
- The system never displayed a Now Playing card for this module.

After this change, running the exact same flow results in a visible and interactive Now Playing tile.

# Test Plan

**Device:** iOS 26.x (physical device)

### Repro before the fix

1. Configure audio with Expo’s audio APIs so that:
   - Audio plays correctly.
   - Background playback is enabled.
2. Start playback using this module, with lock screen / metadata options set
   (title, artist, artwork, etc.).
3. Background the app.
4. Observe:
   - Audio continues playing in the background ✅  
   - Native code is calling the Now Playing update method ✅  
   - Lock screen / Control Center shows **no** Now Playing card ❌  

### Repro after the fix

1. Apply this change so that `setActivePlayer` configures the audio session category to `.playback` before enabling remote commands and updating the Now Playing info.
2. Start the same playback flow as above.
3. Background the app.
4. Observe:
   - Audio continues playing in the background ✅  
   - Lock screen and Control Center now show a Now Playing card with:
     - Correct title / artist / album  
     - Artwork (if provided)  
     - Progress / duration when available ✅  
   - Play / pause and scrubbing work via lock screen / Control Center.  
5. Stopping or clearing the player preserves the existing behavior (e.g. Now
   Playing card is cleared or frozen according to current logic).

_No automated tests were added for this change because the behavior depends on iOS system UI rendering of the Now Playing screen and is currently verified manually._

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
