### PR TITLE
[glass-effect] - Fix crash on UIGlassEffect init call on iOS 26 beta

### DIFF
--- a/packages/expo-glass-effect/CHANGELOG.md
+++ b/packages/expo-glass-effect/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fix `border(Left|Right|Start|End)Radius` ([#40780](https://github.com/expo/expo/pull/40780) by [@nishan](https://github.com/intergalacticspacehighway))
+- Fix crash on `UIGlassEffect` initialiser on iOS 26 beta ([#40920](https://github.com/expo/expo/pull/40920) by [@nishan](https://github.com/intergalacticspacehighway))
 
 ### 💡 Others
 

--- a/packages/expo-glass-effect/ios/GlassContainer.swift
+++ b/packages/expo-glass-effect/ios/GlassContainer.swift
@@ -16,9 +16,23 @@ public final class GlassContainer: ExpoView {
     addSubview(containerEffectView)
   }
 
+  // UIGlassEffect initialiser is failing for iOS 26 beta versions for some reason, so we need to check if it's available at runtime
+  // https://github.com/expo/expo/issues/40911
+  private func isGlassContainerEffectAvailable() -> Bool {
+    #if compiler(>=6.2)
+    if #available(iOS 26.0, *) {
+      return NSClassFromString("UIGlassContainerEffect") != nil
+    }
+    #endif
+    return false
+  }
+
   public func setSpacing(_ spacing: CGFloat?) {
     if containerSpacing != spacing {
       containerSpacing = spacing
+      guard isGlassContainerEffectAvailable() else {
+        return
+      }
       if #available(iOS 26.0, *) {
         #if compiler(>=6.2) // Xcode 26
         let effect = UIGlassContainerEffect()

--- a/packages/expo-glass-effect/ios/GlassView.swift
+++ b/packages/expo-glass-effect/ios/GlassView.swift
@@ -10,13 +10,13 @@ public final class GlassView: ExpoView {
   private var glassStyle: GlassStyle?
   private var glassTintColor: UIColor?
   private var glassIsInteractive: Bool?
-  
+
   private var radius: CGFloat?
   private var bottomLeftRadius: CGFloat?
   private var bottomRightRadius: CGFloat?
   private var topLeftRadius: CGFloat?
   private var topRightRadius: CGFloat?
-  
+
   private var bottomStartRadius: CGFloat?
   private var bottomEndRadius: CGFloat?
   private var topStartRadius: CGFloat?
@@ -30,7 +30,21 @@ public final class GlassView: ExpoView {
     addSubview(glassEffectView)
   }
 
+  // UIGlassEffect initialiser is crashing for iOS 26 beta versions for some reason, so we need to check if it's available at runtime
+  // https://github.com/expo/expo/issues/40911
+  private func isGlassEffectAvailable() -> Bool {
+    #if compiler(>=6.2)
+    if #available(iOS 26.0, *) {
+      return NSClassFromString("UIGlassEffect") != nil
+    }
+    #endif
+    return false
+  }
+
   public func updateBorderRadius() {
+    guard isGlassEffectAvailable() else {
+      return
+    }
     if #available(iOS 26.0, *) {
       #if compiler(>=6.2) // Xcode 26
       let isRTL = RCTI18nUtil.sharedInstance()?.isRTL() ?? false
@@ -70,14 +84,17 @@ public final class GlassView: ExpoView {
   public func setGlassStyle(_ style: GlassStyle) {
     if glassStyle != style {
       glassStyle = style
+      guard isGlassEffectAvailable() else {
+        return
+      }
       if #available(iOS 26.0, *) {
-        #if compiler(>=6.2) // Xcode 26
+      #if compiler(>=6.2) // Xcode 26
         let effect = UIGlassEffect(style: glassStyle?.toUIGlassEffectStyle() ?? .regular)
         glassEffectView.effect = effect
         glassEffect = effect
+        updateEffect()
         #endif
       }
-      updateEffect()
     }
   }
 
@@ -163,6 +180,9 @@ public final class GlassView: ExpoView {
   }
 
   private func updateEffect() {
+    guard isGlassEffectAvailable() else {
+      return
+    }
     if #available(iOS 26.0, *) {
       #if compiler(>=6.2) // Xcode 26
       if let effect = glassEffect as? UIGlassEffect {

--- a/packages/expo-glass-effect/ios/GlassView.swift
+++ b/packages/expo-glass-effect/ios/GlassView.swift
@@ -35,7 +35,11 @@ public final class GlassView: ExpoView {
   private func isGlassEffectAvailable() -> Bool {
     #if compiler(>=6.2)
     if #available(iOS 26.0, *) {
-      return NSClassFromString("UIGlassEffect") != nil
+      guard let glassEffectClass = NSClassFromString("UIGlassEffect") as? NSObject.Type else {
+        return false
+      }
+      let respondsToSelector = glassEffectClass.responds(to: Selector(("effectWithStyle:")))
+      return respondsToSelector
     }
     #endif
     return false


### PR DESCRIPTION
# Why
Closes #40911

We do not have a repro but someone reported that the crash is happening in beta iOS 26 versions.
https://www.reddit.com/r/SwiftUI/comments/1oqui1x/glasseffect_in_crushing_on_ios_26_public_beta

So this PR adds a runtime check if the class is available. This seems like iOS beta bug, but we should handle it. 


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Add runtime UIGlassEffect class check

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Test glass effect examples work in iOS 26 and renders regular view in iOS 18
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
