### PR TITLE
[docs] Update 'Limitations' section to include web in Expo GLView reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/gl-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/gl-view.mdx
@@ -136,7 +136,6 @@ Worklet runtime is imposing some limitations on the code that runs inside it, so
 - Third-party libraries like Pixi.js or Three.js won't work inside the worklet, you can only use functions that have `'worklet'` added at the start.
 - If you need to load some assets to pass to the WebGL code, it needs to be done on the main thread and passed via some reference to the worklet. If you are using `expo-assets` you can just pass asset object returned by `Asset.fromModule` or from hook `useAssets` to the `runOnUI` function.
 - To implement a rendering loop you need to use `requestAnimationFrame`, APIs like `setTimeout` are not supported.
-- It's supported on Android, iOS and Web.
 
 Check [Reanimated documentation](https://docs.swmansion.com/react-native-reanimated/docs/guides/worklets/) to learn more.
 

--- a/docs/pages/versions/unversioned/sdk/gl-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/gl-view.mdx
@@ -136,7 +136,7 @@ Worklet runtime is imposing some limitations on the code that runs inside it, so
 - Third-party libraries like Pixi.js or Three.js won't work inside the worklet, you can only use functions that have `'worklet'` added at the start.
 - If you need to load some assets to pass to the WebGL code, it needs to be done on the main thread and passed via some reference to the worklet. If you are using `expo-assets` you can just pass asset object returned by `Asset.fromModule` or from hook `useAssets` to the `runOnUI` function.
 - To implement a rendering loop you need to use `requestAnimationFrame`, APIs like `setTimeout` are not supported.
-- It's supported only on Android and iOS, it doesn't work on Web.
+- It's supported on Android, iOS and Web.
 
 Check [Reanimated documentation](https://docs.swmansion.com/react-native-reanimated/docs/guides/worklets/) to learn more.
 

--- a/docs/pages/versions/v54.0.0/sdk/gl-view.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/gl-view.mdx
@@ -136,7 +136,6 @@ Worklet runtime is imposing some limitations on the code that runs inside it, so
 - Third-party libraries like Pixi.js or Three.js won't work inside the worklet, you can only use functions that have `'worklet'` added at the start.
 - If you need to load some assets to pass to the WebGL code, it needs to be done on the main thread and passed via some reference to the worklet. If you are using `expo-assets` you can just pass asset object returned by `Asset.fromModule` or from hook `useAssets` to the `runOnUI` function.
 - To implement a rendering loop you need to use `requestAnimationFrame`, APIs like `setTimeout` are not supported.
-- It's supported on Android, iOS and Web.
 
 Check [Reanimated documentation](https://docs.swmansion.com/react-native-reanimated/docs/guides/worklets/) to learn more.
 

--- a/docs/pages/versions/v54.0.0/sdk/gl-view.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/gl-view.mdx
@@ -136,7 +136,7 @@ Worklet runtime is imposing some limitations on the code that runs inside it, so
 - Third-party libraries like Pixi.js or Three.js won't work inside the worklet, you can only use functions that have `'worklet'` added at the start.
 - If you need to load some assets to pass to the WebGL code, it needs to be done on the main thread and passed via some reference to the worklet. If you are using `expo-assets` you can just pass asset object returned by `Asset.fromModule` or from hook `useAssets` to the `runOnUI` function.
 - To implement a rendering loop you need to use `requestAnimationFrame`, APIs like `setTimeout` are not supported.
-- It's supported only on Android and iOS, it doesn't work on Web.
+- It's supported on Android, iOS and Web.
 
 Check [Reanimated documentation](https://docs.swmansion.com/react-native-reanimated/docs/guides/worklets/) to learn more.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes #40840

`gl-view` is already supported in web but docs isn't updated.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Change the line of 'Limitations' section from '- It's supported only on Android and iOS, it doesn't work on Web.' to '- It's supported on Android, iOS and Web.'

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
