### PR TITLE
[docs] Document supported React Native TV versions

### DIFF
--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -125,13 +125,15 @@ The following walkthrough describes the steps required to modify an Expo project
 
 In **package.json**, modify the `react-native` dependency to use the TV repo, and exclude this dependency from [`npx expo install` version validation](/more/expo-cli/#configuring-dependency-validation).
 
+> **Warning** The `react-native-tvos` version should match the Expo SDK you are using. For example, Expo SDK 54 uses React Native 0.81, so you should use `react-native-tvos@0.81-stable` (the latest 0.81 version) as shown below. See the [SDK compatibility table](/versions/latest/#each-expo-sdk-version-depends-on-a-react-native-version) for the correct version to use for older SDKs.
+
 {/* prettier-ignore */}
 ```json package.json
 {
   /* @hide ... */ /* @end */
   "dependencies": {
     /* @hide ... */ /* @end */
-    "react-native": "npm:react-native-tvos",
+    "react-native": "npm:react-native-tvos@0.81-stable",
     /* @hide ... */ /* @end */
   },
   "expo": {

--- a/docs/ui/components/SDKTables/ReactNativeCompatibilityTable.tsx
+++ b/docs/ui/components/SDKTables/ReactNativeCompatibilityTable.tsx
@@ -26,6 +26,7 @@ export const ReactNativeCompatibilityTable = () => {
           <HeaderCell>React Native version</HeaderCell>
           <HeaderCell>React version</HeaderCell>
           <HeaderCell>React Native Web version</HeaderCell>
+          <HeaderCell>React Native TV version</HeaderCell>
           <HeaderCell>
             <div className="flex items-center gap-1.5">
               <span>Minimum Node.js version</span>
@@ -67,6 +68,7 @@ export const ReactNativeCompatibilityTable = () => {
             <Cell>{version['react-native']}</Cell>
             <Cell>{version['react']}</Cell>
             <Cell>{version['react-native-web']}</Cell>
+            <Cell>{version['react-native-tvos']}</Cell>
             <Cell>{version['node']}</Cell>
           </Row>
         ))}

--- a/docs/ui/components/SDKTables/sdk-versions.json
+++ b/docs/ui/components/SDKTables/sdk-versions.json
@@ -9,6 +9,7 @@
       "xcode": "16.1+",
       "react-native": "0.81",
       "react-native-web": "0.21.0",
+      "react-native-tvos": "0.81-stable",
       "react": "19.1.0",
       "node": "20.19.x"
     },
@@ -21,6 +22,7 @@
       "xcode": "16.0+",
       "react-native": "0.79",
       "react-native-web": "0.20.0",
+      "react-native-tvos": "0.79-stable",
       "react": "19.0.0",
       "node": "20.18.x"
     },
@@ -33,6 +35,7 @@
       "xcode": "16.0+",
       "react-native": "0.76",
       "react-native-web": "0.19.13",
+      "react-native-tvos": "0.77-stable",
       "react": "18.3.1",
       "node": "20.18.x"
     },
@@ -45,6 +48,7 @@
       "xcode": "15.4 - 16.2",
       "react-native": "0.74",
       "react-native-web": "0.19.10",
+      "react-native-tvos": "0.74-stable",
       "react": "18.2.0",
       "node": "18.20.x"
     },
@@ -57,6 +61,7 @@
       "xcode": "15.4",
       "react-native": "0.73",
       "react-native-web": "0.19.6",
+      "react-native-tvos": "0.74-stable",
       "react": "18.2.0",
       "node": "18.19.x"
     },
@@ -69,6 +74,7 @@
       "xcode": "15.4",
       "react-native": "0.72",
       "react-native-web": "0.19.6",
+      "react-native-tvos": "Not supported",
       "react": "18.2.0",
       "node": "16.20.x"
     }


### PR DESCRIPTION
# Why

The "Building for TV" document has customers installing the latest version of `react-native-tvos`. This is not generally correct, as the latest version can and does move past the version supported by the latest Expo SDK.

# How

- Add React Native TV info to the SDK compatibility table
- Update the Building for TV document with the correct instructions

# Test Plan

- CI should pass
# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
