### PR TITLE
[ui][ios] - Fix subtitle button menu item

### DIFF
--- a/apps/native-component-list/src/screens/UI/ContextMenuScreen.ios.tsx
+++ b/apps/native-component-list/src/screens/UI/ContextMenuScreen.ios.tsx
@@ -6,14 +6,15 @@ import {
   ContextMenu,
   Text,
   Section as SwiftUISection,
+  Image,
+  List,
+  Section,
   Divider,
 } from '@expo/ui/swift-ui';
-import { buttonStyle, fixedSize } from '@expo/ui/swift-ui/modifiers';
+import { buttonStyle } from '@expo/ui/swift-ui/modifiers';
 import { useVideoPlayer, VideoView } from 'expo-video';
 import * as React from 'react';
 import { View, StyleSheet, Text as RNText } from 'react-native';
-
-import { Section } from '../../components/Page';
 
 const videoLink =
   'https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/360/Big_Buck_Bunny_360_10s_2MB.mp4';
@@ -30,10 +31,10 @@ export default function ContextMenuScreen() {
   });
 
   return (
-    <View>
-      <Section title="Context Menu with glass effect button" row>
-        <Host matchContents style={{ margin: 10 }}>
-          <ContextMenu modifiers={[fixedSize(), buttonStyle('glass')]}>
+    <Host style={{ flex: 1 }}>
+      <List>
+        <Section title="Context Menu with glass effect button">
+          <ContextMenu modifiers={[buttonStyle('glass')]}>
             <ContextMenu.Items>
               <Button
                 systemImage="person.crop.circle.badge.xmark"
@@ -51,11 +52,9 @@ export default function ContextMenuScreen() {
               <Text color="accentColor">Show menu</Text>
             </ContextMenu.Trigger>
           </ContextMenu>
-        </Host>
-      </Section>
-      <Section title="Single-Press Context Menu" row>
-        <Host matchContents style={{ margin: 10 }}>
-          <ContextMenu modifiers={[fixedSize(), buttonStyle('bordered')]}>
+        </Section>
+        <Section title="Single-Press Context Menu">
+          <ContextMenu modifiers={[buttonStyle('bordered')]}>
             <ContextMenu.Items>
               <Button
                 systemImage="person.crop.circle.badge.xmark"
@@ -80,10 +79,8 @@ export default function ContextMenuScreen() {
               <Text color="accentColor">Show Menu</Text>
             </ContextMenu.Trigger>
           </ContextMenu>
-        </Host>
-      </Section>
-      <Section title="Long-Press Context Menu" row>
-        <Host style={styles.longPressMenu}>
+        </Section>
+        <Section title="Long-Press Context Menu">
           <ContextMenu activationMethod="longPress">
             <ContextMenu.Items>
               <Switch
@@ -132,11 +129,9 @@ export default function ContextMenuScreen() {
               </View>
             </ContextMenu.Preview>
           </ContextMenu>
-        </Host>
-      </Section>
-      <Section title="SwiftUI Section and Divider Components" row>
-        <Host matchContents>
-          <ContextMenu modifiers={[fixedSize(), buttonStyle('glass')]}>
+        </Section>
+        <Section title="SwiftUI Section and Divider Components">
+          <ContextMenu modifiers={[buttonStyle('glass')]}>
             <ContextMenu.Items>
               <Button role="destructive">Delete</Button>
               <Divider />
@@ -150,9 +145,23 @@ export default function ContextMenuScreen() {
               <Text color="accentColor">Show menu</Text>
             </ContextMenu.Trigger>
           </ContextMenu>
-        </Host>
-      </Section>
-    </View>
+        </Section>
+        <Section title="Menu item with title and subtitle">
+          <ContextMenu modifiers={[buttonStyle('glass')]}>
+            <ContextMenu.Items>
+              <Button role="destructive">
+                <Image systemName="trash" />
+                <Text>Red color item</Text>
+                <Text>Subtitle</Text>
+              </Button>
+            </ContextMenu.Items>
+            <ContextMenu.Trigger>
+              <Text>Show Menu</Text>
+            </ContextMenu.Trigger>
+          </ContextMenu>
+        </Section>
+      </List>
+    </Host>
   );
 }
 

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `ContextMenu` item with subtitle buttons ([#40926](https://github.com/expo/expo/pull/40926) by [@nishan](https://github.com/intergalacticspacehighway))
+
 ### 💡 Others
 
 ## 0.2.0-beta.8 — 2025-11-06

--- a/packages/expo-ui/build/utils/index.d.ts.map
+++ b/packages/expo-ui/build/utils/index.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../../src/utils/index.ts"],"names":[],"mappings":"AAAA,eAAO,MAAM,mBAAmB,GAAI,UAAU,KAAK,CAAC,SAAS,KAAG,MAAM,GAAG,SAWxE,CAAC"}
+{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../../src/utils/index.ts"],"names":[],"mappings":"AAAA,eAAO,MAAM,mBAAmB,GAAI,UAAU,KAAK,CAAC,SAAS,KAAG,MAAM,GAAG,SAYxE,CAAC"}

--- a/packages/expo-ui/src/utils/index.ts
+++ b/packages/expo-ui/src/utils/index.ts
@@ -6,7 +6,8 @@ export const getTextFromChildren = (children: React.ReactNode): string | undefin
     return children.toString();
   }
   if (Array.isArray(children)) {
-    return children.map(getTextFromChildren).join('');
+    const text = children.map(getTextFromChildren).filter(Boolean).join('');
+    return text || undefined;
   }
   return undefined;
 };


### PR DESCRIPTION
# Why

Fixes Menu with subtitle buttons, check below video for demo. Currently it renders as empty string.



<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Fix getTextFromChildren function, it was returning empty string before. Added an example in ContextMenu.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

https://github.com/user-attachments/assets/eb39f9bb-9f0b-46ff-a93e-14d5040398ec

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
