### PR TITLE
[cli] Fix buffer overflow in toCString for multi-byte UTF-8 filenames

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -19,6 +19,7 @@
 - refactor launching Expo Go on Android ([#40020](https://github.com/expo/expo/pull/40020) by [@vonovak](https://github.com/vonovak))
 - only skip dependency validation for `EXPO_NO_DEPENDENCY_VALIDATION=1` ([#40043](https://github.com/expo/expo/pull/40043) by [@kitten](https://github.com/kitten))
 - Fix RSC `[...rsc]+api.ts` template path resolution ([#40760](https://github.com/expo/expo/pull/40760) by [@kitten](https://github.com/kitten))
+- Fixed buffer allocation error for files with emoji or multi-byte UTF-8 characters in filenames. ([#40927](https://github.com/expo/expo/pull/40927) by [@wezter96(https://github.com/wezter96))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/run/ios/appleDevice/client/AFCClient.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/client/AFCClient.ts
@@ -206,7 +206,7 @@ export class AFCClient extends ServiceClient<AFCProtocolClient> {
 }
 
 function toCString(s: string) {
-  const buf = Buffer.alloc(s.length + 1);
+  const buf = Buffer.alloc(Buffer.byteLength(s) + 1);
   const len = buf.write(s);
   buf.writeUInt8(0, len);
   return buf;


### PR DESCRIPTION
Fixes RangeError when uploading files with emoji or multi-byte UTF-8
  characters in filenames (e.g., ❤️.json)

  # Why

  The `toCString` function in AFCClient incorrectly uses `s.length` to
  allocate buffer size, which returns the JavaScript string length
  (UTF-16 code units) rather than the UTF-8 byte length. When filenames
   contain multi-byte UTF-8 characters (emojis, accented characters),
  the buffer is underallocated, causing an out-of-bounds write when
  null-terminating the string.

  This manifests when uploading iOS apps containing resources with
  emoji filenames, such as Zoom SDK's reaction emoji JSON files
  (❤️.json, 🎉.json, etc.).

  # How

  Changed `Buffer.alloc(s.length + 1)` to
  `Buffer.alloc(Buffer.byteLength(s) + 1)` to correctly calculate the
  required buffer size for UTF-8 encoded strings.

  # Test Plan

  **Reproduce the bug:**
  1. Add a file with an emoji in its filename to an iOS app bundle
  (e.g., via a third-party SDK)
  2. Run `npx expo run:ios --device`
  3. Observe `RangeError [ERR_OUT_OF_RANGE]: The value of "offset" is
  out of range` when AFCClient attempts to upload the file

  **Verify the fix:**
  1. Apply the patch
  2. Run the same command
  3. File uploads successfully without error

  # Checklist

  - [x] I added a `changelog.md` entry and rebuilt the package sources
  according to [this short guide](https://github.com/expo/expo/blob/mai
  n/CONTRIBUTING.md#-before-submitting)
  - [x] This diff will work correctly for `npx expo prebuild` & EAS
  Build (eg: updated a module plugin).
  - [x] Conforms with the [Documentation Writing Style
  Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documenta
  tion%20Writing%20Style%20Guide.md)