### PR TITLE
[create-expo-nightly] exclude sqlite-inspector-webui

### DIFF
--- a/packages/create-expo-nightly/src/Packages.ts
+++ b/packages/create-expo-nightly/src/Packages.ts
@@ -31,6 +31,7 @@ const EXCLUDE_PACKAGES = [
   '@react-native-community/cli-platform-android', // mock modules inside expo-modules-autolinkin
   'react', // canary react inside @expo/cli
   'react-dom', // canary react inside @expo/cli
+  'sqlite-inspector-webui', // prebuilt bundle from expo-sqlite
 ];
 
 export const REACT_NATIVE_TRANSITIVE_DEPENDENCIES = [


### PR DESCRIPTION
# Why

fixes nightly ci error: https://github.com/expo/expo/runs/55044584630

# How

exclude sqlite-inspector-webui from installation

# Test Plan

ci passed - not quite there yet. need to resolve other issues on following up prs

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
