### PR TITLE
[ci] fix nightlies

### DIFF
--- a/.github/workflows/test-react-native-nightly.yml
+++ b/.github/workflows/test-react-native-nightly.yml
@@ -25,14 +25,14 @@ jobs:
     runs-on: macos-15
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: 🔨 Switch to Xcode 26.0
         run: sudo xcode-select --switch /Applications/Xcode_26.0.app
       - name: 🍺 Install required tools
         run: |
           brew install watchman || true
       - name: 🚀 Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - name: 💎 Setup Ruby
@@ -43,7 +43,7 @@ jobs:
         run: gem install cocoapods xcpretty
       - name: ♻️ Restore workspace node modules
         # Use restore only cache here because we don't want to nightly react-native version saving back to the cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         id: workspace-modules-cache
         with:
           path: |
@@ -121,11 +121,11 @@ jobs:
       GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx4096m -XX:MaxMetaspaceSize=4096m"
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: true
+        uses: actions/checkout@v5
+      - name: 🧹 Cleanup GitHub Linux runner disk space
+        uses: ./.github/actions/cleanup-linux-disk-space
       - name: 🚀 Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - name: 🔨 Use JDK 17
@@ -135,7 +135,7 @@ jobs:
           java-version: '17'
       - name: ♻️ Restore workspace node modules
         # Use restore only cache here because we don't want to nightly react-native version saving back to the cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         id: workspace-modules-cache
         with:
           path: |

--- a/packages/create-expo-nightly/src/ExpoRepo.ts
+++ b/packages/create-expo-nightly/src/ExpoRepo.ts
@@ -38,6 +38,15 @@ export async function setupExpoRepoAsync(
   console.log(`Running \`yarn install\` in ${expoRepoPath}`);
   console.time('Installed dependencies in expo repository');
   await setupDependenciesAsync(expoRepoPath, nightlyVersion);
+
+  // log-box on-demand bundle doesn't work well in out-of-tree setups
+  await fs.promises.rm(
+    path.join(expoRepoPath, 'packages', '@expo', 'log-box', '.bundle-on-demand'),
+    {
+      force: true,
+    }
+  );
+
   try {
     await runAsync('yarn', ['install'], { cwd: expoRepoPath });
   } catch (e) {


### PR DESCRIPTION
# Why

fixes nightlies ci error: https://github.com/expo/expo/actions/runs/19253956761/job/55044584630

# How

bundling for log-box doesn't work when running from out-of-tree nightlies setup. this pr tries to remove the **.bundle-on-demand** to disable to bundling

# Test Plan

- nightlies ci passed on android
- on ios there's the other react-native breaking change: https://github.com/expo/expo/actions/runs/19263833656/job/55074767103?pr=40937

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
