### PR TITLE
[docs] Update installation and testing provider commands in Use build cache providers guide

### DIFF
--- a/docs/pages/guides/cache-builds-remotely.mdx
+++ b/docs/pages/guides/cache-builds-remotely.mdx
@@ -12,7 +12,7 @@ When you run `npx expo run:[android|ios]`, it checks if a build with a matching 
 
 ## Using EAS as a build provider
 
-To use the EAS Build provider plugin, start by installing the `eas-build-cache-provider` package as a developer dependency:
+To use the EAS Build provider plugin, start by installing the `eas-build-cache-provider` package as a dependency:
 
 <Terminal cmd={['$ npx expo install eas-build-cache-provider']} />
 

--- a/docs/pages/guides/cache-builds-remotely.mdx
+++ b/docs/pages/guides/cache-builds-remotely.mdx
@@ -6,15 +6,30 @@ description: Accelerate local development by caching and reusing builds from a p
 
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { Tabs, Tab } from '~/ui/components/Tabs';
 
 Build caching is a feature that speeds up `npx expo run:[android|ios]` by caching builds remotely, based on the project [fingerprint](/versions/latest/sdk/fingerprint/).
 When you run `npx expo run:[android|ios]`, it checks if a build with a matching fingerprint exists, then downloads and launches it rather than compiling it again. Otherwise, the project is compiled as usual and then the resulting binary is uploaded to the remote cache for future runs.
 
 ## Using EAS as a build provider
 
-To use the EAS Build provider plugin, start by installing the `eas-build-cache-provider` package as a dependency:
+To use the EAS Build provider plugin, start by installing the `eas-build-cache-provider` package as a developer dependency:
 
-<Terminal cmd={['$ npx expo install eas-build-cache-provider']} />
+<Tabs>
+
+<Tab label="macOS/Linux">
+
+<Terminal cmd={['$ npx expo install eas-build-cache-provider --dev']} />
+
+</Tab>
+
+<Tab label="Windows">
+
+<Terminal cmd={['$ npx expo install eas-build-cache-provider "--" --dev']} />
+
+</Tab>
+
+</Tabs>
 
 Then, update your **app.json** to include the `buildCacheProvider` property and its provider:
 
@@ -152,7 +167,18 @@ At the root of your project, run `npm run build provider` to start the TypeScrip
 ### Test your provider
 When you run the `npx expo run` command inside your **example** directory, you should see your plugin's console statements in the logs.
 
-<Terminal cmd={['$ cd example', '$ npx expo run:ios']} />
+<Terminal
+  cmd={[
+    '# Navigate to the example directory',
+    '$ cd example',
+    '',
+    '# Run the example on Android',
+    '$ npx expo run:android',
+    '',
+    '# Run the example on iOS',
+    '$ npx expo run:ios',
+  ]}
+/>
 
 That's it! You now have a remote build cache provider to speed up your builds.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18054

# How

<!--
How did you build this feature or fix this bug and why?
-->

~~Remove "developer" in Use build cache providers guide. The phrase "developer dependency" is confusing because the dependency installed is not under `devDependency`.~~

As per review below, it is a developer depenedency: https://github.com/expo/expo/pull/40943#discussion_r2519025918.
This PR adjusts the installation command and also fixes the `npx expo run` commands snippet (which was missing `npx expo run:android`).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
