### PR TITLE
docs(router-protected): fix prop name

### DIFF
--- a/docs/pages/router/advanced/protected.mdx
+++ b/docs/pages/router/advanced/protected.mdx
@@ -143,7 +143,7 @@ export function AppLayout() {
 }
 ```
 
-Here, because the **index** screen is protected and the **protected** is **false**, the router redirects to the first available screen &mdash; **login**.
+Here, because the **index** screen is protected and the **guard** is **false**, the router redirects to the first available screen &mdash; **login**.
 
 ## Tabs and Drawer
 

--- a/docs/pages/router/advanced/protected.mdx
+++ b/docs/pages/router/advanced/protected.mdx
@@ -143,7 +143,7 @@ export function AppLayout() {
 }
 ```
 
-Here, because the **index** screen is protected and the **guard** is **false**, the router redirects to the first available screen &mdash; **login**.
+In the above example, since the **index** screen is protected and the `guard` is **false**, the router redirects to the first available screen &mdash; **login**.
 
 ## Tabs and Drawer
 


### PR DESCRIPTION
# Why

Makes the docs read a little clearer when talking about the protected route fallback reasoning

# How

Used the prop name the code refers to

# Test Plan

n/a

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
