### PR TITLE
[expo] Fix EXReactRootViewFactory compatibility with macOS and tvOS

### DIFF
--- a/apps/bare-expo/macos/Podfile.lock
+++ b/apps/bare-expo/macos/Podfile.lock
@@ -48,6 +48,8 @@ PODS:
     - ExpoModulesCore
   - ExpoLocalAuthentication (17.0.7):
     - ExpoModulesCore
+  - ExpoLogBox (0.0.13-canary-20251023-4c86f95):
+    - React-Core
   - ExpoMeshGradient (0.4.7):
     - ExpoModulesCore
   - ExpoModulesCore (3.0.16):
@@ -120,7 +122,7 @@ PODS:
     - hermes-engine/Pre-built (= 0.79.6)
   - hermes-engine/Pre-built (0.79.6)
   - lottie-ios (4.5.0)
-  - lottie-react-native (7.3.1):
+  - lottie-react-native (7.3.4):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1984,6 +1986,7 @@ DEPENDENCIES:
   - ExpoKeepAwake (from `../../../packages/expo-keep-awake/ios`)
   - ExpoLinking (from `../../../packages/expo-linking/ios`)
   - ExpoLocalAuthentication (from `../../../packages/expo-local-authentication/ios`)
+  - "ExpoLogBox (from `../../../packages/@expo/log-box`)"
   - ExpoMeshGradient (from `../../../packages/expo-mesh-gradient/ios`)
   - ExpoModulesCore (from `../../../packages/expo-modules-core`)
   - ExpoSQLite (from `../../../packages/expo-sqlite/ios`)
@@ -2111,6 +2114,9 @@ EXTERNAL SOURCES:
   ExpoLocalAuthentication:
     inhibit_warnings: false
     :path: "../../../packages/expo-local-authentication/ios"
+  ExpoLogBox:
+    inhibit_warnings: false
+    :path: "../../../packages/@expo/log-box"
   ExpoMeshGradient:
     inhibit_warnings: false
     :path: "../../../packages/expo-mesh-gradient/ios"
@@ -2290,7 +2296,7 @@ SPEC CHECKSUMS:
   EASClient: de38c20c1dd9af7ff435afdc8b2c9b7c20d46767
   EXConstants: 59d46d25b89f88cc38291a56dbce4d550758f72d
   EXManifests: 7469efed75d694ce3c43a6da9c6f3886f66d3c26
-  Expo: bf4d616332c9ad2c4af6698d3611eb16fe814207
+  Expo: 5185e26e090412625624330b13bf7855c352440d
   ExpoAsset: 4375a46b45b12bbfcf6efac8c8a33aebdb8ba12b
   ExpoCrypto: 4c50a152f5939e16a2ca10be77b002a3a391c4d3
   ExpoFileSystem: adffad7d1f57f768ca7a5e3bf450312fb9ebd27a
@@ -2298,12 +2304,13 @@ SPEC CHECKSUMS:
   ExpoKeepAwake: 3f5e3ac53627849174f3603271df8e08f174ed4a
   ExpoLinking: f5c171877e118e792cb9a77e5ade0b080d899b14
   ExpoLocalAuthentication: 8f11d958b956fa372c0a49975f54ed1dc617ae1d
+  ExpoLogBox: b4c81de3f21bbe2e9467a26455563c76c7709efb
   ExpoMeshGradient: 763087d3b1e6e9a0974e9700ea24cb598816d93c
-  ExpoModulesCore: 1f58292be04d71465231222ce53d894e15aebbbe
+  ExpoModulesCore: 28cc0dd73e825ede95e97369758f88b5ac7fd2d5
   ExpoSQLite: f9d1202877e12bfa78a58309a3977ee4ea0b1314
   ExpoWebBrowser: 4f0dc52a559027cc0fba6920adc19a7604e2733d
   EXStructuredHeaders: c951e77f2d936f88637421e9588c976da5827368
-  EXUpdates: 50eb85c508f37965b8464e8708a99baf1c82beab
+  EXUpdates: 64db8f60b0ed534db01533a746798cdf60f26297
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   fast_float: 44983b3bddb2d2ed3021a98be86f60ec8abc9ffd
   FBLazyVector: 71133f116ceb23bd2d81af6df1a7ae5496c9f322
@@ -2311,7 +2318,7 @@ SPEC CHECKSUMS:
   glog: b7594b792ee4e02ed1f44b01d046ca25fa713e3d
   hermes-engine: 44bb6fe76a6eb400d3a992e2d0b21946ae999fa9
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
-  lottie-react-native: 6a52403e4090a499d7080fea0c92f31df797030e
+  lottie-react-native: 0992f59b1bbf07c523d3a86a359ce4aa1b49dd2e
   RCT-Folly: abec2d7f4af402b4957c44e86ceff8725b23c1b4
   RCTDeprecation: c147f8912f768e5eedbc5f115b2b223d007d9fe3
   RCTRequired: ae1e2d916a79190663b82b4cc5cddb1466bd788b
@@ -2379,7 +2386,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 7cf0e76983fc9f5e599b7969e4efcc47d540ef40
   ReactCommon: a2877349c13ee61be275db2c80ff3cc3eb02010e
   RNCAsyncStorage: 2cf7d05f5b1bc38680b6c83971e535a6ae9c5bc7
-  RNSVG: 363f6a7dc3d63870befaf64bfe78da20a4906b9d
+  RNSVG: 1239cc29364e032de5f1501bf5ed0b16f86dab48
   SocketRocket: 03f7111df1a343b162bf5b06ead333be808e1e0a
   Yoga: 45ce05cb11db042ba2e5e51a2dfaf0ff63d269f9
 

--- a/packages/expo/ios/AppDelegates/EXReactRootViewFactory.h
+++ b/packages/expo/ios/AppDelegates/EXReactRootViewFactory.h
@@ -24,10 +24,16 @@ NS_SWIFT_NAME(ExpoReactRootViewFactory)
 /**
  Calls super `viewWithModuleName:initialProperties:launchOptions:` from `RCTRootViewFactory`.
  */
+#if TARGET_OS_IOS
 - (UIView *)superViewWithModuleName:(NSString *)moduleName
                   initialProperties:(nullable NSDictionary *)initialProperties
                       launchOptions:(nullable NSDictionary *)launchOptions
                devMenuConfiguration:(nullable RCTDevMenuConfiguration *)devMenuConfiguration;
+#else
+- (UIView *)superViewWithModuleName:(NSString *)moduleName
+                  initialProperties:(nullable NSDictionary *)initialProperties
+                      launchOptions:(nullable NSDictionary *)launchOptions;
+#endif
 
 @end
 

--- a/packages/expo/ios/AppDelegates/EXReactRootViewFactory.mm
+++ b/packages/expo/ios/AppDelegates/EXReactRootViewFactory.mm
@@ -31,6 +31,7 @@
   return self;
 }
 
+#if TARGET_OS_IOS
 - (UIView *)viewWithModuleName:(NSString *)moduleName
              initialProperties:(nullable NSDictionary *)initialProperties
                  launchOptions:(nullable NSDictionary *)launchOptions
@@ -50,9 +51,27 @@
   if (devMenuConfiguration == nil) {
     devMenuConfiguration = [RCTDevMenuConfiguration defaultConfiguration];
   }
-  
+
   return [super viewWithModuleName:moduleName initialProperties:initialProperties launchOptions:launchOptions devMenuConfiguration:devMenuConfiguration];
 }
+#else
+- (UIView *)viewWithModuleName:(NSString *)moduleName
+             initialProperties:(nullable NSDictionary *)initialProperties
+                 launchOptions:(nullable NSDictionary *)launchOptions
+{
+  if (self.reactDelegate != nil) {
+    return [self.reactDelegate createReactRootViewWithModuleName:moduleName initialProperties:initialProperties launchOptions:launchOptions];
+  }
+  return [super viewWithModuleName:moduleName initialProperties:initialProperties launchOptions:launchOptions];
+}
+
+- (UIView *)superViewWithModuleName:(NSString *)moduleName
+                  initialProperties:(nullable NSDictionary *)initialProperties
+                      launchOptions:(nullable NSDictionary *)launchOptions
+{
+  return [super viewWithModuleName:moduleName initialProperties:initialProperties launchOptions:launchOptions];
+}
+#endif
 
 - (NSURL *)bundleURL
 {

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
@@ -120,6 +120,8 @@ public class ExpoReactNativeFactory: RCTReactNativeFactory, ExpoReactNativeFacto
 
     let rootView: UIView
     if let factory = self.rootViewFactory as? ExpoReactRootViewFactory {
+      // RCTDevMenuConfiguration is only available in react-native 0.83+
+#if os(iOS)
       // When calling `recreateRootViewWithBundleURL:` from `EXReactRootViewFactory`,
       // we don't want to loop the ReactDelegate again. Otherwise, it will be an infinite loop.
       rootView = factory.superView(
@@ -128,13 +130,28 @@ public class ExpoReactNativeFactory: RCTReactNativeFactory, ExpoReactNativeFacto
         launchOptions: launchOptions ?? [:],
         devMenuConfiguration: self.devMenuConfiguration
       )
+#else
+      rootView = factory.superView(
+        withModuleName: moduleName ?? defaultModuleName,
+        initialProperties: initialProps,
+        launchOptions: launchOptions ?? [:]
+      )
+#endif
     } else {
+#if os(iOS)
       rootView = rootViewFactory.view(
         withModuleName: moduleName ?? defaultModuleName,
         initialProperties: initialProps,
         launchOptions: launchOptions,
         devMenuConfiguration: self.devMenuConfiguration
       )
+#else
+      rootView = rootViewFactory.view(
+        withModuleName: moduleName ?? defaultModuleName,
+        initialProperties: initialProps,
+        launchOptions: launchOptions
+      )
+#endif
     }
 
     return rootView


### PR DESCRIPTION
# Why

React native 0.83 introduces a new class to configure the dev menu, `RCTDevMenuConfiguration`. The problem is that react-native-macos and react-native-tvos have not released their 0.83 variants yet, causing EXReactRootViewFactory compilation to fail 

# How

Fix EXReactRootViewFactory compatibility with older macOS and tvOS react native versions

# Test Plan

Run BareExpo macOS

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
