### PR TITLE
Update Elixir SDK link in documentation

### DIFF
--- a/docs/pages/push-notifications/sending-notifications.mdx
+++ b/docs/pages/push-notifications/sending-notifications.mdx
@@ -33,7 +33,7 @@ The Expo team and community have taken care of creating back-ends for you in a f
 | [expo-server-sdk-php](https://github.com/ctwillie/expo-server-sdk-php)                                   | PHP      | Community     |
 | [exponent-server-sdk-golang](https://github.com/oliveroneill/exponent-server-sdk-golang)                 | Golang   | Community     |
 | [exponent](https://github.com/9ssi7/exponent)                                                            | Golang   | Community     |
-| [exponent-server-sdk-elixir](https://github.com/rdrop/exponent-server-sdk-elixir)                        | Elixir   | Community     |
+| [exponent-server-sdk-elixir](https://github.com/pachun/exponent-server-sdk-elixir)                       | Elixir   | Community     |
 | [expo-server-sdk-dotnet](https://github.com/glyphard/expo-server-sdk-dotnet)                             | dotnet   | Community     |
 | [expo-server-sdk-java](https://github.com/hlspablo/expo-server-sdk-java)                                 | Java     | Community     |
 | [laravel-expo-notifier](https://github.com/YieldStudio/laravel-expo-notifier)                            | Laravel  | Community     |


### PR DESCRIPTION
The prior exponent server SDK for elixir works fine, but it hasn't been updated in 7 years. I updated the project to remove a bunch of compile time warnings I've been ignoring and opened a pull request, but it doesn't look like the author is active on GitHub anymore. In lieu of merging my changes to their repo, I figured maybe I should ask you all to update the link in your docs to version with more modern dependencies and fewer compile time warnings.

I'm not sure if this is the best way to handle the situation. At least here we'll be able to have a conversation about what we should do, even if this isn't quite right.

# Why

The prior exponent elixir server SDK is dated (~7 years) and has compile time warnings. I can't get attention in the pull request I opened in that repo, so I'm opening a pull request for the Expo docs here to update the link to point to the repository with more modern dependencies (my fork).

# How

I forked the prior authors repo, changed the main branch from "master" to "main" and made 5 commits:

* Update README installation instructions
* Remove obsolete dependencies (dialyze and inch_ex)
*  Use modern extra_applications pattern for OTP apps
* Migrate from Poison to Jason for JSON encoding/decoding
* Update to Elixir 1.14 and modernize critical dependencies

[You can check out the original PR I made here with a description](https://github.com/rdrop/exponent-server-sdk-elixir/pull/7).

# Test Plan

I'm not sure. I'll start using the updated version in my project to see if anything's busted. I think it'll just take people trying it.

EDIT: There are a handful of automated tests. They were broken in the old repository's master branch. I fixed them in my fork.