### PR TITLE
Fix running unit tests on iOS

### DIFF
--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -78,7 +78,7 @@ jobs:
           RCT_USE_RN_DEP: 1
         working-directory: apps/native-tests/ios
       - name: 🧪 Run native iOS unit tests
-        timeout-minutes: 60
+        timeout-minutes: 30
         env:
           FASTLANE_SKIP_UPDATE_CHECK: '1'
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 30

--- a/apps/native-tests/ios/Podfile.lock
+++ b/apps/native-tests/ios/Podfile.lock
@@ -370,51 +370,12 @@ PODS:
     - Yoga
   - ExpoModulesJSI (3.0.16):
     - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-jsinspector
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - Yoga
+    - ReactCommon
   - ExpoModulesJSI/Tests (3.0.16):
-    - ExpoModulesTestCore
     - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
     - React-Core
-    - React-Core-prebuilt
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-jsinspector
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - Yoga
+    - ReactCommon
   - ExpoModulesTestCore (1.0.0):
     - ExpoModulesCore
     - Nimble (~> 13.0.0)
@@ -2591,13 +2552,14 @@ SPEC CHECKSUMS:
   ExpoClipboard: 99109306a2d9ed2fbd16f6b856e6267b2afa8472
   ExpoImage: 0fc185a4a4e462fedfe877ae66204a7c541dfee0
   ExpoMediaLibrary: 648cee3f5dcba13410ec9cc8ac9a426e89a61a31
-  ExpoModulesCore: ce49ce28272906372ddaaea1c680d4422a76e308
+  ExpoModulesCore: 22f2efcefda2486b06a0b9f0dcaab8eccdfaf0b4
+  ExpoModulesJSI: b5e87deda640f9710d08446db5d110e91db64cc9
   ExpoModulesTestCore: e65555b75a4ed7dd3bcf421ad01d7748bd372c88
   EXStructuredHeaders: c951e77f2d936f88637421e9588c976da5827368
   EXUpdates: 83e4d666a085b44149f3b21d5bd057ad37b2c3e5
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   FBLazyVector: b733c6ff598607c9c5a2757669306ca5481fa7a1
-  hermes-engine: 7eaa8aa5d282250d11f85d144ea5121b5950a34f
+  hermes-engine: 8044e2041f40aac194ae9df22077c2db152c0903
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -2613,7 +2575,7 @@ SPEC CHECKSUMS:
   React: 0d33ae696cce9f29ef4ef9395b677461f819edff
   React-callinvoker: 98827bd8d13282630bd3ac420d9deab3ef9c4404
   React-Core: c53a32ac2fd877b127d678668eacb32ee5b278a2
-  React-Core-prebuilt: 5c88286698138b22f5eaf78bc19f4505bee5163c
+  React-Core-prebuilt: e4e617bce2fc30e0ab54deac54e57927a89db1e0
   React-CoreModules: 55744f49f098b26e46de697a828f0a22540246cd
   React-cxxreact: 07d452b1ca44cb6bf003b36d8263a1fa772d2cae
   React-debug: 65a8b0304322f0641d4aa5fcd1d9bdeae3f97327
@@ -2673,7 +2635,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: c55bd3998b0b548d2e81f5aae4758096d4321a7a
   ReactCodegen: 2da193111b4f0d8761cfb4b4f00914e7d9df9f0f
   ReactCommon: 558d37855c8b281c4fdfe8f9ba2d7bc102fb55ff
-  ReactNativeDependencies: e4a97d35dae6356c298b63c0b0c04c779bd8d125
+  ReactNativeDependencies: f40e1803d335251ce327873058d02828f6b4d552
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -182,7 +182,7 @@ platform :ios do
       clean: false,
       skip_build: true,
       prelaunch_simulator: true,
-      skip_detect_devices: true,
+      skip_detect_devices: false,
       skip_package_dependencies_resolution: true,
       derived_data_path: "/tmp/ExpoUnitTestsDerivedData",
       xcargs: 'CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO',

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptObjectBinding.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptObjectBinding.h
@@ -1,7 +1,7 @@
 // Copyright 2023-present 650 Industries. All rights reserved.
 
 #import <Foundation/Foundation.h>
-#import <ExpoModulesJSI/EXJavaScriptRuntime.h>
+#import <ExpoModulesJSI/EXJavaScriptObject.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
@@ -19,7 +19,6 @@ namespace react = facebook::react;
 
 @class EXJavaScriptValue;
 @class EXJavaScriptObject;
-@class EXJavaScriptSharedObject;
 
 typedef void (^JSRuntimeExecutionBlock)(void);
 

--- a/packages/expo-modules-core/ios/JSI/Tests/JavaScriptRuntimeTests.swift
+++ b/packages/expo-modules-core/ios/JSI/Tests/JavaScriptRuntimeTests.swift
@@ -8,13 +8,9 @@ import Testing
 struct JavaScriptRuntimeTests {
   @Test
   func `initializes`() {
-    _ = JavaScriptRuntime()
-  }
-
-  @Test
-  func `has global object`() async throws {
+    // Just check it does not crash
     let runtime = JavaScriptRuntime()
-    try #require(runtime.global())
+    runtime.global()
   }
 
   // TODO: Move tests from ExpoModulesCore/JavaScriptRuntimeSpec and add more

--- a/tools/src/Packages.ts
+++ b/tools/src/Packages.ts
@@ -61,7 +61,7 @@ export type PackageDependency = {
 /**
  * Union with possible platform names.
  */
-type Platform = 'ios' | 'android' | 'web';
+type Platform = 'ios' | 'android' | 'web' | 'apple';
 
 /**
  * Type representing `expo-modules.config.json` structure.
@@ -221,7 +221,12 @@ export class Package {
   isSupportedOnPlatform(platform: 'ios' | 'android'): boolean {
     if (this.expoModuleConfig && !fs.existsSync(path.join(this.path, 'react-native.config.js'))) {
       // check platform support from expo autolinking but not rn-cli linking which is not platform aware
-      return this.expoModuleConfig.platforms?.includes(platform) ?? false;
+      const platforms = this.expoModuleConfig.platforms ?? [];
+      if (platform === 'ios') {
+        return platforms.includes(platform) || platforms.includes('apple');
+      } else {
+        return platforms.includes(platform);
+      }
     } else if (platform === 'android') {
       return fs.existsSync(path.join(this.path, this.androidSubdirectory, 'build.gradle'));
     } else if (platform === 'ios') {

--- a/tools/src/commands/IosNativeUnitTests.ts
+++ b/tools/src/commands/IosNativeUnitTests.ts
@@ -54,6 +54,13 @@ export async function iosNativeUnitTests({ packages }: { packages?: string }) {
     packagesToTest.push(pkg.packageName);
   }
 
+  // @tsapeta: `expo-modules-core` has two podspecs – for the core and for the JSI. This is supported by autolinking,
+  // but not by expotools and as a result only `ExpoModulesJSI` tests are being included. Here we make sure the tests
+  // for the core are included. Long-term plan is to move JSI pod to a separate package, then this can be removed.
+  if (packagesToTest.includes('expo-modules-core')) {
+    targetsToTest.unshift(`ExpoModulesCore-Unit-Tests`);
+  }
+
   if (packageNamesFilter.length && !targetsToTest.length) {
     throw new Error(
       `No packages were found with the specified names: ${packageNamesFilter.join(', ')}`
@@ -61,6 +68,7 @@ export async function iosNativeUnitTests({ packages }: { packages?: string }) {
   }
 
   try {
+    console.log(`Running tests for targets:\n- ${targetsToTest.join('\n- ')}\n`);
     await runTests(targetsToTest);
   } catch (error) {
     console.error('iOS unit tests failed:');


### PR DESCRIPTION
# Why

I'm used to run native tests manually from Xcode instead of expotools/Fastlane. This time I was trying to debug one failure on the CI and I've noticed a few problems with our current setup for running native unit tests:
1. `expo-modules-core` now has two podspecs – this is supported by autolinking, but as it turned out not by expotools. As a result only tests from `ExpoModulesJSI` were included, without tests for the `ExpoModulesCore` pod.
2. Modules that declare support using the generic `apple` platform were not included (expotools don't handle them well too).
3. Fastlane is failing if the specified device cannot be found, which happened to me as I only have simulators for iOS 26.1 (we explicitly ask for iOS 26.0 in the Fastfile).

I'm also thinking about decreasing the timeout for native tests. Currently it's 60 minutes which is way too long. It shouldn't take more than 20 minutes. If the job takes longer time, it probably stuck forever on launching the simulator.

# How

1. Simply enforced including `ExpoModulesCore` tests. This is probably not the best approach, but I think adding support for multiple pods to expotools is not worth it. Long-term we'll probably make a separate package `expo-modules-jsi` for this additional pod.
2. Added another check whether `apple` is used instead of `ios`.
3. Disabled `skip_detect_devices` option to let Fastlane do the fallback to other devices.

# Test Plan

`expotools native-unit-tests --platform ios` does not fail