### PR TITLE
[expo-font] update ExpoFontUtils mock, to align with new API

### DIFF
--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- update ExpoFontUtils mock, to align with new API ([#40964](https://github.com/expo/expo/pull/40964) by [@Ubax](https://github.com/Ubax))
+
 ## 14.0.9 - 2025-10-09
 
 ### 🐛 Bug fixes

--- a/packages/expo-font/mocks/ExpoFontUtils.ts
+++ b/packages/expo-font/mocks/ExpoFontUtils.ts
@@ -1,8 +1,15 @@
+import type { RenderToImageResult } from '../src/FontUtils.types';
+
 export type RenderToImageOptions = any;
 
 export async function renderToImageAsync(
   glyphs: string,
   options: RenderToImageOptions
-): Promise<string> {
-  return '';
+): Promise<RenderToImageResult> {
+  return {
+    width: 0,
+    height: 0,
+    scale: 1,
+    uri: '',
+  };
 }


### PR DESCRIPTION
# Why

The `renderToImageAsync` API was changed in https://github.com/expo/expo/pull/40113, but the ExpoFontUtils mock was not adjusted.

# How

Change the return type in mock to be `Promise<RenderToImageResult>`

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
