### PR TITLE
Fix compilation errors about RCTComponent on macOS

### DIFF
--- a/apps/bare-expo/macos/Podfile.lock
+++ b/apps/bare-expo/macos/Podfile.lock
@@ -54,6 +54,7 @@ PODS:
     - ExpoModulesCore
   - ExpoModulesCore (3.0.16):
     - DoubleConversion
+    - ExpoModulesJSI
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -77,6 +78,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
+  - ExpoModulesJSI (3.0.16):
+    - hermes-engine
+    - React-Core
+    - ReactCommon
   - ExpoSQLite (16.0.8):
     - ExpoModulesCore
   - ExpoWebBrowser (15.0.7):
@@ -1989,6 +1994,7 @@ DEPENDENCIES:
   - "ExpoLogBox (from `../../../packages/@expo/log-box`)"
   - ExpoMeshGradient (from `../../../packages/expo-mesh-gradient/ios`)
   - ExpoModulesCore (from `../../../packages/expo-modules-core`)
+  - ExpoModulesJSI (from `../../../packages/expo-modules-core`)
   - ExpoSQLite (from `../../../packages/expo-sqlite/ios`)
   - ExpoWebBrowser (from `../../../packages/expo-web-browser/ios`)
   - EXStructuredHeaders (from `../../../packages/expo-structured-headers/ios`)
@@ -2121,6 +2127,9 @@ EXTERNAL SOURCES:
     inhibit_warnings: false
     :path: "../../../packages/expo-mesh-gradient/ios"
   ExpoModulesCore:
+    inhibit_warnings: false
+    :path: "../../../packages/expo-modules-core"
+  ExpoModulesJSI:
     inhibit_warnings: false
     :path: "../../../packages/expo-modules-core"
   ExpoSQLite:
@@ -2306,7 +2315,8 @@ SPEC CHECKSUMS:
   ExpoLocalAuthentication: 8f11d958b956fa372c0a49975f54ed1dc617ae1d
   ExpoLogBox: b4c81de3f21bbe2e9467a26455563c76c7709efb
   ExpoMeshGradient: 763087d3b1e6e9a0974e9700ea24cb598816d93c
-  ExpoModulesCore: 28cc0dd73e825ede95e97369758f88b5ac7fd2d5
+  ExpoModulesCore: 1ec87df132dacae5255ec376c98e07de6f66852a
+  ExpoModulesJSI: b5e87deda640f9710d08446db5d110e91db64cc9
   ExpoSQLite: f9d1202877e12bfa78a58309a3977ee4ea0b1314
   ExpoWebBrowser: 4f0dc52a559027cc0fba6920adc19a7604e2733d
   EXStructuredHeaders: c951e77f2d936f88637421e9588c976da5827368
@@ -2315,7 +2325,7 @@ SPEC CHECKSUMS:
   fast_float: 44983b3bddb2d2ed3021a98be86f60ec8abc9ffd
   FBLazyVector: 71133f116ceb23bd2d81af6df1a7ae5496c9f322
   fmt: f6af2d677a106e3e44c9536a4c0c7f03ab53c854
-  glog: b7594b792ee4e02ed1f44b01d046ca25fa713e3d
+  glog: ea1690290b2b90f923ffcce07436498f09b428ee
   hermes-engine: 44bb6fe76a6eb400d3a992e2d0b21946ae999fa9
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
   lottie-react-native: 0992f59b1bbf07c523d3a86a359ce4aa1b49dd2e

--- a/packages/expo-modules-core/ios/RCTComponentData+Privates.h
+++ b/packages/expo-modules-core/ios/RCTComponentData+Privates.h
@@ -1,7 +1,6 @@
 // Copyright 2021-present 650 Industries. All rights reserved.
 
-@class RCTComponent;
-
+#import <React/RCTComponent.h>
 #import <React/RCTComponentData.h>
 
 typedef void (^RCTPropBlockAlias)(id<RCTComponent> _Nonnull view, id _Nullable json);


### PR DESCRIPTION
# Why

Fixes compilation errors on macOS as in here: https://github.com/expo/expo/actions/runs/19281652507/job/55133828796?pr=40951

# How

It turned out the forward declaration was an issue. I don't think it's even necessary here. I also added an explicit import to ensure the `RCTComponent` protocol is visible from our own `RCTComponentData` header.
I'm not sure why it worked on iOS though.

# Test Plan

The CI should pass now. Tested locally with bare-expo app.