### PR TITLE
[docs] Update example and Invoke permissions for videos sub-section in ImagePicker reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/imagepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.mdx
@@ -233,7 +233,7 @@ When you run this example and pick an image, you will see the image that you pic
 
 ### Invoke permissions for videos <PlatformTags platforms={['ios']} />
 
-Starting SDK 54, picking videos on iOS while `allowsEditing` is `true` or when [`videoExportPreset`](#videoexportpreset) is set to any other value than `Passthrough`, it won't trigger a permission request by default. However, there will be an increase in time for picker to open for large or freshly recorded videos which haven't been processed internally by iOS.
+Starting SDK 54, picking videos on iOS while `allowsEditing` is `true` or when [`videoExportPreset`](#videoexportpreset) is set to any other value than `Passthrough`, it won't trigger a permission request by default. However, there will be an increase in time for picker to open for large or newly recorded videos which haven't been processed internally by iOS.
 
 We recommend requesting media library permissions either using [`requestMediaLibraryPermissionsAsync`](#imagepickerrequestmedialibrarypermissionsasyncwriteonly) or [`useMediaLibraryPermissions`](#usemedialibrarypermissionsoptions) before opening the picker for videos.
 

--- a/docs/pages/versions/unversioned/sdk/imagepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.mdx
@@ -233,7 +233,7 @@ When you run this example and pick an image, you will see the image that you pic
 
 ### Invoke permissions for videos <PlatformTags platforms={['ios']} />
 
-Starting SDK 54, picking videos on iOS while `allowsEditing` is `true` or when [`videoExportPreset`](#videoexportpreset) is set to any other value than `Passthrough`, it won't trigger a permission request by default. However, there will be an increase in time for picker to open for large or newly recorded videos which haven't been processed internally by iOS.
+In SDK 54 and later, picking videos on iOS while `allowsEditing` is `true` or when [`videoExportPreset`](#videoexportpreset) is set to any other value than `Passthrough`, it won't trigger a permission request by default. However, there will be an increase in time for picker to open for large or newly recorded videos which haven't been processed internally by iOS.
 
 We recommend requesting media library permissions either using [`requestMediaLibraryPermissionsAsync`](#imagepickerrequestmedialibrarypermissionsasyncwriteonly) or [`useMediaLibraryPermissions`](#usemedialibrarypermissionsoptions) before opening the picker for videos.
 

--- a/docs/pages/versions/unversioned/sdk/imagepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.mdx
@@ -155,14 +155,23 @@ If you're not using Continuous Native Generation ([CNG](/workflow/continuous-nat
 
 ```tsx
 import { useState } from 'react';
-import { Button, Image, View, StyleSheet } from 'react-native';
+import { Alert, Button, Image, View, StyleSheet } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 
 export default function ImagePickerExample() {
   const [image, setImage] = useState<string | null>(null);
 
   const pickImage = async () => {
-    // No permissions request is necessary for launching the image library
+    // No permissions request is necessary for launching the image library.
+    // Permissions are required for videos on iOS when `allowsEditing` is `true`.
+    // See "Invoke permissions for videos" sub section for more details.
+    const permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
+
+    if (!permissionResult.granted) {
+      Alert.alert('Permission required', 'Permission to access the media library is required.');
+      return;
+    }
+
     let result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ['images', 'videos'],
       allowsEditing: true,
@@ -221,6 +230,12 @@ When you run this example and pick an image, you will see the image that you pic
   "canceled": false
 }
 ```
+
+### Invoke permissions for videos <PlatformTags platforms={['ios']} />
+
+Starting SDK 54, picking videos on iOS while `allowsEditing` is `true` or when [`videoExportPreset`](#videoexportpreset) is set to any other value than `Passthrough`, it won't trigger a permission request by default. However, there will be an increase in time for picker to open for large or freshly recorded videos which haven't been processed internally by iOS.
+
+We recommend requesting media library permissions either using [`requestMediaLibraryPermissionsAsync`](#imagepickerrequestmedialibrarypermissionsasyncwriteonly) or [`useMediaLibraryPermissions`](#usemedialibrarypermissionsoptions) before opening the picker for videos.
 
 ### With AWS S3
 

--- a/docs/pages/versions/v54.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/imagepicker.mdx
@@ -102,14 +102,23 @@ If you're not using Continuous Native Generation ([CNG](/workflow/continuous-nat
 
 ```tsx
 import { useState } from 'react';
-import { Button, Image, View, StyleSheet } from 'react-native';
+import { Alert, Button, Image, View, StyleSheet } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 
 export default function ImagePickerExample() {
   const [image, setImage] = useState<string | null>(null);
 
   const pickImage = async () => {
-    // No permissions request is necessary for launching the image library
+    // No permissions request is necessary for launching the image library.
+    // Permissions are required for videos on iOS when `allowsEditing` is `true`.
+    // See "Invoke permissions for videos" sub section for more details.
+    const permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
+
+    if (!permissionResult.granted) {
+      Alert.alert('Permission required', 'Permission to access the media library is required.');
+      return;
+    }
+
     let result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ['images', 'videos'],
       allowsEditing: true,
@@ -168,6 +177,12 @@ When you run this example and pick an image, you will see the image that you pic
   "canceled": false
 }
 ```
+
+### Invoke permissions for videos <PlatformTags platforms={['ios']} />
+
+Starting SDK 54, picking videos on iOS while `allowsEditing` is `true` or when [`videoExportPreset`](#videoexportpreset) is set to any other value than `Passthrough`, it won't trigger a permission request by default. However, there will be an increase in time for picker to open for large or freshly recorded videos which haven't been processed internally by iOS.
+
+We recommend requesting media library permissions either using [`requestMediaLibraryPermissionsAsync`](#imagepickerrequestmedialibrarypermissionsasyncwriteonly) or [`useMediaLibraryPermissions`](#usemedialibrarypermissionsoptions) before opening the picker for videos.
 
 ### With AWS S3
 

--- a/docs/pages/versions/v54.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/imagepicker.mdx
@@ -180,7 +180,7 @@ When you run this example and pick an image, you will see the image that you pic
 
 ### Invoke permissions for videos <PlatformTags platforms={['ios']} />
 
-Starting SDK 54, picking videos on iOS while `allowsEditing` is `true` or when [`videoExportPreset`](#videoexportpreset) is set to any other value than `Passthrough`, it won't trigger a permission request by default. However, there will be an increase in time for picker to open for large or freshly recorded videos which haven't been processed internally by iOS.
+Starting SDK 54, picking videos on iOS while `allowsEditing` is `true` or when [`videoExportPreset`](#videoexportpreset) is set to any other value than `Passthrough`, it won't trigger a permission request by default. However, there will be an increase in time for picker to open for large or newly recorded videos which haven't been processed internally by iOS.
 
 We recommend requesting media library permissions either using [`requestMediaLibraryPermissionsAsync`](#imagepickerrequestmedialibrarypermissionsasyncwriteonly) or [`useMediaLibraryPermissions`](#usemedialibrarypermissionsoptions) before opening the picker for videos.
 

--- a/docs/pages/versions/v54.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/imagepicker.mdx
@@ -180,7 +180,7 @@ When you run this example and pick an image, you will see the image that you pic
 
 ### Invoke permissions for videos <PlatformTags platforms={['ios']} />
 
-Starting SDK 54, picking videos on iOS while `allowsEditing` is `true` or when [`videoExportPreset`](#videoexportpreset) is set to any other value than `Passthrough`, it won't trigger a permission request by default. However, there will be an increase in time for picker to open for large or newly recorded videos which haven't been processed internally by iOS.
+In SDK 54 and later, picking videos on iOS while `allowsEditing` is `true` or when [`videoExportPreset`](#videoexportpreset) is set to any other value than `Passthrough`, it won't trigger a permission request by default. However, there will be an increase in time for picker to open for large or newly recorded videos which haven't been processed internally by iOS.
 
 We recommend requesting media library permissions either using [`requestMediaLibraryPermissionsAsync`](#imagepickerrequestmedialibrarypermissionsasyncwriteonly) or [`useMediaLibraryPermissions`](#usemedialibrarypermissionsoptions) before opening the picker for videos.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18042

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update the example and invoke permissions for the videos sub-section in the ImagePicker reference.
- Changes applied to SDK 54 and unversioned reference.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
