### PR TITLE
[docs] amend request proxying

### DIFF
--- a/docs/pages/eas-update/request-proxying.mdx
+++ b/docs/pages/eas-update/request-proxying.mdx
@@ -14,7 +14,7 @@ EAS Update supports request proxying, which allows you to proxy requests to the 
    - One for the update asset requests (JavaScript bundles, images, and so on).
      - This must forward requests to `assets.eascdn.net`, the EAS Update asset server.
      - This must pass-through all URL contents (path, query parameters, and so on).
-     - This must pass-through all headers prefixed with `expo-` or `eas-`.
+     - This must pass-through all headers.
    - One for the update manifest requests.
      - This must forward requests to `u.expo.dev`, the EAS Update server.
      - This must pass-through all URL contents (path, query parameters, and so on).

--- a/docs/pages/eas-update/request-proxying.mdx
+++ b/docs/pages/eas-update/request-proxying.mdx
@@ -14,7 +14,9 @@ EAS Update supports request proxying, which allows you to proxy requests to the 
    - One for the update asset requests (JavaScript bundles, images, and so on).
      - This must forward requests to `assets.eascdn.net`, the EAS Update asset server.
      - This must pass-through all URL contents (path, query parameters, and so on).
-     - This must pass-through all headers.
+     - This must forward all request headers that:
+       - start with `expo-` or `eas-`, or
+       - are exactly `authorization` or `aim`.
    - One for the update manifest requests.
      - This must forward requests to `u.expo.dev`, the EAS Update server.
      - This must pass-through all URL contents (path, query parameters, and so on).

--- a/docs/pages/eas-update/request-proxying.mdx
+++ b/docs/pages/eas-update/request-proxying.mdx
@@ -16,7 +16,7 @@ EAS Update supports request proxying, which allows you to proxy requests to the 
      - This must pass-through all URL contents (path, query parameters, and so on).
      - This must forward all request headers that:
        - start with `expo-` or `eas-`, or
-       - are exactly `authorization` or `aim`.
+       - are exactly `authorization` or `a-im`.
    - One for the update manifest requests.
      - This must forward requests to `u.expo.dev`, the EAS Update server.
      - This must pass-through all URL contents (path, query parameters, and so on).


### PR DESCRIPTION
# Why

In addition to the `expo` and `exp` prefixed headers, you'd also need to proxy the `authorization` and `aim` headers. We need `authorization` to pass the hmac checks and get the asset, and we need `aim` for patch support

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
