### PR TITLE
[go][Android] Fix multiple projects in this build have the same project directory

### DIFF
--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -110,6 +110,9 @@
         "../../react-native-lab/react-native/packages",
         "./node_modules",
         "../../node_modules"
+      ],
+      "exclude": [
+        "@expo/home"
       ]
     }
   }


### PR DESCRIPTION
# Why

Fixes multiple projects in this build have the same project directory. 

# How

For some reason, `@expo/home` is linked, which leads to a problem during Gradle sync.

# Test Plan

- expo go on Android ✅ 