### PR TITLE
[haptics][android] fix missing await for `performHapticsAsync`

### DIFF
--- a/packages/expo-haptics/CHANGELOG.md
+++ b/packages/expo-haptics/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 💡 Others
 
+- [Android] Fix missing await for performHapticsAsync ([#40987](https://github.com/expo/expo/pull/40987) by [@kamui545](https://github.com/kamui545))
 - [Android] Removed unused `androidx.annotation:annotation` dependency. ([#39759](https://github.com/expo/expo/pull/39759) by [@lukmccall](https://github.com/lukmccall))
 
 ## 15.0.7 — 2025-09-11

--- a/packages/expo-haptics/CHANGELOG.md
+++ b/packages/expo-haptics/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [Android] Fix missing await for performHapticsAsync ([#40987](https://github.com/expo/expo/pull/40987) by [@kamui545](https://github.com/kamui545))
+- [Android] Fix missing `await` for `performHapticsAsync` ([#40987](https://github.com/expo/expo/pull/40987) by [@kamui545](https://github.com/kamui545))
 - [Android] Removed unused `androidx.annotation:annotation` dependency. ([#39759](https://github.com/expo/expo/pull/39759) by [@lukmccall](https://github.com/lukmccall))
 
 ## 15.0.7 — 2025-09-11

--- a/packages/expo-haptics/src/Haptics.ts
+++ b/packages/expo-haptics/src/Haptics.ts
@@ -60,7 +60,7 @@ export async function performAndroidHapticsAsync(type: AndroidHaptics) {
   if (Platform.OS !== 'android') {
     return;
   }
-  ExpoHaptics.performHapticsAsync(type);
+  await ExpoHaptics.performHapticsAsync(type);
 }
 
 export { NotificationFeedbackType, ImpactFeedbackStyle, AndroidHaptics };


### PR DESCRIPTION
# Why

`performAndroidHapticsAsync` currently calls `ExpoHaptics.performHapticsAsync(type)` without `await`.
This means any promise rejection inside `performHapticsAsync` is unhandled and cannot be caught.

I noticed this bug because it is currently spamming our Sentry even though we are calling it with `catch`:

```
Error: Call to function 'ExpoHaptics.performHapticsAsync' has been rejected.
→ Caused by: A haptics engine is not available on this device
```

This seems to have been an unintentional omission since other related functions from this files are using `await`.

---

# How

Added `await` to the `ExpoHaptics.performHapticsAsync(type)` call inside `performAndroidHapticsAsync`.

---

# Test Plan

1. Call `performAndroidHapticsAsync()` on Android with `.catch()` attached.
2. Simulate or force an error in `ExpoHaptics.performHapticsAsync`
3. Confirm that the error is now caught by the calling code instead of producing an unhandled promise rejection warning.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
