### PR TITLE
[expo-asset][ios] fix adding transparent png Image Assets

### DIFF
--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [ios] fix adding transparent png Image Assets ([#40991](https://github.com/expo/expo/pull/40991) by [@kosmydel](https://github.com/kosmydel))
+
 ### 💡 Others
 
 - validate asset names with `isAndroidAssetNameValid` from `expo/config-plugins` ([#39883](https://github.com/expo/expo/pull/39883) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-asset/plugin/src/withAssetsIos.ts
+++ b/packages/expo-asset/plugin/src/withAssetsIos.ts
@@ -1,4 +1,4 @@
-import { generateImageAsync } from '@expo/image-utils';
+import { generateImageAsync, ImageOptions } from '@expo/image-utils';
 import type { ExpoConfig } from 'expo/config';
 import {
   type ConfigPlugin,
@@ -70,7 +70,7 @@ async function addImageAssets(assets: string[], root: string) {
       // Use generateImageAsync to handle the conversion properly
       const buffer = await generateImageAsync({ projectRoot: root }, {
         src: asset,
-      } as any);
+      } as unknown as ImageOptions);
       await fs.writeFile(path.resolve(assetPath, outputImage), buffer.source);
     } else {
       // For PNG and JPG, copy the file directly to preserve all original properties including transparency


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes https://github.com/expo/expo/issues/35249

# How

<!--
How did you build this feature or fix this bug and why?
-->

Jimp’s transform step breaks image transparency (see https://github.com/jimp-dev/jimp/issues/442). Since we don’t need to apply any transformations when the asset isn’t being resized (`png` and `jpg` files), we can safely skip the transform entirely. For GIFs, we continue using the existing path because Xcode does not support GIF assets.

**PNG and JPG:** Copy files directly without processing to preserve transparency and original image properties
**GIF:** Continue using `generateImageAsync` to convert to PNG, since iOS asset catalogs don't support animated GIFs

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

1. Create an Expo project with `expo-asset` config plugin configured. [Assets link](https://drive.google.com/drive/folders/1zQIGgqfFOqIFC9JFg--J99k7O4HEMFg2?usp=sharing).
```
"assets": [
    "./assets/lines.png",
    "./assets/linesjpg.jpg",
    "./assets/linesgif.gif",
]
```
```
<Image source="lines" style={{ width, height }} cachePolicy={"none"} />
<Image source="linesjpg" style={{ width, height }} cachePolicy={"none"} />
<Image source="linesgif" style={{ width, height }} cachePolicy={"none"} />
```
2. Build for iOS and verify images render with correct transparency (no black edges)
3. Test with PNG, JPG, and GIF files to ensure all formats work correctly

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
