### PR TITLE
[core][iOS] Fix `null` not being correctly converted to `ValueOrUndefined` in `Record`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -36,6 +36,7 @@
 - [iOS] Fix sizing glitch when React Native components are used as child in Expo UI components ([#40693](https://github.com/expo/expo/pull/40693) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Improve RN component layout when hosted in SwiftUI ([#40794](https://github.com/expo/expo/pull/40794) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix `TextField` causing crash when reload and unmounting. ([#40960](https://github.com/expo/expo/pull/40960) by [@nishan](https://github.com/intergalacticspacehighway))
+- [iOS] Fixed `null` not being correctly converted to `ValueOrUndefined` in `Record`.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -36,7 +36,7 @@
 - [iOS] Fix sizing glitch when React Native components are used as child in Expo UI components ([#40693](https://github.com/expo/expo/pull/40693) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Improve RN component layout when hosted in SwiftUI ([#40794](https://github.com/expo/expo/pull/40794) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix `TextField` causing crash when reload and unmounting. ([#40960](https://github.com/expo/expo/pull/40960) by [@nishan](https://github.com/intergalacticspacehighway))
-- [iOS] Fixed `null` not being correctly converted to `ValueOrUndefined` in `Record`.
+- [iOS] Fixed `null` not being correctly converted to `ValueOrUndefined` in `Record`. ([#41005](https://github.com/expo/expo/pull/41005) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/JSI/EXJSIConversions.h
+++ b/packages/expo-modules-core/ios/JSI/EXJSIConversions.h
@@ -44,6 +44,8 @@ namespace expo
 
     id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &value, std::shared_ptr<CallInvoker> jsInvoker);
 
+    id convertJSIValueToObjCObjectAsDictValue(jsi::Runtime &runtime, const jsi::Value &value, std::shared_ptr<CallInvoker> jsInvoker);
+
     RCTResponseSenderBlock convertJSIFunctionToCallback(jsi::Runtime &runtime, const jsi::Function &value, std::shared_ptr<CallInvoker> jsInvoker);
 
 } // namespace expo

--- a/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
@@ -256,6 +256,10 @@ class FunctionSpec: ExpoSpec {
         @Field var a: ValueOrUndefined<Double> = .value(unwrapped: 1.0)
         @Field var b: ValueOrUndefined<Double> = .undefined
       }
+      
+      struct NullableValueOfUndefinedRecord: Record {
+        @Field var a: ValueOrUndefined<Double?> = .value(unwrapped: 1.0)
+      }
 
       struct TestEncodable: Encodable {
         let name: String
@@ -321,6 +325,19 @@ class FunctionSpec: ExpoSpec {
 
           Function("withOptionalRecord") { (f: TestRecord?) in
             return "\(f?.property ?? "no value")"
+          }
+          
+          Function("withNullableValueOrUndefinded") { (record: NullableValueOfUndefinedRecord) in
+            expect(record.a.isUndefined).to(beFalse())
+            expect(record.a.optional).to(beNil())
+          }
+          
+          Function("withNullableValueOrUndefindedInArray") { (items: [ValueOrUndefined<Double?>]) in
+            expect(items[0].isUndefined).to(beFalse())
+            expect(items[0].optional).to(beNil())
+
+            expect(items[1].isUndefined).to(beTrue())
+            expect(items[1].optional).to(beNil())
           }
 
           Function("returnEncodable") {
@@ -416,6 +433,14 @@ class FunctionSpec: ExpoSpec {
 
       it("accepts optional record") {
         expect(try runtime.eval("expo.modules.TestModule.withOptionalRecord({property: \"123\"})").asString()) == "123"
+      }
+
+      it("accepts nullable ValueOrUndefinded") {
+        try runtime.eval("expo.modules.TestModule.withNullableValueOrUndefinded({a: null})")
+      }
+
+      it("accepts nullable ValueOrUndefinded in array") {
+        try runtime.eval("expo.modules.TestModule.withNullableValueOrUndefindedInArray([null, undefined])")
       }
 
       it("returns encodable struct") {


### PR DESCRIPTION
# Why

Fixes `null` not being correctly converted to `ValueOrUndefined` in `Record`.

# How

Add a special case for converting a value from JSI to Objective-C that handles values expected in a dictionary. For `null`, we want to produce [NSNull null] instead of omitting the value. 

# Test Plan

- unit tests ✅ 