### PR TITLE
[go][Andorid] Fix `@expo/home` and `eas-expo-go` being linked

### DIFF
--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -110,9 +110,6 @@
         "../../react-native-lab/react-native/packages",
         "./node_modules",
         "../../node_modules"
-      ],
-      "exclude": [
-        "@expo/home"
       ]
     }
   }

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="host.exp.exponent">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <permission
         android:name="host.exp.exponent.permission.C2D_MESSAGE"


### PR DESCRIPTION
# Why

A better approach than https://github.com/expo/expo/commit/c4b89666589990d4c1d7348dbf73f802bca35cba

# How

In `expo-go`, we use `searchPaths` to link all React Native modules that can be discovered in the repository. This leads to a side effect where we're trying to link `expo-go` (`@expo/home`) and `eas-expo-go` as well. We could try to exclude them; however, I believe removing the package name from `AndroidManifest` in the Expo Go template is a better approach, as it's deprecated. By doing this, `expo-go` no longer appears like an RN package.

# Test Plan

- expo-go ✅  