### PR TITLE
[ios][mail-composer] Migrate to modern UniformTypeIdentifiers API

### DIFF
--- a/packages/expo-mail-composer/CHANGELOG.md
+++ b/packages/expo-mail-composer/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [iOS] Migrate from deprecated MobileCoreServices to modern UniformTypeIdentifiers API for MIME type detection. ([Apple Documentation](https://developer.apple.com/documentation/uniformtypeidentifiers))
+
 ## 56.0.3 — 2026-05-06
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-mail-composer/CHANGELOG.md
+++ b/packages/expo-mail-composer/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [iOS] Migrate from deprecated MobileCoreServices to modern UniformTypeIdentifiers API for MIME type detection. ([Apple Documentation](https://developer.apple.com/documentation/uniformtypeidentifiers))
+- [iOS] Migrate from deprecated MobileCoreServices to modern UniformTypeIdentifiers API for MIME type detection. ([Apple Documentation](https://developer.apple.com/documentation/uniformtypeidentifiers)) ([#41008](https://github.com/expo/expo/pull/41008) by [@tarikfp](https://github.com/tarikfp))
 
 ## 56.0.3 — 2026-05-06
 

--- a/packages/expo-mail-composer/ios/MailComposerModule.swift
+++ b/packages/expo-mail-composer/ios/MailComposerModule.swift
@@ -1,7 +1,6 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
 import MessageUI
-import MobileCoreServices
 import ExpoModulesCore
 
 public class MailComposerModule: Module {

--- a/packages/expo-mail-composer/ios/MailComposingSession.swift
+++ b/packages/expo-mail-composer/ios/MailComposingSession.swift
@@ -1,7 +1,7 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
 import MessageUI
-import MobileCoreServices
+import UniformTypeIdentifiers
 import ExpoModulesCore
 
 internal final class MailComposingSession: NSObject, MFMailComposeViewControllerDelegate, UIAdaptivePresentationControllerDelegate {
@@ -85,9 +85,9 @@ internal final class MailComposingSession: NSObject, MFMailComposeViewController
 }
 
 private func findMimeType(forAttachment attachment: URL) -> String {
-  if let identifier = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, attachment.pathExtension as CFString, nil)?.takeRetainedValue(),
-     let type = UTTypeCopyPreferredTagWithClass(identifier, kUTTagClassMIMEType)?.takeRetainedValue() {
-    return type as String
+  if let utType = UTType(filenameExtension: attachment.pathExtension),
+     let mimeType = utType.preferredMIMEType {
+    return mimeType
   }
   return "application/octet-stream"
 }


### PR DESCRIPTION
Replace deprecated MobileCoreServices framework with UniformTypeIdentifiers for MIME type detection.




# Why
  **Deprecated API:**
  - [MobileCoreServices](https://developer.apple.com/documentation/mobilecoreservices) was deprecated
  - Apple recommends migrating to [UniformTypeIdentifiers](https://developer.apple.com/documentation/uniformtypeidentifiers)

  **Safe to Migrate:**
  - expo-mail-composer minimum iOS version: **15.1**
  ([podspec](https://github.com/expo/expo/blob/main/packages/expo-mail-composer/ios/ExpoMailComposer.podspec#L6))
  - UniformTypeIdentifiers available since: **iOS 14.0**

Apple Documentation:
- https://developer.apple.com/documentation/mobilecoreservices (deprecated)
- https://developer.apple.com/documentation/uniformtypeidentifiers (modern replacement)
- https://developer.apple.com/documentation/uniformtypeidentifiers/uttype

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Updated imports from MobileCoreServices to UniformTypeIdentifiers
- Refactored findMimeType() to use UTType(filenameExtension:) instead of deprecated UTTypeCreatePreferredIdentifierForTag
- Removed manual memory management with takeRetainedValue()
- Simplified code while maintaining identical functionality

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
