### PR TITLE
fix(expo-localization): add missing iOS calendar identifiers (Bangla, Odia, Telugu, etc.)

### DIFF
--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 - Correct types for getCalendars and getLocales ([#39703](https://github.com/expo/expo/pull/39703) by [@kadikraman](https://github.com/kadikraman))
-- Added missing iOS 16+ calendar identifiers (bangla, gujarati, kannada, malayalam,
+- Added missing iOS 16+ calendar identifiers (bangla, gujarati, kannada, malayalam, ([#41017](https://github.com/expo/expo/pull/41017) by [@codebyharry](https://github.com/codebyharry))
   marathi, odia, tamil, telugu, dangi, vietnamese, vikram) to `getCalendars` on iOS,
   ensuring correct BCP47 mapping. ([#39945](https://github.com/expo/expo/issues/39945)) by [@codebyharry](https://github.com/codebyharry)
 

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -8,9 +8,7 @@
 
 ### 🐛 Bug fixes
 - Correct types for getCalendars and getLocales ([#39703](https://github.com/expo/expo/pull/39703) by [@kadikraman](https://github.com/kadikraman))
-- Added missing iOS 16+ calendar identifiers (bangla, gujarati, kannada, malayalam, ([#41017](https://github.com/expo/expo/pull/41017) by [@codebyharry](https://github.com/codebyharry))
-  marathi, odia, tamil, telugu, dangi, vietnamese, vikram) to `getCalendars` on iOS,
-  ensuring correct BCP47 mapping. ([#39945](https://github.com/expo/expo/issues/39945)) by [@codebyharry](https://github.com/codebyharry)
+- Added missing iOS 16+ calendar identifiers. ([#41017](https://github.com/expo/expo/pull/41017) by [@codebyharry](https://github.com/codebyharry))
 
 ### 💡 Others
 

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### 🐛 Bug fixes
 - Correct types for getCalendars and getLocales ([#39703](https://github.com/expo/expo/pull/39703) by [@kadikraman](https://github.com/kadikraman))
+- Added missing iOS 16+ calendar identifiers (bangla, gujarati, kannada, malayalam,
+  marathi, odia, tamil, telugu, dangi, vietnamese, vikram) to `getCalendars` on iOS,
+  ensuring correct BCP47 mapping. ([#39945](https://github.com/expo/expo/issues/39945)) by [@codebyharry](https://github.com/codebyharry)
 
 ### 💡 Others
 

--- a/packages/expo-localization/ios/LocalizationModule.swift
+++ b/packages/expo-localization/ios/LocalizationModule.swift
@@ -116,6 +116,8 @@ public class LocalizationModule: Module {
       return "islamic-tbla"
     case .islamicUmmAlQura:
       return "islamic-umalqura"
+    case .islamicObservational:
+      return "islamic-rgsa"
     case .japanese:
       return "japanese"
     case .persian:
@@ -124,8 +126,34 @@ public class LocalizationModule: Module {
       return "roc"
     case .iso8601:
       return "iso8601"
+    case .bengali:
+      return "bangla"
+    case .gujarati:
+      return "gujarati"
+    case .gurmukhi:
+      return "gurmukhi"
+    case .kannada:
+      return "kannada"
+    case .malayalam:
+      return "malayalam"
+    case .marathi:
+      return "marathi"
+    case .odia:
+      return "odia"
+    case .tamil:
+      return "tamil"
+    case .telugu:
+      return "telugu"
+    case .dangi:
+      return "dangi"
+    case .vietnamese:
+      return "vietnamese"
+    case .buddhistRevised:
+      return "buddhist-revised"
+    case .vikramSamvat:
+      return "vikram"
     @unknown default:
-      log.error("Unhandled `Calendar.Identifier` value: \(calendar.identifier), returning `iso8601` as fallback. Add the missing case as soon as possible.")
+      log.error("Unhandled `Calendar.Identifier`: \(calendar.identifier). Falling back to iso8601.")
       return "iso8601"
     }
   }


### PR DESCRIPTION
# Why

Expo Localization throws:

[EXPO Localization] switch must be exhaustive


on iOS 16+ because Apple added new Calendar.Identifier values (Bangla, Odia, Telugu, Vietnamese, etc.) which are not handled in the current switch statement.

This PR resolves expo/expo issue [#39945](https://github.com/expo/expo/issues/39945) by adding all missing calendar identifiers.

# How

Added newly introduced iOS calendar identifiers to getUnicodeCalendarIdentifier:
- .bangla
- .gujarati
- .kannada
- .malayalam
- .marathi
- .odia
- .tamil
- .telugu
- .dangi
- .vikram
- .vietnamese

Mapped each identifier to appropriate BCP-47 values using:
- CLDR calendar definitions
- Apple documentation

Ensured the switch remains exhaustive while keeping fallback in `@unknown default`.

Updated `CHANGELOG.md`

Apple Reference Links

Calendar.Identifier enum:
[https://developer.apple.com/documentation/foundation/calendar/identifier-swift.enum](https://developer.apple.com/documentation/foundation/calendar/identifier-swift.enum)

# Test Plan

Change system calendar on iOS device to any of the newly added types (Bangla, Odia, Tamil, Telugu, Vietnamese, etc.).

Run:
`import {getCalendars} from 'expo-localization';`
`console.log(getCalendars());`

Verify:
No more “switch must be exhaustive” errors.
Correct BCP-47 calendar code is returned.
Ran yarn build in packages/expo-localization to confirm TypeScript + plugin builds succeed.

# Checklist

- [x] I added a CHANGELOG.md entry and rebuilt package sources
- [x] Works correctly with npx expo prebuild & EAS Build.
- [x] Conforms with Expo Documentation Writing Style Guide.
