### PR TITLE
[ci] migrate to slackapi/slack-github-action

### DIFF
--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -1,67 +1,198 @@
 name: 'Slack Notify'
-description: 'Send test suite notifications to Slack with artifacts download url'
+description: 'Send formatted job notifications to Slack (replacement for 8398a7/action-slack)'
 inputs:
+  webhook:
+    description: 'Slack webhook URL'
+    required: true
   channel:
-    description: 'Slack channel'
-    required: true
+    description: 'Override the default target channel'
+    required: false
+  author_name:
+    description: 'Author name to display in notification'
+    required: false
+    default: 'GitHub Actions'
   job_name:
-    description: 'Job name for display at the top of slack message'
-    required: true
+    description: 'Job name to display (defaults to github.job)'
+    required: false
+    default: ${{ github.job }}
+  github_token:
+    description: 'GitHub token for API calls'
+    required: false
+    default: ${{ github.token }}
+  status:
+    description: 'Job status (success, failure, cancelled)'
+    required: false
+    default: ${{ github.job.status }}
+  fields:
+    description: 'Comma-separated list of fields to include (job,message,ref,eventName,author,took). Default: job,message,ref,eventName,author,took'
+    required: false
+    default: 'job,message,ref,eventName,author,took'
   artifact_url:
-    description: 'Artifact download URL'
-    required: true
+    description: 'Artifact download URL (optional)'
+    required: false
+
 runs:
   using: 'composite'
   steps:
-    - uses: 8398a7/action-slack@v3
+    - name: Gather job details
+      id: details
+      uses: actions/github-script@v8
       env:
-        GITHUB_TOKEN: ${{ github.token }}
-        SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
+        JOB_NAME: ${{ inputs.job_name }}
+        JOB_STATUS: ${{ inputs.status }}
+        INCLUDE_FIELDS: ${{ inputs.fields }}
+        ARTIFACT_URL: ${{ inputs.artifact_url }}
+        AUTHOR_NAME: ${{ inputs.author_name }}
       with:
-        channel: ${{ inputs.channel }}
-        status: custom
-        fields: job,message,ref,eventName,author,took
-        author_name: ${{ inputs.job_name }}
-        custom_payload: |
-          {
-            attachments: [{
-              color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
-              fields: [
-                {
-                  title: '${{ inputs.job_name }}',
-                  value: process.env.AS_JOB,
-                  short: true
-                },
-                {
-                  title: 'Message',
-                  value: process.env.AS_MESSAGE,
-                  short: true
-                },
-                {
-                  title: 'Ref',
-                  value: process.env.AS_REF,
-                  short: true
-                },
-                {
-                  title: 'Event Name',
-                  value: process.env.AS_EVENT_NAME,
-                  short: true
-                },
-                {
-                  title: 'Author',
-                  value: process.env.AS_AUTHOR,
-                  short: true
-                },
-                {
-                  title: 'Took',
-                  value: process.env.AS_TOOK,
-                  short: true
-                },
-                {
-                  title: 'Artifacts URL',
-                  value: '<${{ inputs.artifact_url }}|Download Artifacts>',
-                  short: false
-                }
-              ]
-            }]
+        github-token: ${{ inputs.github_token }}
+        script: |
+          const { owner, repo } = context.repo;
+          const { sha } = context;
+          const fields = process.env.INCLUDE_FIELDS.split(',').map(f => f.trim());
+
+          function escape(text) {
+            if (!text) return '';
+            return String(text)
+              .replace(/&/g, '&amp;')
+              .replace(/</g, '&lt;')
+              .replace(/>/g, '&gt;');
           }
+
+          // Fetch commit details
+          const commit = await github.rest.repos.getCommit({
+            owner,
+            repo,
+            ref: sha
+          });
+
+          // [fields] message
+          const commitMessage = escape(commit.data.commit.message.split('\n')[0]);
+          const messageField = `<${commit.data.html_url}|${commitMessage}>`;
+
+          // [fields] author
+          const author = commit.data.commit.author;
+          const authorField = `${escape(author.name)} &lt;${escape(author.email)}&gt;`;
+
+          // [fields] ref
+          const refField = escape(context.ref);
+
+          // [fields] eventName
+          const eventNameField = escape(context.eventName);
+
+          // [fields] job / took
+          let jobField = 'Job not found';
+          let tookField = 'N/A';
+
+          if (fields.includes('job') || fields.includes('took')) {
+            const jobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRun,
+              {
+                owner,
+                repo,
+                run_id: context.runId
+              }
+            );
+
+            // JOB_NAME doesn't include matrix values, but listJobsForWorkflowRun returns job names with matrix.
+            // e.g., JOB_NAME="android-test-e2e" but job.name="android-test-e2e (36)"
+            // We use startsWith to match the base job name and support matrix jobs.
+            const baseJobName = process.env.JOB_NAME;
+            const currentJob = jobs.find(job =>
+              job.name === baseJobName || job.name.startsWith(`${baseJobName} (`)
+            );
+
+            if (currentJob) {
+              // Use formatted job name (with matrix) for display
+              jobField = `<${currentJob.html_url}|${currentJob.name}>`;
+
+              const startTime = new Date(currentJob.started_at).getTime();
+              const endTime = new Date().getTime();
+              let duration = endTime - startTime;
+
+              const hours = Math.floor(duration / (1000 * 60 * 60));
+              duration -= hours * 1000 * 60 * 60;
+              const minutes = Math.floor(duration / (1000 * 60));
+              duration -= minutes * 1000 * 60;
+              const seconds = Math.floor(duration / 1000);
+
+              let tookParts = [];
+              if (hours > 0) tookParts.push(`${hours} hour`);
+              if (minutes > 0) tookParts.push(`${minutes} min`);
+              if (seconds > 0) tookParts.push(`${seconds} sec`);
+              tookField = tookParts.join(' ') || '0 sec';
+            }
+          }
+
+          // [outputs] color and text based on status
+          const status = process.env.JOB_STATUS.toLowerCase();
+          let color = 'danger';
+          let text = ':no_entry: Failed GitHub Actions\n';
+
+          if (status === 'success') {
+            color = 'good';
+            text = ':white_check_mark: Succeeded GitHub Actions\n';
+          } else if (status === 'cancelled') {
+            color = 'warning';
+            text = ':warning: Cancelled GitHub Actions\n';
+          }
+
+          // [outputs] fields
+          const slackFields = [];
+          if (fields.includes('message')) {
+            slackFields.push({ title: 'message', value: messageField, short: true });
+          }
+          if (fields.includes('author')) {
+            slackFields.push({ title: 'author', value: authorField, short: true });
+          }
+          if (fields.includes('job')) {
+            slackFields.push({ title: 'job', value: jobField, short: true });
+          }
+          if (fields.includes('took')) {
+            slackFields.push({ title: 'took', value: tookField, short: true });
+          }
+          if (fields.includes('ref')) {
+            slackFields.push({ title: 'ref', value: refField, short: true });
+          }
+          if (fields.includes('eventName')) {
+            slackFields.push({ title: 'eventName', value: eventNameField, short: true });
+          }
+
+          const artifactUrl = process.env.ARTIFACT_URL;
+          if (artifactUrl && artifactUrl !== '') {
+            try {
+              const url = new URL(artifactUrl);
+              const trustedDomains = ['github.com'];
+              const isTrusted = trustedDomains.some(domain =>
+                url.hostname === domain || url.hostname.endsWith(`.${domain}`)
+              );
+
+              if (isTrusted) {
+                slackFields.push({
+                  title: 'artifacts',
+                  value: `<${artifactUrl}|download artifacts>`,
+                  short: false
+                });
+              } else {
+                core.warning(`Artifact URL rejected - must be from trusted domain: ${url.hostname}`);
+              }
+            } catch (e) {
+              core.warning(`Invalid artifact URL format: ${artifactUrl}`);
+            }
+          }
+
+          core.setOutput('fields', JSON.stringify(slackFields));
+          core.setOutput('color', color);
+          core.setOutput('text', text);
+          core.setOutput('author_name', escape(process.env.AUTHOR_NAME));
+
+    - name: Send to Slack
+      uses: slackapi/slack-github-action@v2.1.1
+      with:
+        webhook: ${{ inputs.webhook }}
+        webhook-type: incoming-webhook
+        payload: |
+          text: "${{ steps.details.outputs.text }}"
+          attachments:
+            - color: "${{ steps.details.outputs.color }}"
+              author_name: "${{ steps.details.outputs.author_name }}"
+              fields: ${{ steps.details.outputs.fields }}

--- a/.github/workflows/bare-diffs.yml
+++ b/.github/workflows/bare-diffs.yml
@@ -30,14 +30,10 @@ jobs:
           echo "Checking that expo-template-bare-minimum diffs are updated"
           bin/expotools generate-bare-diffs --check
       - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
+        uses: ./.github/actions/slack-notify
         if: failure() && github.event.ref == 'refs/heads/main'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_docs }}
         with:
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
+          webhook: ${{ secrets.slack_webhook_docs }}
           author_name: Check for Changes in Bare Diffs
       - name: 💾 Store artifacts of diff failures
         if: failure()

--- a/.github/workflows/development-client-latest-e2e.yml
+++ b/.github/workflows/development-client-latest-e2e.yml
@@ -63,14 +63,9 @@ jobs:
           name: expo-dev-client-latest-e2e-artifacts
           path: packages/expo-dev-client/artifacts
       - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
+        uses: ./.github/actions/slack-notify
         if: failure()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_dev_client }}
-          MATRIX_CONTEXT: ${{ toJson(matrix) }}
         with:
+          webhook: ${{ secrets.slack_webhook_dev_client }}
           channel: '#dev-clients'
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
           author_name: Dev Client e2e

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -82,13 +82,9 @@ jobs:
           AWS_DEFAULT_REGION: 'us-east-2'
           AWS_BUCKET: 'docs.expo.dev'
       - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
+        uses: ./.github/actions/slack-notify
         if: failure() && github.event.ref == 'refs/heads/main'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_docs }}
         with:
+          webhook: ${{ secrets.slack_webhook_docs }}
           channel: '#docs'
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
           author_name: Docs

--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -65,12 +65,8 @@ jobs:
         working-directory: apps/expo-go
 
       - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
+        uses: ./.github/actions/slack-notify
         if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_api }}
         with:
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
+          webhook: ${{ secrets.slack_webhook_api }}
           author_name: Home app

--- a/.github/workflows/ios-static-frameworks.yml
+++ b/.github/workflows/ios-static-frameworks.yml
@@ -46,13 +46,9 @@ jobs:
           pod install --project-directory=ios
           xcodebuild -workspace ios/BareExpo.xcworkspace -scheme BareExpo -configuration Release -sdk iphonesimulator -derivedDataPath "ios/build" | xcpretty
       - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
+        uses: ./.github/actions/slack-notify
         if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_ios }}
         with:
+          webhook: ${{ secrets.slack_webhook_ios }}
           channel: '#expo-ios'
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
           author_name: Static Frameworks iOS Test (minimal-tester)

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -11,13 +11,10 @@ jobs:
   check-if-trusted:
     runs-on: ubuntu-24.04
     steps:
-      - uses: 8398a7/action-slack@v3
+        uses: ./.github/actions/slack-notify
         if: ${{ contains( env.TRUSTED_USERS, github.event.issue.user.login ) }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_expo_support }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          status: ${{ job.status }}
+          webhook: ${{ secrets.slack_webhook_expo_support }}
           channel: '#support'
           text: 'This issue should be triaged ASAP: ${{ github.event.issue.html_url }}'
           author_name: ${{ github.event.issue.user.login }}

--- a/.github/workflows/native-component-list.yml
+++ b/.github/workflows/native-component-list.yml
@@ -50,12 +50,8 @@ jobs:
         run: yarn lint --max-warnings 0
         working-directory: apps/native-component-list
       - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
+        uses: ./.github/actions/slack-notify
         if: failure() && (github.event.ref == 'refs/heads/main')
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_api }}
         with:
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
+          webhook: ${{ secrets.slack_webhook_api }}
           author_name: Build Native Component List

--- a/.github/workflows/publish-canaries.yml
+++ b/.github/workflows/publish-canaries.yml
@@ -48,12 +48,9 @@ jobs:
         env:
           FORCE_COLOR: '2'
       - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
+        uses: ./.github/actions/slack-notify
         if: failure() && github.event_name == 'schedule'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_api }}
         with:
-          status: ${{ job.status }}
-          fields: job,message,author,took
+          webhook: ${{ secrets.slack_webhook_api }}
           author_name: Publish Canaries
+          fields: job,message,author,took

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -74,12 +74,8 @@ jobs:
             bin/expotools check-packages --since ${{ github.base_ref || github.event.before || 'main' }} --core
           fi
       - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
+        uses: ./.github/actions/slack-notify
         if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_api }}
         with:
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
+          webhook: ${{ secrets.slack_webhook_api }}
           author_name: Check packages

--- a/.github/workflows/test-react-native-nightly.yml
+++ b/.github/workflows/test-react-native-nightly.yml
@@ -79,16 +79,11 @@ jobs:
           name: ios-builds-arch-${{ matrix.build-type }}
           path: ${{ runner.temp }}/test-nightlies/ios/build/**/testnightlies.app/
       - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
+        uses: ./.github/actions/slack-notify
         if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main')
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_ios }}
-          MATRIX_CONTEXT: ${{ toJson(matrix) }}
         with:
+          webhook: ${{ secrets.slack_webhook_ios }}
           channel: '#expo-ios'
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
           author_name: React Native Nightly (iOS)
 
   android-build:
@@ -145,14 +140,9 @@ jobs:
           name: android-builds-${{ matrix.build-type }}
           path: ${{ runner.temp }}/test-nightlies/android/app/build/outputs/apk/
       - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
+        uses: ./.github/actions/slack-notify
         if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main')
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_android }}
-          MATRIX_CONTEXT: ${{ toJson(matrix) }}
         with:
+          webhook: ${{ secrets.slack_webhook_android }}
           channel: '#expo-android'
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
           author_name: React Native Nightly (Android)

--- a/.github/workflows/test-suite-macos.yml
+++ b/.github/workflows/test-suite-macos.yml
@@ -89,13 +89,9 @@ jobs:
           name: bare-expo-macos-builds
           path: apps/bare-expo/macos/build/BareExpo.app
       - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
+        uses: ./.github/actions/slack-notify
         if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_ios }}
         with:
+          webhook: ${{ secrets.slack_webhook_ios }}
           channel: '#expo-ios'
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
           author_name: Test Suite (macOS)

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -72,15 +72,11 @@ jobs:
           name: bare-expo-ios-builds
           path: apps/bare-expo/ios/build/BareExpo.app
       - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
+        uses: ./.github/actions/slack-notify
         if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main')
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_ios }}
         with:
+          webhook: ${{ secrets.slack_webhook_ios }}
           channel: '#expo-ios'
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
           author_name: Test Suite Nightly (iOS)
 
   ios-test:
@@ -138,15 +134,11 @@ jobs:
             ~/Library/Logs/maestro/**/*
           overwrite: true
       - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
+        uses: ./.github/actions/slack-notify
         if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main')
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_ios }}
         with:
+          webhook: ${{ secrets.slack_webhook_ios }}
           channel: '#expo-ios'
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
           author_name: Test Suite Nightly (iOS)
 
   android-build:
@@ -197,16 +189,11 @@ jobs:
           name: bare-expo-android-builds
           path: apps/bare-expo/android/app/build/outputs/apk
       - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
+        uses: ./.github/actions/slack-notify
         if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main')
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_android }}
-          MATRIX_CONTEXT: ${{ toJson(matrix) }}
         with:
+          webhook: ${{ secrets.slack_webhook_android }}
           channel: '#expo-android'
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
           author_name: Test Suite Nightly (Android)
 
   android-test:
@@ -258,14 +245,8 @@ jobs:
             ~/Library/Logs/maestro/**/*
           overwrite: true
       - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
+        uses: ./.github/actions/slack-notify
         if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main')
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_android }}
-          MATRIX_CONTEXT: ${{ toJson(matrix) }}
-        with:
+          webhook: ${{ secrets.slack_webhook_android }}
           channel: '#expo-android'
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
           author_name: Test Suite Nightly (Android)

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -107,15 +107,11 @@ jobs:
           build-output: apps/bare-expo/ios/build/BareExpo.app
           artifact-name: bare-expo-ios-builds
       - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
+        uses: ./.github/actions/slack-notify
         if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_ios }}
         with:
+          webhook: ${{ secrets.slack_webhook_ios }}
           channel: '#expo-ios'
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
           author_name: Test Suite e2e (iOS)
 
   ios-test-e2e:
@@ -196,11 +192,10 @@ jobs:
       - name: 🔔 Notify on Slack
         uses: ./.github/actions/slack-notify
         if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_ios }}
         with:
+          webhook: ${{ secrets.slack_webhook_ios }}
           channel: '#expo-ios'
-          job_name: 'Test Suite e2e (iOS)'
+          author_name: Test Suite e2e (iOS)
           artifact_url: ${{ steps.upload-artifacts.outputs.artifact-url }}
       - name: 🛑 Stop image comparison server
         if: always()
@@ -288,16 +283,11 @@ jobs:
           build-output: apps/bare-expo/android/app/build/outputs/apk/release
           artifact-name: bare-expo-android-builds
       - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
+        uses: ./.github/actions/slack-notify
         if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_android }}
-          MATRIX_CONTEXT: ${{ toJson(matrix) }}
         with:
+          webhook: ${{ secrets.slack_webhook_android }}
           channel: '#expo-android'
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
           author_name: Test Suite e2e (Android)
 
   android-test-e2e:
@@ -364,11 +354,10 @@ jobs:
       - name: 🔔 Notify on Slack
         uses: ./.github/actions/slack-notify
         if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_android }}
         with:
+          webhook: ${{ secrets.slack_webhook_android }}
           channel: '#expo-android'
-          job_name: 'Test Suite e2e (Android)'
+          author_name: Test Suite e2e (Android)
           artifact_url: ${{ steps.upload-artifacts.outputs.artifact-url }}
       - name: 🛑 Stop image comparison server
         if: always()

--- a/.github/workflows/validate-npm-owners.yml
+++ b/.github/workflows/validate-npm-owners.yml
@@ -23,11 +23,8 @@ jobs:
         env:
           NPM_TOKEN_READ_ONLY: ${{ secrets.NPM_TOKEN_READ_ONLY }}
       - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
+        uses: ./.github/actions/slack-notify
         if: failure()
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_api }}
         with:
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
+          webhook: ${{ secrets.slack_webhook_api }}
           author_name: Validate npm owners


### PR DESCRIPTION
# Why

the original 8398a7/action-slack has been deprecated. this pr tries to implement similar logic in a composite action.
also fixed "job not found" issue from matrix support: https://exponent-internal.slack.com/archives/C1QNF5L3C/p1763153183309149

# How

- implement the logic 8398a7/action-slack into existing slack-notify composite action
- migrate 8398a7/action-slack to ./.github/actions/slack-notify
- for matrix support, we don't pass`MATRIX_CONTEXT: ${{ toJson(matrix) }}` but using startsWith to check

```js
           // JOB_NAME doesn't include matrix values, but listJobsForWorkflowRun returns job names with matrix.
           // e.g., JOB_NAME="android-test-e2e" but job.name="android-test-e2e (36)"
           // We use startsWith to match the base job name and support matrix jobs.
           const baseJobName = process.env.JOB_NAME;
           const currentJob = jobs.find(job =>
             job.name === baseJobName || job.name.startsWith(`${baseJobName} (`)
           );
```

# Test Plan

- tested on some slack messages
  - https://exponent-internal.slack.com/archives/C1QNF5L3C/p1763233677638009
  - https://exponent-internal.slack.com/archives/C08AN12SFRT/p1763220133387489

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
