### PR TITLE
[bare-expo] add expo-router

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -61,6 +61,7 @@
     "expo-insights": "~0.10.7",
     "expo-network-addons": "~0.10.7",
     "expo-notifications": "~0.32.11",
+    "expo-router": "~6.0.6",
     "expo-splash-screen": "~31.0.10",
     "lottie-react-native": "^7.3.4",
     "native-component-list": "*",


### PR DESCRIPTION
# Why

fix canary publishing error:  https://github.com/expo/expo/runs/55501841579

# How

when publishing precompile aar, we execute it [from the bare-expo project](https://github.com/expo/expo/blob/2d46268586c91aa3aff95507d564f209b8e78fdb/tools/src/publish-packages/tasks/publishAndroidPackages.ts#L85). we should also add expo-router to bare-expo

# Test Plan

run `./gradlew :expo-router:tasks | grep expoPublish` under bare-expo

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
