### PR TITLE
[android][camera] Fix ignored exif values

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix certain exif keys being dropped because of invalid values.
+- [Android] Fix certain exif keys being dropped because of invalid values. ([#41043](https://github.com/expo/expo/pull/41043) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix certain exif keys being dropped because of invalid values.
+
 ### 💡 Others
 
 - [iOS] Support all valid gps tags from `CGImageProperties` in exif data. ([#40801](https://github.com/expo/expo/pull/40801) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/utils/ExifTags.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/utils/ExifTags.kt
@@ -111,7 +111,7 @@ val exifTags = arrayOf(
   arrayOf("double", ExifInterface.TAG_GPS_DEST_LONGITUDE),
   arrayOf("string", ExifInterface.TAG_GPS_DEST_LONGITUDE_REF),
   arrayOf("int", ExifInterface.TAG_GPS_DIFFERENTIAL),
-  arrayOf("string", ExifInterface.TAG_GPS_H_POSITIONING_ERROR),
+  arrayOf("double", ExifInterface.TAG_GPS_H_POSITIONING_ERROR),
   arrayOf("double", ExifInterface.TAG_GPS_IMG_DIRECTION),
   arrayOf("string", ExifInterface.TAG_GPS_IMG_DIRECTION_REF),
   arrayOf("double", ExifInterface.TAG_GPS_LATITUDE),


### PR DESCRIPTION
# Why
Closes #41037

# How
The issue was valid but not for any of the reasons stated. Android was iterating through all valid keys but there was an issue with the format. For some keys, android uses a private `Rational` type to store the value and will only accept values in the format of "numerator/denominator". The "/" identifies it as a Rational and android parses and stores it correctly. Unfortunately, I can't find a provided api that does this conversion so we generate it ourselves doing what they do internally.

# Test Plan
Using the provided example. All the provided keys are now stored and returned correctly

