### PR TITLE
Convert expo module scripts to node for cross-platform support

### DIFF
--- a/packages/expo-module-scripts/bin/expo-module-babel
+++ b/packages/expo-module-scripts/bin/expo-module-babel
@@ -1,7 +1,12 @@
-#!/usr/bin/env bash
+#!/usr/bin/env node
+'use strict';
 
-set -eo pipefail
+import { npx } from './npx';
 
-script_dir="$(dirname "$0")"
+export function expoModuleBuild(args) {
+  npx(['babel', ...args]);
+}
 
-"$script_dir/npx" babel "$@"
+if (import.meta.main)  {
+  expoModuleBuild(process.argv);
+}

--- a/packages/expo-module-scripts/bin/expo-module-build
+++ b/packages/expo-module-scripts/bin/expo-module-build
@@ -1,34 +1,37 @@
-#!/usr/bin/env bash
+#!/usr/bin/env node
+'use strict';
 
-set -eo pipefail
+import process from 'node:process';
+import fs from 'node:fs';
 
-script_dir="$(dirname "$0")"
+import { getExtraModuleBuildTypes, isInteractiveSession } from './expo-module-utils.js';
+import { expoModuleTsc } from './expo-module-tsc';
 
-args=("$@")
+function hasTypeScriptConfig(buildType) {
+  const tsconfigPath = `../${buildType}/tsconfig.json`;
+  return fs.existsSync(tsconfigPath);
+}
 
-# If the command is used like `yarn build plugin`, set the --build option to point to
-# plugin/tsconfig.json
-extra_module_build_types=("plugin" "cli" "utils" "scripts")
-for i in "${extra_module_build_types[@]}"
-do
-  if [ "$1" == "$i" ]; then
-    # Check if tsconfig.json exists in the directory
-    if [ -f "$(pwd)/$i/tsconfig.json" ]; then
-      # `--build` must be the first argument, so reset the array
-      args=()
-      args+=("--build")
-      args+=("$(pwd)/$i")
-      # Push the rest of the arguments minus the `plugin` arg
-      args+=("${@:2}")
-    else
-      echo "tsconfig.json not found in $@, skipping build for $@/"
-      exit
-    fi
-  fi
-done
+export function expoModuleBuild(args) {
+  const maybeBuildType = args[1];
+  let tscArgs = [...args];
 
-if [[ -t 1 && (-z "$CI" && -z "$EXPO_NONINTERACTIVE") ]]; then
-  args+=("--watch")
-fi
+  if (getExtraModuleBuildTypes().includes(maybeBuildType)) {
+    if (!hasTypeScriptConfig(maybeBuildType)) {
+      console.log(`tsconfig.json not found in ${args}, skipping build for ${args}/`);
+      process.exit(1)
+    }
 
-"$script_dir/expo-module-tsc" "${args[@]}"
+    tscArgs = ['--build', `../${maybeBuildType}`, ...(args.slice(2))]
+  }
+
+  if (isInteractiveSession()) {
+    tscArgs.push('--watch');
+  }
+
+  expoModuleTsc(tscArgs)
+}
+
+if (import.meta.main) {
+  expoModuleBuild()
+}

--- a/packages/expo-module-scripts/bin/expo-module-clean
+++ b/packages/expo-module-scripts/bin/expo-module-clean
@@ -1,16 +1,23 @@
-#!/usr/bin/env bash
+#!/usr/bin/env node
+'use strict';
 
-set -eo pipefail
+import process from 'node:process';
+import fs from 'node:fs';
 
-if [[ ! -f package.json ]]; then
-  echo "The current working directory is not a package's root directory"
-  exit 1
-fi
+export function expoModuleClean() {
+  if (!fs.existsSync('./package.json')) {
+    console.log('The current working directory is not a package\'s root directory');
+    process.exit(1)
+  }
 
-directory=$1
-# Support `yarn clean plugin` to delete ./plugin/build/
-if [[ -n $directory ]]; then
-  rm -rf "$directory/build"
-else
-  rm -rf build
-fi
+  const directory = process.argv[1];
+  if (directory.length) {
+    fs.rmSync(`${directory}/build`, { force: true })
+  } else {
+    fs.rmSync('build', { force: true })
+  }
+}
+
+if (import.meta.main) {
+  expoModuleClean(process.argv);
+}

--- a/packages/expo-module-scripts/bin/expo-module-configure
+++ b/packages/expo-module-scripts/bin/expo-module-configure
@@ -1,77 +1,55 @@
-#!/usr/bin/env bash
+#!/usr/bin/env node
 
-set -eo pipefail
+import process from 'node:process';
+import fs from 'node:fs';
+import path from 'node:path';
 
-script_dir="$(dirname "$0")"
+const OPTIONAL_TEMPLATE_FILES = [
+  'eslint.config.js',
+  'scripts/with-node.sh'
+];
 
-shopt -s dotglob
+function getTemplateFiles() {
+  const files = fs.readdirSync(`${__dirname}/../templates/`, { recursive: true, withFileTypes: true });
 
-# an optional template file will be synced only if the target file is present in the file system,
-# and its content contains the string `@generated`.
-OPTIONAL_TEMPLATE_FILES=(
-  # add a relative file path from `templates/` for each new optional file
-  "eslint.config.js"
-  "scripts/with-node.sh"
-)
-
-# returns relative file paths inside a given directory without the leading "./".
-# usage: get_relative_files "/path/to/dir"
-get_relative_files() {
-  pushd "$1" > /dev/null
-  local files=$(find . -type f | cut -c 3-)
-  popd > /dev/null
-  echo "$files"
+  return files
+    .filter(f => f.isFile)
+    .map(f => path.join(f.parentPath, f.name));
 }
 
-
-# syncs the source file if the target file is missing or the existing file contains `@generated`.
-# usage: sync_file_if_missing "/path/source_path" "/path/target_path"
-sync_file_if_missing() {
-  local source=$1
-  local target=$2
-  # echo "sync_file_if_missing $source -> $target"
-  if [ ! -f "$target" ] || grep --quiet "@generated" "$target"; then
-    rsync --checksum "$source" "$target"
-  fi
+function isGeneratedFile(file) {
+  const contents = fs.readFileSync(file, { encoding: 'utf8 '});
+  return contents.includes('@generated');
 }
 
-# syncs the source file if the target file is present in the file system and its content contains `@generated`.
-# usage: sync_file_if_present "/path/source_path" "/path/target_path"
-sync_file_if_present() {
-  local source=$1
-  local target=$2
-  # echo "sync_file_if_present $source -> $target"
-  if [ -f "$target" ] && grep --quiet "@generated" "$target"; then
-    rsync --checksum "$source" "$target"
-  fi
+function syncFileIfMissing(templateFile, targetFile) {
+  if (!fs.existsSync(targetFile) || isGeneratedFile(targetFile)) {
+    fs.copyFileSync(templateFile, targetFile);
+  }
 }
 
-# check if a file is listed in `OPTIONAL_TEMPLATE_FILES`.
-# usage: if is_optional_file "path/to/file"; then ... fi
-is_optional_file() {
-  local file=$1
-  for optional_file in "${OPTIONAL_TEMPLATE_FILES[@]}"; do
-    if [ "$file" = "$optional_file" ]; then
-      true
-      return
-    fi
-  done
-
-  false
-  return
+function syncFileIfPresent(templateFile, targetFile) {
+  if (fs.existsSync(targetFile) && isGeneratedFile(targetFile)) {
+    fs.copyFileSync(templateFile, targetFile);
+  }
 }
 
-#
-# script main starts from here
-#
+export function expoModuleConfigure() {
+  npx([`${__dirname}/expo-module-readme`]);
 
-"$script_dir/expo-module-readme"
+  const templateFiles = getTemplateFiles();
 
-template_files=$(get_relative_files "$script_dir/../templates")
-for template_relative_file in $template_files; do
-  if is_optional_file "$template_relative_file"; then
-    sync_file_if_present "$script_dir/../templates/$template_relative_file" "$template_relative_file"
-  else
-    sync_file_if_missing "$script_dir/../templates/$template_relative_file" "$template_relative_file"
-  fi
-done
+  for (const templateFile of templateFiles) {
+    const templateSource = `${__dirname}/../templates/${templateFile}`;
+
+    if (OPTIONAL_TEMPLATE_FILES.includes(templateFile)) {
+      syncFileIfPresent(templateSource, templateFile);
+    } else {
+      syncFileIfMissing(templateSource, templateFile);
+    }
+  }
+}
+
+if (import.meta.main) {
+  expoModuleConfigure(process.argv)
+}

--- a/packages/expo-module-scripts/bin/expo-module-eslint
+++ b/packages/expo-module-scripts/bin/expo-module-eslint
@@ -1,7 +1,14 @@
-#!/usr/bin/env bash
+#!/usr/bin/env node
+'use strict';
 
-set -eo pipefail
+import process from 'node:process';
 
-script_dir="$(dirname "$0")"
+import { npx } from './npx';
 
-"$script_dir/npx" eslint "$@"
+export function expoModuleEslint(args) {
+  npx(['eslint', ...args]);
+}
+
+if (import.meta.main) {
+  expoModuleEslint(process.argv);
+}

--- a/packages/expo-module-scripts/bin/expo-module-jest
+++ b/packages/expo-module-scripts/bin/expo-module-jest
@@ -1,7 +1,13 @@
-#!/usr/bin/env bash
+#!/usr/bin/env node
+'use strict';
 
-set -eo pipefail
+import process from 'node:process';
+import { npx } from './npx';
 
-script_dir="$(dirname "$0")"
+function expoModuleJest(args) {
+  npx(['jest', ...args]);
+}
 
-"$script_dir/npx" jest "$@"
+if (import.meta.main) {
+  expoModuleJest(process.argv);
+}

--- a/packages/expo-module-scripts/bin/expo-module-lint
+++ b/packages/expo-module-scripts/bin/expo-module-lint
@@ -1,33 +1,32 @@
-#!/usr/bin/env bash
+#!/usr/bin/env node
+'use strict';
 
-set -eo pipefail
+import process from 'node:process';
+import fs from 'node:fs';
 
-script_dir="$(dirname "$0")"
+import { getExtraModuleBuildTypes } from './expo-module-utils.js';
+import { expoModuleEslint } from './expo-module-eslint';
 
-args=()
+function expoModuleLint() {
+  const args = [];
 
-# If the command is used like `yarn lint plugin` then set the target to `plugin/src`
-extra_module_build_types=("plugin" "cli" "utils" "scripts")
-found_target=""
-for i in "${extra_module_build_types[@]}"
-do
-  if [ "$1" == "$i" ]; then
-    found_target=$i
-  fi
-done
+  const maybeBuildType = process.argv[1];
 
-if [[ -n "$found_target" ]]; then
-  # Push the rest of the arguments minus the `plugin` arg
-  args+=("${@:2}")
-  args+=("$found_target/src")
-  if ! [[ -d "$found_target" ]]; then
-    # Good DX cuz Expo
-    printf "\n\033[1;33mThe \`$found_target/src\` folder does not exist in this project; please create it and try again.\033[0m\n\n"
-    exit 0
-  fi
-else
-  args+=("$@")
-  args+=("src")
-fi
+  if (getExtraModuleBuildTypes().includes(maybeBuildType)) {
+    args = process.argv.slice(2);
+    args.push(`${maybeBuildType}/src`);
 
-"$script_dir/expo-module-eslint" "${args[@]}"
+    if (!fs.existsSync(maybeBuildType))  {
+      console.log("\n\x1b[1;33mThe \`$found_target/src\` folder does not exist in this project; please create it and try again.\x1b[0m\n\n");
+      process.exit(0)
+    }
+  } else {
+    args = [...process.argv, 'src'];
+  }
+
+  expoModuleEslint(args);
+}
+
+if (import.meta.main) {
+  expoModuleLint(process.argv);
+}

--- a/packages/expo-module-scripts/bin/expo-module-prepare
+++ b/packages/expo-module-scripts/bin/expo-module-prepare
@@ -1,22 +1,31 @@
-#!/usr/bin/env bash
+#!/usr/bin/env node
+'use strict';
 
-set -eo pipefail
+import fs from 'node:fs';
 
-script_dir="$(dirname "$0")"
+import { expoModuleBuild } from './expo-module-build';
+import { expoModuleClean } from './expo-module-clean';
+import { expoModuleConfigure } from './expo-module-configure';
+import { getExtraModuleBuildTypes, setExpoNonInteractive } from './expo-module-utils.js';
 
-export EXPO_NONINTERACTIVE=1
+function expoModulePrepare() {
+  setExpoNonInteractive();
 
-echo "Configuring module"
-"$script_dir/expo-module-clean"
-"$script_dir/expo-module-configure"
-"$script_dir/expo-module-build"
+  console.log('Configuring module');
+  expoModuleClean([]);
+  expoModuleConfigure([]);
+  expoModuleBuild([])
 
-extra_module_build_types=("plugin" "cli" "utils" "scripts")
-for i in "${extra_module_build_types[@]}"
-do
-  if [[ -d "$i" ]]; then
-    echo "Configuring $i"
-    "$script_dir/expo-module-clean" "$i"
-    "$script_dir/expo-module-build" "$i"
-  fi
-done
+  for (const buildType of getExtraModuleBuildTypes()) {
+    if (fs.existsSync(buildType)) {
+      console.log(`Configuring ${buildType}`);
+
+      expoModuleClean([buildType]);
+      expoModuleBuild([buildType])
+    }
+  }
+}
+
+if (import.meta.main) {
+  expoModulePrepare();
+}

--- a/packages/expo-module-scripts/bin/expo-module-prepublishOnly
+++ b/packages/expo-module-scripts/bin/expo-module-prepublishOnly
@@ -1,9 +1,14 @@
-#!/usr/bin/env bash
+#!/usr/bin/env node
+'use strict';
 
-set -eo pipefail
+import { npx } from './npx';
+import { setExpoNonInteractive } from './expo-module-utils.js';
 
-script_dir="$(dirname "$0")"
+function expoModulePrepublishOnly() {
+  setExpoNonInteractive();
+  npx(['proofread']);
+}
 
-export EXPO_NONINTERACTIVE=1
-
-"$script_dir/npx" proofread
+if (import.meta.main) {
+  expoModulePrepublishOnly();
+}

--- a/packages/expo-module-scripts/bin/expo-module-test
+++ b/packages/expo-module-scripts/bin/expo-module-test
@@ -1,35 +1,38 @@
-#!/usr/bin/env bash
+#!/usr/bin/env node
+'use strict';
 
-set -eo pipefail
+import process from 'node:process';
+import fs from 'node:fs';
 
-script_dir="$(dirname "$0")"
+function expoModuleTest(args) {
+  const maybeBuildType = args[1];
 
-args=("$@")
+  if (getExtraModuleBuildTypes().includes(maybeBuildType)) {
+    const buildType = maybeBuildType;
 
-# If the command is used like `yarn test plugin`, set the --rootDir option to the `plugin` directory
-extra_module_build_types=("plugin" "cli" "utils" "scripts")
-for i in "${extra_module_build_types[@]}"
-do
-  if [ "$1" == "$i" ]; then
-    args=()
-    args+=("--rootDir")
-    args+=("$i")
+    args = [];
 
-    if [[ -f "$i/jest.config.js" ]]; then
-      args+=("--config")
-      args+=("$i/jest.config.js")
-    else
-      args+=("--config")
-      args+=("$(node --print "require.resolve('expo-module-scripts/jest-preset-$i.js')")")
-    fi
+    args.push('--rootDir');
+    args.push(buildType);
 
-    # Push the rest of the arguments minus the `plugin` arg
-    args+=("${@:2}")
-  fi
-done
+    if (fs.existsSync(`${buildType}/jest.config.js`)) {
+      args.push('--config')
+      args.push(`${buildType}/jest.config.js`);
+    } else {
+      args.push('--config');
+      args.push(require.resolve(`expo-module-scripts/jest-preset-${buildType}.js`))
+    }
 
-if [[ -t 1 && (-z "$CI" && -z "$EXPO_NONINTERACTIVE") ]]; then
-  args+=("--watch")
-fi
+    args.push(...argv.slice(2));
+  }
 
-"$script_dir/expo-module-jest" "${args[@]}"
+  if (isInterativeSession()) {
+    args.push('--watch');
+  }
+
+  expoModuleJest(args);
+}
+
+if (import.meta.main) {
+  expoModuleTest(process.argv);
+}

--- a/packages/expo-module-scripts/bin/expo-module-tsc
+++ b/packages/expo-module-scripts/bin/expo-module-tsc
@@ -1,7 +1,14 @@
-#!/usr/bin/env bash
+#!/usr/bin/env node
+'use strict';
 
-set -eo pipefail
+import process from 'node:process';
 
-script_dir="$(dirname "$0")"
+import { npx } from './npx';
 
-"$script_dir/npx" tsc "$@"
+export function expoModuleTsc(args) {
+  npx(['tsc', ...args]);
+}
+
+if (import.meta.main) {
+  expoModuleTsc(process.argv)
+}

--- a/packages/expo-module-scripts/bin/expo-module-typecheck
+++ b/packages/expo-module-scripts/bin/expo-module-typecheck
@@ -1,12 +1,17 @@
-#!/usr/bin/env bash
+#!/usr/bin/env node
+'use strict';
 
-set -eo pipefail
+import { isInteractiveSession } from './expo-module-utils.js';
+import { expoModuleTsc } from './expo-module-tsc';
 
-script_dir="$(dirname "$0")"
+function expoModuleTypecheck(args) {
+  if (isInteractiveSession()) {
+    args.push('--watch');
+  }
 
-args=("$@")
-if [[ -t 1 && (-z "$CI" && -z "$EXPO_NONINTERACTIVE") ]]; then
-  args+=("--watch")
-fi
+  expoModuleTsc(['--noEmit', ...args])
+}
 
-"$script_dir/expo-module-tsc" --noEmit "${args[@]}"
+if (import.meta.main) {
+  expoModuleTypecheck(process.argv)
+}

--- a/packages/expo-module-scripts/bin/expo-module-utils.js
+++ b/packages/expo-module-scripts/bin/expo-module-utils.js
@@ -1,0 +1,23 @@
+import process from 'node:process';
+
+const EXTRA_MODULE_BUILD_TYPES = ["plugin", "cli", "utils", "scripts"];
+
+const ENV_CI = "CI";
+const ENV_EXPO_NONINTERACTIVE = "EXPO_NONINTERACTIVE";
+
+export function getExtraModuleBuildTypes() {
+  return EXTRA_MODULE_BUILD_TYPES
+}
+
+export function setExpoNonInteractive() {
+  process.env[ENV_EXPO_NONINTERACTIVE] = 1;
+}
+
+export function isInteractiveSession() {
+  const isCiSession = !!process.env[ENV_CI];
+  const isNonInteractiveSession = !!process.env[ENV_EXPO_NONINTERACTIVE];
+
+  // TODO: -t 1 equivalent check here.
+
+  return !isCiSession && !isNonInteractiveSession;
+}

--- a/packages/expo-module-scripts/bin/npx
+++ b/packages/expo-module-scripts/bin/npx
@@ -1,13 +1,25 @@
-#!/usr/bin/env bash
+#!/usr/bin/env node
+'use strict';
 
-# Runs `npx` through Yarn or pnpm if necessary so that the environment variables are set up similarly across
-# Yarn, pnpm and npm.
+import process from 'node:process';
+import child_process from 'node:child_process';
 
-# shellcheck disable=SC2154
-if [[ "$npm_config_user_agent" =~ yarn ]] && [ -x "$(command -v yarn)" ]; then
-  yarn exec -- npx "$@"
-elif [[ "$npm_config_user_agent" =~ pnpm ]] && [ -x "$(command -v pnpm)" ]; then
-  pnpm exec -- npx "$@"
-else
-  npx "$@"
-fi
+function isExecutableAvailable(name) {
+  return child_process.spawnSync(name, ['-v']).status === 0
+}
+
+export function npx(args) {
+  const userAgent = process.env['npm_config_user_agent']
+
+  if (userAgent === 'yarn' && isExecutableAvailable('yarn')) {
+    child_process.spawnSync('yarn', ['exec', '--', 'npx', ...args]);
+  } else if (userAgent === 'pnpm' && isExecutableAvailable('pnpm')) {
+    child_process.spawnSync('pnpm', ['exec', '--', 'npx', ...args]);
+  } else {
+    child_process.spawnSync('npx', args);
+  }
+}
+
+if (import.meta.main) {
+  npx(process.argv);
+}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The expo-module* commands fail in win32 environments because commander unconditionally interprets subcommands as node scripts. Since most of these bash scripts are pretty simple, it should be possible to just convert them to node scripts which will be truly cross platform, not dependent on a specific shell environment.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
