### PR TITLE
[docs] Fix focus lost in Show settings menu

### DIFF
--- a/docs/ui/components/Dropdown/index.tsx
+++ b/docs/ui/components/Dropdown/index.tsx
@@ -23,7 +23,7 @@ export function Dropdown({
   ...rest
 }: Props) {
   return (
-    <Root>
+    <Root modal={false}>
       <Trigger asChild>{trigger}</Trigger>
       <Portal className="bg-danger">
         <Content

--- a/docs/ui/components/MarkdownActions/MarkdownActionsDropdown.tsx
+++ b/docs/ui/components/MarkdownActions/MarkdownActionsDropdown.tsx
@@ -143,7 +143,5 @@ export function MarkdownActionsDropdown() {
     </Button>
   );
 
-  return (
-    <Dropdown.Dropdown trigger={<div>{dropdownTrigger}</div>}>{dropdownItems}</Dropdown.Dropdown>
-  );
+  return <Dropdown.Dropdown trigger={dropdownTrigger}>{dropdownItems}</Dropdown.Dropdown>;
 }

--- a/docs/ui/components/Snippet/actions/SettingsAction.tsx
+++ b/docs/ui/components/Snippet/actions/SettingsAction.tsx
@@ -26,14 +26,12 @@ export const SettingsAction = ({ ...rest }: SnippetActionProps) => {
   return (
     <Dropdown.Dropdown
       trigger={
-        <div>
-          <SnippetAction
-            className="min-w-[44px] px-3"
-            aria-label="Show settings"
-            leftSlot={<DotsVerticalIcon className="icon-md shrink-0 text-icon-secondary" />}
-            {...rest}
-          />
-        </div>
+        <SnippetAction
+          className="min-w-[44px] px-3"
+          aria-label="Show settings"
+          leftSlot={<DotsVerticalIcon className="icon-md shrink-0 text-icon-secondary" />}
+          {...rest}
+        />
       }>
       <Dropdown.Item
         preventAutoClose


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix https://github.com/expo/expo/issues/39939

**Reproduction**

In the reproduction below, notice that the focus is lost after the "Show settings" menu in a code block opens and closes. The focus, in this case, starts at the start of the page again (as pointed out in the issue).

https://github.com/user-attachments/assets/1055e6a6-3f45-406d-88cb-af7c55b7a0c1

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Set `modal` to `false` in `Dropdown` component to allow focus to move to other controls with `Tab` and `Shift + Tab`.
- Remove `div` elements from `SettingsAction` component because the dropdown trigger is wrapped in this non-focusable `div` element. So, after pressing the `Escape` key, the focus returns to its previous position.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally.

## Preview

https://github.com/user-attachments/assets/22070f84-e59c-4d93-bfa4-a7d39357a301

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
