### PR TITLE
[docs] Add screen reader labels for strikethrough items in Sidebar and TOC

### DIFF
--- a/docs/ui/components/Sidebar/SidebarLink.tsx
+++ b/docs/ui/components/Sidebar/SidebarLink.tsx
@@ -71,17 +71,18 @@ export const SidebarLink = ({ info, className, children }: SidebarLinkProps) => 
         )}
       />
       {children}
+      {info.isDeprecated && <span className="sr-only">Deprecated</span>}
       {info.hasVideoLink && !isSelected && (
-        <PlaySquareIcon className="icon-xs ml-1.5 text-icon-secondary" />
+        <PlaySquareIcon className="icon-xs ml-1.5 text-icon-secondary" aria-hidden="true" />
       )}
       {info.hasVideoLink && isSelected && (
-        <PlaySquareDuotoneIcon className="icon-xs ml-1.5 text-palette-blue11" />
+        <PlaySquareDuotoneIcon className="icon-xs ml-1.5 text-palette-blue11" aria-hidden="true" />
       )}
       {info.isDeprecated && !isSelected && (
-        <AlertTriangleIcon className="icon-xs ml-1.5 !text-icon-warning" />
+        <AlertTriangleIcon className="icon-xs ml-1.5 !text-icon-warning" aria-hidden="true" />
       )}
       {info.isDeprecated && isSelected && (
-        <AlertTriangleSolidIcon className="icon-xs ml-1.5 !text-icon-warning" />
+        <AlertTriangleSolidIcon className="icon-xs ml-1.5 !text-icon-warning" aria-hidden="true" />
       )}
       {info.isNew && (
         <div

--- a/docs/ui/components/TableOfContents/TableOfContentsLink.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContentsLink.tsx
@@ -56,6 +56,7 @@ export const TableOfContentsLink = forwardRef<HTMLAnchorElement, SidebarLinkProp
                 isDeprecated && 'line-through opacity-80'
               )}>
               {displayTitle}
+              {isDeprecated && <span className="sr-only">Deprecated section</span>}
             </TitleElement>
           </Link>
         </Tooltip.Trigger>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix #39940


https://github.com/user-attachments/assets/45df1c82-be1a-412a-9aa3-d853338d56ca



# How

<!--
How did you build this feature or fix this bug and why?
-->

Add screen reader labels for strikethrough items in Sidebar (left sidebar) and TOC (Table of Contents - right sidebar) by adding `sr-only` text to deprecated sidebar links so screen readers announce "Deprecated" alongside the existing strike-through styling

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

Using macOS VoiceOver, the deprecated link is now announced correctly. In the example below, `expo-av` is deprecated:


https://github.com/user-attachments/assets/bfc4a5cf-eeea-4573-8555-9cc4dfff47e2


The same change is applied to the right side bar (Table of Contents) for deprecated properties:


https://github.com/user-attachments/assets/6459f717-d82d-4e00-be6a-fa5aa43d9232


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
