### PR TITLE
Add Expo configuration for react-native-maps

### DIFF
--- a/docs/pages/versions/unversioned/sdk/map-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/map-view.mdx
@@ -20,6 +20,38 @@ No additional setup is required when testing your project using Expo Go. However
 
 <APIInstallSection href="https://github.com/react-native-maps/react-native-maps/blob/master/docs/installation.md" />
 
+## Expo configuration (react-native-maps ≥ 1.22, Expo SDK ≥ 53)
+
+If you're using Expo, add the plugin to `app.json` or `app.config.js`:
+
+```json
+{
+  "expo": {
+    "plugins": ["react-native-maps"]
+  }
+}
+````
+
+If you're using Google as the map provider, also provide API keys:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "react-native-maps",
+        {
+          "iosGoogleMapsApiKey": "YOUR_KEY_HERE",
+          "androidGoogleMapsApiKey": "YOUR_KEY_HERE"
+        }
+      ]
+    ]
+  }
+}
+```
+
+For **bare workflow** projects, you must follow the manual iOS and Android setup described below.
+
 ## Usage
 
 See full documentation at [`react-native-maps/react-native-maps`](https://github.com/react-native-maps/react-native-maps).
@@ -28,25 +60,23 @@ See full documentation at [`react-native-maps/react-native-maps`](https://github
 
 ```jsx
 import React from 'react';
-import MapView from 'react-native-maps';
+import MapView, { PROVIDER_GOOGLE } from 'react-native-maps';
 import { StyleSheet, View } from 'react-native';
 
 export default function App() {
   return (
     <View style={styles.container}>
-      <MapView style={styles.map} />
+      <MapView
+        style={styles.map}
+        provider={PROVIDER_GOOGLE} // Optional: works on both iOS & Android
+      />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  map: {
-    width: '100%',
-    height: '100%',
-  },
+  container: { flex: 1 },
+  map: { width: '100%', height: '100%' },
 });
 ```
 
@@ -56,66 +86,65 @@ const styles = StyleSheet.create({
 
 ### Android
 
-> If you have already registered a project for another Google service on Android, such as Google Sign In, you enable the **Maps SDK for Android** on your project and jump to step 4.
+> If you've already registered a Google project for another Android service (e.g., Google Sign-In), just enable **Maps SDK for Android** and skip to step 4.
 
 <Step label="1">
-#### Register a Google Cloud API project and enable the Maps SDK for Android
+#### Create a Google Cloud project and enable **Maps SDK for Android**
 
-- Open your browser to the [Google API Manager](https://console.developers.google.com/apis) and create a project.
-- Once it's created, go to the project and enable the **Maps SDK for Android**.
+* Visit the [Google API Manager](https://console.developers.google.com/apis) and create a project.
+* Enable **Maps SDK for Android**.
 
-</Step>
+  </Step>
 
 <Step label="2">
-#### Copy your app's SHA-1 certificate fingerprint
+#### Copy your app's SHA-1 fingerprint
 
 <Tabs>
-<Tab label="For Google Play Store">
+<Tab label="Google Play Store">
 
-- **If you are deploying your app to the Google Play Store**, you'll need to [upload your app binary to Google Play console](/submit/android/) at least once. This is required for Google to generate your app signing credentials.
-- Go to the **[Google Play Console](https://play.google.com/console) > (your app) > Test and release > App integrity > Play app signing > Settings > App signing key certificate**.
-- Copy the value of **SHA-1 certificate fingerprint**.
-
-</Tab>
-
-<Tab label="For development builds">
-
-- If you have already created a [development build](/develop/development-builds/introduction/), your project will be signed using a debug keystore.
-- After the build is complete, go to your [project's dashboard](https://expo.dev/accounts/[username]/projects/[project-name]), then, under **Configure** > click **Credentials**.
-- Under **Application Identifiers**, click your project's package name and under **Android Keystore** copy the value of **SHA-1 Certificate Fingerprint**.
+* Upload your app at least once to the Google Play Console to generate app signing keys.
+* Go to **Google Play Console → Your App → Test and Release → App Integrity → App signing key certificate**.
+* Copy the **SHA-1 certificate fingerprint**.
 
 </Tab>
 
+<Tab label="Development builds">
+
+* After creating a development build, go to your project dashboard on **expo.dev** → **Configure → Credentials**.
+* Under **Android Keystore**, copy the **SHA-1 Certificate Fingerprint**.
+
+</Tab>
 </Tabs>
 
 </Step>
 
 <Step label="3">
-#### Create an API key
+#### Create a Google API key
 
-- Go to [Google Cloud Credential manager](https://console.cloud.google.com/apis/credentials) and click **Create Credentials**, then **API Key**.
-- In the modal, click **Edit API key**.
-- Under **Key restrictions** > **Application restrictions**, choose **Android apps**.
-- Under **Restrict usage to your Android apps**, click **Add an item**.
-- Add your `android.package` from **app.json** (for example: `com.company.myapp`) to the package name field.
-- Then, add the **SHA-1 certificate fingerprint's** value from step 2.
-- Click **Done** and then click **Save**.
+* Go to the [Google Cloud Credentials](https://console.cloud.google.com/apis/credentials).
+* Create a new **API Key**.
+* Edit the key → **Application restrictions** → **Android apps**.
+* Add:
+
+  * Your package name (`android.package` in app.json)
+  * The SHA-1 fingerprint from step 2
+* Save.
 
 </Step>
 
 <Step label="4">
-#### Add the API key to your project
+#### Add the API key to Expo config
 
-Since you are using Google as the map provider, you need to add the API key to the `react-native-maps` [config plugin](/config-plugins/introduction/). Copy your **API Key** into your project to either a **.env** file or copy it directly and then add it to your app config under the `plugins.react-native-maps.androidGoogleMapsApiKey` field like:
+Add this to your `app.json`:
 
-```json app.json
+```json
 {
   "expo": {
     "plugins": [
       [
         "react-native-maps",
         {
-          "androidGoogleMapsApiKey": "process.env.YOUR_GOOGLE_MAPS_API_KEY"
+          "androidGoogleMapsApiKey": "YOUR_GOOGLE_MAPS_API_KEY"
         }
       ]
     ]
@@ -123,48 +152,44 @@ Since you are using Google as the map provider, you need to add the API key to t
 }
 ```
 
-- In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider={PROVIDER_GOOGLE}` to your `<MapView>`. This property works on both Android and iOS.
-- Rebuild the app binary (or re-submit to the Google Play Store in case your app is already uploaded). An easy way to test if the configuration was successful is to do an [emulator build](/develop/development-builds/create-a-build/#build-the-native-app-ios-simulator).
+Then rebuild your Android app.
 
 </Step>
 
 ### iOS
 
-> If you have already registered a project for another Google service on iOS, such as Google Sign In, you enable the **Maps SDK for iOS** on your project and jump to step 3.
+> If you've already registered a Google project for another iOS service (e.g., Google Sign-In), enable **Maps SDK for iOS** and skip to step 3.
 
 <Step label="1">
-#### Register a Google Cloud API project and enable the Maps SDK for iOS
+#### Create a Google Cloud project and enable **Maps SDK for iOS**
 
-- Open your browser to the [Google API Manager](https://console.developers.google.com/apis) and create a project.
-- Then, go to the project, click **Enable APIs and Services** and enable the **Maps SDK for iOS**.
+* Open [Google API Manager](https://console.developers.google.com/apis).
+* Create a project and enable **Maps SDK for iOS**.
 
 </Step>
 
 <Step label="2">
 #### Create an API key
 
-- Go to [Google Cloud Credential manager](https://console.cloud.google.com/apis/credentials) and click **Create Credentials**, then **API Key**.
-- In the modal, click **Edit API key**.
-- Under **Key restrictions** > **Application restrictions**, choose **iOS apps**.
-- Under **Accept requests from an iOS application with one of these bundle identifiers**, click the **Add an item** button.
-- Add your `ios.bundleIdentifier` from **app.json** (for example: `com.company.myapp`) to the bundle ID field.
-- Click **Done** and then click **Save**.
+* Go to the [Google Cloud Credentials](https://console.cloud.google.com/apis/credentials).
+* Create a new **API Key**.
+* Edit the key → **Application restrictions** → **iOS apps**.
+* Add your iOS bundle ID (`ios.bundleIdentifier` from app.json).
+* Save.
 
 </Step>
 
 <Step label="3">
-#### Add the API key to your project
+#### Add the API key to Expo config
 
-Since you are using Google as the map provider, you need to add the API key to the `react-native-maps` [config plugin](/config-plugins/introduction/). Copy your **API Key** into your project to either a **.env** file or copy it directly and then add it to your app config under the `plugins.react-native-maps.iosGoogleMapsApiKey` field like:
-
-```json app.json
+```json
 {
   "expo": {
     "plugins": [
       [
         "react-native-maps",
         {
-          "iosGoogleMapsApiKey": "process.env.YOUR_GOOGLE_MAPS_API_KEY"
+          "iosGoogleMapsApiKey": "YOUR_GOOGLE_MAPS_API_KEY"
         }
       ]
     ]
@@ -172,7 +197,8 @@ Since you are using Google as the map provider, you need to add the API key to t
 }
 ```
 
-- In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider={PROVIDER_GOOGLE}` to your `<MapView>`. This property works on both Android and iOS.
-- Rebuild the app binary. An easy way to test if the configuration was successful is to do a [simulator build](/develop/development-builds/create-a-build/#build-the-native-app-ios-simulator).
+Rebuild your iOS app.
 
 </Step>
+```
+


### PR DESCRIPTION
Added Expo configuration instructions for react-native-maps, including API key setup for both Android and iOS.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
