### PR TITLE
[docs] Add a callout on using `dom-to-image` library in Expo tutorial

### DIFF
--- a/docs/pages/tutorial/platform-differences.mdx
+++ b/docs/pages/tutorial/platform-differences.mdx
@@ -33,6 +33,8 @@ Stop the development server and run the following command to install the library
 
 <Terminal cmd={['$ npm install dom-to-image']} />
 
+> **Note:** The `dom-to-image` library is used here for illustrative purposes. For production apps, you may want to explore other solutions or APIs that better suit your specific use case.
+
 After installing it, make sure to restart the development server and press <kbd>w</kbd> in the terminal.
 
 </Step>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18100

# How

<!--
How did you build this feature or fix this bug and why?
-->

 Add a callout on using the `dom-to-image` library in the Expo tutorial that points out that the library used in the tutorial chapter is for illustrative purposes.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
