### PR TITLE
[docs] Fix permissions guidelines for Video in ImagePicker reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/imagepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.mdx
@@ -235,7 +235,7 @@ When you run this example and pick an image, you will see the image that you pic
 
 ### Invoke permissions for videos <PlatformTags platforms={['ios']} />
 
-In SDk 54 and later, the default configuration keeps `allowsEditing` set to `false` and [`videoExportPreset`](#videoexportpreset) set to `'Passthrough'`. Those settings return the original asset (including HEIC/AVIF files) instantly because the picker skips compression, but iOS needs media library permission to hand over the original file and shows the dialog immediately after a user selects a video.
+In SDK 54 and later, the default configuration keeps `allowsEditing` set to `false` and [`videoExportPreset`](#videoexportpreset) set to `'Passthrough'`. Those settings return the original asset (including HEIC/AVIF files) instantly because the picker skips compression, but iOS needs media library permission to hand over the original file and shows the dialog immediately after a user selects a video.
 
 To avoid showing permissions dialog after selection, **manually request media library permissions before opening the picker** via [`requestMediaLibraryPermissionsAsync`](#imagepickerrequestmedialibrarypermissionsasyncwriteonly) or [`useMediaLibraryPermissions`](#usemedialibrarypermissionsoptions).
 

--- a/docs/pages/versions/unversioned/sdk/imagepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.mdx
@@ -163,7 +163,9 @@ export default function ImagePickerExample() {
 
   const pickImage = async () => {
     // No permissions request is necessary for launching the image library.
-    // Permissions are required for videos on iOS when `allowsEditing` is `true`.
+    // Manually request permissions for videos on iOS when `allowsEditing` is set to `false`
+    // and `videoExportPreset` is `'Passthrough'` (the default), ideally before launching the picker
+    // so the app users aren't surprised by a system dialog after picking a video.
     // See "Invoke permissions for videos" sub section for more details.
     const permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
 
@@ -233,9 +235,9 @@ When you run this example and pick an image, you will see the image that you pic
 
 ### Invoke permissions for videos <PlatformTags platforms={['ios']} />
 
-In SDK 54 and later, picking videos on iOS while `allowsEditing` is `true` or when [`videoExportPreset`](#videoexportpreset) is set to any other value than `Passthrough`, it won't trigger a permission request by default. However, there will be an increase in time for picker to open for large or newly recorded videos which haven't been processed internally by iOS.
+In SDk 54 and later, the default configuration keeps `allowsEditing` set to `false` and [`videoExportPreset`](#videoexportpreset) set to `'Passthrough'`. Those settings return the original asset (including HEIC/AVIF files) instantly because the picker skips compression, but iOS needs media library permission to hand over the original file and shows the dialog immediately after a user selects a video.
 
-We recommend requesting media library permissions either using [`requestMediaLibraryPermissionsAsync`](#imagepickerrequestmedialibrarypermissionsasyncwriteonly) or [`useMediaLibraryPermissions`](#usemedialibrarypermissionsoptions) before opening the picker for videos.
+To avoid showing permissions dialog after selection, **manually request media library permissions before opening the picker** via [`requestMediaLibraryPermissionsAsync`](#imagepickerrequestmedialibrarypermissionsasyncwriteonly) or [`useMediaLibraryPermissions`](#usemedialibrarypermissionsoptions).
 
 ### With AWS S3
 

--- a/docs/pages/versions/unversioned/sdk/imagepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.mdx
@@ -235,7 +235,7 @@ When you run this example and pick an image, you will see the image that you pic
 
 ### Invoke permissions for videos <PlatformTags platforms={['ios']} />
 
-In SDK 54 and later, the default configuration keeps `allowsEditing` set to `false` and [`videoExportPreset`](#videoexportpreset) set to `'Passthrough'`. Those settings return the original asset (including HEIC/AVIF files) instantly because the picker skips compression, but iOS needs media library permission to hand over the original file and shows the dialog immediately after a user selects a video.
+In SDK 54 and later, the default configuration keeps `allowsEditing` set to `false` and [`videoExportPreset`](#videoexportpreset) set to `'Passthrough'`. These settings return the original asset (including HEIC and AVIF files) instantly because the picker skips compression, but iOS requires media library permission to access the original file and displays a permission dialog immediately after the user selects a video.
 
 To avoid showing permissions dialog after selection, **manually request media library permissions before opening the picker** via [`requestMediaLibraryPermissionsAsync`](#imagepickerrequestmedialibrarypermissionsasyncwriteonly) or [`useMediaLibraryPermissions`](#usemedialibrarypermissionsoptions).
 

--- a/docs/pages/versions/v54.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/imagepicker.mdx
@@ -182,7 +182,7 @@ When you run this example and pick an image, you will see the image that you pic
 
 ### Invoke permissions for videos <PlatformTags platforms={['ios']} />
 
-In SDK 54 and later, the default configuration keeps `allowsEditing` set to `false` and [`videoExportPreset`](#videoexportpreset) set to `'Passthrough'`. Those settings return the original asset (including HEIC/AVIF files) instantly because the picker skips compression, but iOS needs media library permission to hand over the original file and shows the dialog immediately after a user selects a video.
+In SDK 54 and later, the default configuration keeps `allowsEditing` set to `false` and [`videoExportPreset`](#videoexportpreset) set to `'Passthrough'`. These settings return the original asset (including HEIC and AVIF files) instantly because the picker skips compression, but iOS requires media library permission to access the original file and displays a permission dialog immediately after the user selects a video.
 
 To avoid showing permissions dialog after selection, **manually request media library permissions before opening the picker** via [`requestMediaLibraryPermissionsAsync`](#imagepickerrequestmedialibrarypermissionsasyncwriteonly) or [`useMediaLibraryPermissions`](#usemedialibrarypermissionsoptions).
 

--- a/docs/pages/versions/v54.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/imagepicker.mdx
@@ -182,7 +182,7 @@ When you run this example and pick an image, you will see the image that you pic
 
 ### Invoke permissions for videos <PlatformTags platforms={['ios']} />
 
-In SDk 54 and later, the default configuration keeps `allowsEditing` set to `false` and [`videoExportPreset`](#videoexportpreset) set to `'Passthrough'`. Those settings return the original asset (including HEIC/AVIF files) instantly because the picker skips compression, but iOS needs media library permission to hand over the original file and shows the dialog immediately after a user selects a video.
+In SDK 54 and later, the default configuration keeps `allowsEditing` set to `false` and [`videoExportPreset`](#videoexportpreset) set to `'Passthrough'`. Those settings return the original asset (including HEIC/AVIF files) instantly because the picker skips compression, but iOS needs media library permission to hand over the original file and shows the dialog immediately after a user selects a video.
 
 To avoid showing permissions dialog after selection, **manually request media library permissions before opening the picker** via [`requestMediaLibraryPermissionsAsync`](#imagepickerrequestmedialibrarypermissionsasyncwriteonly) or [`useMediaLibraryPermissions`](#usemedialibrarypermissionsoptions).
 

--- a/docs/pages/versions/v54.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/imagepicker.mdx
@@ -110,7 +110,9 @@ export default function ImagePickerExample() {
 
   const pickImage = async () => {
     // No permissions request is necessary for launching the image library.
-    // Permissions are required for videos on iOS when `allowsEditing` is `true`.
+    // Manually request permissions for videos on iOS when `allowsEditing` is set to `false`
+    // and `videoExportPreset` is `'Passthrough'` (the default), ideally before launching the picker
+    // so the app users aren't surprised by a system dialog after picking a video.
     // See "Invoke permissions for videos" sub section for more details.
     const permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
 
@@ -180,9 +182,9 @@ When you run this example and pick an image, you will see the image that you pic
 
 ### Invoke permissions for videos <PlatformTags platforms={['ios']} />
 
-In SDK 54 and later, picking videos on iOS while `allowsEditing` is `true` or when [`videoExportPreset`](#videoexportpreset) is set to any other value than `Passthrough`, it won't trigger a permission request by default. However, there will be an increase in time for picker to open for large or newly recorded videos which haven't been processed internally by iOS.
+In SDk 54 and later, the default configuration keeps `allowsEditing` set to `false` and [`videoExportPreset`](#videoexportpreset) set to `'Passthrough'`. Those settings return the original asset (including HEIC/AVIF files) instantly because the picker skips compression, but iOS needs media library permission to hand over the original file and shows the dialog immediately after a user selects a video.
 
-We recommend requesting media library permissions either using [`requestMediaLibraryPermissionsAsync`](#imagepickerrequestmedialibrarypermissionsasyncwriteonly) or [`useMediaLibraryPermissions`](#usemedialibrarypermissionsoptions) before opening the picker for videos.
+To avoid showing permissions dialog after selection, **manually request media library permissions before opening the picker** via [`requestMediaLibraryPermissionsAsync`](#imagepickerrequestmedialibrarypermissionsasyncwriteonly) or [`useMediaLibraryPermissions`](#usemedialibrarypermissionsoptions).
 
 ### With AWS S3
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/expo/pull/40971#discussion_r2539629749

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix permissions guidelines for Video in ImagePicker reference as per feedback.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
