### PR TITLE
[expo-router] add android to package.json files

### DIFF
--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -13,6 +13,7 @@
   ],
   "files": [
     "link",
+    "android",
     "assets",
     "build",
     "internal",


### PR DESCRIPTION
# Why

`android` directory was missing from `package.json` files. Thus when router was released, this directory was not shipped.

# How

Add the directory to files

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
