### PR TITLE
[core][Android] Split and clean up cmake

### DIFF
--- a/packages/expo-modules-core/android/CMakeLists.txt
+++ b/packages/expo-modules-core/android/CMakeLists.txt
@@ -1,21 +1,11 @@
 cmake_minimum_required(VERSION 3.16)
+set(CMAKE_VERBOSE_MAKEFILE ON)
+set(CMAKE_CXX_STANDARD 20)
 
 project(expo-modules-core)
 
-set(CMAKE_VERBOSE_MAKEFILE ON)
-set(CMAKE_CXX_STANDARD 20)
-set(PACKAGE_NAME "expo-modules-core")
-set(BUILD_DIR ${CMAKE_SOURCE_DIR}/build)
-
-string(APPEND CMAKE_CXX_FLAGS " -DREACT_NATIVE_TARGET_VERSION=${REACT_NATIVE_TARGET_VERSION}")
-
-if (${NATIVE_DEBUG})
-    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g")
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
-endif ()
-
-set(SRC_DIR ${CMAKE_SOURCE_DIR}/src)
-set(COMMON_DIR ${CMAKE_SOURCE_DIR}/../common/cpp)
+include(${CMAKE_SOURCE_DIR}/cmake/variables.cmake)
+include(${CMAKE_SOURCE_DIR}/cmake/common.cmake)
 
 file(GLOB sources_android "${SRC_DIR}/main/cpp/*.cpp")
 file(GLOB sources_android_types "${SRC_DIR}/main/cpp/types/*.cpp")
@@ -27,18 +17,8 @@ file(GLOB common_sources_jsi "${COMMON_DIR}/JSI/*.cpp")
 
 # shared
 
-macro(createVarAsBoolToInt name value)
-  if(${value})
-    set(${name} "1")
-  else()
-    set(${name} "0")
-  endif()
-endmacro()
-
-add_library(CommonSettings INTERFACE)
-
 add_library(
-  ${PACKAGE_NAME}
+  expo-modules-core
   SHARED
   ${common_sources}
   ${common_sources_jsi}
@@ -49,72 +29,12 @@ add_library(
   ${sources_android_worklets}
 )
 
-target_precompile_headers(${PACKAGE_NAME} PRIVATE ${SRC_DIR}/main/cpp/ExpoHeader.pch)
-
-if(IS_NEW_ARCHITECTURE_ENABLED)
-  add_subdirectory("${SRC_DIR}/fabric")
-  set(NEW_ARCHITECTURE_DEPENDENCIES "fabric")
-  set(NEW_ARCHITECTURE_COMPILE_OPTIONS -DIS_NEW_ARCHITECTURE_ENABLED=1 -DRN_FABRIC_ENABLED=1 -DRN_SERIALIZABLE_STATE=1)
-else()
-  set(NEW_ARCHITECTURE_DEPENDENCIES "")
-  set(NEW_ARCHITECTURE_COMPILE_OPTIONS "")
-endif()
-
-if (REACT_NATIVE_WORKLETS_DIR)
-  set(WORKLETS_INTEGRATION_COMPILE_OPTIONS "-DWORKLETS_ENABLED=1")
-else()
-  set(WORKLETS_INTEGRATION_COMPILE_OPTIONS "")
-endif()
-
-createVarAsBoolToInt("USE_HERMES_INT" ${USE_HERMES})
-createVarAsBoolToInt("UNIT_TEST_INT" ${UNIT_TEST})
-
-target_compile_options(CommonSettings INTERFACE
-  -O2
-  -frtti
-  -fexceptions
-  -Wall
-  -fstack-protector-all
-  -DUSE_HERMES=${USE_HERMES_INT}
-  -DUNIT_TEST=${UNIT_TEST_INT}
-  ${NEW_ARCHITECTURE_COMPILE_OPTIONS}
-  ${WORKLETS_INTEGRATION_COMPILE_OPTIONS}
-)
-
-# tests
-
-if(${UNIT_TEST})
-  if(${USE_HERMES})
-    find_package(hermes-engine REQUIRED CONFIG)
-    set(JSEXECUTOR_LIB hermes-engine::hermesvm)
-  else()
-    set(JSEXECUTOR_LIB ReactAndroid::jscexecutor)
-  endif()
-else()
-  set(JSEXECUTOR_LIB "")
-endif()
-
-# find libraries
-
-find_library(LOG_LIB log)
-
-find_package(ReactAndroid REQUIRED CONFIG)
-
-find_package(fbjni REQUIRED CONFIG)
-
-# includes
-
-
-get_target_property(INCLUDE_reactnativejni
-  ReactAndroid::reactnative
-  INTERFACE_INCLUDE_DIRECTORIES
-)
+use_expo_common(expo-modules-core)
 
 target_include_directories(
-  ${PACKAGE_NAME}
+  expo-modules-core
   PRIVATE
-  ${INCLUDE_reactnativejni}/react
-
+  ${REACT_NATIVE_INTERFACE_INCLUDE_DIRECTORIES}/react
   # header only imports from turbomodule, e.g. CallInvokerHolder.h
   "${REACT_NATIVE_DIR}/ReactAndroid/src/main/jni/react/turbomodule"
   "${COMMON_DIR}"
@@ -124,7 +44,7 @@ target_include_directories(
 
 if (REACT_NATIVE_WORKLETS_DIR)
   target_include_directories(
-    ${PACKAGE_NAME}
+    expo-modules-core
     PRIVATE
     "${REACT_NATIVE_DIR}/ReactCommon"
     "${REACT_NATIVE_DIR}/ReactCommon/jsiexecutor"
@@ -133,31 +53,19 @@ if (REACT_NATIVE_WORKLETS_DIR)
   )
 endif()
 
-# linking
+if (IS_NEW_ARCHITECTURE_ENABLED)
+  add_subdirectory("${SRC_DIR}/fabric")
 
-include("${REACT_NATIVE_DIR}/ReactAndroid/cmake-utils/folly-flags.cmake")
-
-target_compile_options(
-  ${PACKAGE_NAME}
-  PRIVATE
-  ${folly_FLAGS}
-)
+  target_link_libraries(expo-modules-core PRIVATE fabric)
+endif()
 
 target_link_libraries(
-  ${PACKAGE_NAME}
-  CommonSettings
+  expo-modules-core
+  PRIVATE
   ${LOG_LIB}
-  fbjni::fbjni
-  ReactAndroid::jsi
   android
   ${JSEXECUTOR_LIB}
   ${NEW_ARCHITECTURE_DEPENDENCIES}
-)
-
-
-target_link_libraries(
-  ${PACKAGE_NAME}
-  ReactAndroid::reactnative
 )
 
 if (REACT_NATIVE_WORKLETS_DIR)
@@ -177,7 +85,8 @@ if (REACT_NATIVE_WORKLETS_DIR)
   )
 
   target_link_libraries(
-    ${PACKAGE_NAME}
+    expo-modules-core
+    PRIVATE
     worklets
   )
 endif()

--- a/packages/expo-modules-core/android/cmake/common.cmake
+++ b/packages/expo-modules-core/android/cmake/common.cmake
@@ -1,0 +1,35 @@
+add_library(EXPO_COMMON INTERFACE)
+
+target_precompile_headers(
+  EXPO_COMMON 
+  INTERFACE
+  ${CMAKE_SOURCE_DIR}/src/main/cpp/ExpoHeader.pch
+)
+
+target_compile_options(
+  EXPO_COMMON 
+  INTERFACE
+  --std=c++20
+  ${OPTIMIZATION_FLAGS}
+  -frtti
+  -fexceptions
+  -Wall
+  -fstack-protector-all
+  -DUSE_HERMES=${USE_HERMES_INT}
+  -DUNIT_TEST=${UNIT_TEST_INT}
+  ${folly_FLAGS}
+  ${ADDITIONAL_CXX_FLAGS}
+  ${NEW_ARCHITECTURE_COMPILE_OPTIONS}
+)
+
+target_link_libraries(
+  EXPO_COMMON 
+  INTERFACE
+  ReactAndroid::jsi
+  fbjni::fbjni
+  ReactAndroid::reactnative
+)
+
+function (use_expo_common target_name)
+  target_link_libraries(${target_name} PRIVATE EXPO_COMMON)
+endfunction ()

--- a/packages/expo-modules-core/android/cmake/variables.cmake
+++ b/packages/expo-modules-core/android/cmake/variables.cmake
@@ -1,0 +1,54 @@
+macro(createVarAsBoolToInt name value)
+  if (${value})
+    set(${name} "1")
+  else()
+    set(${name} "0")
+  endif()
+endmacro()
+
+createVarAsBoolToInt(USE_HERMES_INT ${USE_HERMES})
+createVarAsBoolToInt(UNIT_TEST_INT ${UNIT_TEST})
+
+set(SRC_DIR ${CMAKE_SOURCE_DIR}/src)
+set(COMMON_DIR ${CMAKE_SOURCE_DIR}/../common/cpp)
+
+include("${REACT_NATIVE_DIR}/ReactAndroid/cmake-utils/folly-flags.cmake")
+
+find_package(ReactAndroid REQUIRED CONFIG)
+find_package(fbjni REQUIRED CONFIG)
+find_library(LOG_LIB log)
+
+get_target_property(
+  REACT_NATIVE_INTERFACE_INCLUDE_DIRECTORIES
+  ReactAndroid::reactnative
+  INTERFACE_INCLUDE_DIRECTORIES
+)
+
+set(ADDITIONAL_CXX_FLAGS "-DREACT_NATIVE_TARGET_VERSION=${REACT_NATIVE_TARGET_VERSION}")
+set(OPTIMIZATION_FLAGS "-O2")
+if (${NATIVE_DEBUG})
+  set(ADDITIONAL_CXX_FLAGS "${ADDITIONAL_CXX_FLAGS} -g")
+  set(OPTIMIZATION_FLAGS "-O0")
+endif()
+
+set(NEW_ARCHITECTURE_COMPILE_OPTIONS "")
+if (IS_NEW_ARCHITECTURE_ENABLED)
+  set(NEW_ARCHITECTURE_COMPILE_OPTIONS -DIS_NEW_ARCHITECTURE_ENABLED=1 -DRN_FABRIC_ENABLED=1 -DRN_SERIALIZABLE_STATE=1)
+endif()
+
+if (${UNIT_TEST})
+  if (${USE_HERMES})
+    find_package(hermes-engine REQUIRED CONFIG)
+    set(JSEXECUTOR_LIB hermes-engine::hermesvm)
+  else()
+    set(JSEXECUTOR_LIB ReactAndroid::jscexecutor)
+  endif()
+else()
+  set(JSEXECUTOR_LIB "")
+endif()
+
+if (REACT_NATIVE_WORKLETS_DIR)
+  set(WORKLETS_INTEGRATION_COMPILE_OPTIONS "-DWORKLETS_ENABLED=1")
+else()
+  set(WORKLETS_INTEGRATION_COMPILE_OPTIONS "")
+endif()

--- a/packages/expo-modules-core/android/src/fabric/CMakeLists.txt
+++ b/packages/expo-modules-core/android/src/fabric/CMakeLists.txt
@@ -1,42 +1,21 @@
 # Copyright 2018-present 650 Industries. All rights reserved.
 
-set(COMMON_FABRIC_DIR ${COMMON_DIR}/fabric)
-file(GLOB SOURCES "*.cpp")
-file(GLOB COMMON_FABRIC_SOURCES "${COMMON_FABRIC_DIR}/*.cpp")
+set(common_fabric_dir ${COMMON_DIR}/fabric)
+file(GLOB sources "*.cpp")
+file(GLOB common_fabric_sources "${common_fabric_dir}/*.cpp")
 
-add_library(fabric STATIC
-  ${COMMON_FABRIC_SOURCES}
-  ${SOURCES}
+add_library(
+  fabric 
+  STATIC
+  ${common_fabric_sources}
+  ${sources}
 )
 
-target_precompile_headers(fabric PRIVATE ${SRC_DIR}/main/cpp/ExpoHeader.pch)
-
-include("${REACT_NATIVE_DIR}/ReactAndroid/cmake-utils/folly-flags.cmake")
-
-target_compile_options(fabric PRIVATE
-  "-std=c++20"
-  ${folly_FLAGS}
+target_include_directories(
+  fabric 
+  PRIVATE
+  "${common_fabric_dir}"
+  "${REACT_NATIVE_INTERFACE_INCLUDE_DIRECTORIES}/react/fabric"
 )
 
-find_package(ReactAndroid REQUIRED CONFIG)
-
-find_package(fbjni REQUIRED CONFIG)
-
-get_target_property(INCLUDE_fabricjni
-  ReactAndroid::reactnative
-  INTERFACE_INCLUDE_DIRECTORIES
-)
-
-target_include_directories(fabric PRIVATE
-  "${REACT_NATIVE_DIR}/ReactCommon"
-  "${COMMON_FABRIC_DIR}"
-  "${INCLUDE_fabricjni}/react/fabric"
-)
-
-target_link_libraries(fabric
-  CommonSettings
-  fbjni::fbjni
-  ReactAndroid::jsi
-)
-
-target_link_libraries(fabric ReactAndroid::reactnative)
+use_expo_common(fabric)


### PR DESCRIPTION
# Why

Splits and cleans up the Android CMake setup. 
I want to separate the jsi-related code into a separate target/package, but with the current setup, that's proving to be difficult. So, I've decided to clean it up first. The configuration should remain the same. 

# Test Plan

- bare-expo ✅ 