### PR TITLE
[ios][dev-launcher] Fix Safe Area being ignored on physical devices

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [iOS] Fix React Native dev menu not showing up in 0.83.x ([#40819](https://github.com/expo/expo/pull/40819) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Fix port scanning on pysical devices. ([#40824](https://github.com/expo/expo/pull/40824) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix RCTDevMenuConfiguration in release builds ([#40870](https://github.com/expo/expo/pull/40870) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Fix Safe Area being ignored on physical devices ([#41119](https://github.com/expo/expo/pull/41119) by [@betomoedano](https://github.com/betomoedano))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -4,6 +4,35 @@ import ExpoModulesCore
 import EXUpdatesInterface
 import React
 
+private class DevLauncherWrapperView: UIView {
+  weak var devLauncherViewController: UIViewController?
+
+  override func didMoveToWindow() {
+    super.didMoveToWindow()
+
+    guard let devLauncherViewController = devLauncherViewController,
+      let window = window,
+      let rootViewController = window.rootViewController else {
+      return
+    }
+
+    if devLauncherViewController.parent != rootViewController {
+      rootViewController.addChild(devLauncherViewController)
+      devLauncherViewController.didMove(toParent: rootViewController)
+      devLauncherViewController.view.setNeedsLayout()
+      devLauncherViewController.view.layoutIfNeeded()
+    }
+  }
+
+  override func willMove(toWindow newWindow: UIWindow?) {
+    super.willMove(toWindow: newWindow)
+    if newWindow == nil {
+      devLauncherViewController?.willMove(toParent: nil)
+      devLauncherViewController?.removeFromParent()
+    }
+  }
+}
+
 @objc
 public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, EXDevLauncherControllerDelegate {
   private weak var reactNativeFactory: RCTReactNativeFactory?
@@ -39,7 +68,8 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, EXDe
     rootViewController = viewController
 
     // We need to create a wrapper View because React Native Factory will reassign rootViewController later
-    let wrapperView = UIView()
+    let wrapperView = DevLauncherWrapperView()
+    wrapperView.devLauncherViewController = viewController
     wrapperView.addSubview(viewController.view)
     viewController.view.translatesAutoresizingMaskIntoConstraints = false
     NSLayoutConstraint.activate([

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -10,8 +10,8 @@ private class DevLauncherWrapperView: UIView {
   override func didMoveToWindow() {
     super.didMoveToWindow()
 
-    guard let devLauncherViewController = devLauncherViewController,
-      let window = window,
+    guard let devLauncherViewController,
+      let window,
       let rootViewController = window.rootViewController else {
       return
     }


### PR DESCRIPTION
# Why

When running a development build on a physical device, the top safe area is being ignored. See:

<img width="676" height="365" alt="image" src="https://github.com/user-attachments/assets/d8fefa77-8edb-49c1-af31-9e13bca3f652" />

The issue is that the DevLauncherViewController, which hosts the SwiftUI interface for the Dev Launcher, is created and its view is added to a wrapper UIView in ExpoDevLauncherReactDelegateHandler.swift, but the view controller itself is never added to the application's view controller hierarchy. This "detached" state means the view controller (and its child UIHostingController) does not receive system events, specifically viewSafeAreaInsetsDidChange, leading to the Safe Area being ignored or reported incorrectly on physical devices (simulators sometimes behave differently with default insets).

# How

Fixed by creating a DevLauncherWrapperView that detects when it is moved to a window and automatically adds the DevLauncherViewController as a child of the window's root view controller. This ensures the view controller is properly contained in the hierarchy and receives safe area updates.

# Test Plan

Since I cannot run Bare Expo in my physical device due to not being part of the Expo Apple team, I wrote a patch in a different project and tested the changes there. 

| Before | Physical iPhone 17 Pro|Simulator iPhone Air |
|----------|----------|----------|
| <img width="676" height="365" alt="image" src="https://github.com/user-attachments/assets/d8fefa77-8edb-49c1-af31-9e13bca3f652" /> | <img width="1206" height="911" alt="image" src="https://github.com/user-attachments/assets/e0a153d0-d0ae-4388-b855-f4990cc8803d" /> | <img width="467" height="484" alt="image" src="https://github.com/user-attachments/assets/fb2b88c8-d71a-490b-a4fb-131970fa6100" /> |


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
