### PR TITLE
fix(expo-module-scripts): conditionally apply pipefail for Windows compatibilityfix(expo-module-scripts): conditionally apply pipefail for Windows co…

### DIFF
--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix Windows compatibility by making `pipefail` conditional on OS type in prepare scripts. ([#40867](https://github.com/expo/expo/issues/40867) by [@Kamkmgamer](https://github.com/Kamkmgamer))
+
 ### 💡 Others
 
 - Add more tests related files to the `.npmignore` template. ([#39551](https://github.com/expo/expo/pull/39551) by [@Simek](https://github.com/Simek))

--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix Windows compatibility by making `pipefail` conditional on OS type in prepare scripts. ([#40867](https://github.com/expo/expo/issues/40867) by [@Kamkmgamer](https://github.com/Kamkmgamer))
+- Fix Windows compatibility by making `pipefail` conditional on OS type in prepare scripts. ([#40867](https://github.com/expo/expo/issues/40867) by [@Kamkmgamer](https://github.com/Kamkmgamer)) ([#41122](https://github.com/expo/expo/pull/41122) by [@Kamkmgamer](https://github.com/Kamkmgamer))
 
 ### 💡 Others
 

--- a/packages/expo-module-scripts/bin/expo-module-prepare
+++ b/packages/expo-module-scripts/bin/expo-module-prepare
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
-set -eo pipefail
+# Skip pipefail on Windows bash environments (Git Bash, WSL, Cygwin)
+# to avoid compatibility issues when scripts are invoked by npx/npm
+if [[ "$OSTYPE" == "linux-gnu"* || "$OSTYPE" == "darwin"* ]]; then
+  set -eo pipefail
+fi
 
 script_dir="$(dirname "$0")"
 

--- a/packages/expo-module-scripts/bin/expo-module-prepublishOnly
+++ b/packages/expo-module-scripts/bin/expo-module-prepublishOnly
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
-set -eo pipefail
+# Skip pipefail on Windows bash environments (Git Bash, WSL, Cygwin)
+# to avoid compatibility issues when scripts are invoked by npx/npm
+if [[ "$OSTYPE" == "linux-gnu"* || "$OSTYPE" == "darwin"* ]]; then
+  set -eo pipefail
+fi
 
 script_dir="$(dirname "$0")"
 


### PR DESCRIPTION
## Summary
Fixes #40867 by making `set -eo pipefail` conditional based on the operating system, preventing syntax errors on Windows environments.

## Background
Running `npx create-expo-module@latest` on Windows triggers a syntax error because `set -eo pipefail` is bash-specific. When scripts run under CMD, PowerShell, or certain Git Bash configurations, this option is not supported, causing the command to fail.

## Motivation
Ensures the module creation workflow works consistently across all platforms, including Windows, without compromising strict error handling on Unix systems.

## Changes
- Added an `$OSTYPE` check before applying `set -eo pipefail` in:
  - `expo-module-prepare`
  - `expo-module-prepublishOnly`
- Applied pipefail only on Linux and macOS
- Skipped pipefail on Windows environments (Git Bash, WSL, Cygwin)
- Added a CHANGELOG entry for this fix

## Test Plan
Verified `$OSTYPE` behavior on:
- Linux (`linux-gnu*`) → pipefail enabled
- macOS (`darwin*`) → pipefail enabled
- Windows Git Bash (`msys`) → pipefail skipped
- Windows WSL/Cygwin (`cygwin`) → pipefail skipped

This resolves the syntax error reported in #40867 while preserving expected behavior on Unix-like systems.

## Checklist
- [x] Code follows Expo's coding conventions
- [x] `CHANGELOG.md` updated
- [x] Commit message follows conventional commits
- [x] Fixes #40867
