### PR TITLE
[expo-router] add local-maven-repo to files in package.json

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -43,6 +43,7 @@
 - [iOS] rename ExpoHead to ExpoRouter podspec ([#40941](https://github.com/expo/expo/pull/40941) by [@Ubax](https://github.com/Ubax))
 - remove redundant comments from NativeOption ([#41067](https://github.com/expo/expo/pull/41067) by [@Ubax](https://github.com/Ubax))
 - use constants instead of magic strings for internal param names ([#41082](https://github.com/expo/expo/pull/41082) by [@Ubax](https://github.com/Ubax))
+- add local-maven-repo to files in package.json ([#41130](https://github.com/expo/expo/pull/41130) by [@Ubax](https://github.com/Ubax))
 
 ## 6.0.13 - 2025-10-20
 

--- a/packages/expo-router/android/build.gradle
+++ b/packages/expo-router/android/build.gradle
@@ -4,12 +4,13 @@ plugins {
 }
 
 group = 'expo.modules.router'
+version = '6.0.6'
 
 android {
   namespace "expo.modules.router"
   defaultConfig {
     versionCode 1
-    versionName "0.7.6"
+    versionName "6.0.6"
   }
   lintOptions {
     abortOnError false

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -14,6 +14,7 @@
   "files": [
     "link",
     "android",
+    "local-maven-repo",
     "assets",
     "build",
     "internal",


### PR DESCRIPTION
# Why

The `local-maven-repo` folder was missing in expo-router artifacts. This caused build errors when using canary version of router

# How

1. Add `local-maven-repo` to `files`
2. Clean up version in `build.gradle`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
