### PR TITLE
[docs] Add a Vale rule to warn for British spellings

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/BritishSpellings.yml
+++ b/docs/.vale/writing-styles/expo-docs/BritishSpellings.yml
@@ -1,0 +1,18 @@
+extends: substitution
+message: "Use American English spelling '%s' instead of British English '%s'."
+level: warning
+ignorecase: true
+action:
+  name: replace
+swap:
+  '\b(?:amongst)\b': among
+  '\b(?:analyse)\b': analyze
+  '\b(?:authorise)\b': authorize
+  '\b(?:behaviour)\b': behavior
+  '\b(?:customise)\b': customize
+  '\b(?:emphasise)\b': emphasize
+  '\b(?:grey)\b': gray
+  '\b(?:licence)\b': license
+  '\b(?:organise)\b': organize
+  '\b(?:realise)\b': realize
+  '\b(?:towards)\b': toward

--- a/docs/.vale/writing-styles/expo-docs/BritishSpellings.yml
+++ b/docs/.vale/writing-styles/expo-docs/BritishSpellings.yml
@@ -1,6 +1,6 @@
 extends: substitution
 message: "Use American English spelling '%s' instead of British English '%s'."
-level: error
+level: warning
 ignorecase: true
 action:
   name: replace

--- a/docs/.vale/writing-styles/expo-docs/BritishSpellings.yml
+++ b/docs/.vale/writing-styles/expo-docs/BritishSpellings.yml
@@ -1,6 +1,6 @@
 extends: substitution
 message: "Use American English spelling '%s' instead of British English '%s'."
-level: warning
+level: error
 ignorecase: true
 action:
   name: replace

--- a/docs/pages/archive/technical-specs/expo-updates-0.mdx
+++ b/docs/pages/archive/technical-specs/expo-updates-0.mdx
@@ -73,7 +73,7 @@ A conformant server MUST return a response structured in at least one of two way
 - For a response with `content-type: application/json` or `content-type: application/expo+json`, the [manifest headers](#manifest-response-headers) MUST be sent in the response headers and the [manifest body](#manifest-response-body) MUST be sent in the response body.
 - For a response with `content-type: multipart/mixed`, the response MUST be structured as specified in the [multipart manifest response](#multipart-manifest-response) section.
 
-The choice of manifest and headers are dependent on the values of the request headers. A conformant server MUST respond with a manifest for the most recent update, ordered by creation time, satisfying all parameters and constraints imposed by the [request headers](#manifest-request). The server MAY use any properties of the request like its headers and source IP address to choose amongst several updates that all satisfy the request's constraints.
+The choice of manifest and headers are dependent on the values of the request headers. A conformant server MUST respond with a manifest for the most recent update, ordered by creation time, satisfying all parameters and constraints imposed by the [request headers](#manifest-request). The server MAY use any properties of the request like its headers and source IP address to choose among several updates that all satisfy the request's constraints.
 
 ### Manifest response headers
 

--- a/docs/pages/build/building-from-github.mdx
+++ b/docs/pages/build/building-from-github.mdx
@@ -256,7 +256,7 @@ a build trigger row to disable, edit, or delete the trigger.
   className="max-w-[320px]"
 />
 
-You can also run a GitHub build with the parameters from the trigger manually. This will not count towards your automatic build trigger record.
+You can also run a GitHub build with the parameters from the trigger manually. This will not count toward your automatic build trigger record.
 
 #### Automatic app stores submission with EAS Submit
 

--- a/docs/pages/config-plugins/mods.mdx
+++ b/docs/pages/config-plugins/mods.mdx
@@ -53,7 +53,7 @@ The following mod plugins are available in the `expo/config-plugins` library:
 | `mods.ios.appDelegate`       | `withAppDelegate` ([Example](https://github.com/expo/expo/blob/main/packages/%40expo/config-plugins/src/ios/Maps.ts#L6))                      | <WarningIcon /> | Modify the **ios/&lt;name&gt;/AppDelegate.m** as a string.                                                                          |
 
 > **info** **Note about default Android and iOS mods:** <br />
-> Default mods are provided by the mod compiler for common file manipulation. Dangerous modifications rely on regular expressions (regex) to modify application code, which may cause the build to break. Regex mods are also difficult to version, and therefore should be used sparingly. Always opt towards using application code to modify application code, that is, [Expo Modules](https://github.com/expo/expo/tree/main/packages/expo-modules-core) native API.
+> Default mods are provided by the mod compiler for common file manipulation. Dangerous modifications rely on regular expressions (regex) to modify application code, which may cause the build to break. Regex mods are also difficult to version, and therefore should be used sparingly. Always opt toward using application code to modify application code, that is, [Expo Modules](https://github.com/expo/expo/tree/main/packages/expo-modules-core) native API.
 
 ## Mods
 

--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -35,7 +35,7 @@ Expo MCP Server teaches your AI-assisted tools about the Expo SDK and lets them 
 - "Search the Expo docs for implementing deep linking"
 - "What is Expo CNG?"
 
-**Manage dependencies.** Expo MCP Server guides you towards installing our recommended packages and uses `npx expo install` to install known, compatible versions.
+**Manage dependencies.** Expo MCP Server guides you toward installing our recommended packages and uses `npx expo install` to install known, compatible versions.
 
 - "Add SQLite with basic CRUD operations"
 - "Install `expo-camera` and show me how to take photos"

--- a/docs/pages/guides/editing-richtext.mdx
+++ b/docs/pages/guides/editing-richtext.mdx
@@ -73,7 +73,7 @@ In this section, let's discuss if it is possible to have a feature complete rich
 
 React Native allows nested `<Text>` components and allows them to be used as children of `<TextInput>` to render and edit styled text. It is synchronous with the new React Native architecture (the `onChange` event fires immediately after a new character is typed into the text input field).
 
-Unfortunately, the `<TextInput>` component is built towards working with regular text, and it only returns a string in it's `onTextChange` callback. This is a significant limitation.
+Unfortunately, the `<TextInput>` component is built toward working with regular text, and it only returns a string in it's `onTextChange` callback. This is a significant limitation.
 
 Here is a quick example. Let's start by rendering a text input with the following bold text:
 

--- a/docs/pages/guides/icons.mdx
+++ b/docs/pages/guides/icons.mdx
@@ -186,11 +186,11 @@ const styles = StyleSheet.create({
 
 Any [`Text`](http://reactnative.dev/docs/text), [`TouchableHighlight`](http://reactnative.dev/docs/touchablehighlight), or [`TouchableWithoutFeedback`](http://reactnative.dev/docs/touchablewithoutfeedback) property in addition to these:
 
-| Prop              | Description                                                                                                                                       | Default             |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| `color`           | Text and icon color, use `iconStyle` or nest a `Text` component if you need different colors.                                                     | `white`             |
-| `size`            | Icon size.                                                                                                                                        | `20`                |
-| `iconStyle`       | Styles applied to the icon only, good for setting margins or a different color. _Note: use `iconStyle` for margins or expect unstable behaviour._ | `{marginRight: 10}` |
-| `backgroundColor` | Background color of the button.                                                                                                                   | `#007AFF`           |
-| `borderRadius`    | Border radius of the button, set to `0` to disable.                                                                                               | `5`                 |
-| `onPress`         | A function called when the button is pressed.                                                                                                     | _None_              |
+| Prop              | Description                                                                                                                                      | Default             |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------- |
+| `color`           | Text and icon color, use `iconStyle` or nest a `Text` component if you need different colors.                                                    | `white`             |
+| `size`            | Icon size.                                                                                                                                       | `20`                |
+| `iconStyle`       | Styles applied to the icon only, good for setting margins or a different color. _Note: use `iconStyle` for margins or expect unstable behavior._ | `{marginRight: 10}` |
+| `backgroundColor` | Background color of the button.                                                                                                                  | `#007AFF`           |
+| `borderRadius`    | Border radius of the button, set to `0` to disable.                                                                                              | `5`                 |
+| `onPress`         | A function called when the button is pressed.                                                                                                    | _None_              |

--- a/docs/pages/guides/new-architecture.mdx
+++ b/docs/pages/guides/new-architecture.mdx
@@ -175,7 +175,7 @@ If you want to opt out of using the New Architecture, set the `newArchEnabled` p
 
 ## Troubleshooting
 
-Meta and Expo are working towards making the New Architecture the default for all new apps and ensuring it is as easy as possible to migrate existing apps. However, the New Architecture isn't just a name &mdash; many of the internals of React Native has been re-architected and rebuilt from the ground up. As a result, you may encounter issues when enabling the New Architecture in your app. The following is some advice for troubleshooting these issues.
+Meta and Expo are working toward making the New Architecture the default for all new apps and ensuring it is as easy as possible to migrate existing apps. However, the New Architecture isn't just a name &mdash; many of the internals of React Native has been re-architected and rebuilt from the ground up. As a result, you may encounter issues when enabling the New Architecture in your app. The following is some advice for troubleshooting these issues.
 
 <Collapsible summary="Can I still try the New Architecture even if some of the libraries I use aren't supported?">
 

--- a/docs/pages/push-notifications/faq.mdx
+++ b/docs/pages/push-notifications/faq.mdx
@@ -170,6 +170,6 @@ If the device you're experiencing this on hasn't been setup with a SIM card it l
 
 If you are not using [Expo push notification service](/push-notifications/sending-notifications) and instead, would like to communicate with Google and Apple directly, see [Send notifications with FCM and APNs](/push-notifications/sending-notifications-custom).
 
-### Notification icon on Android is a grey or white square
+### Notification icon on Android is a gray or white square
 
 This indicates an issue with the image asset you're providing. The image should be all white with a transparent background (this is required and enforced by Google, not Expo). For more information, see [this article](https://clevertap.com/blog/fixing-notification-icon-for-android-lollipop-and-above/).

--- a/docs/pages/router/web/static-rendering.mdx
+++ b/docs/pages/router/web/static-rendering.mdx
@@ -327,7 +327,7 @@ This generates the following static HTML:
 
 There is no prescriptive way to add a custom server. You can use any server you want. However, you will need to handle dynamic routes yourself. You can use the `generateStaticParams` function to generate static HTML files for known routes.
 
-In the future, there will be a server API, and a new `web.output` mode which will generate a project that will (amongst other things) support dynamic routes.
+In the future, there will be a server API, and a new `web.output` mode which will generate a project that will (among other things) support dynamic routes.
 
 ## Server-side Rendering
 

--- a/docs/pages/technical-specs/expo-updates-1.mdx
+++ b/docs/pages/technical-specs/expo-updates-1.mdx
@@ -80,7 +80,7 @@ A conformant server MUST return a response structured in at least one of the two
 - For a response with `content-type: multipart/mixed`, the response MUST be structured as specified in the [multipart response](#multipart-response) section.
 - A [multipart response](#multipart-response) with no parts MAY respond with an HTTP `204` status and no content, and thus no `content-type` response header.
 
-The choice of update and headers are dependent on the values of the request headers. A conformant server MUST respond with the most recent update, ordered by creation time, satisfying all parameters and constraints imposed by the [request headers](#request). The server MAY use any properties of the request like its headers and source IP address to choose amongst several updates that all satisfy the request's constraints.
+The choice of update and headers are dependent on the values of the request headers. A conformant server MUST respond with the most recent update, ordered by creation time, satisfying all parameters and constraints imposed by the [request headers](#request). The server MAY use any properties of the request like its headers and source IP address to choose among several updates that all satisfy the request's constraints.
 
 ### Common response headers
 

--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -506,7 +506,7 @@ By default, Metro will match different conditions depending on the platform and 
 
 For native platforms, the condition `react-native` is added, for web exports, the `browser` condition is added, and for server exports (such as API routes or React Server functions), the `node`, `react-server`, and `workerd` conditions are added. These conditions aren't matched in the order they're defined in. Instead, they're matched against the order of properties in the `package.json:exports` map.
 
-TypeScript performs ES Module resolution separately from Metro and will also respect `package.json:exports` maps, when its `compilerOptions.moduleResolution` configuration option has either been set to `"bundler"` (which matches Metro's behaviour more closely) or to `"node16"` / `"nodenext"`. TypeScript will however also match the `types` condition. As such, types may not resolve properly when a package doesn't put the `types` condition first in its exports map.
+TypeScript performs ES Module resolution separately from Metro and will also respect `package.json:exports` maps, when its `compilerOptions.moduleResolution` configuration option has either been set to `"bundler"` (which matches Metro's behavior more closely) or to `"node16"` / `"nodenext"`. TypeScript will however also match the `types` condition. As such, types may not resolve properly when a package doesn't put the `types` condition first in its exports map.
 
 Since an exports map may contain subpaths, a package import may not have to match a file in the package's modules folder any longer, but may be a "redirected" import. Importing `'package/submodule'` may match a different file than **node_modules/package/submodule.js** if it's specified in `package.json:exports`.
 

--- a/docs/pages/versions/v53.0.0/config/metro.mdx
+++ b/docs/pages/versions/v53.0.0/config/metro.mdx
@@ -494,7 +494,7 @@ By default, Metro will match different conditions depending on the platform and 
 
 For native platforms, the condition `react-native` is added, for web exports, the `browser` condition is added, and for server exports (such as API routes or React Server functions), the `node`, `react-server`, and `workerd` conditions are added. These conditions aren't matched in the order they're defined in. Instead, they're matched against the order of properties in the `package.json:exports` map.
 
-TypeScript performs ES Module resolution separately from Metro and will also respect `package.json:exports` maps, when its `compilerOptions.moduleResolution` configuration option has either been set to `"bundler"` (which matches Metro's behaviour more closely) or to `"node16"` / `"nodenext"`. TypeScript will however also match the `types` condition. As such, types may not resolve properly when a package doesn't put the `types` condition first in its exports map.
+TypeScript performs ES Module resolution separately from Metro and will also respect `package.json:exports` maps, when its `compilerOptions.moduleResolution` configuration option has either been set to `"bundler"` (which matches Metro's behavior more closely) or to `"node16"` / `"nodenext"`. TypeScript will however also match the `types` condition. As such, types may not resolve properly when a package doesn't put the `types` condition first in its exports map.
 
 Since an exports map may contain subpaths, a package import may not have to match a file in the package's modules folder any longer, but may be a "redirected" import. Importing `'package/submodule'` may match a different file than **node_modules/package/submodule.js** if it's specified in `package.json:exports`.
 

--- a/docs/pages/versions/v54.0.0/config/metro.mdx
+++ b/docs/pages/versions/v54.0.0/config/metro.mdx
@@ -506,7 +506,7 @@ By default, Metro will match different conditions depending on the platform and 
 
 For native platforms, the condition `react-native` is added, for web exports, the `browser` condition is added, and for server exports (such as API routes or React Server functions), the `node`, `react-server`, and `workerd` conditions are added. These conditions aren't matched in the order they're defined in. Instead, they're matched against the order of properties in the `package.json:exports` map.
 
-TypeScript performs ES Module resolution separately from Metro and will also respect `package.json:exports` maps, when its `compilerOptions.moduleResolution` configuration option has either been set to `"bundler"` (which matches Metro's behaviour more closely) or to `"node16"` / `"nodenext"`. TypeScript will however also match the `types` condition. As such, types may not resolve properly when a package doesn't put the `types` condition first in its exports map.
+TypeScript performs ES Module resolution separately from Metro and will also respect `package.json:exports` maps, when its `compilerOptions.moduleResolution` configuration option has either been set to `"bundler"` (which matches Metro's behavior more closely) or to `"node16"` / `"nodenext"`. TypeScript will however also match the `types` condition. As such, types may not resolve properly when a package doesn't put the `types` condition first in its exports map.
 
 Since an exports map may contain subpaths, a package import may not have to match a file in the package's modules folder any longer, but may be a "redirected" import. Importing `'package/submodule'` may match a different file than **node_modules/package/submodule.js** if it's specified in `package.json:exports`.
 

--- a/docs/pages/workflow/using-libraries.mdx
+++ b/docs/pages/workflow/using-libraries.mdx
@@ -80,7 +80,7 @@ After the React Native Directory, the [npm registry](https://www.npmjs.com/) is 
 
 Use Expo [development builds](/workflow/overview/#development-builds) for building production-quality apps. It includes all of the native code that your project needs to run. This is a great way to test your app before you publish it to the App Store or Google Play. You can also include libraries that require native projects (**android** and **ios** directories) configuration.
 
-The Expo Go app is an optional stepping stone towards development builds. You can use it to quickly test your app while you are developing it, but it does not include all of the native code required to support every library. You can check **React Native Directory** to find a library compatible with Expo Go by visiting the website and verifying that it has a "✔️ Expo Go" tag. You can also enable the [filter by Expo Go](https://reactnative.directory/?expoGo=true).
+The Expo Go app is an optional stepping stone toward development builds. You can use it to quickly test your app while you are developing it, but it does not include all of the native code required to support every library. You can check **React Native Directory** to find a library compatible with Expo Go by visiting the website and verifying that it has a "✔️ Expo Go" tag. You can also enable the [filter by Expo Go](https://reactnative.directory/?expoGo=true).
 
 To determine if a new dependency changes native project directories, you can check the following:
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Corrected spelling in documentation tables and descriptions to ensure consistent use of American English throughout the docs, such as changing "behaviour" to "behavior".

Writing style guide already lists to use American spellings: https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#voice-and-tone.

Having a Vale rule will help us avoid these spellings from sneaking into docs.

# How

<!--
How did you build this feature or fix this bug and why?
-->

* Added a new Vale style file `BritishSpellings.yml` to automatically warn about and suggest replacements for British spellings with American spellings in documentation.
* Updated documentation to use American spellings such as "among", "behavior", "gray", and "toward" instead of their British equivalents in multiple files.
* These updates/corrections are only applied non-SDK docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn run lint-prose`, there should be no warnings for active pages.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
