### PR TITLE
[docs] Update `lint-prose` script

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
     "export-server": "http-server out -p 8000",
     "lint": "tsc --noEmit && node scripts/lint.js --max-warnings 0",
     "lint-links": "remark -u validate-links ./pages",
-    "lint-prose": "yarn vale .",
+    "lint-prose": "yarn vale --glob='!pages/versions/latest/**' .",
     "watch": "tsc --noEmit -w",
     "test": "yarn generate-static-resources && yarn node --experimental-vm-modules $(yarn bin jest)",
     "remove-version": "node --unhandled-rejections=strict ./scripts/remove-version.js",


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Running the `yarn run lint-prose` script sometimes throws warnings for files under the `/versions/latest/` directory. 
<img width="863" height="185" alt="CleanShot 2025-11-20 at 17 55 56" src="https://github.com/user-attachments/assets/e53c4a25-9bc8-4da0-a9e3-e200410de401" />


Since the files under this directory are generated and updated from the current Expo SDK version during deployment, and we don't edit these files directly, Vale should ignore these files.

This only happens locally and not on CI.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update `lint-prose` script to use `glob` pattern to ignore these files locally.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn run lint-prose` locally in the docs app and there should be no warnings.

<img width="894" height="63" alt="CleanShot 2025-11-20 at 17 59 14" src="https://github.com/user-attachments/assets/64ceb417-034b-4621-9afa-8cc790b097bf" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
