### PR TITLE
[android][audio] Use correct method to start service

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -18,7 +18,7 @@
 - [Android] Fix incorrect volume read. ([#40258](https://github.com/expo/expo/pull/40258) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix issue where local assets don't resolve correctly in release mode. ([#40642](https://github.com/expo/expo/pull/40642) by [@alanjhughes](https://github.com/alanjhughes))
 - [web] Bring fix from [#38273](https://github.com/expo/expo/pull/38273) to web. ([#40802](https://github.com/expo/expo/pull/40802) by [@alanjhughes](https://github.com/alanjhughes)
-- [Android] Use correct method to start foreground service on android 15+.
+- [Android] Use correct method to start foreground service on android 15+. ([#41145](https://github.com/expo/expo/pull/41145) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -18,7 +18,7 @@
 - [Android] Fix incorrect volume read. ([#40258](https://github.com/expo/expo/pull/40258) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix issue where local assets don't resolve correctly in release mode. ([#40642](https://github.com/expo/expo/pull/40642) by [@alanjhughes](https://github.com/alanjhughes))
 - [web] Bring fix from [#38273](https://github.com/expo/expo/pull/38273) to web. ([#40802](https://github.com/expo/expo/pull/40802) by [@alanjhughes](https://github.com/alanjhughes)
-- [Android] Use correct method to start foreground service on android 15+. ([#41145](https://github.com/expo/expo/pull/41145) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Use correct method to start foreground service on android 14+. ([#41145](https://github.com/expo/expo/pull/41145) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [Android] Fix incorrect volume read. ([#40258](https://github.com/expo/expo/pull/40258) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix issue where local assets don't resolve correctly in release mode. ([#40642](https://github.com/expo/expo/pull/40642) by [@alanjhughes](https://github.com/alanjhughes))
 - [web] Bring fix from [#38273](https://github.com/expo/expo/pull/38273) to web. ([#40802](https://github.com/expo/expo/pull/40802) by [@alanjhughes](https://github.com/alanjhughes)
+- [Android] Use correct method to start foreground service on android 15+.
 
 ### 💡 Others
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
@@ -6,6 +6,7 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ServiceInfo
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.os.Binder
@@ -59,9 +60,11 @@ class AudioControlsService : MediaSessionService() {
       ACTION_TOGGLE -> withPlayerOnAppThread { player ->
         if (player.isPlaying) player.pause() else player.play()
       }
+
       ACTION_SEEK_FORWARD -> withPlayerOnAppThread { player ->
         player.seekTo(player.currentPosition + SEEK_INTERVAL_MS)
       }
+
       ACTION_SEEK_BACKWARD -> withPlayerOnAppThread { player ->
         player.seekTo(player.currentPosition - SEEK_INTERVAL_MS)
       }
@@ -88,7 +91,13 @@ class AudioControlsService : MediaSessionService() {
     val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       if (notificationManager.getNotificationChannel(CHANNEL_ID) == null) {
-        notificationManager.createNotificationChannel(NotificationChannel(CHANNEL_ID, CHANNEL_ID, NotificationManager.IMPORTANCE_LOW))
+        notificationManager.createNotificationChannel(
+          NotificationChannel(
+            CHANNEL_ID,
+            CHANNEL_ID,
+            NotificationManager.IMPORTANCE_LOW
+          )
+        )
       }
     }
   }
@@ -166,7 +175,15 @@ class AudioControlsService : MediaSessionService() {
     val notification = buildNotification() ?: return
 
     if (startInForeground) {
-      startForeground(notificationId, notification)
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        startForeground(
+          notificationId,
+          notification,
+          ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+        )
+      } else {
+        startForeground(notificationId, notification)
+      }
     } else {
       notificationManager.notify(notificationId, notification)
     }
@@ -177,7 +194,11 @@ class AudioControlsService : MediaSessionService() {
     postOrStartForegroundNotification(startInForegroundRequired)
   }
 
-  private fun setActivePlayerInternal(player: AudioPlayer?, metadata: Metadata? = null, options: AudioLockScreenOptions? = null) {
+  private fun setActivePlayerInternal(
+    player: AudioPlayer?,
+    metadata: Metadata? = null,
+    options: AudioLockScreenOptions? = null
+  ) {
     // Detach listener from previous player, clear active flag and hide
     playbackListener?.let { listener ->
       currentPlayer?.ref?.removeListener(listener)
@@ -293,7 +314,8 @@ class AudioControlsService : MediaSessionService() {
   }
 
   private fun hideNotification() {
-    val notificationManager: NotificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    val notificationManager: NotificationManager =
+      getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
     notificationManager.cancel(notificationId)
   }
 
@@ -329,7 +351,12 @@ class AudioControlsService : MediaSessionService() {
 
     fun getInstance(): AudioControlsService? = instance
 
-    fun setActivePlayer(context: Context, player: AudioPlayer?, metadata: Metadata? = null, options: AudioLockScreenOptions? = null) {
+    fun setActivePlayer(
+      context: Context,
+      player: AudioPlayer?,
+      metadata: Metadata? = null,
+      options: AudioLockScreenOptions? = null
+    ) {
       val service = getInstance()
       if (service != null) {
         service.setActivePlayerInternal(player, metadata, options)


### PR DESCRIPTION
# Why
We need to use a different method to start the foreground service on android 14+ to avoid getting an error when submitting to the play store. 

# How
Add a version check and use 
`startForeground(int id, Notification notification, int foregroundServiceType)` to start the service on apis above 29

# Test Plan
bare-expo. Audio controls work as normal
