### PR TITLE
[docs] Add Dreambase analytics guide link

### DIFF
--- a/docs/pages/guides/using-analytics.mdx
+++ b/docs/pages/guides/using-analytics.mdx
@@ -70,3 +70,10 @@ The following list provides common analytics providers that are available in the
   href="https://posthog.com/docs/libraries/react-native"
   Icon={BookOpen02Icon}
 />
+
+<BoxLink
+  title="Dreambase"
+  description="Turn your Supabase data into answers. Learn how to integrate Dreambase in a few clicks."
+  href="https://dreambase.ai/docs"
+  Icon={BookOpen02Icon}
+/>


### PR DESCRIPTION
> Added a new BoxLink for Dreambase integration.

# Why

We'd like to tell users that there's a simple option to create analytics reports when they use Expo with Supabase.

We are highlighting Dreambase in this doc since it's a solution to create reports in a few clicks.

The PR adds a new box link to the existing Using Analytics page.

# Screenshot

<img width="3144" height="2824" alt="image" src="https://github.com/user-attachments/assets/94bbff1b-849e-4310-85db-7f4e4b52ff1b" />

# Test Plan

- [ ] View /guides/using-analytics/ and ensure the Dreambase box link loads and links to https://dreambase.ai/docs

