### PR TITLE
[maps] - Fix MapKit built-in buttons are not responding

### DIFF
--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -8,13 +8,15 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix MapKit built-in buttons not responding ([#41151](https://github.com/expo/expo/pull/41151) by [@nishan](https://github.com/intergalacticspacehighway))
+
 ### 💡 Others
 
 ## 0.12.8 - 2025-10-01
 
 ### 🐛 Bug fixes
 
-- [iOS] Add workaround for iOS 26 onTapGesture known issue ([#39849](https://github.com/expo/expo/pull/39849) by [@nishan](https://github.com/intergalacticspacehighway)) ([#39849](https://github.com/expo/expo/pull/39849) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
+- [iOS] Add workaround for iOS 26 onTapGesture known issue ([#39849](https://github.com/expo/expo/pull/39849) by [@nishan](https://github.com/intergalacticspacehighway))
 
 ## 0.12.7 — 2025-09-11
 

--- a/packages/expo-maps/ios/AppleMapsViewiOS18.swift
+++ b/packages/expo-maps/ios/AppleMapsViewiOS18.swift
@@ -113,14 +113,12 @@ struct AppleMapsViewiOS18: View, AppleMapsViewProtocol {
           UserAnnotation()
         }
       }
-      // We use simultaneousGesture to work around the iOS 26 onTapGesture known issue
+      // https://developer.apple.com/forums/thread/795909?answerId=855111022#855111022
+      // onTapGesture with Map is broken on iOS 26 so we use this workaround
       // https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-26-release-notes#Maps
-      // TODO: Replace with onTapGesture once apple fixes the issue
-      .simultaneousGesture(
-        DragGesture(minimumDistance: 0)
-          // swiftlint:disable:next closure_body_length
-          .onEnded { value in
-            if let coordinate = reader.convert(value.location, from: .local) {
+      .simultaneousGesture(SpatialTapGesture()
+          .onEnded { event in
+            if let coordinate = reader.convert(event.location, from: .local) {
               // check if we hit a polygon and send an event
               if let hit = props.polygons.first(where: { polygon in
                 isTapInsidePolygon(tapCoordinate: coordinate, polygonCoordinates: polygon.clLocationCoordinates2D)


### PR DESCRIPTION
# Why

To solve iOS 26's `onTapGesture` bug, this [PR](https://github.com/expo/expo/pull/39849) introduced a workaround of using `DragGesture` with `minimumDistance` 0, but it broke the map's built-in buttons. This PR adds a better fix using SpatialTapGesture, which fixes the original bug and does not introduce an additional bug.
 <!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Use [SpatialTapGesture](https://developer.apple.com/documentation/swiftui/spatialtapgesture) which enables accessing tap position.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested bult-in button taps work with this fix and onMapClick also fires.


https://github.com/user-attachments/assets/01049382-13f7-4843-99ea-854e7f1b239b






<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
