### PR TITLE
[android][updates] Fix issue where launch is called multiple times

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix issue where launch is called twice on the same database instance.
+- [Android] Fix issue where launch is called twice on the same database instance. ([#41152](https://github.com/expo/expo/pull/41152) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix issue where launch is called twice on the same database instance.
+
 ### 💡 Others
 
 - [Android] Migrated from `kotlinOptions` to `compilerOptions` DSL. ([#39794](https://github.com/expo/expo/pull/39794) by [@huextrat](https://github.com/huextrat))

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.kt
@@ -296,14 +296,13 @@ class LoaderTask(
       ) {
         try {
           val embeddedLoader = EmbeddedLoader(context, configuration, logger, database, directory)
-          val result = embeddedLoader.load { updateResponse ->
+          embeddedLoader.load { _ ->
             Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
           }
-          launcher.launch(database)
         } catch (e: Exception) {
           logger.error("Unexpected error copying embedded update", e, UpdatesErrorCode.Unknown)
-          launcher.launch(database)
         }
+        launcher.launch(database)
       } else {
         launcher.launch(database)
       }


### PR DESCRIPTION
# Why
Closes #41147
The user is correct. The same launcher can be called twice. Once in the try block and when it throws, again in the catch block. 

# How
Move the `launch` call outside of the try/catch so it is only called once and errors propagate back to `start` where they are handled correctly

# Test Plan
CI
