### PR TITLE
[expo-router] prevent `onPreviewTapped` from firing when `<Link.Preview />` is not configured

### DIFF
--- a/apps/router-e2e/__e2e__/link-preview/app/menu.tsx
+++ b/apps/router-e2e/__e2e__/link-preview/app/menu.tsx
@@ -36,7 +36,7 @@ const Menus = () => {
 
   const toggleIconVisibility = () => {
     setIsIconVisible(!isIconVisible);
-  }
+  };
 
   return (
     <ScrollView
@@ -110,8 +110,21 @@ const Menus = () => {
           </Link.Menu>
         </Link.Menu>
       </Link>
-      <Link href="/one">
-        <Link.Trigger>Link.Menu no preview: /one</Link.Trigger>
+      <Link href="/one" asChild>
+        <Link.Trigger>
+          <Pressable>
+            <Text
+              style={{
+                height: 50,
+                width: '100%',
+                backgroundColor: '#DDD',
+                textAlign: 'center',
+                lineHeight: 50,
+              }}>
+              Custom Trigger without preview
+            </Text>
+          </Pressable>
+        </Link.Trigger>
         <Link.Menu title="Actions" icon="ellipsis">
           <Link.MenuAction
             title="Share"
@@ -242,7 +255,7 @@ const Menus = () => {
         <Link.Menu>
           <Link.MenuAction
             title="Menu action"
-            icon={isIconVisible ? "0.square" : undefined}
+            icon={isIconVisible ? '0.square' : undefined}
             disabled={isDisabled ? true : undefined}
             destructive={isDestructive ? true : undefined}
             unstable_keepPresented={keepPresented ? true : undefined}

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 - Fix dynamic updates of headless tabs ([#40352](https://github.com/expo/expo/pull/40352) by [@Ubax](https://github.com/Ubax))
 - activate animation on back navigation, when initial animation was disabled using internal param ([#41141](https://github.com/expo/expo/pull/41141) by [@Ubax](https://github.com/Ubax))
+- prevent `onPreviewTapped` from firing when `<Link.Preview />` is not configured ([#41160](https://github.com/expo/expo/pull/41160) by [@Ubax](https://github.com/Ubax))
 
 ### 💡 Others
 

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeView.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeView.swift
@@ -1,7 +1,8 @@
 import ExpoModulesCore
 
 class NativeLinkPreviewView: ExpoView, UIContextMenuInteractionDelegate,
-  LinkPreviewModalDismissible, LinkPreviewMenuUpdatable {
+  LinkPreviewModalDismissible, LinkPreviewMenuUpdatable
+{
   private var preview: NativeLinkPreviewContentView?
   private var interaction: UIContextMenuInteraction?
   private var directChild: UIView?
@@ -167,10 +168,12 @@ class NativeLinkPreviewView: ExpoView, UIContextMenuInteractionDelegate,
     willPerformPreviewActionForMenuWith configuration: UIContextMenuConfiguration,
     animator: UIContextMenuInteractionCommitAnimating
   ) {
-    self.onPreviewTapped()
-    animator.addCompletion { [weak self] in
-      self?.linkPreviewNativeNavigation.pushPreloadedView()
-      self?.onPreviewTappedAnimationCompleted()
+    if preview != nil {
+      self.onPreviewTapped()
+      animator.addCompletion { [weak self] in
+        self?.linkPreviewNativeNavigation.pushPreloadedView()
+        self?.onPreviewTappedAnimationCompleted()
+      }
     }
   }
 


### PR DESCRIPTION
# Why

When there was no preview added to the link, the previewTapped event could be executed by tapping on the default preview. This was unintentional behavior. 

This PR fixes it, and prevents previewTapped from firing when there is no preview added (by using `Link.Preview`)

**Before**

https://github.com/user-attachments/assets/b33db658-5150-43f5-bd5f-3ee814cb99c0

**After**

https://github.com/user-attachments/assets/c356a57b-3939-4118-9a28-832dd5cb0fc2

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

1. Manual testing

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
