### PR TITLE
Upgrade react-native-screens to nightly version

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2883,7 +2883,7 @@ PODS:
     - ReactNativeDependencies
     - RNWorklets
     - Yoga
-  - RNScreens (4.18.0):
+  - RNScreens (4.19.0-nightly-20251123-253b82666):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2905,9 +2905,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNScreens/common (= 4.18.0)
+    - RNScreens/common (= 4.19.0-nightly-20251123-253b82666)
     - Yoga
-  - RNScreens/common (4.18.0):
+  - RNScreens/common (4.19.0-nightly-20251123-253b82666):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3789,7 +3789,7 @@ SPEC CHECKSUMS:
   EXUpdates: 83e4d666a085b44149f3b21d5bd057ad37b2c3e5
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   FBLazyVector: b733c6ff598607c9c5a2757669306ca5481fa7a1
-  hermes-engine: 8044e2041f40aac194ae9df22077c2db152c0903
+  hermes-engine: f5fc1f6e7f9d3d3982201f9c9d8f1e25e4f4b59d
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -3807,7 +3807,7 @@ SPEC CHECKSUMS:
   React: 0d33ae696cce9f29ef4ef9395b677461f819edff
   React-callinvoker: 98827bd8d13282630bd3ac420d9deab3ef9c4404
   React-Core: c53a32ac2fd877b127d678668eacb32ee5b278a2
-  React-Core-prebuilt: 603b8e4e6d0071a0018e5b4050387202861932b7
+  React-Core-prebuilt: 29668101fca35c588c853a75ce8904a9a3e3a244
   React-CoreModules: 55744f49f098b26e46de697a828f0a22540246cd
   React-cxxreact: 07d452b1ca44cb6bf003b36d8263a1fa772d2cae
   React-debug: 65a8b0304322f0641d4aa5fcd1d9bdeae3f97327
@@ -3876,14 +3876,14 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: c55bd3998b0b548d2e81f5aae4758096d4321a7a
   ReactCodegen: c63ed13899d192e3ac78b794f4149e950dc86122
   ReactCommon: 558d37855c8b281c4fdfe8f9ba2d7bc102fb55ff
-  ReactNativeDependencies: 039f8d33be4110dc8041e9492ae7e65e85b99245
+  ReactNativeDependencies: 6012c41b8b2962e2af6d9cb299c05c1811be9d87
   RNCAsyncStorage: e85a99325df9eb0191a6ee2b2a842644c7eb29f4
   RNCMaskedView: 3c9d7586e2b9bbab573591dcb823918bc4668005
   RNCPicker: 38a9deb903d9a8ae18b598bac727e6c84b3cf0fa
   RNDateTimePicker: 6fdd63f5d1e0f21faf4cc8674957c52958a7efae
   RNGestureHandler: 72efe2ab9d5d1b1d25b96f3ad3d174992f3bad87
   RNReanimated: a8df76e5dd2315dfd8711d7937ec3e0e09800c74
-  RNScreens: 448161bce0b7d670222bf4ac967b0c3449cdcefa
+  RNScreens: a783ad69553533bf2d7f034fa21777150773b486
   RNSVG: 595d31b6cd45e92424c6b623bd93e1e9b6aa8b79
   RNWorklets: c181ebc224265a35743abc490e54a5cf66eb2add
   SDWebImage: f29024626962457f3470184232766516dee8dfea

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -74,7 +74,7 @@
     "react-native-pager-view": "6.9.1",
     "react-native-reanimated": "4.1.3",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.18.0",
+    "react-native-screens": "4.19.0-nightly-20251123-253b82666",
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.15.0",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3606,7 +3606,7 @@ PODS:
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNScreens (4.18.0):
+  - RNScreens (4.19.0-nightly-20251123-253b82666):
     - boost
     - DoubleConversion
     - fast_float
@@ -3633,10 +3633,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.18.0)
+    - RNScreens/common (= 4.19.0-nightly-20251123-253b82666)
     - SocketRocket
     - Yoga
-  - RNScreens/common (4.18.0):
+  - RNScreens/common (4.19.0-nightly-20251123-253b82666):
     - boost
     - DoubleConversion
     - fast_float
@@ -4609,7 +4609,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 53f8aecd4b137eb7013a4a3620db4c2b57f03a3e
+  hermes-engine: 21f7021a3364f5f9dab02bdfd1fa0e21053e5dd5
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -4707,7 +4707,7 @@ SPEC CHECKSUMS:
   RNDateTimePicker: c4a42c6a77d474f05162d61a4ab4253d13008277
   RNGestureHandler: afae32614741017de0f813f74586eee29773f31a
   RNReanimated: ef9140fe842a253834fdf8aaff0c0edacf560dde
-  RNScreens: 3693ec4bbc0065151b843269e50e9807644e9918
+  RNScreens: 37488c034f22072a8c5404cb8372a35d0e3b90b0
   RNSVG: 6e742388ed2c7bfe7c9f5baf42b8eb850adc0442
   RNWorklets: 089683f4a4564f30393d32352d41d9e92c3e5a55
   SDWebImage: f29024626962457f3470184232766516dee8dfea

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -80,7 +80,7 @@
     "react-native-paper": "^5.12.5",
     "react-native-reanimated": "4.1.3",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.18.0",
+    "react-native-screens": "4.19.0-nightly-20251123-253b82666",
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.15.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -151,7 +151,7 @@
     "react-native-worklets": "0.6.1",
     "react-native-reanimated": "4.1.3",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.18.0",
+    "react-native-screens": "4.19.0-nightly-20251123-253b82666",
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-web": "~0.21.0",

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -33,7 +33,7 @@
     "react": "19.2.0",
     "react-native": "0.83.0-nightly-20251104-502efe1cc",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.18.0"
+    "react-native-screens": "4.19.0-nightly-20251123-253b82666"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -57,7 +57,7 @@
     "react": "19.2.0",
     "react-native": "0.83.0-nightly-20251104-502efe1cc",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.18.0",
+    "react-native-screens": "4.19.0-nightly-20251123-253b82666",
     "react-native-webview": "13.15.0"
   },
   "devDependencies": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -103,7 +103,7 @@
   "react-native-pager-view": "6.9.1",
   "react-native-worklets": "0.6.1",
   "react-native-reanimated": "~4.1.1",
-  "react-native-screens": "~4.18.0",
+  "react-native-screens": "~4.19.0-nightly-20251123-253b82666",
   "react-native-safe-area-context": "~5.6.0",
   "react-native-svg": "15.12.1",
   "react-native-view-shot": "4.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14071,10 +14071,10 @@ react-native-screens@4.11.1-nightly-20250611-8b82e081e:
     react-native-is-edge-to-edge "^1.1.7"
     warn-once "^0.1.0"
 
-react-native-screens@4.18.0:
-  version "4.18.0"
-  resolved "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.18.0.tgz#ba5a951b3f145e3b773d201143c19e1b1c1337ff"
-  integrity sha512-mRTLWL7Uc1p/RFNveEIIrhP22oxHduC2ZnLr/2iHwBeYpGXR0rJZ7Bgc0ktxQSHRjWTPT70qc/7yd4r9960PBQ==
+react-native-screens@4.19.0-nightly-20251123-253b82666:
+  version "4.19.0-nightly-20251123-253b82666"
+  resolved "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.19.0-nightly-20251123-253b82666.tgz#fee414eb0bbfdf71aeac4da19e6b8b8f5c0cb1bd"
+  integrity sha512-ETD/iZM/HgqSWH1tJhkmppIWXrjJZkbBqBXD4yUuhYe8zWmh7s4tqlPujU4YKeLrmwpbi8kEW+FEoXtFUyVwkw==
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"


### PR DESCRIPTION
# Why

react-native-screens shipped many fixes and new features in recent weeks. It is better for us to tests them sooner on nightly version, rather then wait for the actual release.

# How


# Test Plan

1. Build bare expo
2. Build expo go
3. Test router-e2e

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
