### PR TITLE
[docs] Optimize scroll performance on large content pages

### DIFF
--- a/docs/common/utilities.ts
+++ b/docs/common/utilities.ts
@@ -122,3 +122,42 @@ export function formatSdkVersion(version: string): string {
 export function capitalize(str: string) {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
+
+/**
+ * Throttles a function to only execute at most once per specified delay.
+ * Useful for performance optimization of high-frequency events like scroll.
+ *
+ * @param func The function to throttle
+ * @param delay The minimum time in milliseconds between function executions
+ * @returns A throttled version of the function
+ */
+export function throttle<TArgs extends unknown[]>(
+  func: (...args: TArgs) => void,
+  delay: number
+): (...args: TArgs) => void {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  let lastExecuted = 0;
+
+  return function throttled(...args: TArgs) {
+    const now = Date.now();
+    const timeSinceLastExecution = now - lastExecuted;
+
+    const execute = () => {
+      lastExecuted = now;
+      func(...args);
+    };
+
+    if (timeSinceLastExecution >= delay) {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+      execute();
+    } else {
+      timeoutId ??= setTimeout(() => {
+        timeoutId = null;
+        execute();
+      }, delay - timeSinceLastExecution);
+    }
+  };
+}

--- a/docs/components/DocumentationNestedScrollLayout.tsx
+++ b/docs/components/DocumentationNestedScrollLayout.tsx
@@ -128,7 +128,7 @@ export default function DocumentationNestedScrollLayout({
           ) : null}
           <div
             className={mergeClasses(
-              'flex h-full max-w-[280px] flex-col overflow-hidden border-r border-r-default transition-[max-width,opacity,width] duration-200 ease-out',
+              'flex h-full max-w-[280px] flex-col overflow-hidden border-r border-r-default transition-[max-width,opacity,width] duration-200 ease-out will-change-[max-width,width,opacity]',
               isSidebarCollapsed
                 ? 'w-0 max-w-0 border-r-0 opacity-0'
                 : 'w-[280px] max-w-[280px] opacity-100'
@@ -156,7 +156,7 @@ export default function DocumentationNestedScrollLayout({
           <ScrollContainer ref={contentRef} scrollHandler={scrollHandler}>
             <div
               className={mergeClasses(
-                'mx-auto max-w-screen-xl transition-[padding,max-width,margin] duration-200 ease-out',
+                'mx-auto max-w-screen-xl transition-[padding,max-width,margin] duration-200 ease-out will-change-[padding,max-width,margin]',
                 isChatExpanded &&
                   'lg:pr-[360px] lg:pl-8 lg:max-w-[calc(100%-360px)] max-lg-gutters:max-w-screen-xl max-lg-gutters:pl-0 max-lg-gutters:pr-0'
               )}>

--- a/docs/components/DocumentationNestedScrollLayout.tsx
+++ b/docs/components/DocumentationNestedScrollLayout.tsx
@@ -2,15 +2,16 @@ import { Button, mergeClasses } from '@expo/styleguide';
 import { ChevronLeftIcon } from '@expo/styleguide-icons/outline/ChevronLeftIcon';
 import { ChevronRightIcon } from '@expo/styleguide-icons/outline/ChevronRightIcon';
 import {
-  Component,
   cloneElement,
-  createRef,
   type PropsWithChildren,
   type ReactElement,
   type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
 } from 'react';
 
-import { ScrollContainer } from '~/components/ScrollContainer';
+import { ScrollContainer, type ScrollContainerHandle } from '~/components/ScrollContainer';
 import { SidebarFooter } from '~/ui/components/Sidebar/SidebarFooter';
 import { SidebarHead } from '~/ui/components/Sidebar/SidebarHead';
 import { TableOfContentsProps } from '~/ui/components/TableOfContents';
@@ -21,151 +22,163 @@ type Props = PropsWithChildren<{
   isMobileMenuVisible: boolean;
   hideTOC: boolean;
   header: ReactNode;
-  sidebarScrollPosition: number;
+  sidebarScrollPosition?: number;
   sidebar: ReactNode;
   sidebarActiveGroup: string;
   sidebarRight: ReactElement<TableOfContentsProps>;
   onSidebarToggle?: () => void;
   isSidebarCollapsed?: boolean;
   isChatExpanded?: boolean;
+  layoutRef?: { current: DocumentationNestedScrollLayoutHandles | null } | null;
 }>;
 
-export default class DocumentationNestedScrollLayout extends Component<Props> {
-  static defaultProps = {
-    sidebarScrollPosition: 0,
+export type DocumentationNestedScrollLayoutHandles = {
+  getSidebarScrollTop: () => number;
+  getContentScrollTop: () => number;
+  contentRef: { current: ScrollContainerHandle | null };
+};
+
+export default function DocumentationNestedScrollLayout({
+  header,
+  sidebar,
+  sidebarActiveGroup,
+  sidebarRight,
+  sidebarScrollPosition = 0,
+  isMobileMenuVisible,
+  hideTOC,
+  children,
+  onSidebarToggle,
+  isSidebarCollapsed = false,
+  isChatExpanded = false,
+  onContentScroll,
+  layoutRef,
+}: Props) {
+  const sidebarRef = useRef<ScrollContainerHandle | null>(null);
+  const contentRef = useRef<ScrollContainerHandle | null>(null);
+  const sidebarRightRef = useRef<ScrollContainerHandle | null>(null);
+
+  const getSidebarScrollTop = useCallback(() => sidebarRef.current?.getScrollTop() ?? 0, []);
+  const getContentScrollTop = useCallback(() => contentRef.current?.getScrollTop() ?? 0, []);
+
+  useEffect(() => {
+    if (!layoutRef) {
+      return;
+    }
+    layoutRef.current = {
+      getSidebarScrollTop,
+      getContentScrollTop,
+      contentRef,
+    };
+    return () => {
+      layoutRef.current = null;
+    };
+  }, [layoutRef, getSidebarScrollTop, getContentScrollTop]);
+
+  const scrollHandler = () => {
+    if (onContentScroll) {
+      onContentScroll(getContentScrollTop());
+    }
   };
 
-  sidebarRef = createRef<ScrollContainer>();
-  contentRef = createRef<ScrollContainer>();
-  sidebarRightRef = createRef<ScrollContainer>();
-
-  public getSidebarScrollTop = () => {
-    return this.sidebarRef.current?.getScrollTop() ?? 0;
-  };
-
-  public getContentScrollTop = () => {
-    return this.contentRef.current?.getScrollTop() ?? 0;
-  };
-
-  render() {
-    const {
-      header,
-      sidebar,
-      sidebarActiveGroup,
-      sidebarRight,
-      sidebarScrollPosition,
-      isMobileMenuVisible,
-      hideTOC,
-      children,
-      onSidebarToggle,
-      isSidebarCollapsed = false,
-      isChatExpanded = false,
-    } = this.props;
-
-    return (
-      <div className="mx-auto flex h-dvh w-full flex-col overflow-hidden">
-        <div className="max-lg-gutters:sticky">{header}</div>
-        <div className="mx-auto flex h-[calc(100dvh-60px)] w-full items-center justify-between">
-          <div className="relative h-full max-lg-gutters:hidden">
-            {onSidebarToggle ? (
-              <div
-                className={mergeClasses(
-                  'absolute z-20 flex items-center justify-center transition-all duration-200 ease-out',
-                  'bottom-6',
-                  isSidebarCollapsed ? 'left-5 translate-x-0' : 'left-[280px] -translate-x-1/2'
-                )}>
-                <Tooltip.Root delayDuration={300}>
-                  <Tooltip.Trigger asChild>
-                    <Button
-                      type="button"
-                      theme="quaternary"
-                      size="xs"
-                      className={mergeClasses(
-                        'inline-flex size-9 items-center justify-center rounded-full border !p-0 transition-colors duration-150 ease-out',
-                        'shadow-sm',
-                        isSidebarCollapsed
-                          ? 'border-palette-gray5 bg-palette-gray4 text-icon-secondary dark:border-palette-gray6 dark:bg-palette-gray5'
-                          : 'border-default bg-default text-icon-secondary',
-                        'hover:bg-element focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-palette-blue9'
-                      )}
-                      aria-label={isSidebarCollapsed ? 'Show navigation' : 'Hide navigation'}
-                      title={isSidebarCollapsed ? 'Show navigation' : 'Hide navigation'}
-                      aria-pressed={!isSidebarCollapsed}
-                      onClick={onSidebarToggle}>
-                      {isSidebarCollapsed ? (
-                        <ChevronRightIcon className="icon-sm" />
-                      ) : (
-                        <ChevronLeftIcon className="icon-sm" />
-                      )}
-                      <span className="sr-only">
-                        {isSidebarCollapsed ? 'Show navigation' : 'Hide navigation'}
-                      </span>
-                    </Button>
-                  </Tooltip.Trigger>
-                  <Tooltip.Content sideOffset={8} className="max-w-[260px] text-center text-xs">
-                    Use Cmd/Ctrl + Shift + Enter to toggle immersive mode.
-                  </Tooltip.Content>
-                </Tooltip.Root>
-              </div>
-            ) : null}
+  return (
+    <div className="mx-auto flex h-dvh w-full flex-col overflow-hidden">
+      <div className="max-lg-gutters:sticky">{header}</div>
+      <div className="mx-auto flex h-[calc(100dvh-60px)] w-full items-center justify-between">
+        <div className="relative h-full max-lg-gutters:hidden">
+          {onSidebarToggle ? (
             <div
               className={mergeClasses(
-                'flex h-full max-w-[280px] flex-col overflow-hidden border-r border-r-default transition-[max-width,opacity,width] duration-200 ease-out',
-                isSidebarCollapsed
-                  ? 'w-0 max-w-0 border-r-0 opacity-0'
-                  : 'w-[280px] max-w-[280px] opacity-100'
+                'absolute z-20 flex items-center justify-center transition-all duration-200 ease-out',
+                'bottom-6',
+                isSidebarCollapsed ? 'left-5 translate-x-0' : 'left-[280px] -translate-x-1/2'
               )}>
-              {isSidebarCollapsed ? null : (
-                <>
-                  <SidebarHead sidebarActiveGroup={sidebarActiveGroup} />
-                  <ScrollContainer
-                    ref={this.sidebarRef}
-                    scrollPosition={sidebarScrollPosition}
-                    className="pt-1.5">
-                    {sidebar}
-                    <SidebarFooter />
-                  </ScrollContainer>
-                </>
-              )}
+              <Tooltip.Root delayDuration={300}>
+                <Tooltip.Trigger asChild>
+                  <Button
+                    type="button"
+                    theme="quaternary"
+                    size="xs"
+                    className={mergeClasses(
+                      'inline-flex size-9 items-center justify-center rounded-full border !p-0 transition-colors duration-150 ease-out',
+                      'shadow-sm',
+                      isSidebarCollapsed
+                        ? 'border-palette-gray5 bg-palette-gray4 text-icon-secondary dark:border-palette-gray6 dark:bg-palette-gray5'
+                        : 'border-default bg-default text-icon-secondary',
+                      'hover:bg-element focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-palette-blue9'
+                    )}
+                    aria-label={isSidebarCollapsed ? 'Show navigation' : 'Hide navigation'}
+                    title={isSidebarCollapsed ? 'Show navigation' : 'Hide navigation'}
+                    aria-pressed={!isSidebarCollapsed}
+                    onClick={onSidebarToggle}>
+                    {isSidebarCollapsed ? (
+                      <ChevronRightIcon className="icon-sm" />
+                    ) : (
+                      <ChevronLeftIcon className="icon-sm" />
+                    )}
+                    <span className="sr-only">
+                      {isSidebarCollapsed ? 'Show navigation' : 'Hide navigation'}
+                    </span>
+                  </Button>
+                </Tooltip.Trigger>
+                <Tooltip.Content sideOffset={8} className="max-w-[260px] text-center text-xs">
+                  Use Cmd/Ctrl + Shift + Enter to toggle immersive mode.
+                </Tooltip.Content>
+              </Tooltip.Root>
             </div>
-          </div>
+          ) : null}
           <div
             className={mergeClasses(
-              'relative flex h-[calc(100dvh-60px)] w-full overflow-hidden',
-              'max-lg-gutters:overflow-auto',
-              isMobileMenuVisible && 'hidden'
+              'flex h-full max-w-[280px] flex-col overflow-hidden border-r border-r-default transition-[max-width,opacity,width] duration-200 ease-out',
+              isSidebarCollapsed
+                ? 'w-0 max-w-0 border-r-0 opacity-0'
+                : 'w-[280px] max-w-[280px] opacity-100'
             )}>
-            <ScrollContainer ref={this.contentRef} scrollHandler={this.scrollHandler}>
-              <div
-                className={mergeClasses(
-                  'mx-auto max-w-screen-xl transition-[padding,max-width,margin] duration-200 ease-out',
-                  isChatExpanded &&
-                    'lg:pr-[360px] lg:pl-8 lg:max-w-[calc(100%-360px)] max-lg-gutters:max-w-screen-xl max-lg-gutters:pl-0 max-lg-gutters:pr-0'
-                )}>
-                {children}
-              </div>
-            </ScrollContainer>
+            {isSidebarCollapsed ? null : (
+              <>
+                <SidebarHead sidebarActiveGroup={sidebarActiveGroup} />
+                <ScrollContainer
+                  ref={sidebarRef}
+                  scrollPosition={sidebarScrollPosition}
+                  className="pt-1.5">
+                  {sidebar}
+                  <SidebarFooter />
+                </ScrollContainer>
+              </>
+            )}
           </div>
-          {!hideTOC && (
+        </div>
+        <div
+          className={mergeClasses(
+            'relative flex h-[calc(100dvh-60px)] w-full overflow-hidden',
+            'max-lg-gutters:overflow-auto',
+            isMobileMenuVisible && 'hidden'
+          )}>
+          <ScrollContainer ref={contentRef} scrollHandler={scrollHandler}>
             <div
               className={mergeClasses(
-                'flex h-[calc(100dvh-60px)] max-w-[280px] shrink-0 flex-col overflow-hidden border-l border-l-default',
-                'max-xl-gutters:hidden'
+                'mx-auto max-w-screen-xl transition-[padding,max-width,margin] duration-200 ease-out',
+                isChatExpanded &&
+                  'lg:pr-[360px] lg:pl-8 lg:max-w-[calc(100%-360px)] max-lg-gutters:max-w-screen-xl max-lg-gutters:pl-0 max-lg-gutters:pr-0'
               )}>
-              <ScrollContainer ref={this.sidebarRightRef}>
-                {cloneElement(sidebarRight, {
-                  selfRef: this.sidebarRightRef,
-                  contentRef: this.contentRef,
-                })}
-              </ScrollContainer>
+              {children}
             </div>
-          )}
+          </ScrollContainer>
         </div>
+        {!hideTOC && (
+          <div
+            className={mergeClasses(
+              'flex h-[calc(100dvh-60px)] max-w-[280px] shrink-0 flex-col overflow-hidden border-l border-l-default',
+              'max-xl-gutters:hidden'
+            )}>
+            <ScrollContainer ref={sidebarRightRef}>
+              {cloneElement(sidebarRight, {
+                selfRef: sidebarRightRef,
+                contentRef,
+              })}
+            </ScrollContainer>
+          </div>
+        )}
       </div>
-    );
-  }
-
-  private readonly scrollHandler = () => {
-    this.props.onContentScroll && this.props.onContentScroll(this.getContentScrollTop());
-  };
+    </div>
+  );
 }

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -1,7 +1,7 @@
 import { mergeClasses } from '@expo/styleguide';
 import { breakpoints } from '@expo/styleguide-base';
 import { useRouter } from 'next/compat/router';
-import { useEffect, useState, createRef, type PropsWithChildren, useRef, useCallback } from 'react';
+import { useEffect, useState, type PropsWithChildren, useRef, useCallback } from 'react';
 
 import { InlineHelp } from 'ui/components/InlineHelp';
 import { PageHeader } from 'ui/components/PageHeader';
@@ -10,7 +10,9 @@ import { appendSectionToRoute, isRouteActive } from '~/common/routes';
 import { versionToText } from '~/common/utilities';
 import * as WindowUtils from '~/common/window';
 import DocumentationHead from '~/components/DocumentationHead';
-import DocumentationNestedScrollLayout from '~/components/DocumentationNestedScrollLayout';
+import DocumentationNestedScrollLayout, {
+  DocumentationNestedScrollLayoutHandles,
+} from '~/components/DocumentationNestedScrollLayout';
 import { usePageApiVersion } from '~/providers/page-api-version';
 import versions from '~/public/static/constants/versions.json';
 import { PageMetadata } from '~/types/common';
@@ -52,7 +54,7 @@ export default function DocumentationPage({
   const { version } = usePageApiVersion();
   const router = useRouter();
 
-  const layoutRef = createRef<DocumentationNestedScrollLayout>();
+  const layoutRef = useRef<DocumentationNestedScrollLayoutHandles | null>(null);
   const tableOfContentsRef = useRef<TableOfContentsHandles>(null);
 
   const pathname = router?.pathname ?? '/';
@@ -291,7 +293,7 @@ export default function DocumentationPage({
   return (
     <>
       <DocumentationNestedScrollLayout
-        ref={layoutRef}
+        layoutRef={layoutRef}
         header={headerElement}
         sidebar={sidebarElement}
         sidebarRight={<TableOfContentsWithManager ref={tableOfContentsRef} />}

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -1,13 +1,13 @@
 import { mergeClasses } from '@expo/styleguide';
 import { breakpoints } from '@expo/styleguide-base';
 import { useRouter } from 'next/compat/router';
-import { useEffect, useState, type PropsWithChildren, useRef, useCallback } from 'react';
+import { useEffect, useState, type PropsWithChildren, useRef, useCallback, useMemo } from 'react';
 
 import { InlineHelp } from 'ui/components/InlineHelp';
 import { PageHeader } from 'ui/components/PageHeader';
 import * as RoutesUtils from '~/common/routes';
 import { appendSectionToRoute, isRouteActive } from '~/common/routes';
-import { versionToText } from '~/common/utilities';
+import { versionToText, throttle } from '~/common/utilities';
 import * as WindowUtils from '~/common/window';
 import DocumentationHead from '~/components/DocumentationHead';
 import DocumentationNestedScrollLayout, {
@@ -202,13 +202,17 @@ export default function DocumentationPage({
     }
   };
 
-  const handleContentScroll = (contentScrollPosition: number) => {
-    window.requestAnimationFrame(() => {
-      if (tableOfContentsRef.current?.handleContentScroll) {
-        tableOfContentsRef.current.handleContentScroll(contentScrollPosition);
-      }
-    });
-  };
+  const handleContentScroll = useMemo(
+    () =>
+      throttle((contentScrollPosition: number) => {
+        window.requestAnimationFrame(() => {
+          if (tableOfContentsRef.current?.handleContentScroll) {
+            tableOfContentsRef.current.handleContentScroll(contentScrollPosition);
+          }
+        });
+      }, 150),
+    []
+  );
 
   useEffect(() => {
     if (typeof window === 'undefined') {

--- a/docs/components/ScrollContainer.tsx
+++ b/docs/components/ScrollContainer.tsx
@@ -40,9 +40,13 @@ export const ScrollContainer = forwardRef<ScrollContainerHandle, ScrollContainer
 
     return (
       <div
-        className={mergeClasses('size-full overflow-y-auto overflow-x-hidden', className)}
+        className={mergeClasses(
+          'size-full transform-gpu overflow-y-auto overflow-x-hidden',
+          className
+        )}
         ref={scrollRef}
-        onScroll={scrollHandler}>
+        onScroll={scrollHandler}
+        style={{ transform: 'translate3d(0, 0, 0)' }}>
         {children}
       </div>
     );

--- a/docs/components/ScrollContainer.tsx
+++ b/docs/components/ScrollContainer.tsx
@@ -1,5 +1,12 @@
 import { mergeClasses } from '@expo/styleguide';
-import { Component, createRef, PropsWithChildren } from 'react';
+import {
+  forwardRef,
+  type PropsWithChildren,
+  type RefObject,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from 'react';
 
 type ScrollContainerProps = PropsWithChildren<{
   className?: string;
@@ -7,34 +14,39 @@ type ScrollContainerProps = PropsWithChildren<{
   scrollHandler?: () => void;
 }>;
 
-export class ScrollContainer extends Component<ScrollContainerProps> {
-  scrollRef = createRef<HTMLDivElement>();
+export type ScrollContainerHandle = {
+  getScrollTop: () => number;
+  getScrollRef: () => RefObject<HTMLDivElement | null>;
+};
 
-  componentDidMount() {
-    if (this.props.scrollPosition && this.scrollRef.current) {
-      this.scrollRef.current.scrollTop = this.props.scrollPosition;
-    }
-  }
+export const ScrollContainer = forwardRef<ScrollContainerHandle, ScrollContainerProps>(
+  ({ className, scrollPosition, scrollHandler, children }, ref) => {
+    const scrollRef = useRef<HTMLDivElement>(null);
 
-  public getScrollTop = () => {
-    return this.scrollRef.current?.scrollTop ?? 0;
-  };
+    useEffect(() => {
+      if (scrollPosition != null && scrollRef.current) {
+        scrollRef.current.scrollTop = scrollPosition;
+      }
+    }, [scrollPosition]);
 
-  public getScrollRef = () => {
-    return this.scrollRef;
-  };
+    useImperativeHandle(
+      ref,
+      () => ({
+        getScrollTop: () => scrollRef.current?.scrollTop ?? 0,
+        getScrollRef: () => scrollRef,
+      }),
+      []
+    );
 
-  render() {
     return (
       <div
-        className={mergeClasses(
-          'size-full overflow-y-auto overflow-x-hidden',
-          this.props.className
-        )}
-        ref={this.scrollRef}
-        onScroll={this.props.scrollHandler}>
-        {this.props.children}
+        className={mergeClasses('size-full overflow-y-auto overflow-x-hidden', className)}
+        ref={scrollRef}
+        onScroll={scrollHandler}>
+        {children}
       </div>
     );
   }
-}
+);
+
+ScrollContainer.displayName = 'ScrollContainer';

--- a/docs/ui/components/TableOfContents/TableOfContents.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContents.tsx
@@ -19,7 +19,7 @@ import { BASE_HEADING_LEVEL, Heading } from '~/common/headingManager';
 import { isVersionedPath } from '~/common/routes';
 import { prefersReducedMotion } from '~/common/window';
 import { HeadingManagerProps, HeadingsContext } from '~/common/withHeadingManager';
-import { ScrollContainer } from '~/components/ScrollContainer';
+import { type ScrollContainerHandle } from '~/components/ScrollContainer';
 import { CALLOUT } from '~/ui/components/Text';
 
 import { TableOfContentsLink } from './TableOfContentsLink';
@@ -30,8 +30,8 @@ const ACTIVE_ITEM_OFFSET_FACTOR = 1 / 20;
 
 export type TableOfContentsProps = PropsWithChildren<{
   maxNestingDepth?: number;
-  selfRef?: RefObject<ScrollContainer | null>;
-  contentRef?: RefObject<ScrollContainer | null>;
+  selfRef?: RefObject<ScrollContainerHandle | null>;
+  contentRef?: RefObject<ScrollContainerHandle | null>;
 }>;
 
 export type TableOfContentsHandles = {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18172

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Convert `DocumentationNestedScrollLayout` and `ScrollContainer` to React 19 function components
- Add type-safe throttle utility with 150ms delay
- Apply GPU acceleration to scroll containers
- Add will-change hints for sidebar/content transitions  
- Optimize TOC heading loop with early exit
- Prevent unnecessary state updates during scroll
- Fixes scroll jank and blank layout issues on large pages like `notifications.mdx`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Run the docs app locally (`yarn run dev`) and visit http://localhost:3002/versions/latest/sdk/notifications/
- Hover over the header or the collapse toggle and scroll the page, which should not scroll because the content is not in view

## Preview


https://github.com/user-attachments/assets/f64d2ed1-984e-4db8-bfd7-9fd2c431dc58



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
