### PR TITLE
[docs] Convert `HeadingManager` class to function component

### DIFF
--- a/docs/common/headingManager.test.ts
+++ b/docs/common/headingManager.test.ts
@@ -1,6 +1,6 @@
 import GithubSlugger from 'github-slugger';
 
-import { BASE_HEADING_LEVEL, HeadingManager, HeadingType } from './headingManager';
+import { BASE_HEADING_LEVEL, HeadingType, createHeadingManager } from './headingManager';
 
 const SluggerStub: GithubSlugger = {
   occurrences: {},
@@ -11,7 +11,7 @@ const SluggerStub: GithubSlugger = {
 describe('HeadingManager tests', () => {
   test('instantiates properly', () => {
     const meta = { maxHeadingDepth: 2, headings: [] };
-    const headingManager = new HeadingManager(SluggerStub, meta);
+    const headingManager = createHeadingManager(SluggerStub, meta);
 
     expect(headingManager.headings).toEqual([]);
     expect(headingManager.metadata.headings).toEqual([]);
@@ -21,18 +21,18 @@ describe('HeadingManager tests', () => {
   test('_findMetaForTitle not returning same title twice', () => {
     const TITLE = 'Some Title';
     const meta = { headings: [{ title: TITLE, depth: 1, type: 'text', _processed: true }] };
-    const headingManager = new HeadingManager(SluggerStub, meta);
+    const headingManager = createHeadingManager(SluggerStub, meta);
 
-    const result = headingManager['findMetaForTitle'](TITLE);
+    const result = headingManager.findMetaForTitle?.(TITLE);
     expect(result).toBeUndefined();
   });
 
   test('_findMetaForTitle marks meta as processed', () => {
     const TITLE = 'Some Title';
     const meta = { headings: [{ title: TITLE, depth: 1, type: 'text' }] };
-    const headingManager = new HeadingManager(SluggerStub, meta);
+    const headingManager = createHeadingManager(SluggerStub, meta);
 
-    const result = headingManager['findMetaForTitle'](TITLE);
+    const result = headingManager.findMetaForTitle?.(TITLE);
     expect(result?._processed).toBeTruthy();
   });
 });
@@ -44,7 +44,7 @@ describe('HeadingManager.addHeading()', () => {
     maxHeadingDepth: 3,
     headings: [{ title: META_TITLE, depth: META_LEVEL, type: 'text' }],
   };
-  const headingManager = new HeadingManager(SluggerStub, meta);
+  const headingManager = createHeadingManager(SluggerStub, meta);
 
   test('finds info from meta', () => {
     const result = headingManager.addHeading(META_TITLE);

--- a/docs/common/test-utilities.tsx
+++ b/docs/common/test-utilities.tsx
@@ -5,12 +5,12 @@ import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtim
 import { type NextRouter } from 'next/router';
 import { type PropsWithChildren, type ReactElement } from 'react';
 
-import { HeadingManager } from '~/common/headingManager';
+import { createHeadingManager } from '~/common/headingManager';
 import { HeadingsContext } from '~/common/withHeadingManager';
 
 const Wrapper = ({ children }: PropsWithChildren) => (
   <TooltipProvider>
-    <HeadingsContext.Provider value={new HeadingManager(new GithubSlugger(), { headings: [] })}>
+    <HeadingsContext.Provider value={createHeadingManager(new GithubSlugger(), { headings: [] })}>
       {children}
     </HeadingsContext.Provider>
   </TooltipProvider>

--- a/docs/common/withHeadingManager.tsx
+++ b/docs/common/withHeadingManager.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren, createContext, ComponentType } from 'react';
 
-import { HeadingManager } from '~/common/headingManager';
+import { type HeadingManager } from '~/common/headingManager';
 
 export const HeadingsContext = createContext<HeadingManager | null>(null);
 

--- a/docs/components/DocumentationPageWrapper.tsx
+++ b/docs/components/DocumentationPageWrapper.tsx
@@ -1,7 +1,7 @@
 import GithubSlugger from 'github-slugger';
 import type { PropsWithChildren } from 'react';
 
-import { HeadingManager } from '~/common/headingManager';
+import { createHeadingManager } from '~/common/headingManager';
 import { HeadingsContext } from '~/common/withHeadingManager';
 import DocumentationPage from '~/components/DocumentationPage';
 import { PageApiVersionProvider } from '~/providers/page-api-version';
@@ -16,7 +16,7 @@ type DocumentationElementsProps = PropsWithChildren<{
 
 export function DocumentationPageWrapper(props: DocumentationElementsProps) {
   const slugger = new GithubSlugger();
-  const manager = new HeadingManager(slugger, {
+  const manager = createHeadingManager(slugger, {
     ...props.meta,
     headings: props.headings,
   });

--- a/docs/ui/components/Collapsible/Collapsible.test.tsx
+++ b/docs/ui/components/Collapsible/Collapsible.test.tsx
@@ -2,13 +2,13 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import GithubSlugger from 'github-slugger';
 import { PropsWithChildren } from 'react';
 
-import { HeadingManager } from '~/common/headingManager';
+import { createHeadingManager } from '~/common/headingManager';
 import { HeadingsContext } from '~/common/withHeadingManager';
 
 import { Collapsible } from '.';
 
 const prepareHeadingManager = () => {
-  return new HeadingManager(new GithubSlugger(), { headings: [] });
+  return createHeadingManager(new GithubSlugger(), { headings: [] });
 };
 
 const WrapWithContext = ({ children }: PropsWithChildren) => {

--- a/docs/ui/components/Navigation/Navigation.test.tsx
+++ b/docs/ui/components/Navigation/Navigation.test.tsx
@@ -6,14 +6,14 @@ import { MemoryRouterProvider } from 'next-router-mock/MemoryRouterProvider';
 import { u as node } from 'unist-builder';
 import { visit } from 'unist-util-visit';
 
-import { HeadingManager } from '~/common/headingManager';
+import { createHeadingManager } from '~/common/headingManager';
 import { HeadingsContext } from '~/common/withHeadingManager';
 
 import { findActiveRoute, Navigation } from './Navigation';
 import { NavigationNode } from './types';
 
 function prepareHeadingManager() {
-  return new HeadingManager(new GithubSlugger(), { headings: [] });
+  return createHeadingManager(new GithubSlugger(), { headings: [] });
 }
 
 jest.mock('next/router', () => mockRouter);

--- a/docs/ui/components/TableOfContents/TableOfContents.test.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContents.test.tsx
@@ -1,7 +1,7 @@
 import { jest } from '@jest/globals';
 import GithubSlugger from 'github-slugger';
 
-import { HeadingManager, HeadingType } from '~/common/headingManager';
+import { HeadingType, createHeadingManager } from '~/common/headingManager';
 import { renderWithHeadings } from '~/common/test-utilities';
 import { HeadingsContext } from '~/common/withHeadingManager';
 
@@ -13,7 +13,7 @@ Object.defineProperty(window, 'matchMedia', {
 });
 
 const prepareHeadingManager = () => {
-  const headingManager = new HeadingManager(new GithubSlugger(), { headings: [] });
+  const headingManager = createHeadingManager(new GithubSlugger(), { headings: [] });
   headingManager.addHeading('Base level heading', undefined, {});
   headingManager.addHeading('Level 3 subheading', 3, {});
   headingManager.addHeading('Code heading depth 1', 0, {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18174

# How

<!--
How did you build this feature or fix this bug and why?
-->

Convert the `HeadingManager` class to a function component.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn run test`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
