### PR TITLE
Add Cloudflare tunnel provider

### DIFF
--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -113,7 +113,7 @@ Will open apps to: `exp://expo.dev:80` (the `:80` is a temporary workaround for 
 
 Restrictive network conditions (common for public Wi-Fi), firewalls (common for Windows users), or Emulator misconfiguration can make it difficult to connect a remote device to your dev server over lan/localhost.
 
-Sometimes it's easier to connect to a dev server over a proxy URL that's accessible from any device with internet access, this is referred to as **tunneling**. `npx expo start` provides built-in support for **tunneling** via [ngrok][ngrok].
+Sometimes it's easier to connect to a dev server over a proxy URL that's accessible from any device with internet access, this is referred to as **tunneling**. `npx expo start` provides built-in support for **tunneling** via [ngrok][ngrok] (default) or Cloudflare quick tunnels.
 
 To enable tunneling, first install `@expo/ngrok`:
 
@@ -125,7 +125,9 @@ Then run the following to start your dev server from a _tunnel_ URL:
 
 This will serve your app from a public URL like: `https://xxxxxxx.bacon.19000.exp.direct:80`.
 
-Use the `EXPO_TUNNEL_SUBDOMAIN` environment variable to experimentally set the subdomain for the tunnel URL. This is useful for testing universal links on iOS. This may cause unexpected issues with `expo-linking` and Expo Go. Select the exact subdomain to use by passing a `string` value that is not one of: `true`, `false`, `1`, `0`.
+Use the `EXPO_TUNNEL_SUBDOMAIN` environment variable to experimentally set the subdomain for the tunnel URL. This is useful for testing universal links on iOS. This may cause unexpected issues with `expo-linking` and Expo Go. Select the exact subdomain to use by passing a `string` value that is not one of: `true`, `false`, `1`, `0`. This setting is only used for ngrok tunnels.
+
+To use Cloudflare instead of ngrok, set `EXPO_TUNNEL_PROVIDER=cloudflare` before running `npx expo start --tunnel` and install the [`cloudflared`](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation/) CLI so it is available on your `PATH`. Cloudflare quick tunnels return a host like `https://...trycloudflare.com` and don't require a Cloudflare account.
 
 **Drawbacks**
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added support for bundling apps with a new error overlay from `@expo/log-box` package ([#39958](https://github.com/expo/expo/pull/39958) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Ensure `loader()` functions are stripped from client bundles ([#40670](https://github.com/expo/expo/pull/40670) by [@hassankhan](https://github.com/hassankhan))
 - Add support for server data loaders in static export mode ([#40130](https://github.com/expo/expo/pull/40130) by [@hassankhan](https://github.com/hassankhan))
+- Add Cloudflare tunnel provider ([#41170](https://github.com/expo/expo/pull/41170) by [@iPalash](https://github.com/iPalash))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/start/index.ts
+++ b/packages/@expo/cli/src/start/index.ts
@@ -64,7 +64,7 @@ export const expoStart: Command = async (argv) => {
         ``,
         chalk`-m, --host <string>             Dev server hosting type. {dim Default: lan}`,
         chalk`                                {bold lan}: Use the local network`,
-        chalk`                                {bold tunnel}: Use any network by tunnel through ngrok`,
+        chalk`                                {bold tunnel}: Use any network by tunnel (ngrok by default, or Cloudflare when EXPO_TUNNEL_PROVIDER=cloudflare)`,
         chalk`                                {bold localhost}: Connect to the dev server over localhost`,
         `--tunnel                        Same as --host tunnel`,
         `--lan                           Same as --host lan`,

--- a/packages/@expo/cli/src/start/server/AsyncCloudflareTunnel.ts
+++ b/packages/@expo/cli/src/start/server/AsyncCloudflareTunnel.ts
@@ -1,0 +1,165 @@
+import chalk from 'chalk';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+
+import * as Log from '../../log';
+import { delayAsync, resolveWithTimeout } from '../../utils/delay';
+import { env } from '../../utils/env';
+import { CommandError } from '../../utils/errors';
+
+const debug = require('debug')('expo:start:server:cloudflare') as typeof console.log;
+
+const TUNNEL_TIMEOUT = 10 * 1000;
+
+export class AsyncCloudflareTunnel {
+  /** Info about the currently running instance of cloudflared. */
+  private serverUrl: string | null = null;
+  private child: ChildProcessWithoutNullStreams | null = null;
+
+  constructor(
+    private projectRoot: string,
+    private port: number
+  ) {}
+
+  public getActiveUrl(): string | null {
+    return this.serverUrl;
+  }
+
+  async startAsync({ timeout }: { timeout?: number } = {}): Promise<void> {
+    this.serverUrl = await this._connectToCloudflareAsync({ timeout });
+
+    debug('Tunnel URL:', this.serverUrl);
+    Log.log('Tunnel ready.');
+  }
+
+  async stopAsync(): Promise<void> {
+    debug('Stopping Cloudflare tunnel');
+    if (this.child) {
+      this.child.removeAllListeners();
+      // Gracefully terminate the child process; fall back to SIGKILL if it lingers.
+      this.child.kill();
+      const proc = this.child;
+      this.child = null;
+      await Promise.race([
+        new Promise<void>((resolve) => proc.once('exit', () => resolve())),
+        delayAsync(1000),
+      ]);
+    }
+    this.serverUrl = null;
+  }
+
+  private async _connectToCloudflareAsync(
+    options: { timeout?: number } = {},
+    attempts: number = 0
+  ): Promise<string> {
+    await this.stopAsync();
+
+    debug('Using project root', this.projectRoot);
+    const cloudflaredBin = env.EXPO_CLOUDFLARED_PATH || 'cloudflared';
+    const args = [
+      'tunnel',
+      '--no-autoupdate',
+      '--url',
+      `http://localhost:${this.port}`,
+    ];
+
+    debug('Starting cloudflared:', cloudflaredBin, args.join(' '));
+
+    let child: ChildProcessWithoutNullStreams;
+    try {
+      child = spawn(cloudflaredBin, args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch (error: any) {
+      throw new CommandError(
+        'CLOUDFLARE_TUNNEL_START',
+        `Failed to launch cloudflared (${cloudflaredBin}). Install it from https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation/ or set EXPO_CLOUDFLARED_PATH.\n${error?.message ?? error}`
+      );
+    }
+
+    this.child = child;
+
+    try {
+      const result = await resolveWithTimeout(
+        () => this.readCloudflareUrlAsync(child, attempts),
+        {
+          timeout: options.timeout ?? TUNNEL_TIMEOUT,
+          errorMessage: 'cloudflare tunnel took too long to connect.',
+        }
+      );
+      if (typeof result === 'string') {
+        return result;
+      }
+    } catch (error) {
+      await this.stopAsync();
+      throw error;
+    }
+
+    // Stop any existing process before retrying.
+    await this.stopAsync();
+    // Wait 100ms and then try again
+    await delayAsync(100);
+
+    return this._connectToCloudflareAsync(options, attempts + 1);
+  }
+
+  private async readCloudflareUrlAsync(
+    child: ChildProcessWithoutNullStreams,
+    attempts: number
+  ): Promise<string | false> {
+    return await new Promise((resolve, reject) => {
+      let resolved: string | null = null;
+      const cleanup = () => {
+        child.stdout.removeListener('data', onOutput);
+        child.stderr.removeListener('data', onOutput);
+        child.removeListener('exit', onExit);
+        child.removeListener('error', onError);
+      };
+
+      const onExit = (code: number | null) => {
+        cleanup();
+        if (resolved) {
+          resolve(resolved);
+          return;
+        }
+        reject(
+          new CommandError(
+            'CLOUDFLARE_TUNNEL_START',
+            `cloudflared exited unexpectedly (code ${code ?? 'unknown'}).`
+          )
+        );
+      };
+      const onError = (error: Error) => {
+        cleanup();
+        reject(
+          new CommandError(
+            'CLOUDFLARE_TUNNEL_START',
+            `Failed to start cloudflared. ${error.message}`
+          )
+        );
+      };
+
+      const onOutput = (buffer: Buffer) => {
+        const text = buffer.toString();
+        debug(text.trim());
+
+        const match = text.match(/https?:\/\/[-\w.]+\.trycloudflare\.com/);
+        if (match?.[0]) {
+          resolved = match[0];
+          cleanup();
+          resolve(resolved);
+        }
+      };
+
+      child.stdout.on('data', onOutput);
+      child.stderr.on('data', onOutput);
+      child.on('exit', onExit);
+      child.on('error', onError);
+    }).catch(async (error) => {
+      // Attempt to retry in a limited fashion.
+      if (attempts >= 2) {
+        throw error;
+      }
+      return false;
+    });
+  }
+}

--- a/packages/@expo/cli/src/start/server/UrlCreator.ts
+++ b/packages/@expo/cli/src/start/server/UrlCreator.ts
@@ -90,10 +90,11 @@ export class UrlCreator {
       return null;
     }
     const parsed = new URL(tunnelUrl);
+    const parsedProtocol = parsed.protocol ? parsed.protocol.replace(':', '') : undefined;
     return {
       port: parsed.port,
       hostname: parsed.hostname,
-      protocol: options.scheme ?? 'http',
+      protocol: options.scheme ?? parsedProtocol ?? 'http',
     };
   }
 

--- a/packages/@expo/cli/src/start/server/__mocks__/AsyncCloudflareTunnel.ts
+++ b/packages/@expo/cli/src/start/server/__mocks__/AsyncCloudflareTunnel.ts
@@ -1,0 +1,13 @@
+export class AsyncCloudflareTunnel {
+  private serverUrl: string | null = null;
+
+  getActiveUrl = jest.fn(() => this.serverUrl);
+
+  startAsync = jest.fn(async () => {
+    this.serverUrl = 'http://exp.cloudflare-tunnel.dev/foobar';
+  });
+
+  stopAsync = jest.fn(async () => {
+    this.serverUrl = null;
+  });
+}

--- a/packages/@expo/cli/src/start/server/__tests__/AsyncCloudflareTunnel-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/AsyncCloudflareTunnel-test.ts
@@ -1,0 +1,80 @@
+import { EventEmitter } from 'events';
+
+import { AsyncCloudflareTunnel } from '../AsyncCloudflareTunnel';
+
+jest.mock('../../../log');
+jest.mock('../../../utils/delay', () => ({
+  delayAsync: jest.fn(async () => {}),
+  resolveWithTimeout: jest.fn(async (fn) => fn()),
+}));
+
+type Spawned = EventEmitter & {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: jest.Mock;
+};
+
+const mockSpawn = jest.fn();
+jest.mock('node:child_process', () => ({
+  spawn: (...args: any[]) => mockSpawn(...args),
+}));
+
+function createSpawned(url?: string): Spawned {
+  const cp: Spawned = Object.assign(new EventEmitter(), {
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    kill: jest.fn(function kill(this: Spawned) {
+      this.emit('exit', 0);
+    }),
+  });
+
+  if (url) {
+    // Resolve on next tick once listeners are registered.
+    setImmediate(() => {
+      cp.stdout.emit('data', Buffer.from(`Your quick Tunnel has been created! ${url}\n`));
+    });
+  }
+
+  return cp;
+}
+
+describe('AsyncCloudflareTunnel', () => {
+  const projectRoot = '/';
+  const port = 3000;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('connects and exposes active url', async () => {
+    const url = 'https://example.trycloudflare.com';
+    mockSpawn.mockReturnValueOnce(createSpawned(url));
+
+    const tunnel = new AsyncCloudflareTunnel(projectRoot, port);
+    expect(tunnel.getActiveUrl()).toBeNull();
+    await tunnel.startAsync();
+    expect(tunnel.getActiveUrl()).toBe(url);
+  });
+
+  it('stops and kills child process', async () => {
+    const url = 'https://stop.trycloudflare.com';
+    const proc = createSpawned(url);
+    mockSpawn.mockReturnValueOnce(proc);
+
+    const tunnel = new AsyncCloudflareTunnel(projectRoot, port);
+    await tunnel.startAsync();
+    await tunnel.stopAsync();
+
+    expect(proc.kill).toHaveBeenCalled();
+    expect(tunnel.getActiveUrl()).toBeNull();
+  });
+
+  it('throws when cloudflared fails to launch', async () => {
+    mockSpawn.mockImplementationOnce(() => {
+      throw new Error('missing binary');
+    });
+
+    const tunnel = new AsyncCloudflareTunnel(projectRoot, port);
+    await expect(tunnel.startAsync()).rejects.toThrow(/cloudflared/i);
+  });
+});

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -128,6 +128,20 @@ class Env {
   }
 
   /**
+   * Selects the tunnel provider. Defaults to `ngrok`. Set to `cloudflare` to use Cloudflare quick tunnels.
+   */
+  get EXPO_TUNNEL_PROVIDER(): string {
+    return string('EXPO_TUNNEL_PROVIDER', 'ngrok');
+  }
+
+  /**
+   * Optional path override for the cloudflared binary.
+   */
+  get EXPO_CLOUDFLARED_PATH(): string {
+    return string('EXPO_CLOUDFLARED_PATH', '');
+  }
+
+  /**
    * Force Expo CLI to use the [`resolver.resolverMainFields`](https://facebook.github.io/metro/docs/configuration/#resolvermainfields) from the project `metro.config.js` for all platforms.
    *
    * By default, Expo CLI will use `['browser', 'module', 'main']` (default for Webpack) for web and the user-defined main fields for other platforms.


### PR DESCRIPTION
  # Why

  - Allow Expo CLI tunnels to use Cloudflare “quick tunnels” as an alternative to ngrok, giving HTTPS
  endpoints without extra setup and avoiding ngrok outages/rate limits.
  - Still default to ngrok; make provider choice explicit via an env var.

  # How

  - Added `AsyncCloudflareTunnel` that shells out to `cloudflared tunnel --no-autoupdate --url http://
  localhost:<port>` and parses the quick-tunnel URL.
  - Wired provider selection: `EXPO_TUNNEL_PROVIDER=cloudflare` picks Cloudflare; WebContainer still picks
  `AsyncWsTunnel`; otherwise ngrok remains default.
  - Exposed `EXPO_CLOUDFLARED_PATH` to point at a custom binary; kept existing `EXPO_TUNNEL_SUBDOMAIN` for
  ngrok.
  - Updated URL construction to preserve tunnel protocol (so Cloudflare tunnels stay https).
  - Added tests/mocks for the Cloudflare tunnel and provider selection; updated docs and CLI help to mention
  the Cloudflare option.

  # Test Plan

  - `yarn test AsyncCloudflareTunnel-test.ts --runInBand`
  - `yarn test BundlerDevServer-test.ts --runInBand`
  - `yarn test UrlCreator-test.ts --runInBand`
  - Manual: `EXPO_TUNNEL_PROVIDER=cloudflare EXPO_CLOUDFLARED_PATH=/opt/homebrew/bin/cloudflared npx expo
  start --tunnel` → received `https://...trycloudflare.com`, dev server reachable.

  # Checklist

  - [x] I added a `changelog.md` entry and rebuilt the package sources according to the guide.
  - [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin). - NA
  - [x] Conforms with the Documentation Writing Style Guide. 