### PR TITLE
[haptics][ios] WIP: Add support for iOS Core Haptics with pattern playback

### DIFF
--- a/packages/expo-haptics/ios/ExpoHaptics.podspec
+++ b/packages/expo-haptics/ios/ExpoHaptics.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
+  s.frameworks = 'CoreHaptics'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {

--- a/packages/expo-haptics/ios/ExpoHaptics.podspec
+++ b/packages/expo-haptics/ios/ExpoHaptics.podspec
@@ -18,7 +18,6 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.frameworks = 'CoreHaptics'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {

--- a/packages/expo-haptics/ios/HapticPattern.swift
+++ b/packages/expo-haptics/ios/HapticPattern.swift
@@ -1,0 +1,124 @@
+import ExpoModulesCore
+import CoreHaptics
+
+enum EventType: String, Enumerable {
+  case hapticTransient
+  case hapticContinuous
+
+  func toCHHapticEventType() -> CHHapticEvent.EventType {
+    switch self {
+    case .hapticTransient:
+      return .hapticTransient
+    case .hapticContinuous:
+      return .hapticContinuous
+    }
+  }
+}
+
+enum EventParameterID: String, Enumerable {
+  case hapticIntensity
+  case hapticSharpness
+  case attackTime
+  case decayTime
+  case releaseTime
+  case sustained
+
+  func toCHHapticEventParameterID() -> CHHapticEvent.ParameterID {
+    switch self {
+    case .hapticIntensity:
+      return .hapticIntensity
+    case .hapticSharpness:
+      return .hapticSharpness
+    case .attackTime:
+      return .attackTime
+    case .decayTime:
+      return .decayTime
+    case .releaseTime:
+      return .releaseTime
+    case .sustained:
+      return .sustained
+    }
+  }
+}
+
+enum DynamicParameterID: String, Enumerable {
+  case hapticIntensityControl
+  case hapticSharpnessControl
+
+  func toCHHapticDynamicParameterID() -> CHHapticDynamicParameter.ID {
+    switch self {
+    case .hapticIntensityControl:
+      return .hapticIntensityControl
+    case .hapticSharpnessControl:
+      return .hapticSharpnessControl
+    }
+  }
+}
+
+struct HapticEventParameter: Record {
+  @Field var parameterID: EventParameterID
+  @Field var value: Double
+}
+
+struct HapticEvent: Record {
+  @Field var eventType: EventType
+  @Field var time: Double?
+  @Field var eventDuration: Double?
+  @Field var parameters: [HapticEventParameter]?
+}
+
+struct HapticParameterCurveControlPoint: Record {
+  @Field var relativeTime: Double
+  @Field var value: Double
+}
+
+struct HapticParameterCurve: Record {
+  @Field var parameterID: DynamicParameterID
+  @Field var controlPoints: [HapticParameterCurveControlPoint]?
+  @Field var relativeTime: Double?
+}
+
+struct HapticPattern: Record {
+  @Field var events: [HapticEvent]
+  @Field var parameterCurves: [HapticParameterCurve]?
+}
+
+extension HapticEventParameter {
+  func toCHHapticParameter() -> CHHapticEventParameter {
+    CHHapticEventParameter(parameterID: parameterID.toCHHapticEventParameterID(), value: value)
+  }
+}
+
+extension HapticEvent {
+  func toCHHapticEvent() -> CHHapticEvent {
+    let params = (parameters ?? []).map { $0.toCHHapticParameter() }
+    let timeValue = time ?? 0.0
+    if let duration = eventDuration {
+      return CHHapticEvent(eventType: eventType.toCHHapticEventType(), parameters: params, relativeTime: timeValue, duration: duration)
+    } else {
+      return CHHapticEvent(eventType: eventType.toCHHapticEventType(), parameters: params, relativeTime: timeValue)
+    }
+  }
+}
+
+extension HapticParameterCurveControlPoint {
+  func toCHHapticParameterCurveControlPoint() -> CHHapticParameterCurve.ControlPoint {
+    CHHapticParameterCurve.ControlPoint(relativeTime: relativeTime, value: value)
+  }
+}
+
+extension HapticParameterCurve {
+  func toCHHapticParameterCurve() throws -> CHHapticParameterCurve {
+    let points = (controlPoints ?? []).map { $0.toCHHapticParameterCurveControlPoint() }
+    let startTime = relativeTime ?? 0.0
+    return try CHHapticParameterCurve(parameterID: parameterID.toCHHapticDynamicParameterID(), controlPoints: points, relativeTime: startTime)
+  }
+}
+
+extension HapticPattern {
+  func toCHHapticPattern() throws -> CHHapticPattern {
+    let events = self.events.map { $0.toCHHapticEvent() }
+    let curves = try (self.parameterCurves ?? []).map { try $0.toCHHapticParameterCurve() }
+    return try CHHapticPattern(events: events, parameterCurves: curves)
+  }
+}

--- a/packages/expo-haptics/ios/HapticsModule.swift
+++ b/packages/expo-haptics/ios/HapticsModule.swift
@@ -31,12 +31,12 @@ public class HapticsModule: Module {
     }
     .runOnQueue(.main)
 
-    AsyncFunction("playPatternAsync") { (patternData: HapticPatternData) in
+    AsyncFunction("playPatternAsync") { (pattern: HapticPattern) in
       guard CHHapticEngine.capabilitiesForHardware().supportsHaptics else { return }
       guard let engine = self.hapticEngine else { return }
 
-      let pattern = try patternData.toCHHapticPattern()
-      let player = try engine.makePlayer(with: pattern)
+      let chPattern = try pattern.toCHHapticPattern()
+      let player = try engine.makePlayer(with: chPattern)
       try player.start(atTime: CHHapticTimeImmediate)
     }
     .runOnQueue(.main)
@@ -81,119 +81,8 @@ public class HapticsModule: Module {
       }
     }
   }
-}
 
-struct HapticEventParameter: Record {
-  @Field var parameterID: String
-  @Field var value: Double
-}
-
-struct HapticEvent: Record {
-  @Field var eventType: String
-  @Field var time: Double?
-  @Field var eventDuration: Double?
-  @Field var parameters: [HapticEventParameter]?
-}
-
-struct HapticParameterCurveControlPoint: Record {
-  @Field var relativeTime: Double
-  @Field var value: Double
-}
-
-struct HapticParameterCurve: Record {
-  @Field var parameterID: String
-  @Field var controlPoints: [HapticParameterCurveControlPoint]?
-  @Field var relativeTime: Double?
-}
-
-struct HapticPatternData: Record {
-  @Field var events: [HapticEvent]
-  @Field var parameterCurves: [HapticParameterCurve]?
-}
-
-
-extension CHHapticEvent.EventType {
-  init(from string: String) throws {
-    switch string {
-    case "hapticTransient": self = .hapticTransient
-    case "hapticContinuous": self = .hapticContinuous
-    default:
-      throw NSError(domain: "ExpoHaptics", code: 1, userInfo: [NSLocalizedDescriptionKey: "Unknown event type: \(string)"])
-    }
-  }
-}
-
-extension CHHapticEvent.ParameterID {
-  init(from string: String) throws {
-    switch string {
-    case "hapticIntensity": self = .hapticIntensity
-    case "hapticSharpness": self = .hapticSharpness
-    case "attackTime": self = .attackTime
-    case "decayTime": self = .decayTime
-    case "releaseTime": self = .releaseTime
-    case "sustained": self = .sustained
-    default:
-      throw NSError(domain: "ExpoHaptics", code: 2, userInfo: [NSLocalizedDescriptionKey: "Unknown parameter ID: \(string)"])
-    }
-  }
-}
-
-extension CHHapticDynamicParameter.ID {
-  init(from string: String) throws {
-    switch string {
-    case "hapticIntensityControl": self = .hapticIntensityControl
-    case "hapticSharpnessControl": self = .hapticSharpnessControl
-    default:
-      throw NSError(domain: "ExpoHaptics", code: 3, userInfo: [NSLocalizedDescriptionKey: "Unknown dynamic parameter ID: \(string)"])
-    }
-  }
-}
-
-extension HapticEventParameter {
-  func toCHHapticParameter() throws -> CHHapticEventParameter {
-    let id = try CHHapticEvent.ParameterID(from: parameterID)
-    return CHHapticEventParameter(parameterID: id, value: value)
-  }
-}
-
-extension HapticEvent {
-  func toCHHapticEvent() throws -> CHHapticEvent {
-    let type = try CHHapticEvent.EventType(from: eventType)
-    let params = try (parameters ?? []).map { try $0.toCHHapticParameter() }
-    let timeValue = time ?? 0.0
-    if let duration = eventDuration {
-      return CHHapticEvent(eventType: type, parameters: params, relativeTime: timeValue, duration: duration)
-    } else {
-      return CHHapticEvent(eventType: type, parameters: params, relativeTime: timeValue)
-    }
-  }
-}
-
-extension HapticParameterCurveControlPoint {
-  func toCHHapticParameterCurveControlPoint() -> CHHapticParameterCurve.ControlPoint {
-    CHHapticParameterCurve.ControlPoint(relativeTime: relativeTime, value: value)
-  }
-}
-
-extension HapticParameterCurve {
-  func toCHHapticParameterCurve() throws -> CHHapticParameterCurve {
-    let id = try CHHapticDynamicParameter.ID(from: parameterID)
-    let points = (controlPoints ?? []).map { $0.toCHHapticParameterCurveControlPoint() }
-    let startTime = relativeTime ?? 0.0
-    return try CHHapticParameterCurve(parameterID: id, controlPoints: points, relativeTime: startTime)
-  }
-}
-
-extension HapticPatternData {
-  func toCHHapticPattern() throws -> CHHapticPattern {
-    let events = try self.events.map { try $0.toCHHapticEvent() }
-    let curves = try (self.parameterCurves ?? []).map { try $0.toCHHapticParameterCurve() }
-    return try CHHapticPattern(events: events, parameterCurves: curves)
-  }
-}
-
-private extension HapticsModule {
-  func initializeHapticEngine() {
+  private func initializeHapticEngine() {
     guard CHHapticEngine.capabilitiesForHardware().supportsHaptics else { return }
     do {
       hapticEngine = try CHHapticEngine()
@@ -203,7 +92,7 @@ private extension HapticsModule {
     }
   }
 
-  func cleanupHapticEngine() {
+  private func cleanupHapticEngine() {
     hapticEngine?.stop(completionHandler: nil)
     hapticEngine = nil
   }

--- a/packages/expo-haptics/ios/HapticsModule.swift
+++ b/packages/expo-haptics/ios/HapticsModule.swift
@@ -1,8 +1,14 @@
 import ExpoModulesCore
+import CoreHaptics
+
 
 public class HapticsModule: Module {
+  var hapticEngine: CHHapticEngine?
+
   public func definition() -> ModuleDefinition {
     Name("ExpoHaptics")
+
+    OnCreate { self.initializeHapticEngine() }
 
     AsyncFunction("notificationAsync") { (notificationType: NotificationType) in
       let generator = UINotificationFeedbackGenerator()
@@ -22,6 +28,16 @@ public class HapticsModule: Module {
       let generator = UISelectionFeedbackGenerator()
       generator.prepare()
       generator.selectionChanged()
+    }
+    .runOnQueue(.main)
+
+    AsyncFunction("playPatternAsync") { (patternData: HapticPatternData) in
+      guard CHHapticEngine.capabilitiesForHardware().supportsHaptics else { return }
+      guard let engine = self.hapticEngine else { return }
+
+      let pattern = try patternData.toCHHapticPattern()
+      let player = try engine.makePlayer(with: pattern)
+      try player.start(atTime: CHHapticTimeImmediate)
     }
     .runOnQueue(.main)
   }
@@ -64,5 +80,131 @@ public class HapticsModule: Module {
         return .rigid
       }
     }
+  }
+}
+
+struct HapticEventParameter: Record {
+  @Field var parameterID: String
+  @Field var value: Double
+}
+
+struct HapticEvent: Record {
+  @Field var eventType: String
+  @Field var time: Double?
+  @Field var eventDuration: Double?
+  @Field var parameters: [HapticEventParameter]?
+}
+
+struct HapticParameterCurveControlPoint: Record {
+  @Field var relativeTime: Double
+  @Field var value: Double
+}
+
+struct HapticParameterCurve: Record {
+  @Field var parameterID: String
+  @Field var controlPoints: [HapticParameterCurveControlPoint]?
+  @Field var relativeTime: Double?
+}
+
+struct HapticPatternData: Record {
+  @Field var events: [HapticEvent]
+  @Field var parameterCurves: [HapticParameterCurve]?
+}
+
+
+extension CHHapticEvent.EventType {
+  init(from string: String) throws {
+    switch string {
+    case "hapticTransient": self = .hapticTransient
+    case "hapticContinuous": self = .hapticContinuous
+    default:
+      throw NSError(domain: "ExpoHaptics", code: 1, userInfo: [NSLocalizedDescriptionKey: "Unknown event type: \(string)"])
+    }
+  }
+}
+
+extension CHHapticEvent.ParameterID {
+  init(from string: String) throws {
+    switch string {
+    case "hapticIntensity": self = .hapticIntensity
+    case "hapticSharpness": self = .hapticSharpness
+    case "attackTime": self = .attackTime
+    case "decayTime": self = .decayTime
+    case "releaseTime": self = .releaseTime
+    case "sustained": self = .sustained
+    default:
+      throw NSError(domain: "ExpoHaptics", code: 2, userInfo: [NSLocalizedDescriptionKey: "Unknown parameter ID: \(string)"])
+    }
+  }
+}
+
+extension CHHapticDynamicParameter.ID {
+  init(from string: String) throws {
+    switch string {
+    case "hapticIntensityControl": self = .hapticIntensityControl
+    case "hapticSharpnessControl": self = .hapticSharpnessControl
+    default:
+      throw NSError(domain: "ExpoHaptics", code: 3, userInfo: [NSLocalizedDescriptionKey: "Unknown dynamic parameter ID: \(string)"])
+    }
+  }
+}
+
+extension HapticEventParameter {
+  func toCHHapticParameter() throws -> CHHapticEventParameter {
+    let id = try CHHapticEvent.ParameterID(from: parameterID)
+    return CHHapticEventParameter(parameterID: id, value: value)
+  }
+}
+
+extension HapticEvent {
+  func toCHHapticEvent() throws -> CHHapticEvent {
+    let type = try CHHapticEvent.EventType(from: eventType)
+    let params = try (parameters ?? []).map { try $0.toCHHapticParameter() }
+    let timeValue = time ?? 0.0
+    if let duration = eventDuration {
+      return CHHapticEvent(eventType: type, parameters: params, relativeTime: timeValue, duration: duration)
+    } else {
+      return CHHapticEvent(eventType: type, parameters: params, relativeTime: timeValue)
+    }
+  }
+}
+
+extension HapticParameterCurveControlPoint {
+  func toCHHapticParameterCurveControlPoint() -> CHHapticParameterCurve.ControlPoint {
+    CHHapticParameterCurve.ControlPoint(relativeTime: relativeTime, value: value)
+  }
+}
+
+extension HapticParameterCurve {
+  func toCHHapticParameterCurve() throws -> CHHapticParameterCurve {
+    let id = try CHHapticDynamicParameter.ID(from: parameterID)
+    let points = (controlPoints ?? []).map { $0.toCHHapticParameterCurveControlPoint() }
+    let startTime = relativeTime ?? 0.0
+    return try CHHapticParameterCurve(parameterID: id, controlPoints: points, relativeTime: startTime)
+  }
+}
+
+extension HapticPatternData {
+  func toCHHapticPattern() throws -> CHHapticPattern {
+    let events = try self.events.map { try $0.toCHHapticEvent() }
+    let curves = try (self.parameterCurves ?? []).map { try $0.toCHHapticParameterCurve() }
+    return try CHHapticPattern(events: events, parameterCurves: curves)
+  }
+}
+
+private extension HapticsModule {
+  func initializeHapticEngine() {
+    guard CHHapticEngine.capabilitiesForHardware().supportsHaptics else { return }
+    do {
+      hapticEngine = try CHHapticEngine()
+      try hapticEngine?.start()
+    } catch {
+      print("ExpoHaptics: Failed to initialize haptic engine: \(error)")
+    }
+  }
+
+  func cleanupHapticEngine() {
+    hapticEngine?.stop(completionHandler: nil)
+    hapticEngine = nil
   }
 }

--- a/packages/expo-haptics/src/Haptics.ts
+++ b/packages/expo-haptics/src/Haptics.ts
@@ -1,7 +1,12 @@
 import { Platform, UnavailabilityError } from 'expo-modules-core';
 
 import ExpoHaptics from './ExpoHaptics';
-import { NotificationFeedbackType, ImpactFeedbackStyle, AndroidHaptics } from './Haptics.types';
+import {
+  NotificationFeedbackType,
+  ImpactFeedbackStyle,
+  AndroidHaptics,
+  HapticPatternData,
+} from './Haptics.types';
 
 // @needsAudit
 /**
@@ -63,4 +68,19 @@ export async function performAndroidHapticsAsync(type: AndroidHaptics) {
   await ExpoHaptics.performHapticsAsync(type);
 }
 
-export { NotificationFeedbackType, ImpactFeedbackStyle, AndroidHaptics };
+/**
+ * Plays a Core Haptics pattern on iOS using the device haptics engine.
+ *
+ * @platform ios
+ */
+export async function playPatternAsync(pattern: HapticPatternData): Promise<void> {
+  if (Platform.OS !== 'ios') {
+    return;
+  }
+  if (!ExpoHaptics?.playPatternAsync) {
+    throw new UnavailabilityError('Haptics', 'playPatternAsync');
+  }
+  await ExpoHaptics.playPatternAsync(pattern);
+}
+
+export { NotificationFeedbackType, ImpactFeedbackStyle, AndroidHaptics, HapticPatternData };

--- a/packages/expo-haptics/src/Haptics.types.ts
+++ b/packages/expo-haptics/src/Haptics.types.ts
@@ -129,3 +129,54 @@ export enum AndroidHaptics {
    */
   Text_Handle_Move = 'text-handle-move',
 }
+
+/** @platform ios */
+export type HapticEventType = 'hapticTransient' | 'hapticContinuous';
+
+/** @platform ios */
+export type HapticEventParameterID =
+  | 'hapticIntensity'
+  | 'hapticSharpness'
+  | 'attackTime'
+  | 'decayTime'
+  | 'releaseTime'
+  | 'sustained';
+
+/** @platform ios */
+export type HapticDynamicParameterID =
+  | 'hapticIntensityControl'
+  | 'hapticSharpnessControl';
+
+/** @platform ios */
+export type HapticEventParameter = {
+  parameterID: HapticEventParameterID;
+  value: number;
+};
+
+/** @platform ios */
+export type HapticEvent = {
+  eventType: HapticEventType;
+  time?: number;
+  eventDuration?: number;
+  parameters?: HapticEventParameter[];
+};
+
+/** @platform ios */
+export type HapticParameterCurveControlPoint = {
+  relativeTime: number;
+  value: number;
+};
+
+/** @platform ios */
+export type HapticParameterCurve = {
+  parameterID: HapticDynamicParameterID;
+  controlPoints: HapticParameterCurveControlPoint[];
+  relativeTime?: number;
+};
+
+/** @platform ios */
+export type HapticPatternData = {
+  events: HapticEvent[];
+  parameterCurves?: HapticParameterCurve[];
+};
+


### PR DESCRIPTION
# Why

This PR integrates a part of iOS [Core Haptics](https://developer.apple.com/documentation/corehaptics/) API into `expo-haptics` that allows playing custom haptic patterns. It omits the audio-related part of the framework and only focuses on the subset of API that works with haptic events.

We have this functionality implemented as a custom native expo module in [Fuse](https://fusewallet.com) app, we find it quite useful and potentially benefitting the community. Also: https://x.com/tsapeta/status/1992532424086127087 😀

# How

This is just still a WIP, I wanted to check if this approach makes sense for Expo, before writing docs and examples, so would be cool if @tsapeta (or whoever is responsible for this module) could take a look and give a green light to proceed.

# Test Plan

TODO

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
