### PR TITLE
[tools] fix the add-changelog command not working when prompting for package names

### DIFF
--- a/tools/src/commands/AddChangelog.ts
+++ b/tools/src/commands/AddChangelog.ts
@@ -26,17 +26,25 @@ async function checkOrAskForOptions(options: ActionOptions): Promise<ActionOptio
     filter: (s: string) => s.trim(),
     validate: lengthValidator,
   };
+  const listOfStringsValidator = {
+    filter: (s: string) =>
+      s
+        .trim()
+        .split(/\s+/g)
+        // avoid a case where the input string is empty
+        .filter((it) => it.length > 0),
+    validate: (list) => list.length > 0,
+    // inquirer calls this both before and after `filter` is applied
+    transformer: (listOrStr) => (typeof listOrStr === 'string' ? listOrStr : listOrStr.join(', ')),
+  };
 
   const questions: QuestionCollection[] = [];
   if (options.packageNames.length === 0) {
     questions.push({
       type: 'input',
-      name: 'package',
+      name: 'packageNames',
       message: 'What are the packages that you want to add a changelog entry?',
-      ...stringValidator,
-      transformer(input) {
-        return input.split(/\s+/g);
-      },
+      ...listOfStringsValidator,
     });
   }
 


### PR DESCRIPTION
# Why

The add-changelog command doesn't work if you provide the package name(s) interactively. It appears to have been broken for a few years since support for multiple package names was added.

# How

#18876 broke the interactive part for the package names argument. While the command line option was renamed from `package` to `packageNames`, we still store it under the key `package` when getting this option interactively.

Additionally, there is some confusion about how the filter/transformer/validate options work in `inquirer`. `transformer`, while it sounds like it transforms a string into whatever value type we want to use elsewhere, is actually just for formatting a value for display after it is entered. the splitting of the input string to an array should instead be done by `filter`.

# Test Plan

Fixed both these things, run the `add-changelog` command locally and try to pass multiple package names both as command line args and through the interactive interface. Seems to work OK.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
