### PR TITLE
Use the correct obj-c selector for universal links

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Universal links not working on cold start. ([#41185](https://github.com/expo/expo/pull/41185)) by [@jbaudanza](https://github.com/jbaudanza)
 - [iOS] Fix throwing `InvalidArgsNumberException` when declaring `AsyncFunction` with optional arguments and `Promise`. ([#41054](https://github.com/expo/expo/pull/41054) by [@Wenszel](https://github.com/Wenszel))
 - [core] [iOS] Addresses a potential crash where `[NSString UTF8String]` could return `nil` for certain string inputs (non-English), leading to an attempt to dereference a null pointer during `jsi::String` creation. ([#40639](https://github.com/expo/expo/pull/40639) by [@mohammadamin16](https://github.com/mohammadamin16))
 - [iOS] Fix `Either` conversion in `Record` ([#40655](https://github.com/expo/expo/pull/40655) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriberManager.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriberManager.swift
@@ -285,7 +285,7 @@ public class ExpoAppDelegateSubscriberManager: NSObject {
     continue userActivity: NSUserActivity,
     restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
   ) -> Bool {
-    let selector = #selector(application(_:continue:restorationHandler:))
+    let selector = NSSelectorFromString("application:continueUserActivity:restorationHandler:")
     let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
     var subscribersLeft = subs.count
     let dispatchQueue = DispatchQueue(label: "expo.application.continueUserActivity", qos: .userInteractive)

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriberManager.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriberManager.swift
@@ -316,7 +316,7 @@ public class ExpoAppDelegateSubscriberManager: NSObject {
     continue userActivity: NSUserActivity,
     restorationHandler: @escaping ([any NSUserActivityRestoring]) -> Void
   ) -> Bool {
-    let selector = #selector(application(_:continue:restorationHandler:))
+    let selector = NSSelectorFromString("application:continueUserActivity:restorationHandler:")
     let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
     var subscribersLeft = subs.count
     let dispatchQueue = DispatchQueue(label: "expo.application.continueUserActivity", qos: .userInteractive)
@@ -365,7 +365,7 @@ public class ExpoAppDelegateSubscriberManager: NSObject {
     performActionFor shortcutItem: UIApplicationShortcutItem,
     completionHandler: @escaping (Bool) -> Void
   ) {
-    let selector = #selector(application(_:performActionFor:completionHandler:))
+    let selector = NSSelectorFromString("application:performActionForShortcutItem:completionHandler:")
     let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
     var subscribersLeft = subs.count
     var result: Bool = false
@@ -471,7 +471,7 @@ public class ExpoAppDelegateSubscriberManager: NSObject {
     let infoPlistOrientations = deviceOrientationMask.isEmpty ? universalOrientationMask : deviceOrientationMask
 
     let parsedSubscribers = ExpoAppDelegateSubscriberRepository.subscribers.filter {
-      $0.responds(to: #selector(application(_:supportedInterfaceOrientationsFor:)))
+      $0.responds(to: NSSelectorFromString("application:supportedInterfaceOrientationsForWindow:"))
     }
 
     // We want to create an intersection of all orientations set by subscribers.


### PR DESCRIPTION
# Why

Universal links currently don't work on expo on iOS when starting from cold boot. There are some user's reporting this issue here: https://github.com/expo/expo/issues/37401

The root cause is a mismatched obj-c selector. I believe this was introduced in this PR: https://github.com/expo/expo/pull/40008. When the base class changed from `UIApplicationDelegate` to just `NSObject`, then the `#selector` keyword stopped being a suitable tool to derive the correct selector.

The correct selector is `application:continueUserActivity:restorationHandler:`, as defined here: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/application(_:continue:restorationhandler:)?language=objc

This PR is only to fix universal links, but I suspect other selectors also broken in https://github.com/expo/expo/pull/40008.

# How

Deep links were not working in my app, so I debugged the ExpoAppDelegateSubscriberManager class and noticed that none of the subscribers were matching the selector.

# Test Plan

- Create an expo app that uses a universal link to navigate to a route.
- With the app CLOSED, try to open the link on your device
- BEFORE PR: App will navigate to home screen
- AFTER PR: App will navigate to the correct page

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
