### PR TITLE
[docs] Emphasize installing `tsx` in TypeScript guide

### DIFF
--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -185,7 +185,9 @@ Some Expo libraries provide both static types and type generation capabilities. 
 
 ## TypeScript for project's config files
 
-Additional setup is required to use TypeScript for configuration files such as **metro.config.js** or **app.config.js**. You need to utilize [`tsx/cjs` require hook](https://tsx.is/dev-api/entry-point#commonjs-mode-only) to import TypeScript files within your JS config file. This hook allows TypeScript imports while keeping the root file as JavaScript.
+Additional setup is required to use TypeScript for configuration files such as **metro.config.js** or **app.config.js**.
+
+Install [`tsx`](https://tsx.is/) as a dev dependency and utilize its [`tsx/cjs` require hook](https://tsx.is/dev-api/entry-point#commonjs-mode-only) to import TypeScript files within your JS configuration file. This hook allows TypeScript imports while keeping the root file as JavaScript. The command below adds `tsx` so `import 'tsx/cjs'` works in the following sub-section examples.
 
 <Tabs>
 
@@ -208,7 +210,7 @@ Additional setup is required to use TypeScript for configuration files such as *
 Update **metro.config.js** to require **metro.config.ts** file:
 
 ```js metro.config.js
-require('tsx/cjs');
+require('tsx/cjs'); // Add this to import TypeScript files
 module.exports = require('./metro.config.ts');
 ```
 
@@ -227,7 +229,7 @@ module.exports = config;
 Install the `@expo/webpack-config` package.
 
 ```js webpack.config.js
-require('tsx/cjs');
+require('tsx/cjs'); // Add this to import TypeScript files
 module.exports = require('./webpack.config.ts');
 ```
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18137

# How

<!--
How did you build this feature or fix this bug and why?
-->

Emphasize installing `tsx` in TypeScript guide.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
