### PR TITLE
[github][docs] Add Install workspace deps on cache miss

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,6 +38,13 @@ jobs:
           yarn-docs: 'true'
           yarn-tools: 'true'
           yarn-workspace: 'true'
+      - name: 🧶 Install workspace deps on cache miss
+        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
+        run: yarn install --immutable
+      - name: 🧶 Install tools deps on cache miss
+        if: steps.expo-caches.outputs.yarn-tools-hit != 'true'
+        working-directory: tools
+        run: yarn install --immutable
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 📝 Regenerate `unversioned` data for Docs


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

We're getting errors continuously when merging docs PRs to production. Recent: https://github.com/expo/expo/actions/runs/19634022661/job/56220838923

<img width="3566" height="1874" alt="CleanShot 2025-11-24 at 18 01 05@2x" src="https://github.com/user-attachments/assets/69dbc295-230b-4d2c-b200-ce38ae3df8a8" />

My guess is that it is related to root cache issues, which are now unavailable. Comparing it to a PR (https://github.com/expo/expo/actions/runs/19631578507/job/56212405852) that was successfully merged earlier today:

<img width="3572" height="1378" alt="CleanShot 2025-11-24 at 18 06 05@2x" src="https://github.com/user-attachments/assets/7e51a194-fa8b-4845-83f4-880de52881a0" />


# How

<!--
How did you build this feature or fix this bug and why?
-->

Install workspace deps when the root cache misses and tools deps when the tools cache misses before running expotools generate-docs-api-data in .github/workflows/docs.yml.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

CI in this job should pass.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
