### PR TITLE
[blob][web] Fix export to match other platforms

### DIFF
--- a/packages/expo-blob/CHANGELOG.md
+++ b/packages/expo-blob/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `Blob` export on web.
+
 ### 💡 Others
 
 ## 0.1.6 — 2025-09-11

--- a/packages/expo-blob/CHANGELOG.md
+++ b/packages/expo-blob/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed `Blob` export on web.
+- Fixed `Blob` export on web. ([#41195](https://github.com/expo/expo/pull/41195) by [@barthap](https://github.com/barthap))
 
 ### 💡 Others
 

--- a/packages/expo-blob/build/ExpoBlob.web.d.ts
+++ b/packages/expo-blob/build/ExpoBlob.web.d.ts
@@ -1,5 +1,6 @@
-export declare const ExpoBlob: {
+declare const ExpoBlob: {
     new (blobParts?: BlobPart[], options?: BlobPropertyBag): Blob;
     prototype: Blob;
 };
+export { ExpoBlob as Blob };
 //# sourceMappingURL=ExpoBlob.web.d.ts.map

--- a/packages/expo-blob/build/ExpoBlob.web.d.ts.map
+++ b/packages/expo-blob/build/ExpoBlob.web.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"ExpoBlob.web.d.ts","sourceRoot":"","sources":["../src/ExpoBlob.web.ts"],"names":[],"mappings":"AAAA,eAAO,MAAM,QAAQ;;;CAAO,CAAC"}
+{"version":3,"file":"ExpoBlob.web.d.ts","sourceRoot":"","sources":["../src/ExpoBlob.web.ts"],"names":[],"mappings":"AAAA,QAAA,MAAM,QAAQ;;;CAAO,CAAC;AACtB,OAAO,EAAE,QAAQ,IAAI,IAAI,EAAE,CAAC"}

--- a/packages/expo-blob/build/ExpoBlob.web.js
+++ b/packages/expo-blob/build/ExpoBlob.web.js
@@ -1,2 +1,3 @@
-export const ExpoBlob = Blob;
+const ExpoBlob = Blob;
+export { ExpoBlob as Blob };
 //# sourceMappingURL=ExpoBlob.web.js.map

--- a/packages/expo-blob/build/ExpoBlob.web.js.map
+++ b/packages/expo-blob/build/ExpoBlob.web.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"ExpoBlob.web.js","sourceRoot":"","sources":["../src/ExpoBlob.web.ts"],"names":[],"mappings":"AAAA,MAAM,CAAC,MAAM,QAAQ,GAAG,IAAI,CAAC","sourcesContent":["export const ExpoBlob = Blob;\n"]}
+{"version":3,"file":"ExpoBlob.web.js","sourceRoot":"","sources":["../src/ExpoBlob.web.ts"],"names":[],"mappings":"AAAA,MAAM,QAAQ,GAAG,IAAI,CAAC;AACtB,OAAO,EAAE,QAAQ,IAAI,IAAI,EAAE,CAAC","sourcesContent":["const ExpoBlob = Blob;\nexport { ExpoBlob as Blob };\n"]}

--- a/packages/expo-blob/src/ExpoBlob.web.ts
+++ b/packages/expo-blob/src/ExpoBlob.web.ts
@@ -1,1 +1,2 @@
-export const ExpoBlob = Blob;
+const ExpoBlob = Blob;
+export { ExpoBlob as Blob };


### PR DESCRIPTION
# Why

Normally, Expo Blob object is exported as `Blob` - [see code](https://github.com/expo/expo/blob/4ce075814c3ffcb712057a2ac4c4bc4cbe1e0ae0/packages/expo-blob/src/ExpoBlob.ts#L23)
On web however, it is [exported as `ExpoBlob`](https://github.com/expo/expo/blob/4ce075814c3ffcb712057a2ac4c4bc4cbe1e0ae0/packages/expo-blob/src/ExpoBlob.web.ts#L1).
This causes runtime error when using imported `import { Blob} from 'expo-blob'` on web: `TypeError: _expoBlob.Blob is not a constructor`.

Workarounds with platform-specific imports are needed:

```ts
// android / iOS - some-file.ts
import { Blob } from "expo-blob";

// web - some-file.web.ts
import { ExpoBlob as Blob } from "expo-blob";
```

# How

Fixed web export to match the regular one.

# Test Plan

Created a new Expo app, added expo-blob (patched with this PR),
Created a Blob object and confirmed that the code worked on both web and simulator.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
