### PR TITLE
[audio][iOS] fix incorrect notify others on deactivation

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [web] Bring fix from [#38273](https://github.com/expo/expo/pull/38273) to web. ([#40802](https://github.com/expo/expo/pull/40802) by [@alanjhughes](https://github.com/alanjhughes)
 - [Android] Use correct method to start foreground service on android 14+. ([#41145](https://github.com/expo/expo/pull/41145) by [@alanjhughes](https://github.com/alanjhughes))
 - [Web] Fix recording options not being applied to web correctly. ([#41154](https://github.com/expo/expo/pull/41154) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix incorrect notify others on deactivation ([#41196](https://github.com/expo/expo/pull/41196) by [@dylancom](https://github.com/dylancom))
 
 ### 💡 Others
 

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -408,7 +408,7 @@ public class AudioModule: Module {
 
   private func handleInterruptionEnded(with options: AVAudioSession.InterruptionOptions) {
     do {
-      try AVAudioSession.sharedInstance().setActive(true, options: [.notifyOthersOnDeactivation])
+      try AVAudioSession.sharedInstance().setActive(true)
       if options.contains(.shouldResume) {
         resumeInterruptedPlayers()
       }
@@ -509,7 +509,7 @@ public class AudioModule: Module {
     }
 
     do {
-      try AVAudioSession.sharedInstance().setActive(isActive, options: [.notifyOthersOnDeactivation])
+      try AVAudioSession.sharedInstance().setActive(isActive, options: isActive ? [] : [.notifyOthersOnDeactivation])
       sessionIsActive = isActive
     } catch {
       throw AudioStateException(error.localizedDescription)
@@ -582,7 +582,7 @@ public class AudioModule: Module {
   }
 
   private func activateSession() throws {
-    try AVAudioSession.sharedInstance().setActive(true, options: [.notifyOthersOnDeactivation])
+    try AVAudioSession.sharedInstance().setActive(true)
   }
 
   private func deactivateSession() {


### PR DESCRIPTION
# Why

Currently .notifyOthersOnDeactivation is always passed as an option also when activating an audio session.

The docs state:
**Only use this option when deactivating your audio session; that is, when you pass a value of [false](https://developer.apple.com/documentation/Swift/false) to the [setActive(_:options:)](https://developer.apple.com/documentation/avfaudio/avaudiosession/setactive(_:options:)) instance method.**

# How

Only add `.notifyOthersOnDeactivation` option when actually deactivating an audio session.

# Test Plan

See the docs: https://developer.apple.com/documentation/AVFAudio/AVAudioSession/SetActiveOptions/notifyOthersOnDeactivation#Discussion