### PR TITLE
chore: add missing dependencies

### DIFF
--- a/packages/@expo/log-box/package.json
+++ b/packages/@expo/log-box/package.json
@@ -24,6 +24,7 @@
     "stacktrace-parser": "^0.1.10"
   },
   "devDependencies": {
+    "@expo/metro-runtime": "^6.1.2",
     "@expo/spawn-async": "^1.7.2",
     "@types/react": "~19.2.0",
     "expo-module-scripts": "^5.0.7",

--- a/packages/@expo/metro-runtime/package.json
+++ b/packages/@expo/metro-runtime/package.json
@@ -50,6 +50,7 @@
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
+    "expo-module-scripts": "^5.0.7",
     "react-dom": "19.2.0"
   }
 }

--- a/packages/@expo/osascript/package.json
+++ b/packages/@expo/osascript/package.json
@@ -41,6 +41,7 @@
     "exec-async": "^2.2.0"
   },
   "devDependencies": {
+    "@types/node": "^22.14.0",
     "expo-module-scripts": "^5.0.7"
   },
   "publishConfig": {

--- a/packages/@expo/osascript/tsconfig.json
+++ b/packages/@expo/osascript/tsconfig.json
@@ -8,8 +8,7 @@
     "sourceMap": true,
     "typeRoots": [
       "ts-declarations",
-      "../../expo-module-scripts/ts-declarations",
-      "../../../node_modules/@types"
+      "../../expo-module-scripts/ts-declarations"
     ]
   },
 }

--- a/packages/expo-doctor/package.json
+++ b/packages/expo-doctor/package.json
@@ -33,6 +33,7 @@
     "prepublishOnly": "expo-module prepublishOnly"
   },
   "devDependencies": {
+    "@expo/cli": "*",
     "@expo/config": "~12.0.9",
     "@expo/env": "~2.0.7",
     "@expo/json-file": "~10.0.7",

--- a/packages/expo-server/package.json
+++ b/packages/expo-server/package.json
@@ -60,6 +60,7 @@
   ],
   "devDependencies": {
     "@types/express": "^5.0.3",
+    "expo-module-scripts": "^5.0.7",
     "npm-run-all2": "^8.0.4",
     "rimraf": "^6.1.2"
   },

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -98,6 +98,8 @@
     "whatwg-url-without-unicode": "8.0.0-3"
   },
   "devDependencies": {
+    "@expo/dom-webview": "0.2.7",
+    "@expo/metro-runtime": "^6.1.2",
     "@types/node": "^22.14.0",
     "@types/react": "~19.2.0",
     "@types/react-test-renderer": "~19.1.0",

--- a/packages/patch-project/package.json
+++ b/packages/patch-project/package.json
@@ -42,6 +42,7 @@
   },
   "homepage": "https://github.com/expo/expo/tree/main/packages/patch-project#readme",
   "devDependencies": {
+    "@expo/cli": "*",
     "expo-module-scripts": "^5.0.7",
     "memfs": "^3.2.0"
   },


### PR DESCRIPTION
# Why

In preparation for [the migration to `pnpm`](https://github.com/expo/expo/pull/41131), I'd like to fix any phantom dependency issues that were being papered over by Yarn's hoisting.

# How

Added missing dependencies to:

- `@expo/log-box`
- `@expo/metro-runtime`
- `@expo/osascript`
- `expo-doctor`
- `expo-server`
- `expo`
- `patch-project`

# Test Plan

- CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
