### PR TITLE
[ci] only run check-packages on windows for scheduled or manual job

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -35,7 +35,7 @@ jobs:
           - ubuntu-24.04
           - ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'windows-latest' || '' }}
     runs-on: ${{ matrix.os }}
-    if: matrix.os != ''
+    if: ${{ matrix.os != '' }}
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -31,9 +31,11 @@ jobs:
   check-packages:
     strategy:
       matrix:
-        os:
-          - ubuntu-24.04
-          - ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'windows-latest' || '' }}
+        os: [ubuntu-24.04]
+        include:
+          - os: windows-latest
+            # Optional: only include this OS in schedule or workflow_dispatch events
+            include_conditions: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: 👀 Checkout

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -29,11 +29,7 @@ concurrency:
 
 jobs:
   check-packages:
-    strategy:
-      matrix:
-        os: ["ubuntu-24.04", "windows-latest"]
-    runs-on: ${{ matrix.os }}
-    if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+    runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
@@ -79,6 +75,39 @@ jobs:
         env:
           SINCE: ${{ github.base_ref || github.event.before || 'main' }}
         run: node bin/expotools check-packages --since $SINCE --core
+      - name: 🔔 Notify on Slack
+        uses: ./.github/actions/slack-notify
+        if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        with:
+          webhook: ${{ secrets.slack_webhook_api }}
+          author_name: Check packages
+
+  check-packages-windows:
+    runs-on: windows-latest
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 100
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: 🏗️ Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: ♻️ Restore caches
+        uses: ./.github/actions/expo-caches
+        id: expo-caches
+        with:
+          yarn-workspace: 'true'
+          yarn-tools: 'true'
+      - name: 🧶 Install workspace node modules
+        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
+        run: yarn install --frozen-lockfile
+      - name: 🧐 Check all packages
+        run: node bin/expotools check-packages --all
       - name: 🔔 Notify on Slack
         uses: ./.github/actions/slack-notify
         if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -31,7 +31,9 @@ jobs:
   check-packages:
     strategy:
       matrix:
-        os: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && fromJSON('["ubuntu-24.04", "windows-latest"]') || fromJSON('["ubuntu-24.04"]') }}
+        os:
+          - ubuntu-24.04
+          - ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'windows-latest' || '' }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: 👀 Checkout

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -31,8 +31,9 @@ jobs:
   check-packages:
     strategy:
       matrix:
-        os: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && fromJSON('["ubuntu-24.04", "windows-latest"]') || fromJSON('["ubuntu-24.04"]') }}
+        os: ["ubuntu-24.04", "windows-latest"]
     runs-on: ${{ matrix.os }}
+    if: ${{ runner.os != 'Windows' || (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         os: ["ubuntu-24.04", "windows-latest"]
     runs-on: ${{ matrix.os }}
-    if: ${{ runner.os != 'Windows' || (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+    if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -29,13 +29,7 @@ concurrency:
 
 jobs:
   check-packages:
-    strategy:
-      matrix:
-        os:
-          - ubuntu-24.04
-          - ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'windows-latest' || '' }}
-    runs-on: ${{ matrix.os }}
-    if: ${{ matrix.os != '' }}
+    runs-on: ["ubuntu-24.04", "${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'windows-latest' || '' }}"]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -31,7 +31,11 @@ jobs:
   check-packages:
     strategy:
       matrix:
-        os: [ubuntu-24.04, windows-latest]
+        os: ${{
+          (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+          && fromJSON('["ubuntu-24.04", "windows-latest"]')
+          || fromJSON('["ubuntu-24.04"]')
+        }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: 👀 Checkout

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -31,11 +31,8 @@ jobs:
   check-packages:
     strategy:
       matrix:
-        os:
-          - ubuntu-24.04
-          - windows-latest
+        os: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && fromJSON('["ubuntu-24.04", "windows-latest"]') || fromJSON('["ubuntu-24.04"]') }}
     runs-on: ${{ matrix.os }}
-    if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && true || runner.os != 'windows-latest' }}
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -31,11 +31,7 @@ jobs:
   check-packages:
     strategy:
       matrix:
-        os: ${{
-          (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
-          && fromJSON('["ubuntu-24.04", "windows-latest"]')
-          || fromJSON('["ubuntu-24.04"]')
-        }}
+        os: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && fromJSON('["ubuntu-24.04", "windows-latest"]') || fromJSON('["ubuntu-24.04"]') }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: 👀 Checkout

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -29,7 +29,13 @@ concurrency:
 
 jobs:
   check-packages:
-    runs-on: ["ubuntu-24.04", "${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'windows-latest' || '' }}"]
+    strategy:
+      matrix:
+        os:
+          - ubuntu-24.04
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && true || runner.os != 'windows-latest' }}
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -31,12 +31,11 @@ jobs:
   check-packages:
     strategy:
       matrix:
-        os: [ubuntu-24.04]
-        include:
-          - os: windows-latest
-            # Optional: only include this OS in schedule or workflow_dispatch events
-            include_conditions: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+        os:
+          - ubuntu-24.04
+          - ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'windows-latest' || '' }}
     runs-on: ${{ matrix.os }}
+    if: matrix.os != ''
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# Why

running check-packages on windows is slow. we don't need it every time

# How

only run check-packages on windows for scheduled ci or manual triggered ci

# Test Plan

this pr should only have check-packages running on ubuntu

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
