### PR TITLE
chore: bump base64-js from 1.2.3 to 1.5.1

### DIFF
--- a/packages/@expo/plist/CHANGELOG.md
+++ b/packages/@expo/plist/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- bump base64-js from 1.2.3 to 1.5.1 ([#41211](https://github.com/expo/expo/pull/41211) by [@hassankhan](https://github.com/hassankhan))
+
 ## 0.4.8 - 2025-12-05
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/plist/package.json
+++ b/packages/@expo/plist/package.json
@@ -31,11 +31,10 @@
   ],
   "dependencies": {
     "@xmldom/xmldom": "^0.8.8",
-    "base64-js": "^1.2.3",
+    "base64-js": "^1.5.1",
     "xmlbuilder": "^15.1.1"
   },
   "devDependencies": {
-    "@types/base64-js": "^1.2.5",
     "expo-module-scripts": "^5.0.7"
   },
   "publishConfig": {

--- a/packages/expo-crypto/CHANGELOG.md
+++ b/packages/expo-crypto/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- bump base64-js from 1.2.3 to 1.5.1 ([#41211](https://github.com/expo/expo/pull/41211) by [@hassankhan](https://github.com/hassankhan))
+
 ## 15.0.8 - 2025-12-05
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-crypto/package.json
+++ b/packages/expo-crypto/package.json
@@ -39,7 +39,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "base64-js": "^1.3.0"
+    "base64-js": "^1.5.1"
   },
   "devDependencies": {
     "expo-module-scripts": "^5.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5890,7 +5890,7 @@ base64-arraybuffer@^1.0.2:
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz#1c37589a7c4b0746e34bd1feb951da2df01c1bdc"
   integrity sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==
 
-base64-js@^1.2.3, base64-js@^1.3.0, base64-js@^1.3.1, base64-js@^1.5.1:
+base64-js@^1.2.3, base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4282,11 +4282,6 @@
   dependencies:
     "@babel/types" "^7.28.2"
 
-"@types/base64-js@^1.2.5":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@types/base64-js/-/base64-js-1.3.2.tgz#9e94abe3c521f4127f2e6a8b537b63bbc04d0956"
-  integrity sha512-Q2Xn2/vQHRGLRXhQ5+BSLwhHkR3JVflxVKywH0Q6fVoAiUE8fFYL2pE5/l2ZiOiBDfA8qUqRnSxln4G/NFz1Sg==
-
 "@types/better-sqlite3@^7.6.6":
   version "7.6.6"
   resolved "https://registry.yarnpkg.com/@types/better-sqlite3/-/better-sqlite3-7.6.6.tgz#d4c21613df0518be58d56ae4d58576121a6f56fa"


### PR DESCRIPTION
# Why

Upgrade `base64-js` and align the monorepo on a single version.

# How

Upgrades the dependency version, and additionally removes `@types/base64-js` as types are now included in the upstream package.

# Test Plan

- CI

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
