### PR TITLE
[ci] changed our expotools wrapper to not use @expo/spawn-async

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           yarn-tools: "true"
       - name: 🧶 Yarn install
-        #working-directory: tools
+        working-directory: tools
         if: steps.expo-caches.outputs.yarn-tools-hit != 'true'
         run: yarn install --immutable
 
@@ -50,6 +50,14 @@ jobs:
       #     path: SwiftLint/.build
       #     include-hidden-files: true
 
+      - name: 🔍 Debug bin/expotools
+        run: |
+          echo "=== Git status ==="
+          git status
+          echo "=== Content of bin/expotools ==="
+          cat bin/expotools
+          echo "=== Check if @expo/spawn-async is mentioned ==="
+          grep -r "spawn-async" bin/ || echo "Not found in bin/"
       - name: 🔬 Reviewing a pull request
         run: expotools code-review --pr ${{ github.event.inputs.pullNumber || github.event.number }}
         env:

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       pullNumber:
-        description: "Number of the pull request to review"
+        description: 'Number of the pull request to review'
         required: true
   pull_request_target:
 
@@ -28,7 +28,7 @@ jobs:
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         with:
-          yarn-tools: "true"
+          yarn-tools: 'true'
       - name: 🧶 Yarn install
         working-directory: tools
         if: steps.expo-caches.outputs.yarn-tools-hit != 'true'

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -50,14 +50,6 @@ jobs:
       #     path: SwiftLint/.build
       #     include-hidden-files: true
 
-      - name: 🔍 Debug bin/expotools
-        run: |
-          echo "=== Git status ==="
-          git status
-          echo "=== Content of bin/expotools ==="
-          cat bin/expotools
-          echo "=== Check if @expo/spawn-async is mentioned ==="
-          grep -r "spawn-async" bin/ || echo "Not found in bin/"
       - name: 🔬 Reviewing a pull request
         run: expotools code-review --pr ${{ github.event.inputs.pullNumber || github.event.number }}
         env:

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -6,7 +6,8 @@ on:
       pullNumber:
         description: 'Number of the pull request to review'
         required: true
-  pull_request_target:
+  #pull_request_target:
+  pull_request:  # Instead of pull_request_target
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.pullNumber || github.event.number }}

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       pullNumber:
-        description: 'Number of the pull request to review'
+        description: "Number of the pull request to review"
         required: true
   pull_request_target:
 
@@ -28,9 +28,9 @@ jobs:
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         with:
-          yarn-tools: 'true'
+          yarn-tools: "true"
       - name: 🧶 Yarn install
-        working-directory: tools
+        #working-directory: tools
         if: steps.expo-caches.outputs.yarn-tools-hit != 'true'
         run: yarn install --immutable
 

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -6,8 +6,7 @@ on:
       pullNumber:
         description: 'Number of the pull request to review'
         required: true
-  #pull_request_target:
-  pull_request:  # Instead of pull_request_target
+  pull_request_target:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.pullNumber || github.event.number }}

--- a/bin/expotools
+++ b/bin/expotools
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 
-import { spawn } from 'node:child_process';
-import path from 'path';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
 
 const repositoryRoot = path.resolve(import.meta.dirname, '..');
 const expotoolsDir = path.join(repositoryRoot, 'tools');
 const nodeBinary = process.env.NODE_BINARY || 'node';
 
-const child = spawn(
+const result = spawnSync(
   nodeBinary,
   [path.join(expotoolsDir, 'bin', 'expotools.js'), ...process.argv.slice(2)],
   {
@@ -16,11 +16,9 @@ const child = spawn(
   }
 );
 
-child.on('close', (code) => {
-  process.exit(code ?? 0);
-});
-
-child.on('error', (error) => {
-  console.error(error);
+if (result.error) {
+  console.error(result.error);
   process.exit(1);
-});
+}
+
+process.exit(result.status ?? 0);

--- a/bin/expotools
+++ b/bin/expotools
@@ -1,16 +1,26 @@
 #!/usr/bin/env node
 
-import { execFile } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import path from 'path';
-import spawnAsync from "@expo/spawn-async";
 
 const repositoryRoot = path.resolve(import.meta.dirname, '..');
 const expotoolsDir = path.join(repositoryRoot, 'tools');
 const nodeBinary = process.env.NODE_BINARY || 'node';
 
-await spawnAsync(nodeBinary, [path.join(expotoolsDir, 'bin', 'expotools.js'), ...process.argv.slice(2)], {
-  stdio: 'inherit',
-  cwd: expotoolsDir,
-}).catch((error) => {
-  process.exit(error.status);
+const child = spawn(
+  nodeBinary,
+  [path.join(expotoolsDir, 'bin', 'expotools.js'), ...process.argv.slice(2)],
+  {
+    stdio: 'inherit',
+    cwd: expotoolsDir,
+  }
+);
+
+child.on('close', (code) => {
+  process.exit(code ?? 0);
+});
+
+child.on('error', (error) => {
+  console.error(error);
+  process.exit(1);
 });


### PR DESCRIPTION
# Why

After merging #36296, ci fails because it can't find the @expo/spawn-async package (since it is in the tools folder).

# How

This commit fixes this by changing the script to use `spawn` from `node:child_process` instead.

# Test Plan

CI Green
