### PR TITLE
fix: update react-navigation/stack version

### DIFF
--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -37,7 +37,7 @@
     "@react-navigation/bottom-tabs": "^7.7.3",
     "@react-navigation/elements": "^2.8.1",
     "@react-navigation/native": "^7.1.21",
-    "@react-navigation/stack": "^7.6.2",
+    "@react-navigation/stack": "^7.6.7",
     "@shopify/react-native-skia": "2.2.12",
     "@stripe/stripe-react-native": "0.50.3",
     "date-fns": "^2.28.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -50,7 +50,7 @@
     "@react-navigation/drawer": "^7.7.2",
     "@react-navigation/elements": "^2.8.1",
     "@react-navigation/native": "^7.1.21",
-    "@react-navigation/stack": "^7.6.2",
+    "@react-navigation/stack": "^7.6.7",
     "@shopify/flash-list": "2.0.2",
     "@shopify/react-native-skia": "2.2.12",
     "date-format": "^2.0.0",

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -13,7 +13,7 @@
     "@expo/html-elements": "^0.13.7",
     "@expo/styleguide-base": "^1.0.1",
     "@react-navigation/native": "^7.1.21",
-    "@react-navigation/stack": "^7.8.0",
+    "@react-navigation/stack": "^7.6.7",
     "async-retry": "^1.1.4",
     "expo": "~54.0.8",
     "expo-application": "~7.0.7",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@react-navigation/native": "7.1.21",
     "@react-navigation/native-stack": "7.8.0",
     "@react-navigation/routers": "7.5.1",
-    "@react-navigation/stack": "7.6.2",
+    "@react-navigation/stack": "7.6.7",
     "**/util": "~0.12.4"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3938,13 +3938,14 @@
   dependencies:
     nanoid "^3.3.11"
 
-"@react-navigation/stack@7.6.2", "@react-navigation/stack@^7.6.2", "@react-navigation/stack@^7.8.0":
-  version "7.6.2"
-  resolved "https://registry.yarnpkg.com/@react-navigation/stack/-/stack-7.6.2.tgz#cb1d0d380f11ca619954b0b08988a9069de306d2"
-  integrity sha512-DVWYYTj5/QXYlFuO8Y232aDcJ4SFABQs9m99BYPs+hepjXzXivva9L4rbmsymFtqEPASx69dzX+nIKzlnxyqpw==
+"@react-navigation/stack@7.6.7", "@react-navigation/stack@^7.6.7":
+  version "7.6.7"
+  resolved "https://registry.npmjs.org/@react-navigation/stack/-/stack-7.6.7.tgz#8cd599681964ba930a15b70134bcbe38bf96424d"
+  integrity sha512-8NZWKTBYRVl8oSvhLKs26C6Dw5a3OhyfRc8ITS9A0kRSYaaX/KcZpObbAxp8kCJfTaJ7ZmghyX2NCGwnKw6V7A==
   dependencies:
-    "@react-navigation/elements" "^2.8.1"
+    "@react-navigation/elements" "^2.8.3"
     color "^4.2.3"
+    use-latest-callback "^0.2.4"
 
 "@repeaterjs/repeater@3.0.4", "@repeaterjs/repeater@^3.0.4":
   version "3.0.4"


### PR DESCRIPTION
# Why

@gabrieldonadel noticed that `react-navigation/stack` was updated to incorrect version in this PR - https://github.com/expo/expo/pull/41192#discussion_r2560041246

# How


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
