### PR TITLE
[ci] increased disk size for Android emulator

### DIFF
--- a/.github/actions/use-android-emulator/action.yml
+++ b/.github/actions/use-android-emulator/action.yml
@@ -46,6 +46,7 @@ runs:
         arch: x86_64
         target: google_apis
         profile: pixel_7_pro # We use pixel 7 pro for alignment with iPhone. Similar screen sizes mean easier test reuse.
+        disk-size: 4G
         # gpu hw acceleration is not available on GitHub-hosted runners
         emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
         script: |
@@ -72,6 +73,7 @@ runs:
         arch: x86_64
         target: google_apis
         profile: pixel_7_pro # We use pixel 7 pro for alignment with iPhone. Similar screen sizes mean easier test reuse.
+        disk-size: 4G
         emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
         script: |
           # Wait for emulator to fully ready
@@ -97,6 +99,7 @@ runs:
         arch: x86_64
         target: google_apis
         profile: pixel_7_pro # We use pixel 7 pro for alignment with iPhone. Similar screen sizes mean easier test reuse.
+        disk-size: 4G
         emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
         script: |
           # Wait for emulator to fully ready


### PR DESCRIPTION
# Why

When running the Android e2e tests we often get the following errors and a failing test:

Not enough space to create userdata partition. Available: 5303.36 MB at /home/runner/.android/avd/avd-36.avd, need 7372.80 MB.

# How

This commit tries to fix this by setting the disk-size parameter in the emulator setup action. The disk-size is set to 4GB which should be enough for Android, BareExpo and Maestro.

# Test Plan

✅ Test-run: https://github.com/expo/expo/actions/runs/19671194383/job/56343245842 - Green CI