### PR TITLE
[tools] Ignore errors caused by git diff being too large

### DIFF
--- a/tools/src/commands/CodeReviewCommand.ts
+++ b/tools/src/commands/CodeReviewCommand.ts
@@ -17,9 +17,26 @@ async function action(options: ActionOptions) {
   try {
     await reviewPullRequestAsync(+options.pr);
   } catch (error) {
+    if (isDiffTooLargeError(error)) {
+      // If the diff is too large, we can't do much. It's better not to fail the workflow though.
+      logger.info(error.message);
+      return;
+    }
     logger.error(error, error.stack);
     throw error;
   }
+}
+
+/**
+ * Checks if the error is a GitHub API error caused by the diff being too large.
+ * Currently it's limited to 20000 lines.
+ */
+function isDiffTooLargeError(error: any) {
+  const apiErrors = error.response?.data?.errors ?? [];
+
+  return apiErrors.some((apiError) => {
+    return apiError.field === 'diff' && apiError.code === 'too_large';
+  });
 }
 
 export default (program: Command) => {

--- a/tools/src/commands/CodeReviewCommand.ts
+++ b/tools/src/commands/CodeReviewCommand.ts
@@ -19,7 +19,7 @@ async function action(options: ActionOptions) {
   } catch (error) {
     if (isDiffTooLargeError(error)) {
       // If the diff is too large, we can't do much. It's better not to fail the workflow though.
-      logger.info(error.message);
+      logger.warn(error.message);
       return;
     }
     logger.error(error, error.stack);


### PR DESCRIPTION
# Why

GitHub API has a limit of 20000 lines in the diff of the PR. It causes failures in the `et code-review` command. I think in that case we can ignore it and exit gracefully.
See https://github.com/expo/expo/actions/runs/19670063616/job/56336401592?pr=41176

# How

Return gracefully when the error is an API error caused by the diff exceeding the limit

# Test Plan

```
→ et review -p 41176
 🛠  Rebuilding expotools
 ✨ Successfully built expotools

👾 Fetching head commit 7ae31897bc14da5f12335cd7473e8a6dbf66d563
Sorry, the diff exceeded the maximum number of lines (20000): {"resource":"PullRequest","field":"diff","code":"too_large"}
```

☝️ it only logs the actual error and exits the process gracefully