### PR TITLE
[ios][updates] Attempt to fix invalid file size

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Remove `ExpoAppDelegate` inheritance requirement ([#39417](https://github.com/expo/expo/pull/39417) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Add patch content negotiation headers. ([#40583](https://github.com/expo/expo/pull/40583) by [@alanjhughes](https://github.com/alanjhughes))
+- Add launch asset size validation. ([#41229](https://github.com/expo/expo/pull/41229) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift
@@ -315,6 +315,7 @@ open class AppLoader: NSObject {
     }
     asset.contentHash = UpdatesUtils.hexEncodedSHA256WithData(data)
     asset.downloadTime = Date()
+    asset.expectedSize = NSNumber(value: data.count)
 
     finishedAssets.append(asset)
     notifyProgress(withAsset: asset)

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/UpdateAsset.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/UpdateAsset.swift
@@ -30,6 +30,7 @@ public final class UpdateAsset: NSObject {
   public var downloadTime: Date?
   public var contentHash: String? // base64url-encoded sha-256
   public var headers: [String: Any]?
+  public var expectedSize: NSNumber? // file size in bytes for validation
 
   /**
    * properties determined by updates database

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration11To12.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration11To12.swift
@@ -1,0 +1,20 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+#if canImport(sqlite3)
+import sqlite3
+#else
+import SQLite3
+#endif
+
+internal final class UpdatesDatabaseMigration11To12: UpdatesDatabaseMigration {
+  private(set) var filename: String = "expo-v11.db"
+
+  func runMigration(onDatabase db: OpaquePointer) throws {
+    try db.withTransaction { trx in
+      try trx.safeExecOrRollback(sql: """
+        ALTER TABLE "assets" ADD COLUMN "expected_size" INTEGER;
+      """)
+    }
+  }
+}

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigrationRegistry.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigrationRegistry.swift
@@ -12,7 +12,8 @@ internal final class UpdatesDatabaseMigrationRegistry {
       UpdatesDatabaseMigration7To8(),
       UpdatesDatabaseMigration8To9(),
       UpdatesDatabaseMigration9To10(),
-      UpdatesDatabaseMigration10To11()
+      UpdatesDatabaseMigration10To11(),
+      UpdatesDatabaseMigration11To12()
     ]
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabaseInitialization.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabaseInitialization.swift
@@ -43,7 +43,7 @@ enum UpdatesDatabaseInitializationError: Error, Sendable, LocalizedError {
  * Utility class that handles database initialization and migration.
  */
 internal final class UpdatesDatabaseInitialization {
-  private static let LatestFilename = "expo-v11.db"
+  private static let LatestFilename = "expo-v12.db"
   private static let LatestSchema = """
     CREATE TABLE "updates" (
       "id"  BLOB UNIQUE,
@@ -75,7 +75,8 @@ internal final class UpdatesDatabaseInitialization {
       "relative_path"  TEXT NOT NULL,
       "hash"  BLOB NOT NULL,
       "hash_type"  INTEGER NOT NULL,
-      "marked_for_deletion"  INTEGER NOT NULL
+      "marked_for_deletion"  INTEGER NOT NULL,
+      "expected_size"  INTEGER
     );
     CREATE TABLE "updates_assets" (
       "update_id"  BLOB NOT NULL,

--- a/packages/expo-updates/ios/Tests/AppLauncherAssetValidationSpec.swift
+++ b/packages/expo-updates/ios/Tests/AppLauncherAssetValidationSpec.swift
@@ -1,0 +1,270 @@
+//  Copyright (c) 2024 650 Industries, Inc. All rights reserved.
+
+import ExpoModulesTestCore
+import EXManifests
+
+@testable import EXUpdates
+
+class AppLauncherAssetValidationSpec : ExpoSpec {
+  override class func spec() {
+    var testDatabaseDir: URL!
+    var db: UpdatesDatabase!
+    var config: UpdatesConfig!
+
+    beforeEach {
+      let applicationSupportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).last
+      testDatabaseDir = applicationSupportDir!.appendingPathComponent("AppLauncherAssetValidationTests")
+
+      try? FileManager.default.removeItem(atPath: testDatabaseDir.path)
+
+      if !FileManager.default.fileExists(atPath: testDatabaseDir.path) {
+        try! FileManager.default.createDirectory(atPath: testDatabaseDir.path, withIntermediateDirectories: true)
+      }
+
+      db = UpdatesDatabase()
+      db.databaseQueue.sync {
+        try! db.openDatabase(inDirectory: testDatabaseDir, logger: UpdatesLogger())
+      }
+
+      config = try! UpdatesConfig.config(fromDictionary: [
+        UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://example.com",
+        UpdatesConfig.EXUpdatesConfigScopeKeyKey: "dummyScope",
+        UpdatesConfig.EXUpdatesConfigRuntimeVersionKey: "1",
+        UpdatesConfig.EXUpdatesConfigHasEmbeddedUpdateKey: false
+      ])
+    }
+
+    afterEach {
+      db.databaseQueue.sync {
+        db.closeDatabase()
+      }
+
+      try? FileManager.default.removeItem(atPath: testDatabaseDir.path)
+    }
+
+    describe("asset validation with size mismatch") {
+      it("detects size mismatch for corrupted files") {
+        // Create an update with a launch asset
+        let testUpdate = Update(
+          manifest: ManifestFactory.manifest(forManifestJSON: [:]),
+          config: config,
+          database: db,
+          updateId: UUID(),
+          scopeKey: "dummyScope",
+          commitTime: Date(timeIntervalSince1970: 1608667851),
+          runtimeVersion: "1.0",
+          keep: true,
+          status: .StatusReady,
+          isDevelopmentMode: false,
+          assetsFromManifest: [],
+          url: URL(string: "https://example.com"),
+          requestHeaders: [:]
+        )
+
+        let asset = UpdateAsset(key: "bundle-123", type: "js")
+        asset.isLaunchAsset = true
+        asset.filename = "corrupted-bundle.js"
+        asset.downloadTime = Date()
+        asset.contentHash = "expected-hash"
+        asset.expectedSize = NSNumber(value: 72728472)
+        asset.url = nil // No download URL - recovery will fail
+
+        let assetPath = testDatabaseDir.appendingPathComponent(asset.filename)
+        let corruptedSize = 61063168
+        let corruptedData = Data(repeating: 0, count: corruptedSize)
+        try! corruptedData.write(to: assetPath)
+
+        db.databaseQueue.sync {
+          try! db.addUpdate(testUpdate, config: config)
+          try! db.addNewAssets([asset], toUpdateWithId: testUpdate.updateId)
+        }
+
+        var reloadedUpdate: Update?
+        db.databaseQueue.sync {
+          reloadedUpdate = try! db.update(withId: testUpdate.updateId, config: config)
+        }
+
+        let launcher = AppLauncherWithDatabase(
+          config: config,
+          database: db,
+          directory: testDatabaseDir,
+          completionQueue: DispatchQueue.global(qos: .default),
+          logger: UpdatesLogger()
+        )
+
+        launcher.launchedUpdate = reloadedUpdate
+
+        let successValue = Synchronized<Bool>(false)
+        let launchAssetUrlValue = Synchronized<URL?>(nil)
+
+        launcher.launchUpdate(withSelectionPolicy: SelectionPolicyFactory.filterAwarePolicy(withRuntimeVersion: "1", config: config)) { error, success in
+          successValue.value = success
+          launchAssetUrlValue.value = launcher.launchAssetUrl
+        }
+
+        // The file should be detected as invalid due to size mismatch
+        // Since we can't download or copy from embedded, launch should fail
+        expect(successValue.value).toEventually(beFalse(), timeout: .seconds(5))
+        expect(launchAssetUrlValue.value).toEventually(beNil(), timeout: .seconds(5))
+
+        expect(FileManager.default.fileExists(atPath: assetPath.path)).toEventually(beFalse(), timeout: .seconds(5))
+      }
+    }
+
+    describe("asset validation with correct size") {
+      it("accepts file when size matches") {
+        let testUpdate = Update(
+          manifest: ManifestFactory.manifest(forManifestJSON: [:]),
+          config: config,
+          database: db,
+          updateId: UUID(),
+          scopeKey: "dummyScope",
+          commitTime: Date(timeIntervalSince1970: 1608667851),
+          runtimeVersion: "1.0",
+          keep: true,
+          status: .StatusReady,
+          isDevelopmentMode: false,
+          assetsFromManifest: [],
+          url: URL(string: "https://example.com"),
+          requestHeaders: [:]
+        )
+
+        let asset = UpdateAsset(key: "bundle-456", type: "js")
+        asset.isLaunchAsset = true
+        asset.filename = "valid-bundle.js"
+        asset.downloadTime = Date()
+
+        let content = "function test() { return 'hello'; }"
+        let assetPath = testDatabaseDir.appendingPathComponent(asset.filename)
+        try! content.write(to: assetPath, atomically: true, encoding: .utf8)
+
+        let data = content.data(using: .utf8)!
+        asset.expectedSize = NSNumber(value: data.count)
+        asset.contentHash = UpdatesUtils.hexEncodedSHA256WithData(data)
+
+        db.databaseQueue.sync {
+          try! db.addUpdate(testUpdate, config: config)
+          try! db.addNewAssets([asset], toUpdateWithId: testUpdate.updateId)
+        }
+        var reloadedUpdate: Update?
+        db.databaseQueue.sync {
+          reloadedUpdate = try! db.update(withId: testUpdate.updateId, config: config)
+        }
+
+        let launcher = AppLauncherWithDatabase(
+          config: config,
+          database: db,
+          directory: testDatabaseDir,
+          completionQueue: DispatchQueue.global(qos: .default),
+          logger: UpdatesLogger()
+        )
+
+        launcher.launchedUpdate = reloadedUpdate
+
+        let successValue = Synchronized<Bool>(false)
+
+        launcher.launchUpdate(withSelectionPolicy: SelectionPolicyFactory.filterAwarePolicy(withRuntimeVersion: "1", config: config)) { error, success in
+          successValue.value = success
+        }
+
+        // Launch should succeed
+        expect(successValue.value).toEventually(beTrue(), timeout: .seconds(5))
+
+        // The file should still exist
+        let fileStillExists = FileManager.default.fileExists(atPath: assetPath.path)
+        expect(fileStillExists) == true
+      }
+    }
+
+    describe("backward compatibility with old assets") {
+      it("validates old assets without expected size") {
+        let testUpdate = Update(
+          manifest: ManifestFactory.manifest(forManifestJSON: [:]),
+          config: config,
+          database: db,
+          updateId: UUID(),
+          scopeKey: "dummyScope",
+          commitTime: Date(timeIntervalSince1970: 1608667851),
+          runtimeVersion: "1.0",
+          keep: true,
+          status: .StatusReady,
+          isDevelopmentMode: false,
+          assetsFromManifest: [],
+          url: URL(string: "https://example.com"),
+          requestHeaders: [:]
+        )
+
+        let asset = UpdateAsset(key: "old-bundle", type: "js")
+        asset.isLaunchAsset = true
+        asset.filename = "old-bundle.js"
+        asset.downloadTime = Date()
+        asset.expectedSize = nil
+
+        let content = "old bundle content"
+        let assetPath = testDatabaseDir.appendingPathComponent(asset.filename)
+        try! content.write(to: assetPath, atomically: true, encoding: .utf8)
+
+        let data = content.data(using: .utf8)!
+        asset.contentHash = UpdatesUtils.hexEncodedSHA256WithData(data)
+
+        db.databaseQueue.sync {
+          try! db.addUpdate(testUpdate, config: config)
+          try! db.addNewAssets([asset], toUpdateWithId: testUpdate.updateId)
+        }
+
+        var reloadedUpdate: Update?
+        db.databaseQueue.sync {
+          reloadedUpdate = try! db.update(withId: testUpdate.updateId, config: config)
+        }
+
+        let launcher = AppLauncherWithDatabase(
+          config: config,
+          database: db,
+          directory: testDatabaseDir,
+          completionQueue: DispatchQueue.global(qos: .default),
+          logger: UpdatesLogger()
+        )
+
+        launcher.launchedUpdate = reloadedUpdate
+
+        let successValue = Synchronized<Bool>(false)
+
+        launcher.launchUpdate(withSelectionPolicy: SelectionPolicyFactory.filterAwarePolicy(withRuntimeVersion: "1", config: config)) { error, success in
+          successValue.value = success
+        }
+
+        expect(successValue.value).toEventually(beTrue(), timeout: .seconds(5))
+      }
+    }
+  }
+}
+
+/// Allows for synchronization pertaining to the file scope.
+private final class Synchronized<T> {
+  private var _storage: T
+  private let lock = NSLock()
+
+  /// Thread safe access here.
+  var value: T {
+    get {
+      return lockAround {
+        _storage
+      }
+    }
+    set {
+      lockAround {
+        _storage = newValue
+      }
+    }
+  }
+
+  init(_ storage: T) {
+    self._storage = storage
+  }
+
+  private func lockAround<U>(_ closure: () -> U) -> U {
+    lock.lock()
+    defer { lock.unlock() }
+    return closure()
+  }
+}


### PR DESCRIPTION
# Why
Attempts to fix ENG-18152.
https://exponent-internal.slack.com/archives/C05SM5GPL31/p1763417461632249

# How
Hard to say definitively what the problem is, but I suspect since users who's bundle is large, the write to disk is potentially being interrupted before it completes. Because we only check for the existence of the file, we assume it was written in it's entirety. This PR stores a new field to assets, the `expected_size` and uses it to verify the file is what we expect it to be. When we don't have a size we fall back to validating by hash.

# Test Plan
Local e2e pass. 
