### PR TITLE
[ci] fixed working dir in expotools wrapper

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -52,5 +52,6 @@ jobs:
 
       - name: 🔬 Reviewing a pull request
         run: expotools code-review --pr ${{ github.event.inputs.pullNumber || github.event.number }}
+        working-directory: .
         env:
           GITHUB_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -52,6 +52,5 @@ jobs:
 
       - name: 🔬 Reviewing a pull request
         run: expotools code-review --pr ${{ github.event.inputs.pullNumber || github.event.number }}
-        working-directory: .
         env:
           GITHUB_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}

--- a/bin/expotools
+++ b/bin/expotools
@@ -12,7 +12,7 @@ const result = spawnSync(
   [path.join(expotoolsDir, 'bin', 'expotools.js'), ...process.argv.slice(2)],
   {
     stdio: 'inherit',
-    cwd: expotoolsDir,
+    cwd: repositoryRoot,
   }
 );
 


### PR DESCRIPTION
# Why

Instead of running with the workingdir "tools" which caused an error to happen:

https://github.com/expo/expo/actions/runs/19677257528/job/56361818155?pr=41229

# How

This commit fixes it by setting `repositoryRoot` instad of the tools direcory as the current working directory for expotools.

# Test Plan

CI Green

