### PR TITLE
[ui][android] Add missing scopes to modifiers.

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 🐛 Bug fixes
 
+- [android] Add missing scopes to modifiers. ([#41231](https://github.com/expo/expo/pull/41231) by [@aleqsio](https://github.com/aleqsio))
 - [iOS] Fix `ContextMenu` item with subtitle buttons ([#40926](https://github.com/expo/expo/pull/40926) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix `TextField` causing crash when reload and unmounting. ([#40960](https://github.com/expo/expo/pull/40960) by [@nishan](https://github.com/intergalacticspacehighway))
 

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/AlertDialogView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/AlertDialogView.kt
@@ -46,7 +46,7 @@ class AlertDialogView(context: Context, appContext: AppContext) :
     }
 
     AlertDialog(
-      modifier = Modifier.fromExpoModifiers(props.modifiers.value),
+      modifier = Modifier.fromExpoModifiers(props.modifiers.value, this@Content),
       confirmButton = {
         confirmButtonText?.let {
           TextButton(onClick = { onConfirmPressed.invoke(AlertDialogButtonPressedEvent()) }) {

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ComposeViews.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ComposeViews.kt
@@ -188,7 +188,7 @@ class TextView(context: Context, appContext: AppContext) : ExpoComposeView<TextP
   override fun ComposableScope.Content() {
     Text(
       text = props.text.value,
-      modifier = Modifier.fromExpoModifiers(props.modifiers.value),
+      modifier = Modifier.fromExpoModifiers(props.modifiers.value, this@Content),
       color = colorToComposeColor(props.color.value),
       style = TextStyle(
         fontSize = props.fontSize.value.sp,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/DatePickerView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/DatePickerView.kt
@@ -76,11 +76,11 @@ class DateTimePickerView(context: Context, appContext: AppContext) :
   @Composable
   override fun ComposableScope.Content() {
     if (props.displayedComponents.value == DisplayedComponents.HOUR_AND_MINUTE) {
-      ExpoTimePicker(props = props, modifier = Modifier.fromExpoModifiers(props.modifiers.value)) {
+      ExpoTimePicker(props = props, modifier = Modifier.fromExpoModifiers(props.modifiers.value, this@Content)) {
         onDateSelected(it)
       }
     } else {
-      ExpoDatePicker(props = props, modifier = Modifier.fromExpoModifiers(props.modifiers.value)) {
+      ExpoDatePicker(props = props, modifier = Modifier.fromExpoModifiers(props.modifiers.value, this@Content)) {
         onDateSelected(it)
       }
     }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/PickerView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/PickerView.kt
@@ -95,7 +95,7 @@ class PickerView(context: Context, appContext: AppContext) :
       DynamicTheme {
         AutoSizingComposable(shadowNodeProxy) {
           SingleChoiceSegmentedButtonRow(
-            modifier = Modifier.fromExpoModifiers(props.modifiers.value)
+            modifier = Modifier.fromExpoModifiers(props.modifiers.value, this@Content)
           ) {
             options.forEachIndexed { index, label ->
               SegmentedButton(
@@ -106,7 +106,7 @@ class PickerView(context: Context, appContext: AppContext) :
                 onClick = {
                   onOptionSelected(mapOf("index" to index, "label" to label))
                 },
-                modifier = Modifier.fromExpoModifiers(props.buttonModifiers.value),
+                modifier = Modifier.fromExpoModifiers(props.buttonModifiers.value, this@Content),
                 selected = index == selectedIndex,
                 label = { Text(label) },
                 colors = SegmentedButtonDefaults.colors(

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ProgressView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ProgressView.kt
@@ -67,7 +67,7 @@ class ProgressView(context: Context, appContext: AppContext) :
                 color = composeColor,
                 trackColor = trackColor,
                 drawStopIndicator = {},
-                modifier = Modifier.fromExpoModifiers(props.modifiers.value)
+                modifier = Modifier.fromExpoModifiers(props.modifiers.value, this@Content)
               )
             } else {
               LinearProgressIndicator(
@@ -85,13 +85,13 @@ class ProgressView(context: Context, appContext: AppContext) :
                 progress = { progress },
                 color = composeColor,
                 trackColor = colors.trackColor.composeOrNull ?: ProgressIndicatorDefaults.circularDeterminateTrackColor,
-                modifier = Modifier.fromExpoModifiers(props.modifiers.value)
+                modifier = Modifier.fromExpoModifiers(props.modifiers.value, this@Content)
               )
             } else {
               CircularProgressIndicator(
                 color = composeColor,
                 trackColor = colors.trackColor.composeOrNull ?: ProgressIndicatorDefaults.circularIndeterminateTrackColor,
-                modifier = Modifier.fromExpoModifiers(props.modifiers.value)
+                modifier = Modifier.fromExpoModifiers(props.modifiers.value, this@Content)
               )
             }
           }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SliderView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SliderView.kt
@@ -71,7 +71,7 @@ class SliderView(context: Context, appContext: AppContext) :
           activeTickColor = colors.activeTickColor.compose,
           inactiveTickColor = colors.inactiveTickColor.compose
         ),
-        modifier = Modifier.fromExpoModifiers(props.modifiers.value)
+        modifier = Modifier.fromExpoModifiers(props.modifiers.value, this@Content)
       )
     }
   }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SwitchView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SwitchView.kt
@@ -131,7 +131,7 @@ class SwitchView(context: Context, appContext: AppContext) :
     }
 
     AutoSizingComposable(shadowNodeProxy) {
-      ThemedHybridSwitch(variant, checked, onCheckedChange, colors, Modifier.fromExpoModifiers(props.modifiers.value))
+      ThemedHybridSwitch(variant, checked, onCheckedChange, colors, Modifier.fromExpoModifiers(props.modifiers.value, this@Content))
     }
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/TextInputView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/TextInputView.kt
@@ -93,7 +93,7 @@ class TextInputView(context: Context, appContext: AppContext) :
           autoCorrectEnabled = props.autocorrection.value,
           capitalization = props.autoCapitalize.value.autoCapitalize()
         ),
-        modifier = Modifier.fromExpoModifiers(props.modifiers.value)
+        modifier = Modifier.fromExpoModifiers(props.modifiers.value, composableScope = this@Content)
       )
     }
   }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/button/Button.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/button/Button.kt
@@ -179,7 +179,7 @@ class Button(context: Context, appContext: AppContext) :
         colors,
         disabled ?: false,
         onPress = { onButtonPressed.invoke(ButtonPressedEvent()) },
-        modifier = Modifier.fromExpoModifiers(props.modifiers.value),
+        modifier = Modifier.fromExpoModifiers(props.modifiers.value, composableScope = this@Content),
         shape = shapeFromShapeRecord(props.shape.value)
       ) {
         Row(verticalAlignment = Alignment.CenterVertically) {


### PR DESCRIPTION
# Why

This was missing which was causing some layout issues when using modifiers such as fillMaxSize or width.

# How
Added that for all components.

# Test Plan

Tested in my dogfooding app.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
