### PR TITLE
[docs] Update `PageHeader` for docs under Reference

### DIFF
--- a/docs/ui/components/AskPageAI/AskPageAITrigger.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAITrigger.tsx
@@ -16,18 +16,12 @@ export function AskPageAITrigger({ onClick, isActive = false }: AskPageAITrigger
         <Button
           type="button"
           theme="quaternary"
-          className={mergeClasses(
-            'min-h-[48px] min-w-[60px] justify-center px-2 max-xl-gutters:min-h-[unset]'
-          )}
+          className="justify-center px-2.5"
           onClick={onClick}
           aria-pressed={isActive}
           aria-label="Ask about this page with AI">
-          <div
-            className={mergeClasses(
-              'flex flex-col items-center',
-              'max-xl-gutters:flex-row max-xl-gutters:gap-1.5'
-            )}>
-            <Star06Icon className="mt-0.5 text-palette-purple11" />
+          <div className="flex items-center gap-1.5">
+            <Star06Icon className="icon-sm text-palette-purple11" />
             <FOOTNOTE crawlable={false} className="text-palette-purple11">
               Ask AI
             </FOOTNOTE>

--- a/docs/ui/components/PageHeader/PageHeader.test.tsx
+++ b/docs/ui/components/PageHeader/PageHeader.test.tsx
@@ -18,7 +18,7 @@ describe(PageHeader, () => {
     fireEvent.focus(linkElement);
     const tooltip = await screen.findByRole('tooltip', {}, { timeout: 1000 });
     expect(tooltip).toBeInTheDocument();
-    expect(tooltip).toHaveTextContent('View package in npm registry');
+    expect(tooltip).toHaveTextContent('View library in npm registry');
   });
 
   test('displays GitHub source code link', async () => {
@@ -58,7 +58,7 @@ describe(PageHeader, () => {
     fireEvent.focus(linkElement);
     const tooltip = await screen.findByRole('tooltip', {}, { timeout: 1000 });
     expect(tooltip).toBeInTheDocument();
-    expect(tooltip).toHaveTextContent('View package changelog on GitHub');
+    expect(tooltip).toHaveTextContent('View library changelog on GitHub');
   });
 
   test('do not display GitHub changelog link for vendored packages', async () => {

--- a/docs/ui/components/PageHeader/PageHeader.tsx
+++ b/docs/ui/components/PageHeader/PageHeader.tsx
@@ -84,7 +84,7 @@ export function PageHeader({
           <div className="flex flex-wrap items-center">
             {renderAskAIButton()}
             {renderAskAIButton() && (sourceCodeUrl || packageName) && (
-              <div className="max-sm:hidden bg-secondary mx-2 h-5 w-px" />
+              <div className="max-sm:hidden bg-secondary mx-1 h-5 w-px" />
             )}
             <PageTitleButtons packageName={packageName} sourceCodeUrl={sourceCodeUrl} />
           </div>

--- a/docs/ui/components/PageHeader/PageHeader.tsx
+++ b/docs/ui/components/PageHeader/PageHeader.tsx
@@ -45,9 +45,10 @@ export function PageHeader({
   });
   const showPackageMarkdown = packageName ? !hasDynamicData(currentPath) : false;
   const isSdkPage = currentPath.includes('/sdk/');
+  const hasAskAIButton = showAskAIButton && !!onAskAIClick;
 
   const renderAskAIButton = () => {
-    if (!showAskAIButton || !onAskAIClick) {
+    if (!hasAskAIButton) {
       return null;
     }
 
@@ -80,19 +81,36 @@ export function PageHeader({
           )}
           {platforms && <PagePlatformTags platforms={platforms} className="mt-4" />}
         </div>
-        <div className="mt-4 flex flex-wrap items-center justify-between gap-3 pb-1">
-          <div className="flex flex-wrap items-center">
-            {renderAskAIButton()}
-            {renderAskAIButton() && (sourceCodeUrl || packageName) && (
-              <div className="max-sm:hidden bg-secondary mx-1 h-5 w-px" />
-            )}
-            <PageTitleButtons packageName={packageName} sourceCodeUrl={sourceCodeUrl} />
+        <div
+          className={mergeClasses(
+            'mt-4 flex flex-wrap items-center justify-between gap-3 pb-1',
+            'max-md-gutters:flex-col max-md-gutters:items-stretch max-md-gutters:gap-0 max-md-gutters:pb-0'
+          )}>
+          <div
+            className={mergeClasses(
+              'flex flex-wrap items-center gap-2',
+              'max-md-gutters:w-full max-md-gutters:items-center max-md-gutters:justify-between max-md-gutters:border-b max-md-gutters:border-default max-md-gutters:py-3'
+            )}>
+            <div className="flex flex-wrap items-center">
+              {renderAskAIButton()}
+              {hasAskAIButton && (sourceCodeUrl || packageName) && (
+                <div className="max-sm:hidden bg-secondary mx-1 h-5 w-px" />
+              )}
+            </div>
+            <div className="flex items-center gap-1.5">
+              <PageTitleButtons packageName={packageName} sourceCodeUrl={sourceCodeUrl} />
+            </div>
           </div>
-          <div className="flex flex-wrap items-center gap-3">
+          <div
+            className={mergeClasses(
+              'flex flex-wrap items-center gap-3',
+              'max-md-gutters:w-full max-md-gutters:justify-between max-md-gutters:py-3'
+            )}>
             <PagePackageVersion
               packageName={packageName}
               testRequire={testRequire}
               showMarkdownActions={showPackageMarkdown}
+              className="max-md-gutters:w-full max-md-gutters:justify-between"
             />
           </div>
         </div>
@@ -120,13 +138,13 @@ export function PageHeader({
         </H1>
         <span className="-mt-0.5 flex items-center gap-1 max-xl-gutters:hidden">
           <PageTitleButtons packageName={packageName} sourceCodeUrl={sourceCodeUrl} />
-          {(showMarkdownActions || (showAskAIButton && onAskAIClick)) && (
+          {(showMarkdownActions || hasAskAIButton) && (
             <span className="flex items-center gap-1">
-              {showAskAIButton && onAskAIClick && askAIButtonVariant === 'config' && (
+              {hasAskAIButton && askAIButtonVariant === 'config' && (
                 <AskPageAIConfigTrigger onClick={onAskAIClick} isActive={isAskAIVisible} />
               )}
               {showMarkdownActions && <MarkdownActionsDropdown />}
-              {showAskAIButton && onAskAIClick && askAIButtonVariant !== 'config' && (
+              {hasAskAIButton && askAIButtonVariant !== 'config' && (
                 <AskPageAITrigger onClick={onAskAIClick} isActive={isAskAIVisible} />
               )}
             </span>
@@ -140,13 +158,13 @@ export function PageHeader({
       )}
       <span className="mb-1 mt-3 hidden items-center gap-1 max-xl-gutters:flex">
         <PageTitleButtons packageName={packageName} sourceCodeUrl={sourceCodeUrl} />
-        {(showMarkdownActions || (showAskAIButton && onAskAIClick)) && (
+        {(showMarkdownActions || hasAskAIButton) && (
           <span className="ml-1 flex items-center gap-1">
-            {showAskAIButton && onAskAIClick && askAIButtonVariant === 'config' && (
+            {hasAskAIButton && askAIButtonVariant === 'config' && (
               <AskPageAIConfigTrigger onClick={onAskAIClick} isActive={isAskAIVisible} />
             )}
             {showMarkdownActions && <MarkdownActionsDropdown />}
-            {showAskAIButton && onAskAIClick && askAIButtonVariant !== 'config' && (
+            {hasAskAIButton && askAIButtonVariant !== 'config' && (
               <AskPageAITrigger onClick={onAskAIClick} isActive={isAskAIVisible} />
             )}
           </span>

--- a/docs/ui/components/PageHeader/PageHeader.tsx
+++ b/docs/ui/components/PageHeader/PageHeader.tsx
@@ -44,6 +44,61 @@ export function PageHeader({
     path: currentPath,
   });
   const showPackageMarkdown = packageName ? !hasDynamicData(currentPath) : false;
+  const isSdkPage = currentPath.includes('/sdk/');
+
+  const renderAskAIButton = () => {
+    if (!showAskAIButton || !onAskAIClick) {
+      return null;
+    }
+
+    if (askAIButtonVariant === 'config') {
+      return <AskPageAIConfigTrigger onClick={onAskAIClick} isActive={isAskAIVisible} />;
+    }
+
+    return <AskPageAITrigger onClick={onAskAIClick} isActive={isAskAIVisible} />;
+  };
+
+  if (packageName && isSdkPage) {
+    return (
+      <>
+        <div className="mt-2 flex flex-col">
+          <H1 className="!my-0">
+            {iconUrl && (
+              <img
+                src={iconUrl}
+                className="relative -top-0.5 float-left mr-3.5 size-[42px]"
+                alt={`Expo ${title} icon`}
+              />
+            )}
+            {packageName && packageName.startsWith('expo-') && 'Expo '}
+            {title}
+          </H1>
+          {description && (
+            <P theme="secondary" data-description="true" className="mt-2">
+              {description}
+            </P>
+          )}
+          {platforms && <PagePlatformTags platforms={platforms} className="mt-4" />}
+        </div>
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-3 pb-1">
+          <div className="flex flex-wrap items-center">
+            {renderAskAIButton()}
+            {renderAskAIButton() && (sourceCodeUrl || packageName) && (
+              <div className="max-sm:hidden bg-secondary mx-2 h-5 w-px" />
+            )}
+            <PageTitleButtons packageName={packageName} sourceCodeUrl={sourceCodeUrl} />
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <PagePackageVersion
+              packageName={packageName}
+              testRequire={testRequire}
+              showMarkdownActions={showPackageMarkdown}
+            />
+          </div>
+        </div>
+      </>
+    );
+  }
 
   return (
     <>

--- a/docs/ui/components/PageHeader/PagePackageVersion.tsx
+++ b/docs/ui/components/PageHeader/PagePackageVersion.tsx
@@ -1,3 +1,4 @@
+import { mergeClasses } from '@expo/styleguide';
 import { PackageIcon } from '@expo/styleguide-icons/outline/PackageIcon';
 import { useRouter } from 'next/compat/router';
 
@@ -13,9 +14,15 @@ const { LATEST_VERSION } = versions;
 type Props = {
   packageName: string;
   showMarkdownActions?: boolean;
+  className?: string;
 } & WithTestRequire;
 
-export function PagePackageVersion({ packageName, testRequire, showMarkdownActions }: Props) {
+export function PagePackageVersion({
+  packageName,
+  testRequire,
+  showMarkdownActions,
+  className,
+}: Props) {
   const { version } = usePageApiVersion();
   const router = useRouter();
   const currentPath = router?.asPath ?? router?.pathname ?? '';
@@ -37,7 +44,7 @@ export function PagePackageVersion({ packageName, testRequire, showMarkdownActio
   }
 
   return (
-    <div className="flex items-center gap-2">
+    <div className={mergeClasses('flex items-center gap-2', className)}>
       {versionRange && (
         <div className="flex items-center justify-center gap-1.5 text-xs text-secondary">
           <PackageIcon className="icon-sm text-icon-secondary" />

--- a/docs/ui/components/PageHeader/PagePlatformTags.tsx
+++ b/docs/ui/components/PageHeader/PagePlatformTags.tsx
@@ -1,12 +1,15 @@
+import { mergeClasses } from '@expo/styleguide';
+
 import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
 
 type Props = {
   platforms: string[];
+  className?: string;
 };
 
-export function PagePlatformTags({ platforms }: Props) {
+export function PagePlatformTags({ platforms, className }: Props) {
   return (
-    <div className="inline-flex flex-wrap">
+    <div className={mergeClasses('inline-flex flex-wrap', className)}>
       {platforms
         .sort((a, b) => a.localeCompare(b))
         .map(platform => {

--- a/docs/ui/components/PageHeader/PageTitleButtons.tsx
+++ b/docs/ui/components/PageHeader/PageTitleButtons.tsx
@@ -39,7 +39,7 @@ export function PageTitleButtons({ packageName, sourceCodeUrl }: Props) {
       {(sourceCodeUrl ||
         sourceCodeUrl?.startsWith('https://github.com/expo/expo') ||
         packageName) && (
-        <span className="flex items-center">
+        <span className="flex items-center gap-1">
           {sourceCodeUrl && (
             <>
               <SdkPackageButton
@@ -49,7 +49,7 @@ export function PageTitleButtons({ packageName, sourceCodeUrl }: Props) {
                 tooltip="View source code on GitHub"
               />
               {(packageName || sourceCodeUrl?.startsWith('https://github.com/expo/expo')) && (
-                <div className="max-sm:hidden bg-secondary mx-1 h-5 w-px" />
+                <div className="max-sm:hidden bg-secondary h-5 w-px" />
               )}
             </>
           )}
@@ -62,7 +62,7 @@ export function PageTitleButtons({ packageName, sourceCodeUrl }: Props) {
                 tooltip="View library in npm registry"
               />
               {sourceCodeUrl?.startsWith('https://github.com/expo/expo') && (
-                <div className="max-sm:hidden bg-secondary mx-1 h-5 w-px" />
+                <div className="max-sm:hidden bg-secondary h-5 w-px" />
               )}
             </>
           )}

--- a/docs/ui/components/PageHeader/PageTitleButtons.tsx
+++ b/docs/ui/components/PageHeader/PageTitleButtons.tsx
@@ -49,7 +49,7 @@ export function PageTitleButtons({ packageName, sourceCodeUrl }: Props) {
                 tooltip="View source code on GitHub"
               />
               {(packageName || sourceCodeUrl?.startsWith('https://github.com/expo/expo')) && (
-                <div className="max-sm:hidden bg-secondary mx-2 h-5 w-px" />
+                <div className="max-sm:hidden bg-secondary mx-1 h-5 w-px" />
               )}
             </>
           )}
@@ -62,7 +62,7 @@ export function PageTitleButtons({ packageName, sourceCodeUrl }: Props) {
                 tooltip="View library in npm registry"
               />
               {sourceCodeUrl?.startsWith('https://github.com/expo/expo') && (
-                <div className="max-sm:hidden bg-secondary mx-2 h-5 w-px" />
+                <div className="max-sm:hidden bg-secondary mx-1 h-5 w-px" />
               )}
             </>
           )}

--- a/docs/ui/components/PageHeader/PageTitleButtons.tsx
+++ b/docs/ui/components/PageHeader/PageTitleButtons.tsx
@@ -1,8 +1,8 @@
 import { Button } from '@expo/styleguide';
-import { BuildIcon } from '@expo/styleguide-icons/custom/BuildIcon';
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+import { NpmIcon } from '@expo/styleguide-icons/custom/NpmIcon';
+import { ClockRefreshIcon } from '@expo/styleguide-icons/outline/ClockRefreshIcon';
 import { Edit05Icon } from '@expo/styleguide-icons/outline/Edit05Icon';
-import { Tag03Icon } from '@expo/styleguide-icons/outline/Tag03Icon';
 import { useRouter } from 'next/compat/router';
 
 import { githubUrl } from '~/ui/components/Footer/utils';
@@ -39,29 +39,39 @@ export function PageTitleButtons({ packageName, sourceCodeUrl }: Props) {
       {(sourceCodeUrl ||
         sourceCodeUrl?.startsWith('https://github.com/expo/expo') ||
         packageName) && (
-        <span className="flex items-center gap-1">
+        <span className="flex items-center">
           {sourceCodeUrl && (
-            <SdkPackageButton
-              label="GitHub"
-              Icon={GithubIcon}
-              href={sourceCodeUrl}
-              tooltip="View source code on GitHub"
-            />
+            <>
+              <SdkPackageButton
+                label="GitHub"
+                Icon={GithubIcon}
+                href={sourceCodeUrl}
+                tooltip="View source code on GitHub"
+              />
+              {(packageName || sourceCodeUrl?.startsWith('https://github.com/expo/expo')) && (
+                <div className="max-sm:hidden bg-secondary mx-2 h-5 w-px" />
+              )}
+            </>
+          )}
+          {packageName && (
+            <>
+              <SdkPackageButton
+                label="npm"
+                Icon={NpmIcon}
+                href={`https://www.npmjs.com/package/${packageName}`}
+                tooltip="View library in npm registry"
+              />
+              {sourceCodeUrl?.startsWith('https://github.com/expo/expo') && (
+                <div className="max-sm:hidden bg-secondary mx-2 h-5 w-px" />
+              )}
+            </>
           )}
           {sourceCodeUrl?.startsWith('https://github.com/expo/expo') && (
             <SdkPackageButton
               label="Changelog"
-              Icon={Tag03Icon}
+              Icon={ClockRefreshIcon}
               href={`${sourceCodeUrl}/CHANGELOG.md`}
-              tooltip="View package changelog on GitHub"
-            />
-          )}
-          {packageName && (
-            <SdkPackageButton
-              label="npm"
-              Icon={BuildIcon}
-              href={`https://www.npmjs.com/package/${packageName}`}
-              tooltip="View package in npm registry"
+              tooltip="View library changelog on GitHub"
             />
           )}
         </span>

--- a/docs/ui/components/PageHeader/SdkPackageButton.tsx
+++ b/docs/ui/components/PageHeader/SdkPackageButton.tsx
@@ -15,10 +15,15 @@ export const SdkPackageButton = ({ label, Icon, tooltip, href }: SdkPackageButto
   return (
     <Tooltip.Root key={label} delayDuration={500}>
       <Tooltip.Trigger asChild>
-        <Button theme="quaternary" className="justify-center px-2.5" openInNewTab href={href}>
+        <Button
+          theme="quaternary"
+          className="justify-center px-2.5"
+          openInNewTab
+          href={href}
+          aria-label={label}>
           <div className="flex items-center gap-1.5">
             <Icon className="icon-sm text-icon-secondary" />
-            <FOOTNOTE crawlable={false} theme="secondary">
+            <FOOTNOTE crawlable={false} theme="secondary" className="max-md-gutters:hidden">
               {label}
             </FOOTNOTE>
           </div>

--- a/docs/ui/components/PageHeader/SdkPackageButton.tsx
+++ b/docs/ui/components/PageHeader/SdkPackageButton.tsx
@@ -1,4 +1,4 @@
-import { Button, mergeClasses } from '@expo/styleguide';
+import { Button } from '@expo/styleguide';
 import { ComponentType, HTMLAttributes, ReactNode } from 'react';
 
 import { FOOTNOTE } from '~/ui/components/Text';
@@ -15,17 +15,9 @@ export const SdkPackageButton = ({ label, Icon, tooltip, href }: SdkPackageButto
   return (
     <Tooltip.Root key={label} delayDuration={500}>
       <Tooltip.Trigger asChild>
-        <Button
-          theme="quaternary"
-          className="min-h-[48px] min-w-[60px] justify-center px-2 max-xl-gutters:min-h-[unset]"
-          openInNewTab
-          href={href}>
-          <div
-            className={mergeClasses(
-              'flex flex-col items-center',
-              'max-xl-gutters:flex-row max-xl-gutters:gap-1.5'
-            )}>
-            <Icon className="mt-0.5 text-icon-secondary" />
+        <Button theme="quaternary" className="justify-center px-2.5" openInNewTab href={href}>
+          <div className="flex items-center gap-1.5">
+            <Icon className="icon-sm text-icon-secondary" />
             <FOOTNOTE crawlable={false} theme="secondary">
               {label}
             </FOOTNOTE>

--- a/docs/ui/components/Separator.tsx
+++ b/docs/ui/components/Separator.tsx
@@ -1,3 +1,13 @@
+import { useRouter } from 'next/compat/router';
+
 export function Separator() {
+  const router = useRouter();
+  const currentPath = router?.asPath ?? router?.pathname ?? '';
+  const isSdkPage = currentPath.includes('/sdk/');
+
+  if (isSdkPage) {
+    return <hr className="mb-6 h-[0.05rem] border-0 bg-palette-gray6" />;
+  }
+
   return <hr className="mb-6 mt-4 h-[0.05rem] border-0 bg-palette-gray6" />;
 }

--- a/docs/ui/components/Separator.tsx
+++ b/docs/ui/components/Separator.tsx
@@ -6,7 +6,7 @@ export function Separator() {
   const isSdkPage = currentPath.includes('/sdk/');
 
   if (isSdkPage) {
-    return <hr className="mb-6 h-[0.05rem] border-0 bg-palette-gray6" />;
+    return <hr className="mb-6 h-[0.05rem] border-0 bg-palette-gray6 max-md-gutters:hidden" />;
   }
 
   return <hr className="mb-6 mt-4 h-[0.05rem] border-0 bg-palette-gray6" />;


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18179

# How

<!--
How did you build this feature or fix this bug and why?
-->

* Refactored the `PageHeader` component to render a specialized layout for SDK pages, including a distinct section for the title, description, platform tags, and a reorganized action bar with better grouping of the "Ask AI" button and package/library links. 
* Updated the `PageTitleButtons` component to use more descriptive icons (e.g., `NpmIcon` for npm, `ClockRefreshIcon` for changelog), improved tooltip text to refer to "library" instead of "package," and adjusted the visual grouping and dividers between buttons for clarity. 
* Updated test assertions in `PageHeader.test.tsx` to match the new tooltip text.
* The `Separator` component now conditionally renders a different style for SDK pages based on the current path.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See /versions/latest/sdk/localization/ & /versions/latest/sdk/local-authentication/

## Preview

<img width="3144" height="2456" alt="CleanShot 2025-11-26 at 01 11 14" src="https://github.com/user-attachments/assets/5c4ff60b-cb00-49d5-a0b4-b7867714d7ac" />

<img width="687" height="1019" alt="CleanShot 2025-11-26 at 01 12 01" src="https://github.com/user-attachments/assets/15ffc182-1b1f-4ac8-99dd-e0c7add60116" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
