### PR TITLE
Cleanup BridgeDevSupportManager

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/factories/ExpoGoDevSupportFactory.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/factories/ExpoGoDevSupportFactory.kt
@@ -2,7 +2,6 @@ package host.exp.exponent.factories
 
 import android.content.Context
 import com.facebook.react.common.SurfaceDelegateFactory
-import com.facebook.react.devsupport.BridgeDevSupportManager
 import com.facebook.react.devsupport.DevSupportManagerFactory
 import com.facebook.react.devsupport.ReactInstanceDevHelper
 import com.facebook.react.devsupport.ReleaseDevSupportManager
@@ -29,19 +28,8 @@ class ExpoGoDevSupportFactory(private val devBundleDownloadListener: DevBundleDo
     devLoadingViewManager: DevLoadingViewManager?,
     pausedInDebuggerOverlayManager: PausedInDebuggerOverlayManager?
   ): DevSupportManager {
-    return BridgeDevSupportManager(
-      applicationContext,
-      reactInstanceManagerHelper,
-      packagerPathForJSBundleName,
-      enableOnCreate,
-      redBoxHandler,
-      this.devBundleDownloadListener,
-      this.minNumShakes,
-      customPackagerCommandHandlers,
-      surfaceDelegateFactory,
-      devLoadingViewManager,
-      pausedInDebuggerOverlayManager
-    )
+    // This method was used only by legacy architecture and is stubbed here.
+    return ReleaseDevSupportManager()
   }
 
   override fun create(

--- a/packages/@expo/log-box/android/src/main/expo/modules/logbox/ExpoLogBoxDevSupportManager.kt
+++ b/packages/@expo/log-box/android/src/main/expo/modules/logbox/ExpoLogBoxDevSupportManager.kt
@@ -97,10 +97,6 @@ class ExpoLogBoxDevSupportManager(
  * An implementation of [DevSupportManager] that extends the functionality in
  * [DevSupportManagerBase] with some additional, more flexible APIs for asynchronously loading the
  * JS bundle.
- *
- * @constructor The primary constructor mirrors the same constructor we have for
- *   [BridgeDevSupportManager] and
- *     * is kept for backward compatibility.
  */
 open class ExpoBridgelessDevSupportManager(
   applicationContext: Context,


### PR DESCRIPTION
# Why

This class was from the legacy architecture. We're removing it from 0.84 as it was deprecated for a long time.
So I'm removing all the occurrences in your codebase.

# Test Plan

Mostly CI as this method was not invoked anymore on NewArch.

