### PR TITLE
[ci] added disk-cleanup before running android tests

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -299,6 +299,8 @@ jobs:
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v5
+      - name: 🧹 Cleanup GitHub Linux runner disk space
+        uses: ./.github/actions/cleanup-linux-disk-space
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
# Why

Still trying to remedy the errors on our Android tests where we see this one:

```
Not enough space to create userdata partition. Available: 5303.19 MB at /home/runner/.android/avd/avd-36.avd, need 7372.80 MB.
  ```

# How

Added `cleanup-linux-disk-space` step when running the tests.

# Test Plan

✅ CI Green → https://github.com/expo/expo/actions/runs/19702841765/job/56444429552

Thanks to @vonovak for the suggestion!