### PR TITLE
[docs] Add a reference guide on using shared objects from Expo Modules API

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -285,3 +285,4 @@ exceptions:
   - 'Mode 2: Payload mode'
   - 'Method 1: Use'
   - 'Method 2: Use'
+  - 'Image manipulation without disk I/O'

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -311,6 +311,7 @@ export const general = [
         makePage('modules/android-lifecycle-listeners.mdx'),
         makePage('modules/appdelegate-subscribers.mdx'),
         makePage('modules/autolinking.mdx'),
+        makePage('modules/shared-objects.mdx'),
         makePage('modules/module-config.mdx'),
         makePage('modules/mocking.mdx'),
         makePage('modules/design.mdx'),

--- a/docs/pages/modules/shared-objects.mdx
+++ b/docs/pages/modules/shared-objects.mdx
@@ -233,7 +233,7 @@ export function SharedImageExample() {
 }
 ```
 
-In the above example, the React component never receives raw pixels or deals with file paths after the initial load. It only manages a context object and a shared reference.
+In the above example, the React component only consumes the native image transformed by the image manipulator context, which is already in memory and referenced by the shared object (`ImageRef`). As a result, the image view can display the image immediately on the next frame.
 
 The JavaScript API picks an image using `ImagePicker`, which returns a standard file URI. This URI is handed to a custom native module to create a shared object in `SharedImageExample()`:
 
@@ -264,6 +264,8 @@ Some examples of [Expo SDK libraries](/versions/latest/) that use shared objects
 
 - `expo-image` library uses `SharedObject` to keep a decoded operation alive and the view component accepts `SharedRef<Bitmap>` on Android and `SharedRef<UIImage>` on iOS. This design allows images to be passed between modules without decoding it again. To explore more, see `expo-image` library's source code for [Android](https://github.com/expo/expo/tree/main/packages/expo-image/android/src/main/java/expo/modules/image) and [iOS](https://github.com/expo/expo/tree/main/packages/expo-image/ios).
 - `expo-image-manipulator` library demonstrates handling asynchronous operations, queuing multiple operations, and exposing a clean JavaScript API. To explore more, see `expo-image-manipulator` library's source code for [Android](https://github.com/expo/expo/tree/main/packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator) and [iOS](https://github.com/expo/expo/tree/main/packages/expo-image-manipulator/ios).
+- `expo-sqlite` library uses shared objects to keep database, session, and statement handles across calls while coordinating access to the underlying database. To explore more, see `expo-sqlite` library's source code for [Android](https://github.com/expo/expo/tree/main/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite) and [iOS](https://github.com/expo/expo/tree/main/packages/expo-sqlite/ios).
+- `expo/fetch` library uses shared objects to keep request and response lifecycles alive for streaming, cancellation, and redirect handling while presenting a JavaScript fetch-compatible API. To explore more, see `expo/fetch` library's source code for [Android](https://github.com/expo/expo/tree/main/packages/expo/android/src/main/java/expo/modules/fetch) and [iOS](https://github.com/expo/expo/tree/main/packages/expo/ios/Fetch).
 
 ## Performance benefits of shared objects
 

--- a/docs/pages/modules/shared-objects.mdx
+++ b/docs/pages/modules/shared-objects.mdx
@@ -34,9 +34,9 @@ Without shared objects, `ImagePicker` returns a file URI such as `"file:///path/
 
 ### With shared objects
 
-The same scenario becomes much more efficient with shared objects. `ImagePicker` returns a file URI, but the image manipulator module reads the URI and decodes the image once into a shared object. When the app user calls `rotate()`, the module manipulates the in-memory bitmap without writing to the disk.
+The same scenario becomes much more efficient with shared objects. `ImagePicker` reads the URI and decodes the image once into a shared object. When the app user calls `rotate()`, the module manipulates the in-memory bitmap without writing to the disk.
 
-Finally, the new URI is passed to the `Image` component and this time the image is rendered from memory. The entire workflow requires just one disk read and one decode operation, with all transformations happening in memory.
+Finally, the shared object is passed to the `Image` component and this time the image is rendered from memory. The entire workflow requires just one disk read and one decode operation, with all transformations happening in memory.
 
 The performance gains are significant. By eliminating redundant disk I/O and decode operations, you keep only a single bitmap in memory instead of multiple copies. This reduces CPU usage, which helps preserve battery life, and lowers the risk of crashes from memory pressure.
 
@@ -58,7 +58,7 @@ import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.kotlin.sharedobjects.SharedObject
 
-class ImageRef(bitmap: Bitmap, runtimeContext: RuntimeContext) : SharedRef<Bitmap>(bitmap, runtimeContext)
+class ImageRef : SharedRef<Bitmap>()
 
 class SimpleImageContext(
   runtimeContext: RuntimeContext,
@@ -122,11 +122,7 @@ In iOS, you create a shared object by inheriting from `SharedObject` class provi
 import ExpoModulesCore
 import UIKit
 
-final class ImageRef: SharedRef<UIImage> {
-  init(_ image: UIImage) {
-    super.init(object: image)
-  }
-}
+final class ImageRef: SharedRef<UIImage> {}
 
 final class SimpleImageContext: SharedObject {
   private let original: UIImage

--- a/docs/pages/modules/shared-objects.mdx
+++ b/docs/pages/modules/shared-objects.mdx
@@ -1,0 +1,290 @@
+---
+title: Using shared objects
+description: Learn how to use a shared object from the Expo Modules API.
+---
+
+import { BoxLink } from '~/ui/components/BoxLink';
+
+import { BookOpen02Icon } from '~/ui/icons/BookOpen02Icon';
+
+Shared objects let you expose long-lived native instances from Android and iOS to your app's JavaScript/TypeScript without giving control of their lifecycle. They can be used to keep heavy state objects, such as a decoded bitmap, alive across React components, rather than spinning up a new native instance every time a component mounts.
+
+In this guide, let's understand what a shared object is and how they are implemented in native platforms.
+
+## What is a shared object?
+
+A shared object is a custom class that bridges a native instance from Android and/or iOS to your app's JavaScript/TypeScript code through an Expo module. On the native side in Kotlin and Swift, you declare the class by inheriting from `SharedObject` and expose it in your module definition using `Class()`. The Expo Modules API handles reference counting, lifecycle management, and cleanup automatically.
+
+## Why use shared objects?
+
+Large media assets, like images, can exceed several megabytes once decoded into memory. Without shared objects, passing these assets between different parts of your app forces each part to reload from the disk every time and decode the same file multiple times. This can increase memory pressure, create an I/O bottleneck, drop frames, or cause battery drain.
+
+Shared objects solve this by keeping a single native instance alive in memory while multiple JavaScript references point to it.
+
+## Example: Image manipulation without disk I/O
+
+To understand shared objects, consider an example where you need to rotate an image picked by the app user and then display that image in your app after manipulating it.
+
+### Without shared objects
+
+Historically, native modules were often written in a _stateless_ way, where each function operated independently without maintaining state between calls. If you wanted to perform two separate operations on the same object (such as an image file), you would load it from disk in both places and repeat the I/O operation each time.
+
+Without shared objects, `ImagePicker` returns a file URI such as `"file:///path/to/image.jpg"`. The image manipulator module then reads the URI and decodes the image from the disk into memory. When the app user calls `rotate()` method to rotate the image, the module saves the rotated image to a new file. Finally, when the new URI is passed to the `Image` component, it decodes the image from disk again to render the image. This workflow results in two or more decode and disk read operations.
+
+### With shared objects
+
+The same scenario becomes much more efficient with shared objects. `ImagePicker` returns a file URI, but the image manipulator module reads the URI and decodes the image once into a shared object. When the app user calls `rotate()`, the module manipulates the in-memory bitmap without writing to the disk.
+
+Finally, the new URI is passed to the `Image` component and this time the image is rendered from memory. The entire workflow requires just one disk read and one decode operation, with all transformations happening in memory.
+
+The performance gains are significant. By eliminating redundant disk I/O and decode operations, you keep only a single bitmap in memory instead of multiple copies. This reduces CPU usage, which helps preserve battery life, and lowers the risk of crashes from memory pressure.
+
+### Implementation with shared objects
+
+Now that you understand why shared objects matter, let's look into a minimal implementation that demonstrates the core concepts of the previous example.
+
+The example creates a simple image manipulation module that loads an image from a file path, rotates it in memory, and exposes a shared reference that other modules can consume.
+
+### Android implementation
+
+In Android, you create a shared object from `SharedObject` class provided by `expo.modules.kotlin.sharedobjects.SharedObject`. This class manages the decoded bitmap and exposes methods to manipulate it. The implementation keeps track of both the original image and the current state after any transformation, allowing you to reset to the original image if needed:
+
+```kotlin
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Matrix
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+import expo.modules.kotlin.sharedobjects.SharedObject
+
+class ImageRef(bitmap: Bitmap, runtimeContext: RuntimeContext) : SharedRef<Bitmap>(bitmap, runtimeContext)
+
+class SimpleImageContext(
+  runtimeContext: RuntimeContext,
+  private val original: Bitmap
+) : SharedObject(runtimeContext) {
+  private var current = original.copy(original.config, true)
+
+  fun rotate(degrees: Float) = apply {
+    val matrix = Matrix().apply { postRotate(degrees) }
+    current = Bitmap.createBitmap(current, 0, 0, current.width, current.height, matrix, true)
+  }
+
+  fun render(): ImageRef {
+    return ImageRef(current.copy(current.config, true), runtimeContext)
+  }
+
+  override fun sharedObjectDidRelease() {
+    if (!current.isRecycled) current.recycle()
+  }
+}
+```
+
+The above example is quite similar to the iOS implementation. However, there is one difference on Android: the `sharedObjectDidRelease()` method. This lifecycle callback is invoked when JavaScript releases all references to the shared object, providing an opportunity to clean up native resources.
+
+When the result of this class is passed to another module, the `render` method returns an `ImageRef`, which is a specialized `SharedRef<Bitmap>` type that `expo-image` and other image-aware modules already understand.
+
+The module definition exposes an async function to create the context and a class definition to bind methods. The Expo Modules API uses a declarative syntax where you specify the module name, functions to create instances, and a class definition that maps methods to the shared object:
+
+```kotlin
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+class SimpleImageModule : Module() {
+  override fun definition() = ModuleDefinition {
+    Name("SimpleImageModule")
+
+    AsyncFunction("createContextAsync") { path: String ->
+      val bitmap = BitmapFactory.decodeFile(path)
+        ?: throw Exceptions.IllegalArgument("Unable to decode image at $path")
+      SimpleImageContext(runtimeContext, bitmap)
+    }
+
+    Class<SimpleImageContext>("Context") {
+      Function("rotate") { ctx: SimpleImageContext, degrees: Float -> ctx.rotate(degrees) }
+      AsyncFunction("renderAsync") Coroutine { ctx: SimpleImageContext -> ctx.render() }
+      Function("reset") { ctx: SimpleImageContext -> ctx.apply { rotate(0f) } }
+    }
+  }
+}
+```
+
+In the above example, `createContextAsync` function decodes the bitmap from the file path and returns a new `SimpleImageContext` instance. Once the context exists, the `rotate` function runs synchronously because it only manipulates in memory. The `renderAsync` function is marked async to signal that it might involve copying or preparing the bitmap for consumption by other modules.
+
+### iOS implementation
+
+In iOS, you create a shared object by inheriting from `SharedObject` class provided by `ExpoModulesCore`. This class manages the decoded bitmap and exposes methods to manipulate it. The implementation keeps track of both the original image and the current state after any transformation, allowing you to reset to the original image if needed:
+
+```swift
+import ExpoModulesCore
+import UIKit
+
+final class ImageRef: SharedRef<UIImage> {
+  init(_ image: UIImage) {
+    super.init(object: image)
+  }
+}
+
+final class SimpleImageContext: SharedObject {
+  private let original: UIImage
+  private var current: UIImage
+
+  init(path: String) throws {
+    guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+          let image = UIImage(data: data) else {
+      throw Exceptions.InvalidArgument()
+    }
+    self.original = image
+    self.current = image
+    super.init()
+  }
+
+  func rotate(by degrees: Double) {
+    current = current.rotated(degrees: degrees)
+  }
+
+  func render() -> ImageRef {
+    return ImageRef(current)
+  }
+
+  func reset() {
+    current = original
+  }
+}
+```
+
+In the above example, `SimpleImageContext` class reads an image file and stores both the original and current versions. The `rotate` method mutates the current image in memory without touching the disk.
+
+When the result of this class is passed to another module, the `render` method returns an `ImageRef`, which is a specialized `SharedRef<UIImage>` type that `expo-image` and other image-aware modules already understand.
+
+Now, with the shared object class definition, you can expose it through your module definition. The Expo Modules API uses a declarative syntax where you specify the module name, functions to create instances, and a class definition that maps methods to the shared object:
+
+```swift
+public final class SimpleImageModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("SimpleImageModule")
+
+    AsyncFunction("createContextAsync") { (path: String) -> SimpleImageContext in
+      return try SimpleImageContext(path: path)
+    }
+
+    Class("Context", SimpleImageContext.self) {
+      Function("rotate") { (ctx, degrees: Double) -> SimpleImageContext in
+        ctx.rotate(by: degrees)
+        return ctx
+      }
+
+      AsyncFunction("renderAsync") { (ctx: SimpleImageContext) -> ImageRef in
+        return ctx.render()
+      }
+
+      Function("reset") { (ctx: SimpleImageContext) in
+        ctx.reset()
+      }
+    }
+  }
+}
+```
+
+In the above example, the `createContextAsync` is an asynchronous function because loading and decoding an image from disk is an I/O operation. Once the context exists, the `rotate` runs synchronously because it only manipulates in memory. The `renderAsync` function is marked async to signal that it might involve copying or preparing the bitmap for consumption by other modules, though in this simple example, it returns immediately.
+
+### Using a shared object in your app
+
+You can now use the shared object in your app's JavaScript/TypeScript code to load the image from the path, create a context of the loaded image, rotate it, render it to get a shared reference, and then pass that reference to an `Image` component:
+
+```tsx
+import { useState } from 'react';
+import { Button } from 'react-native';
+import { Image } from 'expo-image';
+import type { SharedRef } from 'expo';
+import SimpleImageModule from 'simple-image-module'; // The native custom module
+
+import { pickImageAsync } from './pickImage'; // The custom TypeScript function
+
+export function SharedImageExample() {
+  const [context, setContext] = useState(null);
+  const [result, setResult] = useState<SharedRef<'image'> | null>(null);
+
+  const load = async () => {
+    const uri = await pickImageAsync();
+    if (!uri) {
+      return;
+    }
+
+    const ctx = await SimpleImageModule.createContextAsync(uri);
+
+    setContext(ctx);
+    setResult(await ctx.renderAsync());
+  };
+
+  const rotate = async () => {
+    if (!context) {
+      return;
+    }
+
+    context.rotate(90);
+    setResult(await context.renderAsync());
+  };
+
+  return (
+    <>
+      <Button title="Pick image" onPress={load} />
+      <Button title="Rotate 90°" onPress={rotate} disabled={!context} />
+      {result && <Image source={result} style={{ width: 200, height: 200 }} />}
+    </>
+  );
+}
+```
+
+In the above example, the React component never receives raw pixels or deals with file paths after the initial load. It only manages a context object and a shared reference.
+
+The JavaScript API picks an image using `ImagePicker`, which returns a standard file URI. This URI is handed to a custom native module to create a shared object in `SharedImageExample()`:
+
+```tsx
+import * as ImagePicker from 'expo-image-picker';
+
+export async function pickImageAsync() {
+  const result = await ImagePicker.launchImageLibraryAsync({
+    quality: 1,
+    allowsMultipleSelection: false,
+  });
+
+  if (result.canceled || !result.assets?.length) {
+    return null;
+  }
+
+  // At this point we still have a disk URI.
+  // The native module will lift it into a shared object.
+  return result.assets[0].uri;
+}
+```
+
+In the above example, `ImagePicker` doesn't need to know about shared objects. It returns what it should, which is a file path. Your native module is responsible for transforming that path into a shared object that other modules (whether custom or Expo modules) can work with, such as `Image` from `expo-image`.
+
+## Expo libraries that use shared objects
+
+Some examples of [Expo SDK libraries](/versions/latest/) that use shared objects and their purpose:
+
+- `expo-image` library uses `SharedObject` to keep a decoded operation alive and the view component accepts `SharedRef<Bitmap>` on Android and `SharedRef<UIImage>` on iOS. This design allows images to be passed between modules without decoding it again. To explore more, see `expo-image` library's source code for [Android](https://github.com/expo/expo/tree/main/packages/expo-image/android/src/main/java/expo/modules/image) and [iOS](https://github.com/expo/expo/tree/main/packages/expo-image/ios).
+- `expo-image-manipulator` library demonstrates handling asynchronous operations, queuing multiple operations, and exposing a clean JavaScript API. To explore more, see `expo-image-manipulator` library's source code for [Android](https://github.com/expo/expo/tree/main/packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator) and [iOS](https://github.com/expo/expo/tree/main/packages/expo-image-manipulator/ios).
+
+## Performance benefits of shared objects
+
+Using shared objects provides several performance improvements, such as:
+
+- **Reduced disk I/O:** A single read operation instead of multiple reads across different modules or function calls
+- **Fewer decode operations:** Expensive decoding (such as JPEG/PNG to bitmap) happens once, not repeatedly
+- **Lower memory pressure:** One decode instance in memory instead of multiple copies
+- **Faster operations:** In-memory transformations are significantly faster than disk-based ones
+- **Avoid frame drops:** Less I/O blocking means smoother UI interactions
+
+## Additional resources
+
+<BoxLink
+  title="The real-world impact of Shared Objects in Expo Modules"
+  description="Shared Objects solve a lot of fundamental problems with Expo APIs and also unlock a whole new way to design object-oriented APIs."
+  href="https://expo.dev/blog/the-real-world-impact-of-shared-objects"
+  Icon={BookOpen02Icon}
+/>

--- a/docs/pages/modules/shared-objects.mdx
+++ b/docs/pages/modules/shared-objects.mdx
@@ -258,7 +258,7 @@ export async function pickImageAsync() {
 }
 ```
 
-In the above example, `ImagePicker` doesn't need to know about shared objects. It returns what it should, which is a file path. Your native module is responsible for transforming that path into a shared object that other modules (whether custom or Expo modules) can work with, such as `Image` from `expo-image`.
+In the above example, `ImagePicker` doesn't need to know about shared objects. It returns what it should, which is a file path. Your native module is responsible for transforming that path into a shared object that other Expo modules can work with, such as `Image` from `expo-image`.
 
 ## Expo libraries that use shared objects
 

--- a/docs/pages/modules/shared-objects.mdx
+++ b/docs/pages/modules/shared-objects.mdx
@@ -1,11 +1,12 @@
 ---
 title: Using shared objects
+sidebar_title: Shared objects
 description: Learn how to use a shared object from the Expo Modules API.
 ---
 
-import { BoxLink } from '~/ui/components/BoxLink';
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
-import { BookOpen02Icon } from '~/ui/icons/BookOpen02Icon';
+import { BoxLink } from '~/ui/components/BoxLink';
 
 Shared objects let you expose long-lived native instances from Android and iOS to your app's JavaScript/TypeScript without giving control of their lifecycle. They can be used to keep heavy state objects, such as a decoded bitmap, alive across React components, rather than spinning up a new native instance every time a component mounts.
 
@@ -41,7 +42,7 @@ The performance gains are significant. By eliminating redundant disk I/O and dec
 
 ### Implementation with shared objects
 
-Now that you understand why shared objects matter, let's look into a minimal implementation that demonstrates the core concepts of the previous example.
+Now that you understand why shared objects are useful, let's look into a minimal implementation that demonstrates the core concepts of the previous example.
 
 The example creates a simple image manipulation module that loads an image from a file path, rotates it in memory, and exposes a shared reference that other modules can consume.
 

--- a/docs/pages/modules/shared-objects.mdx
+++ b/docs/pages/modules/shared-objects.mdx
@@ -24,7 +24,7 @@ Shared objects solve this by keeping a single native instance alive in memory wh
 
 ## Example: Image manipulation without disk I/O
 
-To understand shared objects, consider an example where you need to rotate an image picked by the app user and then display that image in your app after manipulating it.
+To understand shared objects, consider an example where you need to rotate and flip an image picked by the app user and then display that image in your app after manipulating it.
 
 ### Without shared objects
 
@@ -44,11 +44,11 @@ The performance gains are significant. By eliminating redundant disk I/O and dec
 
 Now that you understand why shared objects are useful, let's look into a minimal implementation that demonstrates the core concepts of the previous example.
 
-The example creates a simple image manipulation module that loads an image from a file path, rotates it in memory, and exposes a shared reference that other modules can consume.
+The example creates a simple image manipulation module that loads an image from a file path, applies transforms (rotate and flip) in memory, and exposes a shared reference that other modules can consume.
 
 ### Android implementation
 
-In Android, you create a shared object from `SharedObject` class provided by `expo.modules.kotlin.sharedobjects.SharedObject`. This class manages the decoded bitmap and exposes methods to manipulate it. The implementation keeps track of both the original image and the current state after any transformation while reusing the initial bitmap. This allows you to reset the original image if needed:
+In Android, you create a shared object from `SharedObject` class provided by `expo.modules.kotlin.sharedobjects.SharedObject`. This class manages the decoded bitmap and exposes methods to manipulate it. The implementation keeps only the current image in memory and applies transforms in place, so you allocate a new bitmap only when a transformation like rotation or flip produces one:
 
 ```kotlin
 import android.graphics.Bitmap
@@ -68,6 +68,11 @@ class SimpleImageContext(
 
   fun rotate(degrees: Float) = apply {
     val matrix = Matrix().apply { postRotate(degrees) }
+    current = Bitmap.createBitmap(current, 0, 0, current.width, current.height, matrix, true)
+  }
+
+  fun flipX() = apply {
+    val matrix = Matrix().apply { preScale(-1f, 1f) }
     current = Bitmap.createBitmap(current, 0, 0, current.width, current.height, matrix, true)
   }
 
@@ -103,18 +108,18 @@ class SimpleImageModule : Module() {
 
     Class<SimpleImageContext>("Context") {
       Function("rotate") { ctx: SimpleImageContext, degrees: Float -> ctx.rotate(degrees) }
+      Function("flipX") { ctx: SimpleImageContext -> ctx.flipX() }
       AsyncFunction("renderAsync") Coroutine { ctx: SimpleImageContext -> ctx.render() }
-      Function("reset") { ctx: SimpleImageContext -> ctx.apply { rotate(0f) } }
     }
   }
 }
 ```
 
-In the above example, `createContextAsync` function decodes the bitmap from the file path and returns a new `SimpleImageContext` instance. Once the context exists, the `rotate` function runs synchronously because it only manipulates in memory. The `renderAsync` function is marked async to signal that it might involve copying or preparing the bitmap for consumption by other modules.
+In the above example, `createContextAsync` function decodes the bitmap from the file path and returns a new `SimpleImageContext` instance. Once the context exists, the `rotate` and `flipX` functions run synchronously because they only manipulate in memory. The `renderAsync` function is marked async to signal that it might involve copying or preparing the bitmap for consumption by other modules.
 
 ### iOS implementation
 
-In iOS, you create a shared object by inheriting from `SharedObject` class provided by `ExpoModulesCore`. This class manages the decoded bitmap and exposes methods to manipulate it. The implementation keeps track of both the original image and the current state after any transformation, allowing you to reset to the original image if needed:
+In iOS, you create a shared object by inheriting from `SharedObject` class provided by `ExpoModulesCore`. This class manages the decoded bitmap and exposes methods to manipulate it. The implementation keeps only the current image in memory and applies transforms in place:
 
 ```swift
 import ExpoModulesCore
@@ -123,7 +128,6 @@ import UIKit
 final class ImageRef: SharedRef<UIImage> {}
 
 final class SimpleImageContext: SharedObject {
-  private let original: UIImage
   private var current: UIImage
 
   init(path: String) throws {
@@ -131,7 +135,6 @@ final class SimpleImageContext: SharedObject {
           let image = UIImage(data: data) else {
       throw Exceptions.InvalidArgument()
     }
-    self.original = image
     self.current = image
     super.init()
   }
@@ -140,17 +143,17 @@ final class SimpleImageContext: SharedObject {
     current = current.rotated(degrees: degrees)
   }
 
-  func render() -> ImageRef {
-    return ImageRef(current)
+  func flipX() {
+    current = current.withHorizontallyFlippedOrientation()
   }
 
-  func reset() {
-    current = original
+  func render() -> ImageRef {
+    return ImageRef(current)
   }
 }
 ```
 
-In the above example, `SimpleImageContext` class reads an image file and stores both the original and current versions. The `rotate` method mutates the current image in memory without touching the disk.
+In the above example, `SimpleImageContext` reads an image file and keeps a single `UIImage` in memory. The `rotate` and `flipX` methods mutate the current image in memory without touching the disk.
 
 When the result of this class is passed to another module, the `render` method returns an `ImageRef`, which is a specialized `SharedRef<UIImage>` type that `expo-image` and other image-aware modules already understand.
 
@@ -171,23 +174,24 @@ public final class SimpleImageModule: Module {
         return ctx
       }
 
-      AsyncFunction("renderAsync") { (ctx: SimpleImageContext) -> ImageRef in
-        return ctx.render()
+      Function("flipX") { (ctx: SimpleImageContext) -> SimpleImageContext in
+        ctx.flipX()
+        return ctx
       }
 
-      Function("reset") { (ctx: SimpleImageContext) in
-        ctx.reset()
+      AsyncFunction("renderAsync") { (ctx: SimpleImageContext) -> ImageRef in
+        return ctx.render()
       }
     }
   }
 }
 ```
 
-In the above example, the `createContextAsync` is an asynchronous function because loading and decoding an image from disk is an I/O operation. Once the context exists, the `rotate` runs synchronously because it only manipulates in memory. The `renderAsync` function is marked async to signal that it might involve copying or preparing the bitmap for consumption by other modules, though in this simple example, it returns immediately.
+In the above example, the `createContextAsync` is an asynchronous function because loading and decoding an image from disk is an I/O operation. Once the context exists, the `rotate` and `flipX` functions run synchronously because they only manipulate in memory. The `renderAsync` function is marked async to signal that it might involve copying or preparing the bitmap for consumption by other modules, though in this simple example, it returns immediately.
 
 ### Using a shared object in your app
 
-You can now use the shared object in your app's JavaScript/TypeScript code to load the image from the path, create a context of the loaded image, rotate it, render it to get a shared reference, and then pass that reference to an `Image` component:
+You can now use the shared object in your app's JavaScript/TypeScript code to load the image from the path, create a context of the loaded image, chain in-memory transforms, render to get a shared reference, and then pass that reference to an `Image` component:
 
 ```tsx
 import { useState } from 'react';
@@ -214,26 +218,25 @@ export function SharedImageExample() {
     setResult(await ctx.renderAsync());
   };
 
-  const rotate = async () => {
+  const rotateAndFlip = async () => {
     if (!context) {
       return;
     }
 
-    context.rotate(90);
-    setResult(await context.renderAsync());
+    setResult(await context.rotate(90).flipX().renderAsync());
   };
 
   return (
     <>
       <Button title="Pick image" onPress={load} />
-      <Button title="Rotate 90°" onPress={rotate} disabled={!context} />
+      <Button title="Rotate 90° + flip X" onPress={rotateAndFlip} disabled={!context} />
       {result && <Image source={result} style={{ width: 200, height: 200 }} />}
     </>
   );
 }
 ```
 
-In the above example, the React component only consumes the native image transformed by the image manipulator context, which is already in memory and referenced by the shared object (`ImageRef`). As a result, the image view can display the image immediately on the next frame.
+In the above example, the React component only consumes the native image transformed by the image manipulator context, which is already in memory and referenced by the shared object (`ImageRef`). As a result, the image view can display the image immediately on the next frame, and chained transforms never touch the file system.
 
 The JavaScript API picks an image using `ImagePicker`, which returns a standard file URI. This URI is handed to a custom native module to create a shared object in `SharedImageExample()`:
 

--- a/docs/pages/modules/shared-objects.mdx
+++ b/docs/pages/modules/shared-objects.mdx
@@ -48,7 +48,7 @@ The example creates a simple image manipulation module that loads an image from 
 
 ### Android implementation
 
-In Android, you create a shared object from `SharedObject` class provided by `expo.modules.kotlin.sharedobjects.SharedObject`. This class manages the decoded bitmap and exposes methods to manipulate it. The implementation keeps track of both the original image and the current state after any transformation, allowing you to reset to the original image if needed:
+In Android, you create a shared object from `SharedObject` class provided by `expo.modules.kotlin.sharedobjects.SharedObject`. This class manages the decoded bitmap and exposes methods to manipulate it. The implementation keeps track of both the original image and the current state after any transformation while reusing the initial bitmap. This allows you to reset the original image if needed:
 
 ```kotlin
 import android.graphics.Bitmap
@@ -64,16 +64,14 @@ class SimpleImageContext(
   runtimeContext: RuntimeContext,
   private val original: Bitmap
 ) : SharedObject(runtimeContext) {
-  private var current = original.copy(original.config, true)
+  private var current: Bitmap = original
 
   fun rotate(degrees: Float) = apply {
     val matrix = Matrix().apply { postRotate(degrees) }
     current = Bitmap.createBitmap(current, 0, 0, current.width, current.height, matrix, true)
   }
 
-  fun render(): ImageRef {
-    return ImageRef(current.copy(current.config, true), runtimeContext)
-  }
+  fun render(): ImageRef = ImageRef(current, runtimeContext)
 
   override fun sharedObjectDidRelease() {
     if (!current.isRecycled) current.recycle()

--- a/docs/pages/modules/shared-objects.mdx
+++ b/docs/pages/modules/shared-objects.mdx
@@ -14,7 +14,7 @@ In this guide, let's understand what a shared object is and how they are impleme
 
 ## What is a shared object?
 
-A shared object is a custom class that bridges a native instance from Android and/or iOS to your app's JavaScript/TypeScript code through an Expo module. On the native side in Kotlin and Swift, you declare the class by inheriting from `SharedObject` and expose it in your module definition using `Class()`. The Expo Modules API handles reference counting, lifecycle management, and cleanup automatically.
+A shared object is a custom class that bridges a native instance from Android and/or iOS to your app's JavaScript/TypeScript code through an Expo module. On the native side in Kotlin and Swift, you declare the class by inheriting from `SharedObject` and expose it in your module definition using `Class()`. A shared object is deallocated automatically once neither JavaScript nor native holds a reference.
 
 ## Why use shared objects?
 
@@ -30,11 +30,11 @@ To understand shared objects, consider an example where you need to rotate and f
 
 Historically, native modules were often written in a _stateless_ way, where each function operated independently without maintaining state between calls. If you wanted to perform two separate operations on the same object (such as an image file), you would load it from disk in both places and repeat the I/O operation each time.
 
-Without shared objects, `ImagePicker` returns a file URI such as `"file:///path/to/image.jpg"`. The image manipulator module then reads the URI and decodes the image from the disk into memory. When the app user calls `rotate()` method to rotate the image, the module saves the rotated image to a new file. Finally, when the new URI is passed to the `Image` component, it decodes the image from disk again to render the image. This workflow results in two or more decode and disk read operations.
+Without shared objects, `ImagePicker` reads from a file URI such as `"file:///path/to/image.jpg"` and decodes the image into memory. The image manipulator module then reads the same URI and decodes the image into memory again. When the app user calls a transform method (for example, `rotate()`) to rotate the image, the module saves the rotated image to a new file. Finally, when the new URI is passed to the `Image` component, it decodes the image from disk again to render the image. This workflow results in two or more decode and disk read operations.
 
 ### With shared objects
 
-The same scenario becomes much more efficient with shared objects. `ImagePicker` reads the URI and decodes the image once into a shared object. When the app user calls `rotate()`, the module manipulates the in-memory bitmap without writing to the disk.
+The same scenario becomes much more efficient with shared objects. `ImagePicker` reads the URI and decodes the image once into a shared object. When the app user calls a transform method (for example, `rotate()`), the module manipulates the in-memory bitmap without writing to the disk. If you need a file output, call an explicit save function (for example, `saveAsync` in an image manipulator), otherwise the transforms stay in memory only.
 
 Finally, the shared object is passed to the `Image` component and this time the image is rendered from memory. The entire workflow requires just one disk read and one decode operation, with all transformations happening in memory.
 

--- a/docs/pages/modules/shared-objects.mdx
+++ b/docs/pages/modules/shared-objects.mdx
@@ -40,6 +40,8 @@ Finally, the shared object is passed to the `Image` component and this time the 
 
 The performance gains are significant. By eliminating redundant disk I/O and decode operations, you keep only a single bitmap in memory instead of multiple copies. This reduces CPU usage, which helps preserve battery life, and lowers the risk of crashes from memory pressure.
 
+Shared objects also unlock a more convenient, object-oriented API shape. You can expose methods on a long-lived instance (for example, `rotate()`, `flipX()`, `renderAsync()`) and let callers chain operations on that stateful object, instead of exposing a flat set of stateless functions.
+
 ### Implementation with shared objects
 
 Now that you understand why shared objects are useful, let's look into a minimal implementation that demonstrates the core concepts of the previous example.
@@ -62,9 +64,9 @@ class ImageRef : SharedRef<Bitmap>()
 
 class SimpleImageContext(
   runtimeContext: RuntimeContext,
-  private val original: Bitmap
+  bitmap: Bitmap
 ) : SharedObject(runtimeContext) {
-  private var current: Bitmap = original
+  private var current: Bitmap = bitmap
 
   fun rotate(degrees: Float) = apply {
     val matrix = Matrix().apply { postRotate(degrees) }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-16724 ENG-16725

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add a reference guide on using shared objects from Expo Modules API.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs app locally and visit http://localhost:3002/modules/shared-objects/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
