### PR TITLE
[e-m-c] more detailed error when module not found

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -224,7 +224,7 @@ class AppContext(
    * @return true if there is an non-null, alive react native instance
    */
   val hasActiveReactInstance: Boolean
-    get() = hostingRuntimeContext.reactContext?.hasActiveReactInstance() ?: false
+    get() = hostingRuntimeContext.reactContext?.hasActiveReactInstance() == true
 
   /**
    * Provides access to the event emitter
@@ -234,7 +234,8 @@ class AppContext(
       ?: return null
     return KModuleEventEmitterWrapper(
       requireNotNull(registry.getModuleHolder(module)) {
-        "Cannot create an event emitter for the module that isn't present in the module registry."
+        val availableModulesNames = registry.registry.keys.joinToString(", ")
+        "Cannot create an event emitter for module ${module.javaClass} that isn't present in the module registry. Available modules: $availableModulesNames."
       },
       legacyEventEmitter,
       hostingRuntimeContext.reactContextHolder


### PR DESCRIPTION
# Why

Improve debugging in the Expo modules core by enhancing error message.



# Test Plan

"faked" the condition and got 

```
Cannot create an event emitter for module class expo.modules.notifications.tokens.PushTokenModule that isn't present in the module registry. Available modules: NativeModulesProxy, ExpoModulesCoreJSLogger, ExpoDomWebViewModule, ExpoFetchModule, ExpoApplication, ExpoAsset, ExponentConstants, ExpoDevMenu, ExpoDevice, FileSystem, ExponentFileSystem, ExpoFontLoader, ExpoFontUtils, ExpoKeepAwake, ExpoLinking, ExpoBadgeModule, ExpoBackgroundNotificationTasksModule, ExpoNotificationCategoriesModule, ExpoNotificationChannelGroupManager, ExpoNotificationChannelManager, ExpoNotificationsEmitter, ExpoNotificationsHandlerModule, ExpoNotificationPermissionsModule, ExpoNotificationPresenter, ExpoNotificationScheduler, NotificationsServerRegistrationModule, ExpoPushTokenManager, ExpoRouter, ExpoSQLite, ExpoTaskManager
```

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)