### PR TITLE
[constants] fix empty expoConfig

### DIFF
--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed empty `expoConfig` on Android. ([#41259](https://github.com/expo/expo/pull/41259) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - [Android] Removed unused native dependencies. ([#39763](https://github.com/expo/expo/pull/39763) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.kt
+++ b/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsService.kt
@@ -67,7 +67,7 @@ open class ConstantsService(private val context: Context) : InternalModule, Cons
   private val appConfig: String?
     get() {
       try {
-        context
+        return context
           .assets
           .open(CONFIG_FILE_NAME)
           .use { input ->


### PR DESCRIPTION
# Why 

fixed that `expoConfig` is null. a regression from #39763
it's also the root cause of breaking updates e2e: https://expo.dev/accounts/expo-ci/projects/expo-workflow-testing/workflows/019ac060-9da7-75f8-a1d5-6bbcba60624c

# How

return something

# Test Plan

updates e2e ci passed (in upstack pr)

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
