### PR TITLE
[expo] fix broken reloading for expo-updates

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fixed DOM Components entry not found from updates on Android. ([#40574](https://github.com/expo/expo/pull/40574) by [@kudo](https://github.com/kudo))
 - Empty HMR update should not reset the error overlay ([#40741](https://github.com/expo/expo/pull/40741) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Fix `ExpoAppDelegate` not extending `UIResponder`. ([#41066](https://github.com/expo/expo/pull/41066) by [@tsapeta](https://github.com/tsapeta))
+- Fixed broken `Updates.reloadAsync`. ([#41260](https://github.com/expo/expo/pull/41260) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo/android/src/main/java/expo/modules/ExpoReactHostFactory.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ExpoReactHostFactory.kt
@@ -39,23 +39,23 @@ object ExpoReactHostFactory {
     private val hostHandlers: List<ReactNativeHostHandler>
   ) : ReactHostDelegate {
 
-    val hostDelegateJsBundleFilePath: String? by lazy {
-      hostHandlers.asSequence()
-        .mapNotNull { it.getJSBundleFile(useDevSupport) }
-        .firstOrNull() ?: jsBundleFilePath
-    }
+    val hostDelegateJsBundleFilePath: String?
+      get() =
+        hostHandlers.asSequence()
+          .mapNotNull { it.getJSBundleFile(useDevSupport) }
+          .firstOrNull() ?: jsBundleFilePath
 
-    val hostDelegateJSBundleAssetPath: String? by lazy {
-      hostHandlers.asSequence()
-        .mapNotNull { it.getBundleAssetName(useDevSupport) }
-        .firstOrNull() ?: jsBundleAssetPath
-    }
+    val hostDelegateJSBundleAssetPath: String?
+      get() =
+        hostHandlers.asSequence()
+          .mapNotNull { it.getBundleAssetName(useDevSupport) }
+          .firstOrNull() ?: jsBundleAssetPath
 
-    val hostDelegateUseDeveloperSupport: Boolean by lazy {
-      hostHandlers.asSequence()
-        .mapNotNull { it.useDeveloperSupport }
-        .firstOrNull() ?: useDevSupport
-    }
+    val hostDelegateUseDeveloperSupport: Boolean
+      get() =
+        hostHandlers.asSequence()
+          .mapNotNull { it.useDeveloperSupport }
+          .firstOrNull() ?: useDevSupport
 
     // Keeps this `_jsBundleLoader` backing property for DevLauncher to replace its internal value
     private var _jsBundleLoader: JSBundleLoader? = null


### PR DESCRIPTION
# Why

fix broken `Updates.reloadAsync` on android. a regression since #40222

# How

the bundle configurations cannot be lazy. the `Updates.reloadAsync()` may switch bundle url dynamically

# Test Plan

updates e2e ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)