### PR TITLE
[templates,autolinking] Switch back to `node -e` for `expo-modules-autolinking` invocation in `Podfile` command

### DIFF
--- a/apps/bare-expo/ios/Podfile
+++ b/apps/bare-expo/ios/Podfile
@@ -28,7 +28,10 @@ abstract_target 'BareExpoMain' do
   use_frameworks! :linkage => ENV['USE_FRAMEWORKS'].to_sym if ENV['USE_FRAMEWORKS']
 
   config_command = [
-    'npx',
+    'node',
+    '--no-warnings',
+    '--eval',
+    'require(\'expo/bin/autolinking\')',
     'expo-modules-autolinking',
     'react-native-config',
     '--json',

--- a/apps/brownfield-tester/ios/Podfile
+++ b/apps/brownfield-tester/ios/Podfile
@@ -16,7 +16,10 @@ target 'BrownfieldTester' do
   })
 
   config_command = [
-    'npx',
+    'node',
+    '--no-warnings',
+    '--eval',
+    'require(\'expo/bin/autolinking\')',
     'expo-modules-autolinking',
     'react-native-config',
     '--json',

--- a/apps/expo-go/ios/Podfile
+++ b/apps/expo-go/ios/Podfile
@@ -64,7 +64,10 @@ target 'Expo Go' do
   pod 'expo-dev-menu', :path => '../../../packages/expo-dev-menu', :configurations => ['Debug', 'Release']
 
   config_command = [
-    'npx',
+    'node',
+    '--no-warnings',
+    '--eval',
+    'require(\'expo/bin/autolinking\')',
     'expo-modules-autolinking',
     'react-native-config',
     '--json',

--- a/apps/minimal-tester/ios/Podfile
+++ b/apps/minimal-tester/ios/Podfile
@@ -17,7 +17,10 @@ target 'minimaltester' do
   use_expo_modules!
 
   config_command = [
-    'npx',
+    'node',
+    '--no-warnings',
+    '--eval',
+    'require(\'expo/bin/autolinking\')',
     'expo-modules-autolinking',
     'react-native-config',
     '--json',

--- a/apps/native-tests/ios/Podfile
+++ b/apps/native-tests/ios/Podfile
@@ -22,7 +22,10 @@ target 'NativeTests' do
   pod 'ExpoModulesTestCore', :path => "../../../packages/expo-modules-test-core/ios"
 
   config_command = [
-    'npx',
+    'node',
+    '--no-warnings',
+    '--eval',
+    'require(\'expo/bin/autolinking\')',
     'expo-modules-autolinking',
     'react-native-config',
     '--json',

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - [Android] Move generate-package-list to Gradle task ([#39917](https://github.com/expo/expo/pull/39917) by [@jakex7](https://github.com/jakex7))
 - [Android] Use module name from `expo-module.config.json`. ([#39985](https://github.com/expo/expo/pull/39985) by [@jakex7](https://github.com/jakex7))
+- [Android] Align `expo-gradle-plugin`'s CLI command to align with iOS invocation of `expo-modules-autolinking` ([#41264](https://github.com/expo/expo/pull/41264) by [@kitten](https://github.com/kitten))
 - Refactor test suite and file discovery implementation to drop `glob` ([#40601](https://github.com/expo/expo/pull/40601) by [@kitten](https://github.com/kitten))
 - Improve recursive dependency resolution performance ([#40651](https://github.com/expo/expo/pull/40651) by [@kitten](https://github.com/kitten))
 

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/main/kotlin/expo/modules/plugin/AutolinkigCommandBuilder.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/main/kotlin/expo/modules/plugin/AutolinkigCommandBuilder.kt
@@ -11,8 +11,8 @@ class AutolinkingCommandBuilder {
     "node",
     "--no-warnings",
     "--eval",
-    "require(require.resolve('expo-modules-autolinking', { paths: [require.resolve('expo/package.json')] }))(process.argv.slice(1))",
-    "--"
+    "require('expo/bin/autolinking')",
+    "expo-modules-autolinking"
   )
 
   private val platform = listOf(

--- a/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
+++ b/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
@@ -185,9 +185,8 @@ class ExpoAutolinkingManager {
       'node',
       '--no-warnings',
       '--eval',
-      // Resolve the `expo` > `expo-modules-autolinking` chain from the project root
-      'require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo\')] }))(process.argv.slice(1))',
-      '--',
+      'require(\'expo/bin/autolinking\')',
+      'expo-modules-autolinking',
       command,
       '--platform',
       'android'

--- a/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
@@ -216,7 +216,8 @@ module Expo
         'node',
         '--no-warnings',
         '--eval',
-        'require(require.resolve(\'expo-modules-autolinking\', { paths: [\'' +  __dir__ + '\'] }))(process.argv.slice(1))',
+        'require(\'expo/bin/autolinking\')',
+        'expo-modules-autolinking',
         command_name,
         '--platform',
         'apple'

--- a/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
@@ -293,7 +293,8 @@ module Expo
 
       with_node \\
         --no-warnings \\
-        --eval "require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo/package.json\')] }))(process.argv.slice(1))" \\
+        --eval "require(\'expo/bin/autolinking\')" \\
+        expo-modules-autolinking \\
         generate-modules-provider #{args.join(' ')} \\
         --target "#{modules_provider_path}" \\
         #{entitlement_param} \\

--- a/packages/expo/bin/autolinking
+++ b/packages/expo/bin/autolinking
@@ -1,3 +1,5 @@
 #!/usr/bin/env node
 
+// Executes expo-modules-autolinking CLI directly
+// WARN: This is used in expo-templates-bare-minimum (prebuild) templates and expo-modules-autolinking's expo-gradle-plugin
 require('expo-modules-autolinking/bin/expo-modules-autolinking');

--- a/packages/expo/bin/autolinking
+++ b/packages/expo/bin/autolinking
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
-// Executes expo-modules-autolinking CLI directly
-// WARN: This is used in expo-templates-bare-minimum (prebuild) templates and expo-modules-autolinking's expo-gradle-plugin
+// Executes expo-modules-autolinking CLI directly. This is accessed in three ways
+// - via the `expo-modules-autolinking` command declared via `package.json:bin` in `expo`
+// - in expo-templates-bare-minimum (prebuild) via Node resolution
+// - in expo-modules-autolinking's expo-gradle-plugin
 require('expo-modules-autolinking/bin/expo-modules-autolinking');

--- a/templates/expo-template-bare-minimum/ios/Podfile
+++ b/templates/expo-template-bare-minimum/ios/Podfile
@@ -27,7 +27,10 @@ target 'HelloWorld' do
     config_command = ['node', '-e', "process.argv=['', '', 'config'];require('@react-native-community/cli').run()"];
   else
     config_command = [
-      'npx',
+      'node',
+      '--no-warnings',
+      '--eval',
+      'require(\'expo/bin/autolinking\')',
       'expo-modules-autolinking',
       'react-native-config',
       '--json',


### PR DESCRIPTION
# Why

Effectively, this reverts #35661 but instead uses `expo/bin/autolinking` as a target for readability. A comment was added to denote this.

# How

Replace the invocation with:

```sh
node --no-warnings --eval "require('expo/bin/autolinking')" expo-modules-autolinking
```

This resolves the target CLI directly without `npx` causing extra printing to `stdout` (in some affected v10 versions), and without performing extra installation, prompting, or resolution.

This differs in what we had previously to target `expo/bin/autolinking` to avoid the double `require.resolve` invocation.

The added `expo-modules-autolinking` argument is purely to shift `argv` and is arbitrary.

The PR was actually not having an effect on Android since the command there has been moved to the Gradle plugin. I've aligned the command there to be the same as for iOS. I've omitted `--` since it's error-prone. It's not needed in this position, and can, under some circumstances, cause our flags to be ignored, so it's probably safer to leave out.

# Test Plan

- Manually invoked a local app iOS build with the command altered
- E2E CI should cover this

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
