### PR TITLE
[mail-composer][android] Fix mail composer not suggesting an e-mail client on some devices in share modal

### DIFF
--- a/packages/expo-mail-composer/CHANGELOG.md
+++ b/packages/expo-mail-composer/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix mail composer not suggesting an e-mail client on some devices. ([#41274](https://github.com/expo/expo/pull/41274) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 ## 15.0.7 — 2025-09-11

--- a/packages/expo-mail-composer/android/src/main/java/expo/modules/mailcomposer/MailIntentBuilder.kt
+++ b/packages/expo-mail-composer/android/src/main/java/expo/modules/mailcomposer/MailIntentBuilder.kt
@@ -13,7 +13,12 @@ import java.io.File
 class MailIntentBuilder(
   private val options: MailComposerOptions
 ) {
-  private val mailIntent = Intent(Intent.ACTION_SEND_MULTIPLE)
+  private val mailIntent: Intent =
+    if (options.attachments.isNullOrEmpty()) {
+      Intent(Intent.ACTION_SENDTO)
+    } else {
+      Intent(Intent.ACTION_SEND_MULTIPLE)
+    }
 
   private fun contentUriFromFile(file: File, application: Application): Uri = try {
     FileProvider.getUriForFile(


### PR DESCRIPTION
# Why

The mail-composer on some devices will try to share the e-mail as plaintext instead of as mail.
Fixes https://github.com/expo/expo/issues/37740

# How

We ask apps to declare whether they support SENDTO intent, but then actually send an intent with `ACTION_SEND_MULTIPLE`, which should be used when attachements are present. If we use SENDTO when there are no attachements, it should work.

# Test Plan

Tested in BareExpo on my Pixel (although my device didn't reproduce the issue, people have reported these changes to fix the issue and they didn't break anything)
