### PR TITLE
[notifications] remove token listener on module destroy

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -235,7 +235,7 @@ class AppContext(
     return KModuleEventEmitterWrapper(
       requireNotNull(registry.getModuleHolder(module)) {
         val availableModulesNames = registry.registry.keys.joinToString(", ")
-        "Cannot create an event emitter for module ${module.javaClass} that isn't present in the module registry. Available modules: $availableModulesNames."
+        "Cannot create an event emitter for module ${module.javaClass} that isn't present in the module registry. Available modules: [$availableModulesNames]."
       },
       legacyEventEmitter,
       hostingRuntimeContext.reactContextHolder

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 💡 Others
 
+- remove token listener on module destroy ([#41275](https://github.com/expo/expo/pull/41275) by [@vonovak](https://github.com/vonovak))
 - Remove tests related files from the published package content. ([#39551](https://github.com/expo/expo/pull/39551) by [@Simek](https://github.com/Simek))
 - [ios] migrate notification serializer to swift ([#38633](https://github.com/expo/expo/pull/38633) by [@vonovak](https://github.com/vonovak))
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/FirebaseMessagingDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/FirebaseMessagingDelegate.kt
@@ -45,7 +45,7 @@ open class FirebaseMessagingDelegate(protected val context: Context) : FirebaseM
      * @param listener A listener instance to be informed of new push device tokens.
      */
     @JvmStatic
-    fun addTokenListener(listener: FirebaseTokenListener) {
+    fun addTokenListener(listener: FirebaseTokenListener) = synchronized(sTokenListenersReferences) {
       // Checks whether this listener has already been registered
       if (!sTokenListenersReferences.contains(listener)) {
         sTokenListenersReferences.add(listener)
@@ -57,7 +57,7 @@ open class FirebaseMessagingDelegate(protected val context: Context) : FirebaseM
     }
 
     @JvmStatic
-    fun removeTokenListener(listener: FirebaseTokenListener) {
+    fun removeTokenListener(listener: FirebaseTokenListener) = synchronized(sTokenListenersReferences) {
       sTokenListenersReferences.remove(listener)
     }
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/tokens/PushTokenModule.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/tokens/PushTokenModule.kt
@@ -5,6 +5,7 @@ import expo.modules.kotlin.Promise
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.notifications.service.delegates.FirebaseMessagingDelegate.Companion.addTokenListener
+import expo.modules.notifications.service.delegates.FirebaseMessagingDelegate.Companion.removeTokenListener
 import expo.modules.notifications.tokens.interfaces.FirebaseTokenListener
 
 private const val NEW_TOKEN_EVENT_NAME = "onDevicePushToken"
@@ -35,6 +36,10 @@ class PushTokenModule : Module(), FirebaseTokenListener {
 
     OnCreate {
       addTokenListener(this@PushTokenModule)
+    }
+
+    OnDestroy {
+      removeTokenListener(this@PushTokenModule)
     }
 
     /**


### PR DESCRIPTION
# Why

This PR attempts to fix invalid push token event emissions by calling `removeTokenListener` in `OnDestroy`.

Originally opened to try fix #41040, it doesn't seem to help, but I'd still like to get it in.


# How

- Changed the token listeners collection from a `WeakHashMap<FirebaseTokenListener, WeakReference<FirebaseTokenListener?>?>` to a `HashSet<FirebaseTokenListener>` which was somewhat odd
- Implemented `OnDestroy` in the `PushTokenModule` to properly unregister the token listener when the module is destroyed

# Test Plan

tested locally


# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)