### PR TITLE
chore: change notification tester entry to ts

### DIFF
--- a/apps/notification-tester/index.ts
+++ b/apps/notification-tester/index.ts
@@ -1,4 +1,5 @@
 import { registerTask } from './src/registerTaskAsync';
-// Register app entry through Expo Router
-import 'expo-router/entry';
 registerTask();
+// Register app entry through Expo Router
+// eslint-disable-next-line import/first
+import 'expo-router/entry';

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notification-tester",
-  "main": "index.js",
+  "main": "index.ts",
   "version": "1.0.0",
   "scripts": {
     "start": "expo start --dev-client",


### PR DESCRIPTION
# Why

Convert the notification-tester app entry point from JavaScript to TypeScript.

# How



# Test Plan

1. Run the notification-tester app locally

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)