### PR TITLE
fix(expo-modules-core): add index.ts to sideEffects

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix `expo-modules-core` initialization being tree-shaken out in some bundlers (e.g. Next.js). ([#41282](https://github.com/expo/expo/pull/41282) by [@alantoa](https://github.com/alantoa))
 - [iOS] Fix throwing `InvalidArgsNumberException` when declaring `AsyncFunction` with optional arguments and `Promise`. ([#41054](https://github.com/expo/expo/pull/41054) by [@Wenszel](https://github.com/Wenszel))
 - [core] [iOS] Addresses a potential crash where `[NSString UTF8String]` could return `nil` for certain string inputs (non-English), leading to an attempt to dereference a null pointer during `jsi::String` creation. ([#40639](https://github.com/expo/expo/pull/40639) by [@mohammadamin16](https://github.com/mohammadamin16))
 - [iOS] Fix `Either` conversion in `Record` ([#40655](https://github.com/expo/expo/pull/40655) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-modules-core/package.json
+++ b/packages/expo-modules-core/package.json
@@ -6,7 +6,8 @@
   "types": "build/index.d.ts",
   "sideEffects": [
     "*.fx.ts",
-    "./src/polyfill/*.ts"
+    "./src/polyfill/*.ts",
+    "./src/index.ts"
   ],
   "exports": {
     "./package.json": "./package.json",


### PR DESCRIPTION
# Why

Fixes an issue where `expo-modules-core` initialization code (polyfills, logger setup) was being tree-shaken out in some bundlers (like Webpack in Next.js) because `src/index.ts` was not marked as having side effects.

The `src/index.ts` file imports modules specifically for their side effects (e.g., `./polyfill`), which are crucial for the environment setup. Without this change, strict tree-shaking configurations might skip these imports, leading to runtime errors or missing polyfills.

<img width="2168" height="2008" alt="CleanShot 2025-11-27 at 23 35 07@2x" src="https://github.com/user-attachments/assets/84a2fce9-134b-44cf-b887-ff4be61b5b1f" />

# How

Added `"./src/index.ts"` to the `sideEffects` list in `packages/expo-modules-core/package.json`. This explicitly tells bundlers that this file contains side effects and should not be skipped even if its exports are not fully utilized.

# Test Plan

1. Create a Next.js project that depends on `expo-modules-core`.
2. Before the fix: Observe build errors or runtime issues due to missing polyfills/initialization when the bundler optimizes imports.
3. Apply this fix.
4. After the fix: Verify that the project builds successfully and runs correctly, confirming that the side-effect imports in `index.ts` are executed.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)