### PR TITLE
[e-m-c] fix queue assertion crash

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -29,6 +29,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix throwing `InvalidArgsNumberException` when declaring `AsyncFunction` with optional arguments and `Promise`. ([#41054](https://github.com/expo/expo/pull/41054) by [@Wenszel](https://github.com/Wenszel))
+- [iOS] fix queue assertion crash ([#41296](https://github.com/expo/expo/pull/41296) by [@vonovak](https://github.com/vonovak))
 - [core] [iOS] Addresses a potential crash where `[NSString UTF8String]` could return `nil` for certain string inputs (non-English), leading to an attempt to dereference a null pointer during `jsi::String` creation. ([#40639](https://github.com/expo/expo/pull/40639) by [@mohammadamin16](https://github.com/mohammadamin16))
 - [iOS] Fix `Either` conversion in `Record` ([#40655](https://github.com/expo/expo/pull/40655) by [@vonovak](https://github.com/vonovak))
 - [RSC] Fix server components asserting from missing native modules. ([#40388](https://github.com/expo/expo/pull/40388) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriberManager.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriberManager.swift
@@ -167,11 +167,14 @@ public class ExpoAppDelegateSubscriberManager: NSObject {
   ) {
     let selector = #selector(application(_:handleEventsForBackgroundURLSession:completionHandler:))
     let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
+    if subs.isEmpty {
+      completionHandler()
+      return
+    }
     var subscribersLeft = subs.count
-    let dispatchQueue = DispatchQueue(label: "expo.application.handleBackgroundEvents")
 
-    let handler = {
-      dispatchQueue.sync {
+    let aggregatedHandler = {
+      DispatchQueue.main.async {
         subscribersLeft -= 1
 
         if subscribersLeft == 0 {
@@ -180,12 +183,8 @@ public class ExpoAppDelegateSubscriberManager: NSObject {
       }
     }
 
-    if subs.isEmpty {
-      completionHandler()
-    } else {
-      subs.forEach {
-        $0.application?(application, handleEventsForBackgroundURLSession: identifier, completionHandler: handler)
-      }
+    subs.forEach {
+      $0.application?(application, handleEventsForBackgroundURLSession: identifier, completionHandler: aggregatedHandler)
     }
   }
 
@@ -216,40 +215,39 @@ public class ExpoAppDelegateSubscriberManager: NSObject {
   ) {
     let selector = #selector(application(_:didReceiveRemoteNotification:fetchCompletionHandler:))
     let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
-    let lock = NSLock()
+    if subs.isEmpty {
+      completionHandler(.noData)
+      return
+    }
+
     var subscribersLeft = subs.count
     var failedCount = 0
     var newDataCount = 0
 
-    let aggregateHandler = { (result: UIBackgroundFetchResult) in
-      lock.lock()
-      defer { lock.unlock() }
+    let aggregatedHandler = { (result: UIBackgroundFetchResult) in
+      DispatchQueue.main.async {
+        if result == .failed {
+          failedCount += 1
+        } else if result == .newData {
+          newDataCount += 1
+        }
 
-      if result == .failed {
-        failedCount += 1
-      } else if result == .newData {
-        newDataCount += 1
-      }
+        subscribersLeft -= 1
 
-      subscribersLeft -= 1
-
-      if subscribersLeft == 0 {
-        if newDataCount > 0 {
-          completionHandler(.newData)
-        } else if failedCount > 0 {
-          completionHandler(.failed)
-        } else {
-          completionHandler(.noData)
+        if subscribersLeft == 0 {
+          if newDataCount > 0 {
+            completionHandler(.newData)
+          } else if failedCount > 0 {
+            completionHandler(.failed)
+          } else {
+            completionHandler(.noData)
+          }
         }
       }
     }
 
-    if subs.isEmpty {
-      completionHandler(.noData)
-    } else {
-      subs.forEach { subscriber in
-        subscriber.application?(application, didReceiveRemoteNotification: userInfo, fetchCompletionHandler: aggregateHandler)
-      }
+    subs.forEach { subscriber in
+      subscriber.application?(application, didReceiveRemoteNotification: userInfo, fetchCompletionHandler: aggregatedHandler)
     }
   }
 
@@ -289,11 +287,10 @@ public class ExpoAppDelegateSubscriberManager: NSObject {
     let selector = #selector(application(_:continue:restorationHandler:))
     let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
     var subscribersLeft = subs.count
-    let dispatchQueue = DispatchQueue(label: "expo.application.continueUserActivity", qos: .userInteractive)
     var allRestorableObjects = [UIUserActivityRestoring]()
 
-    let handler = { (restorableObjects: [UIUserActivityRestoring]?) in
-      dispatchQueue.sync {
+    let aggregatedHandler = { (restorableObjects: [UIUserActivityRestoring]?) in
+      DispatchQueue.main.async {
         if let restorableObjects = restorableObjects {
           allRestorableObjects.append(contentsOf: restorableObjects)
         }
@@ -307,7 +304,7 @@ public class ExpoAppDelegateSubscriberManager: NSObject {
     }
 
     return subs.reduce(false) { result, subscriber in
-      return subscriber.application?(application, continue: userActivity, restorationHandler: handler) ?? false || result
+      return subscriber.application?(application, continue: userActivity, restorationHandler: aggregatedHandler) ?? false || result
     }
   }
 #elseif os(macOS)
@@ -320,11 +317,10 @@ public class ExpoAppDelegateSubscriberManager: NSObject {
     let selector = #selector(application(_:continue:restorationHandler:))
     let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
     var subscribersLeft = subs.count
-    let dispatchQueue = DispatchQueue(label: "expo.application.continueUserActivity", qos: .userInteractive)
     var allRestorableObjects = [NSUserActivityRestoring]()
 
-    let handler = { (restorableObjects: [NSUserActivityRestoring]?) in
-      dispatchQueue.sync {
+    let aggregatedHandler = { (restorableObjects: [NSUserActivityRestoring]?) in
+      DispatchQueue.main.async {
         if let restorableObjects = restorableObjects {
           allRestorableObjects.append(contentsOf: restorableObjects)
         }
@@ -338,7 +334,7 @@ public class ExpoAppDelegateSubscriberManager: NSObject {
     }
 
     return subs.reduce(false) { result, subscriber in
-      return subscriber.application?(application, continue: userActivity, restorationHandler: handler) ?? false || result
+      return subscriber.application?(application, continue: userActivity, restorationHandler: aggregatedHandler) ?? false || result
     }
   }
 #endif
@@ -370,10 +366,14 @@ public class ExpoAppDelegateSubscriberManager: NSObject {
     let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
     var subscribersLeft = subs.count
     var result: Bool = false
-    let dispatchQueue = DispatchQueue(label: "expo.application.performAction", qos: .userInteractive)
 
-    let handler = { (succeeded: Bool) in
-      dispatchQueue.sync {
+    if subs.isEmpty {
+      completionHandler(result)
+      return
+    }
+
+    let aggregatedHandler = { (succeeded: Bool) in
+      DispatchQueue.main.async {
         result = result || succeeded
         subscribersLeft -= 1
 
@@ -383,12 +383,8 @@ public class ExpoAppDelegateSubscriberManager: NSObject {
       }
     }
 
-    if subs.isEmpty {
-      completionHandler(result)
-    } else {
-      subs.forEach { subscriber in
-        subscriber.application?(application, performActionFor: shortcutItem, completionHandler: handler)
-      }
+    subs.forEach { subscriber in
+      subscriber.application?(application, performActionFor: shortcutItem, completionHandler: aggregatedHandler)
     }
   }
 #endif
@@ -404,12 +400,15 @@ public class ExpoAppDelegateSubscriberManager: NSObject {
     let selector = #selector(application(_:performFetchWithCompletionHandler:))
     let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
     var subscribersLeft = subs.count
-    let dispatchQueue = DispatchQueue(label: "expo.application.performFetch", qos: .userInteractive)
+    if subs.isEmpty {
+      completionHandler(.noData)
+      return
+    }
     var failedCount = 0
     var newDataCount = 0
 
-    let handler = { (result: UIBackgroundFetchResult) in
-      dispatchQueue.sync {
+    let aggregatedHandler = { (result: UIBackgroundFetchResult) in
+      DispatchQueue.main.async {
         if result == .failed {
           failedCount += 1
         } else if result == .newData {
@@ -430,12 +429,8 @@ public class ExpoAppDelegateSubscriberManager: NSObject {
       }
     }
 
-    if subs.isEmpty {
-      completionHandler(.noData)
-    } else {
-      subs.forEach { subscriber in
-        subscriber.application?(application, performFetchWithCompletionHandler: handler)
-      }
+    subs.forEach { subscriber in
+      subscriber.application?(application, performFetchWithCompletionHandler: aggregatedHandler)
     }
   }
 


### PR DESCRIPTION
# Why

Ran into an issue with background tasks (triggered by a background notification):

<details>
<summary>Details</summary>

```
(lldb) bt
* thread #19, queue = 'expo.application.remoteNotification', stop reason = EXC_BREAKPOINT (code=1, subcode=0x1038578e4)
    frame #0: 0x00000001038578e4 libdispatch.dylib`_dispatch_assert_queue_fail + 120
    frame #1: 0x000000010388e01c libdispatch.dylib`dispatch_assert_queue$V2.cold.1 + 116
    frame #2: 0x0000000103857868 libdispatch.dylib`dispatch_assert_queue + 108
    frame #3: 0x000000018996003c libswift_Concurrency.dylib`_swift_task_checkIsolatedSwift + 48
    frame #4: 0x00000001899bf724 libswift_Concurrency.dylib`swift_task_isCurrentExecutorWithFlagsImpl(swift::SerialExecutorRef, swift::swift_task_is_current_executor_flag) + 356
    frame #5: 0x00000001050e6678 notificationtester.debug.dylib`closure #1 in closure #2 in static ExpoAppDelegateSubscriberManager.application(result=.noData, failedCount=0, newDataCount=0, 
subscribersLeft=2, completionHandler=0x0000000104f6dea8 notificationtester.debug.dylib`partial apply forwarder for reabstraction thunk helper from @escaping @callee_unowned @convention(block) (@unowned 
__C.UIBackgroundFetchResult) -> () to @escaping @callee_guaranteed (@unowned __C.UIBackgroundFetchResult) -> () at <compiler-generated>) at ExpoAppDelegateSubscriberManager.swift:0
    frame #8: 0x000000010386e2e0 libdispatch.dylib`_dispatch_client_callout + 16
    frame #9: 0x00000001038653cc libdispatch.dylib`_dispatch_lane_barrier_sync_invoke_and_complete + 172
  * frame #10: 0x00000001050e650c notificationtester.debug.dylib`closure #2 in static ExpoAppDelegateSubscriberManager.application(result=.noData, dispatchQueue=0x000000012c455d80, failedCount=0, 
newDataCount=0, subscribersLeft=2, completionHandler=0x0000000104f6dea8 notificationtester.debug.dylib`partial apply forwarder for reabstraction thunk helper from @escaping @callee_unowned @convention(block)
 (@unowned __C.UIBackgroundFetchResult) -> () to @escaping @callee_guaranteed (@unowned __C.UIBackgroundFetchResult) -> () at <compiler-generated>) at ExpoAppDelegateSubscriberManager.swift:225:21
    frame #12: 0x0000000104f6bad8 notificationtester.debug.dylib`__94-[EXLegacyAppDelegateWrapper 
application:didReceiveRemoteNotification:fetchCompletionHandler:]_block_invoke(.block_descriptor=0x0000000120206340, result=UIBackgroundFetchResultNoData) at EXLegacyAppDelegateWrapper.m:212:9
    frame #13: 0x0000000104f65064 notificationtester.debug.dylib`__63-[EXTaskService runTasksWithReason:userInfo:completionHandler:]_block_invoke(.block_descriptor=0x000000012bbebc90, results=@"1 element") 
at EXTaskService.m:351:7
    frame #14: 0x0000000104f666f8 notificationtester.debug.dylib`__67-[EXTaskService _runTasksSupportingLaunchReason:userInfo:callback:]_block_invoke(.block_descriptor=0x0000000120204f80, results=@"1 
element") at EXTaskService.m:517:7
    frame #15: 0x0000000104f60cdc notificationtester.debug.dylib`-[EXTaskExecutionRequest _maybeExecuteCallback](self=0x000000012c519b60, _cmd="_maybeExecuteCallback") at EXTaskExecutionRequest.m:59:5
    frame #16: 0x0000000104f60c74 notificationtester.debug.dylib`-[EXTaskExecutionRequest maybeEvaluate](self=0x000000012c519b60, _cmd="maybeEvaluate") at EXTaskExecutionRequest.m:46:5
    frame #17: 0x0000000104f60b98 notificationtester.debug.dylib`-[EXTaskExecutionRequest task:didFinishWithResult:](self=0x000000012c519b60, _cmd="task:didFinishWithResult:", task=0x0000000120370840, 
result=(long)1) at EXTaskExecutionRequest.m:35:3
    frame #18: 0x0000000104f63e64 notificationtester.debug.dylib`-[EXTaskService notifyTaskWithName:forAppId:didFinishWithResponse:](self=0x00000001200014c0, 
_cmd="notifyTaskWithName:forAppId:didFinishWithResponse:", taskName=@"BACKGROUND_NOTIFICATION_TASK", appId=@"mainApplication", response=1 key/value pair) at EXTaskService.m:217:7
    frame #19: 0x0000000104f617c4 notificationtester.debug.dylib`-[EXTaskManager notifyTaskFinished:withResponse:resolve:reject:](self=0x0000000120371600, 
_cmd="notifyTaskFinished:withResponse:resolve:reject:", taskName=@"BACKGROUND_NOTIFICATION_TASK", response=1 key/value pair, resolve=0x000000010ad20e7c, reject=0x000000010ad213bc) at EXTaskManager.m:104:3
    frame #20: 0x000000018b4ee6c4 CoreFoundation`__invoking___ + 148
    frame #21: 0x000000018b4ee550 CoreFoundation`-[NSInvocation invoke] + 424
    frame #22: 0x0000000105015b5c notificationtester.debug.dylib`-[EXExportedModule callExportedMethod:withArguments:resolver:rejecter:](self=0x0000000120371600, 
_cmd="callExportedMethod:withArguments:resolver:rejecter:", methodName=@"notifyTaskFinishedAsync", arguments=@"2 elements", resolve=0x000000010ad20e7c, reject=0x000000010ad213bc) at EXExportedModule.m:168:3
    frame #23: 0x000000010501fa10 notificationtester.debug.dylib`__79-[EXNativeModulesProxy callMethod:methodNameOrKey:arguments:resolver:rejecter:]_block_invoke(.block_descriptor=0x0000000122ea9270) at 
EXNativeModulesProxy.mm:243:7
    frame #24: 0x000000010385463c libdispatch.dylib`_dispatch_call_block_and_release + 32
    frame #25: 0x000000010386e2e0 libdispatch.dylib`_dispatch_client_callout + 16
    frame #26: 0x000000010385cb4c libdispatch.dylib`_dispatch_lane_serial_drain + 796
    frame #27: 0x000000010385d7d4 libdispatch.dylib`_dispatch_lane_invoke + 432
    frame #28: 0x0000000103869b20 libdispatch.dylib`_dispatch_root_queue_drain_deferred_wlh + 344
    frame #29: 0x00000001038691c4 libdispatch.dylib`_dispatch_workloop_worker_thread + 752
    frame #30: 0x00000001e7d803b8 libsystem_pthread.dylib`_pthread_wqthread + 292
```

</details>

# How

- dispatch the completion handlers on main queue

# Test Plan

- tested locally with notification-tester app

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
