### PR TITLE
[ios][precompiled] added expomodulejsi to ignore force-static-linking list

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Added the new ExpoModulesJSI to the forceStaticLinking default values
 - [Android] Fix passing exclude options. ([#40014](https://github.com/expo/expo/pull/40014) by [@jakex7](https://github.com/jakex7))
 - Sort results from file discovery to keep fingerprint stable ([#40601](https://github.com/expo/expo/pull/40601) by [@kitten](https://github.com/kitten))
 - Fix [#40601](https://github.com/expo/expo/pull/40601) assuming case-insensitive path for default derived podspec path in `react-native-config` resolution ([#40894](https://github.com/expo/expo/pull/40894) by [@kitten](https://github.com/kitten)) ([#40931](https://github.com/expo/expo/pull/40931) by [@kitten](https://github.com/kitten))

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Added the new ExpoModulesJSI to the forceStaticLinking default values
+- [iOS] Added the new ExpoModulesJSI to the forceStaticLinking default values ([#41298](https://github.com/expo/expo/pull/41298) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Fix passing exclude options. ([#40014](https://github.com/expo/expo/pull/40014) by [@jakex7](https://github.com/jakex7))
 - Sort results from file discovery to keep fingerprint stable ([#40601](https://github.com/expo/expo/pull/40601) by [@kitten](https://github.com/kitten))
 - Fix [#40601](https://github.com/expo/expo/pull/40601) assuming case-insensitive path for default derived podspec path in `react-native-config` resolution ([#40894](https://github.com/expo/expo/pull/40894) by [@kitten](https://github.com/kitten)) ([#40931](https://github.com/expo/expo/pull/40931) by [@kitten](https://github.com/kitten))

--- a/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
@@ -11,7 +11,7 @@ module Pod
     public
 
     def framework_modules_to_patch
-      @framework_modules_to_patch ||= ['ExpoModulesCore', 'Expo', 'ReactAppDependencyProvider', 'expo-dev-menu']
+      @framework_modules_to_patch ||= ['ExpoModulesCore', 'ExpoModulesJSI', 'Expo', 'ReactAppDependencyProvider', 'expo-dev-menu']
     end
 
     def expo_add_modules_to_patch(modules)


### PR DESCRIPTION
# Why

When using `USE_FRAMEWORKS` on iOS with precompiled frameworks, we have a list of expo modules that should be ignored since when they're using the React framework they fail since they expose headers from the React framework.

After splitting out the iOS JSI layer in #40755 we got another POD target that needs to be on the ignore list.

# How

This commit fixes this by adding the ExpoModulesJSI to the ignore list.

# Test Plan

Compile using `USE_FRAMEWORKS` and precompiled

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
