### PR TITLE
[notifications] fix completion handler never called

### DIFF
--- a/apps/notification-tester/src/registerTaskAsync.ts
+++ b/apps/notification-tester/src/registerTaskAsync.ts
@@ -3,6 +3,7 @@ import {
   addNotificationResponseReceivedListener,
   setNotificationHandler,
   NotificationTaskPayload,
+  BackgroundNotificationTaskResult,
 } from 'expo-notifications';
 import { defineTask } from 'expo-task-manager';
 import { AppState, Platform } from 'react-native';
@@ -120,11 +121,13 @@ export const registerTask = () => {
       }
 
       doSomeAsyncWork('BG_ASYNC_FETCH_RESULT');
+      return BackgroundNotificationTaskResult.NewData;
     } catch (err: any) {
       addItemToStorage({
         source: 'BACKGROUND_TASK_ERR',
         data: { err: err.toString(), payload: JSON.stringify(taskPayload, null, 2) },
       });
+      return BackgroundNotificationTaskResult.Failed;
     }
   });
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- fix completion handler never called for background notifications ([#41300](https://github.com/expo/expo/pull/41300) by [@vonovak](https://github.com/vonovak))
+
 ### 💡 Others
 
 - remove token listener on module destroy ([#41275](https://github.com/expo/expo/pull/41275) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Emitter/EmitterModule.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Emitter/EmitterModule.swift
@@ -32,11 +32,6 @@ open class EmitterModule: Module, NotificationDelegate {
     }
   }
 
-  public func didReceive(_ userInfo: [AnyHashable: Any], completionHandler: @escaping (UIBackgroundFetchResult) -> Void) -> Bool {
-    completionHandler(.noData)
-    return true
-  }
-
   open func didReceive(_ response: UNNotificationResponse, completionHandler: @escaping () -> Void) -> Bool {
     let notificationResponse = serializedResponse(response)
     lastResponse = notificationResponse

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/NotificationCenterManager.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/NotificationCenterManager.swift
@@ -24,6 +24,7 @@ public extension NotificationDelegate {
     return false
   }
   func didReceive(_ userInfo: [AnyHashable: Any], completionHandler: @escaping (UIBackgroundFetchResult) -> Void) -> Bool {
+    // false is equivalent to not handled, we then call completionHandler(.noData) below
     return false
   }
   func openSettings(_ notification: UNNotification?) {}
@@ -129,7 +130,7 @@ public class NotificationCenterManager: NSObject,
   }
 
   // MARK: - Called from NotificationsAppDelegateSubscriber
-  public func didReceiveNotification(_ userInfo: [AnyHashable: Any], completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+  public func didReceive(_ userInfo: [AnyHashable: Any], completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
     var handled = false
     for delegate in delegates {
       handled = delegate.didReceive(userInfo, completionHandler: completionHandler) || handled


### PR DESCRIPTION
# Why

Fixed a method naming issue in iOS notifications handling - `public func didReceiveNotification...` was never called for background notifications because the method had a wrong name. That ended up meaning that the completion handler for any given background notification was never called.
 
Also removed a redundant implementation of `didReceive` in the `EmitterModule` class.

# How

- Renamed `didReceiveNotification` to `didReceive` in `NotificationCenterManager` to make sure completion handler is called [here](https://github.com/expo/expo/blob/ba5ac3e9c8d2d92b897f8e0016cbad59da9c2491/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriberManager.swift#L233). 
- Removed the redundant implementation of `didReceive` in `EmitterModule` - the default implementation now behaves the same


# Test Plan

Tested locally on device; send a notification of this shape:

```
const messageTemplate: TestMessage = {
	to: '', // Will be replaced by the real push tokens
	priority: 'high',
	_contentAvailable: true,
	data: {
		type: 'whatever',
	},
}
```

this triggers the app delegate's 

```
public static func application(
    _ application: UIApplication,
    didReceiveRemoteNotification userInfo: [AnyHashable: Any],
    fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
  )
```

method. Ensured the completion handler is called in `ExpoAppDelegateSubscriberManager.swift`. Unfortunately this is somewhat hard to write automated tests for.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)