### PR TITLE
feat(cli,expo): Allow prebuild from local `expo-template-bare-minimum` peer installation

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Added MCP server handshaking and graceful shutdown. ([#40660](https://github.com/expo/expo/pull/40660) by [@kudo](https://github.com/kudo))
 - Update to `glob@^13.0.0` ([#41079](https://github.com/expo/expo/pull/41079) by [@kitten](https://github.com/kitten))
 - Use `@expo/mcp-tunnel` from `expo-mcp`. ([#41276](https://github.com/expo/expo/pull/41276) by [@kudo](https://github.com/kudo))
+- Use `expo/internal/unstable-template` as preferred local prebuild template path ([#41306](https://github.com/expo/expo/pull/41306) by [@kitten](https://github.com/kitten))
 
 ### ⚠️ Notices
 

--- a/packages/@expo/cli/src/prebuild/resolveLocalTemplate.ts
+++ b/packages/@expo/cli/src/prebuild/resolveLocalTemplate.ts
@@ -2,7 +2,7 @@ import type { ExpoConfig } from '@expo/config';
 import fs from 'fs';
 import resolveFrom from 'resolve-from';
 
-import { extractNpmTarballAsync } from '../utils/npm';
+import { copyNodeModuleAsync, extractNpmTarballAsync } from '../utils/npm';
 
 const debug = require('debug')('expo:prebuild:resolveLocalTemplate') as typeof console.log;
 
@@ -15,11 +15,22 @@ export async function resolveLocalTemplateAsync({
   projectRoot: string;
   exp: Pick<ExpoConfig, 'name'>;
 }): Promise<string> {
-  const templatePath = resolveFrom(projectRoot, 'expo/template.tgz');
-  debug('Using local template from Expo package:', templatePath);
-  const stream = fs.createReadStream(templatePath);
-  return await extractNpmTarballAsync(stream, {
-    cwd: templateDirectory,
-    name: exp.name,
-  });
+  try {
+    // In our monorepo, `expo/template.tgz` may not exist, or may be outdated, but we allow the template
+    // to be resolved by manually installing `expo-template-bare-minimum`
+    const templateRawPath = require(resolveFrom(projectRoot, 'expo/internal/unstable-template'));
+    return await copyNodeModuleAsync(templateRawPath, {
+      cwd: templateDirectory,
+      name: exp.name,
+    });
+  } catch (error) {
+    // The default is to use `expo/template.tgz` which exists in all published versions of it
+    const templatePath = resolveFrom(projectRoot, 'expo/template.tgz');
+    debug('Using local template from Expo package:', templatePath);
+    const stream = fs.createReadStream(templatePath);
+    return await extractNpmTarballAsync(stream, {
+      cwd: templateDirectory,
+      name: exp.name,
+    });
+  }
 }

--- a/packages/@expo/cli/src/utils/npm.ts
+++ b/packages/@expo/cli/src/utils/npm.ts
@@ -194,18 +194,21 @@ export async function copyNodeModuleAsync(
   });
 
   await pipeline(
-    tarCreate({
-      cwd: targetPath,
-      filter(entry) {
-        switch (path.basename(entry)) {
-          case '.npmignore':
-          case 'node_modules':
-            return false;
-          default:
-            return true;
-        }
+    tarCreate(
+      {
+        cwd: targetPath,
+        filter(entry) {
+          switch (path.basename(entry)) {
+            case '.npmignore':
+            case 'node_modules':
+              return false;
+            default:
+              return true;
+          }
+        },
       },
-    }, ['.']),
+      ['.']
+    ),
     transformStream,
     tarExtract(
       {

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -35,6 +35,7 @@
 - [Android] Remove edge-to-edge logic from `ReactActivityDelegateWrapper`. ([#40263](https://github.com/expo/expo/pull/40263) by [@behenate](https://github.com/behenate))
 - [expo/dom] Add `overrideUri` to `DOMProps` to enable pre-bundled DOM Components. ([#40397](https://github.com/expo/expo/pull/40397) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Add `internal/async-require-module` for `@expo/metro-config`'s `asyncRequireModulePath`([#40584](https://github.com/expo/expo/pull/40584) by [@kitten](https://github.com/kitten))
+- [Internal] Add `internal/unstable-template` for local prebuild ([#41306](https://github.com/expo/expo/pull/41306) by [@kitten](https://github.com/kitten))
 
 ### ⚠️ Notices
 

--- a/packages/expo/internal/unstable-template.d.ts
+++ b/packages/expo/internal/unstable-template.d.ts
@@ -1,0 +1,3 @@
+// WARN: Internal export, don't rely on this to be a public API or use it outside of `expo/expo`'s monorepo
+declare const targetPath: string;
+export = targetPath;

--- a/packages/expo/internal/unstable-template.js
+++ b/packages/expo/internal/unstable-template.js
@@ -1,0 +1,3 @@
+// WARN: Internal export, don't rely on this to be a public API or use it outside of `expo/expo`'s monorepo
+const path = require('path');
+module.exports = path.dirname(require.resolve('expo-template-bare-minimum/package.json'));

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -98,6 +98,7 @@
     "whatwg-url-without-unicode": "8.0.0-3"
   },
   "devDependencies": {
+    "expo-template-bare-minimum": "link:../../templates/expo-template-bare-minimum",
     "@expo/dom-webview": "0.2.7",
     "@expo/metro-runtime": "^6.1.2",
     "@types/node": "^22.14.0",
@@ -112,6 +113,7 @@
   "peerDependencies": {
     "@expo/dom-webview": "*",
     "@expo/metro-runtime": "*",
+    "expo-template-bare-minimum": "*",
     "react": "*",
     "react-native": "*",
     "react-native-webview": "*"
@@ -124,6 +126,9 @@
       "optional": true
     },
     "react-native-webview": {
+      "optional": true
+    },
+    "expo-templates-bare-minimum": {
       "optional": true
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8312,6 +8312,10 @@ expo-progress@^0.0.2:
   resolved "https://registry.yarnpkg.com/expo-progress/-/expo-progress-0.0.2.tgz#0d42470f8f1f019d3ae0f1da377c9bca891f3dd8"
   integrity sha512-RFd6aUxuZSH+ZhFeQB7Z6llnm8MZo7PmmgjoHeN5Hfvq1zc1gjQw0H4pCFcf3h6f08SXg32VMoaoi5A+D7Cs1A==
 
+"expo-template-bare-minimum@link:templates/expo-template-bare-minimum":
+  version "0.0.0"
+  uid ""
+
 expo-three@7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/expo-three/-/expo-three-7.0.1.tgz#689688b529b8443fe6c1324000c0714858e37c55"


### PR DESCRIPTION
# Why

We're often making changes to local templates, e.g.:
- https://github.com/expo/expo/pull/41264
- https://github.com/expo/expo/pull/39418

Since we don't have a concept of local templates, we then have to make sure to specify a local prebuild template manually. However, this seems pretty redundant because `expo-template-bare-minimum` is just a package and in the monorepo.

Failing to apply template changes to prebuild CNG folders often causes build issues on `main` as we upgrade React Native.

# How

- Mark `expo-template-bare-minimum` as an optional peer of `expo` and expose it via `expo/internal/unstable-template`
- Link to `expo-template-bare-minimum` in monorepo as dev dependency
- Extend `resolveLocalTemplateAsync` to try to load from `expo/internal/unstable-template` first

> [!NOTE]
> This means, even if `expo/template.tgz` exists, we prefer the "raw" `expo-template-bare-minimum`. **This also applies to our users, but we simply won't document this for now**

# Test Plan

- CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
