### PR TITLE
[expo-sqlite] fix encoding and decoding of result length

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- Fixed encoding and decoding of result length for web workers. ([#41307](https://github.com/expo/expo/pull/41307) by [@amidabucu](https://github.com/amidabucu))
 - Throwing error when `ExpoSQLite.defaultDatabaseDirectory` returns undefined. ([#40680](https://github.com/expo/expo/pull/40680) by [@kudo](https://github.com/kudo))
 - Fixed node runtime bundling error on web. ([#40739](https://github.com/expo/expo/pull/40739) by [@kudo](https://github.com/kudo))
 - Fixed Android 16kb page size issue when enabling `useSQLCipher`. ([#40781](https://github.com/expo/expo/pull/40781) by [@ronickg](https://github.com/ronickg))

--- a/packages/expo-sqlite/web/WorkerChannel.ts
+++ b/packages/expo-sqlite/web/WorkerChannel.ts
@@ -40,7 +40,8 @@ export function sendWorkerResult({
     const resultJson = error != null ? serialize({ error }) : serialize({ result });
     const resultBytes = new TextEncoder().encode(resultJson);
     const length = resultBytes.length;
-    resultArray.set(new Uint32Array([length]), 0);
+    const view = new DataView(resultArray.buffer);
+    view.setUint32(0, length, true);
     resultArray.set(resultBytes, 4);
     Atomics.store(lock, 0, RESOLVED);
   } else {
@@ -137,7 +138,8 @@ export function invokeWorkerSync<T extends SQLiteWorkerMessageType & keyof Resul
     }
   }
 
-  const length = new Uint32Array(resultArray.buffer, 0, 1)[0];
+  const view = new DataView(resultArray.buffer);
+  const length = view.getUint32(0, true);
   const resultCopy = new Uint8Array(length);
   resultCopy.set(new Uint8Array(resultArray.buffer, 4, length));
   const resultJson = new TextDecoder().decode(resultCopy);


### PR DESCRIPTION
# Why

There was a small bug in how the message length at the beginning of the result buffer was encoded and then decoded.

This is how the encoding part looked like:

```
const resultArray = new Uint8Array(...);
// ...
const length = resultBytes.length;
resultArray.set(new Uint32Array([length]), 0);
```

The source of the issue here is that the `resultArray` is an array of uint8 elements whereas `new Uint32Array([length])` has uint32 elements. The elements are copied and casted one by one, causing truncated values to be stored in the target array. For example, if the `length` was 504, the first 4 bytes in the target buffer are be 248, 0, 0, 0 instead of 248, 1, 0, 0.

This means that the encoding/decoding logic was broken for every scenario where the buffer length was at 256 or above.

# How

This issue has been fixed with the use of `DataView`:

```
const view = new DataView(resultArray.buffer);
view.setUint32(0, length, true);
```

Similarly, the decoder implementation also has been migrated to this approach.

# Test Plan

I was able to load results of multiple rows that easily exceeded 256 bytes. I also confirmed that such length are properly encoded and decoded.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
