### PR TITLE
[iOS] Use RCTHostRuntimeDelegate instead of the bridge to access the runtime

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [iOS] Added `appDelegateWillBeginInitialization` function to AppDelegate subscribers. ([#41456](https://github.com/expo/expo/pull/41456) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Added `RNHost` to improve RN component layout inside SwiftUI views ([#40938](https://github.com/expo/expo/pull/40938) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Added `ignoreSafeAreaKeyboardInsets` to `SwiftUIHostingView`. ([#41302](https://github.com/expo/expo/pull/41302) by [@nishan](https://github.com/intergalacticspacehighway))
+- [iOS] JSI runtime is now accessed from public `RCTHostRuntimeDelegate` instead of unofficial `bridge.runtime`. ([#41311](https://github.com/expo/expo/pull/41311) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Core/ExpoBridgeModule.mm
+++ b/packages/expo-modules-core/ios/Core/ExpoBridgeModule.mm
@@ -54,7 +54,7 @@ RCT_EXPORT_MODULE(ExpoModulesCore);
 
     _appContext.reactBridge = _bridge;
     _appContext._runtime = runtime;
-    [_appContext useModulesProvider:@"ExpoModulesProvider"];
+    [_appContext registerNativeModules];
   }
 }
 

--- a/packages/expo-modules-core/ios/Core/Views/ViewModuleWrapper.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ViewModuleWrapper.swift
@@ -14,7 +14,7 @@ protocol DynamicModuleWrapperProtocol {
  Unfortunately, we can't use just one class because React Native checks for duplicated classes.
  We're generating its subclasses in runtime as a workaround.
  */
-@objc
+@objc(EXViewModuleWrapper)
 public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtocol {
   /**
    A reference to the module holder that stores the module definition.

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
@@ -28,6 +28,7 @@
 #endif // !RCT_NEW_ARCH_ENABLED
 
 @class EXAppContext;
+@class EXViewModuleWrapper;
 
 // Addition to the interface that is visible in both Swift and Objective-C
 @interface ExpoFabricViewObjC (ExpoFabricViewInterface)

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
@@ -59,4 +59,11 @@
  */
 - (void)unmountChildComponentView:(nonnull UIView *)childComponentView index:(NSInteger)index;
 
+#pragma mark - Component registration
+
+/**
+ Registers given view module in the global `RCTComponentViewFactory`.
+ */
++ (void)registerComponent:(nonnull EXViewModuleWrapper *)viewModule appContext:(nonnull EXAppContext *)appContext;
+
 @end

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
@@ -11,6 +11,7 @@
 
 #import <ExpoModulesJSI/EXJSIConversions.h>
 
+#import <React/RCTComponentViewFactory.h>
 #import <react/renderer/componentregistry/ComponentDescriptorProvider.h>
 
 using namespace expo;
@@ -196,6 +197,19 @@ static std::unordered_map<std::string, ExpoViewComponentDescriptor::Flavor> _com
     _state->updateState(expo::ExpoViewState::withStyleDimensions(widthValue, heightValue));
 #endif
   }
+}
+
+#pragma mark - Component registration
+
++ (void)registerComponent:(nonnull EXViewModuleWrapper *)viewModule appContext:(nonnull EXAppContext *)appContext
+{
+  Class wrappedViewModuleClass = [EXViewModuleWrapper createViewModuleWrapperClassWithModule:viewModule appId:appContext.appIdentifier];
+  Class viewClass = [ExpoFabricView makeViewClassForAppContext:appContext
+                                                    moduleName:[viewModule moduleName]
+                                                      viewName:[viewModule viewName]
+                                                     className:NSStringFromClass(wrappedViewModuleClass)];
+
+  [[RCTComponentViewFactory currentComponentViewFactory] registerComponentViewClass:viewClass];
 }
 
 @end

--- a/packages/expo-modules-core/ios/JSI/EXJSIUtils.h
+++ b/packages/expo-modules-core/ios/JSI/EXJSIUtils.h
@@ -9,6 +9,7 @@
 #import <ReactCommon/TurboModuleUtils.h>
 #import <ReactCommon/CallInvoker.h>
 #import <react/bridging/CallbackWrapper.h>
+#import <react/renderer/runtimescheduler/RuntimeScheduler.h>
 
 namespace jsi = facebook::jsi;
 namespace react = facebook::react;
@@ -47,6 +48,10 @@ namespace expo
 #pragma mark - Errors
 
     jsi::Value makeCodedError(jsi::Runtime &runtime, NSString *code, NSString *message);
+
+#pragma mark - RuntimeScheduler
+
+std::shared_ptr<react::RuntimeScheduler> runtimeSchedulerFromRuntime(jsi::Runtime &runtime);
 
 } // namespace expo
 

--- a/packages/expo-modules-core/ios/JSI/EXJSIUtils.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIUtils.mm
@@ -1,6 +1,6 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
-#import <sstream>
+#import <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
 
 #import <ExpoModulesJSI/EXJSIConversions.h>
 #import <ExpoModulesJSI/EXJSIUtils.h>
@@ -123,6 +123,15 @@ jsi::Value makeCodedError(jsi::Runtime &runtime, NSString *code, NSString *messa
       jsi::Value(runtime, jsCode),
       jsi::Value(runtime, jsMessage)
     });
+}
+
+#pragma mark - RuntimeScheduler
+
+std::shared_ptr<react::RuntimeScheduler> runtimeSchedulerFromRuntime(jsi::Runtime &runtime) {
+  if (auto binding = react::RuntimeSchedulerBinding::getBinding(runtime)) {
+    return binding->getRuntimeScheduler();
+  }
+  return nullptr;
 }
 
 } // namespace expo

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
@@ -48,11 +48,7 @@ NS_SWIFT_NAME(JavaScriptRuntime)
 
 #ifdef __cplusplus
 
-- (nonnull instancetype)initWithRuntime:(nonnull jsi::Runtime *)runtime
-                            callInvoker:(std::shared_ptr<react::CallInvoker>)callInvoker;
-- (nonnull instancetype)initWithRuntime:(nonnull jsi::Runtime *)runtime
-                            callInvoker:(std::shared_ptr<react::CallInvoker>)callInvoker
-                       runtimeScheduler:(std::shared_ptr<facebook::react::RuntimeScheduler>)runtimeScheduler;
+- (nonnull instancetype)initWithRuntime:(jsi::Runtime &)runtime;
 
 /**
  Returns the underlying runtime object.

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -8,8 +8,8 @@
 
 #import <jsi/jsi.h>
 #import <hermes/hermes.h>
-#import <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #import <ReactCommon/SchedulerPriority.h>
+#import <react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h>
 
 @implementation EXJavaScriptRuntime {
   std::shared_ptr<jsi::Runtime> _runtime;
@@ -46,23 +46,15 @@
   return self;
 }
 
-- (nonnull instancetype)initWithRuntime:(nonnull jsi::Runtime *)runtime
-                            callInvoker:(std::shared_ptr<react::CallInvoker>)callInvoker
-{
-  return [self initWithRuntime:runtime callInvoker:callInvoker runtimeScheduler:nullptr];
-}
-
-- (nonnull instancetype)initWithRuntime:(nonnull jsi::Runtime *)runtime
-                            callInvoker:(std::shared_ptr<react::CallInvoker>)callInvoker
-                       runtimeScheduler:(std::shared_ptr<facebook::react::RuntimeScheduler>)runtimeScheduler
+- (nonnull instancetype)initWithRuntime:(jsi::Runtime &)runtime
 {
   if (self = [super init]) {
     // Creating a shared pointer that points to the runtime but doesn't own it, thus doesn't release it.
     // In this code flow, the runtime should be owned by something else like the RCTBridge.
     // See explanation for constructor (8): https://en.cppreference.com/w/cpp/memory/shared_ptr/shared_ptr
-    _runtime = std::shared_ptr<jsi::Runtime>(std::shared_ptr<jsi::Runtime>(), runtime);
-    _jsCallInvoker = callInvoker;
-    _runtimeScheduler = runtimeScheduler;
+    _runtime = std::shared_ptr<jsi::Runtime>(std::shared_ptr<jsi::Runtime>(), &runtime);
+    _runtimeScheduler = expo::runtimeSchedulerFromRuntime(runtime);
+    _jsCallInvoker = std::make_shared<RuntimeSchedulerCallInvoker>(_runtimeScheduler);
   }
   return self;
 }

--- a/packages/expo-modules-core/ios/Legacy/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/Legacy/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -261,7 +261,7 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
   NSMutableSet *visitedSweetModules = [NSMutableSet new];
 
   // Add dynamic wrappers for view modules written in Sweet API.
-  for (ViewModuleWrapper *swiftViewModule in [_appContext getViewManagers]) {
+  for (EXViewModuleWrapper *swiftViewModule in [_appContext getViewManagers]) {
     Class wrappedViewModuleClass = [self registerComponentData:swiftViewModule
                                                       inBridge:bridge
                                                       forAppId:_appContext.appIdentifier];
@@ -269,8 +269,8 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
     [visitedSweetModules addObject:swiftViewModule.name];
   }
 
-  [additionalModuleClasses addObject:[ViewModuleWrapper class]];
-  [self registerLegacyComponentData:[ViewModuleWrapper class] inBridge:bridge];
+  [additionalModuleClasses addObject:[EXViewModuleWrapper class]];
+  [self registerLegacyComponentData:[EXViewModuleWrapper class] inBridge:bridge];
 
   // Add modules from legacy module registry only when the NativeModulesProxy owns the registry.
   if (ownsModuleRegistry) {
@@ -335,12 +335,12 @@ RCT_EXPORT_METHOD(callMethod:(NSString *)moduleName methodNameOrKey:(id)methodNa
   }
 }
 
-- (Class)registerComponentData:(ViewModuleWrapper *)viewModule inBridge:(RCTBridge *)bridge forAppId:(NSString *)appId
+- (Class)registerComponentData:(EXViewModuleWrapper *)viewModule inBridge:(RCTBridge *)bridge forAppId:(NSString *)appId
 {
   // Hacky way to get a dictionary with `RCTComponentData` from UIManager.
   NSMutableDictionary<NSString *, RCTComponentData *> *componentDataByName = [[bridge uiManager] valueForKey:@"_componentDataByName"];
 
-  Class wrappedViewModuleClass = [ViewModuleWrapper createViewModuleWrapperClassWithModule:viewModule appId:appId];
+  Class wrappedViewModuleClass = [EXViewModuleWrapper createViewModuleWrapperClassWithModule:viewModule appId:appId];
   NSString *className = NSStringFromClass(wrappedViewModuleClass);
 
   if (componentDataByName[className]) {

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Split out JSI layer from the modules core. ([#40755](https://github.com/expo/expo/pull/40755) by [@tsapeta](https://github.com/tsapeta))
 - Add `@expo/local-build-cache-provider` package ([#41270](https://github.com/expo/expo/pull/41270) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Added `appDelegateWillBeginInitialization` function to AppDelegate subscribers. ([#41456](https://github.com/expo/expo/pull/41456) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] JSI runtime is now accessed from public `RCTHostRuntimeDelegate` instead of unofficial `bridge.runtime`. ([#41311](https://github.com/expo/expo/pull/41311) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.h
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.h
@@ -1,0 +1,12 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+#import <ExpoModulesCore/ExpoModulesCore.h>
+#import <Expo/RCTAppDelegateUmbrella.h>
+
+@protocol RCTHostDelegate;
+@protocol RCTHostRuntimeDelegate;
+
+NS_SWIFT_NAME(ExpoReactNativeFactoryObjC)
+@interface EXReactNativeFactory : RCTReactNativeFactory <RCTHostDelegate, RCTHostRuntimeDelegate>
+
+@end

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
@@ -1,0 +1,41 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+#import <ReactCommon/RCTHost.h>
+
+#import <Expo/ExpoReactNativeFactory.h>
+#import <ExpoModulesCore/ExpoModulesCore.h>
+#import <ExpoModulesCore/EXRuntime.h>
+#import <ExpoModulesCore-Swift.h>
+
+@implementation EXReactNativeFactory {
+  EXAppContext *_appContext;
+}
+
+#pragma mark - RCTHostDelegate
+
+// [main thread]
+- (void)hostDidStart:(nonnull RCTHost *)host
+{
+  // Setting the runtime delegate here doesn't feel right, but there is no other way
+  // to capture the `host:didInitializeRuntime:` method call.
+  // With the current API design we also depend that the runtime is initialized after the host started,
+  // which isn't obvious, especially they are invoked on different threads.
+  // Ideally if the current `RCTHostRuntimeDelegate` is part of `RCTHostDelegate`.
+  host.runtimeDelegate = self;
+}
+
+#pragma mark - RCTHostRuntimeDelegate
+
+// [JS thread]
+- (void)host:(nonnull RCTHost *)host didInitializeRuntime:(jsi::Runtime &)runtime
+{
+  _appContext = [[EXAppContext alloc] init];
+
+  // Inject and decorate the `global.expo` object
+  _appContext._runtime = [[EXRuntime alloc] initWithRuntime:runtime];
+
+  // Load modules
+  [_appContext useModulesProvider:@"ExpoModulesProvider"];
+}
+
+@end

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
@@ -11,6 +11,8 @@
   EXAppContext *_appContext;
 }
 
+// TODO: Remove check when react-native-macos 0.81 is released (this init was not available before)
+#if !TARGET_OS_OSX
 - (instancetype)initWithDelegate:(id<RCTReactNativeFactoryDelegate>)delegate releaseLevel:(RCTReleaseLevel)releaseLevel
 {
   if (self = [super initWithDelegate:delegate releaseLevel:releaseLevel]) {
@@ -18,6 +20,7 @@
   }
   return self;
 }
+#endif
 
 #pragma mark - RCTHostDelegate
 

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
@@ -1,11 +1,11 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
-#import <ReactCommon/RCTHost.h>
-
 #import <Expo/ExpoReactNativeFactory.h>
+
 #import <ExpoModulesCore/ExpoModulesCore.h>
 #import <ExpoModulesCore/EXRuntime.h>
 #import <ExpoModulesCore-Swift.h>
+#import <ReactCommon/RCTHost.h>
 
 @implementation EXReactNativeFactory {
   EXAppContext *_appContext;

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
@@ -11,6 +11,14 @@
   EXAppContext *_appContext;
 }
 
+- (instancetype)initWithDelegate:(id<RCTReactNativeFactoryDelegate>)delegate releaseLevel:(RCTReleaseLevel)releaseLevel
+{
+  if (self = [super initWithDelegate:delegate releaseLevel:releaseLevel]) {
+    _appContext = [[EXAppContext alloc] init];
+  }
+  return self;
+}
+
 #pragma mark - RCTHostDelegate
 
 // [main thread]
@@ -29,13 +37,10 @@
 // [JS thread]
 - (void)host:(nonnull RCTHost *)host didInitializeRuntime:(jsi::Runtime &)runtime
 {
-  _appContext = [[EXAppContext alloc] init];
-
   // Inject and decorate the `global.expo` object
   _appContext._runtime = [[EXRuntime alloc] initWithRuntime:runtime];
 
-  // Load modules
-  [_appContext useModulesProvider:@"ExpoModulesProvider"];
+  [_appContext registerNativeModules];
 }
 
 @end

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
@@ -2,7 +2,7 @@
 
 import React
 
-public class ExpoReactNativeFactory: RCTReactNativeFactory, ExpoReactNativeFactoryProtocol {
+public class ExpoReactNativeFactory: ExpoReactNativeFactoryObjC, ExpoReactNativeFactoryProtocol {
   private let defaultModuleName = "main"
 
   @MainActor

--- a/packages/expo/ios/Expo.h
+++ b/packages/expo/ios/Expo.h
@@ -1,3 +1,4 @@
 #import <ExpoModulesCore/ExpoModulesCore.h>
 #import <Expo/EXAppDefinesLoader.h>
+#import <Expo/ExpoReactNativeFactory.h>
 #import <Expo/RCTAppDelegateUmbrella.h>


### PR DESCRIPTION
# Why

Resolves ENG-12520

# How

Instead of using the `ExpoBridgeModule` to access the bridge, runtime and call invoker, we'll do it from the `ExpoReactNativeFactory` by implementing `RCTHostDelegate` and `RCTHostRuntimeDelegate` to access the host and the runtime.

The benefit of this approach is that we have very early access to the runtime, even before the JS bundle starts executing. Therefore, the `global.expo` object can be installed and decorated with modules host object, core classes, polyfills etc. Moreover, we will not need to use [ensureNativeModulesAreInstalled](https://github.com/expo/expo/blob/12b1bbc690d2a6038e7f96ccd46b4330b9d3278c/packages/expo-modules-core/src/requireNativeModule.ts#L35) anymore and access `globalThis.expo.modules.MyModule` directly.

Sadly, this early initialization works well only when `ExpoReactNativeFactory` is used in the project, so it will not work out of the box in bare workflow projects, unless our factory is used. That being said, I think we should keep `ExpoBridgeModule` still working for a while, so people have some time to migrate to our factory. 

Since `ExpoBridgeModule` is now not the only place where the AppContext is created, the view registration from `EXNativeModulesProxy` doesn't work when it's initialized from the factory. I've copied just a small part of the registration that is NewArchitecture-only.

# Test Plan

Tested all three ways of creating the AppContext and installing Expo bindings on the runtime:
- New approach in `ExpoReactNativeFactory`
- By `ExpoBridgeModule` from `setBridge:` method
- By `ExpoBridgeModule` from the exported `installModules` function

As it touches view registration, I also tested some components like `expo-image`, `expo-blur` and `expo-ui`.