### PR TITLE
[plist] Add xmlbuilder-js CreateOptions parameter

### DIFF
--- a/packages/@expo/plist/CHANGELOG.md
+++ b/packages/@expo/plist/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add xmlbuilder-js CreateOptions parameter. ([#41314](https://github.com/expo/expo/pull/41314) by [@dnicolson](https://github.com/dnicolson))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/@expo/plist/src/build.ts
+++ b/packages/@expo/plist/src/build.ts
@@ -26,6 +26,8 @@ OTHER DEALINGS IN THE SOFTWARE. */
 import base64 from 'base64-js';
 import xmlbuilder from 'xmlbuilder';
 
+import { PlistValue } from '.';
+
 /**
  * Accepts a `Date` instance and returns an ISO date string.
  *
@@ -80,7 +82,7 @@ function type(obj: object): string | null {
  */
 
 export function build(
-  obj: any,
+  obj: PlistValue,
   xmlToStringOpts?: xmlbuilder.XMLToStringOptions,
   createOpts?: xmlbuilder.CreateOptions
 ): string {

--- a/packages/@expo/plist/src/build.ts
+++ b/packages/@expo/plist/src/build.ts
@@ -73,12 +73,21 @@ function type(obj: object): string | null {
  * Generate an XML plist string from the input object `obj`.
  *
  * @param {Object} obj - the object to convert
- * @param {Object} [opts] - optional options object
+ * @param {Object} [xmlToStringOpts] - optional XMLToStringOptions object
+ * @param {Object} [createOpts] - optional CreateOptions object
  * @returns {String} converted plist XML string
  * @api public
  */
 
-export function build(obj: any, opts?: { [key: string]: any }): string {
+export function build(
+  obj: any,
+  xmlToStringOpts?: xmlbuilder.XMLToStringOptions,
+  createOpts?: xmlbuilder.CreateOptions
+): string {
+  if (xmlToStringOpts === undefined) xmlToStringOpts = {};
+  if (createOpts === undefined) createOpts = {};
+  xmlToStringOpts.pretty = xmlToStringOpts.pretty !== false;
+
   const XMLHDR = {
     version: '1.0',
     encoding: 'UTF-8',
@@ -89,7 +98,7 @@ export function build(obj: any, opts?: { [key: string]: any }): string {
     sysid: 'http://www.apple.com/DTDs/PropertyList-1.0.dtd',
   };
 
-  const doc = xmlbuilder.create('plist');
+  const doc = xmlbuilder.create('plist', createOpts);
 
   doc.dec(XMLHDR.version, XMLHDR.encoding, XMLHDR.standalone);
   doc.dtd(XMLDTD.pubid, XMLDTD.sysid);
@@ -97,10 +106,7 @@ export function build(obj: any, opts?: { [key: string]: any }): string {
 
   walk_obj(obj, doc);
 
-  if (!opts) opts = {};
-  // default `pretty` to `true`
-  opts.pretty = opts.pretty !== false;
-  return doc.end(opts);
+  return doc.end(xmlToStringOpts);
 }
 
 /**

--- a/packages/@expo/plist/src/build.ts
+++ b/packages/@expo/plist/src/build.ts
@@ -83,11 +83,9 @@ function type(obj: object): string | null {
 
 export function build(
   obj: PlistValue,
-  xmlToStringOpts?: xmlbuilder.XMLToStringOptions,
-  createOpts?: xmlbuilder.CreateOptions
+  xmlToStringOpts: xmlbuilder.XMLToStringOptions = {},
+  createOpts: xmlbuilder.CreateOptions = {}
 ): string {
-  if (xmlToStringOpts === undefined) xmlToStringOpts = {};
-  if (createOpts === undefined) createOpts = {};
   xmlToStringOpts.pretty = xmlToStringOpts.pretty !== false;
 
   const XMLHDR = {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
https://github.com/TooTallNate/plist.js/pull/144

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
