### PR TITLE
[location] use WGS 84 as reference for altitude on iOS

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- use WGS 84 as reference for altitude on iOS ([#41318](https://github.com/expo/expo/pull/41318) by [@vonovak](https://github.com/vonovak))
+
 ### 💡 Others
 
 - [Android] Removed unused `androidx.annotation:annotation` dependency. ([#39758](https://github.com/expo/expo/pull/39758) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-location/ios/EXLocation.m
+++ b/packages/expo-location/ios/EXLocation.m
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
     @"coords": @{
         @"latitude": @(location.coordinate.latitude),
         @"longitude": @(location.coordinate.longitude),
-        @"altitude": @(location.altitude),
+        @"altitude": @(location.ellipsoidalAltitude),
         @"accuracy": @(location.horizontalAccuracy),
         @"altitudeAccuracy": @(location.verticalAccuracy),
         @"heading": @(location.course),

--- a/packages/expo-location/ios/Geocoder.swift
+++ b/packages/expo-location/ios/Geocoder.swift
@@ -14,7 +14,7 @@ internal struct Geocoder {
         return [
           "latitude": location?.coordinate.latitude,
           "longitude": location?.coordinate.longitude,
-          "altitude": location?.altitude,
+          "altitude": location?.ellipsoidalAltitude,
           "accuracy": location?.horizontalAccuracy
         ]
       }


### PR DESCRIPTION
# Why

to align the code with docs that say "The altitude in meters above the WGS 84 reference ellipsoid." - at https://docs.expo.dev/versions/latest/sdk/location/#locationgeocodedlocation

see https://developer.apple.com/documentation/corelocation/cllocation/ellipsoidalaltitude

closes #19084


# How

- use the `ellipsoidalAltitude` value on iOS

# Test Plan

- green CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
