### PR TITLE
ci: do not boot simulator in native unit tests to avoid timeouts

### DIFF
--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -60,11 +60,6 @@ jobs:
           xcrun simctl erase all
           xcrun simctl shutdown all
           sudo xcodebuild -runFirstLaunch
-      - name: 📱 Pre-boot simulator
-        timeout-minutes: 8
-        run: |
-          # NOTE: Keep simulator name in sync with fastlane/Fastfile unit_tests lane
-          # xcrun simctl boot "iPhone 17 Pro"
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -60,6 +60,11 @@ jobs:
           xcrun simctl erase all
           xcrun simctl shutdown all
           sudo xcodebuild -runFirstLaunch
+      - name: 📱 Pre-boot simulator
+        timeout-minutes: 8
+        run: |
+          # NOTE: Keep simulator name in sync with fastlane/Fastfile unit_tests lane
+          # xcrun simctl boot "iPhone 17 Pro"
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -177,11 +177,12 @@ platform :ios do
     run_tests(
       workspace: workspace,
       scheme: generated_scheme,
+      # NOTE: Keep simulator name in sync with .github/workflows/ios-unit-tests.yml
       devices: ["iPhone 17 Pro (26.0)"],
       configuration: 'Debug',
       clean: false,
       skip_build: true,
-      prelaunch_simulator: true,
+      prelaunch_simulator: false,
       skip_detect_devices: false,
       skip_package_dependencies_resolution: true,
       derived_data_path: "/tmp/ExpoUnitTestsDerivedData",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -177,11 +177,11 @@ platform :ios do
     run_tests(
       workspace: workspace,
       scheme: generated_scheme,
-      # NOTE: Keep simulator name in sync with .github/workflows/ios-unit-tests.yml
       devices: ["iPhone 17 Pro (26.0)"],
       configuration: 'Debug',
       clean: false,
       skip_build: true,
+      # .github/workflows/ios-unit-tests.yml runs XCTests w/o needing a simulator
       prelaunch_simulator: false,
       skip_detect_devices: false,
       skip_package_dependencies_resolution: true,


### PR DESCRIPTION
# Why

ran into a (intermittent) timeout. "Booting iPhone 17 Pro" takes 30 minutes:

```
Mon, 01 Dec 2025 12:16:47 GMT
[12:16:47]: $ xcodebuild -showBuildSettings -workspace apps/native-tests/ios/NativeTests.xcworkspace -scheme NativeTests_generated -configuration Debug -derivedDataPath /tmp/ExpoUnitTestsDerivedData 2>&1
Mon, 01 Dec 2025 12:16:55 GMT

Mon, 01 Dec 2025 12:16:55 GMT
+------------------------------------------------------------------------------------------------------+
Mon, 01 Dec 2025 12:16:55 GMT
|                                       Summary for scan 2.225.0                                       |
Mon, 01 Dec 2025 12:16:55 GMT
+------------------------------------------------+-----------------------------------------------------+
Mon, 01 Dec 2025 12:16:55 GMT
| workspace                                      | apps/native-tests/ios/NativeTests.xcworkspace       |
Mon, 01 Dec 2025 12:16:55 GMT
| scheme                                         | NativeTests_generated                               |
Mon, 01 Dec 2025 12:16:55 GMT
| devices                                        | ["iPhone 17 Pro (26.0)"]                            |
Mon, 01 Dec 2025 12:16:55 GMT
| configuration                                  | Debug                                               |
Mon, 01 Dec 2025 12:16:55 GMT
| clean                                          | false                                               |
Mon, 01 Dec 2025 12:16:55 GMT
| skip_build                                     | true                                                |
Mon, 01 Dec 2025 12:16:55 GMT
| prelaunch_simulator                            | true                                                |
Mon, 01 Dec 2025 12:16:55 GMT
| skip_detect_devices                            | false                                               |
Mon, 01 Dec 2025 12:16:55 GMT
| skip_package_dependencies_resolution           | true                                                |
Mon, 01 Dec 2025 12:16:55 GMT
| derived_data_path                              | /tmp/ExpoUnitTestsDerivedData                       |
Mon, 01 Dec 2025 12:16:55 GMT
| xcargs                                         | CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO      |
Mon, 01 Dec 2025 12:16:55 GMT
| ensure_devices_found                           | false                                               |
Mon, 01 Dec 2025 12:16:55 GMT
| force_quit_simulator                           | false                                               |
Mon, 01 Dec 2025 12:16:55 GMT
| reset_simulator                                | false                                               |
Mon, 01 Dec 2025 12:16:55 GMT
| disable_slide_to_type                          | true                                                |
Mon, 01 Dec 2025 12:16:55 GMT
| reinstall_app                                  | false                                               |
Mon, 01 Dec 2025 12:16:55 GMT
| open_report                                    | false                                               |
Mon, 01 Dec 2025 12:16:55 GMT
| output_directory                               | ./fastlane/test_output                              |
Mon, 01 Dec 2025 12:16:55 GMT
| output_types                                   | html,junit                                          |
Mon, 01 Dec 2025 12:16:55 GMT
| buildlog_path                                  | ~/Library/Logs/scan                                 |
Mon, 01 Dec 2025 12:16:55 GMT
| include_simulator_logs                         | false                                               |
Mon, 01 Dec 2025 12:16:55 GMT
| xcodebuild_formatter                           | xcbeautify                                          |
Mon, 01 Dec 2025 12:16:55 GMT
| output_remove_retry_attempts                   | false                                               |
Mon, 01 Dec 2025 12:16:55 GMT
| should_zip_build_products                      | false                                               |
Mon, 01 Dec 2025 12:16:55 GMT
| output_xctestrun                               | false                                               |
Mon, 01 Dec 2025 12:16:55 GMT
| result_bundle                                  | false                                               |
Mon, 01 Dec 2025 12:16:55 GMT
| use_clang_report_name                          | false                                               |
Mon, 01 Dec 2025 12:16:55 GMT
| disable_concurrent_testing                     | false                                               |
Mon, 01 Dec 2025 12:16:55 GMT
| slack_use_webhook_configured_username_and_icon | false                                               |
Mon, 01 Dec 2025 12:16:55 GMT
| slack_username                                 | fastlane                                            |
Mon, 01 Dec 2025 12:16:55 GMT
| slack_icon_url                                 | https://fastlane.tools/assets/img/fastlane_icon.png |
Mon, 01 Dec 2025 12:16:55 GMT
| skip_slack                                     | false                                               |
Mon, 01 Dec 2025 12:16:55 GMT
| slack_only_on_failure                          | false                                               |
Mon, 01 Dec 2025 12:16:55 GMT
| run_rosetta_simulator                          | false                                               |
Mon, 01 Dec 2025 12:16:55 GMT
| xcodebuild_command                             | env NSUnbufferedIO=YES xcodebuild                   |
Mon, 01 Dec 2025 12:16:56 GMT
| disable_package_automatic_updates              | false                                               |
Mon, 01 Dec 2025 12:16:56 GMT
| use_system_scm                                 | false                                               |
Mon, 01 Dec 2025 12:16:56 GMT
| number_of_retries                              | 0                                                   |
Mon, 01 Dec 2025 12:16:56 GMT
| fail_build                                     | true                                                |
Mon, 01 Dec 2025 12:16:56 GMT
| xcode_path                                     | /Applications/Xcode_26.0.app                        |
Mon, 01 Dec 2025 12:16:56 GMT
+------------------------------------------------+-----------------------------------------------------+
Mon, 01 Dec 2025 12:16:56 GMT

Mon, 01 Dec 2025 12:16:56 GMT
[12:16:56]: Disabling 'Slide to Type' iPhone 17 Pro
Mon, 01 Dec 2025 12:16:56 GMT
[12:16:56]: $ /usr/libexec/PlistBuddy -c "Add :KeyboardContinuousPathEnabled bool false" /Users/runner/Library/Developer/CoreSimulator/Devices/E33CA349-4F18-4C72-9C7A-54176CC9C7CB/data/Library/Preferences/com.apple.keyboard.ContinuousPath.plist >/dev/null 2>&1
Mon, 01 Dec 2025 12:16:56 GMT
[12:16:56]: Booting iPhone 17 Pro
Mon, 01 Dec 2025 12:46:54 GMT
Error: The action '🧪 Run native iOS unit tests' has timed out after 30 minutes.
```
# How

disabled simulator pre-boot, as our unit tests can run without a simulator

# Test Plan

- green CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
