### PR TITLE
[expo-router][iOS] add isRNScreen function to helpers

### DIFF
--- a/packages/expo-router/ios/RouterNavigationHelpers.h
+++ b/packages/expo-router/ios/RouterNavigationHelpers.h
@@ -38,6 +38,8 @@
 
 + (nullable RNSTabBarController *)getBottomTabControllerFromView:(UIView *)view;
 
++ (BOOL)isRNScreen:(UIResponder *)view;
+
 + (BOOL)isRNSBottomTabsHostComponentView:(UIView *)view;
 
 + (nullable UIView *)getTab:(UITabBarController *)controller
@@ -45,6 +47,7 @@
 
 @end
 
-@protocol RouterNavigationHelpersDismissibleModalProtocol <RNSDismissibleModalProtocol>
+@protocol RouterNavigationHelpersDismissibleModalProtocol <
+    RNSDismissibleModalProtocol>
 @required
 @end

--- a/packages/expo-router/ios/RouterNavigationHelpers.h.mm
+++ b/packages/expo-router/ios/RouterNavigationHelpers.h.mm
@@ -25,6 +25,14 @@
   return NO;
 }
 
++ (BOOL)isRNScreen:(UIResponder *)view {
+  if (view != nil) {
+    return [view isKindOfClass:[RNSScreen class]];
+  }
+
+  return NO;
+}
+
 + (BOOL)isRNSBottomTabsHostComponentView:(UIView *)view {
   if (view != nil) {
     return [view isKindOfClass:[RNSBottomTabsHostComponentView class]];


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
