### PR TITLE
[core][iOS] Move EXConstantsService to the modules core

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -52,6 +52,7 @@
 - [iOS] Removed some runtime type checks for dynamic types. ([#40611](https://github.com/expo/expo/pull/40611) by [@tsapeta](https://github.com/tsapeta))
 - Remove tests related files from the published package content. ([#39551](https://github.com/expo/expo/pull/39551) by [@Simek](https://github.com/Simek))
 - Remove old REACT_NATIVE_TARGET_VERSION checks ([#40843](https://github.com/expo/expo/pull/40843) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Moved the implementation of the constants provider (`EXConstantsService`) from `expo-constants`. ([#41339](https://github.com/expo/expo/pull/41339) by [@tsapeta](https://github.com/tsapeta))
 
 ## 3.0.22 - 2025-10-20
 

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -213,11 +213,9 @@ public final class AppContext: NSObject, @unchecked Sendable {
   }
 
   /**
-   Provides access to app's constants from legacy module registry.
+   Provides access to app's constants.
    */
-  public var constants: EXConstantsInterface? {
-    return legacyModule(implementing: EXConstantsInterface.self)
-  }
+  public lazy var constants: EXConstantsInterface? = ConstantsProvider.shared
 
   /**
    Provides access to the file system manager from legacy module registry.

--- a/packages/expo-modules-core/ios/Interfaces/Constants/EXConstantsInterface.h
+++ b/packages/expo-modules-core/ios/Interfaces/Constants/EXConstantsInterface.h
@@ -1,20 +1,9 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
 #import <Foundation/Foundation.h>
-#import <CoreGraphics/CoreGraphics.h>
 
 @protocol EXConstantsInterface
 
 - (NSDictionary *)constants;
-
-- (NSString *)buildVersion;
-- (CGFloat)statusBarHeight;
-- (NSString *)iosVersion;
-- (NSString *)userInterfaceIdiom;
-- (BOOL)isDevice;
-- (NSArray<NSString *> *)systemFontNames;
-
-+ (NSString *)devicePlatform;
-+ (NSString *)deviceName;
 
 @end

--- a/packages/expo-modules-core/ios/Utilities/ConstantsProvider.swift
+++ b/packages/expo-modules-core/ios/Utilities/ConstantsProvider.swift
@@ -69,7 +69,7 @@ private func getSystemFontNames() -> [String] {
   }
   return fontNames.sorted()
   #elseif os(macOS)
-  return FontManager.shared.availableFontFamilies
+  return NSFontManager.shared.availableFontFamilies
   #endif
 }
 
@@ -78,7 +78,7 @@ private func getDeviceName() -> String {
   #if os(iOS) || os(tvOS)
   return UIDevice.current.name
   #elseif os(macOS)
-  return NSHost.current.localizedName
+  return ProcessInfo.processInfo.hostName
   #endif
 }
 

--- a/packages/expo-modules-core/ios/Utilities/ConstantsProvider.swift
+++ b/packages/expo-modules-core/ios/Utilities/ConstantsProvider.swift
@@ -1,0 +1,101 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+internal final class ConstantsProvider: EXConstantsInterface {
+  nonisolated(unsafe) static let shared = ConstantsProvider()
+
+  func constants() -> [AnyHashable: Any] {
+    // Some constants can be safely read only on the main thread
+    let (statusBarHeight, deviceName, systemFonts) = performSynchronouslyOnMainActor {
+      return (
+        getStatusBarHeight(),
+        getDeviceName(),
+        getSystemFontNames()
+      )
+    }
+    #if DEBUG
+    let isDebugXcodeScheme = true
+    #else
+    let isDebugXcodeScheme = false
+    #endif
+
+    return [
+      "sessionId": UUID().uuidString,
+      "executionEnvironment": "bare",
+      "statusBarHeight": statusBarHeight,
+      "deviceName": deviceName,
+      "systemFonts": systemFonts,
+      "debugMode": isDebugXcodeScheme,
+      "isHeadless": false,
+      "manifest": getManifest(), // Deprecated, but still used internally.
+      "platform": [
+        "ios": [
+          "buildNumber": getBuildVersion(),
+        ],
+      ],
+    ]
+  }
+}
+
+private func getBuildVersion() -> String? {
+  return Bundle.main.infoDictionary?["CFBundleVersion"] as? String
+}
+
+@MainActor
+private func getStatusBarHeight() -> Double {
+  #if os(iOS)
+  let statusBarSize = UIApplication.shared.statusBarFrame.size
+  return min(statusBarSize.width, statusBarSize.height)
+  #else
+  return 0
+  #endif
+}
+
+@MainActor
+private func getSystemFontNames() -> [String] {
+  #if os(iOS) || os(tvOS)
+  let familyNames = UIFont.familyNames
+  var fontNames = Set<String>()
+
+  // "System Font" is added to `UIFont.familyNames` in iOS 15, and the font names that
+  // correspond with it are dot prefixed .SFUI-* fonts which log the following warning
+  // when passed in to `UIFont.fontNames(forFamilyName:)`:
+  // > CoreText note: Client requested name “.SFUI-HeavyItalic”, it will get TimesNewRomanPSMT rather than the intended font.
+  // All system UI font access should be through proper APIs such as `CTFontCreateUIFontForLanguage()` or `UIFont.systemFont(ofSize:)`.
+  for familyName in familyNames where familyName != "System Font" {
+    fontNames.insert(familyName)
+    UIFont.fontNames(forFamilyName: familyName).forEach { fontName in
+      fontNames.insert(fontName)
+    }
+  }
+  return fontNames.sorted()
+  #elseif os(macOS)
+  return FontManager.shared.availableFontFamilies
+  #endif
+}
+
+@MainActor
+private func getDeviceName() -> String {
+  #if os(iOS) || os(tvOS)
+  return UIDevice.current.name
+  #elseif os(macOS)
+  return NSHost.current.localizedName
+  #endif
+}
+
+private func getManifest() -> [String: Any]? {
+  let frameworkBundle = Bundle(for: ConstantsProvider.self)
+
+  guard let bundleUrl = frameworkBundle.resourceURL?.appendingPathComponent("EXConstants.bundle"),
+        let bundle = Bundle(url: bundleUrl),
+        let url = bundle.url(forResource: "app", withExtension: "config") else {
+    log.error("Unable to find the embedded app config")
+    return nil
+  }
+  do {
+    let configData = try Data(contentsOf: url)
+    return try JSONSerialization.jsonObject(with: configData, options: []) as? [String: Any]
+  } catch {
+    log.error("Error reading the embedded app config: \(error)")
+    return nil
+  }
+}

--- a/packages/expo-modules-core/ios/Utilities/Utilities.swift
+++ b/packages/expo-modules-core/ios/Utilities/Utilities.swift
@@ -95,6 +95,13 @@ internal class NonisolatedUnsafeVar<VarType>: @unchecked Sendable {
   }
 }
 
+internal func performSynchronouslyOnMainActor<Result: Sendable>(_ closure: @MainActor () throws -> Result) rethrows -> Result {
+  if Thread.isMainThread {
+    return try MainActor.assumeIsolated(closure)
+  }
+  return try DispatchQueue.main.sync(execute: closure)
+}
+
 /**
  A collection of utility functions for various Expo Modules common tasks.
  */


### PR DESCRIPTION
# Why

Part of the effort to remove the legacy module registry.

# How

Created `ConstantsProvider` inside the modules core that is more or less the same as the existing `EXConstantsService` from `expo-constants` (just rewritten to Swift).
Modules were accessing the constants through `appContext.constants` which now will return the new provider instead of looking up in the legacy module registry.
I also cleaned up `EXConstantsInterface` as all of its methods (except `-constants`) are unused or unimplemented.

It may not work correctly in Expo Go, but I'll address it later.

In the long run this lets us remove `expo-constants` entirely.

# Test Plan

Ran test-suite tests and NCL for expo-constants and expo-asset