### PR TITLE
[docs] Add brownfield instructions for configuring lifecycle listeners

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -223,6 +223,7 @@ export const general = [
     makeSection('Existing native apps', [
       makePage('brownfield/overview.mdx'),
       makePage('brownfield/get-started.mdx'),
+      makePage('brownfield/lifecycle-listeners.mdx'),
     ]),
     makeGroup(
       'Reference',

--- a/docs/pages/brownfield/lifecycle-listeners.mdx
+++ b/docs/pages/brownfield/lifecycle-listeners.mdx
@@ -46,20 +46,10 @@ class MainApplication : Application() {
 
 ### iOS
 
-To integrate `AppDelegate` subscribers on iOS, update your `AppDelegate` to inherit from `ExpoAppDelegate`, which you can import from the Expo module:
+To integrate `AppDelegate` subscribers on iOS, forward the relevant calls to `ExpoAppDelegateSubscriberManager` in your existing `AppDelegate` implementation so that subscribers can respond to them:
 
 ```diff AppDelegate.swift
 +import Expo
-
-@main
--public class AppDelegate: NSObject, UIApplicationDelegate {
-+public class AppDelegate: ExpoAppDelegate {
-```
-
-If you cannot extend `ExpoAppDelegate` directly (for example, if you already extend another class), you can forward the calls manually by invoking `ExpoAppDelegateSubscriberManager` methods in your existing `AppDelegate` implementation:
-
-```diff AppDelegate.swift
-+ import Expo
 
 public class AppDelegate: UIApplicationDelegate {
 
@@ -79,6 +69,16 @@ public class AppDelegate: UIApplicationDelegate {
 
   ...
 }
+```
+
+Alternatively, if your `AppDelegate` doesn't already extend another class, you can simplify the setup by inheriting from `ExpoAppDelegate`, which handles the forwarding automatically:
+
+```diff AppDelegate.swift
++import Expo
+
+@main
+-public class AppDelegate: NSObject, UIApplicationDelegate {
++public class AppDelegate: ExpoAppDelegate {
 ```
 
 > **Note:** Not all `UIApplicationDelegate` methods that could cause significant side effects are supported. See the Expo source (**ExpoAppDelegate.swift**) for the full list of forwarded methods if you need to rely on a specific delegate.

--- a/docs/pages/brownfield/lifecycle-listeners.mdx
+++ b/docs/pages/brownfield/lifecycle-listeners.mdx
@@ -4,11 +4,10 @@ sidebar_title: Lifecycle listeners
 description: Learn about the mechanism that allows the Expo Modules API to hook into the lifecycle of your app.
 ---
 
-import { Terminal } from '~/ui/components/Snippet';
-import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
 import { DiffBlock, Terminal } from '~/ui/components/Snippet';
+import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
 
-Some Expo libraries need to handle system events such as deep links, push notifications, and configuration changes by implementing `Activity`/`Application` or `AppDelegate`  lifecycle callbacks.
+Some Expo libraries need to handle system events such as deep links, push notifications, and configuration changes by implementing `Activity`/`Application` or `AppDelegate` lifecycle callbacks.
 
 The Expo Modules API provides an easy way to manage such callbacks:
 

--- a/docs/pages/brownfield/lifecycle-listeners.mdx
+++ b/docs/pages/brownfield/lifecycle-listeners.mdx
@@ -1,0 +1,104 @@
+---
+title: Configuring lifecycle listeners
+sidebar_title: Lifecycle listeners
+description: Learn about the mechanism that allows the Expo Modules API to hook into the lifecycle of your app.
+---
+
+import { Terminal } from '~/ui/components/Snippet';
+import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
+
+Some Expo libraries need to handle system events such as deep links, push notifications, and configuration changes by implementing `AppDelegate` or `Activity`/`Application` lifecycle callbacks.
+
+The Expo Modules API provides an easy way to manage such callbacks:
+
+- <PlatformTag platform="ios" /> `ExpoAppDelegate` forwards `AppDelegate` calls to registered
+  subscribers. Modules can provide an `ExpoAppDelegateSubscriber` implementation to register
+  callbacks.
+- <PlatformTag platform="android" /> `ApplicationLifecycleDispatcher` and `ReactActivityHandler`
+  forward `Application` and `Activity` lifecycle events to registered listeners. Modules can provide
+  `ReactActivityLifecycleListener` and `ApplicationLifecycleListener` implementations through a
+  `Package` class to register callbacks.
+
+Using these mechanisms allows modules to register behavior without requiring you to edit native entry points repeatedly.
+
+## Configure your native project
+
+### Android
+
+To integrate `Application` lifecycle listeners on Android, forward the `onCreate()` and `onConfigurationChanged()` calls from your `Application` class to `ApplicationLifecycleDispatcher`:
+
+```diff
+class MainApplication : Application() {
+
+  override fun onCreate() {
+    super.onCreate()
+    ...
++   ApplicationLifecycleDispatcher.onApplicationCreate(this)
+  }
+
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    super.onConfigurationChanged(newConfig)
+    ...
++   ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig)
+  }
+}
+```
+
+### iOS
+
+To integrate `AppDelegate` subscribers on iOS, update your `AppDelegate` to inherit from `ExpoAppDelegate`, which you can import from the Expo module:
+
+```diff AppDelegate.swift
++import Expo
+
+@main
+-public class AppDelegate: NSObject, UIApplicationDelegate {
++public class AppDelegate: ExpoAppDelegate {
+```
+
+If you cannot extend `ExpoAppDelegate` directly (for example, if you already extend another class), you can forward the calls manually by invoking `ExpoAppDelegateSubscriberManager` methods in your existing `AppDelegate` implementation:
+
+```diff AppDelegate.swift
++ import Expo
+
+public class AppDelegate: UIApplicationDelegate {
+
+  open func application(
+    _ application: UIApplication,
+    willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
++    return ExpoAppDelegateSubscriberManager.application(application, willFinishLaunchingWithOptions: launchOptions)
+  }
+
+  open func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
++    return ExpoAppDelegateSubscriberManager.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  ...
+}
+```
+
+> **Note:** Not all `UIApplicationDelegate` methods that could cause significant side effects are supported. See the Expo source (**ExpoAppDelegate.swift**) for the full list of forwarded methods if you need to rely on a specific delegate.
+
+## Test your integration
+
+A simple way to test if the callbacks are working correctly is to install a module that relies on them. You can install `expo-linking`, which uses lifecycle listeners to handle deep links:
+
+<Terminal cmd={['$ npx expo install expo-linking']} />
+
+Then, add a listener for deep links in your code and observe the console when opening a deep link:
+
+```jsx
+import * as Linking from 'expo-linking';
+
+React.useEffect(() => {
+  const listener = Linking.addEventListener('url', ({ url }) => {
+    console.log('Received deep link:', url);
+  });
+
+  return listener.remove;
+}, []);
+```

--- a/docs/pages/brownfield/lifecycle-listeners.mdx
+++ b/docs/pages/brownfield/lifecycle-listeners.mdx
@@ -6,6 +6,7 @@ description: Learn about the mechanism that allows the Expo Modules API to hook 
 
 import { Terminal } from '~/ui/components/Snippet';
 import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
+import { DiffBlock } from '~/ui/components/Snippet';
 
 Some Expo libraries need to handle system events such as deep links, push notifications, and configuration changes by implementing `Activity`/`Application` or `AppDelegate`  lifecycle callbacks.
 
@@ -27,59 +28,17 @@ Using these mechanisms allows modules to register behavior without requiring you
 
 To integrate `Application` lifecycle listeners on Android, forward the `onCreate()` and `onConfigurationChanged()` calls from your `Application` class to `ApplicationLifecycleDispatcher`:
 
-```diff
-class MainApplication : Application() {
-
-  override fun onCreate() {
-    super.onCreate()
-    ...
-+   ApplicationLifecycleDispatcher.onApplicationCreate(this)
-  }
-
-  override fun onConfigurationChanged(newConfig: Configuration) {
-    super.onConfigurationChanged(newConfig)
-    ...
-+   ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig)
-  }
-}
-```
+<DiffBlock source="/static/diffs/brownfield/lifecycle-listeners/application-lifecycle-dispatcher.diff" />
 
 ### iOS
 
 To integrate `AppDelegate` subscribers on iOS, forward the relevant calls to `ExpoAppDelegateSubscriberManager` in your existing `AppDelegate` implementation so that subscribers can respond to them:
 
-```diff AppDelegate.swift
-+import Expo
-
-public class AppDelegate: UIApplicationDelegate {
-
-  open func application(
-    _ application: UIApplication,
-    willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
-  ) -> Bool {
-+    return ExpoAppDelegateSubscriberManager.application(application, willFinishLaunchingWithOptions: launchOptions)
-  }
-
-  open func application(
-    _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
-  ) -> Bool {
-+    return ExpoAppDelegateSubscriberManager.application(application, didFinishLaunchingWithOptions: launchOptions)
-  }
-
-  ...
-}
-```
+<DiffBlock source="/static/diffs/brownfield/lifecycle-listeners/expo-app-delegate-subscriber-manager.diff" />
 
 Alternatively, if your `AppDelegate` doesn't already extend another class, you can simplify the setup by inheriting from `ExpoAppDelegate`, which handles the forwarding automatically:
 
-```diff AppDelegate.swift
-+import Expo
-
-@main
--public class AppDelegate: NSObject, UIApplicationDelegate {
-+public class AppDelegate: ExpoAppDelegate {
-```
+<DiffBlock source="/static/diffs/brownfield/lifecycle-listeners/expo-app-delegate.diff" />
 
 > **Note:** Not all `UIApplicationDelegate` methods that could cause significant side effects are supported. See the Expo source (**ExpoAppDelegate.swift**) for the full list of forwarded methods if you need to rely on a specific delegate.
 

--- a/docs/pages/brownfield/lifecycle-listeners.mdx
+++ b/docs/pages/brownfield/lifecycle-listeners.mdx
@@ -6,7 +6,7 @@ description: Learn about the mechanism that allows the Expo Modules API to hook 
 
 import { Terminal } from '~/ui/components/Snippet';
 import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
-import { DiffBlock } from '~/ui/components/Snippet';
+import { DiffBlock, Terminal } from '~/ui/components/Snippet';
 
 Some Expo libraries need to handle system events such as deep links, push notifications, and configuration changes by implementing `Activity`/`Application` or `AppDelegate`  lifecycle callbacks.
 
@@ -52,8 +52,9 @@ Add a listener for deep links in your code and observe the console when opening 
 
 ```jsx
 import * as Linking from 'expo-linking';
+import { useEffect } from 'react';
 
-React.useEffect(() => {
+useEffect(() => {
   const listener = Linking.addEventListener('url', ({ url }) => {
     console.log('Received deep link:', url);
   });

--- a/docs/pages/brownfield/lifecycle-listeners.mdx
+++ b/docs/pages/brownfield/lifecycle-listeners.mdx
@@ -7,17 +7,17 @@ description: Learn about the mechanism that allows the Expo Modules API to hook 
 import { Terminal } from '~/ui/components/Snippet';
 import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
 
-Some Expo libraries need to handle system events such as deep links, push notifications, and configuration changes by implementing `AppDelegate` or `Activity`/`Application` lifecycle callbacks.
+Some Expo libraries need to handle system events such as deep links, push notifications, and configuration changes by implementing `Activity`/`Application` or `AppDelegate`  lifecycle callbacks.
 
 The Expo Modules API provides an easy way to manage such callbacks:
 
-- <PlatformTag platform="ios" /> `ExpoAppDelegate` forwards `AppDelegate` calls to registered
-  subscribers. Modules can provide an `ExpoAppDelegateSubscriber` implementation to register
-  callbacks.
 - <PlatformTag platform="android" /> `ApplicationLifecycleDispatcher` and `ReactActivityHandler`
   forward `Application` and `Activity` lifecycle events to registered listeners. Modules can provide
   `ReactActivityLifecycleListener` and `ApplicationLifecycleListener` implementations through a
   `Package` class to register callbacks.
+- <PlatformTag platform="ios" /> `ExpoAppDelegate` forwards `AppDelegate` calls to registered
+  subscribers. Modules can provide an `ExpoAppDelegateSubscriber` implementation to register
+  callbacks.
 
 Using these mechanisms allows modules to register behavior without requiring you to edit native entry points repeatedly.
 
@@ -85,11 +85,11 @@ Alternatively, if your `AppDelegate` doesn't already extend another class, you c
 
 ## Test your integration
 
-A simple way to test if the callbacks are working correctly is to install a module that relies on them. You can install `expo-linking`, which uses lifecycle listeners to handle deep links:
+To test if the callbacks are working correctly, install a module that relies on them. Install `expo-linking`, which uses lifecycle listeners to handle deep links:
 
 <Terminal cmd={['$ npx expo install expo-linking']} />
 
-Then, add a listener for deep links in your code and observe the console when opening a deep link:
+Add a listener for deep links in your code and observe the console when opening a deep link:
 
 ```jsx
 import * as Linking from 'expo-linking';
@@ -103,7 +103,7 @@ React.useEffect(() => {
 }, []);
 ```
 
-And run the following command to open a deep link to your app:
+Run the following command to open a deep link to your app:
 
 <Terminal
   cmd={[

--- a/docs/pages/brownfield/lifecycle-listeners.mdx
+++ b/docs/pages/brownfield/lifecycle-listeners.mdx
@@ -102,3 +102,15 @@ React.useEffect(() => {
   return listener.remove;
 }, []);
 ```
+
+And run the following command to open a deep link to your app:
+
+<Terminal
+  cmd={[
+    '# If you have `android.package` or `ios.bundleIdentifier` defined in your app.json',
+    '$ npx uri-scheme open com.example.app://somepath/details --android',
+    '',
+    '# If you have a `scheme` defined in your app.json',
+    '$ npx uri-scheme open myapp://somepath/details --ios',
+  ]}
+/>

--- a/docs/public/static/diffs/brownfield/lifecycle-listeners/application-lifecycle-dispatcher.diff
+++ b/docs/public/static/diffs/brownfield/lifecycle-listeners/application-lifecycle-dispatcher.diff
@@ -1,0 +1,17 @@
+diff --git a/MainApplication.kt b/MainApplication.kt
+index 5e0552887d2..535edd47e53 100644
+--- a/MainApplication.kt
++++ b/MainApplication.kt
+@@ -3,10 +3,12 @@ class MainApplication : Application() {
+   override fun onCreate() {
+     super.onCreate()
+     ...
++    ApplicationLifecycleDispatcher.onApplicationCreate(this)
+   }
+
+   override fun onConfigurationChanged(newConfig: Configuration) {
+     super.onConfigurationChanged(newConfig)
+     ...
++    ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig)
+   }
+ }

--- a/docs/public/static/diffs/brownfield/lifecycle-listeners/expo-app-delegate-subscriber-manager.diff
+++ b/docs/public/static/diffs/brownfield/lifecycle-listeners/expo-app-delegate-subscriber-manager.diff
@@ -1,0 +1,26 @@
+diff --git a/AppDelegate.swift b/AppDelegate.swift
+index 68219923e77..4d885879bfc 100644
+--- a/AppDelegate.swift
++++ b/AppDelegate.swift
+@@ -1,17 +1,19 @@
++import Expo
++
+ public class AppDelegate: UIApplicationDelegate {
+
+   open func application(
+     _ application: UIApplication,
+     willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+   ) -> Bool {
+-
++    return ExpoAppDelegateSubscriberManager.application(application, willFinishLaunchingWithOptions: launchOptions)
+   }
+
+   open func application(
+     _ application: UIApplication,
+     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+   ) -> Bool {
+-
++    return ExpoAppDelegateSubscriberManager.application(application, didFinishLaunchingWithOptions: launchOptions)
+   }
+
+   ...

--- a/docs/public/static/diffs/brownfield/lifecycle-listeners/expo-app-delegate.diff
+++ b/docs/public/static/diffs/brownfield/lifecycle-listeners/expo-app-delegate.diff
@@ -1,0 +1,10 @@
+diff --git a/AppDelegate.swift b/AppDelegate.swift
+index c218a0f7c3c..10afd38c64a 100644
+--- a/AppDelegate.swift
++++ b/AppDelegate.swift
+@@ -1,2 +1,4 @@
++import Expo
++
+ @main
+-public class AppDelegate: NSObject, UIApplicationDelegate {
++public class AppDelegate: ExpoAppDelegate {


### PR DESCRIPTION
# Why

As part of the ongoing brownfield effort, we should document how users can set up lifecycle listeners manually

# How

Add brownfield instructions for configuring lifecycle listeners

# Test Plan

N / A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
