### PR TITLE
chore(cli/e2e): Add `@expo/local-build-cache-provider` to linked E2E packages

### DIFF
--- a/packages/@expo/cli/e2e/__tests__/metro-server-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/metro-server-test.ts
@@ -10,7 +10,7 @@ const expo = createExpoStart({
 
 beforeAll(async () => {
   expo.options.cwd = await setupTestProjectWithOptionsAsync('metro-server', 'with-assets', {
-    linkExpoPackages: ['expo', '@expo/log-box'],
+    linkExpoPackages: ['expo', '@expo/log-box', '@expo/local-build-cache-provider'],
   });
   await expo.startAsync();
 });

--- a/packages/@expo/cli/e2e/__tests__/start-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/start-test.ts
@@ -99,7 +99,12 @@ describeSkipWin('server', () => {
   beforeEach(async () => {
     expo.options.cwd = await setupTestProjectWithOptionsAsync('basic-start', 'with-blank', {
       // TODO(@hassankhan, @krystofwoldrich): remove all linked after publishing
-      linkExpoPackages: ['@expo/router-server', '@expo/log-box', 'expo'],
+      linkExpoPackages: [
+        '@expo/router-server',
+        '@expo/log-box',
+        'expo',
+        '@expo/local-build-cache-provider',
+      ],
     });
     await fs.promises.rm(path.join(projectRoot, '.expo'), { force: true, recursive: true });
     await expo.startAsync();

--- a/packages/@expo/cli/e2e/playwright/dev/hmr-env-vars.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/hmr-env-vars.test.ts
@@ -3,15 +3,14 @@
  * while the dev server is running.
  */
 import { test, expect } from '@playwright/test';
+import path from 'node:path';
 import { platform } from 'node:process';
 
-import { setupTestProjectWithOptionsAsync } from '../../__tests__/utils';
 import { clearEnv, restoreEnv } from '../../__tests__/export/export-side-effects';
+import { setupTestProjectWithOptionsAsync } from '../../__tests__/utils';
 import { createExpoStart } from '../../utils/expo';
-import { pageCollectErrors } from '../page';
-
-import path from 'node:path';
 import { mutateFile, openPageAndEagerlyLoadJS } from '../../utils/hmr';
+import { pageCollectErrors } from '../page';
 
 test.beforeAll(() => clearEnv());
 test.afterAll(() => restoreEnv());
@@ -36,9 +35,15 @@ test.describe('router-e2e with spaces', () => {
       // created project. This is required to be able to execute the SSR bundle
       // outside the Expo monorepo module
       {
-        linkExpoPackages: ['expo'],
+        linkExpoPackages: ['expo', '@expo/local-build-cache-provider'],
         // TODO(@hassankhan): remove @expo/router-server after publishing
-        linkExpoPackagesDev: ['@expo/cli', '@expo/router-server', 'babel-preset-expo', '@expo/metro-config', 'expo-server'],
+        linkExpoPackagesDev: [
+          '@expo/cli',
+          '@expo/router-server',
+          'babel-preset-expo',
+          '@expo/metro-config',
+          'expo-server',
+        ],
       }
     );
 


### PR DESCRIPTION
# Why

New cascading dependency from: https://github.com/expo/expo/pull/41270

# How

Added package is a dependency in `expo`

# Test Plan

- E2E tests should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
