### PR TITLE
fix: Update import wrapper to handle absolute paths

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -20,6 +20,7 @@
 - refactor launching Expo Go on Android ([#40020](https://github.com/expo/expo/pull/40020) by [@vonovak](https://github.com/vonovak))
 - only skip dependency validation for `EXPO_NO_DEPENDENCY_VALIDATION=1` ([#40043](https://github.com/expo/expo/pull/40043) by [@kitten](https://github.com/kitten))
 - Fix RSC `[...rsc]+api.ts` template path resolution ([#40760](https://github.com/expo/expo/pull/40760) by [@kitten](https://github.com/kitten))
+- Fix updated import wrapper to handle absolute paths ([#41349](https://github.com/expo/expo/pull/41349) by [@TheAmphibianX](https://github.com/TheAmphibianX))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/add-module.js
+++ b/packages/@expo/cli/add-module.js
@@ -1,3 +1,6 @@
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
 // A wrapper that allows to import an ESM module from a CJS module.
 // This works because the `import` in this wrapper is not transpiled by SWC.
 module.exports = function (name) {

--- a/packages/@expo/cli/add-module.js
+++ b/packages/@expo/cli/add-module.js
@@ -1,5 +1,5 @@
 // A wrapper that allows to import an ESM module from a CJS module.
 // This works because the `import` in this wrapper is not transpiled by SWC.
 module.exports = function (name) {
-  return import(name);
+  return import(path.isAbsolute(name) ? pathToFileURL(name).href : name);
 };


### PR DESCRIPTION
# Why

https://github.com/expo/expo/issues/41348

# How

On Windows, the add-module.js wrapper passes absolute paths (e.g., C:\Users\...) directly to import(). Node.js interprets it as a URL scheme and rejects it with ERR_UNSUPPORTED_ESM_URL_SCHEME because only file, data and node schemes are allowed.

Unix paths (/home/...) work because Node.js auto-converts them to URLs, but Windows paths require explicit conversion.

The fix uses Node.js built-in pathToFileURL() to convert absolute paths to proper URLs before passing to import().

# Test Plan

Tested on Windows 10 with Expo SDK 54 and expo-mcp 0.1.15:

`DEBUG=expo:start:server:mcp EXPO_UNSTABLE_MCP_SERVER=1 npx expo start`

Before:
```
expo:start:server:mcp Creating MCP tunnel - server URL: wss://mcp.expo.dev +0ms
expo:start:server:mcp Error creating MCP tunnel: Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:' +2ms
```

After:
```
expo:start:server:mcp [MCP] Connected to remote MCP tunnel server +569ms
expo:start:server:mcp [MCP] Refreshing all MCP registrations... +2ms
```
# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
