### PR TITLE
[core][iOS] Replace `appContext.fileSystem` with the core implementation

### DIFF
--- a/packages/expo-file-system/ios/FileSystemModule.swift
+++ b/packages/expo-file-system/ios/FileSystemModule.swift
@@ -143,11 +143,11 @@ public final class FileSystemModule: Module {
       output.exists = false
       output.isDirectory = nil
 
-      guard let permissionsManager: EXFilePermissionModuleInterface = appContext?.legacyModule(implementing: EXFilePermissionModuleInterface.self) else {
+      guard let fileSystemManager = appContext?.fileSystem else {
         return output
       }
 
-      if permissionsManager.getPathPermissions(url.path).contains(.read) {
+      if fileSystemManager.getPathPermissions(url.path).contains(.read) {
         var isDirectory: ObjCBool = false
         if FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) {
           output.exists = true

--- a/packages/expo-file-system/ios/Legacy/FileSystemHelpers.swift
+++ b/packages/expo-file-system/ios/Legacy/FileSystemHelpers.swift
@@ -60,10 +60,10 @@ internal func getResourceValues(from directory: URL?, forKeys: Set<URLResourceKe
 }
 
 internal func ensurePathPermission(_ appContext: AppContext?, path: String, flag: EXFileSystemPermissionFlags) throws {
-  guard let permissionsManager: EXFilePermissionModuleInterface = appContext?.legacyModule(implementing: EXFilePermissionModuleInterface.self) else {
+  guard let fileSystemManager = appContext?.fileSystem else {
     throw Exceptions.PermissionsModuleNotFound()
   }
-  guard permissionsManager.getPathPermissions(path).contains(flag) else {
+  guard fileSystemManager.getPathPermissions(path).contains(flag) else {
     throw flag == .read ? FileNotReadableException(path) : FileNotWritableException(path)
   }
 }

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -53,7 +53,7 @@
 - Remove tests related files from the published package content. ([#39551](https://github.com/expo/expo/pull/39551) by [@Simek](https://github.com/Simek))
 - Remove old REACT_NATIVE_TARGET_VERSION checks ([#40843](https://github.com/expo/expo/pull/40843) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Moved the implementation of the constants provider (`EXConstantsService`) from `expo-constants`. ([#41339](https://github.com/expo/expo/pull/41339) by [@tsapeta](https://github.com/tsapeta))
-- [iOS] Replaced `appContext.fileSystem` with the core implementation.
+- [iOS] Replaced `appContext.fileSystem` with the core implementation. ([#41350](https://github.com/expo/expo/pull/41350) by [@tsapeta](https://github.com/tsapeta))
 
 ## 3.0.22 - 2025-10-20
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Remove tests related files from the published package content. ([#39551](https://github.com/expo/expo/pull/39551) by [@Simek](https://github.com/Simek))
 - Remove old REACT_NATIVE_TARGET_VERSION checks ([#40843](https://github.com/expo/expo/pull/40843) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Moved the implementation of the constants provider (`EXConstantsService`) from `expo-constants`. ([#41339](https://github.com/expo/expo/pull/41339) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Replaced `appContext.fileSystem` with the core implementation.
 
 ## 3.0.22 - 2025-10-20
 

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -43,15 +43,7 @@ public final class AppContext: NSObject, @unchecked Sendable {
    The legacy module registry with modules written in the old-fashioned way.
    */
   @objc
-  public weak var legacyModuleRegistry: EXModuleRegistry? {
-    didSet {
-      if let registry = legacyModuleRegistry,
-        let legacyModule = registry.getModuleImplementingProtocol(EXFileSystemInterface.self) as? EXFileSystemInterface,
-        let fileSystemLegacyModule = legacyModule as? FileSystemLegacyUtilities {
-        fileSystemLegacyModule.maybeInitAppGroupSharedDirectories(self.config.appGroupSharedDirectories)
-      }
-    }
-  }
+  public weak var legacyModuleRegistry: EXModuleRegistry?
 
   @objc
   public weak var legacyModulesProxy: LegacyNativeModulesProxy?
@@ -218,11 +210,11 @@ public final class AppContext: NSObject, @unchecked Sendable {
   public lazy var constants: EXConstantsInterface? = ConstantsProvider.shared
 
   /**
-   Provides access to the file system manager from legacy module registry.
+   Provides access to the file system utilities. Can be overridden if the app should use different different directories or file permissions.
+   For instance, Expo Go uses sandboxed environment per project where the cache and document directories must be scoped.
+   It's an optional type for historical reasons, for now let's keep it like this for backwards compatibility.
    */
-  public var fileSystem: EXFileSystemInterface? {
-    return legacyModule(implementing: EXFileSystemInterface.self)
-  }
+  public lazy var fileSystem: FileSystemManager? = FileSystemManager(appGroupSharedDirectories: self.config.appGroupSharedDirectories)
 
   /**
    Provides access to the permissions manager from legacy module registry.

--- a/packages/expo-modules-core/ios/FileSystemUtilities/FileSystemManager.swift
+++ b/packages/expo-modules-core/ios/FileSystemUtilities/FileSystemManager.swift
@@ -3,15 +3,15 @@
 import Foundation
 
 @objc(EXFileSystemLegacyUtilities)
-public class FileSystemLegacyUtilities: NSObject, EXInternalModule, EXFileSystemInterface, EXFilePermissionModuleInterface {
+public class FileSystemManager: NSObject, EXInternalModule, EXFileSystemInterface, EXFilePermissionModuleInterface {
   @objc
-  public var documentDirectory: String
+  public let documentDirectory: String
 
   @objc
-  public var cachesDirectory: String
+  public let cachesDirectory: String
 
   @objc
-  public var applicationSupportDirectory: String
+  public let applicationSupportDirectory: String
 
   var appGroupSharedDirectories: [String]?
 
@@ -45,6 +45,11 @@ public class FileSystemLegacyUtilities: NSObject, EXInternalModule, EXFileSystem
     ensureDirExists(withPath: self.cachesDirectory)
     ensureDirExists(withPath: self.documentDirectory)
     ensureDirExists(withPath: self.applicationSupportDirectory)
+  }
+
+  public convenience init(appGroupSharedDirectories directories: [URL]) {
+    self.init()
+    maybeInitAppGroupSharedDirectories(directories)
   }
 
   public static func exportedInterfaces() -> [Protocol] {

--- a/packages/expo-modules-core/ios/Tests/FileSystemManagerSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FileSystemManagerSpec.swift
@@ -4,9 +4,9 @@ import ExpoModulesTestCore
 
 @testable import ExpoModulesCore
 
-final class FileSystemLegacyUtilitiesSpec: ExpoSpec {
+final class FileSystemManagerSpec: ExpoSpec {
   override class func spec() {
-    let fsUtils = FileSystemLegacyUtilities()
+    let fsManager = FileSystemManager()
 
     describe("getPathPermissions") {
       it("should return read/write permissions for filePath with `file:` scheme") {
@@ -14,7 +14,7 @@ final class FileSystemLegacyUtilitiesSpec: ExpoSpec {
         let fileUrl = dirUrl.appendingPathComponent("dir/test.txt")
         let filePath = fileUrl.absoluteString
         expect(filePath.starts(with: "file:")) == true
-        expect(fsUtils.getPathPermissions(filePath)) == [.read, .write]
+        expect(fsManager.getPathPermissions(filePath)) == [.read, .write]
       }
 
       it("should return read/write permissions for filePath without `file:` scheme") {
@@ -22,7 +22,7 @@ final class FileSystemLegacyUtilitiesSpec: ExpoSpec {
         let fileUrl = dirUrl.appendingPathComponent("dir/test.txt")
         let filePath = fileUrl.path
         expect(filePath.starts(with: "file:")) == false
-        expect(fsUtils.getPathPermissions(filePath)) == [.read, .write]
+        expect(fsManager.getPathPermissions(filePath)) == [.read, .write]
       }
     }
   }


### PR DESCRIPTION
# Why

Part of the effort to remove the legacy module registry.

# How

- Renamed `FileSystemLegacyUtilities` to `FileSystemManager` as it's actually not legacy anymore – we'll continue using it, for scoping in Expo Go. `FileSystemUtilities` is already in use, any ideas for a better name?
- `appContext.fileSystem` no longer returns an internal module from the legacy module registry, but an instance of the new manager that Expo Go could override. Now it can be used to access `EXFilePermissionModuleInterface` as well.

# Test Plan

Tested some modules in bare-expo (namely: file system, assets, audio recorder, document picker, image picker, SQLite)