### PR TITLE
[dev-menu] don't trigger double reload on r key press

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - [iOS] Fix React Native dev menu not showing up in 0.83.x ([#40819](https://github.com/expo/expo/pull/40819) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Fix broken hotkeys after reload. ([#40829](https://github.com/expo/expo/pull/40829) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] don't trigger double reload on r key press ([#41355](https://github.com/expo/expo/pull/41355) by [@vonovak](https://github.com/vonovak))
 - Hide Action button in PiP mode to prevent crash ([#40792](https://github.com/expo/expo/pull/40792) by [@kosmydel](https://github.com/kosmydel))
 
 ### 💡 Others

--- a/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift
+++ b/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift
@@ -43,14 +43,6 @@ class DevMenuKeyCommandsInterceptor {
 
     commands.registerKeyCommand(
       withInput: "r",
-      modifierFlags: .command,
-      action: { _ in
-        DevMenuManager.shared.reload()
-      }
-    )
-
-    commands.registerKeyCommand(
-      withInput: "r",
       modifierFlags: [],
       action: { _ in
         DevMenuManager.shared.reload()


### PR DESCRIPTION
# Why

Remove the Command+R keyboard shortcut for reloading the app in the dev menu. This shortcut was redundant as 

- cmd+r is a shortcut for video recording
- pressing 'r' key would trigger both commands, resulting in `DevMenuManager.shared.reload()` called twice. I suppose that's why I would sometimes see the loading / downloading grey bar at top longer than anticipated. Reloading now seems to work more smoothly afaict.

why listening for just `cmd+r` would work too https://github.com/facebook/react-native/blob/0b1f86200629fa33b56c7a22870dab5cf81cf4a1/packages/react-native/React/Base/RCTKeyCommands.m#L73 (but doesn't make sense imho)

# How

Removed the key command registration for "r" with the command modifier flag, while keeping the registration for "r" without any modifier flags.

# Test Plan

1. Run an Expo app on iOS simulator
2. Verify that pressing 'r' still reloads the app
3. when an input is focused, no reload takes place (as expected) due to [this check in RN core](https://github.com/facebook/react-native/blob/0b1f86200629fa33b56c7a22870dab5cf81cf4a1/packages/react-native/React/Base/RCTKeyCommands.m#L141)


Command+R no longer triggers a reload and neither did before afaict

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)