### PR TITLE
[cli] allow starting mcp tunnel on background

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Added MCP server handshaking and graceful shutdown. ([#40660](https://github.com/expo/expo/pull/40660) by [@kudo](https://github.com/kudo))
 - Update to `glob@^13.0.0` ([#41079](https://github.com/expo/expo/pull/41079) by [@kitten](https://github.com/kitten))
 - Use `@expo/mcp-tunnel` from `expo-mcp`. ([#41276](https://github.com/expo/expo/pull/41276) by [@kudo](https://github.com/kudo))
+- Allow MCP tunnel starting in background tasks. ([#41359](https://github.com/expo/expo/pull/41359) by [@kudo](https://github.com/kudo))
 
 ### ⚠️ Notices
 

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -114,20 +114,18 @@ export async function startAsync(
   await profile(openPlatformsAsync)(devServerManager, options);
 
   const defaultServerUrl = devServerManager.getDefaultDevServer()?.getDevServerUrl() ?? '';
+  const mcpServer =
+    (await profile(maybeCreateMCPServerAsync)({
+      projectRoot,
+      devServerUrl: defaultServerUrl,
+    })) ?? undefined;
+
   // Present the Terminal UI.
   if (isInteractive()) {
-    const mcpServer =
-      (await profile(maybeCreateMCPServerAsync)({
-        projectRoot,
-        devServerUrl: defaultServerUrl,
-      })) ?? undefined;
-
     await profile(startInterfaceAsync)(devServerManager, {
       platforms: exp.platforms ?? ['ios', 'android', 'web'],
       mcpServer,
     });
-
-    mcpServer?.start();
   } else {
     // Display the server location in CI...
     if (defaultServerUrl) {
@@ -138,6 +136,7 @@ export async function startAsync(
       Log.log(chalk`Waiting on {underline ${defaultServerUrl}}`);
     }
   }
+  mcpServer?.start();
 
   // Final note about closing the server.
   const logLocation = settings.webOnly ? 'in the browser console' : 'below';


### PR DESCRIPTION
# Why

to allow agents to start the dev server (claude code supports running background tasks without tty)

# How

update the logic to start the mcp server even without tty

# Test Plan

- test normal starting
- test starting from claude code

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
