### PR TITLE
[dev-launcher] Restore config plugin

### DIFF
--- a/packages/expo-dev-client/plugin/build/withDevClient.d.ts
+++ b/packages/expo-dev-client/plugin/build/withDevClient.d.ts
@@ -1,4 +1,5 @@
-type DevClientPluginConfigType = {
+import type { PluginConfigType } from 'expo-dev-launcher/plugin/build/pluginConfig';
+type DevClientPluginConfigType = PluginConfigType & {
     addGeneratedScheme?: boolean;
 };
 declare const _default: import("expo/config-plugins").ConfigPlugin<DevClientPluginConfigType>;

--- a/packages/expo-dev-client/plugin/build/withDevClient.js
+++ b/packages/expo-dev-client/plugin/build/withDevClient.js
@@ -5,12 +5,15 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const config_plugins_1 = require("expo/config-plugins");
 // @ts-expect-error missing types
-const app_plugin_1 = __importDefault(require("expo-dev-menu/app.plugin"));
+const app_plugin_1 = __importDefault(require("expo-dev-launcher/app.plugin"));
+// @ts-expect-error missing types
+const app_plugin_2 = __importDefault(require("expo-dev-menu/app.plugin"));
 const withGeneratedAndroidScheme_1 = require("./withGeneratedAndroidScheme");
 const withGeneratedIosScheme_1 = require("./withGeneratedIosScheme");
 const pkg = require('expo-dev-client/package.json');
 function withDevClient(config, props) {
-    config = (0, app_plugin_1.default)(config);
+    config = (0, app_plugin_2.default)(config);
+    config = (0, app_plugin_1.default)(config, props);
     const mySchemeProps = { addGeneratedScheme: true, ...props };
     if (mySchemeProps.addGeneratedScheme) {
         config = (0, withGeneratedAndroidScheme_1.withGeneratedAndroidScheme)(config);

--- a/packages/expo-dev-client/plugin/src/withDevClient.ts
+++ b/packages/expo-dev-client/plugin/src/withDevClient.ts
@@ -1,6 +1,9 @@
 import type { ExpoConfig } from 'expo/config';
 import { createRunOncePlugin } from 'expo/config-plugins';
 // @ts-expect-error missing types
+import withDevLauncher from 'expo-dev-launcher/app.plugin';
+import type { PluginConfigType } from 'expo-dev-launcher/plugin/build/pluginConfig';
+// @ts-expect-error missing types
 import withDevMenu from 'expo-dev-menu/app.plugin';
 
 import { withGeneratedAndroidScheme } from './withGeneratedAndroidScheme';
@@ -8,12 +11,13 @@ import { withGeneratedIosScheme } from './withGeneratedIosScheme';
 
 const pkg = require('expo-dev-client/package.json');
 
-type DevClientPluginConfigType = {
+type DevClientPluginConfigType = PluginConfigType & {
   addGeneratedScheme?: boolean;
 };
 
 function withDevClient(config: ExpoConfig, props: DevClientPluginConfigType) {
   config = withDevMenu(config);
+  config = withDevLauncher(config, props);
 
   const mySchemeProps = { addGeneratedScheme: true, ...props };
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [iOS] Fix port scanning on pysical devices. ([#40824](https://github.com/expo/expo/pull/40824) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix RCTDevMenuConfiguration in release builds ([#40870](https://github.com/expo/expo/pull/40870) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Fix Safe Area being ignored on physical devices ([#41119](https://github.com/expo/expo/pull/41119) by [@betomoedano](https://github.com/betomoedano))
+- Restore config plugin `launchMode` support ([#41363](https://github.com/expo/expo/pull/41363) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/app.plugin.js
+++ b/packages/expo-dev-launcher/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./plugin/build/withDevLauncher');

--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev",
   "dependencies": {
+    "ajv": "^8.11.0",
     "expo-dev-menu": "7.0.11",
     "expo-manifests": "~1.0.8"
   },

--- a/packages/expo-dev-launcher/plugin/build/pluginConfig.d.ts
+++ b/packages/expo-dev-launcher/plugin/build/pluginConfig.d.ts
@@ -1,0 +1,43 @@
+/**
+ * Type representing base dev launcher configuration.
+ */
+export type PluginConfigType = PluginConfigOptionsByPlatform & PluginConfigOptions;
+/**
+ * Type representing available configuration for each platform.
+ */
+export type PluginConfigOptionsByPlatform = {
+    /**
+     * Type representing available configuration for Android dev launcher.
+     * @platform android
+     */
+    android?: PluginConfigOptions;
+    /**
+     * Type representing available configuration for iOS dev launcher.
+     * @platform ios
+     */
+    ios?: PluginConfigOptions;
+};
+/**
+ * Type representing available configuration for dev launcher.
+ */
+export type PluginConfigOptions = {
+    /**
+     * Determines whether to launch the most recently opened project or navigate to the launcher screen.
+     *
+     * - `'most-recent'` - Attempt to launch directly into a previously opened project and if unable to connect,
+     * fall back to the launcher screen.
+     *
+     * - `'launcher'` - Opens the launcher screen.
+     *
+     * @default 'most-recent'
+     */
+    launchMode?: 'most-recent' | 'launcher';
+    /**
+     * @deprecated use the `launchMode` property instead
+     */
+    launchModeExperimental?: 'most-recent' | 'launcher';
+};
+/**
+ * @ignore
+ */
+export declare function validateConfig<T>(config: T): PluginConfigType;

--- a/packages/expo-dev-launcher/plugin/build/pluginConfig.js
+++ b/packages/expo-dev-launcher/plugin/build/pluginConfig.js
@@ -1,0 +1,76 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.validateConfig = validateConfig;
+const ajv_1 = __importDefault(require("ajv"));
+const schema = {
+    type: 'object',
+    properties: {
+        launchMode: {
+            type: 'string',
+            enum: ['most-recent', 'launcher'],
+            nullable: true,
+        },
+        launchModeExperimental: {
+            type: 'string',
+            enum: ['most-recent', 'launcher'],
+            nullable: true,
+        },
+        android: {
+            type: 'object',
+            properties: {
+                launchMode: {
+                    type: 'string',
+                    enum: ['most-recent', 'launcher'],
+                    nullable: true,
+                },
+                launchModeExperimental: {
+                    type: 'string',
+                    enum: ['most-recent', 'launcher'],
+                    nullable: true,
+                },
+            },
+            nullable: true,
+        },
+        ios: {
+            type: 'object',
+            properties: {
+                launchMode: {
+                    type: 'string',
+                    enum: ['most-recent', 'launcher'],
+                    nullable: true,
+                },
+                launchModeExperimental: {
+                    type: 'string',
+                    enum: ['most-recent', 'launcher'],
+                    nullable: true,
+                },
+            },
+            nullable: true,
+        },
+    },
+};
+/**
+ * @ignore
+ */
+function validateConfig(config) {
+    const validate = new ajv_1.default({ allowUnionTypes: true }).compile(schema);
+    if (!validate(config)) {
+        throw new Error('Invalid expo-dev-launcher config: ' + JSON.stringify(validate.errors));
+    }
+    if (config.launchModeExperimental ||
+        config.ios?.launchModeExperimental ||
+        config.android?.launchModeExperimental) {
+        warnOnce('The `launchModeExperimental` property of expo-dev-launcher config plugin is deprecated and will be removed in a future SDK release. Use `launchMode` instead.');
+    }
+    return config;
+}
+const warnMap = {};
+function warnOnce(message) {
+    if (!warnMap[message]) {
+        warnMap[message] = true;
+        console.warn(message);
+    }
+}

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.d.ts
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.d.ts
@@ -1,0 +1,3 @@
+import { PluginConfigType } from './pluginConfig';
+declare const _default: import("expo/config-plugins").ConfigPlugin<PluginConfigType>;
+export default _default;

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -1,0 +1,30 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const config_plugins_1 = require("expo/config-plugins");
+const pluginConfig_1 = require("./pluginConfig");
+const pkg = require('expo-dev-launcher/package.json');
+exports.default = (0, config_plugins_1.createRunOncePlugin)((config, props = {}) => {
+    (0, pluginConfig_1.validateConfig)(props);
+    const iOSLaunchMode = props.ios?.launchMode ??
+        props.launchMode ??
+        props.ios?.launchModeExperimental ??
+        props.launchModeExperimental;
+    if (iOSLaunchMode === 'launcher') {
+        config = (0, config_plugins_1.withInfoPlist)(config, (config) => {
+            config.modResults['DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE'] = false;
+            return config;
+        });
+    }
+    const androidLaunchMode = props.android?.launchMode ??
+        props.launchMode ??
+        props.android?.launchModeExperimental ??
+        props.launchModeExperimental;
+    if (androidLaunchMode === 'launcher') {
+        config = (0, config_plugins_1.withAndroidManifest)(config, (config) => {
+            const mainApplication = config_plugins_1.AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
+            config_plugins_1.AndroidConfig.Manifest.addMetaDataItemToMainApplication(mainApplication, 'DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE', false?.toString());
+            return config;
+        });
+    }
+    return config;
+}, pkg.name, pkg.version);

--- a/packages/expo-dev-launcher/plugin/jest.config.js
+++ b/packages/expo-dev-launcher/plugin/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
+++ b/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
@@ -1,0 +1,121 @@
+import Ajv, { JSONSchemaType } from 'ajv';
+
+/**
+ * Type representing base dev launcher configuration.
+ */
+export type PluginConfigType = PluginConfigOptionsByPlatform & PluginConfigOptions;
+
+/**
+ * Type representing available configuration for each platform.
+ */
+export type PluginConfigOptionsByPlatform = {
+  /**
+   * Type representing available configuration for Android dev launcher.
+   * @platform android
+   */
+  android?: PluginConfigOptions;
+  /**
+   * Type representing available configuration for iOS dev launcher.
+   * @platform ios
+   */
+  ios?: PluginConfigOptions;
+};
+
+/**
+ * Type representing available configuration for dev launcher.
+ */
+export type PluginConfigOptions = {
+  /**
+   * Determines whether to launch the most recently opened project or navigate to the launcher screen.
+   *
+   * - `'most-recent'` - Attempt to launch directly into a previously opened project and if unable to connect,
+   * fall back to the launcher screen.
+   *
+   * - `'launcher'` - Opens the launcher screen.
+   *
+   * @default 'most-recent'
+   */
+  launchMode?: 'most-recent' | 'launcher';
+  /**
+   * @deprecated use the `launchMode` property instead
+   */
+  launchModeExperimental?: 'most-recent' | 'launcher';
+};
+
+const schema: JSONSchemaType<PluginConfigType> = {
+  type: 'object',
+  properties: {
+    launchMode: {
+      type: 'string',
+      enum: ['most-recent', 'launcher'],
+      nullable: true,
+    },
+    launchModeExperimental: {
+      type: 'string',
+      enum: ['most-recent', 'launcher'],
+      nullable: true,
+    },
+    android: {
+      type: 'object',
+      properties: {
+        launchMode: {
+          type: 'string',
+          enum: ['most-recent', 'launcher'],
+          nullable: true,
+        },
+        launchModeExperimental: {
+          type: 'string',
+          enum: ['most-recent', 'launcher'],
+          nullable: true,
+        },
+      },
+      nullable: true,
+    },
+    ios: {
+      type: 'object',
+      properties: {
+        launchMode: {
+          type: 'string',
+          enum: ['most-recent', 'launcher'],
+          nullable: true,
+        },
+        launchModeExperimental: {
+          type: 'string',
+          enum: ['most-recent', 'launcher'],
+          nullable: true,
+        },
+      },
+      nullable: true,
+    },
+  },
+};
+
+/**
+ * @ignore
+ */
+export function validateConfig<T>(config: T): PluginConfigType {
+  const validate = new Ajv({ allowUnionTypes: true }).compile(schema);
+  if (!validate(config)) {
+    throw new Error('Invalid expo-dev-launcher config: ' + JSON.stringify(validate.errors));
+  }
+
+  if (
+    config.launchModeExperimental ||
+    config.ios?.launchModeExperimental ||
+    config.android?.launchModeExperimental
+  ) {
+    warnOnce(
+      'The `launchModeExperimental` property of expo-dev-launcher config plugin is deprecated and will be removed in a future SDK release. Use `launchMode` instead.'
+    );
+  }
+
+  return config;
+}
+
+const warnMap: Record<string, boolean> = {};
+function warnOnce(message: string) {
+  if (!warnMap[message]) {
+    warnMap[message] = true;
+    console.warn(message);
+  }
+}

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -1,0 +1,50 @@
+import {
+  createRunOncePlugin,
+  AndroidConfig,
+  withInfoPlist,
+  withAndroidManifest,
+} from 'expo/config-plugins';
+
+import { PluginConfigType, validateConfig } from './pluginConfig';
+
+const pkg = require('expo-dev-launcher/package.json');
+
+export default createRunOncePlugin<PluginConfigType>(
+  (config, props = {}) => {
+    validateConfig(props);
+
+    const iOSLaunchMode =
+      props.ios?.launchMode ??
+      props.launchMode ??
+      props.ios?.launchModeExperimental ??
+      props.launchModeExperimental;
+    if (iOSLaunchMode === 'launcher') {
+      config = withInfoPlist(config, (config) => {
+        config.modResults['DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE'] = false;
+        return config;
+      });
+    }
+
+    const androidLaunchMode =
+      props.android?.launchMode ??
+      props.launchMode ??
+      props.android?.launchModeExperimental ??
+      props.launchModeExperimental;
+    if (androidLaunchMode === 'launcher') {
+      config = withAndroidManifest(config, (config) => {
+        const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
+
+        AndroidConfig.Manifest.addMetaDataItemToMainApplication(
+          mainApplication,
+          'DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE',
+          false?.toString()
+        );
+        return config;
+      });
+    }
+
+    return config;
+  },
+  pkg.name,
+  pkg.version
+);

--- a/packages/expo-dev-launcher/plugin/tsconfig.json
+++ b/packages/expo-dev-launcher/plugin/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "expo-module-scripts/tsconfig.plugin",
+    "compilerOptions": {
+      "outDir": "build",
+      "rootDir": "src",
+
+    },
+    "include": ["./src"],
+    "exclude": ["**/__mocks__/*", "**/__tests__/*"],
+  }

--- a/packages/expo-dev-launcher/plugin/tsconfig.json
+++ b/packages/expo-dev-launcher/plugin/tsconfig.json
@@ -1,10 +1,9 @@
 {
-    "extends": "expo-module-scripts/tsconfig.plugin",
-    "compilerOptions": {
-      "outDir": "build",
-      "rootDir": "src",
-
-    },
-    "include": ["./src"],
-    "exclude": ["**/__mocks__/*", "**/__tests__/*"],
-  }
+	"extends": "expo-module-scripts/tsconfig.plugin",
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src",
+  },
+  "include": ["./src"],
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"],
+}


### PR DESCRIPTION
# Why

We've mistakenly removed the dev-launcher config plugin when we removed all the launcher React Native JS code in a20afd4194e844902ee272af95f280b71f33f669 and then removed the remaining config plugin references in 1225627c1894426100f1c54ff9a3393e933c0adb, causing the `launchMode` config to stop working, even though we still have this in our docs https://docs.expo.dev/versions/latest/sdk/dev-client/#example-appjson-with-config-plugin 

The ability of not launch directly into a previously opened project is quite useful when testing and we should restore it.

# How

`git revert --no-commit 1225627c1894426100f1c54ff9a3393e933c0adb` and `git revert --no-commit  a20afd4194e844902ee272af95f280b71f33f669`

# Test Plan

1. Modify app.json to include the `expo-dev-client` config plugin

```
"plugins": [
      [
        "expo-dev-client",
        {
          "launchMode": "most-recent"
        }
      ]
    ]
```

2. Run npx prebuild
3. Build the app and observe


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
