### PR TITLE
[docs] Fix GitHub capitalization

### DIFF
--- a/docs/pages/eas-update/github-actions.mdx
+++ b/docs/pages/eas-update/github-actions.mdx
@@ -1,6 +1,6 @@
 ---
-title: Github Action for PR previews
-sidebar_title: Github PR previews
+title: GitHub Action for PR previews
+sidebar_title: GitHub PR previews
 description: Learn how to use GitHub Actions to automate publishing updates with EAS Update.
 ---
 


### PR DESCRIPTION
# Why

Very minor - the title had the incorrect GitHub capitalization while the rest of the document had it correct.

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
