### PR TITLE
[core][iOS] Replace `appContext.utilities` with the core implementation

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -52,7 +52,7 @@
 - Remove tests related files from the published package content. ([#39551](https://github.com/expo/expo/pull/39551) by [@Simek](https://github.com/Simek))
 - Remove old REACT_NATIVE_TARGET_VERSION checks ([#40843](https://github.com/expo/expo/pull/40843) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Moved the implementation of the constants provider (`EXConstantsService`) from `expo-constants`. ([#41339](https://github.com/expo/expo/pull/41339) by [@tsapeta](https://github.com/tsapeta))
-- [iOS] Replaced `appContext.fileSystem` with the core implementation. ([#41350](https://github.com/expo/expo/pull/41350) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Replaced `appContext.fileSystem` and `appContext.utilities` with the core implementations. ([#41350](https://github.com/expo/expo/pull/41350), [#41370](https://github.com/expo/expo/pull/41370) by [@tsapeta](https://github.com/tsapeta))
 
 ## 3.0.22 - 2025-10-20
 

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -231,11 +231,9 @@ public final class AppContext: NSObject, @unchecked Sendable {
   }
 
   /**
-   Provides access to the utilities from legacy module registry.
+   Provides access to the utilities (such as looking up for the current view controller).
    */
-  public var utilities: EXUtilitiesInterface? {
-    return legacyModule(implementing: EXUtilitiesInterface.self)
-  }
+  public var utilities: Utilities? = Utilities()
 
   /**
    Provides an event emitter that is compatible with the legacy interface.

--- a/packages/expo-modules-core/ios/Utilities/Utilities.swift
+++ b/packages/expo-modules-core/ios/Utilities/Utilities.swift
@@ -112,4 +112,20 @@ public struct Utilities {
   public static func urlFrom(string: String) -> URL? {
     return convertToUrl(string: string)
   }
+
+  nonisolated public func currentViewController() -> UIViewController? {
+    return MainActor.assumeIsolated {
+#if os(iOS) || os(tvOS)
+      var controller = UIApplication.shared.keyWindow?.rootViewController
+
+      while let presentedController = controller?.presentedViewController, !presentedController.isBeingDismissed {
+        controller = presentedController
+      }
+      return controller
+#elseif os(macOS)
+      // Even though the function's return type is `UIViewController`, react-native-macos will alias `NSViewController` to `UIViewController`.
+      return NSApplication.shared.keyWindow?.contentViewController
+#endif
+    }
+  }
 }


### PR DESCRIPTION
# Why

Part of the effort to remove the legacy module registry from the `AppContext`.

# How

Replaced `appContext.utilities` with the existing `Utilities` struct. Previously it was an instance of `EXUtilities` conforming to `EXUtilitiesInterface`. There is only one non-static function that is used across the repo – `currentViewController()`. I rewrote this function to Swift and moved to `Utilities` so it's still accessible by other modules without any changes.
Besides this function, other modules use some static functions from `EXUtilities` such as `performSynchronouslyOnMainThread:` and `screenScale`, that's why I'm not removing this class entirely. In the long run it'll be great to remove it though.

# Test Plan

Tested in bare-expo on some modules that use `currentViewController()`