### PR TITLE
[ui][android] Fix events for functional view definitions.

### DIFF
--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -150,6 +150,7 @@ class ExpoViewComposableScope(val view: ComposeFunctionHolder<*>) {
 class ComposeFunctionHolder<Props : ComposeProps>(
   context: Context,
   appContext: AppContext,
+  val name: String,
   private val composableContent: @Composable ExpoViewComposableScope.(props: Props) -> Unit,
   override val props: Props
 ) : ExpoComposeView<Props>(context, appContext) {

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ModuleDefinitionBuilderComposeExtension.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ModuleDefinitionBuilderComposeExtension.kt
@@ -65,7 +65,7 @@ class ComposeViewFunctionDefinitionBuilder<Props : ComposeProps>(
         } catch (e: Exception) {
           throw IllegalStateException("Could not instantiate props instance of $name compose component.", e)
         }
-        ComposeFunctionHolder(context, appContext, viewFunction, instance)
+        ComposeFunctionHolder(context, appContext, name, viewFunction, instance)
       },
       callbacksDefinition = callbacksDefinition,
       viewType = ComposeFunctionHolder::class.java,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
@@ -76,6 +76,10 @@ class ModuleRegistry(
     return holder.definition.viewManagerDefinitions.values.find { it.viewType == viewClass }
   }
 
+  fun getViewDefinition(holder: ModuleHolder<*>, viewName: String): ViewManagerDefinition? {
+    return holder.definition.viewManagerDefinitions.values.find { it.name == viewName }
+  }
+
   /**
    * Post onCreate event to all modules. It has its own method to ensure that it’s called first.
    */

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEvent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEvent.kt
@@ -8,6 +8,7 @@ import expo.modules.kotlin.getUnimoduleProxy
 import expo.modules.kotlin.logger
 import expo.modules.kotlin.types.JSTypeConverter
 import expo.modules.kotlin.types.putGeneric
+import expo.modules.kotlin.views.ComposeFunctionHolder
 
 fun interface ViewEventCallback<T> {
   operator fun invoke(arg: T)
@@ -30,7 +31,14 @@ open class ViewEvent<T>(
         logger.warn("⚠️ Cannot get module holder for ${view::class.java}")
         return
       }
-      val callbacks = appContext.registry.getViewDefinition(holder, view::class.java)?.callbacksDefinition.ifNull {
+
+      val callbacksDefinition = if (view is ComposeFunctionHolder<*>) {
+        appContext.registry.getViewDefinition(holder, view.name)?.callbacksDefinition
+      } else {
+        appContext.registry.getViewDefinition(holder, view::class.java)?.callbacksDefinition
+      }
+
+      val callbacks = callbacksDefinition.ifNull {
         logger.warn("⚠️ Cannot get callbacks for ${holder.module::class.java}")
         return
       }

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### 🐛 Bug fixes
 
+- [android] Fix events for functional view definitions. ([#41374](https://github.com/expo/expo/pull/41374) by [@aleqsio](https://github.com/aleqsio))
 - [android] Remove style prop from components. ([#41233](https://github.com/expo/expo/pull/41233) by [@aleqsio](https://github.com/aleqsio))
 - [android] Add missing scopes to modifiers. ([#41231](https://github.com/expo/expo/pull/41231) by [@aleqsio](https://github.com/aleqsio))
 - [iOS] Fix `ContextMenu` item with subtitle buttons ([#40926](https://github.com/expo/expo/pull/40926) by [@nishan](https://github.com/intergalacticspacehighway))


### PR DESCRIPTION
# Why

Events didn't work when having multiple `ComposeFunctionHolders` in one module.

# How

Tracking events by name not by view class.

# Test Plan

Tested in a tester app.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
