### PR TITLE
Add the app.json configuration for expo-media-library

### DIFF
--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -35,6 +35,30 @@ To install `react-native-view-shot` and `expo-media-library`, run the following 
 
 An app that requires sensitive information, such as accessing a device's media library, has to prompt permission to allow or deny access. Using `usePermissions()` hook from `expo-media-library`, we can use the permission `permissionResponse` and `requestPermission()` method to ask for access.
 
+Firstly, we need to configure `expo-media-library` in  **app.json**, as in the [Documentation](https://docs.expo.dev/versions/latest/sdk/media-library/#medialibraryrequestpermissionsasync):
+
+{/* prettier-ignore */}
+```json app.json
+{
+  "expo": {
+    // ... rest of configuration
+    "plugins": [
+      // ... other plugins
+      /* @tutinfo Add the configuration for <CODE>expo-media-library</CODE>. */
+      [
+        "expo-media-library",
+        {
+          "photosPermission": "Allow $(PRODUCT_NAME) to access your photos.",
+          "savePhotosPermission": "Allow $(PRODUCT_NAME) to save photos.",
+          "isAccessMediaLocationEnabled": true,
+          "granularPermissions": ["audio", "photo"]
+        }
+      ]/* @end */
+    ],
+  }
+}
+```
+
 When the app loads for the first time and the permission status is neither granted nor denied, the value of the `permissionResponse` is `null`. When asked for permission, a user can either grant the permission or deny it. We can add a condition to check if it is not granted. If it is not granted, trigger the `requestPermission()` method. After getting the access, the value of the `permissionResponse` changes to `granted`.
 
 Add the following code snippet inside the **app/(tabs)/index.tsx**:


### PR DESCRIPTION
Avoids the error:

> ExpoMediaLibrary.requestPermissionsAsync has been reject You have requested the AUDIO permission but it is not declared in AndroidManifest


# Why
I was following the tutorial and [this chapter](https://docs.expo.dev/tutorial/screenshot/) failed to explain the need to configure the app.json for the permissions

# How

Following the [dedicated documentation on the media library](https://docs.expo.dev/versions/latest/sdk/media-library/)

# Test Plan

Follow with the tutorial without setting the configuration and open the app in an Android Device version >=13

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
