### PR TITLE
[docs] add video link for a quick upgrade tutorial in Upgrade Expo SDK reference

### DIFF
--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
@@ -1,18 +1,25 @@
 ---
 title: Upgrade Expo SDK
 description: Learn how to incrementally upgrade the Expo SDK version in your project.
+hasVideoLink: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 > **info** We recommend upgrading SDK versions incrementally, one at a time. Doing so will help you pinpoint breakages and issues that arise during the upgrade process.
 
 With a new SDK release, the latest version enters the current release status. This applies to Expo Go as it only supports the latest SDK version and previous versions are no longer supported. We recommend using [development builds](/develop/development-builds/introduction/) for production apps as the backwards compatibility for older SDK versions on EAS services tends to be much longer, but not forever.
 
 If you are looking to install a specific version of Expo Go, visit [expo.dev/go](https://expo.dev/go). It supports downloads for Android devices/emulators and iOS simulators. However, due to iOS platform restrictions, only the latest version of Expo Go is available for installation on physical iOS devices.
+
+<VideoBoxLink
+  videoId="QuN63BRRhAM"
+  title="Watch: How to upgrade from Expo SDK 53 to SDK 54 in 5 minutes"
+/>
 
 ## How to upgrade to the latest SDK version
 


### PR DESCRIPTION
# Test Plan

Ran locally

<img width="1148" height="606" alt="image" src="https://github.com/user-attachments/assets/ee546bae-b25a-41d0-bd38-35280e21f693" />

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
