### PR TITLE
test(@expo/cli): extract logic for multiple server type creation in E2E tests

### DIFF
--- a/packages/@expo/cli/e2e/__tests__/export/__snapshots__/server.test.ts.snap
+++ b/packages/@expo/cli/e2e/__tests__/export/__snapshots__/server.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`server-output express server requests has expected routes manifest entries 1`] = `
+exports[`server-output express requests exported files has expected routes manifest entries 1`] = `
 {
   "apiRoutes": [
     {
@@ -174,7 +174,7 @@ exports[`server-output express server requests has expected routes manifest entr
 }
 `;
 
-exports[`server-output workerd server requests has expected routes manifest entries 1`] = `
+exports[`server-output workerd requests exported files has expected routes manifest entries 1`] = `
 {
   "apiRoutes": [
     {

--- a/packages/@expo/cli/e2e/__tests__/export/server-headers.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-headers.test.ts
@@ -3,140 +3,38 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { runExportSideEffects } from './export-side-effects';
-import { createExpoServe, executeExpoAsync } from '../../utils/expo';
-import { executeAsync, processFindPrefixedValue } from '../../utils/process';
-import { BackgroundServer, createBackgroundServer } from '../../utils/server';
-import { getRouterE2ERoot } from '../utils';
+import {
+  prepareServers,
+  setupServer,
+  RUNTIME_EXPO_SERVE,
+  RUNTIME_WORKERD,
+} from '../../utils/runtime';
 
 runExportSideEffects();
 
-const EXPRESS_SERVER = 'expo serve server';
-const WORKERD_SERVER = 'workerd server';
-const inputDir = 'server-headers';
-
 describe('export server with custom headers', () => {
-  const projectRoot = getRouterE2ERoot();
-
-  describe.each([
-    {
-      name: EXPRESS_SERVER,
-      prepareDist: async () => {
-        const outputName = `dist-${inputDir}-expo-serve`;
-        const outputDir = path.join(projectRoot, outputName);
-
-        await executeExpoAsync(projectRoot, ['export', '-p', 'web', '--output-dir', outputName], {
-          env: {
-            NODE_ENV: 'production',
-            EXPO_USE_STATIC: 'server',
-            E2E_ROUTER_SRC: inputDir,
-            E2E_ROUTER_HEADERS: JSON.stringify({
-              'X-Powered-By': 'expo-server',
-              'Set-Cookie': ['hello=world', 'foo=bar'],
-              'Content-Type': 'application/pdf',
-            }),
-            E2E_ROUTER_REWRITES: JSON.stringify([
-              {
-                source: '/rewrite/api',
-                destination: '/api',
-              },
-            ]),
-          },
-        });
-
-        return [outputDir, outputName];
+  describe.each(
+    prepareServers([RUNTIME_EXPO_SERVE, RUNTIME_WORKERD], {
+      fixtureName: 'server-headers',
+      export: {
+        env: {
+          E2E_ROUTER_HEADERS: JSON.stringify({
+            'X-Powered-By': 'expo-server',
+            'Set-Cookie': ['hello=world', 'foo=bar'],
+            'Content-Type': 'application/pdf',
+          }),
+          E2E_ROUTER_REWRITES: JSON.stringify([
+            { source: '/rewrite/api', destination: '/api' },
+          ]),
+        },
       },
-      createServer: () =>
-        createExpoServe({
-          cwd: projectRoot,
-          env: {
-            NODE_ENV: 'production',
-          },
-        }),
-    },
-    {
-      name: WORKERD_SERVER,
-      prepareDist: async () => {
-        const outputName = `dist-${inputDir}-workerd`;
-        const outputDir = path.join(projectRoot, outputName);
-
-        await executeExpoAsync(projectRoot, ['export', '-p', 'web', '--output-dir', outputName], {
-          env: {
-            NODE_ENV: 'production',
-            EXPO_USE_STATIC: 'server',
-            E2E_ROUTER_SRC: inputDir,
-            E2E_ROUTER_HEADERS: JSON.stringify({
-              'X-Powered-By': 'expo-server',
-              'Set-Cookie': ['hello=world', 'foo=bar'],
-              'Content-Type': 'application/pdf',
-            }),
-            E2E_ROUTER_REWRITES: JSON.stringify([
-              {
-                source: '/rewrite/api',
-                destination: '/api',
-              },
-            ]),
-          },
-        });
-
-        await executeAsync(projectRoot, [
-          'node_modules/.bin/esbuild',
-          '--bundle',
-          '--format=esm',
-          '--platform=node',
-          `--outfile=${path.join(outputDir, 'server/workerd.js')}`,
-          path.join(projectRoot, '__e2e__/server-headers/workerd/workerd.mjs'),
-        ]);
-        fs.copyFileSync(
-          path.join(projectRoot, '__e2e__/server-headers/workerd/config.capnp'),
-          path.join(outputDir, 'server/config.capnp')
-        );
-
-        return [outputDir];
-      },
-      createServer: () =>
-        createBackgroundServer({
-          command: [
-            'node_modules/.bin/workerd',
-            'serve',
-            path.join(
-              path.join(projectRoot, `dist-${inputDir}-workerd`),
-              'server/config.capnp'
-            ),
-          ],
-          host: (chunk: any) => processFindPrefixedValue(chunk, 'Workerd server listening'),
-          port: 8787,
-          cwd: projectRoot,
-        }),
-    },
-  ] as {
-    name: string;
-    createServer: () => BackgroundServer;
-    prepareDist: () => Promise<[string, string?]>;
-  }[])('$name requests', ({ name: _name, createServer, prepareDist }) => {
-    let outputDir: string | undefined;
-    let server: BackgroundServer;
-    beforeAll(async () => {
-      const [newOutputDir, outputName] = await prepareDist();
-      outputDir = newOutputDir;
-      server = createServer();
-      // Start a server instance that we can test against then kill it.
-      if (outputName) {
-        await server.startAsync([outputName]);
-      } else {
-        await server.startAsync();
-      }
-    });
-    afterAll(async () => {
-      await server.stopAsync();
-    });
-
-    const serverFetchAsync = (url: string, init?: RequestInit) => {
-      return server.fetchAsync(url, init, { attempts: 7 });
-    };
+    })
+  )('$name requests', (config) => {
+    const server = setupServer(config);
 
     it('includes headers in routes.json manifest', () => {
       const routesJson = JSON.parse(
-        fs.readFileSync(path.resolve(outputDir!, 'server/_expo/routes.json'), 'utf8')
+        fs.readFileSync(path.resolve(server.outputDir, 'server/_expo/routes.json'), 'utf8')
       );
       expect(routesJson.headers).toEqual({
         'X-Powered-By': 'expo-server',
@@ -167,7 +65,7 @@ describe('export server with custom headers', () => {
         contentType: 'text/html',
       },
     ])('applies custom headers to $path', async ({ path, status, contentType }) => {
-      const response = await serverFetchAsync(path);
+      const response = await server.fetchAsync(path);
 
       expect(response.status).toBe(status);
 

--- a/packages/@expo/cli/e2e/__tests__/export/server.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server.test.ts
@@ -4,263 +4,164 @@ import fs from 'fs/promises';
 import path from 'path';
 
 import { runExportSideEffects } from './export-side-effects';
-import { createExpoStart, executeExpoAsync } from '../../utils/expo';
-import { executeAsync, processFindPrefixedValue } from '../../utils/process';
-import { type BackgroundServer, createBackgroundServer } from '../../utils/server';
-import { findProjectFiles, getRouterE2ERoot } from '../utils';
+import {
+  prepareServers,
+  setupServer,
+  RUNTIME_EXPRESS_SERVER,
+  RUNTIME_EXPO_START,
+  RUNTIME_WORKERD,
+} from '../../utils/runtime';
+import { findProjectFiles } from '../utils';
 
 runExportSideEffects();
 
-const EXPRESS_SERVER = 'express server';
-const EXPO_DEV_SERVER = 'dev server';
-const WORKERD_SERVER = 'workerd server';
-
 describe('server-output', () => {
-  const projectRoot = getRouterE2ERoot();
-
-  describe.each([
-    {
-      name: EXPRESS_SERVER,
-      prepareDist: async () => {
-        const outputDirName = 'dist-server-express';
-        const outputDir = path.join(projectRoot, outputDirName);
-
-        console.time('export-server');
-        await executeExpoAsync(projectRoot, ['export', '-p', 'web', '--output-dir', outputDir], {
-          env: {
-            NODE_ENV: 'production',
-            EXPO_USE_STATIC: 'server',
-            E2E_ROUTER_SRC: 'server',
-            E2E_ROUTER_ASYNC: 'development',
-          },
-        });
-        console.timeEnd('export-server');
-
-        return outputDir;
+  describe.each(
+    prepareServers([RUNTIME_EXPRESS_SERVER, RUNTIME_EXPO_START, RUNTIME_WORKERD], {
+      fixtureName: 'server',
+      export: {
+        env: {
+          E2E_ROUTER_ASYNC: 'development',
+        },
       },
-      createServer: () =>
-        createBackgroundServer({
-          command: ['node', path.join(projectRoot, '__e2e__/server/express.js')],
-          host: (chunk: any) => processFindPrefixedValue(chunk, 'Express server listening'),
-          cwd: projectRoot,
-          env: {
-            NODE_ENV: 'production',
-            TEST_SECRET_KEY: 'test-secret-key',
-          },
-        }),
-    },
-    {
-      name: EXPO_DEV_SERVER,
-      createServer: () =>
-        createExpoStart({
-          cwd: projectRoot,
-          env: {
-            NODE_ENV: 'development',
-            EXPO_USE_STATIC: 'server',
-            E2E_ROUTER_SRC: 'server',
-            E2E_ROUTER_ASYNC: 'development',
-            TEST_SECRET_KEY: 'test-secret-key',
-          },
-        }),
-    },
-    {
-      name: WORKERD_SERVER,
-      prepareDist: async () => {
-        const outputDirName = 'dist-server-workerd';
-        const outputDir = path.join(projectRoot, outputDirName);
-
-        console.time('export-server');
-        await executeExpoAsync(
-          projectRoot,
-          ['export', '-p', 'web', '--output-dir', outputDirName],
-          {
-            env: {
-              NODE_ENV: 'production',
-              EXPO_USE_STATIC: 'server',
-              E2E_ROUTER_SRC: 'server',
-              E2E_ROUTER_ASYNC: 'development',
-            },
-          }
-        );
-        console.timeEnd('export-server');
-
-        await executeAsync(projectRoot, [
-          'node_modules/.bin/esbuild',
-          '--bundle',
-          '--format=esm',
-          '--platform=node',
-          `--outfile=${path.join(outputDir, 'server/workerd.js')}`,
-          path.join(projectRoot, '__e2e__/server/workerd/workerd.mjs'),
-        ]);
-        await fs.copyFile(
-          path.join(projectRoot, '__e2e__/server/workerd/config.capnp'),
-          path.join(outputDir, 'server/config.capnp')
-        );
-
-        return outputDir;
+      serve: {
+        env: {
+          TEST_SECRET_KEY: 'test-secret-key',
+        },
       },
-      createServer: () =>
-        createBackgroundServer({
-          command: [
-            'node_modules/.bin/workerd',
-            'serve',
-            path.join(path.join(projectRoot, 'dist-server-workerd'), 'server/config.capnp'),
-          ],
-          host: (chunk: any) => processFindPrefixedValue(chunk, 'Workerd server listening'),
-          port: 8787,
-          cwd: projectRoot,
-        }),
-    },
-  ] as {
-    name: string;
-    createServer: () => BackgroundServer;
-    prepareDist?: () => Promise<string>;
-  }[])('$name requests', ({ name, createServer, prepareDist }) => {
-    let outputDir: string | undefined;
-    let server: BackgroundServer;
-
-    const serverFetchAsync = (url: string, init?: RequestInit) => {
-      return server.fetchAsync(url, init, { attempts: 7 });
-    };
-
-    beforeAll(async () => {
-      outputDir = await prepareDist?.();
-      server = createServer();
-      await server.startAsync();
-    });
-
-    afterAll(async () => {
-      await server.stopAsync(true);
-    });
+    })
+  )('$name requests', (config) => {
+    const server = setupServer(config);
 
     ['POST', 'GET', 'PUT', 'DELETE'].map(async (method) => {
       it(`can make requests to ${method} routes`, async () => {
-        // Request missing route
-        expect(await serverFetchAsync('/methods', { method }).then((res) => res.json())).toEqual({
+        expect(await server.fetchAsync('/methods', { method }).then((res) => res.json())).toEqual({
           method: method.toLowerCase(),
         });
       });
     });
 
     it(`can serve build-time static dynamic route`, async () => {
-      const res = await serverFetchAsync('/blog-ssg/abc');
+      const res = await server.fetchAsync('/blog-ssg/abc');
       expect(res.status).toEqual(200);
       expect(await res.text()).toMatch(/Post: <!-- -->abc/);
 
-      if (name !== EXPO_DEV_SERVER) {
+      if (!server.isExpoStart) {
         // Behaves like a dynamic route in development, but is pre-rendered in production.
-
         // This route is not pre-rendered and should show the default value for the dynamic parameter.
-        const res2 = await serverFetchAsync('/blog-ssg/123');
+        const res2 = await server.fetchAsync('/blog-ssg/123');
         expect(res2.status).toEqual(200);
         expect(await res2.text()).toMatch(/Post: <!-- -->\[post\]/);
       }
     });
 
     it(`can serve up custom not-found`, async () => {
-      const res = await serverFetchAsync('/missing');
+      const res = await server.fetchAsync('/missing');
       expect(res.status).toEqual(404);
       expect(await res.text()).toMatch(/<div data-testid="custom-404">/);
     });
+
     it(`can serve HTML and a function from the same route`, async () => {
-      expect(await serverFetchAsync('/matching-route/alpha').then((res) => res.text())).toMatch(
+      expect(await server.fetchAsync('/matching-route/alpha').then((res) => res.text())).toMatch(
         /<div data-testid="alpha-text">/
       );
       expect(
         await server
-          .fetchAsync('/matching-route/alpha', {
-            method: 'POST',
-          })
+          .fetchAsync('/matching-route/alpha', { method: 'POST' })
           .then((res) => res.json())
       ).toEqual({ foo: 'bar' });
     });
+
     it(`can serve up index html`, async () => {
-      expect(await serverFetchAsync('').then((res) => res.text())).toMatch(/<div id="root">/);
+      expect(await server.fetchAsync('').then((res) => res.text())).toMatch(/<div id="root">/);
     });
 
     it(`can serve up group routes`, async () => {
       // Can access the same route from different paths
-      expect(await serverFetchAsync('/beta').then((res) => res.text())).toMatch(
+      expect(await server.fetchAsync('/beta').then((res) => res.text())).toMatch(
         /<div data-testid="alpha-beta-text">/
       );
-      expect(await serverFetchAsync('/(alpha)/').then((res) => res.text())).toMatch(
+      expect(await server.fetchAsync('/(alpha)/').then((res) => res.text())).toMatch(
         /<div data-testid="alpha-index">/
       );
-      expect(await serverFetchAsync('/(alpha)/beta').then((res) => res.text())).toMatch(
+      expect(await server.fetchAsync('/(alpha)/beta').then((res) => res.text())).toMatch(
         /<div data-testid="alpha-beta-text">/
       );
     });
 
-    if (prepareDist) {
-      // Behaves like a dynamic route in development, but is pre-rendered in production.
-      it(`can serve up built time generated dynamic html routes`, async () => {
-        expect(await serverFetchAsync('/blog/123').then((res) => res.text())).toMatch(/\[post\]/);
-      });
-    }
+    // Behaves like a dynamic route in development, but is pre-rendered in production.
+    (server.isExpoStart ? it.skip : it)(
+      `can serve up built time generated dynamic html routes`,
+      async () => {
+        expect(await server.fetchAsync('/blog/123').then((res) => res.text())).toMatch(/\[post\]/);
+      }
+    );
 
     it(`can hit the 404 route`, async () => {
-      expect(await serverFetchAsync('/clearly-missing').then((res) => res.text())).toMatch(
+      expect(await server.fetchAsync('/clearly-missing').then((res) => res.text())).toMatch(
         /<div id="root">/
       );
     });
 
     it(`can serve up static html in array group`, async () => {
-      expect(await serverFetchAsync('/multi-group').then((res) => res.text())).toMatch(
+      expect(await server.fetchAsync('/multi-group').then((res) => res.text())).toMatch(
         /<div data-testid="multi-group">/
       );
     });
 
     it(`can serve up static html in specific array group`, async () => {
-      expect(await serverFetchAsync('/(a)/multi-group').then((res) => res.text())).toMatch(
+      expect(await server.fetchAsync('/(a)/multi-group').then((res) => res.text())).toMatch(
         /<div data-testid="multi-group">/
       );
-
-      expect(await serverFetchAsync('/(b)/multi-group').then((res) => res.text())).toMatch(
+      expect(await server.fetchAsync('/(b)/multi-group').then((res) => res.text())).toMatch(
         /<div data-testid="multi-group">/
       );
     });
 
     it(`can not serve up static html in retained array group syntax`, async () => {
       // Should not be able to match the array syntax
-      expect(await serverFetchAsync('/(a,b)/multi-group').then((res) => res.status)).toEqual(404);
+      expect(await server.fetchAsync('/(a,b)/multi-group').then((res) => res.status)).toEqual(404);
     });
 
     it(`can serve up API route in array group`, async () => {
-      expect(await serverFetchAsync('/multi-group-api').then((res) => res.json())).toEqual({
+      expect(await server.fetchAsync('/multi-group-api').then((res) => res.json())).toEqual({
         value: 'multi-group-api-get',
       });
     });
 
     it(`can serve up API route in specific array group`, async () => {
       // Should be able to match all the group variations
-      expect(await serverFetchAsync('/(a)/multi-group-api').then((res) => res.json())).toEqual({
+      expect(await server.fetchAsync('/(a)/multi-group-api').then((res) => res.json())).toEqual({
         value: 'multi-group-api-get',
       });
-      expect(await serverFetchAsync('/(b)/multi-group-api').then((res) => res.json())).toEqual({
+      expect(await server.fetchAsync('/(b)/multi-group-api').then((res) => res.json())).toEqual({
         value: 'multi-group-api-get',
       });
     });
 
     it(`can not serve up API route in retained array group syntax`, async () => {
       // Should not be able to match the array syntax
-      expect(await serverFetchAsync('/(a,b)/multi-group-api').then((res) => res.status)).toEqual(
+      expect(await server.fetchAsync('/(a,b)/multi-group-api').then((res) => res.status)).toEqual(
         404
       );
     });
 
     it('serves the empty route as 405', async () => {
-      await expect(serverFetchAsync('/api/empty').then((r) => r.status)).resolves.toBe(405);
+      await expect(server.fetchAsync('/api/empty').then((r) => r.status)).resolves.toBe(405);
     });
+
     it('serves not-found routes as 404', async () => {
-      await expect(serverFetchAsync('/missing').then((r) => r.status)).resolves.toBe(404);
+      await expect(server.fetchAsync('/missing').then((r) => r.status)).resolves.toBe(404);
     });
+
     it('automatically handles JS errors thrown inside of route handlers as 500', async () => {
-      const res = await serverFetchAsync('/api/problematic');
+      const res = await server.fetchAsync('/api/problematic');
       expect(res.status).toBe(500);
       expect(res.statusText).toBe('Internal Server Error');
     });
+
     it('supports multiple values headers in API routes', async () => {
-      const res = await serverFetchAsync('/api/headers');
+      const res = await server.fetchAsync('/api/headers');
       expect(res.status).toBe(200);
       expect(res.headers.get('x-custom-header')).toBe('customValue');
       // Multiple headers with the same name are combined into a single comma-separated value
@@ -269,31 +170,30 @@ describe('server-output', () => {
       expect(res.headers.get('set-cookie')).toBe('key1=value1, key2=value2');
       expect(await res.json()).toEqual({ message: 'ok' });
     });
+
     describe('Response.json', () => {
       it('can POST json to a route', async () => {
-        const res = await serverFetchAsync('/api/json', {
+        const res = await server.fetchAsync('/api/json', {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
+          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ hello: 'world' }),
         });
         expect(res.status).toBe(200);
         expect(await res.json()).toEqual({ hello: 'world' });
       });
     });
+
     describe('Response.error', () => {
       it('returns a 500 response', async () => {
-        const res = await serverFetchAsync('/api/error', {
-          method: 'GET',
-        });
+        const res = await server.fetchAsync('/api/error', { method: 'GET' });
         expect(res.status).toBe(500);
         expect(await res.text()).toEqual(''); // Ensures 500 from Response.error() and not from another error
       });
     });
+
     describe('Response.redirect', () => {
       it('returns a 302 Location redirect', async () => {
-        const res = await serverFetchAsync('/api/redirect', {
+        const res = await server.fetchAsync('/api/redirect', {
           redirect: 'manual',
           method: 'POST',
         });
@@ -301,60 +201,61 @@ describe('server-output', () => {
         expect(res.headers.get('Location')).toBe('http://test.com/redirect');
       });
       it('rejects invalid status codes with an internal error', async () => {
-        const res = await serverFetchAsync('/api/redirect', {
-          redirect: 'manual',
-          method: 'GET',
-        });
+        const res = await server.fetchAsync('/api/redirect', { redirect: 'manual', method: 'GET' });
         expect(res.status).toBe(500);
         expect(res.statusText).toBe('Internal Server Error');
       });
     });
+
     it('handles pinging routes with unsupported methods with 405 "Method Not Allowed"', async () => {
-      const res = await serverFetchAsync('/api/env-vars', { method: 'POST' });
+      const res = await server.fetchAsync('/api/env-vars', { method: 'POST' });
       expect(res.status).toBe(405);
       expect(res.statusText).toBe('Method Not Allowed');
     });
+
     it('supports accessing dynamic parameters using same convention as client-side Expo Router', async () => {
-      await expect(serverFetchAsync('/api/abc').then((r) => r.json())).resolves.toEqual({
+      await expect(server.fetchAsync('/api/abc').then((r) => r.json())).resolves.toEqual({
         hello: 'abc',
       });
     });
+
     it('supports accessing deep dynamic parameters using different convention to client-side Expo Router', async () => {
-      await expect(serverFetchAsync('/api/a/1/2/3').then((r) => r.json())).resolves.toEqual({
+      await expect(server.fetchAsync('/api/a/1/2/3').then((r) => r.json())).resolves.toEqual({
         results: '1/2/3',
       });
     });
 
-    if (name !== WORKERD_SERVER) {
-      // NOTE(@krystofwoldrich): Skipped for now, we can simulate prod by injecting the env vars
-      it('can use environment variables', async () => {
-        expect(await serverFetchAsync('/api/env-vars').then((res) => res.json())).toEqual({
-          // This is defined when we start the production server in `beforeAll`.
-          var: 'test-secret-key',
-        });
+    // NOTE(@krystofwoldrich): Skipped for workerd, we can simulate prod by injecting the env vars
+    (server.isWorkerd ? it.skip : it)('can use environment variables', async () => {
+      expect(await server.fetchAsync('/api/env-vars').then((res) => res.json())).toEqual({
+        // This is defined when we start the production server in `beforeAll`.
+        var: 'test-secret-key',
       });
+    });
 
-      it('supports using Node.js externals to read local files', async () => {
-        await expect(serverFetchAsync('/api/externals').then((r) => r.text())).resolves.toMatchPath(
-          'a/b/c'
-        );
+    (server.isWorkerd ? it.skip : it)(
+      'supports using Node.js externals to read local files',
+      async () => {
+        await expect(
+          server.fetchAsync('/api/externals').then((r) => r.text())
+        ).resolves.toMatchPath('a/b/c');
+      }
+    );
+
+    (server.isWorkerd ? it.skip : it)('supports runtime API', async () => {
+      await expect(server.fetchAsync('/api/runtime').then((r) => r.json())).resolves.toEqual({
+        environment: expect.stringMatching(/production|development/),
+        origin: 'null',
       });
+    });
 
-      it('supports runtime API', async () => {
-        await expect(serverFetchAsync('/api/runtime').then((r) => r.json())).resolves.toEqual({
-          environment: expect.stringMatching(/production|development/),
-          origin: 'null',
-        });
-      });
-    }
-
-    if (name !== EXPO_DEV_SERVER) {
-      // NOTE(@krystofwoldrich): There is no API to adds the server callbacks in the dev server as the moment.
+    // NOTE(@krystofwoldrich): There is no API to add the server callbacks in the dev server at the moment.
+    (server.isExpoStart ? describe.skip : describe)('server callbacks', () => {
       ['POST', 'GET', 'PUT', 'DELETE'].map(async (method) => {
         it(`\`beforeAPIResponse\` and \`beforeResponse\` are executed for ${method}`, async () => {
-          const headers = await serverFetchAsync('/api/abc').then((r) =>
-            Object.fromEntries(r.headers.entries())
-          );
+          const headers = await server
+            .fetchAsync('/api/abc')
+            .then((r) => Object.fromEntries(r.headers.entries()));
           expect(headers).toEqual(
             expect.objectContaining({
               'custom-api-type': 'api',
@@ -375,9 +276,9 @@ describe('server-output', () => {
       });
 
       it('`beforeHTMLResponse` and `beforeResponse` are executed for index page', async () => {
-        const headers = await serverFetchAsync('/').then((r) =>
-          Object.fromEntries(r.headers.entries())
-        );
+        const headers = await server
+          .fetchAsync('/')
+          .then((r) => Object.fromEntries(r.headers.entries()));
         expect(headers).toEqual(
           expect.objectContaining({
             'custom-html-type': 'html',
@@ -397,9 +298,9 @@ describe('server-output', () => {
       });
 
       it('`beforeErrorResponse` and `beforeResponse` are executed for missing page', async () => {
-        const headers = await serverFetchAsync('/missing').then((r) =>
-          Object.fromEntries(r.headers.entries())
-        );
+        const headers = await server
+          .fetchAsync('/missing')
+          .then((r) => Object.fromEntries(r.headers.entries()));
         expect(headers).toEqual(
           expect.objectContaining({
             'custom-error-type': 'notFoundHtml',
@@ -420,7 +321,7 @@ describe('server-output', () => {
 
       it('no callbacks are executed for unhandled api errors', async () => {
         await expect(
-          serverFetchAsync('/api/problematic').then((r) => Object.fromEntries(r.headers.entries()))
+          server.fetchAsync('/api/problematic').then((r) => Object.fromEntries(r.headers.entries()))
         ).resolves.toEqual(
           expect.not.objectContaining({
             'custom-html-type': expect.anything(),
@@ -437,7 +338,7 @@ describe('server-output', () => {
 
       it('no callbacks are executed for error responses from user code', async () => {
         await expect(
-          serverFetchAsync('/api/error').then((r) => Object.fromEntries(r.headers.entries()))
+          server.fetchAsync('/api/error').then((r) => Object.fromEntries(r.headers.entries()))
         ).resolves.toEqual(
           expect.not.objectContaining({
             'custom-html-type': expect.anything(),
@@ -451,11 +352,12 @@ describe('server-output', () => {
           })
         );
       });
-    }
+    });
 
-    if (name !== EXPO_DEV_SERVER) {
+    // Tests that require exported files (not available for dev server)
+    (server.isExpoStart ? describe.skip : describe)('exported files', () => {
       it(`has expected static html from array group`, async () => {
-        const files = findProjectFiles(outputDir!);
+        const files = findProjectFiles(server.outputDir);
         expect(files).not.toContain('server/multi-group.html');
         expect(files).not.toContain('server/(a,b)/multi-group.html');
         expect(files).toContain('server/(a)/multi-group.html');
@@ -463,7 +365,7 @@ describe('server-output', () => {
       });
 
       it(`has expected API route from array group`, async () => {
-        const files = findProjectFiles(outputDir!);
+        const files = findProjectFiles(server.outputDir);
         expect(files).toContain('server/_expo/functions/(a,b)/multi-group-api+api.js');
         expect(files).toContain('server/_expo/functions/(a,b)/multi-group-api+api.js.map');
         expect(files).not.toContain('server/_expo/functions/(a)/multi-group-api+api.js');
@@ -472,7 +374,7 @@ describe('server-output', () => {
         // Load the sourcemap and check that the paths are relative
         const map = JSON.parse(
           await fs.readFile(
-            path.join(outputDir!, 'server/_expo/functions/(a,b)/multi-group-api+api.js.map'),
+            path.join(server.outputDir, 'server/_expo/functions/(a,b)/multi-group-api+api.js.map'),
             { encoding: 'utf8' }
           )
         );
@@ -481,8 +383,7 @@ describe('server-output', () => {
       });
 
       it('has expected files', async () => {
-        // Request HTML
-        const files = findProjectFiles(outputDir!);
+        const files = findProjectFiles(server.outputDir);
 
         // The wrapper should not be included as a route.
         expect(files).not.toContain('server/+html.html');
@@ -521,9 +422,9 @@ describe('server-output', () => {
       // This test is created to avoid and detect regressions on Windows
       it('has expected routes manifest entries', async () => {
         expect(
-          await JsonFile.readAsync(path.join(outputDir!, 'server/_expo/routes.json'))
+          await JsonFile.readAsync(path.join(server.outputDir, 'server/_expo/routes.json'))
         ).toMatchSnapshot();
       });
-    }
+    });
   });
 });

--- a/packages/@expo/cli/e2e/utils/runtime.ts
+++ b/packages/@expo/cli/e2e/utils/runtime.ts
@@ -1,0 +1,244 @@
+import { getRouterE2ERoot } from "../__tests__/utils";
+import path from "node:path";
+import { createExpoServe, createExpoStart, executeExpoAsync } from "./expo";
+import { executeAsync, processFindPrefixedValue } from "./process";
+import fs from "node:fs";
+import { BackgroundServer, createBackgroundServer } from "./server";
+
+export const RUNTIME_EXPO_SERVE = 'expo serve';
+export const RUNTIME_EXPO_START = 'expo start';
+export const RUNTIME_EXPRESS_SERVER = 'express';
+export const RUNTIME_WORKERD = 'workerd';
+
+type RuntimeType = typeof RUNTIME_EXPO_SERVE
+  | typeof RUNTIME_EXPO_START
+  | typeof RUNTIME_EXPRESS_SERVER
+  | typeof RUNTIME_WORKERD;
+
+export type ServerTestConfiguration = {
+  name: string;
+  createServer: () => BackgroundServer;
+  prepareDist: () => Promise<[outputDir: string, outputName?: string]>;
+};
+
+export type ServerTestOptions = {
+  /** The E2E test scenario directory name (e.g., 'server-middleware-async') */
+  fixtureName: string;
+  /** Options for the export command */
+  export?: {
+    /** Environment variables to pass to the export command */
+    env?: Record<string, string>;
+    /** Additional CLI flags to pass to the export command */
+    cliFlags?: string[];
+  };
+  /** Options for the HTTP server */
+  serve?: {
+    /** Environment variables to pass to the server */
+    env?: Record<string, string>;
+  };
+};
+
+/**
+ * Creates server test configurations for the specified runtimes.
+ * Use with `describe.each()` to run the same tests against multiple server implementations.
+ *
+ * @param runtimes - Array of runtime identifiers to prepare (e.g., `['expo serve', 'workerd']`)
+ * @param options - Configuration options for the test servers
+ *
+ * @example
+ * ```ts
+ * describe.each(
+ *   prepareServers(['expo serve', 'workerd'], {
+ *     fixtureName: 'server-middleware-async',
+ *     export: { env: { E2E_ROUTER_SERVER_MIDDLEWARE: 'true' } },
+ *   })
+ * )('$name requests', (config) => {
+ *   const ctx = setupServer(config);
+ *   it('can serve html', async () => {
+ *     expect(await ctx.fetchAsync('/').then((r) => r.text())).toMatch(/<div id="root">/);
+ *   });
+ * });
+ * ```
+ */
+export function prepareServers(runtimes: RuntimeType[], options: ServerTestOptions): ServerTestConfiguration[] {
+  const { fixtureName } = options;
+  const projectRoot = getRouterE2ERoot();
+
+  const exportEnv = options.export?.env ?? {}
+  const exportCliFlags = options.export?.cliFlags ?? [];
+  const serveEnv = options.serve?.env ?? {};
+
+  const defaultExportEnv = {
+    NODE_ENV: 'production',
+    EXPO_USE_STATIC: 'server',
+    E2E_ROUTER_SRC: fixtureName,
+    ...exportEnv,
+  };
+
+  const knownRuntimeConfigs: Record<RuntimeType, Omit<ServerTestConfiguration, 'name'>> = {
+    [RUNTIME_EXPO_SERVE]: {
+      prepareDist: async () => {
+        const outputName = `dist-${fixtureName}-expo-serve`;
+        const outputDir = path.join(projectRoot, outputName);
+
+        await executeExpoAsync(
+          projectRoot,
+          ['export', '-p', 'web', '--output-dir', outputName, ...exportCliFlags],
+          { env: defaultExportEnv }
+        );
+
+        return [outputDir, outputName];
+      },
+      createServer: () =>
+        createExpoServe({
+          cwd: projectRoot,
+          env: {
+            NODE_ENV: 'production',
+            ...serveEnv,
+          },
+        }),
+    },
+    [RUNTIME_EXPO_START]: {
+      prepareDist: async () => {
+        return [''];
+      },
+      createServer: () =>
+        createExpoStart({
+          cwd: projectRoot,
+          env: {
+            ...defaultExportEnv,
+            ...serveEnv,
+            NODE_ENV: 'development',
+          },
+        }),
+    },
+    [RUNTIME_EXPRESS_SERVER]: {
+      prepareDist: async () => {
+        const outputName = `dist-${fixtureName}-express`;
+        const outputDir = path.join(projectRoot, outputName);
+
+        await executeExpoAsync(projectRoot, ['export', '-p', 'web', '--output-dir', outputName, ...exportCliFlags],
+          { env: defaultExportEnv }
+        );
+
+        return [outputDir, outputName];
+      },
+      createServer: () =>
+        createBackgroundServer({
+          command: ['node', path.join(projectRoot, `__e2e__/${fixtureName}/express.js`)],
+          host: (chunk: any) => processFindPrefixedValue(chunk, 'Express server listening'),
+          cwd: projectRoot,
+          env: {
+            NODE_ENV: 'production',
+            ...serveEnv,
+          },
+        }),
+    },
+    [RUNTIME_WORKERD]: {
+      prepareDist: async () => {
+        const outputName = `dist-${fixtureName}-workerd`;
+        const outputDir = path.join(projectRoot, outputName);
+
+        await executeExpoAsync(
+          projectRoot,
+          ['export', '-p', 'web', '--output-dir', outputName, ...exportCliFlags],
+          {env: defaultExportEnv}
+        );
+
+        await executeAsync(projectRoot, [
+          'node_modules/.bin/esbuild',
+          '--bundle',
+          '--format=esm',
+          '--platform=node',
+          `--outfile=${path.join(outputDir, 'server/workerd.js')}`,
+          path.join(projectRoot, `__e2e__/${fixtureName}/workerd/workerd.mjs`),
+        ]);
+        fs.copyFileSync(
+          path.join(projectRoot, `__e2e__/${fixtureName}/workerd/config.capnp`),
+          path.join(outputDir, 'server/config.capnp')
+        );
+
+        return [outputDir];
+      },
+      createServer: () =>
+        createBackgroundServer({
+          command: [
+            'node_modules/.bin/workerd',
+            'serve',
+            path.join(projectRoot, `dist-${fixtureName}-workerd`, 'server/config.capnp'),
+          ],
+          host: (chunk: any) => processFindPrefixedValue(chunk, 'Workerd server listening'),
+          port: 8787,
+          cwd: projectRoot,
+        }),
+    }
+  };
+
+  const knownRuntimes = Object.keys(knownRuntimeConfigs);
+
+  return runtimes.map((runtime) => {
+    if (!knownRuntimes.includes(runtime)) {
+      throw new Error(
+        `Unknown runtime "${runtime}". Known runtimes: ${knownRuntimes.join(', ')}`
+      );
+    }
+
+    return {
+      ...knownRuntimeConfigs[runtime],
+      name: runtime,
+    };
+  });
+}
+
+/**
+ * Sets up server lifecycle (`beforeAll()`/`afterAll()`) and returns a test context.
+ *
+ * @remarks Must be called at the top level of a `describe()` block that uses `prepareServers()`.
+ */
+export function setupServer(config: ServerTestConfiguration) {
+  let outputDir: string | undefined;
+  let server: BackgroundServer;
+
+  beforeAll(async () => {
+    console.time('export-server');
+    const [newOutputDir, outputName] = await config.prepareDist();
+    console.timeEnd('export-server');
+    outputDir = newOutputDir;
+    server = config.createServer();
+    if (outputName) {
+      await server.startAsync([outputName]);
+    } else {
+      await server.startAsync();
+    }
+  });
+
+  afterAll(async () => {
+    await server.stopAsync(true);
+  });
+
+  return {
+    fetchAsync: (url: string, init?: RequestInit) => server.fetchAsync(url, init, {attempts: 7}),
+    get outputDir() {
+      if (!outputDir) {
+        throw new Error('`outputDir` not available, `beforeAll()` has not run yet');
+      }
+
+      return outputDir;
+    },
+    get serverName() {
+      return config.name;
+    },
+    get isExpoServe() {
+      return config.name === RUNTIME_EXPO_SERVE;
+    },
+    get isExpoStart() {
+      return config.name === RUNTIME_EXPO_START;
+    },
+    get isExpress() {
+      return config.name === RUNTIME_EXPRESS_SERVER;
+    },
+    get isWorkerd() {
+      return config.name === RUNTIME_WORKERD;
+    },
+  };
+}


### PR DESCRIPTION
# Why

Simplify E2E tests that run against multiple server runtimes.

# How

Extract runtime preparation and setup logic to utility functions

# Test Plan

- CI
- Manual testing

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
