### PR TITLE
[docs] Reduce Sentry performance sample rate by 10x

### DIFF
--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -43,7 +43,7 @@ Sentry.init({
     /https:\/\/expo\.nodejs\.cn/,
   ],
   integrations: [Sentry.browserTracingIntegration(), Sentry.extraErrorDataIntegration()],
-  tracesSampleRate: 0.0001,
+  tracesSampleRate: 0.00001,
   replaysSessionSampleRate: 0.000005,
   replaysOnErrorSampleRate: 0.002,
 });


### PR DESCRIPTION
Why
===
Reducing the sample rate by 10x to comfortably free up quota.

How
===
Lower tracesSampleRate from 0.0001 to 0.00001 (0.001%).

Test Plan
===
Monitor Sentry usage stats after deploy.
