### PR TITLE
[core][Android] Improve JavaScriptArrayBuffer support

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Add `map` to `ValueOrUndefined`. ([#40593](https://github.com/expo/expo/pull/40593) by [@Wenszel](https://github.com/Wenszel))
 - Add types for `process.env.EXPO_DOM_HOST_OS`. ([#40382](https://github.com/expo/expo/pull/40382) by [@EvanBacon](https://github.com/EvanBacon))
 - [Android] Add `ComposableScope` for compose Content functions. ([#39155](https://github.com/expo/expo/pull/39155) by [@aleqsio](https://github.com/aleqsio))
-- [Android] Adds support for `ArrayBuffer`. ([#39943](https://github.com/expo/expo/pull/39943) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Adds support for `ArrayBuffer`. ([#39943](https://github.com/expo/expo/pull/39943) by [@lukmccall](https://github.com/lukmccall), [#41404](https://github.com/expo/expo/pull/41404) by [@barthap](https://github.com/barthap))
 - [Android] Add experimental formatters API. ([#38946](https://github.com/expo/expo/pull/38946) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Add `convertResult` to `Convertible`. ([#40302](https://github.com/expo/expo/pull/40302) by [@jakex7](https://github.com/jakex7))
 - [iOS] Adopted Swift 6 ([#40369](https://github.com/expo/expo/pull/40369) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Add `map` to `ValueOrUndefined`. ([#40593](https://github.com/expo/expo/pull/40593) by [@Wenszel](https://github.com/Wenszel))
 - Add types for `process.env.EXPO_DOM_HOST_OS`. ([#40382](https://github.com/expo/expo/pull/40382) by [@EvanBacon](https://github.com/EvanBacon))
 - [Android] Add `ComposableScope` for compose Content functions. ([#39155](https://github.com/expo/expo/pull/39155) by [@aleqsio](https://github.com/aleqsio))
-- [Android] Adds support for `ArrayBuffer`. ([#39943](https://github.com/expo/expo/pull/39943) by [@lukmccall](https://github.com/lukmccall), [#41404](https://github.com/expo/expo/pull/41404) by [@barthap](https://github.com/barthap))
+- [Android] Adds support for `ArrayBuffer`. ([#39943](https://github.com/expo/expo/pull/39943) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Add experimental formatters API. ([#38946](https://github.com/expo/expo/pull/38946) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Add `convertResult` to `Convertible`. ([#40302](https://github.com/expo/expo/pull/40302) by [@jakex7](https://github.com/jakex7))
 - [iOS] Adopted Swift 6 ([#40369](https://github.com/expo/expo/pull/40369) by [@tsapeta](https://github.com/tsapeta))
@@ -24,6 +24,7 @@
 - [Android] Remove `hermesEnabled` property requirement for internal testing ([#40678](https://github.com/expo/expo/pull/40678) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] `Class` definition for shared objects is now optional. ([#40708](https://github.com/expo/expo/pull/40708) by [@tsapeta](https://github.com/tsapeta))
 - Split out JSI layer from the modules core. ([#40755](https://github.com/expo/expo/pull/40755) by [@tsapeta](https://github.com/tsapeta))
+- [Android] Improved support for `ArrayBuffer`s. ([#41404](https://github.com/expo/expo/pull/41404) by [@barthap](https://github.com/barthap))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptArrayBufferTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptArrayBufferTest.kt
@@ -1,0 +1,44 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package expo.modules.kotlin.jni
+
+import com.google.common.truth.Truth
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+
+internal class JavaScriptArrayBufferTest {
+  @Test
+  fun should_be_retrievable_from_js_value() = withJSIInterop {
+    val value = evaluateScript("new Uint8Array([1,2,3,4]).buffer");
+    Truth.assertThat(value.isArrayBuffer()).isTrue()
+
+    val arrayBuffer = value.getArrayBuffer()
+    Truth.assertThat(arrayBuffer.size()).isEqualTo(4)
+  }
+
+  @Test
+  fun should_be_able_access_elements_via_object_api() = withJSIInterop {
+    val arrayBuffer = evaluateScript("new Int16Array([2317, 9001]).buffer").getArrayBuffer()
+
+    val first = arrayBuffer.read2Byte(0)
+    val second = arrayBuffer.read2Byte(2)
+
+    Truth.assertThat(first).isEqualTo(2317)
+    Truth.assertThat(second).isEqualTo(9001)
+  }
+
+  @Test
+  fun should_be_convertible_to_direct_buffer() = withJSIInterop {
+    val arrayBuffer = evaluateScript("new Float32Array([1.2, 3.4]).buffer").getArrayBuffer()
+    val buffer = arrayBuffer.toDirectBuffer()
+
+    Truth.assertThat(buffer.isDirect).isTrue()
+    Truth.assertThat(buffer.isReadOnly).isFalse()
+
+    val first = buffer.getFloat(0)
+    val second = buffer.getFloat(4)
+
+    Truth.assertThat(first).isEqualTo(1.2f)
+    Truth.assertThat(second).isEqualTo(3.4f)
+  }
+}

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptArrayBufferTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptArrayBufferTest.kt
@@ -9,16 +9,16 @@ import org.junit.Test
 internal class JavaScriptArrayBufferTest {
   @Test
   fun should_be_retrievable_from_js_value() = withJSIInterop {
-    val value = evaluateScript("new Uint8Array([1,2,3,4]).buffer");
-    Truth.assertThat(value.isArrayBuffer()).isTrue()
+    val jsObject = evaluateScript("new Uint8Array([1,2,3,4]).buffer").getObject()
+    Truth.assertThat(jsObject.isArrayBuffer()).isTrue()
 
-    val arrayBuffer = value.getArrayBuffer()
+    val arrayBuffer = jsObject.getArrayBuffer()
     Truth.assertThat(arrayBuffer.size()).isEqualTo(4)
   }
 
   @Test
   fun should_be_able_access_elements_via_object_api() = withJSIInterop {
-    val arrayBuffer = evaluateScript("new Int16Array([2317, 9001]).buffer").getArrayBuffer()
+    val arrayBuffer = evaluateScript("new Int16Array([2317, 9001]).buffer").getObject().getArrayBuffer()
 
     val first = arrayBuffer.read2Byte(0)
     val second = arrayBuffer.read2Byte(2)
@@ -29,7 +29,7 @@ internal class JavaScriptArrayBufferTest {
 
   @Test
   fun should_be_convertible_to_direct_buffer() = withJSIInterop {
-    val arrayBuffer = evaluateScript("new Float32Array([1.2, 3.4]).buffer").getArrayBuffer()
+    val arrayBuffer = evaluateScript("new Float32Array([1.2, 3.4]).buffer").getObject().getArrayBuffer()
     val buffer = arrayBuffer.toDirectBuffer()
 
     Truth.assertThat(buffer.isDirect).isTrue()

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/JavaScriptArrayBufferConversionTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/JavaScriptArrayBufferConversionTest.kt
@@ -20,4 +20,39 @@ class JavaScriptArrayBufferConversionTest {
     map = {},
     jsAssertion = {}
   )
+
+  @Test
+  fun array_buffer_should_be_returned() = conversionTest<JavaScriptArrayBuffer, _>(
+    jsValue = "new Uint8Array([0x00, 0xff]).buffer",
+    nativeAssertion = { arrayBuffer ->
+      Truth.assertThat(arrayBuffer.size()).isEqualTo(2)
+      Truth.assertThat(arrayBuffer.readByte(0)).isEqualTo(0x00.toByte())
+      Truth.assertThat(arrayBuffer.readByte(1)).isEqualTo(0xff.toByte())
+    },
+    map = { it },
+    jsAssertion = { jsValue ->
+      Truth.assertThat(jsValue.isArrayBuffer()).isTrue()
+
+      val arrayBuffer = jsValue.getArrayBuffer()
+      Truth.assertThat(arrayBuffer.size()).isEqualTo(2)
+    }
+  )
+
+  @Test
+  fun array_buffer_can_be_modified() = conversionTest<JavaScriptArrayBuffer, _>(
+    jsValue = "new Uint8Array([0x00, 0xff]).buffer",
+    nativeAssertion = { arrayBuffer ->
+      Truth.assertThat(arrayBuffer.readByte(0)).isEqualTo(0x00.toByte())
+
+      arrayBuffer.toDirectBuffer().apply {
+        rewind()
+        put(0x42.toByte())
+      }
+    },
+    map = { it },
+    jsAssertion = { jsValue ->
+      val firstByte = jsValue.getArrayBuffer().readByte(0)
+      Truth.assertThat(firstByte).isEqualTo(0x42.toByte())
+    }
+  )
 }

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/JavaScriptArrayBufferConversionTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/JavaScriptArrayBufferConversionTest.kt
@@ -31,9 +31,9 @@ class JavaScriptArrayBufferConversionTest {
     },
     map = { it },
     jsAssertion = { jsValue ->
-      Truth.assertThat(jsValue.isArrayBuffer()).isTrue()
+      Truth.assertThat(jsValue.getObject().isArrayBuffer()).isTrue()
 
-      val arrayBuffer = jsValue.getArrayBuffer()
+      val arrayBuffer = jsValue.getObject().getArrayBuffer()
       Truth.assertThat(arrayBuffer.size()).isEqualTo(2)
     }
   )
@@ -51,8 +51,8 @@ class JavaScriptArrayBufferConversionTest {
     },
     map = { it },
     jsAssertion = { jsValue ->
-      val firstByte = jsValue.getArrayBuffer().readByte(0)
-      Truth.assertThat(firstByte).isEqualTo(0x42.toByte())
+      val arrayBuffer = jsValue.getObject().getArrayBuffer()
+      Truth.assertThat(arrayBuffer.readByte(0)).isEqualTo(0x42.toByte())
     }
   )
 }

--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
@@ -50,6 +50,7 @@ void JavaCallback::registerNatives() {
                    makeNativeMethod("invokeNative", JavaCallback::invokeWritableArray),
                    makeNativeMethod("invokeNative", JavaCallback::invokeWritableMap),
                    makeNativeMethod("invokeNative", JavaCallback::invokeSharedObject),
+                   makeNativeMethod("invokeNative", JavaCallback::invokeJavaScriptArrayBuffer),
                    makeNativeMethod("invokeNative", JavaCallback::invokeError),
                    makeNativeMethod("invokeIntArray", JavaCallback::invokeIntArray),
                    makeNativeMethod("invokeLongArray", JavaCallback::invokeLongArray),
@@ -193,6 +194,10 @@ void JavaCallback::invokeWritableMap(jni::alias_ref<react::WritableNativeMap::ja
 }
 
 void JavaCallback::invokeSharedObject(jni::alias_ref<JSharedObject::javaobject> result) {
+  invokeJSFunction(jni::make_global(result));
+}
+
+void JavaCallback::invokeJavaScriptArrayBuffer(jni::alias_ref<JavaScriptArrayBuffer::javaobject> result) {
   invokeJSFunction(jni::make_global(result));
 }
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.h
@@ -4,6 +4,7 @@
 
 #include "JNIDeallocator.h"
 #include "JSharedObject.h"
+#include "JavaScriptArrayBuffer.h"
 
 #include <jsi/jsi.h>
 #include <fbjni/fbjni.h>
@@ -82,6 +83,8 @@ private:
   void invokeMap(jni::alias_ref<jni::JMap<jstring, jobject>> result);
 
   void invokeSharedObject(jni::alias_ref<JSharedObject::javaobject> result);
+
+  void invokeJavaScriptArrayBuffer(jni::alias_ref<JavaScriptArrayBuffer::javaobject> result);
 
   void invokeError(jni::alias_ref<jstring> code, jni::alias_ref<jstring> errorMessage);
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.cpp
@@ -44,6 +44,7 @@ JCache::JCache(JNIEnv *env) {
   jJavaScriptObject = REGISTER_CLASS("expo/modules/kotlin/jni/JavaScriptObject");
   jJavaScriptValue = REGISTER_CLASS("expo/modules/kotlin/jni/JavaScriptValue");
   jJavaScriptTypedArray = REGISTER_CLASS("expo/modules/kotlin/jni/JavaScriptTypedArray");
+  jJavaScriptArrayBuffer = REGISTER_CLASS("expo/modules/kotlin/jni/JavaScriptArrayBuffer");
 
   jReadableNativeArray = REGISTER_CLASS("com/facebook/react/bridge/ReadableNativeArray");
   jReadableNativeMap = REGISTER_CLASS("com/facebook/react/bridge/ReadableNativeMap");

--- a/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.h
@@ -48,6 +48,7 @@ public:
   jclass jJavaScriptObject;
   jclass jJavaScriptValue;
   jclass jJavaScriptTypedArray;
+  jclass jJavaScriptArrayBuffer;
 
   jclass jReadableNativeArray;
   jclass jReadableNativeMap;

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptArrayBuffer.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptArrayBuffer.cpp
@@ -14,6 +14,7 @@ void JavaScriptArrayBuffer::registerNatives() {
                    makeNativeMethod("read8Byte", JavaScriptArrayBuffer::read<int64_t>),
                    makeNativeMethod("readFloat", JavaScriptArrayBuffer::read<float>),
                    makeNativeMethod("readDouble", JavaScriptArrayBuffer::read<double>),
+                   makeNativeMethod("toDirectBuffer", JavaScriptArrayBuffer::toDirectBuffer),
                  });
 }
 
@@ -47,6 +48,17 @@ jni::local_ref<JavaScriptArrayBuffer::javaobject> JavaScriptArrayBuffer::newInst
 int JavaScriptArrayBuffer::size() {
   jsi::Runtime &jsRuntime = runtimeHolder.getJSRuntime();
   return (int) arrayBuffer->size(jsRuntime);
+}
+
+uint8_t *JavaScriptArrayBuffer::data() {
+  jsi::Runtime &jsRuntime = runtimeHolder.getJSRuntime();
+  return arrayBuffer->data(jsRuntime);
+}
+
+jni::local_ref<jni::JByteBuffer> JavaScriptArrayBuffer::toDirectBuffer() {
+  auto buffer = jni::JByteBuffer::wrapBytes(data(), size());
+  buffer->order(jni::JByteOrder::nativeOrder());
+  return buffer;
 }
 
 std::shared_ptr<jsi::ArrayBuffer> JavaScriptArrayBuffer::jsiArrayBuffer() {

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptArrayBuffer.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptArrayBuffer.cpp
@@ -49,4 +49,8 @@ int JavaScriptArrayBuffer::size() {
   return (int) arrayBuffer->size(jsRuntime);
 }
 
+std::shared_ptr<jsi::ArrayBuffer> JavaScriptArrayBuffer::jsiArrayBuffer() {
+  return this->arrayBuffer;
+}
+
 }

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptArrayBuffer.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptArrayBuffer.h
@@ -46,6 +46,8 @@ public:
 
   [[nodiscard]] jni::local_ref<jni::JByteBuffer> toDirectBuffer();
 
+  [[nodiscard]] std::shared_ptr<jsi::ArrayBuffer> jsiArrayBuffer();
+
   template<class T>
   T read(int position) {
     return *reinterpret_cast<T *>(this->data() + position);

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptArrayBuffer.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptArrayBuffer.h
@@ -3,6 +3,7 @@
 #include "WeakRuntimeHolder.h"
 #include "JNIDeallocator.h"
 
+#include <fbjni/ByteBuffer.h>
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
 
@@ -39,12 +40,15 @@ public:
     std::shared_ptr<jsi::ArrayBuffer> arrayBuffer
   );
 
-  int size();
+  [[nodiscard]] int size();
+
+  [[nodiscard]] uint8_t* data();
+
+  [[nodiscard]] jni::local_ref<jni::JByteBuffer> toDirectBuffer();
 
   template<class T>
   T read(int position) {
-    jsi::Runtime &jsRuntime = runtimeHolder.getJSRuntime();
-    return *reinterpret_cast<T *>(arrayBuffer->data(jsRuntime) + position);
+    return *reinterpret_cast<T *>(this->data() + position);
   }
 
 private:

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.cpp
@@ -5,6 +5,7 @@
 #include "JavaScriptRuntime.h"
 #include "JavaScriptObject.h"
 #include "JavaScriptTypedArray.h"
+#include "JavaScriptArrayBuffer.h"
 #include "JavaScriptFunction.h"
 #include "TypedArray.h"
 #include "Exceptions.h"
@@ -23,6 +24,7 @@ void JavaScriptValue::registerNatives() {
                    makeNativeMethod("isFunction", JavaScriptValue::isFunction),
                    makeNativeMethod("isArray", JavaScriptValue::isArray),
                    makeNativeMethod("isTypedArray", JavaScriptValue::isTypedArray),
+                   makeNativeMethod("isArrayBuffer", JavaScriptValue::isArrayBuffer),
                    makeNativeMethod("isObject", JavaScriptValue::isObject),
                    makeNativeMethod("getBool", JavaScriptValue::getBool),
                    makeNativeMethod("getDouble", JavaScriptValue::getDouble),
@@ -30,6 +32,7 @@ void JavaScriptValue::registerNatives() {
                    makeNativeMethod("getObject", JavaScriptValue::getObject),
                    makeNativeMethod("getArray", JavaScriptValue::getArray),
                    makeNativeMethod("getTypedArray", JavaScriptValue::getTypedArray),
+                   makeNativeMethod("getArrayBuffer", JavaScriptValue::getArrayBuffer),
                    makeNativeMethod("jniGetFunction", JavaScriptValue::jniGetFunction),
                  });
 }
@@ -140,6 +143,14 @@ bool JavaScriptValue::isTypedArray() {
   return false;
 }
 
+bool JavaScriptValue::isArrayBuffer() {
+  if (jsValue->isObject()) {
+    jsi::Runtime &jsRuntime = runtimeHolder.getJSRuntime();
+    return jsValue->getObject(jsRuntime).isArrayBuffer(jsRuntime);
+  }
+  return false;
+}
+
 bool JavaScriptValue::getBool() {
   return jsValue->getBool();
 }
@@ -213,6 +224,18 @@ jni::local_ref<JavaScriptTypedArray::javaobject> JavaScriptValue::getTypedArray(
     runtimeHolder.getJSIContext(),
     runtimeHolder,
     jsObject
+  );
+}
+
+jni::local_ref<JavaScriptArrayBuffer::javaobject> JavaScriptValue::getArrayBuffer() {
+  auto &jsRuntime = runtimeHolder.getJSRuntime();
+  auto jsArrayBuffer = std::make_shared<jsi::ArrayBuffer>(
+    jsValue->getObject(jsRuntime).getArrayBuffer(jsRuntime)
+  );
+  return JavaScriptArrayBuffer::newInstance(
+    runtimeHolder.getJSIContext(),
+    runtimeHolder,
+    jsArrayBuffer
   );
 }
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.cpp
@@ -24,7 +24,6 @@ void JavaScriptValue::registerNatives() {
                    makeNativeMethod("isFunction", JavaScriptValue::isFunction),
                    makeNativeMethod("isArray", JavaScriptValue::isArray),
                    makeNativeMethod("isTypedArray", JavaScriptValue::isTypedArray),
-                   makeNativeMethod("isArrayBuffer", JavaScriptValue::isArrayBuffer),
                    makeNativeMethod("isObject", JavaScriptValue::isObject),
                    makeNativeMethod("getBool", JavaScriptValue::getBool),
                    makeNativeMethod("getDouble", JavaScriptValue::getDouble),
@@ -32,7 +31,6 @@ void JavaScriptValue::registerNatives() {
                    makeNativeMethod("getObject", JavaScriptValue::getObject),
                    makeNativeMethod("getArray", JavaScriptValue::getArray),
                    makeNativeMethod("getTypedArray", JavaScriptValue::getTypedArray),
-                   makeNativeMethod("getArrayBuffer", JavaScriptValue::getArrayBuffer),
                    makeNativeMethod("jniGetFunction", JavaScriptValue::jniGetFunction),
                  });
 }
@@ -143,14 +141,6 @@ bool JavaScriptValue::isTypedArray() {
   return false;
 }
 
-bool JavaScriptValue::isArrayBuffer() {
-  if (jsValue->isObject()) {
-    jsi::Runtime &jsRuntime = runtimeHolder.getJSRuntime();
-    return jsValue->getObject(jsRuntime).isArrayBuffer(jsRuntime);
-  }
-  return false;
-}
-
 bool JavaScriptValue::getBool() {
   return jsValue->getBool();
 }
@@ -224,18 +214,6 @@ jni::local_ref<JavaScriptTypedArray::javaobject> JavaScriptValue::getTypedArray(
     runtimeHolder.getJSIContext(),
     runtimeHolder,
     jsObject
-  );
-}
-
-jni::local_ref<JavaScriptArrayBuffer::javaobject> JavaScriptValue::getArrayBuffer() {
-  auto &jsRuntime = runtimeHolder.getJSRuntime();
-  auto jsArrayBuffer = std::make_shared<jsi::ArrayBuffer>(
-    jsValue->getObject(jsRuntime).getArrayBuffer(jsRuntime)
-  );
-  return JavaScriptArrayBuffer::newInstance(
-    runtimeHolder.getJSIContext(),
-    runtimeHolder,
-    jsArrayBuffer
   );
 }
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.h
@@ -78,8 +78,6 @@ public:
 
   bool isTypedArray();
 
-  bool isArrayBuffer();
-
   bool getBool();
 
   double getDouble();
@@ -91,8 +89,6 @@ public:
   jni::local_ref<jni::JArrayClass<JavaScriptValue::javaobject>> getArray();
 
   jni::local_ref<JavaScriptTypedArray::javaobject> getTypedArray();
-
-  jni::local_ref<JavaScriptArrayBuffer::javaobject> getArrayBuffer();
 
   jni::local_ref<jni::HybridClass<JavaScriptFunction, Destructible>::javaobject> jniGetFunction();
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.h
@@ -5,6 +5,7 @@
 #include "JSIObjectWrapper.h"
 #include "WeakRuntimeHolder.h"
 #include "JavaScriptTypedArray.h"
+#include "JavaScriptArrayBuffer.h"
 #include "JNIDeallocator.h"
 
 #include <fbjni/fbjni.h>
@@ -21,6 +22,8 @@ class JavaScriptRuntime;
 class JavaScriptObject;
 
 class JavaScriptTypedArray;
+
+class JavaScriptArrayBuffer;
 
 class JavaScriptFunction;
 
@@ -75,6 +78,8 @@ public:
 
   bool isTypedArray();
 
+  bool isArrayBuffer();
+
   bool getBool();
 
   double getDouble();
@@ -86,6 +91,8 @@ public:
   jni::local_ref<jni::JArrayClass<JavaScriptValue::javaobject>> getArray();
 
   jni::local_ref<JavaScriptTypedArray::javaobject> getTypedArray();
+
+  jni::local_ref<JavaScriptArrayBuffer::javaobject> getArrayBuffer();
 
   jni::local_ref<jni::HybridClass<JavaScriptFunction, Destructible>::javaobject> jniGetFunction();
 

--- a/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.cpp
@@ -71,6 +71,7 @@ jsi::Value convert(
   CAST_AND_RETURN(JavaScriptModuleObject::javaobject, cache.jJavaScriptModuleObject)
   CAST_AND_RETURN(JSharedObject::javaobject, cache.jSharedObject)
   CAST_AND_RETURN(JavaScriptTypedArray::javaobject, cache.jJavaScriptTypedArray)
+  CAST_AND_RETURN(JavaScriptArrayBuffer::javaobject, cache.jJavaScriptArrayBuffer)
 
   CAST_AND_RETURN(jni::JMap<jstring COMMA jobject>, cache.jMap)
   CAST_AND_RETURN(jni::JCollection<jobject>, cache.jCollection)

--- a/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.h
@@ -7,6 +7,7 @@
 #include "../JNIUtils.h"
 #include "ObjectDeallocator.h"
 #include "../javaclasses/Collections.h"
+#include "../JavaScriptArrayBuffer.h"
 
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
@@ -314,6 +315,21 @@ public:
   ) {
     auto jsTypedArray = value->get();
     return {rt, *jsTypedArray};
+  }
+};
+
+template<>
+class JNIToJSIConverter<JavaScriptArrayBuffer *> {
+public:
+  typedef SimpleConverter converterType;
+
+  static inline jsi::Value convert(
+    JNIEnv *env,
+    jsi::Runtime &rt,
+    JavaScriptArrayBuffer *value
+  ) {
+    auto jsArrayBuffer = value->jsiArrayBuffer();
+    return {rt, *jsArrayBuffer};
   }
 };
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaCallback.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaCallback.kt
@@ -33,6 +33,7 @@ class JavaCallback @DoNotStrip internal constructor(@DoNotStrip private val mHyb
       is WritableNativeArray -> invokeNative(result)
       is WritableNativeMap -> invokeNative(result)
       is SharedObject -> invokeNative(result)
+      is JavaScriptArrayBuffer -> invokeNative(result)
       is IntArray -> invokeIntArray(result)
       is LongArray -> invokeLongArray(result)
       is FloatArray -> invokeFloatArray(result)
@@ -88,6 +89,7 @@ class JavaCallback @DoNotStrip internal constructor(@DoNotStrip private val mHyb
   private external fun invokeNative(result: WritableNativeArray)
   private external fun invokeNative(result: WritableNativeMap)
   private external fun invokeNative(result: SharedObject)
+  private external fun invokeNative(result: JavaScriptArrayBuffer)
   private external fun invokeNative(code: String, errorMessage: String)
 
   private external fun invokeIntArray(result: IntArray)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptArrayBuffer.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptArrayBuffer.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.jni
 
 import com.facebook.jni.HybridData
 import expo.modules.core.interfaces.DoNotStrip
+import java.nio.ByteBuffer
 
 /**
  * A Kotlin representation of jsi::Value.
@@ -20,6 +21,11 @@ class JavaScriptArrayBuffer @DoNotStrip private constructor(@DoNotStrip private 
   external fun read8Byte(position: Int): Long
   external fun readFloat(position: Int): Float
   external fun readDouble(position: Int): Double
+
+  /**
+   * Returns a direct [ByteBuffer] that wraps this ArrayBuffer's underlying data.
+   */
+  external fun toDirectBuffer(): ByteBuffer
 
   @Throws(Throwable::class)
   protected fun finalize() {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptValue.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptValue.kt
@@ -23,7 +23,6 @@ class JavaScriptValue @DoNotStrip private constructor(@DoNotStrip private val mH
   external fun isFunction(): Boolean
   external fun isArray(): Boolean
   external fun isTypedArray(): Boolean
-  external fun isArrayBuffer(): Boolean
   external fun isObject(): Boolean
 
   external fun getBool(): Boolean
@@ -32,7 +31,6 @@ class JavaScriptValue @DoNotStrip private constructor(@DoNotStrip private val mH
   external fun getObject(): JavaScriptObject
   external fun getArray(): Array<JavaScriptValue>
   external fun getTypedArray(): JavaScriptTypedArray
-  external fun getArrayBuffer(): JavaScriptArrayBuffer
 
   private external fun <T : Any?> jniGetFunction(): JavaScriptFunction<T>
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptValue.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptValue.kt
@@ -23,6 +23,7 @@ class JavaScriptValue @DoNotStrip private constructor(@DoNotStrip private val mH
   external fun isFunction(): Boolean
   external fun isArray(): Boolean
   external fun isTypedArray(): Boolean
+  external fun isArrayBuffer(): Boolean
   external fun isObject(): Boolean
 
   external fun getBool(): Boolean
@@ -31,6 +32,7 @@ class JavaScriptValue @DoNotStrip private constructor(@DoNotStrip private val mH
   external fun getObject(): JavaScriptObject
   external fun getArray(): Array<JavaScriptValue>
   external fun getTypedArray(): JavaScriptTypedArray
+  external fun getArrayBuffer(): JavaScriptArrayBuffer
 
   private external fun <T : Any?> jniGetFunction(): JavaScriptFunction<T>
 


### PR DESCRIPTION
# Why

Follow up #39943, added support for returning array buffers from functions, and obtaining direct `ByteBuffer` for it

# How

- added `JavaScriptArrayBuffer.toDirectBuffer()`
- added JNI to JSI converter

# Test Plan

- unit tests ✅

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
