### PR TITLE
[android][camera] Fix camera creation on old arch

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix certain exif keys being dropped because of invalid values. ([#41043](https://github.com/expo/expo/pull/41043) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Fix camera not being recreated on the old architecture.
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix certain exif keys being dropped because of invalid values. ([#41043](https://github.com/expo/expo/pull/41043) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Fix camera not being recreated on the old architecture.
+- [Android] Fix camera not being recreated on the old architecture. ([#41405](https://github.com/expo/expo/pull/41405) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
@@ -413,9 +413,7 @@ class CameraViewModule : Module() {
       }
 
       OnViewDidUpdateProps { view ->
-        moduleScope.launch {
-          view.createCamera()
-        }
+        view.recreateCamera()
       }
 
       OnViewDestroys { view ->

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -405,8 +405,14 @@ class ExpoCameraView(
     }
   }
 
+  fun recreateCamera() {
+    scope.launch {
+      createCamera()
+    }
+  }
+
   @SuppressLint("UnsafeOptInUsageError")
-  suspend fun createCamera() {
+  private suspend fun createCamera() {
     if (!shouldCreateCamera || previewPaused) {
       return
     }
@@ -781,8 +787,8 @@ class ExpoCameraView(
     addView(
       previewView,
       ViewGroup.LayoutParams(
-        ViewGroup.LayoutParams.MATCH_PARENT,
-        ViewGroup.LayoutParams.MATCH_PARENT
+        LayoutParams.MATCH_PARENT,
+        LayoutParams.MATCH_PARENT
       )
     )
   }


### PR DESCRIPTION
# Why
Closes  #41358

# How
On the old architecture, `OnViewDidUpdateProps` is called before the module is recreated so the `moduleScope` has been cancelled and not reinitialized causing the camera to not be recreated after a reload leaving a black screen. The fix is to use the views scope to recreate the camera.

# Test Plan
Used the provided repro

