### PR TITLE
Upgrade react-native-screens version

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2923,7 +2923,7 @@ PODS:
     - ReactNativeDependencies
     - RNWorklets
     - Yoga
-  - RNScreens (4.19.0-nightly-20251123-253b82666):
+  - RNScreens (4.19.0-nightly-20251203-1746a584e):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2945,9 +2945,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNScreens/common (= 4.19.0-nightly-20251123-253b82666)
+    - RNScreens/common (= 4.19.0-nightly-20251203-1746a584e)
     - Yoga
-  - RNScreens/common (4.19.0-nightly-20251123-253b82666):
+  - RNScreens/common (4.19.0-nightly-20251203-1746a584e):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3922,7 +3922,7 @@ SPEC CHECKSUMS:
   RNDateTimePicker: 6fdd63f5d1e0f21faf4cc8674957c52958a7efae
   RNGestureHandler: 72efe2ab9d5d1b1d25b96f3ad3d174992f3bad87
   RNReanimated: a8df76e5dd2315dfd8711d7937ec3e0e09800c74
-  RNScreens: a783ad69553533bf2d7f034fa21777150773b486
+  RNScreens: 23072e49d81e27f08b9451f63ac81fa33237c48f
   RNSVG: 595d31b6cd45e92424c6b623bd93e1e9b6aa8b79
   RNWorklets: c181ebc224265a35743abc490e54a5cf66eb2add
   SDWebImage: f29024626962457f3470184232766516dee8dfea

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -74,7 +74,7 @@
     "react-native-pager-view": "6.9.1",
     "react-native-reanimated": "4.1.3",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.19.0-nightly-20251123-253b82666",
+    "react-native-screens": "4.19.0-nightly-20251203-1746a584e",
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.15.0",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3661,7 +3661,7 @@ PODS:
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNScreens (4.19.0-nightly-20251123-253b82666):
+  - RNScreens (4.19.0-nightly-20251203-1746a584e):
     - boost
     - DoubleConversion
     - fast_float
@@ -3688,10 +3688,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.19.0-nightly-20251123-253b82666)
+    - RNScreens/common (= 4.19.0-nightly-20251203-1746a584e)
     - SocketRocket
     - Yoga
-  - RNScreens/common (4.19.0-nightly-20251123-253b82666):
+  - RNScreens/common (4.19.0-nightly-20251203-1746a584e):
     - boost
     - DoubleConversion
     - fast_float
@@ -4766,7 +4766,7 @@ SPEC CHECKSUMS:
   RNDateTimePicker: c4a42c6a77d474f05162d61a4ab4253d13008277
   RNGestureHandler: afae32614741017de0f813f74586eee29773f31a
   RNReanimated: ef9140fe842a253834fdf8aaff0c0edacf560dde
-  RNScreens: 37488c034f22072a8c5404cb8372a35d0e3b90b0
+  RNScreens: 4e990ea0c4dac22e87b6a4f8b08c8efb9c3d28b6
   RNSVG: 6e742388ed2c7bfe7c9f5baf42b8eb850adc0442
   RNWorklets: 089683f4a4564f30393d32352d41d9e92c3e5a55
   SDWebImage: f29024626962457f3470184232766516dee8dfea

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -81,7 +81,7 @@
     "react-native-paper": "^5.12.5",
     "react-native-reanimated": "4.1.3",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.19.0-nightly-20251123-253b82666",
+    "react-native-screens": "4.19.0-nightly-20251203-1746a584e",
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.15.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -150,7 +150,7 @@
     "react-native-worklets": "0.6.1",
     "react-native-reanimated": "4.1.3",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.19.0-nightly-20251123-253b82666",
+    "react-native-screens": "4.19.0-nightly-20251203-1746a584e",
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-web": "~0.21.0",

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -33,7 +33,7 @@
     "react": "19.2.0",
     "react-native": "0.83.0-rc.3",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.19.0-nightly-20251123-253b82666"
+    "react-native-screens": "4.19.0-nightly-20251203-1746a584e"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/apps/router-e2e/__e2e__/native-tabs/app/faces/[face].tsx
+++ b/apps/router-e2e/__e2e__/native-tabs/app/faces/[face].tsx
@@ -9,7 +9,7 @@ export default function Index() {
   const { face } = useLocalSearchParams();
 
   const colors = useFaceColors();
-  const { color, name } = colors[Number(face)];
+  const { color, name } = colors[Number(face) % colors.length];
 
   if (shouldPerformHeavyComputation) {
     heavyComputation();

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -60,7 +60,7 @@
     "react": "19.2.0",
     "react-native": "0.83.0-rc.3",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.19.0-nightly-20251123-253b82666",
+    "react-native-screens": "4.19.0-nightly-20251203-1746a584e",
     "react-native-webview": "13.15.0"
   },
   "devDependencies": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -103,7 +103,7 @@
   "react-native-pager-view": "6.9.1",
   "react-native-worklets": "0.6.1",
   "react-native-reanimated": "~4.1.1",
-  "react-native-screens": "~4.19.0-nightly-20251123-253b82666",
+  "react-native-screens": "~4.19.0-nightly-20251203-1746a584e",
   "react-native-safe-area-context": "~5.6.0",
   "react-native-svg": "15.12.1",
   "react-native-view-shot": "4.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13701,10 +13701,10 @@ react-native-screens@4.11.1-nightly-20250611-8b82e081e:
     react-native-is-edge-to-edge "^1.1.7"
     warn-once "^0.1.0"
 
-react-native-screens@4.19.0-nightly-20251123-253b82666:
-  version "4.19.0-nightly-20251123-253b82666"
-  resolved "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.19.0-nightly-20251123-253b82666.tgz#fee414eb0bbfdf71aeac4da19e6b8b8f5c0cb1bd"
-  integrity sha512-ETD/iZM/HgqSWH1tJhkmppIWXrjJZkbBqBXD4yUuhYe8zWmh7s4tqlPujU4YKeLrmwpbi8kEW+FEoXtFUyVwkw==
+react-native-screens@4.19.0-nightly-20251203-1746a584e:
+  version "4.19.0-nightly-20251203-1746a584e"
+  resolved "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.19.0-nightly-20251203-1746a584e.tgz#024435ea96f82b9c7d76beb941075bfd7af52a7a"
+  integrity sha512-V/Wg9Opua4WMFHDG/ybfsDVwX02MHCI6Qe+gd8P2FdGDw9mileQP9f6f8l7FAMFW47SCVs8E1bowGpBA5Dpq1w==
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"


### PR DESCRIPTION
# Why

React native screens fixed several issues, since we upgraded to latest nightly. 

Fixes: https://github.com/expo/expo/issues/41369

# How

Upgrade screens version

# Test Plan

1. Manual testing of apps
2. CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
