### PR TITLE
fix(create-expo-nightly): Tighten workspace pattern

### DIFF
--- a/packages/create-expo-nightly/src/Packages.ts
+++ b/packages/create-expo-nightly/src/Packages.ts
@@ -87,6 +87,7 @@ export async function getExpoPackagesAsync(expoRepoPath: string): Promise<Packag
         '**/__fixtures__/**',
         '**/e2e/**',
         '**/build/**',
+        '@expo/cli/local-template/**',
       ],
     })
   );


### PR DESCRIPTION
# Why

See CI failure in: https://github.com/expo/expo/actions/runs/19916741962/job/57096975273
Caused by symlink added in: #41383

# How

- ~~Update the workspaces pattern to only find Expo package folders by workspace specifier name (mirroring the path in `Project.ts` and root `package.json:workspaces`)~~
- Ignore `local-template` in `@expo/cli`

# Test Plan

- CI should pass the mentioned run

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
