### PR TITLE
[github] Add brownfield build workflow

### DIFF
--- a/.github/workflows/test-suite-brownfield.yml
+++ b/.github/workflows/test-suite-brownfield.yml
@@ -17,6 +17,10 @@ concurrency:
 
 jobs:
   ios-build:
+    strategy:
+      fail-fast: true
+      matrix:
+        build-type: [debug, release]
     runs-on: macos-15
     steps:
       - name: 👀 Checkout
@@ -45,7 +49,17 @@ jobs:
         working-directory: ./apps/brownfield-tester
         run: |
           pod install --project-directory=ios
-          xcodebuild -workspace ios/BrownfieldTester.xcworkspace -scheme BrownfieldTester -configuration Release -sdk iphonesimulator -derivedDataPath "ios/build" | xcpretty
+          xcodebuild -workspace ios/BrownfieldTester.xcworkspace -scheme BrownfieldTester -configuration $CONFIGURATION -sdk iphonesimulator -derivedDataPath "ios/build" | xcpretty
+        shell: bash
+        env:
+          NODE_ENV: production
+          CONFIGURATION: ${{ matrix.build-type == 'release' && 'Release' || 'Debug' }}
+      - name: 📸 Upload builds
+        uses: actions/upload-artifact@v4
+        if: ${{ github.event_name == 'workflow_dispatch' && matrix.build-type == 'release' }} # Only archive release builds
+        with:
+          name: ios-builds-${{ matrix.build-type }}
+          path: ${{ runner.temp }}/brownfield-tester/ios/build/**/BrownfieldTester.app/
       - name: 🔔 Notify on Slack
         uses: ./.github/actions/slack-notify
         if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))

--- a/.github/workflows/test-suite-brownfield.yml
+++ b/.github/workflows/test-suite-brownfield.yml
@@ -1,0 +1,110 @@
+name: Test Suite Brownfield
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - .github/workflows/test-suite-brownfield.yml
+      - apps/brownfield-tester/**
+      - packages/expo/**
+      - packages/expo-modules-core/**
+      - packages/expo-dev-client/**
+      - packages/expo-updates/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ios-build:
+    runs-on: macos-15
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: 🔨 Switch to Xcode 26.0
+        run: sudo xcode-select --switch /Applications/Xcode_26.0.app
+      - name: ➕ Add `bin` to GITHUB_PATH
+        run: echo "$(pwd)/bin" >> $GITHUB_PATH
+      - name: 💎 Setup Ruby and install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: 3.2.2
+      - name: ♻️ Restore caches
+        uses: ./.github/actions/expo-caches
+        id: expo-caches
+        with:
+          yarn-workspace: "true"
+          yarn-tools: "true"
+      - name: 🧶 Install node modules in root dir
+        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
+        run: yarn install --frozen-lockfile
+      - name: 🍏 Build iOS Project
+        working-directory: ./apps/brownfield-tester
+        run: |
+          pod install --project-directory=ios
+          xcodebuild -workspace ios/BrownfieldTester.xcworkspace -scheme BrownfieldTester -configuration Release -sdk iphonesimulator -derivedDataPath "ios/build" | xcpretty
+      - name: 🔔 Notify on Slack
+        uses: ./.github/actions/slack-notify
+        if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        with:
+          webhook: ${{ secrets.slack_webhook_ios }}
+          channel: "#expo-ios"
+          author_name: Brownfield Test Suite (iOS)
+  android-build:
+    strategy:
+      fail-fast: true
+      matrix:
+        build-type: [debug, release]
+    runs-on: ubuntu-24.04
+    env:
+      ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
+      GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx4096m -XX:MaxMetaspaceSize=4096m"
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v5
+      - name: 🧹 Cleanup GitHub Linux runner disk space
+        uses: ./.github/actions/cleanup-linux-disk-space
+      - name: 🚀 Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: 🔨 Use JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+      - name: ♻️ Restore caches
+        uses: ./.github/actions/expo-caches
+        id: expo-caches
+        with:
+          gradle: "true"
+          yarn-workspace: "true"
+          yarn-tools: "true"
+          react-native-gradle-downloads: "true"
+      - name: 🧶 Install node modules in root dir
+        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
+        run: yarn install --frozen-lockfile
+      - name: 🤖 Build Android project
+        run: |
+          cd android && ./gradlew ":app:assemble$VARIANT"
+        shell: bash
+        working-directory: ./apps/brownfield-tester
+        env:
+          NODE_ENV: production
+          VARIANT: ${{ matrix.build-type == 'release' && 'Release' || 'Debug' }}
+      - name: 📸 Upload builds
+        uses: actions/upload-artifact@v4
+        if: ${{ github.event_name == 'workflow_dispatch' && matrix.build-type == 'release' }} # Only archive release builds
+        with:
+          name: android-builds-${{ matrix.build-type }}
+          path: ./apps/brownfield-tester/android/app/build/outputs/apk/
+      - name: 🔔 Notify on Slack
+        uses: ./.github/actions/slack-notify
+        if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        with:
+          webhook: ${{ secrets.slack_webhook_android }}
+          channel: "#expo-android"
+          author_name: Brownfield Test Suite (Android)

--- a/apps/brownfield-tester/android/app/build.gradle.kts
+++ b/apps/brownfield-tester/android/app/build.gradle.kts
@@ -26,6 +26,7 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            signingConfig = signingConfigs.getByName("debug")
         }
     }
     buildFeatures {
@@ -57,6 +58,7 @@ dependencies {
 val projectRoot = File(rootDir.absoluteFile, "../../minimal-tester").absolutePath
 
 react {
+    root = File(projectRoot)
     entryFile = file(listOf("node", "-e", "require('expo/scripts/resolveAppEntry')", projectRoot, "android", "absolute").let { ProcessBuilder(it).directory(rootDir).start().inputStream.bufferedReader().readText().trim() })
     reactNativeDir = file(listOf("node", "--print", "require.resolve('react-native/package.json')").let { ProcessBuilder(it).directory(rootDir).start().inputStream.bufferedReader().readText().trim() }).parentFile.absoluteFile
     hermesCommand = file(listOf("node", "--print", "require.resolve('hermes-compiler/package.json', { paths: [require.resolve('react-native/package.json')] })").let { ProcessBuilder(it).directory(rootDir).start().inputStream.bufferedReader().readText().trim() }).parentFile.absolutePath + "/hermesc/%OS-BIN%/hermesc"


### PR DESCRIPTION
# Why

Now that we're investing more resources into brownfield, we should have a workflow that ensures we don't break this integration.

- https://github.com/expo/expo/pull/41418 Fixes the iOS Release workflow
- https://github.com/expo/expo/pull/41431 Fixes the iOS Debug workflow


# How

- Add GitHub Actions to test our brownfield integration in debug and release mode  
- Fix brownfield Android root configuration

# Test Plan

CI should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
