### PR TITLE
[sdk-54] Add `react-server-dom-webpack` recommended version to `bundledNativeModules.json` and bump

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Add recommended `react-server-dom-webpack` version to `bundledNativeModules.json` ([#41417](https://github.com/expo/expo/pull/41417) by [@kitten](https://github.com/kitten))
+
 ## 54.0.26 — 2025-12-04
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -109,6 +109,7 @@
   "react-native-svg": "15.12.1",
   "react-native-view-shot": "4.0.3",
   "react-native-webview": "13.15.0",
+  "react-server-dom-webpack": "~19.1.2",
   "sentry-expo": "~7.0.0",
   "unimodules-app-loader": "~6.0.7",
   "unimodules-image-loader-interface": "~6.1.0",


### PR DESCRIPTION
# Why

Related to:
- https://github.com/expo/expo/pull/41379
- https://github.com/expo/expo/commit/8f714de4887d6c3da295f0be05889ac1ddf873e1

# How

- ~~Bump `react-server-dom-webpack` to align with `react` version on `sdk-54`~~
- Add to `bundledNativeModules.json`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
