### PR TITLE
[updates][iOS] forward PROJECT_ROOT env var to create updates resources script

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] forward `PROJECT_ROOT` env var to create updates resources script ([#41418](https://github.com/expo/expo/pull/41418) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 - [Android] Migrated from `kotlinOptions` to `compilerOptions` DSL. ([#39794](https://github.com/expo/expo/pull/39794) by [@huextrat](https://github.com/huextrat))

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -110,10 +110,11 @@ Pod::Spec.new do |s|
   end
 
   if $expo_updates_create_updates_resources != false
+    project_root_env_var = ENV['PROJECT_ROOT'] ? "export PROJECT_ROOT=#{ENV['PROJECT_ROOT']}\n" : ""
     force_bundling_flag = ex_updates_native_debug ? "export FORCE_BUNDLING=1\n" : ""
     s.script_phase = {
       :name => 'Generate updates resources for expo-updates',
-      :script => force_bundling_flag + 'bash -l -c "$PODS_TARGET_SRCROOT/../scripts/create-updates-resources-ios.sh"',
+      :script => project_root_env_var + force_bundling_flag + 'bash -l -c "$PODS_TARGET_SRCROOT/../scripts/create-updates-resources-ios.sh"',
       :execution_position => :before_compile
     }
 


### PR DESCRIPTION
# Why

Similar to https://github.com/expo/expo/pull/38208

The `create-updates-resources-ios` script allows users to set a custom location for the root of their project, especially useful for brownfield apps that don't follow the typical /ios folder structure, but right now, you can't set it through CocoaPods because Pods env vars are not injected into build scripts.

https://github.com/expo/expo/blob/921d642b3e94f280b84f4141198ddd6d315a5776/packages/expo-updates/scripts/create-updates-resources-ios.sh#L34-L36

To fix this, we need to forward the `PROJECT_ROOT` env var to the create updates resources script

# How 

Forward the `PROJECT_ROOT` environment variable to `create-updates-resources-ios` script

# Test Plan

Set a custom `PROJECT_ROOT` path inside a Podfile, install pods and build a project in release mode


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
