### PR TITLE
[core] don't build & include rsc_tests

### DIFF
--- a/packages/expo-modules-core/build/__rsc_tests__/index.test.d.ts
+++ b/packages/expo-modules-core/build/__rsc_tests__/index.test.d.ts
@@ -1,2 +1,0 @@
-export {};
-//# sourceMappingURL=index.test.d.ts.map

--- a/packages/expo-modules-core/build/__rsc_tests__/index.test.d.ts.map
+++ b/packages/expo-modules-core/build/__rsc_tests__/index.test.d.ts.map
@@ -1,1 +1,0 @@
-{"version":3,"file":"index.test.d.ts","sourceRoot":"","sources":["../../src/__rsc_tests__/index.test.ts"],"names":[],"mappings":""}

--- a/packages/expo-modules-core/tsconfig.json
+++ b/packages/expo-modules-core/tsconfig.json
@@ -5,5 +5,5 @@
     "emitDeclarationOnly": true
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__rsc_tests__/*"]
 }


### PR DESCRIPTION
# Why

Having `__rsc_tests__` is build output is not desired.

# How

- exclude `__rsc_tests__` from build

# Test Plan

- green check-packages check

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
