### PR TITLE
[sdk-53] Add `react-server-dom-webpack` recommended version to `bundledNativeModules.json`

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Add recommended `react-server-dom-webpack` version to `bundledNativeModules.json` ([#41423](https://github.com/expo/expo/pull/41423) by [@kitten](https://github.com/kitten))
+
 ## 53.0.24 — 2025-11-18
 
 ### 🐛 Bug fixes

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -94,6 +94,7 @@
   "react-dom": "19.0.0",
   "react-native": "0.79.6",
   "react-native-web": "~0.20.0",
+  "react-server-dom-webpack": "~19.0.1",
   "react-native-edge-to-edge": "1.6.0",
   "react-native-gesture-handler": "~2.24.0",
   "react-native-get-random-values": "~1.11.0",


### PR DESCRIPTION
# Why

Related to:
- https://github.com/expo/expo/pull/41379
- https://github.com/expo/expo/commit/a6674f534d3548ffa0e0ccfb6a297aaac4ff8f85

# How

- Add `react-server-dom-webpack` to `bundledNativeModules.json`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
