### PR TITLE
docs(local-credentials): update credentialsSource property depth

### DIFF
--- a/docs/pages/app-signing/local-credentials.mdx
+++ b/docs/pages/app-signing/local-credentials.mdx
@@ -177,13 +177,13 @@ For example, maybe you want to use local credentials when deploying to the Amazo
     "amazon-production": {
       "credentialsSource": "local",
       "android": {
-        /* @hide ... */ /* @end */
+        // ...
       }
     },
     "google-production": {
       "credentialsSource": "remote",
       "android": {
-        /* @hide ... */ /* @end */
+        // ...
       }
     }
   }

--- a/docs/pages/app-signing/local-credentials.mdx
+++ b/docs/pages/app-signing/local-credentials.mdx
@@ -175,13 +175,15 @@ For example, maybe you want to use local credentials when deploying to the Amazo
 {
   "build": {
     "amazon-production": {
+      "credentialsSource": "local",
       "android": {
-        "credentialsSource": "local"
+        // ...
       }
     },
     "google-production": {
+      "credentialsSource": "remote",
       "android": {
-        "credentialsSource": "remote"
+        // ...
       }
     }
   }

--- a/docs/pages/app-signing/local-credentials.mdx
+++ b/docs/pages/app-signing/local-credentials.mdx
@@ -177,13 +177,13 @@ For example, maybe you want to use local credentials when deploying to the Amazo
     "amazon-production": {
       "credentialsSource": "local",
       "android": {
-        // ...
+        /* @hide ... */ /* @end */
       }
     },
     "google-production": {
       "credentialsSource": "remote",
       "android": {
-        // ...
+        /* @hide ... */ /* @end */
       }
     }
   }


### PR DESCRIPTION
# Why

The example `eas.json` shows the `credentialsSource` property being under the platform key, in this case `android`. However, [these docs](https://docs.expo.dev/eas/json/#credentialssource) read that this key is not available under the platform, but a common key.

# How

Updated the documented `eas.json` example to align with the actual way you would configure different credential sources.

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
