### PR TITLE
[canary] Add `react-server-dom-webpack` recommended version to `bundledNativeModules.json`

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [Types] Fix `transitionDuration` type missing the `number` option for Reanimated V4 compatibility. ([#40793](https://github.com/expo/expo/pull/40793) by [@DelphineBugner](https://github.com/DelphineBugner))
 - [android] Add getDefaultReactHost to ExpoReactHostFactory ([#40086](https://github.com/expo/expo/pull/40086) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [expo/dom] Add `overrideUri` to `DOMProps` to enable pre-bundled DOM Components. ([#40397](https://github.com/expo/expo/pull/40397) by [@krystofwoldrich](https://github.com/krystofwoldrich))
+- Add recommended `react-server-dom-webpack` version to `bundledNativeModules.json` ([#41429](https://github.com/expo/expo/pull/41429) by [@kitten](https://github.com/kitten))
 
 ### ⚠️ Notices
 

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -108,6 +108,7 @@
   "react-native-svg": "15.12.1",
   "react-native-view-shot": "4.0.3",
   "react-native-webview": "13.15.0",
+  "react-server-dom-webpack": "~19.2.1",
   "sentry-expo": "~7.0.0",
   "unimodules-app-loader": "~6.0.7",
   "unimodules-image-loader-interface": "~6.1.0",


### PR DESCRIPTION
# Why

Related to: https://github.com/expo/expo/pull/41379

As stated in https://github.com/expo/expo/pull/41417, we won't bump `react-server-dom-webpack` for now for `expo/expo`, since the Flight format has changed and the debug information needs to be parsed and formatted

# How

- Add `react-server-dom-webpack` to `bundledNativeModules.json`

# Test Plan

- n/a

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
