### PR TITLE
[dev-launcher][iOS] Fix DevLauncherWrapperView in SwiftUI brownfield apps

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [iOS] Fix Safe Area being ignored on physical devices ([#41119](https://github.com/expo/expo/pull/41119) by [@betomoedano](https://github.com/betomoedano))
 - Restore config plugin `launchMode` support ([#41363](https://github.com/expo/expo/pull/41363) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Prevent some debug only artifacts from being included in release builds. ([#41378](https://github.com/expo/expo/pull/41378) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Fix `DevLauncherWrapperView` in SwiftUI brownfield apps ([#41431](https://github.com/expo/expo/pull/41431) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -17,7 +17,8 @@ private class DevLauncherWrapperView: UIView {
       return
     }
 
-    if devLauncherViewController.parent != rootViewController {
+    let isSwiftUIController = NSStringFromClass(type(of: rootViewController)).contains("UIHostingController")
+    if !isSwiftUIController && devLauncherViewController.parent != rootViewController {
       rootViewController.addChild(devLauncherViewController)
       devLauncherViewController.didMove(toParent: rootViewController)
       devLauncherViewController.view.setNeedsLayout()


### PR DESCRIPTION
# Why

When testing our brownfield app, I got this error when launching the react-native app

<img width="597" height="224" alt="image" src="https://github.com/user-attachments/assets/a52af20a-b973-41cf-8bf0-ab0e3ede7e42" />

This happens because when using SwiftUI, you can't directly add child views to a UIHostingController

# How

Add a check in the `rootViewController` to skip `UIHostingController`s

# Test Plan

Run BareExpo and BrownfieldTester on iOS

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
