### PR TITLE
[log-box] remove expo/metro-runtime dependency

### DIFF
--- a/packages/@expo/log-box/package.json
+++ b/packages/@expo/log-box/package.json
@@ -24,7 +24,6 @@
     "stacktrace-parser": "^0.1.10"
   },
   "devDependencies": {
-    "@expo/metro-runtime": "^6.1.2",
     "@expo/spawn-async": "^1.7.2",
     "@types/react": "~19.2.0",
     "expo-module-scripts": "^5.0.7",


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Added in https://github.com/expo/expo/pull/41200, but I don't see why. The runtime package is not used in the log-box.

The `expo/metro-runtime` dependency of `expo/log-box` creates circular dependency as `expo/metro-runtime` depends on `expo/log-box`.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove the dev dependency.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

All tests pass as before.