### PR TITLE
[docs]  Fix TOC highlight after programmatic scroll

### DIFF
--- a/docs/ui/components/TableOfContents/TableOfContents.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContents.tsx
@@ -80,13 +80,26 @@ export const TableOfContents = forwardRef<
       setShowScrollTop(showScrollTopValue);
     }
 
-    if (slugScrollingTo.current) {
-      return;
-    }
-
     const viewportMiddle = contentScrollPosition + window.innerHeight / 2;
     const viewportActiveOffset =
       contentScrollPosition + window.innerHeight * ACTIVE_ITEM_OFFSET_FACTOR;
+
+    if (slugScrollingTo.current) {
+      const targetHeading = headings.find(h => h.slug === slugScrollingTo.current);
+      const targetTop = targetHeading?.ref?.current?.offsetTop;
+
+      if (targetTop != null) {
+        const targetInView = targetTop >= viewportActiveOffset && targetTop <= viewportMiddle;
+
+        if (!targetInView) {
+          return;
+        }
+      } else {
+        slugScrollingTo.current = null;
+      }
+
+      slugScrollingTo.current = null;
+    }
 
     for (const { ref, slug, level } of headings) {
       if (!ref?.current) {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/expo/pull/41440

After the heading `id` change, clicking a TOC entry set slugScrollingTo and blocked scroll handling indefinitely, so the active item was never highlighted.


https://github.com/user-attachments/assets/90e3894c-e8ab-44d2-8bf6-27dfef46fecc



# How

<!--
How did you build this feature or fix this bug and why?
-->

In `ui/components/TableOfContents/TableOfContents.tsx`, clear `slugScrollingTo` once the target heading is in view, allowing active slug detection to resume.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Run `yarn dev`, open a versioned SDK page.
- Click multiple TOC entries (including nested ones): page scrolls to each heading and the clicked item highlights once the scroll completes.
- Manually scroll: active TOC item updates as before.


https://github.com/user-attachments/assets/95c5b494-91c9-4c5f-b400-f2b2c40488dc



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
