### PR TITLE
[expo] Add expo/modules-core export

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### 🎉 New features
 
+- Added `expo/modules-core` export to allow importing `expo-modules-core` as a subpath of `expo`. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@LevanKvirkvelia](https://github.com/LevanKvirkvelia))
 - Add `process.env.EXPO_DOM_HOST_OS` for detecting the original platform of a DOM Component. ([#40382](https://github.com/expo/expo/pull/40382) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove `ExpoAppDelegate` inheritance requirement in ExpoReactNativeFactory ([#39417](https://github.com/expo/expo/pull/39417) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Remove bindReactNativeFactory function ([#39418](https://github.com/expo/expo/pull/39418) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### 🎉 New features
 
-- Added `expo/modules-core` export to allow importing `expo-modules-core` as a subpath of `expo`. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@LevanKvirkvelia](https://github.com/LevanKvirkvelia))
+- Added `expo/modules-core` export to allow importing `expo-modules-core` as a subpath of `expo`. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@LevanKvirkvelia](https://github.com/LevanKvirkvelia)) ([#41445](https://github.com/expo/expo/pull/41445) by [@LevanKvirkvelia](https://github.com/LevanKvirkvelia))
 - Add `process.env.EXPO_DOM_HOST_OS` for detecting the original platform of a DOM Component. ([#40382](https://github.com/expo/expo/pull/40382) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove `ExpoAppDelegate` inheritance requirement in ExpoReactNativeFactory ([#39417](https://github.com/expo/expo/pull/39417) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Remove bindReactNativeFactory function ([#39418](https://github.com/expo/expo/pull/39418) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### 🎉 New features
 
-- Added `expo/modules-core` export to allow importing `expo-modules-core` as a subpath of `expo`. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@LevanKvirkvelia](https://github.com/LevanKvirkvelia)) ([#41445](https://github.com/expo/expo/pull/41445) by [@LevanKvirkvelia](https://github.com/LevanKvirkvelia))
+- Added `expo/modules-core` export to allow importing `expo-modules-core` as a subpath of `expo`. ([#41445](https://github.com/expo/expo/pull/41445) by [@LevanKvirkvelia](https://github.com/LevanKvirkvelia))
 - Add `process.env.EXPO_DOM_HOST_OS` for detecting the original platform of a DOM Component. ([#40382](https://github.com/expo/expo/pull/40382) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove `ExpoAppDelegate` inheritance requirement in ExpoReactNativeFactory ([#39417](https://github.com/expo/expo/pull/39417) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Remove bindReactNativeFactory function ([#39418](https://github.com/expo/expo/pull/39418) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo/modules-core.d.ts
+++ b/packages/expo/modules-core.d.ts
@@ -1,0 +1,1 @@
+export * from 'expo-modules-core';

--- a/packages/expo/modules-core.js
+++ b/packages/expo/modules-core.js
@@ -1,0 +1,1 @@
+module.exports = require('expo-modules-core');

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -34,6 +34,8 @@
     "config",
     "config-plugins.js",
     "config-plugins.d.ts",
+    "modules-core.js",
+    "modules-core.d.ts",
     "devtools.js",
     "devtools.d.ts",
     "fetch.js",


### PR DESCRIPTION
## Summary
- Added `expo/modules-core` re-export to allow importing `expo-modules-core` as `expo/modules-core`
- This mirrors the existing pattern used for `expo/config-plugins` which re-exports `@expo/config-plugins`

## Why this change?

When building Expo modules or using low-level APIs like `requireNativeModule`, `EventEmitter`, or other exports from `expo-modules-core`, developers currently need to import directly from `expo-modules-core`:

```ts
import { requireNativeModule } from 'expo-modules-core';
```

However, this creates a problem:

1. **expo doctor warnings**: Tools like `expo doctor` correctly flag this as an issue and suggest not installing `expo-modules-core` explicitly
2. **Version mismatch risk**: If the developer adds `expo-modules-core` to their `package.json`, they might install a different version than what `expo` depends on, leading to runtime issues and version conflicts

By re-exporting `expo-modules-core` as `expo/modules-core`, developers can:

```ts
import { requireNativeModule } from 'expo/modules-core';
```

This guarantees they're using the exact version bundled with their `expo` installation, avoiding version mismatches and eliminating the need for an explicit dependency.

## Test plan
- Verified the export files follow the same pattern as `config-plugins.js` and `config-plugins.d.ts`
- The implementation is straightforward: just re-exporting the existing package

🤖 Generated with [Claude Code](https://claude.com/claude-code)