### PR TITLE
[dev-menu] unregisterKeyCommand for cmd+r

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [iOS] Fix React Native dev menu not showing up in 0.83.x ([#40819](https://github.com/expo/expo/pull/40819) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Hide Action button in PiP mode to prevent crash ([#40792](https://github.com/expo/expo/pull/40792) by [@kosmydel](https://github.com/kosmydel))
+- [iOS] remove unnecessary `unregisterKeyCommand` for cmd+r ([#41449](https://github.com/expo/expo/pull/41449) by [@vonovak](https://github.com/vonovak))
 - [Android] Prevent some debug only artifacts from being included in release builds. ([#41378](https://github.com/expo/expo/pull/41378) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others

--- a/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift
+++ b/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift
@@ -73,7 +73,6 @@ class DevMenuKeyCommandsInterceptor {
     commands.unregisterKeyCommand(withInput: "d", modifierFlags: .command)
     commands.unregisterKeyCommand(withInput: "d", modifierFlags: .control)
     commands.unregisterKeyCommand(withInput: "r", modifierFlags: [])
-    commands.unregisterKeyCommand(withInput: "r", modifierFlags: .command)
     commands.unregisterKeyCommand(withInput: "i", modifierFlags: .command)
     commands.unregisterKeyCommand(withInput: "p", modifierFlags: .command)
 


### PR DESCRIPTION
# Why

- follow-up to https://github.com/expo/expo/pull/41355

# How

remove `unregisterKeyCommand` for cmd+r for which there's no `registerKeyCommand`

# Test Plan

- bare expo

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
