### PR TITLE
[expo-go] avoid depending on global node in xcode scripts

### DIFF
--- a/apps/expo-go/ios/Build-Phases/generate-dynamic-macros.sh
+++ b/apps/expo-go/ios/Build-Phases/generate-dynamic-macros.sh
@@ -15,8 +15,10 @@ fi
 
 export PATH="${SRCROOT}/../../../bin:$PATH"
 
+ET_BIN="$PODS_ROOT/../../../../bin/et"
+
 if [ "${APP_OWNER}" == "Expo" ]; then
-  et ios-generate-dynamic-macros --configuration ${CONFIGURATION}
+  $NODE_BINARY $ET_BIN ios-generate-dynamic-macros --configuration ${CONFIGURATION}
 else
-  et ios-generate-dynamic-macros --configuration ${CONFIGURATION} --skip-template=GoogleService-Info.plist
+  $NODE_BINARY $ET_BIN ios-generate-dynamic-macros --configuration ${CONFIGURATION} --skip-template=GoogleService-Info.plist
 fi


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

When using `nvm`, `volta` and other it's command to not have global node binary. 

# How

<!--
How did you build this feature or fix this bug and why?
-->

RN/Expo scripts check $NODE_BINARY loaded from `.xcode.env.*`. I updated [generate-dynamic-macros.sh](https://github.com/expo/expo/compare/%40krystofwoldrich/fix/expo-go/xcode-scripts-without-global-node?expand=1#diff-2047766e8aa47f098191fa682801f98c8c818cd8527e7ab944d5940982b7c9a7) to also use the node bin selected with the env files.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

CI should pass. expo-go builds without node command error.

<img width="433" height="74" alt="Screenshot 2025-12-05 at 13 24 21" src="https://github.com/user-attachments/assets/b21b11fc-ed9e-4a09-8d2b-f0e53b3b98c0" />