### PR TITLE
[expo-go] fix sql crash on non-unique  development scope key

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
@@ -112,7 +112,7 @@ public final class UpdatesDatabase: NSObject {
 
   public func addUpdate(_ update: Update, config: UpdatesConfig) throws {
     let sql = """
-      INSERT INTO "updates" ("id", "scope_key", "commit_time", "runtime_version", "manifest", "status" , "keep", "last_accessed", "successful_launch_count", "failed_launch_count", "url", "headers")
+      INSERT OR REPLACE INTO "updates" ("id", "scope_key", "commit_time", "runtime_version", "manifest", "status" , "keep", "last_accessed", "successful_launch_count", "failed_launch_count", "url", "headers")
       VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1, ?7, ?8, ?9, ?10, ?11);
     """
     _ = try execute(


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

When reopening the development build of expo-go I'm getting the following sql error due to unique constraint on scopeKey.

My scopeKey is the same in development, not sure if that signs a different issue in my setup, but allowing update on the db record fixes the app for me.

<img width="348" alt="Screenshot 2025-12-05 at 00 58 09" src="https://github.com/user-attachments/assets/9ec62ef6-0c5f-468e-853a-329c8fbf6824" />

### Example of the update object from two consequents start of the app.

First
```
(EXUpdates.Update) update = 0x0000600003318960 {
  ObjectiveC.NSObject = {
    isa = EXUpdatesUpdate
  }
  updateId = 101B082C-0A91-45B8-8769-A18C52A09379
  scopeKey = "@anonymous/home-2995dc01-599b-4909-bcad-e15a9fa9d94b"
  commitTime = 2025-12-05 12:39:11 UTC
  runtimeVersion = "54.0.0"
  keep = true
  isDevelopmentMode = true
  assetsFromManifest = 1 value {
    [0] = 0x000060000370c240 {
      ObjectiveC.NSObject = {
        isa = EXUpdatesAsset
      }
      key = "bundle"
      type = "bundle"
      url = "http://192.168.0.145:80/apps/expo-go/index.bundle?platform=ios&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable"
      metadata = nil
      mainBundleDir = nil
      mainBundleFilename = "app"
      isLaunchAsset = true
      extraRequestHeaders = nil
      expectedHash = nil
      downloadTime = nil
      contentHash = nil
      headers = nil
      assetId = 0
      $__lazy_storage_$_filename = nil
    }
  }
  manifest = 0x0000600000013250 {
    EXManifests.Manifest = {
      ObjectiveC.NSObject = {
        isa = EXManifestsExpoUpdatesManifest
      }
      rawManifestJSONInternal = 7 key/value pairs {
        [0] = {
          key = "assets"
          value = (object = 0x00000001e5cc39d0)
        }
        [1] = {
          key = "runtimeVersion"
          value = (object = 0xbe98470f99e51e30)
        }
        [2] = {
          key = "id"
          value = (object = 0x0000600001763040)
        }
        [3] = {
          key = "extra"
          value = (object = 0x0000600002c3e400)
        }
        [4] = {
          key = "createdAt"
          value = (object = 0x0000600000c4bd80)
        }
        [5] = {
          key = "launchAsset"
          value = (object = 0x0000600001763080)
        }
        [6] = {
          key = "metadata"
          value = (object = 0x00000001e5cc3a00)
        }
      }
    }
  }
  status =
  lastAccessed = 2025-12-05 12:39:21 UTC
  successfulLaunchCount = 0
  failedLaunchCount = 0
  url = "https://expo.dev"
  requestHeaders = 8 key/value pairs {
    [0] = (key = "Expo-Client-Release-Type", value = "SIMULATOR")
    [1] = (key = "User-Agent", value = "Exponent/54.0.5 (arm64; iOS 26.0.1; Scale/3.00; en_US@rg=atzzzz)")
    [2] = (key = "Expo-Client-Environment", value = "EXPO_DEVICE")
    [3] = (key = "Exponent-Version", value = "54.0.5")
    [4] = (key = "Exponent-Platform", value = "ios")
    [5] = (key = "Expo-Updates-Environment", value = "EXPO_DEVICE")
    [6] = (key = "Exponent-Accept-Signature", value = "true")
    [7] = (key = "Exponent-SDK-Version", value = "54.0.0")
  }
  config = 0x000060000301aac0 {
    ObjectiveC.NSObject = {
      isa = EXUpdatesConfig
    }
    scopeKey = "@anonymous/home-2995dc01-599b-4909-bcad-e15a9fa9d94b"
    updateUrl = "https://expo.dev"
    originalEmbeddedUpdateUrl = "https://expo.dev"
    requestHeaders = 8 key/value pairs {
      [0] = (key = "Expo-Client-Release-Type", value = "SIMULATOR")
      [1] = (key = "User-Agent", value = "Exponent/54.0.5 (arm64; iOS 26.0.1; Scale/3.00; en_US@rg=atzzzz)")
      [2] = (key = "Expo-Client-Environment", value = "EXPO_DEVICE")
      [3] = (key = "Exponent-Version", value = "54.0.5")
      [4] = (key = "Exponent-Platform", value = "ios")
      [5] = (key = "Expo-Updates-Environment", value = "EXPO_DEVICE")
      [6] = (key = "Exponent-Accept-Signature", value = "true")
      [7] = (key = "Exponent-SDK-Version", value = "54.0.0")
    }
    originalEmbeddedRequestHeaders = 8 key/value pairs {
      [0] = (key = "Exponent-SDK-Version", value = "54.0.0")
      [1] = (key = "Expo-Client-Release-Type", value = "SIMULATOR")
      [2] = (key = "User-Agent", value = "Exponent/54.0.5 (arm64; iOS 26.0.1; Scale/3.00; en_US@rg=atzzzz)")
      [3] = (key = "Exponent-Accept-Signature", value = "true")
      [4] = (key = "Exponent-Platform", value = "ios")
      [5] = (key = "Exponent-Version", value = "54.0.5")
      [6] = (key = "Expo-Client-Environment", value = "EXPO_DEVICE")
      [7] = (key = "Expo-Updates-Environment", value = "EXPO_DEVICE")
    }
    launchWaitMs = 0
    checkOnLaunch =
    codeSigningConfiguration = nil
    enableExpoUpdatesProtocolV0CompatibilityMode = false
    enableBsdiffPatchSupport = true
    runtimeVersion = "exposdk:54.0.0"
    hasEmbeddedUpdate = false
    originalHasEmbeddedUpdate = false
    disableAntiBrickingMeasures = false
    hasUpdatesOverride = false
    cachedConfigDictionary = 5 key/value pairs {
      [0] = {
        key = "EXUpdatesURL"
        value = (object = 0x0000000116d36e70)
      }
      [1] = {
        key = "EXUpdatesScopeKey"
        value = (object = 0x0000600002132800)
      }
      [2] = {
        key = "EXUpdatesHasEmbeddedUpdate"
        value = (object = 0x00000001e5cc39f0)
      }
      [3] = {
        key = "EXUpdatesRuntimeVersion"
        value = (object = 0x000060000026f2a0)
      }
      [4] = {
        key = "EXUpdatesRequestHeaders"
        value = (object = 0x0000600003b09340)
      }
    }
  }
  database = 0x000060000022f360 {
    ObjectiveC.NSObject = {
      isa = EXUpdatesDatabase
    }
    databaseQueue = 0x0000600002c21d80 {
      baseOS_dispatch_queue_serial_executor@0 = {
        baseOS_dispatch_queue@0 = {
          baseOS_dispatch_object@0 = {
            baseOS_object@0 = {
              baseNSObject@0 = {
                isa = OS_dispatch_queue_serial
              }
            }
          }
        }
      }
    }
    db = 0x0000000106c13c80
  }
}
```

Second
```
(EXUpdates.Update) update = 0x0000600003308fa0 {
  ObjectiveC.NSObject = {
    isa = EXUpdatesUpdate
  }
  updateId = 1DAAB713-9046-4059-A8BD-73F904ECD9AB
  scopeKey = "@anonymous/home-2995dc01-599b-4909-bcad-e15a9fa9d94b"
  commitTime = 2025-12-05 12:46:22 UTC
  runtimeVersion = "54.0.0"
  keep = true
  isDevelopmentMode = true
  assetsFromManifest = 1 value {
    [0] = 0x0000600003708a80 {
      ObjectiveC.NSObject = {
        isa = EXUpdatesAsset
      }
      key = "bundle"
      type = "bundle"
      url = "http://192.168.0.145:80/apps/expo-go/index.bundle?platform=ios&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&unstable_transformProfile=hermes-stable"
      metadata = nil
      mainBundleDir = nil
      mainBundleFilename = "app"
      isLaunchAsset = true
      extraRequestHeaders = nil
      expectedHash = nil
      downloadTime = nil
      contentHash = nil
      headers = nil
      assetId = 0
      $__lazy_storage_$_filename = nil
    }
  }
  manifest = 0x000060000000da90 {
    EXManifests.Manifest = {
      ObjectiveC.NSObject = {
        isa = EXManifestsExpoUpdatesManifest
      }
      rawManifestJSONInternal = 7 key/value pairs {
        [0] = {
          key = "metadata"
          value = (object = 0x00000001e5cc3a00)
        }
        [1] = {
          key = "id"
          value = (object = 0x000060000176c780)
        }
        [2] = {
          key = "runtimeVersion"
          value = (object = 0x8f80eca56fc5e6cc)
        }
        [3] = {
          key = "launchAsset"
          value = (object = 0x000060000176c7c0)
        }
        [4] = {
          key = "extra"
          value = (object = 0x0000600002c1b380)
        }
        [5] = {
          key = "createdAt"
          value = (object = 0x0000600000c59830)
        }
        [6] = {
          key = "assets"
          value = (object = 0x00000001e5cc39d0)
        }
      }
    }
  }
  status =
  lastAccessed = 2025-12-05 12:46:31 UTC
  successfulLaunchCount = 0
  failedLaunchCount = 0
  url = "https://expo.dev"
  requestHeaders = 8 key/value pairs {
    [0] = (key = "Expo-Updates-Environment", value = "EXPO_DEVICE")
    [1] = (key = "Exponent-Platform", value = "ios")
    [2] = (key = "Exponent-Accept-Signature", value = "true")
    [3] = (key = "Exponent-Version", value = "54.0.5")
    [4] = (key = "User-Agent", value = "Exponent/54.0.5 (arm64; iOS 26.0.1; Scale/3.00; en_US@rg=atzzzz)")
    [5] = (key = "Exponent-SDK-Version", value = "54.0.0")
    [6] = (key = "Expo-Client-Environment", value = "EXPO_DEVICE")
    [7] = (key = "Expo-Client-Release-Type", value = "SIMULATOR")
  }
  config = 0x0000600003006130 {
    ObjectiveC.NSObject = {
      isa = EXUpdatesConfig
    }
    scopeKey = "@anonymous/home-2995dc01-599b-4909-bcad-e15a9fa9d94b"
    updateUrl = "https://expo.dev"
    originalEmbeddedUpdateUrl = "https://expo.dev"
    requestHeaders = 8 key/value pairs {
      [0] = (key = "Expo-Updates-Environment", value = "EXPO_DEVICE")
      [1] = (key = "Exponent-Platform", value = "ios")
      [2] = (key = "Exponent-Accept-Signature", value = "true")
      [3] = (key = "Exponent-Version", value = "54.0.5")
      [4] = (key = "User-Agent", value = "Exponent/54.0.5 (arm64; iOS 26.0.1; Scale/3.00; en_US@rg=atzzzz)")
      [5] = (key = "Exponent-SDK-Version", value = "54.0.0")
      [6] = (key = "Expo-Client-Environment", value = "EXPO_DEVICE")
      [7] = (key = "Expo-Client-Release-Type", value = "SIMULATOR")
    }
    originalEmbeddedRequestHeaders = 8 key/value pairs {
      [0] = (key = "Expo-Updates-Environment", value = "EXPO_DEVICE")
      [1] = (key = "Exponent-Platform", value = "ios")
      [2] = (key = "Expo-Client-Environment", value = "EXPO_DEVICE")
      [3] = (key = "Expo-Client-Release-Type", value = "SIMULATOR")
      [4] = (key = "Exponent-Version", value = "54.0.5")
      [5] = (key = "Exponent-Accept-Signature", value = "true")
      [6] = (key = "Exponent-SDK-Version", value = "54.0.0")
      [7] = (key = "User-Agent", value = "Exponent/54.0.5 (arm64; iOS 26.0.1; Scale/3.00; en_US@rg=atzzzz)")
    }
    launchWaitMs = 0
    checkOnLaunch =
    codeSigningConfiguration = nil
    enableExpoUpdatesProtocolV0CompatibilityMode = false
    enableBsdiffPatchSupport = true
    runtimeVersion = "exposdk:54.0.0"
    hasEmbeddedUpdate = false
    originalHasEmbeddedUpdate = false
    disableAntiBrickingMeasures = false
    hasUpdatesOverride = false
    cachedConfigDictionary = 5 key/value pairs {
      [0] = {
        key = "EXUpdatesRequestHeaders"
        value = (object = 0x0000600003b06ca0)
      }
      [1] = {
        key = "EXUpdatesHasEmbeddedUpdate"
        value = (object = 0x00000001e5cc39f0)
      }
      [2] = {
        key = "EXUpdatesRuntimeVersion"
        value = (object = 0x00006000002827c0)
      }
      [3] = {
        key = "EXUpdatesScopeKey"
        value = (object = 0x00006000021345a0)
      }
      [4] = {
        key = "EXUpdatesURL"
        value = (object = 0x00000001128b2e70)
      }
    }
  }
  database = 0x00006000002536a0 {
    ObjectiveC.NSObject = {
      isa = EXUpdatesDatabase
    }
    databaseQueue = 0x0000600002c39f80 {
      baseOS_dispatch_queue_serial_executor@0 = {
        baseOS_dispatch_queue@0 = {
          baseOS_dispatch_object@0 = {
            baseOS_object@0 = {
              baseNSObject@0 = {
                isa = OS_dispatch_queue_serial
              }
            }
          }
        }
      }
    }
    db = 0x0000000101d2ac30
  }
}
```

# How

<!--
How did you build this feature or fix this bug and why?
-->

Allow update on the update records when calling `addUpdate`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Reopening the development build should not crash on unique scopeKey constraint. 