### PR TITLE
[iOS] Add `appDelegateWillBeginInitialization` function to app delegate subscribers

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [iOS] `Class` definition for shared objects is now optional. ([#40708](https://github.com/expo/expo/pull/40708) by [@tsapeta](https://github.com/tsapeta))
 - Split out JSI layer from the modules core. ([#40755](https://github.com/expo/expo/pull/40755) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Improved support for `ArrayBuffer`s. ([#41404](https://github.com/expo/expo/pull/41404) by [@barthap](https://github.com/barthap))
+- [iOS] Added `appDelegateWillBeginInitialization` function to AppDelegate subscribers. ([#41456](https://github.com/expo/expo/pull/41456) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriber.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriber.swift
@@ -31,7 +31,17 @@ public protocol ExpoAppDelegateSubscriberProtocol: UIApplicationDelegate {
    thus even before any other `UIApplicationDelegate` function. Use it if your subscriber needs to run some code as early as possible,
    but keep in mind that this affects the application loading time.
    */
-  @objc optional func subscriberDidRegister()
+  @objc
+  @MainActor
+  optional func subscriberDidRegister()
+
+  /**
+   Function that is called at the beginning of the `AppDelegate` initialization,
+   i.e. during the `main` function and before the application starts launching.
+   */
+  @objc
+  @MainActor
+  optional func appDelegateWillBeginInitialization()
 }
 
 /**

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [iOS] `Class` definition for shared objects is now optional. ([#40708](https://github.com/expo/expo/pull/40708) by [@tsapeta](https://github.com/tsapeta))
 - Split out JSI layer from the modules core. ([#40755](https://github.com/expo/expo/pull/40755) by [@tsapeta](https://github.com/tsapeta))
 - Add `@expo/local-build-cache-provider` package ([#41270](https://github.com/expo/expo/pull/41270) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Added `appDelegateWillBeginInitialization` function to AppDelegate subscribers. ([#41456](https://github.com/expo/expo/pull/41456) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
@@ -21,6 +21,12 @@ open class ExpoAppDelegate: UIResponder, UIApplicationDelegate {
     super.init()
   }
 
+#if os(macOS)
+  required public init?(coder: NSCoder) {
+    super.init(coder: coder)
+  }
+#endif
+
   // MARK: - Initializing the App
 #if os(iOS) || os(tvOS)
 

--- a/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
@@ -11,6 +11,16 @@ import ReactAppDependencyProvider
  */
 @objc(EXExpoAppDelegate)
 open class ExpoAppDelegate: UIResponder, UIApplicationDelegate {
+  override public init() {
+    // The subscribers are initializing and registering before the main code starts executing.
+    // Here we're letting them know when the `AppDelegate` is being created,
+    // which happens at the beginning of the main code execution and before launching the app.
+    ExpoAppDelegateSubscriberRepository.subscribers.forEach {
+      $0.appDelegateWillBeginInitialization?()
+    }
+    super.init()
+  }
+
   // MARK: - Initializing the App
 #if os(iOS) || os(tvOS)
 


### PR DESCRIPTION
# Why

I've recently added `subscriberDidRegister` function to AppDelegate subscribers to let the subscribers execute some code before the main code runs. Now I also need something similar, but that is called when the main code starts executing (`AppDelegate` starts initializing). I feel that it might be useful in some other scenarios.

# How

- Added `appDelegateWillBeginInitialization` function to `ExpoAppDelegateSubscriberProtocol` and call it in `ExpoAppDelegate.init`.
- In addition, I added `@MainActor` annotation to both functions, otherwise the compiler complains about not running it in MainActor-isolated context, even though it's always run on the main thread.

# Test Plan

Implemented the new function in one of our subscribers and confirmed it's executed after `subscriberDidRegister` and before `application:willFinishLaunchingWithOptions:`.