### PR TITLE
fix(expo,cli,babel-preset-expo): Remove remaining direct `metro-*` imports

### DIFF
--- a/packages/@expo/cli/e2e/__tests__/export/serializer-plugins.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/serializer-plugins.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import JsonFile from '@expo/json-file';
+import type { BasicSourceMap } from '@expo/metro/metro-source-map';
 import fs from 'fs';
-import type { BasicSourceMap } from 'metro-source-map';
 import path from 'path';
 
 import { runExportSideEffects } from './export-side-effects';

--- a/packages/babel-preset-expo/src/__tests__/minify-util.ts
+++ b/packages/babel-preset-expo/src/__tests__/minify-util.ts
@@ -1,7 +1,7 @@
 // Rough estimation of how minifying works by default in Expo / Metro.
 // We'll need to update this if we ever change the default minifier.
 import getDefaultConfig from '@expo/metro/metro-config/defaults';
-import metroMinify from 'metro-minify-terser';
+import metroMinify from '@expo/metro/metro-minify-terser';
 
 export async function minifyLikeMetroAsync({
   code,

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Add recommended `react-server-dom-webpack` version to `bundledNativeModules.json` ([#41429](https://github.com/expo/expo/pull/41429) by [@kitten](https://github.com/kitten))
 - Bump `react-server-dom-webpack` ([#41574](https://github.com/expo/expo/pull/41574) by [@kitten](https://github.com/kitten)) ([#41589](https://github.com/expo/expo/pull/41589) by [@kitten](https://github.com/kitten))
 - Bump to `@expo/metro@54.2.0` and `metro@0.83.3` ([#41142](https://github.com/expo/expo/pull/41142) by [@kitten](https://github.com/kitten))
+- Update `metro-source-map` import source in `expo/scripts/compose-source-maps` ([#41458](https://github.com/expo/expo/pull/41458) by [@kitten](https://github.com/kitten))
 
 ### ⚠️ Notices
 

--- a/packages/expo/scripts/compose-source-maps.js
+++ b/packages/expo/scripts/compose-source-maps.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-const { composeSourceMaps } = require('metro-source-map');
+const { composeSourceMaps } = require('@expo/metro/metro-source-map');
 const fs = require('fs');
 
 const argv = process.argv.slice(2);


### PR DESCRIPTION
# Why

With an update to `@expo/metro` we can get rid of the remaining `metro-*` imports in non-runtime files.

# How

- Replace `metro-source-map` import in CLI E2E tests
- Replace `composeSourceMaps` in `expo/scripts/compose-source-maps`
- Replace `metro-minify-terser` in `babel-preset-expo` test util

# Test Plan

- CI should pass (some tests will fail due to temporary vendored `@expo/metro` tarball)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
