### PR TITLE
[docs] Fix inconsistencies in Testing configuration for Expo Router

### DIFF
--- a/docs/pages/router/reference/testing.mdx
+++ b/docs/pages/router/reference/testing.mdx
@@ -28,6 +28,7 @@ Before you proceed, ensure you have set up `jest-expo` according to the [Unit te
 
 ```tsx app.test.tsx
 import { renderRouter, screen } from 'expo-router/testing-library';
+import { View } from 'react-native';
 
 it('my-test', async () => {
   const MockComponent = jest.fn(() => <View />);
@@ -75,7 +76,10 @@ it('my-test', async () => {
 
 `renderRouter` can accept a directory path to mock an existing fixture. Ensure that the provided path is relative to the current test file.
 
-```tsx app.test.js
+```tsx app.test.tsx
+import { renderRouter } from 'expo-router/testing-library';
+import { View } from 'react-native';
+
 it('my-test', async () => {
   const MockComponent = jest.fn(() => <View />);
   renderRouter('./my-test-fixture');
@@ -90,7 +94,10 @@ it('my-test', async () => {
 
 For more intricate testing scenarios, `renderRouter` can leverage both directory path and inline-mocking methods simultaneously. The `appDir` parameter takes a string representing a pathname to a directory. The overrides parameter is an inline mock that can be used to override specific paths within the `appDir`. This combination allows for fine-tuned control over the mock environment.
 
-```tsx app.test.js
+```tsx app.test.tsx
+import { renderRouter } from 'expo-router/testing-library';
+import { View } from 'react-native';
+
 it('my-test', async () => {
   const MockAuthLayout = jest.fn(() => <View />);
   renderRouter({
@@ -112,7 +119,7 @@ The following matches have been added to `expect` and can be used to assert valu
 
 Assert the current pathname against a given string. The matcher uses the value of the [`usePathname`](/router/reference/hooks/#usepathname) hook on the current `screen`.
 
-```tsx app.test.ts
+```tsx app.test.tsx
 expect(screen).toHavePathname('/my-router');
 ```
 
@@ -122,7 +129,7 @@ expect(screen).toHavePathname('/my-router');
 
 Assert the current pathname, including URL parameters, against a given string. This is useful to assert the appearance of URL in a web browser.
 
-```tsx app.test.ts
+```tsx app.test.tsx
 expect(screen).toHavePathnameWithParams('/my-router?hello=world');
 ```
 
@@ -132,7 +139,7 @@ expect(screen).toHavePathnameWithParams('/my-router?hello=world');
 
 Assert the current segments against an array of strings. The matcher uses the value of the [`useSegments`](/router/reference/hooks/#usesegments) hook on the current `screen`.
 
-```tsx app.test.ts
+```tsx app.test.tsx
 expect(screen).toHaveSegments(['[id]']);
 ```
 
@@ -141,7 +148,7 @@ expect(screen).toHaveSegments(['[id]']);
 
 Assert the current local URL parameters against an object. The matcher uses the value of the [`useLocalSearchParams`](/router/reference/hooks/#uselocalsearchparams) hook on the current `screen`.
 
-```tsx app.test.ts
+```tsx app.test.tsx
 expect(screen).useLocalSearchParams({ first: 'abc' });
 ```
 
@@ -152,7 +159,7 @@ Assert the current screen's pathname that matches a value. Compares using the va
 
 Assert the current global URL parameters against an object. The matcher uses the value of the [`useGlobalSearchParams`](/router/reference/hooks/#useglobalsearchparams) hook on the current `screen`.
 
-```tsx app.test.ts
+```tsx app.test.tsx
 expect(screen).useGlobalSearchParams({ first: 'abc' });
 ```
 
@@ -162,7 +169,7 @@ expect(screen).useGlobalSearchParams({ first: 'abc' });
 
 An advanced matcher that asserts the current router state against an object.
 
-```tsx app.test.ts
+```tsx app.test.tsx
 expect(screen).toHaveRouterState({
   routes: [{ name: 'index', path: '/' }],
 });


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix multiple inconsistencies in the Testing configuration for the Expo Router guide.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff or run the docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
