### PR TITLE
[cli] Fix parsing of package names when applying config plugins

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - refactor launching Expo Go on Android ([#40020](https://github.com/expo/expo/pull/40020) by [@vonovak](https://github.com/vonovak))
 - only skip dependency validation for `EXPO_NO_DEPENDENCY_VALIDATION=1` ([#40043](https://github.com/expo/expo/pull/40043) by [@kitten](https://github.com/kitten))
+- Fix parsing of package names when applying config plugins after installing ([#41463](https://github.com/expo/expo/pull/41463) by [@radoslawrolka](https://github.com/radoslawrolka))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/install/applyPlugins.ts
+++ b/packages/@expo/cli/src/install/applyPlugins.ts
@@ -2,6 +2,19 @@ import { getConfig } from '@expo/config';
 
 import * as Log from '../log';
 
+function parsePackageName(pkg: string): string {
+  // Package can be in the most complex form of: @scope/name@version
+  // We only want to extract the @scope/name part.
+  const splittedName = pkg.split('@');
+  if (splittedName[0] === '') {
+    // Scoped package e.g. @scope/name
+    return `@${splittedName[1]}`;
+  } else {
+    // Regular package e.g. react or lodash
+    return splittedName[0];
+  }
+}
+
 /**
  * A convenience feature for automatically applying Expo Config Plugins to the `app.json` after installing them.
  * This should be dropped in favor of autolinking in the future.
@@ -16,8 +29,7 @@ export async function applyPluginsAsync(projectRoot: string, packages: string[])
     await autoAddConfigPluginsAsync(
       projectRoot,
       exp,
-      // Split any possible NPM tags. i.e. `expo@latest` -> `expo`
-      packages.map((pkg) => pkg.split('@')[0]).filter(Boolean)
+      packages.map((pkg) => parsePackageName(pkg)).filter(Boolean)
     );
   } catch (error: any) {
     // If we fail to apply plugins, the log a warning and continue.


### PR DESCRIPTION
# Why

When package was named '@scope/name@version', only '@scope/name' part should be used when applying config plugins. But it was taking empty string instead as splitting by '@' resulted in ['', 'scope/name', 'version'] array.

# How

Instead of splitting by '@' and taking first element, we check if package name starts with '@' (indicating a scoped package) and handle it accordingly.

# Test Plan

install a package with name like '@scope/name@version' and verify that config plugins is applied to app.json correctly.
e.g. @rnrepo/expo-config-plugin

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
