### PR TITLE
[web][mail-composer] Fixes incorrect encoding of content

### DIFF
--- a/packages/expo-mail-composer/CHANGELOG.md
+++ b/packages/expo-mail-composer/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix mail composer not suggesting an e-mail client on some devices. ([#41274](https://github.com/expo/expo/pull/41274) by [@behenate](https://github.com/behenate))
-- [web] Fix mail composer not encoding content correctly. All spaces would appear in the content as "+".
+- [web] Fix mail composer not encoding content correctly. All spaces would appear in the content as "+". ([#41465](https://github.com/expo/expo/pull/41465) by [@jpaas](https://github.com/jpaas))
 
 ### 💡 Others
 

--- a/packages/expo-mail-composer/CHANGELOG.md
+++ b/packages/expo-mail-composer/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix mail composer not suggesting an e-mail client on some devices. ([#41274](https://github.com/expo/expo/pull/41274) by [@behenate](https://github.com/behenate))
+- [web] Fix mail composer not encoding content correctly. All spaces would appear in the content as "+".
 
 ### 💡 Others
 

--- a/packages/expo-mail-composer/src/ExpoMailComposer.web.ts
+++ b/packages/expo-mail-composer/src/ExpoMailComposer.web.ts
@@ -44,13 +44,12 @@ export default {
       body: options.body,
     });
 
-    Object.entries(email).forEach(([key, value]) => {
-      // TODO(@kitten): This was implicitly cast before. Is this what we want?
-      mailtoUrl.searchParams.append(key, '' + value);
-    });
+    const query = Object.entries(email)
+      .map(([key, value]) => `${key}=${encodeURIComponent(String(value))}`)
+      .join('&');
 
-    window.open(mailtoUrl.toString());
-
+    const url = query ? `${mailtoUrl.toString()}?${query}` : mailtoUrl.toString();
+    window.open(url);
     return { status: MailComposerStatus.UNDETERMINED };
   },
   async isAvailableAsync(): Promise<boolean> {


### PR DESCRIPTION
# Why

When composing an email on web the mailto contains params that are not properly encoded. So if you have any spaces in your subject or body, they will all be converted to "+".

# How

Changed how the mailto url is built to encode the params correctly.

# Test Plan

You just have to do something like 
```
export const sendEmail = async () => {
  const result = await MailComposer.composeAsync({
    body: "Please include questions or a description of any issues you may have below",
    recipients: ["help@expo.dev"],
    subject: "Support Request",
  })
}
```

Run it on web to create the email draft and 
instead of the body looking like this
`Please+include+questions+or+a+description+of+any+issues+you+may+have+below`
it will look like this
`Please include questions or a description of any issues you may have below`

In my specific case I was using Chrome and the mailto was being handled by Mac Mail.

# Checklist

I couldn't get `yarn build` to work on the package

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
