### PR TITLE
fix(cli): Restore stack trace on TransformError/SyntaxErrors from transformer

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - refactor launching Expo Go on Android ([#40020](https://github.com/expo/expo/pull/40020) by [@vonovak](https://github.com/vonovak))
 - only skip dependency validation for `EXPO_NO_DEPENDENCY_VALIDATION=1` ([#40043](https://github.com/expo/expo/pull/40043) by [@kitten](https://github.com/kitten))
+- Report stack traces on unexpected `TransformerError`s and `SyntaxError`s from Metro ([#41468](https://github.com/expo/expo/pull/41468) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
@@ -267,6 +267,15 @@ export class MetroTerminalReporter extends TerminalReporter {
     }
 
     attachImportStackToRootMessage(error);
+
+    // NOTE(@kitten): Metro drops the stack forcefully when it finds a `SyntaxError`. However,
+    // this is really unhelpful, since it prevents debugging Babel plugins or reporting bugs
+    // in Babel plugins or a transformer entirely
+    if (error.snippet == null && error.stack != null && error instanceof SyntaxError) {
+      error.message = error.stack;
+      delete error.stack;
+    }
+
     return super._logBundlingError(error);
   }
 }


### PR DESCRIPTION
# Why

Metro usually swaps the `error.stack` into the bundling error for all errors. However, this isn't happening for `SyntaxError`s. This means that many errors simply display almost no helpful information.

<table><tr>
<td><strong>Before</strong></td>
<td><strong>After</strong></td>
</tr><tr>
<td><img width="926" height="44" alt="Screenshot 2025-12-05 at 23 16 16" src="https://github.com/user-attachments/assets/0b56e5f9-cb1d-4867-86a0-9520fc561970" /></td>
<td><img width="1179" height="246" alt="Screenshot 2025-12-05 at 23 15 48" src="https://github.com/user-attachments/assets/6544a3f1-8b6f-4f8d-bc9a-1f48fa330d4e" /></td>
</tr></table>

The problem with not displaying the `stack` is that a transformer can throw `TransformError`s which are always for debugging. Similarly, it can throw any `SyntaxError` and still be helpful. 

In most cases, it's not great to only get the `error.message`. If we get a `SyntaxError` something's gone very wrong, and we should allow the user to see _where_ something has gone wrong. This could happen due to a custom Babel plugin, or a third-party Babel transformer, etc.

See: https://github.com/facebook/metro/blob/5113aadf10b0cb8d36dfff0e8805e43e23188790/packages/metro/src/lib/TerminalReporter.js#L326-L332

This PR effectively "reverts" this change for us: https://github.com/facebook/metro/commit/39892a2b8dfac3c57f31f7ffe4f6fe339c66fd74

# How

- Forcefully swap in `error.stack` if we have no `error.snippet` and see a `SyntaxError`

# Test Plan

- Tested manually

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
