### PR TITLE
[core][iOS] Replace `appContext.permissions` with the core implementation

### DIFF
--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -148,7 +148,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener, EXCameraInterface, Ca
   required init(appContext: AppContext? = nil) {
     super.init(appContext: appContext)
     lifecycleManager = appContext?.legacyModule(implementing: EXAppLifecycleService.self)
-    permissionsManager = appContext?.legacyModule(implementing: EXPermissionsInterface.self)
+    permissionsManager = appContext?.permissions
 
     sessionManager = CameraSessionManager(delegate: self)
     photoCapture = CameraPhotoCapture(delegate: self)

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -46,7 +46,7 @@
 - Remove tests related files from the published package content. ([#39551](https://github.com/expo/expo/pull/39551) by [@Simek](https://github.com/Simek))
 - Remove old REACT_NATIVE_TARGET_VERSION checks ([#40843](https://github.com/expo/expo/pull/40843) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Moved the implementation of the constants provider (`EXConstantsService`) from `expo-constants`. ([#41339](https://github.com/expo/expo/pull/41339) by [@tsapeta](https://github.com/tsapeta))
-- [iOS] Replaced `appContext.fileSystem`, `appContext.utilities` and `appContext.imageLoader` with the core implementations. ([#41350](https://github.com/expo/expo/pull/41350), [#41370](https://github.com/expo/expo/pull/41370), [#41396](https://github.com/expo/expo/pull/41396) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Replaced `appContext.fileSystem`, `appContext.utilities`, `appContext.imageLoader` and `appContext.permissions` with the core implementations. ([#41350](https://github.com/expo/expo/pull/41350), [#41370](https://github.com/expo/expo/pull/41370), [#41396](https://github.com/expo/expo/pull/41396) by [@tsapeta](https://github.com/tsapeta))
 
 ## 3.0.28 - 2025-12-05
 

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -217,11 +217,9 @@ public final class AppContext: NSObject, @unchecked Sendable {
   public lazy var fileSystem: FileSystemManager? = FileSystemManager(appGroupSharedDirectories: self.config.appGroupSharedDirectories)
 
   /**
-   Provides access to the permissions manager from legacy module registry.
+   Provides access to the permissions manager.
    */
-  public var permissions: EXPermissionsInterface? {
-    return legacyModule(implementing: EXPermissionsInterface.self)
-  }
+  public lazy var permissions: EXPermissionsService? = EXPermissionsService()
 
   /**
    Provides access to the image loader from legacy module registry.

--- a/packages/expo-modules-core/ios/Legacy/Services/Permissions/EXPermissionsService.h
+++ b/packages/expo-modules-core/ios/Legacy/Services/Permissions/EXPermissionsService.h
@@ -1,10 +1,9 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
 #import <ExpoModulesCore/EXExportedModule.h>
-#import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 #import <ExpoModulesCore/EXPermissionsInterface.h>
 
-@interface EXPermissionsService : EXExportedModule <EXPermissionsInterface, EXModuleRegistryConsumer>
+@interface EXPermissionsService : NSObject <EXPermissionsInterface>
 
 + (EXPermissionStatus)statusForPermission:(NSDictionary *)permission;
 

--- a/packages/expo-modules-core/ios/Legacy/Services/Permissions/EXPermissionsService.m
+++ b/packages/expo-modules-core/ios/Legacy/Services/Permissions/EXPermissionsService.m
@@ -15,13 +15,10 @@ NSString * const EXPermissionExpiresNever = @"never";
 
 @property (nonatomic, strong) NSMutableDictionary<NSString *, id<EXPermissionsRequester>> *requesters;
 @property (nonatomic, strong) NSMapTable<Class, id<EXPermissionsRequester>> *requestersByClass;
-@property (nonatomic, weak) EXModuleRegistry *moduleRegistry;
 
 @end
 
 @implementation EXPermissionsService
-
-EX_EXPORT_MODULE();
 
 - (instancetype)init
 {
@@ -32,21 +29,11 @@ EX_EXPORT_MODULE();
   return self;
 }
 
-+ (const NSArray<Protocol *> *)exportedInterfaces
-{
-  return @[@protocol(EXPermissionsInterface)];
-}
-
 - (void)registerRequesters:(NSArray<id<EXPermissionsRequester>> *)newRequesters {
   for (id<EXPermissionsRequester> requester in newRequesters) {
     [_requesters setObject:requester forKey:[[requester class] permissionType]];
     [_requestersByClass setObject:requester forKey:[requester class]];
   }
-}
-
-- (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
-{
-  _moduleRegistry = moduleRegistry;
 }
 
 # pragma mark - permission requsters / getters
@@ -183,4 +170,3 @@ EX_EXPORT_MODULE();
 }
 
 @end
-


### PR DESCRIPTION
# Why

Part of the effort to remove the legacy module registry from the AppContext.
Surprisingly, `appContext.permissions` turned out to be the easiest to replace.

# How

- Used `EXPermissionsService` directly instead of getting it from the legacy module registry
- Fixed `expo-camera` to use `appContext.permissions` instead of `appContext.legacyModule(implementing: EXPermissionsInterface.self)`

# Test Plan

I went through some test-suite tests and examples in NCL that asks and gets permissions