### PR TITLE
[core][iOS] Deprecate `executeOnJavaScriptThread` in favor of `runtime.schedule`

### DIFF
--- a/packages/@expo/dom-webview/ios/DomWebView.swift
+++ b/packages/@expo/dom-webview/ios/DomWebView.swift
@@ -209,7 +209,7 @@ internal final class DomWebView: ExpoView, UIScrollViewDelegate, WKUIDelegate, W
       completionHandler("Missing JS Runtime")
       return
     }
-    appContext.executeOnJavaScriptThread {
+    try? appContext.runtime.schedule {
       let wrappedSource = NATIVE_EVAL_WRAPPER_SCRIPT
         .replacingOccurrences(of: "\"%%DEFERRED_ID%%\"", with: String(deferredId))
         .replacingOccurrences(of: "\"%%WEBVIEW_ID%%\"", with: String(webViewId))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Remove old REACT_NATIVE_TARGET_VERSION checks ([#40843](https://github.com/expo/expo/pull/40843) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Moved the implementation of the constants provider (`EXConstantsService`) from `expo-constants`. ([#41339](https://github.com/expo/expo/pull/41339) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Replaced `appContext.fileSystem`, `appContext.utilities`, `appContext.imageLoader` and `appContext.permissions` with the core implementations. ([#41350](https://github.com/expo/expo/pull/41350), [#41370](https://github.com/expo/expo/pull/41370), [#41396](https://github.com/expo/expo/pull/41396) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Deprecated `executeOnJavaScriptThread` in favor of `runtime.schedule`. ([#41478](https://github.com/expo/expo/pull/41478) by [@tsapeta](https://github.com/tsapeta))
 
 ## 3.0.28 - 2025-12-05
 

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -165,9 +165,11 @@ public final class AppContext: NSObject, @unchecked Sendable {
 
   /**
    Runs a code block on the JavaScript thread.
+   - Warning: This is deprecated, use `appContext.runtime.schedule` instead.
    */
-  public func executeOnJavaScriptThread(runBlock: @escaping (() -> Void)) {
-    reactBridge?.dispatchBlock(runBlock, queue: RCTJSThread)
+  @available(*, deprecated, renamed: "runtime.schedule")
+  public func executeOnJavaScriptThread(_ closure: @escaping () -> Void) {
+    _runtime?.schedule(closure)
   }
 
   // MARK: - Classes

--- a/packages/expo-modules-core/ios/Core/Functions/ConcurrentFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/ConcurrentFunctionDefinition.swift
@@ -98,7 +98,7 @@ public final class ConcurrentFunctionDefinition<Args, FirstArgType, ReturnType>:
       }
 
       // Go back to the JS thread to execute the callback
-      appContext.executeOnJavaScriptThread {
+      try appContext.runtime.schedule {
         callback(result)
       }
     }


### PR DESCRIPTION
# Why

Initially I wanted to replace `reactBridge.dispatchBlock` with `runtime.schedule`, but then I thought we should deprecate `executeOnJavaScriptThread` entirely. There should be only one way to do the same thing and the latter seems clearer, safer and also lets us specify the priority.

# How

- Changed the existing implementation to use the runtime scheduler instead of the bridge and marked it as deprecated
- Updated places where we used `executeOnJavaScriptThread`

# Test Plan

This function was used in concurrent async functions to go back to the JS thread to invoke the callback so I ran tests on some modules using them (such as `Image.loadAsync`)