### PR TITLE
[e2e] Update android emulator installation instructions in README.md

### DIFF
--- a/apps/bare-expo/e2e/README.md
+++ b/apps/bare-expo/e2e/README.md
@@ -9,6 +9,9 @@
 - use the following command to generate the Android emulator:
 
 ```bash
+# Install the system image:
+sdkmanager "system-images;android-36;google_apis;x86_64"
+# Create the emulator:
 avdmanager create avd --force -n pixel_7_pro --package 'system-images;android-36;google_apis;x86_64' --device pixel_7_pro
 ```
 

--- a/apps/bare-expo/e2e/README.md
+++ b/apps/bare-expo/e2e/README.md
@@ -6,13 +6,13 @@
 - `brew install oxipng` for image compression
 - run `yarn install` in `bare-expo/e2e/image-comparison`
 - (optional, recommended) Alignment with devices which are used in CI ([iOS](https://github.com/expo/expo/blob/051a306ce7c5b875f7398450e5aeec2e52e313ae/apps/bare-expo/scripts/start-ios-e2e-test.ts#L18), [Android](https://github.com/expo/expo/blob/051a306ce7c5b875f7398450e5aeec2e52e313ae/.github/actions/use-android-emulator/action.yml#L48)). This is necessary for assertions on what is visible on the screen and (especially) for view shots to match.
-- use the following command to generate the Android emulator:
+- use the following commands to generate the Android emulator:
 
 ```bash
 # Install the system image:
-sdkmanager "system-images;android-36;google_apis;x86_64"
+sdkmanager "system-images;android-36;google_apis;arm64-v8a"
 # Create the emulator:
-avdmanager create avd --force -n pixel_7_pro --package 'system-images;android-36;google_apis;x86_64' --device pixel_7_pro
+avdmanager create avd --force -n pixel_7_pro --package 'system-images;android-36;google_apis;arm64-v8a' --device pixel_7_pro
 ```
 
 ### Authoring e2e tests


### PR DESCRIPTION
# Why

In the instructions we provide a command to create the avd, but when the system image is missing it fails.
Also the proposed avd is `x86_64`, our typical development devices are ARM macbooks.

# How

Add the installation command so that the setup is more straightforward, change the architecture to `arm64-v8a`

# Test Plan

Tested when setting up e2e on my machine
