### PR TITLE
[update] add process timeout to testflight job

### DIFF
--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -614,7 +614,7 @@ You can pass the following parameters into the `params` list:
 | external_groups                 | string[] | Optional. An array of TestFlight external group names to add the build to.                                                                  |
 | changelog                       | string   | Optional. Test notes ("What to Test") for TestFlight testers.                                                                               |
 | submit_beta_review              | boolean  | Optional. Whether to submit for Beta App Review. If not specified, defaults to `true` when external_groups are provided, `false` otherwise. |
-| wait_processing_timeout_seconds | number   | Optional. Timeout in seconds for waiting for App Store Connect build processing. Defaults to `1800` (30 minutes).                           |
+| wait_processing_timeout_seconds | number   | Optional. Timeout in seconds to wait for App Store Connect build processing. Defaults to `1800` (30 minutes).                           |
 
 #### Outputs
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -599,20 +599,22 @@ jobs:
       external_groups: string[] # optional
       changelog: string # optional
       submit_beta_review: boolean # optional
+      wait_processing_timeout_seconds: number # optional - default: 1800 (30 minutes)
 ```
 
 #### Parameters
 
 You can pass the following parameters into the `params` list:
 
-| Parameter          | Type     | Description                                                                                                                                 |
-| ------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| build_id           | string   | Required. The ID of the iOS build to distribute.                                                                                            |
-| profile            | string   | Optional. The submit profile to use. Defaults to `production`.                                                                              |
-| internal_groups    | string[] | Optional. An array of TestFlight internal group names to add the build to. Only include groups without automatic distribution enabled.      |
-| external_groups    | string[] | Optional. An array of TestFlight external group names to add the build to.                                                                  |
-| changelog          | string   | Optional. Test notes ("What to Test") for TestFlight testers.                                                                               |
-| submit_beta_review | boolean  | Optional. Whether to submit for Beta App Review. If not specified, defaults to `true` when external_groups are provided, `false` otherwise. |
+| Parameter                       | Type     | Description                                                                                                                                 |
+| ------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| build_id                        | string   | Required. The ID of the iOS build to distribute.                                                                                            |
+| profile                         | string   | Optional. The submit profile to use. Defaults to `production`.                                                                              |
+| internal_groups                 | string[] | Optional. An array of TestFlight internal group names to add the build to. Only include groups without automatic distribution enabled.      |
+| external_groups                 | string[] | Optional. An array of TestFlight external group names to add the build to.                                                                  |
+| changelog                       | string   | Optional. Test notes ("What to Test") for TestFlight testers.                                                                               |
+| submit_beta_review              | boolean  | Optional. Whether to submit for Beta App Review. If not specified, defaults to `true` when external_groups are provided, `false` otherwise. |
+| wait_processing_timeout_seconds | number   | Optional. Timeout in seconds for waiting for App Store Connect build processing. Defaults to `1800` (30 minutes).                           |
 
 #### Outputs
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -614,7 +614,7 @@ You can pass the following parameters into the `params` list:
 | external_groups                 | string[] | Optional. An array of TestFlight external group names to add the build to.                                                                  |
 | changelog                       | string   | Optional. Test notes ("What to Test") for TestFlight testers.                                                                               |
 | submit_beta_review              | boolean  | Optional. Whether to submit for Beta App Review. If not specified, defaults to `true` when external_groups are provided, `false` otherwise. |
-| wait_processing_timeout_seconds | number   | Optional. Timeout in seconds to wait for App Store Connect build processing. Defaults to `1800` (30 minutes).                           |
+| wait_processing_timeout_seconds | number   | Optional. Timeout in seconds to wait for App Store Connect build processing. Defaults to `1800` (30 minutes).                               |
 
 #### Outputs
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -1015,6 +1015,7 @@ jobs:
       external_groups: string[] # optional
       changelog: string # optional
       submit_beta_review: boolean # optional
+      wait_processing_timeout_seconds: number # optional, default: 1800 (30 minutes)
 ```
 
 This job outputs the following properties:


### PR DESCRIPTION
# Why

Set a reasonable default timeout (30 minutes) for App Store Connect build processing of the `testflight` workflow job and allow users to customize it.

# How

Update testflight docs.

# Test Plan

Verify locally
