### PR TITLE
[docs] Fix example code in ImageManipulator reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/imagemanipulator.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagemanipulator.mdx
@@ -29,31 +29,50 @@ files={{
 dependencies={['expo-asset', 'expo-image-manipulator']}>
 
 ```jsx
-import { useState } from 'react';
-import { Button, Image, StyleSheet, View } from 'react-native';
+import { useEffect, useState } from 'react';
+import { Button, Image, StyleSheet, Text, View } from 'react-native';
 import { Asset } from 'expo-asset';
 import { FlipType, SaveFormat, useImageManipulator } from 'expo-image-manipulator';
 
 const IMAGE = Asset.fromModule(require('./assets/snack-icon.png'));
 
 export default function App() {
-  const [image, setImage] = useState(IMAGE);
-  const context = useImageManipulator(IMAGE.uri);
+  const [imageUri, setImageUri] = useState(IMAGE.uri);
+  const [isReady, setIsReady] = useState(false);
+  const context = useImageManipulator(imageUri);
+
+  const loadImageAsync = async () => {
+    await IMAGE.downloadAsync();
+    setImageUri(IMAGE.localUri ?? IMAGE.uri);
+    setIsReady(true);
+  };
+
+  useEffect(() => {
+    loadImageAsync();
+  }, []);
 
   const rotate90andFlip = async () => {
     context.rotate(90).flip(FlipType.Vertical);
-    const image = await context.renderAsync();
-    const result = await image.saveAsync({
+    const renderedImage = await context.renderAsync();
+    const result = await renderedImage.saveAsync({
       format: SaveFormat.PNG,
     });
 
-    setImage(result);
+    setImageUri(result.uri);
   };
+
+  if (!isReady) {
+    return (
+      <View style={styles.container}>
+        <Text>Loading image...</Text>
+      </View>
+    );
+  }
 
   return (
     <View style={styles.container}>
       <View style={styles.imageContainer}>
-        <Image source={{ uri: image.localUri || image.uri }} style={styles.image} />
+        <Image source={{ uri: imageUri }} style={styles.image} />
       </View>
       <Button title="Rotate and Flip" onPress={rotate90andFlip} />
     </View>

--- a/docs/pages/versions/v54.0.0/sdk/imagemanipulator.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/imagemanipulator.mdx
@@ -29,31 +29,50 @@ files={{
 dependencies={['expo-asset', 'expo-image-manipulator']}>
 
 ```jsx
-import { useState } from 'react';
-import { Button, Image, StyleSheet, View } from 'react-native';
+import { useEffect, useState } from 'react';
+import { Button, Image, StyleSheet, Text, View } from 'react-native';
 import { Asset } from 'expo-asset';
 import { FlipType, SaveFormat, useImageManipulator } from 'expo-image-manipulator';
 
 const IMAGE = Asset.fromModule(require('./assets/snack-icon.png'));
 
 export default function App() {
-  const [image, setImage] = useState(IMAGE);
-  const context = useImageManipulator(IMAGE.uri);
+  const [imageUri, setImageUri] = useState(IMAGE.uri);
+  const [isReady, setIsReady] = useState(false);
+  const context = useImageManipulator(imageUri);
+
+  const loadImageAsync = async () => {
+    await IMAGE.downloadAsync();
+    setImageUri(IMAGE.localUri ?? IMAGE.uri);
+    setIsReady(true);
+  };
+
+  useEffect(() => {
+    loadImageAsync();
+  }, []);
 
   const rotate90andFlip = async () => {
     context.rotate(90).flip(FlipType.Vertical);
-    const image = await context.renderAsync();
-    const result = await image.saveAsync({
+    const renderedImage = await context.renderAsync();
+    const result = await renderedImage.saveAsync({
       format: SaveFormat.PNG,
     });
 
-    setImage(result);
+    setImageUri(result.uri);
   };
+
+  if (!isReady) {
+    return (
+      <View style={styles.container}>
+        <Text>Loading image...</Text>
+      </View>
+    );
+  }
 
   return (
     <View style={styles.container}>
       <View style={styles.imageContainer}>
-        <Image source={{ uri: image.localUri || image.uri }} style={styles.image} />
+        <Image source={{ uri: imageUri }} style={styles.image} />
       </View>
       <Button title="Rotate and Flip" onPress={rotate90andFlip} />
     </View>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18268

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix example code in ImageManipulator reference (unversioned and SDK 54).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Tested the updated example code in Snack: https://snack.expo.dev/@amanhimself/basic-imagemanipulator-usage.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
