### PR TITLE
[docs] Fix Android brownfield config for release mode

### DIFF
--- a/docs/public/static/diffs/brownfield/android/app-build-gradle-custom-root.diff
+++ b/docs/public/static/diffs/brownfield/android/app-build-gradle-custom-root.diff
@@ -1,13 +1,14 @@
 diff --git a/app/build.gradle b/app/build.gradle
-index 6b3b074..a35aba1 100644
+index 2c1b374..6aefd77 100644
 --- a/app/build.gradle
 +++ b/app/build.gradle
-@@ -50,7 +50,7 @@ dependencies {
+@@ -49,8 +49,9 @@ dependencies {
      debugImplementation libs.androidx.ui.test.manifest
  }
 
 -def projectRoot = rootDir.getAbsoluteFile().getParentFile().getAbsolutePath()
 +def projectRoot = new File(rootDir.getAbsoluteFile(), 'my-project').getAbsolutePath()
  react {
++    root = new File(projectRoot)
      entryFile = file(["node", "-e", "require('expo/scripts/resolveAppEntry')", projectRoot, "android", "absolute"].execute(null, rootDir).text.trim())
      reactNativeDir = new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim()).getParentFile().getAbsoluteFile()


### PR DESCRIPTION
# Why

We missed an extra config to build in release mode when using a custom folder structure with brownfield on Android, causing release builds to fail to compile the JS bundle.

# How

Update Android brownfiled custom-root diff to include `root = new File(projectRoot)`. This ensures that the CLI commands will be invoked from this folder as working directory

# Test Plan
N / A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
