### PR TITLE
Upgrade React Native to 0.83.0-rc.5

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -644,7 +644,7 @@ PODS:
     - Yoga
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
-  - FBLazyVector (0.83.0-rc.3)
+  - FBLazyVector (0.83.0-rc.5)
   - hermes-engine (0.14.0):
     - hermes-engine/Pre-built (= 0.14.0)
   - hermes-engine/Pre-built (0.14.0)
@@ -704,35 +704,35 @@ PODS:
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (9.1.0)
   - Quick (7.3.1)
-  - RCTDeprecation (0.83.0-rc.3)
-  - RCTRequired (0.83.0-rc.3)
-  - RCTSwiftUI (0.83.0-rc.3)
-  - RCTSwiftUIWrapper (0.83.0-rc.3):
+  - RCTDeprecation (0.83.0-rc.5)
+  - RCTRequired (0.83.0-rc.5)
+  - RCTSwiftUI (0.83.0-rc.5)
+  - RCTSwiftUIWrapper (0.83.0-rc.5):
     - RCTSwiftUI
-  - RCTTypeSafety (0.83.0-rc.3):
-    - FBLazyVector (= 0.83.0-rc.3)
-    - RCTRequired (= 0.83.0-rc.3)
-    - React-Core (= 0.83.0-rc.3)
+  - RCTTypeSafety (0.83.0-rc.5):
+    - FBLazyVector (= 0.83.0-rc.5)
+    - RCTRequired (= 0.83.0-rc.5)
+    - React-Core (= 0.83.0-rc.5)
   - ReachabilitySwift (5.2.4)
-  - React (0.83.0-rc.3):
-    - React-Core (= 0.83.0-rc.3)
-    - React-Core/DevSupport (= 0.83.0-rc.3)
-    - React-Core/RCTWebSocket (= 0.83.0-rc.3)
-    - React-RCTActionSheet (= 0.83.0-rc.3)
-    - React-RCTAnimation (= 0.83.0-rc.3)
-    - React-RCTBlob (= 0.83.0-rc.3)
-    - React-RCTImage (= 0.83.0-rc.3)
-    - React-RCTLinking (= 0.83.0-rc.3)
-    - React-RCTNetwork (= 0.83.0-rc.3)
-    - React-RCTSettings (= 0.83.0-rc.3)
-    - React-RCTText (= 0.83.0-rc.3)
-    - React-RCTVibration (= 0.83.0-rc.3)
-  - React-callinvoker (0.83.0-rc.3)
-  - React-Core (0.83.0-rc.3):
+  - React (0.83.0-rc.5):
+    - React-Core (= 0.83.0-rc.5)
+    - React-Core/DevSupport (= 0.83.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.83.0-rc.5)
+    - React-RCTActionSheet (= 0.83.0-rc.5)
+    - React-RCTAnimation (= 0.83.0-rc.5)
+    - React-RCTBlob (= 0.83.0-rc.5)
+    - React-RCTImage (= 0.83.0-rc.5)
+    - React-RCTLinking (= 0.83.0-rc.5)
+    - React-RCTNetwork (= 0.83.0-rc.5)
+    - React-RCTSettings (= 0.83.0-rc.5)
+    - React-RCTText (= 0.83.0-rc.5)
+    - React-RCTVibration (= 0.83.0-rc.5)
+  - React-callinvoker (0.83.0-rc.5)
+  - React-Core (0.83.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.83.0-rc.3)
+    - React-Core/Default (= 0.83.0-rc.5)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -747,66 +747,9 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core-prebuilt (0.83.0-rc.3):
+  - React-Core-prebuilt (0.83.0-rc.5):
     - ReactNativeDependencies
-  - React-Core/CoreModulesHeaders (0.83.0-rc.3):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/Default (0.83.0-rc.3):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/DevSupport (0.83.0-rc.3):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default (= 0.83.0-rc.3)
-    - React-Core/RCTWebSocket (= 0.83.0-rc.3)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.83.0-rc.3):
+  - React-Core/CoreModulesHeaders (0.83.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -825,7 +768,45 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.83.0-rc.3):
+  - React-Core/Default (0.83.0-rc.5):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/DevSupport (0.83.0-rc.5):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-Core/Default (= 0.83.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.83.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.83.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -844,7 +825,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTBlobHeaders (0.83.0-rc.3):
+  - React-Core/RCTAnimationHeaders (0.83.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -863,7 +844,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTImageHeaders (0.83.0-rc.3):
+  - React-Core/RCTBlobHeaders (0.83.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -882,7 +863,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.83.0-rc.3):
+  - React-Core/RCTImageHeaders (0.83.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -901,7 +882,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.83.0-rc.3):
+  - React-Core/RCTLinkingHeaders (0.83.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -920,7 +901,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.83.0-rc.3):
+  - React-Core/RCTNetworkHeaders (0.83.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -939,7 +920,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTTextHeaders (0.83.0-rc.3):
+  - React-Core/RCTSettingsHeaders (0.83.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -958,7 +939,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.83.0-rc.3):
+  - React-Core/RCTTextHeaders (0.83.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -977,11 +958,11 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTWebSocket (0.83.0-rc.3):
+  - React-Core/RCTVibrationHeaders (0.83.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.83.0-rc.3)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -996,40 +977,59 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-CoreModules (0.83.0-rc.3):
-    - RCTTypeSafety (= 0.83.0-rc.3)
+  - React-Core/RCTWebSocket (0.83.0-rc.5):
+    - hermes-engine
+    - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/CoreModulesHeaders (= 0.83.0-rc.3)
+    - React-Core/Default (= 0.83.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-CoreModules (0.83.0-rc.5):
+    - RCTTypeSafety (= 0.83.0-rc.5)
+    - React-Core-prebuilt
+    - React-Core/CoreModulesHeaders (= 0.83.0-rc.5)
     - React-debug
-    - React-jsi (= 0.83.0-rc.3)
+    - React-jsi (= 0.83.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.83.0-rc.3)
+    - React-RCTImage (= 0.83.0-rc.5)
     - React-runtimeexecutor
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
-  - React-cxxreact (0.83.0-rc.3):
+  - React-cxxreact (0.83.0-rc.5):
     - hermes-engine
-    - React-callinvoker (= 0.83.0-rc.3)
+    - React-callinvoker (= 0.83.0-rc.5)
     - React-Core-prebuilt
-    - React-debug (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
+    - React-debug (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.83.0-rc.3)
-    - React-perflogger (= 0.83.0-rc.3)
+    - React-logger (= 0.83.0-rc.5)
+    - React-perflogger (= 0.83.0-rc.5)
     - React-runtimeexecutor
-    - React-timing (= 0.83.0-rc.3)
+    - React-timing (= 0.83.0-rc.5)
     - React-utils
     - ReactNativeDependencies
-  - React-debug (0.83.0-rc.3)
-  - React-defaultsnativemodule (0.83.0-rc.3):
+  - React-debug (0.83.0-rc.5)
+  - React-defaultsnativemodule (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-domnativemodule
@@ -1044,7 +1044,7 @@ PODS:
     - React-webperformancenativemodule
     - ReactNativeDependencies
     - Yoga
-  - React-domnativemodule (0.83.0-rc.3):
+  - React-domnativemodule (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-Fabric
@@ -1058,7 +1058,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric (0.83.0-rc.3):
+  - React-Fabric (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1066,25 +1066,25 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/animated (= 0.83.0-rc.3)
-    - React-Fabric/animationbackend (= 0.83.0-rc.3)
-    - React-Fabric/animations (= 0.83.0-rc.3)
-    - React-Fabric/attributedstring (= 0.83.0-rc.3)
-    - React-Fabric/bridging (= 0.83.0-rc.3)
-    - React-Fabric/componentregistry (= 0.83.0-rc.3)
-    - React-Fabric/componentregistrynative (= 0.83.0-rc.3)
-    - React-Fabric/components (= 0.83.0-rc.3)
-    - React-Fabric/consistency (= 0.83.0-rc.3)
-    - React-Fabric/core (= 0.83.0-rc.3)
-    - React-Fabric/dom (= 0.83.0-rc.3)
-    - React-Fabric/imagemanager (= 0.83.0-rc.3)
-    - React-Fabric/leakchecker (= 0.83.0-rc.3)
-    - React-Fabric/mounting (= 0.83.0-rc.3)
-    - React-Fabric/observers (= 0.83.0-rc.3)
-    - React-Fabric/scheduler (= 0.83.0-rc.3)
-    - React-Fabric/telemetry (= 0.83.0-rc.3)
-    - React-Fabric/templateprocessor (= 0.83.0-rc.3)
-    - React-Fabric/uimanager (= 0.83.0-rc.3)
+    - React-Fabric/animated (= 0.83.0-rc.5)
+    - React-Fabric/animationbackend (= 0.83.0-rc.5)
+    - React-Fabric/animations (= 0.83.0-rc.5)
+    - React-Fabric/attributedstring (= 0.83.0-rc.5)
+    - React-Fabric/bridging (= 0.83.0-rc.5)
+    - React-Fabric/componentregistry (= 0.83.0-rc.5)
+    - React-Fabric/componentregistrynative (= 0.83.0-rc.5)
+    - React-Fabric/components (= 0.83.0-rc.5)
+    - React-Fabric/consistency (= 0.83.0-rc.5)
+    - React-Fabric/core (= 0.83.0-rc.5)
+    - React-Fabric/dom (= 0.83.0-rc.5)
+    - React-Fabric/imagemanager (= 0.83.0-rc.5)
+    - React-Fabric/leakchecker (= 0.83.0-rc.5)
+    - React-Fabric/mounting (= 0.83.0-rc.5)
+    - React-Fabric/observers (= 0.83.0-rc.5)
+    - React-Fabric/scheduler (= 0.83.0-rc.5)
+    - React-Fabric/telemetry (= 0.83.0-rc.5)
+    - React-Fabric/templateprocessor (= 0.83.0-rc.5)
+    - React-Fabric/uimanager (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1096,26 +1096,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/animated (0.83.0-rc.3):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/animationbackend (0.83.0-rc.3):
+  - React-Fabric/animated (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1134,7 +1115,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/animations (0.83.0-rc.3):
+  - React-Fabric/animationbackend (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1153,7 +1134,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/attributedstring (0.83.0-rc.3):
+  - React-Fabric/animations (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1172,7 +1153,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/bridging (0.83.0-rc.3):
+  - React-Fabric/attributedstring (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1191,7 +1172,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistry (0.83.0-rc.3):
+  - React-Fabric/bridging (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1210,7 +1191,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistrynative (0.83.0-rc.3):
+  - React-Fabric/componentregistry (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1229,30 +1210,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components (0.83.0-rc.3):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.83.0-rc.3)
-    - React-Fabric/components/root (= 0.83.0-rc.3)
-    - React-Fabric/components/scrollview (= 0.83.0-rc.3)
-    - React-Fabric/components/view (= 0.83.0-rc.3)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/components/legacyviewmanagerinterop (0.83.0-rc.3):
+  - React-Fabric/componentregistrynative (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1271,7 +1229,30 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/root (0.83.0-rc.3):
+  - React-Fabric/components (0.83.0-rc.5):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.83.0-rc.5)
+    - React-Fabric/components/root (= 0.83.0-rc.5)
+    - React-Fabric/components/scrollview (= 0.83.0-rc.5)
+    - React-Fabric/components/view (= 0.83.0-rc.5)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/legacyviewmanagerinterop (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1290,7 +1271,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/scrollview (0.83.0-rc.3):
+  - React-Fabric/components/root (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1309,7 +1290,26 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/view (0.83.0-rc.3):
+  - React-Fabric/components/scrollview (0.83.0-rc.5):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/view (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1330,7 +1330,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric/consistency (0.83.0-rc.3):
+  - React-Fabric/consistency (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1349,7 +1349,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/core (0.83.0-rc.3):
+  - React-Fabric/core (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1368,7 +1368,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/dom (0.83.0-rc.3):
+  - React-Fabric/dom (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1387,7 +1387,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/imagemanager (0.83.0-rc.3):
+  - React-Fabric/imagemanager (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1406,7 +1406,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/leakchecker (0.83.0-rc.3):
+  - React-Fabric/leakchecker (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1425,7 +1425,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/mounting (0.83.0-rc.3):
+  - React-Fabric/mounting (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1444,7 +1444,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers (0.83.0-rc.3):
+  - React-Fabric/observers (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1452,8 +1452,8 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.83.0-rc.3)
-    - React-Fabric/observers/intersection (= 0.83.0-rc.3)
+    - React-Fabric/observers/events (= 0.83.0-rc.5)
+    - React-Fabric/observers/intersection (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1465,26 +1465,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers/events (0.83.0-rc.3):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/observers/intersection (0.83.0-rc.3):
+  - React-Fabric/observers/events (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1503,7 +1484,26 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/scheduler (0.83.0-rc.3):
+  - React-Fabric/observers/intersection (0.83.0-rc.5):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/scheduler (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1525,7 +1525,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/telemetry (0.83.0-rc.3):
+  - React-Fabric/telemetry (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1544,7 +1544,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/templateprocessor (0.83.0-rc.3):
+  - React-Fabric/templateprocessor (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1563,7 +1563,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager (0.83.0-rc.3):
+  - React-Fabric/uimanager (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1571,7 +1571,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.83.0-rc.3)
+    - React-Fabric/uimanager/consistency (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1584,7 +1584,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager/consistency (0.83.0-rc.3):
+  - React-Fabric/uimanager/consistency (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1604,7 +1604,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-FabricComponents (0.83.0-rc.3):
+  - React-FabricComponents (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1613,8 +1613,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.83.0-rc.3)
-    - React-FabricComponents/textlayoutmanager (= 0.83.0-rc.3)
+    - React-FabricComponents/components (= 0.83.0-rc.5)
+    - React-FabricComponents/textlayoutmanager (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1627,7 +1627,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components (0.83.0-rc.3):
+  - React-FabricComponents/components (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1636,18 +1636,18 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.83.0-rc.3)
-    - React-FabricComponents/components/iostextinput (= 0.83.0-rc.3)
-    - React-FabricComponents/components/modal (= 0.83.0-rc.3)
-    - React-FabricComponents/components/rncore (= 0.83.0-rc.3)
-    - React-FabricComponents/components/safeareaview (= 0.83.0-rc.3)
-    - React-FabricComponents/components/scrollview (= 0.83.0-rc.3)
-    - React-FabricComponents/components/switch (= 0.83.0-rc.3)
-    - React-FabricComponents/components/text (= 0.83.0-rc.3)
-    - React-FabricComponents/components/textinput (= 0.83.0-rc.3)
-    - React-FabricComponents/components/unimplementedview (= 0.83.0-rc.3)
-    - React-FabricComponents/components/virtualview (= 0.83.0-rc.3)
-    - React-FabricComponents/components/virtualviewexperimental (= 0.83.0-rc.3)
+    - React-FabricComponents/components/inputaccessory (= 0.83.0-rc.5)
+    - React-FabricComponents/components/iostextinput (= 0.83.0-rc.5)
+    - React-FabricComponents/components/modal (= 0.83.0-rc.5)
+    - React-FabricComponents/components/rncore (= 0.83.0-rc.5)
+    - React-FabricComponents/components/safeareaview (= 0.83.0-rc.5)
+    - React-FabricComponents/components/scrollview (= 0.83.0-rc.5)
+    - React-FabricComponents/components/switch (= 0.83.0-rc.5)
+    - React-FabricComponents/components/text (= 0.83.0-rc.5)
+    - React-FabricComponents/components/textinput (= 0.83.0-rc.5)
+    - React-FabricComponents/components/unimplementedview (= 0.83.0-rc.5)
+    - React-FabricComponents/components/virtualview (= 0.83.0-rc.5)
+    - React-FabricComponents/components/virtualviewexperimental (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1660,28 +1660,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.83.0-rc.3):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.83.0-rc.3):
+  - React-FabricComponents/components/inputaccessory (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1702,7 +1681,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/modal (0.83.0-rc.3):
+  - React-FabricComponents/components/iostextinput (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1723,7 +1702,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/rncore (0.83.0-rc.3):
+  - React-FabricComponents/components/modal (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1744,7 +1723,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.83.0-rc.3):
+  - React-FabricComponents/components/rncore (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1765,7 +1744,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/scrollview (0.83.0-rc.3):
+  - React-FabricComponents/components/safeareaview (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1786,7 +1765,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/switch (0.83.0-rc.3):
+  - React-FabricComponents/components/scrollview (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1807,7 +1786,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/text (0.83.0-rc.3):
+  - React-FabricComponents/components/switch (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1828,7 +1807,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/textinput (0.83.0-rc.3):
+  - React-FabricComponents/components/text (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1849,7 +1828,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.83.0-rc.3):
+  - React-FabricComponents/components/textinput (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1870,7 +1849,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/virtualview (0.83.0-rc.3):
+  - React-FabricComponents/components/unimplementedview (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1891,7 +1870,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/virtualviewexperimental (0.83.0-rc.3):
+  - React-FabricComponents/components/virtualview (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1912,7 +1891,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.83.0-rc.3):
+  - React-FabricComponents/components/virtualviewexperimental (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1933,27 +1912,48 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricImage (0.83.0-rc.3):
+  - React-FabricComponents/textlayoutmanager (0.83.0-rc.5):
     - hermes-engine
-    - RCTRequired (= 0.83.0-rc.3)
-    - RCTTypeSafety (= 0.83.0-rc.3)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
+  - React-FabricImage (0.83.0-rc.5):
+    - hermes-engine
+    - RCTRequired (= 0.83.0-rc.5)
+    - RCTTypeSafety (= 0.83.0-rc.5)
     - React-Core-prebuilt
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.83.0-rc.3)
+    - React-jsiexecutor (= 0.83.0-rc.5)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-featureflags (0.83.0-rc.3):
+  - React-featureflags (0.83.0-rc.5):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-featureflagsnativemodule (0.83.0-rc.3):
+  - React-featureflagsnativemodule (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1962,27 +1962,27 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-graphics (0.83.0-rc.3):
+  - React-graphics (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
     - React-jsiexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-hermes (0.83.0-rc.3):
+  - React-hermes (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
-    - React-cxxreact (= 0.83.0-rc.3)
+    - React-cxxreact (= 0.83.0-rc.5)
     - React-jsi
-    - React-jsiexecutor (= 0.83.0-rc.3)
+    - React-jsiexecutor (= 0.83.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.83.0-rc.3)
+    - React-perflogger (= 0.83.0-rc.5)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-idlecallbacksnativemodule (0.83.0-rc.3):
+  - React-idlecallbacksnativemodule (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1992,7 +1992,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-ImageManager (0.83.0-rc.3):
+  - React-ImageManager (0.83.0-rc.5):
     - React-Core-prebuilt
     - React-Core/Default
     - React-debug
@@ -2001,7 +2001,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - ReactNativeDependencies
-  - React-intersectionobservernativemodule (0.83.0-rc.3):
+  - React-intersectionobservernativemodule (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -2016,7 +2016,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-jserrorhandler (0.83.0-rc.3):
+  - React-jserrorhandler (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -2025,11 +2025,11 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - ReactNativeDependencies
-  - React-jsi (0.83.0-rc.3):
+  - React-jsi (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsiexecutor (0.83.0-rc.3):
+  - React-jsiexecutor (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -2042,7 +2042,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-jsinspector (0.83.0-rc.3):
+  - React-jsinspector (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -2051,18 +2051,18 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.83.0-rc.3)
+    - React-perflogger (= 0.83.0-rc.5)
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-jsinspectorcdp (0.83.0-rc.3):
+  - React-jsinspectorcdp (0.83.0-rc.5):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsinspectornetwork (0.83.0-rc.3):
+  - React-jsinspectornetwork (0.83.0-rc.5):
     - React-Core-prebuilt
     - React-jsinspectorcdp
     - ReactNativeDependencies
-  - React-jsinspectortracing (0.83.0-rc.3):
+  - React-jsinspectortracing (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -2070,27 +2070,27 @@ PODS:
     - React-oscompat
     - React-timing
     - ReactNativeDependencies
-  - React-jsitooling (0.83.0-rc.3):
+  - React-jsitooling (0.83.0-rc.5):
     - React-Core-prebuilt
-    - React-cxxreact (= 0.83.0-rc.3)
+    - React-cxxreact (= 0.83.0-rc.5)
     - React-debug
-    - React-jsi (= 0.83.0-rc.3)
+    - React-jsi (= 0.83.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-jsitracing (0.83.0-rc.3):
+  - React-jsitracing (0.83.0-rc.5):
     - React-jsi
-  - React-logger (0.83.0-rc.3):
+  - React-logger (0.83.0-rc.5):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-Mapbuffer (0.83.0-rc.3):
+  - React-Mapbuffer (0.83.0-rc.5):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-microtasksnativemodule (0.83.0-rc.3):
+  - React-microtasksnativemodule (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -2351,7 +2351,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-NativeModulesApple (0.83.0-rc.3):
+  - React-NativeModulesApple (0.83.0-rc.5):
     - hermes-engine
     - React-callinvoker
     - React-Core
@@ -2366,7 +2366,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-networking (0.83.0-rc.3):
+  - React-networking (0.83.0-rc.5):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspectornetwork
@@ -2374,11 +2374,11 @@ PODS:
     - React-performancetimeline
     - React-timing
     - ReactNativeDependencies
-  - React-oscompat (0.83.0-rc.3)
-  - React-perflogger (0.83.0-rc.3):
+  - React-oscompat (0.83.0-rc.5)
+  - React-perflogger (0.83.0-rc.5):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-performancecdpmetrics (0.83.0-rc.3):
+  - React-performancecdpmetrics (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -2386,16 +2386,16 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - ReactNativeDependencies
-  - React-performancetimeline (0.83.0-rc.3):
+  - React-performancetimeline (0.83.0-rc.5):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspectortracing
     - React-perflogger
     - React-timing
     - ReactNativeDependencies
-  - React-RCTActionSheet (0.83.0-rc.3):
-    - React-Core/RCTActionSheetHeaders (= 0.83.0-rc.3)
-  - React-RCTAnimation (0.83.0-rc.3):
+  - React-RCTActionSheet (0.83.0-rc.5):
+    - React-Core/RCTActionSheetHeaders (= 0.83.0-rc.5)
+  - React-RCTAnimation (0.83.0-rc.5):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTAnimationHeaders
@@ -2405,7 +2405,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTAppDelegate (0.83.0-rc.3):
+  - React-RCTAppDelegate (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2433,7 +2433,7 @@ PODS:
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTBlob (0.83.0-rc.3):
+  - React-RCTBlob (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-Core/RCTBlobHeaders
@@ -2446,7 +2446,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFabric (0.83.0-rc.3):
+  - React-RCTFabric (0.83.0-rc.5):
     - hermes-engine
     - RCTSwiftUIWrapper
     - React-Core
@@ -2477,7 +2477,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-RCTFBReactNativeSpec (0.83.0-rc.3):
+  - React-RCTFBReactNativeSpec (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2485,10 +2485,10 @@ PODS:
     - React-Core-prebuilt
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.83.0-rc.3)
+    - React-RCTFBReactNativeSpec/components (= 0.83.0-rc.5)
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFBReactNativeSpec/components (0.83.0-rc.3):
+  - React-RCTFBReactNativeSpec/components (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2505,7 +2505,7 @@ PODS:
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-RCTImage (0.83.0-rc.3):
+  - React-RCTImage (0.83.0-rc.5):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTImageHeaders
@@ -2515,14 +2515,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTLinking (0.83.0-rc.3):
-    - React-Core/RCTLinkingHeaders (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
+  - React-RCTLinking (0.83.0-rc.5):
+    - React-Core/RCTLinkingHeaders (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.83.0-rc.3)
-  - React-RCTNetwork (0.83.0-rc.3):
+    - ReactCommon/turbomodule/core (= 0.83.0-rc.5)
+  - React-RCTNetwork (0.83.0-rc.5):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTNetworkHeaders
@@ -2536,7 +2536,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTRuntime (0.83.0-rc.3):
+  - React-RCTRuntime (0.83.0-rc.5):
     - hermes-engine
     - React-Core
     - React-Core-prebuilt
@@ -2552,7 +2552,7 @@ PODS:
     - React-RuntimeHermes
     - React-utils
     - ReactNativeDependencies
-  - React-RCTSettings (0.83.0-rc.3):
+  - React-RCTSettings (0.83.0-rc.5):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTSettingsHeaders
@@ -2561,10 +2561,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTText (0.83.0-rc.3):
-    - React-Core/RCTTextHeaders (= 0.83.0-rc.3)
+  - React-RCTText (0.83.0-rc.5):
+    - React-Core/RCTTextHeaders (= 0.83.0-rc.5)
     - Yoga
-  - React-RCTVibration (0.83.0-rc.3):
+  - React-RCTVibration (0.83.0-rc.5):
     - React-Core-prebuilt
     - React-Core/RCTVibrationHeaders
     - React-jsi
@@ -2572,15 +2572,15 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-rendererconsistency (0.83.0-rc.3)
-  - React-renderercss (0.83.0-rc.3):
+  - React-rendererconsistency (0.83.0-rc.5)
+  - React-renderercss (0.83.0-rc.5):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.83.0-rc.3):
+  - React-rendererdebug (0.83.0-rc.5):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-RuntimeApple (0.83.0-rc.3):
+  - React-RuntimeApple (0.83.0-rc.5):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -2603,7 +2603,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeCore (0.83.0-rc.3):
+  - React-RuntimeCore (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -2619,14 +2619,14 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-runtimeexecutor (0.83.0-rc.3):
+  - React-runtimeexecutor (0.83.0-rc.5):
     - React-Core-prebuilt
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.83.0-rc.3)
+    - React-jsi (= 0.83.0-rc.5)
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeHermes (0.83.0-rc.3):
+  - React-RuntimeHermes (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -2641,7 +2641,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-runtimescheduler (0.83.0-rc.3):
+  - React-runtimescheduler (0.83.0-rc.5):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -2657,15 +2657,15 @@ PODS:
     - React-timing
     - React-utils
     - ReactNativeDependencies
-  - React-timing (0.83.0-rc.3):
+  - React-timing (0.83.0-rc.5):
     - React-debug
-  - React-utils (0.83.0-rc.3):
+  - React-utils (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-debug
-    - React-jsi (= 0.83.0-rc.3)
+    - React-jsi (= 0.83.0-rc.5)
     - ReactNativeDependencies
-  - React-webperformancenativemodule (0.83.0-rc.3):
+  - React-webperformancenativemodule (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -2676,9 +2676,9 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - ReactAppDependencyProvider (0.83.0-rc.3):
+  - ReactAppDependencyProvider (0.83.0-rc.5):
     - ReactCodegen
-  - ReactCodegen (0.83.0-rc.3):
+  - ReactCodegen (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2698,43 +2698,43 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - ReactCommon (0.83.0-rc.3):
+  - ReactCommon (0.83.0-rc.5):
     - React-Core-prebuilt
-    - ReactCommon/turbomodule (= 0.83.0-rc.3)
+    - ReactCommon/turbomodule (= 0.83.0-rc.5)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule (0.83.0-rc.3):
+  - ReactCommon/turbomodule (0.83.0-rc.5):
     - hermes-engine
-    - React-callinvoker (= 0.83.0-rc.3)
+    - React-callinvoker (= 0.83.0-rc.5)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
-    - React-logger (= 0.83.0-rc.3)
-    - React-perflogger (= 0.83.0-rc.3)
-    - ReactCommon/turbomodule/bridging (= 0.83.0-rc.3)
-    - ReactCommon/turbomodule/core (= 0.83.0-rc.3)
+    - React-cxxreact (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
+    - React-logger (= 0.83.0-rc.5)
+    - React-perflogger (= 0.83.0-rc.5)
+    - ReactCommon/turbomodule/bridging (= 0.83.0-rc.5)
+    - ReactCommon/turbomodule/core (= 0.83.0-rc.5)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/bridging (0.83.0-rc.3):
+  - ReactCommon/turbomodule/bridging (0.83.0-rc.5):
     - hermes-engine
-    - React-callinvoker (= 0.83.0-rc.3)
+    - React-callinvoker (= 0.83.0-rc.5)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
-    - React-logger (= 0.83.0-rc.3)
-    - React-perflogger (= 0.83.0-rc.3)
+    - React-cxxreact (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
+    - React-logger (= 0.83.0-rc.5)
+    - React-perflogger (= 0.83.0-rc.5)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/core (0.83.0-rc.3):
+  - ReactCommon/turbomodule/core (0.83.0-rc.5):
     - hermes-engine
-    - React-callinvoker (= 0.83.0-rc.3)
+    - React-callinvoker (= 0.83.0-rc.5)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.83.0-rc.3)
-    - React-debug (= 0.83.0-rc.3)
-    - React-featureflags (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
-    - React-logger (= 0.83.0-rc.3)
-    - React-perflogger (= 0.83.0-rc.3)
-    - React-utils (= 0.83.0-rc.3)
+    - React-cxxreact (= 0.83.0-rc.5)
+    - React-debug (= 0.83.0-rc.5)
+    - React-featureflags (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
+    - React-logger (= 0.83.0-rc.5)
+    - React-perflogger (= 0.83.0-rc.5)
+    - React-utils (= 0.83.0-rc.5)
     - ReactNativeDependencies
-  - ReactNativeDependencies (0.83.0-rc.3)
+  - ReactNativeDependencies (0.83.0-rc.5)
   - RNCAsyncStorage (2.2.0):
     - hermes-engine
     - RCTRequired
@@ -3817,8 +3817,8 @@ SPEC CHECKSUMS:
   EXTaskManager: 7d80cb59c1faa3dcfa42035b185bcb5209ca7b1b
   EXUpdates: 83e4d666a085b44149f3b21d5bd057ad37b2c3e5
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
-  FBLazyVector: 14b0edddf1446bafe25388fcafb8e752f01c9876
-  hermes-engine: e33c73080ec31b854de9f4c025d453cbcdfb10df
+  FBLazyVector: a9d42cd9acb1b6e87eaef82916d91ad23136e4bb
+  hermes-engine: 9a270294aaec03556862ee83edd0f490710bfbb2
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -3827,43 +3827,43 @@ SPEC CHECKSUMS:
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
-  RCTDeprecation: 743787dda2b5197524c82143ce048738f722b9d1
-  RCTRequired: c095f5258e0c4a723653a42cd0bd63b7bacfabfd
-  RCTSwiftUI: d32a6cb82941045710ec3b4ae68dbb6cccf7e6db
-  RCTSwiftUIWrapper: e0fbc4c1aa47bed80a63602ba0f32cadb90a8377
-  RCTTypeSafety: a5ed9aeb43feb848a4043e72dbc20d29c9632ad0
+  RCTDeprecation: cc0af08b1e51c1d3b07c4fe9cd0b9163df475154
+  RCTRequired: c0cb29582513beb094acd06e0566ace3ce3b15a1
+  RCTSwiftUI: 890ac28774f2fde5cebe1ebbe037e41b0b0c7d18
+  RCTSwiftUIWrapper: 5be2ebb69cf9160438447579ebf5b123cfb0e877
+  RCTTypeSafety: 6f2136f534016f0891d9d39679c1b464eb91f628
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 444caa11c2b83e3b1ed6fa6182102c557c940b99
-  React-callinvoker: 86f02ac20583228911bf903a451b677d802c5863
-  React-Core: 4c30624c61366a085ea0665701137723bbf9d792
-  React-Core-prebuilt: 2903e782a26c1353f633435034ad4042859287db
-  React-CoreModules: fdb45864a5bb6cca3720dbac2659fa8dcf40aed2
-  React-cxxreact: 2fc01174c4a114d4517a739c982d1e594df280e2
-  React-debug: 4ee7c16e085c26584151f98bdf6c23fc350d4cf5
-  React-defaultsnativemodule: 45655eb7cac341e9fe454410fff22165a4be3882
-  React-domnativemodule: 9a73bfb08cded64fe28992efb548c1619e2aa07a
-  React-Fabric: cb6a1540dc8e54a06cbcdd0cc60c4516a535c021
-  React-FabricComponents: cd93c1b85558ea7218272c8202bb9b2f5a94b770
-  React-FabricImage: 5fb1b7c79c3c898506f99c4634dbd13a6eedebde
-  React-featureflags: 21ecfce9ba53bfe99817e8e9be8a89e1ab1df9df
-  React-featureflagsnativemodule: 90e8757fdf1f17d093b85a24f1988064daea6670
-  React-graphics: 52a09ab44d1feeab567e6b58fe1538b3d8ff8500
-  React-hermes: 5b528c756543650c0c61e43eb8878f38afd19dc2
-  React-idlecallbacksnativemodule: d4be8061a122e9b331f036b1236117a4d09588f1
-  React-ImageManager: ec43eeac34d09b0de01a2dfcfa72502510c4f08f
-  React-intersectionobservernativemodule: f49285534fa0283cdaf4d9458225cfe89b954698
-  React-jserrorhandler: 0c865633d6b03119aaa0f4b85ccd453d9329bbdd
-  React-jsi: 5ae7ce9f8669a3b26b915c7c2dcf227a8309c252
-  React-jsiexecutor: ec0953b503a685b00747f7fa3b6dbb3711f46efd
-  React-jsinspector: 32b5f4bc217a45e48f2d8e73528b98f55bdee743
-  React-jsinspectorcdp: 1563321232fa3b698a185e090522535f255e2940
-  React-jsinspectornetwork: 72614b2460f4d1798e86db6e412c5ec086595566
-  React-jsinspectortracing: c51071aad909d8e150fde60e22534f0b5dbfc0ee
-  React-jsitooling: b18310b006a2d3b5b36ee865e345d3da7cb9d09b
-  React-jsitracing: 3a93a6bd35081253c47639dfd234e0631ad308f2
-  React-logger: 52ef6553fc16d12e1abb41de0c3d262b28331ea7
-  React-Mapbuffer: 8c2c21804c1fece13af5572e62cbfcfa355657bf
-  React-microtasksnativemodule: 848bfe62eaa333b0495711d6a59c96d1b56a69f0
+  React: 8896aeaee7431bbbbee8b85592672c2742be80c9
+  React-callinvoker: 2b6eadc2850579c424c4b1bc3ad7f4452d3e48ce
+  React-Core: 66ae91bab722380ad0bb1f0dc1b12bebef20e1fd
+  React-Core-prebuilt: f8542cd6ff3c766df99c06b1ae73b2c96ccbfe5e
+  React-CoreModules: 772a8edd6d3e070410864fec6db5b7714edec5d9
+  React-cxxreact: 81daeec52c0629719a1d7fdd59bcb5b414d72377
+  React-debug: e8441fe272552c7687003906ac065f1067b607ee
+  React-defaultsnativemodule: 3817acd3f32dfe0e15c61ff824655f512a15355e
+  React-domnativemodule: 038bf94e8aa31b90e0c430dcaacdbc705545f5e0
+  React-Fabric: 9007f4fcc2963cbb3450b508ee8cb8595b8a18ae
+  React-FabricComponents: c18f56571b8fb756aa64ede97661b8fb6bc089bd
+  React-FabricImage: 7a6acbdfdf7859edbdc70c76d932fe558c19320f
+  React-featureflags: 9df96cbceeca5d6223953b26a2674db87c1a18b5
+  React-featureflagsnativemodule: a968abaef928d87ada59af07e6bd2f09900bbd82
+  React-graphics: 905f5c1c5956e3a193bbe08bcf7982d605fe63e1
+  React-hermes: a0f0d165074993c7847d933015fb682b01ed2cce
+  React-idlecallbacksnativemodule: eefca67a72d06c1ef52add41cb0379c0a624521c
+  React-ImageManager: dcbc712f96612e9f52454736fedf9f058f481c86
+  React-intersectionobservernativemodule: e5ff32a8f8a9dca060cd082a1a3d6a820ce3aef5
+  React-jserrorhandler: 08dafdd6baef94686f5b4d48eb68e38df2065c51
+  React-jsi: 8e57af579384ef5768b0239b9dfa3da62d9d38e1
+  React-jsiexecutor: 0c95d7412d8a6a8555ec28d067b5e0e3950b6a36
+  React-jsinspector: c7a6ad41569f76154109ef80ad5d677e528ea552
+  React-jsinspectorcdp: 43d44f2f5b54e7bc4d409ee6ed294a7526aefc8a
+  React-jsinspectornetwork: 5bfa398781cec973c4bd4ef2c7f6c689370c91ab
+  React-jsinspectortracing: 627ebe604268690c53a990863cab3fcc7943511b
+  React-jsitooling: 7849ee1596c332a5230679f52fd1beb4f47f9d9c
+  React-jsitracing: ba8d57ef74d3ffc3d9bc15547134b8f4d366360e
+  React-logger: 7fbc64214aab6c3bb3997345038e553937983592
+  React-Mapbuffer: 2f408e3e0c2b7961742d19cb6968ef6fd783a8ab
+  React-microtasksnativemodule: 2631260c7d842dc8fbcdd33189d25b8dbcf06235
   react-native-keyboard-controller: 5587bad7f102125e2020720c4e37e0b58ff5e52e
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
   react-native-pager-view: e37989fc447aa4b5de6d0d2ffb0229e817329246
@@ -3873,40 +3873,40 @@ SPEC CHECKSUMS:
   react-native-slider: b76fa3dd989d25e8c2751c2a546674dfc0c2b6f8
   react-native-view-shot: 26174e54ec6b4b7c5d70b86964b747919759adc1
   react-native-webview: a4f0775a31b73cf13cfc3d2d2b119aa94ec76e49
-  React-NativeModulesApple: 80ad1b2c0f297ddf09018e5539cc5d7c5bc9b4b2
-  React-networking: d8619e04a3d3590798d2bd560815f50307f23579
-  React-oscompat: 5c2b58647e220321355cf15809edfa186c35a07f
-  React-perflogger: ee2278145c48ea3a3de877af7077fe3f0eedf013
-  React-performancecdpmetrics: 366499895db4c8f650ca04928d417b2bbf95c84e
-  React-performancetimeline: a003c7b7c6be2a79bc2ffed461d450daa730c7a8
-  React-RCTActionSheet: e175bdb52bdee7ea507e2a30cd200a115b690215
-  React-RCTAnimation: bf7bf75d9d773f7a10a9cf8123e337d5e2cfc90e
-  React-RCTAppDelegate: 165af38f104fc09978fd689d0ddd98171fb0309c
-  React-RCTBlob: 89345a4768efa9dbf564b302011b164d79def62b
-  React-RCTFabric: 0bbbd3e83aabc29962751697b262e957a8516214
-  React-RCTFBReactNativeSpec: 1cc8b89614d0a04de54b448c9df1364e593bb181
-  React-RCTImage: 2223d4602af59c7fc0ee9592029dfc18391b6949
-  React-RCTLinking: 4d4aa6358872d1c757e497d3c4d349c4d8618b90
-  React-RCTNetwork: a511a9ddb70c9a29815561accc559176a0f48a6c
-  React-RCTRuntime: 529c6113daef13822d1648f1d306780c48caadf7
-  React-RCTSettings: 7dc0750219fc02919d35cdc2b100635219643de7
-  React-RCTText: b581c0bf877f927aa171d671aa51d41c740b3913
-  React-RCTVibration: 34de1a4888e5a827f39a4d10eb0e4c8352dc151b
-  React-rendererconsistency: d7a9a7bcc6eb0c5fd705aff01df878d2c1b009dd
-  React-renderercss: 0e2dc78de58eb0e94e100828d12666066f648642
-  React-rendererdebug: 24e1e3248859c66d71823921f3644768598b8465
-  React-RuntimeApple: ba89590d6a6857bcd709c47d24c54e1f8ec57602
-  React-RuntimeCore: f99adca09ea8a51eb7712f2c45881075196ad8bb
-  React-runtimeexecutor: ac5add875f8e76baae535024eb1e6ded4b33d960
-  React-RuntimeHermes: bf9c7bbf954e9288305f8d15d4c66d621f40b737
-  React-runtimescheduler: cd73c0c169181e6cb026fe73ce7f8468e2bd73ae
-  React-timing: 444b1b4d7a55a4696e42bbaca49e73c0947cffc6
-  React-utils: 592b56a766a3638089316668fe0ff16f64384643
-  React-webperformancenativemodule: 200d840520aa1c9a51ed1040ee810e0310ae8acc
-  ReactAppDependencyProvider: 9ca54963f57b9d01b93b4014ebabf5b39bc61773
-  ReactCodegen: d80949c54d678a87d3d6baba00c7c81ba293b1b7
-  ReactCommon: 5c22adade7e11913a9a72b3c420c0071553b572f
-  ReactNativeDependencies: 17ee4b03687ec730ec226baa89af6be2b15f4044
+  React-NativeModulesApple: 703c3cffcf3a88a977312b7aff9373f320d47b41
+  React-networking: 5d7e03f512935d0a5a2daa1dcf4951851a40fbf5
+  React-oscompat: 326c21cd206db353bb2b716b7ed6e967e53f4270
+  React-perflogger: 6c93378ad8b86f147b4b521bfd7fe4e15528be7b
+  React-performancecdpmetrics: 68987dc00db6c0194fa0b4626c06c485dca5ccca
+  React-performancetimeline: 60012da450aa8c1324bf95f4d9a59e7f6d204166
+  React-RCTActionSheet: b972aa9d319cf3001482804a3137ee11c8a89620
+  React-RCTAnimation: 03bc83ca17fe82f07f903c65f2af6605de0a08a7
+  React-RCTAppDelegate: 5973b6bc18aba3c5f0432c9b937eb108be087a96
+  React-RCTBlob: 2f29fa294dcb8666ae1123926accc03c653ca025
+  React-RCTFabric: 480b8af9e3eca542265d8cdfa128a965ea8840f8
+  React-RCTFBReactNativeSpec: f857e00f108b9b925e117a00e6080cf5dee2afb7
+  React-RCTImage: 2c7bc6f51894fd60d2c6a9983834a03d1f318ba7
+  React-RCTLinking: 32b7df2a5de9c7399891c90c7898f28eb368cbe5
+  React-RCTNetwork: 93b5814fd29be4248fb06cc7c416832f017705f3
+  React-RCTRuntime: 5e0ef6e30fb3c25b810456d6159bffc2b31baeec
+  React-RCTSettings: 95e8fc667242496a927f873d93a7def4e50ed485
+  React-RCTText: dd7b7e20ca7f142bfa1419738e21a09838cf7997
+  React-RCTVibration: 1fce77e5829e27747c2615f94bcba88cd1e95aed
+  React-rendererconsistency: fcba6a533c4f8883ebec40a97ed91b640006c1e3
+  React-renderercss: b3db1263258e9a94ad5e8bf75ef8306887769928
+  React-rendererdebug: 36f0dd428026d944cf9996a92da406ec2fd85753
+  React-RuntimeApple: d0693c7a0774067b7694fce6e2bfd82a8bec9131
+  React-RuntimeCore: ea2818cce7a39e5704ad16c43ede95afb4998f49
+  React-runtimeexecutor: 342d82e5a127c8aadb8339456899422bf4393403
+  React-RuntimeHermes: 2839515edc95bf8c3fdf7268a42bc883d262db59
+  React-runtimescheduler: 0e16cee26cc89c9908da4aa940a54ca3f131ccc6
+  React-timing: 2da67c8d3c5dba510c12be6500e19eff5449e150
+  React-utils: 67ec8a01ed4cae43072d490c54b08d518b266224
+  React-webperformancenativemodule: c85feb7f62a8e5d1665a2e46045a164bb0485131
+  ReactAppDependencyProvider: 07461dc99cceeca991cece80447fd21345113f16
+  ReactCodegen: 924af208e62aaae2696e480188cbfa1f565a6e6b
+  ReactCommon: 95e0bc81ddbc0460fca25e0e9ea8323fc44fd84a
+  ReactNativeDependencies: ca942f2f8c418bf45faf8705922a1f868415c685
   RNCAsyncStorage: e85a99325df9eb0191a6ee2b2a842644c7eb29f4
   RNCMaskedView: 3c9d7586e2b9bbab573591dcb823918bc4668005
   RNCPicker: 38a9deb903d9a8ae18b598bac727e6c84b3cf0fa
@@ -3921,7 +3921,7 @@ SPEC CHECKSUMS:
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   UMAppLoader: e1234c45d2b7da239e9e90fc4bbeacee12afd5b6
-  Yoga: 67d1653c9d28e838e7682451b47bed2d2b3fca9d
+  Yoga: e0eab070104b3e31f025ab4c82a94e076e0cf700
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 293433137ea62a126033703d9237390c4ab6c393

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -67,7 +67,7 @@
     "native-component-list": "*",
     "react": "19.2.0",
     "react-dom": "19.2.0",
-    "react-native": "0.83.0-rc.3",
+    "react-native": "0.83.0-rc.5",
     "react-native-edge-to-edge": "~1.6.1",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-keyboard-controller": "^1.18.5",

--- a/apps/brownfield-tester/ios/Podfile.lock
+++ b/apps/brownfield-tester/ios/Podfile.lock
@@ -320,7 +320,7 @@ PODS:
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.83.0-rc.3)
+  - FBLazyVector (0.83.0-rc.5)
   - fmt (11.0.2)
   - glog (0.3.5)
   - hermes-engine (0.14.0):
@@ -362,31 +362,31 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.83.0-rc.3)
-  - RCTRequired (0.83.0-rc.3)
-  - RCTSwiftUI (0.83.0-rc.3)
-  - RCTSwiftUIWrapper (0.83.0-rc.3):
+  - RCTDeprecation (0.83.0-rc.5)
+  - RCTRequired (0.83.0-rc.5)
+  - RCTSwiftUI (0.83.0-rc.5)
+  - RCTSwiftUIWrapper (0.83.0-rc.5):
     - RCTSwiftUI
-  - RCTTypeSafety (0.83.0-rc.3):
-    - FBLazyVector (= 0.83.0-rc.3)
-    - RCTRequired (= 0.83.0-rc.3)
-    - React-Core (= 0.83.0-rc.3)
+  - RCTTypeSafety (0.83.0-rc.5):
+    - FBLazyVector (= 0.83.0-rc.5)
+    - RCTRequired (= 0.83.0-rc.5)
+    - React-Core (= 0.83.0-rc.5)
   - ReachabilitySwift (5.2.4)
-  - React (0.83.0-rc.3):
-    - React-Core (= 0.83.0-rc.3)
-    - React-Core/DevSupport (= 0.83.0-rc.3)
-    - React-Core/RCTWebSocket (= 0.83.0-rc.3)
-    - React-RCTActionSheet (= 0.83.0-rc.3)
-    - React-RCTAnimation (= 0.83.0-rc.3)
-    - React-RCTBlob (= 0.83.0-rc.3)
-    - React-RCTImage (= 0.83.0-rc.3)
-    - React-RCTLinking (= 0.83.0-rc.3)
-    - React-RCTNetwork (= 0.83.0-rc.3)
-    - React-RCTSettings (= 0.83.0-rc.3)
-    - React-RCTText (= 0.83.0-rc.3)
-    - React-RCTVibration (= 0.83.0-rc.3)
-  - React-callinvoker (0.83.0-rc.3)
-  - React-Core (0.83.0-rc.3):
+  - React (0.83.0-rc.5):
+    - React-Core (= 0.83.0-rc.5)
+    - React-Core/DevSupport (= 0.83.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.83.0-rc.5)
+    - React-RCTActionSheet (= 0.83.0-rc.5)
+    - React-RCTAnimation (= 0.83.0-rc.5)
+    - React-RCTBlob (= 0.83.0-rc.5)
+    - React-RCTImage (= 0.83.0-rc.5)
+    - React-RCTLinking (= 0.83.0-rc.5)
+    - React-RCTNetwork (= 0.83.0-rc.5)
+    - React-RCTSettings (= 0.83.0-rc.5)
+    - React-RCTText (= 0.83.0-rc.5)
+    - React-RCTVibration (= 0.83.0-rc.5)
+  - React-callinvoker (0.83.0-rc.5)
+  - React-Core (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -396,7 +396,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.83.0-rc.3)
+    - React-Core/Default (= 0.83.0-rc.5)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -411,82 +411,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.83.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.83.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.83.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.83.0-rc.3)
-    - React-Core/RCTWebSocket (= 0.83.0-rc.3)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.83.0-rc.3):
+  - React-Core/CoreModulesHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -511,7 +436,57 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.83.0-rc.3):
+  - React-Core/Default (0.83.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.83.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.83.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.83.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -536,7 +511,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.83.0-rc.3):
+  - React-Core/RCTAnimationHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -561,7 +536,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.83.0-rc.3):
+  - React-Core/RCTBlobHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -586,7 +561,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.83.0-rc.3):
+  - React-Core/RCTImageHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -611,7 +586,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.83.0-rc.3):
+  - React-Core/RCTLinkingHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -636,7 +611,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.83.0-rc.3):
+  - React-Core/RCTNetworkHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -661,7 +636,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.83.0-rc.3):
+  - React-Core/RCTSettingsHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -686,7 +661,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.83.0-rc.3):
+  - React-Core/RCTTextHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -711,7 +686,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.83.0-rc.3):
+  - React-Core/RCTVibrationHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -721,7 +696,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.83.0-rc.3)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -736,7 +711,32 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.83.0-rc.3):
+  - React-Core/RCTWebSocket (0.83.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.83.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -744,22 +744,22 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.83.0-rc.3)
-    - React-Core/CoreModulesHeaders (= 0.83.0-rc.3)
+    - RCTTypeSafety (= 0.83.0-rc.5)
+    - React-Core/CoreModulesHeaders (= 0.83.0-rc.5)
     - React-debug
-    - React-jsi (= 0.83.0-rc.3)
+    - React-jsi (= 0.83.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.83.0-rc.3)
+    - React-RCTImage (= 0.83.0-rc.5)
     - React-runtimeexecutor
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.83.0-rc.3):
+  - React-cxxreact (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -768,20 +768,20 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.83.0-rc.3)
-    - React-debug (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
+    - React-callinvoker (= 0.83.0-rc.5)
+    - React-debug (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.83.0-rc.3)
-    - React-perflogger (= 0.83.0-rc.3)
+    - React-logger (= 0.83.0-rc.5)
+    - React-perflogger (= 0.83.0-rc.5)
     - React-runtimeexecutor
-    - React-timing (= 0.83.0-rc.3)
+    - React-timing (= 0.83.0-rc.5)
     - React-utils
     - SocketRocket
-  - React-debug (0.83.0-rc.3)
-  - React-defaultsnativemodule (0.83.0-rc.3):
+  - React-debug (0.83.0-rc.5)
+  - React-defaultsnativemodule (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -802,7 +802,7 @@ PODS:
     - React-webperformancenativemodule
     - SocketRocket
     - Yoga
-  - React-domnativemodule (0.83.0-rc.3):
+  - React-domnativemodule (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -822,7 +822,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.83.0-rc.3):
+  - React-Fabric (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -836,25 +836,25 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animated (= 0.83.0-rc.3)
-    - React-Fabric/animationbackend (= 0.83.0-rc.3)
-    - React-Fabric/animations (= 0.83.0-rc.3)
-    - React-Fabric/attributedstring (= 0.83.0-rc.3)
-    - React-Fabric/bridging (= 0.83.0-rc.3)
-    - React-Fabric/componentregistry (= 0.83.0-rc.3)
-    - React-Fabric/componentregistrynative (= 0.83.0-rc.3)
-    - React-Fabric/components (= 0.83.0-rc.3)
-    - React-Fabric/consistency (= 0.83.0-rc.3)
-    - React-Fabric/core (= 0.83.0-rc.3)
-    - React-Fabric/dom (= 0.83.0-rc.3)
-    - React-Fabric/imagemanager (= 0.83.0-rc.3)
-    - React-Fabric/leakchecker (= 0.83.0-rc.3)
-    - React-Fabric/mounting (= 0.83.0-rc.3)
-    - React-Fabric/observers (= 0.83.0-rc.3)
-    - React-Fabric/scheduler (= 0.83.0-rc.3)
-    - React-Fabric/telemetry (= 0.83.0-rc.3)
-    - React-Fabric/templateprocessor (= 0.83.0-rc.3)
-    - React-Fabric/uimanager (= 0.83.0-rc.3)
+    - React-Fabric/animated (= 0.83.0-rc.5)
+    - React-Fabric/animationbackend (= 0.83.0-rc.5)
+    - React-Fabric/animations (= 0.83.0-rc.5)
+    - React-Fabric/attributedstring (= 0.83.0-rc.5)
+    - React-Fabric/bridging (= 0.83.0-rc.5)
+    - React-Fabric/componentregistry (= 0.83.0-rc.5)
+    - React-Fabric/componentregistrynative (= 0.83.0-rc.5)
+    - React-Fabric/components (= 0.83.0-rc.5)
+    - React-Fabric/consistency (= 0.83.0-rc.5)
+    - React-Fabric/core (= 0.83.0-rc.5)
+    - React-Fabric/dom (= 0.83.0-rc.5)
+    - React-Fabric/imagemanager (= 0.83.0-rc.5)
+    - React-Fabric/leakchecker (= 0.83.0-rc.5)
+    - React-Fabric/mounting (= 0.83.0-rc.5)
+    - React-Fabric/observers (= 0.83.0-rc.5)
+    - React-Fabric/scheduler (= 0.83.0-rc.5)
+    - React-Fabric/telemetry (= 0.83.0-rc.5)
+    - React-Fabric/templateprocessor (= 0.83.0-rc.5)
+    - React-Fabric/uimanager (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -866,32 +866,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animated (0.83.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/animationbackend (0.83.0-rc.3):
+  - React-Fabric/animated (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -916,7 +891,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.83.0-rc.3):
+  - React-Fabric/animationbackend (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -941,7 +916,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/attributedstring (0.83.0-rc.3):
+  - React-Fabric/animations (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -966,7 +941,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/bridging (0.83.0-rc.3):
+  - React-Fabric/attributedstring (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -991,7 +966,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.83.0-rc.3):
+  - React-Fabric/bridging (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1016,7 +991,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.83.0-rc.3):
+  - React-Fabric/componentregistry (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1041,36 +1016,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.83.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.83.0-rc.3)
-    - React-Fabric/components/root (= 0.83.0-rc.3)
-    - React-Fabric/components/scrollview (= 0.83.0-rc.3)
-    - React-Fabric/components/view (= 0.83.0-rc.3)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.83.0-rc.3):
+  - React-Fabric/componentregistrynative (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1095,7 +1041,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.83.0-rc.3):
+  - React-Fabric/components (0.83.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.83.0-rc.5)
+    - React-Fabric/components/root (= 0.83.0-rc.5)
+    - React-Fabric/components/scrollview (= 0.83.0-rc.5)
+    - React-Fabric/components/view (= 0.83.0-rc.5)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1120,7 +1095,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.83.0-rc.3):
+  - React-Fabric/components/root (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1145,7 +1120,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.83.0-rc.3):
+  - React-Fabric/components/scrollview (0.83.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1172,7 +1172,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.83.0-rc.3):
+  - React-Fabric/consistency (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1197,7 +1197,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.83.0-rc.3):
+  - React-Fabric/core (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1222,7 +1222,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.83.0-rc.3):
+  - React-Fabric/dom (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1247,7 +1247,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.83.0-rc.3):
+  - React-Fabric/imagemanager (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1272,7 +1272,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.83.0-rc.3):
+  - React-Fabric/leakchecker (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1297,7 +1297,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.83.0-rc.3):
+  - React-Fabric/mounting (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1322,7 +1322,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.83.0-rc.3):
+  - React-Fabric/observers (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1336,8 +1336,8 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.83.0-rc.3)
-    - React-Fabric/observers/intersection (= 0.83.0-rc.3)
+    - React-Fabric/observers/events (= 0.83.0-rc.5)
+    - React-Fabric/observers/intersection (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1349,32 +1349,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.83.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/observers/intersection (0.83.0-rc.3):
+  - React-Fabric/observers/events (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1399,7 +1374,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.83.0-rc.3):
+  - React-Fabric/observers/intersection (0.83.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/scheduler (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1427,7 +1427,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.83.0-rc.3):
+  - React-Fabric/telemetry (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1452,7 +1452,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.83.0-rc.3):
+  - React-Fabric/templateprocessor (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1477,7 +1477,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.83.0-rc.3):
+  - React-Fabric/uimanager (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1491,7 +1491,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.83.0-rc.3)
+    - React-Fabric/uimanager/consistency (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1504,7 +1504,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager/consistency (0.83.0-rc.3):
+  - React-Fabric/uimanager/consistency (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1530,7 +1530,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.83.0-rc.3):
+  - React-FabricComponents (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1545,8 +1545,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.83.0-rc.3)
-    - React-FabricComponents/textlayoutmanager (= 0.83.0-rc.3)
+    - React-FabricComponents/components (= 0.83.0-rc.5)
+    - React-FabricComponents/textlayoutmanager (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1559,7 +1559,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.83.0-rc.3):
+  - React-FabricComponents/components (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1574,18 +1574,18 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.83.0-rc.3)
-    - React-FabricComponents/components/iostextinput (= 0.83.0-rc.3)
-    - React-FabricComponents/components/modal (= 0.83.0-rc.3)
-    - React-FabricComponents/components/rncore (= 0.83.0-rc.3)
-    - React-FabricComponents/components/safeareaview (= 0.83.0-rc.3)
-    - React-FabricComponents/components/scrollview (= 0.83.0-rc.3)
-    - React-FabricComponents/components/switch (= 0.83.0-rc.3)
-    - React-FabricComponents/components/text (= 0.83.0-rc.3)
-    - React-FabricComponents/components/textinput (= 0.83.0-rc.3)
-    - React-FabricComponents/components/unimplementedview (= 0.83.0-rc.3)
-    - React-FabricComponents/components/virtualview (= 0.83.0-rc.3)
-    - React-FabricComponents/components/virtualviewexperimental (= 0.83.0-rc.3)
+    - React-FabricComponents/components/inputaccessory (= 0.83.0-rc.5)
+    - React-FabricComponents/components/iostextinput (= 0.83.0-rc.5)
+    - React-FabricComponents/components/modal (= 0.83.0-rc.5)
+    - React-FabricComponents/components/rncore (= 0.83.0-rc.5)
+    - React-FabricComponents/components/safeareaview (= 0.83.0-rc.5)
+    - React-FabricComponents/components/scrollview (= 0.83.0-rc.5)
+    - React-FabricComponents/components/switch (= 0.83.0-rc.5)
+    - React-FabricComponents/components/text (= 0.83.0-rc.5)
+    - React-FabricComponents/components/textinput (= 0.83.0-rc.5)
+    - React-FabricComponents/components/unimplementedview (= 0.83.0-rc.5)
+    - React-FabricComponents/components/virtualview (= 0.83.0-rc.5)
+    - React-FabricComponents/components/virtualviewexperimental (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1598,34 +1598,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.83.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.83.0-rc.3):
+  - React-FabricComponents/components/inputaccessory (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1652,7 +1625,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/modal (0.83.0-rc.3):
+  - React-FabricComponents/components/iostextinput (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1679,7 +1652,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.83.0-rc.3):
+  - React-FabricComponents/components/modal (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1706,7 +1679,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.83.0-rc.3):
+  - React-FabricComponents/components/rncore (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1733,7 +1706,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.83.0-rc.3):
+  - React-FabricComponents/components/safeareaview (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1760,7 +1733,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/switch (0.83.0-rc.3):
+  - React-FabricComponents/components/scrollview (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1787,7 +1760,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.83.0-rc.3):
+  - React-FabricComponents/components/switch (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1814,7 +1787,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.83.0-rc.3):
+  - React-FabricComponents/components/text (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1841,7 +1814,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.83.0-rc.3):
+  - React-FabricComponents/components/textinput (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1868,7 +1841,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualview (0.83.0-rc.3):
+  - React-FabricComponents/components/unimplementedview (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1895,7 +1868,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualviewexperimental (0.83.0-rc.3):
+  - React-FabricComponents/components/virtualview (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1922,7 +1895,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.83.0-rc.3):
+  - React-FabricComponents/components/virtualviewexperimental (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1949,7 +1922,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.83.0-rc.3):
+  - React-FabricComponents/textlayoutmanager (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1958,21 +1931,48 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.83.0-rc.3)
-    - RCTTypeSafety (= 0.83.0-rc.3)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.83.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.83.0-rc.5)
+    - RCTTypeSafety (= 0.83.0-rc.5)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.83.0-rc.3)
+    - React-jsiexecutor (= 0.83.0-rc.5)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.83.0-rc.3):
+  - React-featureflags (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1981,7 +1981,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.83.0-rc.3):
+  - React-featureflagsnativemodule (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1996,7 +1996,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.83.0-rc.3):
+  - React-graphics (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2009,7 +2009,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.83.0-rc.3):
+  - React-hermes (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2018,17 +2018,17 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.83.0-rc.3)
+    - React-cxxreact (= 0.83.0-rc.5)
     - React-jsi
-    - React-jsiexecutor (= 0.83.0-rc.3)
+    - React-jsiexecutor (= 0.83.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.83.0-rc.3)
+    - React-perflogger (= 0.83.0-rc.5)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.83.0-rc.3):
+  - React-idlecallbacksnativemodule (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2044,7 +2044,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.83.0-rc.3):
+  - React-ImageManager (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2059,7 +2059,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-intersectionobservernativemodule (0.83.0-rc.3):
+  - React-intersectionobservernativemodule (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2080,7 +2080,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-jserrorhandler (0.83.0-rc.3):
+  - React-jserrorhandler (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2095,7 +2095,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.83.0-rc.3):
+  - React-jsi (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2105,7 +2105,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.83.0-rc.3):
+  - React-jsiexecutor (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2124,7 +2124,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-jsinspector (0.83.0-rc.3):
+  - React-jsinspector (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2139,11 +2139,11 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.83.0-rc.3)
+    - React-perflogger (= 0.83.0-rc.5)
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-jsinspectorcdp (0.83.0-rc.3):
+  - React-jsinspectorcdp (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2152,7 +2152,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.83.0-rc.3):
+  - React-jsinspectornetwork (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2162,7 +2162,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-jsinspectorcdp
     - SocketRocket
-  - React-jsinspectortracing (0.83.0-rc.3):
+  - React-jsinspectortracing (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2176,7 +2176,7 @@ PODS:
     - React-oscompat
     - React-timing
     - SocketRocket
-  - React-jsitooling (0.83.0-rc.3):
+  - React-jsitooling (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2184,18 +2184,18 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.83.0-rc.3)
+    - React-cxxreact (= 0.83.0-rc.5)
     - React-debug
-    - React-jsi (= 0.83.0-rc.3)
+    - React-jsi (= 0.83.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-jsitracing (0.83.0-rc.3):
+  - React-jsitracing (0.83.0-rc.5):
     - React-jsi
-  - React-logger (0.83.0-rc.3):
+  - React-logger (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2204,7 +2204,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.83.0-rc.3):
+  - React-Mapbuffer (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2214,7 +2214,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.83.0-rc.3):
+  - React-microtasksnativemodule (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2228,7 +2228,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-NativeModulesApple (0.83.0-rc.3):
+  - React-NativeModulesApple (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2249,7 +2249,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-networking (0.83.0-rc.3):
+  - React-networking (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2263,8 +2263,8 @@ PODS:
     - React-performancetimeline
     - React-timing
     - SocketRocket
-  - React-oscompat (0.83.0-rc.3)
-  - React-perflogger (0.83.0-rc.3):
+  - React-oscompat (0.83.0-rc.5)
+  - React-perflogger (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2273,7 +2273,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancecdpmetrics (0.83.0-rc.3):
+  - React-performancecdpmetrics (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2287,7 +2287,7 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - SocketRocket
-  - React-performancetimeline (0.83.0-rc.3):
+  - React-performancetimeline (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2300,9 +2300,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.83.0-rc.3):
-    - React-Core/RCTActionSheetHeaders (= 0.83.0-rc.3)
-  - React-RCTAnimation (0.83.0-rc.3):
+  - React-RCTActionSheet (0.83.0-rc.5):
+    - React-Core/RCTActionSheetHeaders (= 0.83.0-rc.5)
+  - React-RCTAnimation (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2318,7 +2318,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.83.0-rc.3):
+  - React-RCTAppDelegate (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2352,7 +2352,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.83.0-rc.3):
+  - React-RCTBlob (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2371,7 +2371,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.83.0-rc.3):
+  - React-RCTFabric (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2408,7 +2408,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.83.0-rc.3):
+  - React-RCTFBReactNativeSpec (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2422,10 +2422,10 @@ PODS:
     - React-Core
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.83.0-rc.3)
+    - React-RCTFBReactNativeSpec/components (= 0.83.0-rc.5)
     - ReactCommon
     - SocketRocket
-  - React-RCTFBReactNativeSpec/components (0.83.0-rc.3):
+  - React-RCTFBReactNativeSpec/components (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2448,7 +2448,7 @@ PODS:
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-RCTImage (0.83.0-rc.3):
+  - React-RCTImage (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2464,14 +2464,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.83.0-rc.3):
-    - React-Core/RCTLinkingHeaders (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
+  - React-RCTLinking (0.83.0-rc.5):
+    - React-Core/RCTLinkingHeaders (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.83.0-rc.3)
-  - React-RCTNetwork (0.83.0-rc.3):
+    - ReactCommon/turbomodule/core (= 0.83.0-rc.5)
+  - React-RCTNetwork (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2491,7 +2491,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.83.0-rc.3):
+  - React-RCTRuntime (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2513,7 +2513,7 @@ PODS:
     - React-RuntimeHermes
     - React-utils
     - SocketRocket
-  - React-RCTSettings (0.83.0-rc.3):
+  - React-RCTSettings (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2528,10 +2528,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.83.0-rc.3):
-    - React-Core/RCTTextHeaders (= 0.83.0-rc.3)
+  - React-RCTText (0.83.0-rc.5):
+    - React-Core/RCTTextHeaders (= 0.83.0-rc.5)
     - Yoga
-  - React-RCTVibration (0.83.0-rc.3):
+  - React-RCTVibration (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2545,11 +2545,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.83.0-rc.3)
-  - React-renderercss (0.83.0-rc.3):
+  - React-rendererconsistency (0.83.0-rc.5)
+  - React-renderercss (0.83.0-rc.5):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.83.0-rc.3):
+  - React-rendererdebug (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2559,7 +2559,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-RuntimeApple (0.83.0-rc.3):
+  - React-RuntimeApple (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2588,7 +2588,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.83.0-rc.3):
+  - React-RuntimeCore (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2610,7 +2610,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.83.0-rc.3):
+  - React-runtimeexecutor (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2620,10 +2620,10 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.83.0-rc.3)
+    - React-jsi (= 0.83.0-rc.5)
     - React-utils
     - SocketRocket
-  - React-RuntimeHermes (0.83.0-rc.3):
+  - React-RuntimeHermes (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2644,7 +2644,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.83.0-rc.3):
+  - React-runtimescheduler (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2666,9 +2666,9 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.83.0-rc.3):
+  - React-timing (0.83.0-rc.5):
     - React-debug
-  - React-utils (0.83.0-rc.3):
+  - React-utils (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2678,9 +2678,9 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - React-debug
-    - React-jsi (= 0.83.0-rc.3)
+    - React-jsi (= 0.83.0-rc.5)
     - SocketRocket
-  - React-webperformancenativemodule (0.83.0-rc.3):
+  - React-webperformancenativemodule (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2697,9 +2697,9 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactAppDependencyProvider (0.83.0-rc.3):
+  - ReactAppDependencyProvider (0.83.0-rc.5):
     - ReactCodegen
-  - ReactCodegen (0.83.0-rc.3):
+  - ReactCodegen (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2725,7 +2725,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.83.0-rc.3):
+  - ReactCommon (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2733,9 +2733,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.83.0-rc.3)
+    - ReactCommon/turbomodule (= 0.83.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule (0.83.0-rc.3):
+  - ReactCommon/turbomodule (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2744,15 +2744,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.83.0-rc.3)
-    - React-cxxreact (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
-    - React-logger (= 0.83.0-rc.3)
-    - React-perflogger (= 0.83.0-rc.3)
-    - ReactCommon/turbomodule/bridging (= 0.83.0-rc.3)
-    - ReactCommon/turbomodule/core (= 0.83.0-rc.3)
+    - React-callinvoker (= 0.83.0-rc.5)
+    - React-cxxreact (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
+    - React-logger (= 0.83.0-rc.5)
+    - React-perflogger (= 0.83.0-rc.5)
+    - ReactCommon/turbomodule/bridging (= 0.83.0-rc.5)
+    - ReactCommon/turbomodule/core (= 0.83.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.83.0-rc.3):
+  - ReactCommon/turbomodule/bridging (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2761,13 +2761,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.83.0-rc.3)
-    - React-cxxreact (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
-    - React-logger (= 0.83.0-rc.3)
-    - React-perflogger (= 0.83.0-rc.3)
+    - React-callinvoker (= 0.83.0-rc.5)
+    - React-cxxreact (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
+    - React-logger (= 0.83.0-rc.5)
+    - React-perflogger (= 0.83.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.83.0-rc.3):
+  - ReactCommon/turbomodule/core (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2776,14 +2776,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.83.0-rc.3)
-    - React-cxxreact (= 0.83.0-rc.3)
-    - React-debug (= 0.83.0-rc.3)
-    - React-featureflags (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
-    - React-logger (= 0.83.0-rc.3)
-    - React-perflogger (= 0.83.0-rc.3)
-    - React-utils (= 0.83.0-rc.3)
+    - React-callinvoker (= 0.83.0-rc.5)
+    - React-cxxreact (= 0.83.0-rc.5)
+    - React-debug (= 0.83.0-rc.5)
+    - React-featureflags (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
+    - React-logger (= 0.83.0-rc.5)
+    - React-perflogger (= 0.83.0-rc.5)
+    - React-utils (= 0.83.0-rc.5)
     - SocketRocket
   - SDWebImage (5.21.3):
     - SDWebImage/Core (= 5.21.3)
@@ -3141,10 +3141,10 @@ SPEC CHECKSUMS:
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
   EXManifests: 7469efed75d694ce3c43a6da9c6f3886f66d3c26
   Expo: 446942b564f6fa3f855457d1f1678a9d5c5f3741
-  expo-dev-client: b0363ce1f16a248d7c9b67ceaee2dbee058c1e05
-  expo-dev-launcher: 66cb3e6dc99d85b33b74c3ce60a376bfdf26fbea
-  expo-dev-menu: 5cb7b596faa72b1134ccf05e183006a867b704e3
-  expo-dev-menu-interface: 600df12ea01efecdd822daaf13cc0ac091775533
+  expo-dev-client: b8c16c699a35787e1ac38c6d44ef7552fe3f0334
+  expo-dev-launcher: 617152822493adda0848170557a79d6bc585e6fe
+  expo-dev-menu: ae1feaf51f47590afc4527c6a75165beb7aed0dd
+  expo-dev-menu-interface: 30d9aa2fbca275a1335ca7e076273dac1d42d40a
   ExpoAppleAuthentication: 414e4316f8e25a2afbc3943cf725579c910f24b8
   ExpoAsset: 4375a46b45b12bbfcf6efac8c8a33aebdb8ba12b
   ExpoBlur: b5b7a26572b3c33a11f0b2aa2f95c17c4c393b76
@@ -3160,10 +3160,10 @@ SPEC CHECKSUMS:
   ExpoModulesJSI: b5e87deda640f9710d08446db5d110e91db64cc9
   ExpoVideo: 7e39a5933892dc640b1b83013f3f9d9d37072151
   EXStructuredHeaders: c951e77f2d936f88637421e9588c976da5827368
-  EXUpdates: d1cc88b95f08b41151c1b07edf8b08fdddf7e3bb
+  EXUpdates: d2cb10cfad0bc209a21cfef8856ea407b8e2e428
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: d7f74537f87b148a7bb047c690036ce7a52c7590
+  FBLazyVector: 5f1d154c17cb9158e4becc24719b2d937f4945fd
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 9a270294aaec03556862ee83edd0f490710bfbb2
@@ -3171,83 +3171,83 @@ SPEC CHECKSUMS:
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
-  RCTDeprecation: fd7dda582e035270b441eec37e0d59f9a93f4cd1
-  RCTRequired: 8769adc104cdfa26af6a42152b3d355d62cd016f
-  RCTSwiftUI: d32a6cb82941045710ec3b4ae68dbb6cccf7e6db
-  RCTSwiftUIWrapper: e0fbc4c1aa47bed80a63602ba0f32cadb90a8377
-  RCTTypeSafety: 7ee27a91354aa8b6f4e2668f92c8a0f5c95ef35a
+  RCTDeprecation: ebbf9e4405e6ff9c1d2db992a3494572c8305198
+  RCTRequired: 758e5b53140d72879317104fb43e19ab1a1193ba
+  RCTSwiftUI: 890ac28774f2fde5cebe1ebbe037e41b0b0c7d18
+  RCTSwiftUIWrapper: 5be2ebb69cf9160438447579ebf5b123cfb0e877
+  RCTTypeSafety: 15292827a8cb22172d657eed0eccd42320687562
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 444caa11c2b83e3b1ed6fa6182102c557c940b99
-  React-callinvoker: 870ebac0b6f228e96144e1d75f4c997b2b9a57af
-  React-Core: a72fc4cd2c28a52b1da63e60891bb6b5c3607f9e
-  React-CoreModules: 01fa71d36c590129d3f70c175b4a8f5aee806606
-  React-cxxreact: bff823e34f270c93f2dc85917aab5d4c5aff7241
-  React-debug: ded5c26d859893b9a1bbb2fc5c690129b567aba7
-  React-defaultsnativemodule: ad6e94fdb56d518642b04ce53df63afa7bd8bf2d
-  React-domnativemodule: c4e8285adc1f230b7dedfa0f99346b25fd781060
-  React-Fabric: 293af299cd2c67627d4e4f51d347a617ba62f6c6
-  React-FabricComponents: 63c7d5bbd3d2eed1a5d2e3864026f276998ef6b9
-  React-FabricImage: bff3c65498ce1e2750d35637c2b10395299ce5ac
-  React-featureflags: a73670b1b54e6054feb1123c607d40998a5dfe89
-  React-featureflagsnativemodule: c7901fbf1d0ecb45a4067eef44918c9ac7c08bb3
-  React-graphics: 0d2c17c289b0b1dd5907f46d996e2b5977e2c5d3
-  React-hermes: b04d1fdbcd891c43b67ca6386e43ea7b95282f0c
-  React-idlecallbacksnativemodule: fe2bc0f22774b409a2e8cc21e66174fbb25d6a5b
-  React-ImageManager: 095bb64f067dd2b72fe3741bf551f803c3fe2c0e
-  React-intersectionobservernativemodule: ca6d045a0bc5d86d71839b3e5f8750e04e88879e
-  React-jserrorhandler: 2c172461ccd791dfcdf43e3e0c07dcf525c7b27f
-  React-jsi: b7c3619ec34d573d59dbd12a66dbd221a9d95263
-  React-jsiexecutor: 381f0bba11eeabb85220392c43f81ff61cc0eb9b
-  React-jsinspector: 56eae8b1872e6f6ff2b847358f88a6af8dc2b44a
-  React-jsinspectorcdp: 99bcb1f7a85f3bf49a69dc4de7673b519e3e404f
-  React-jsinspectornetwork: 26ea72d65831a9de5184434a455174a1e226c743
-  React-jsinspectortracing: 1a89b2d8c21d05031f13815d175a7e07b0c1790a
-  React-jsitooling: 228f862fff62c28135ac8fa23baa2c5aaddce561
-  React-jsitracing: aa63a0ec9ab0cd70ca26bf150245535d889907b6
-  React-logger: ff158f3ec4a6cadbd2b668ff7c60dab5245926c5
-  React-Mapbuffer: c2b016c7c73b70c11250907c97f9bedb6ad726b0
-  React-microtasksnativemodule: cdb701591390d2c08e9770f0f49feeb7d126ad12
-  React-NativeModulesApple: 3342e3a9f273c8b38dbf8139ffcb421c26b763fc
-  React-networking: 995d83889b062ebd36cf87345abc05b406413d08
-  React-oscompat: ca07088cee072dd44730c6d6fb7df965aac9d12b
-  React-perflogger: 4ffe3568c3868ebb087801e69cd000c53337f2e5
-  React-performancecdpmetrics: 9c8814933d1ffb333eb0092e486cc5638d3e667a
-  React-performancetimeline: 23e25b5f595007313dcbe328865b12d3bf584b62
-  React-RCTActionSheet: c99e4aec86b4d96df58f0886de1295f0a3d8fcdb
-  React-RCTAnimation: f3f423ccc8d509bbee8d58ef48501cced88d779f
-  React-RCTAppDelegate: 760a29a3f5d619d671ff660ca15ff732aa4d91e1
-  React-RCTBlob: f6eb42ebf2a1a61499d1ab9ad4881c5312688b39
-  React-RCTFabric: f0da54bb97ada23db824400e3baf566d0c9ed2bd
-  React-RCTFBReactNativeSpec: b6f18d253867d1f08569f20aa6d997d7ccd008c5
-  React-RCTImage: 414d115a056530d5513d5dcf9726829bf04b5e5b
-  React-RCTLinking: 216b5fae7687fd142701ce7b4ac31ac806348f7a
-  React-RCTNetwork: aebf36d12ff12d25847fab9547e7d8bcbe11b3b4
-  React-RCTRuntime: f7d487670363ff6ab54ec97fe8c2043d20aa7db0
-  React-RCTSettings: e4cb8087443fd1a97a19f5b6a2925aceae909417
-  React-RCTText: e1efc422d7f33561f851e59e1aa85bbc2fa37a0c
-  React-RCTVibration: 7353bce6ad10f536d69c9b536194bc8f68cb74b1
-  React-rendererconsistency: 0f52c08979513533defc3567a877bf5b81f055a7
-  React-renderercss: d08dfda709c5c3a41b060526665f42d245a47049
-  React-rendererdebug: 01d39f8b29c81c49bc57b72e63fd184bdc2b5bbb
-  React-RuntimeApple: 4680334ae798eb855d9a0353ef52312a43307500
-  React-RuntimeCore: 8fd660d8f929b336d034c6a4600ad37da17b8c4d
-  React-runtimeexecutor: d1bd03f649816f52be6bbb37cf40a723dbf96493
-  React-RuntimeHermes: 52d6fb2d360eb497472e28e722a6a88b5f0cd069
-  React-runtimescheduler: 5c6698437e6b8cf41ab33af6725bcbfa3dc54d88
-  React-timing: b9c9e523117bbd4622d3c2e14b0594e5698f4412
-  React-utils: 83d8f8ec38fb08ec28f0f1ab64a8a9f3cecde9f1
-  React-webperformancenativemodule: 73fb7c9b5b9e55a323f8a7108b9b83e82785685e
-  ReactAppDependencyProvider: 9ca54963f57b9d01b93b4014ebabf5b39bc61773
-  ReactCodegen: 7c10da9ff175e6a4e8dae8ea5cc9c79cceffb10d
-  ReactCommon: 186521d964be2b0c76daaa031d0916953a60ceb2
+  React: 8896aeaee7431bbbbee8b85592672c2742be80c9
+  React-callinvoker: d64342e47a435565ef0f29d3be649f4fa2c2900b
+  React-Core: 424a8b9734c342ce6405cc7d114e717bebf871d8
+  React-CoreModules: bca5cc57ff1903626235e65852a4a13bb9b743c4
+  React-cxxreact: 2bbb9ee8e9ecf2cdf21f4945a6cdd74cfc7221b0
+  React-debug: 40ce3603f7acf8ce536fbd1b2256d7dde1924267
+  React-defaultsnativemodule: d116bd9b3f372e549c7df94b631b83f67a233219
+  React-domnativemodule: f68417863aa944859d4a8435c68a70240739138e
+  React-Fabric: 36b4f85870edf0a97c91bcb351da60b88888924f
+  React-FabricComponents: c58866b1a6a29cbb90743c7664995fad44de7615
+  React-FabricImage: 739fa870ba9f3a64e115f83438ca62612a172eaf
+  React-featureflags: 2254fdf2554fa6efa41212c0d3adab4e6dc71e51
+  React-featureflagsnativemodule: bb0996bafaf35fdcc9721e8a5c0a423adc18c73d
+  React-graphics: 3ffe759fad74fa962cdd0542f69656bab54141f2
+  React-hermes: 83e6689841c012647450b7d8a38f520a3eeec712
+  React-idlecallbacksnativemodule: c39f4384458074f7e8d801238616b66596d0bcb4
+  React-ImageManager: b8895816803e62edac8e17fc9a8a35e146a02510
+  React-intersectionobservernativemodule: e6bd3ae82d726bb2bc3a5bcf238689932f20aebd
+  React-jserrorhandler: abf4353171d170398254ab83de8e5945dc8163cc
+  React-jsi: 6c2be0fad70db93d9ea3677d35a26e979297180c
+  React-jsiexecutor: b87463dfcffd85b766f96ae262de3935c87111bd
+  React-jsinspector: ca69c2b99d7c6dcdb83f98ae811a3ce6b8302737
+  React-jsinspectorcdp: dfe02915051f543fb62af5724c1c3b5e61f0db13
+  React-jsinspectornetwork: e4ac4c32423c9adb50d29954b656be4fdff0ffe9
+  React-jsinspectortracing: 96b7b3311e0057cff68a3b441810aed6a4536997
+  React-jsitooling: a295b9db2182ca9d368365c685a98fcebca0afe9
+  React-jsitracing: ded1b9591f05f3966f783e79dfb338acc8cc98c9
+  React-logger: d924cbdb1ca5b8201e0e75e61bcf533ab8ba500d
+  React-Mapbuffer: d5b8757899fa4235d2ce0140a2651ef8dcf327b0
+  React-microtasksnativemodule: 0204c4180fddfb125918b464787d04b7bd78f700
+  React-NativeModulesApple: 70e48ed2223d19f8464a34b415673a857ef41d87
+  React-networking: 79a1c0f75ab745981a05db45b8a9042d0f946fb9
+  React-oscompat: 288833c6a87f07dfe80c723d16d5eb893ced5b16
+  React-perflogger: 270d4df0eb451c7c4ee240b005ca7099d087bf8c
+  React-performancecdpmetrics: a890cba394b7bb01b46dbc14088ea1ce9e68cb7b
+  React-performancetimeline: 9f82677bd40a0b383cdb3a4e964d07e06880cb3c
+  React-RCTActionSheet: 617f2ea407dcc8031af58b4edf1ab23267d9fcb4
+  React-RCTAnimation: d005d9e7f7925dc58bae7a4836a1e98abd6b3b74
+  React-RCTAppDelegate: 522d3975f5cf2b92ae9f845c7e72859f647c9543
+  React-RCTBlob: e53bfec9080ca133920e7f1844503abbe72c0dd9
+  React-RCTFabric: 9c477e0c90313ea1967d22f6c900abc3127e778e
+  React-RCTFBReactNativeSpec: fa4089fc8178d0db81b20d8795ec2475ece16e15
+  React-RCTImage: ac182b3d6fb16529225a5fae1d2ea2026cefaa1b
+  React-RCTLinking: 1a08a5d6d4194f6a98810bc0ed75ace51a1aa781
+  React-RCTNetwork: ecb749b8f1b49c93a34374b42c6f6671a12e6c6a
+  React-RCTRuntime: 17dd45929b38c7d15733eceda4db7edfd53ddd08
+  React-RCTSettings: 02fc9e5747b0d3b9365ff564141052d90e315a72
+  React-RCTText: 69207b5b01b7fecd04c31fedbdb882f11614fe09
+  React-RCTVibration: 825060f86f8cc5bc3e8631782eb71e66607266c5
+  React-rendererconsistency: c1771076d441d78c31f0ff7ce8317aae7e44d12c
+  React-renderercss: c4eef5e3dc6bad6687dc0ff9f2f50cb8a76c7ce8
+  React-rendererdebug: 522bd3d58a4826af80bcb9e32611555ada20c640
+  React-RuntimeApple: 55b7dacfd957956c910b2d3c00755009d89930e6
+  React-RuntimeCore: 85284e027c2a33cef289a7b3a143d290c70c0351
+  React-runtimeexecutor: e7db211787f560f955824f263d79499d6afdb859
+  React-RuntimeHermes: c64502edabb96874c3498fb9a5958577e7fb5a50
+  React-runtimescheduler: 60bc9573c7e072b963f1a477426875dc682ee33a
+  React-timing: c2e83bba103ec949371698481f1f2bf75b43e71a
+  React-utils: da1fd1ea9c36f20d86b7e3acb373c9999b57a8b6
+  React-webperformancenativemodule: 8e9272ba6aca935306c8afc488fa226174b8ed30
+  ReactAppDependencyProvider: 07461dc99cceeca991cece80447fd21345113f16
+  ReactCodegen: 300ac8fbe25dcf81721a26efa93ce1b52f749c56
+  ReactCommon: c93e2d89edf5832fe95ec4eae5bfa8e6e428bd09
   SDWebImage: 16309af6d214ba3f77a7c6f6fdda888cb313a50a
   SDWebImageAVIFCoder: afe194a084e851f70228e4be35ef651df0fc5c57
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: cec68ad2cff7afc3e8f47ad6a056aa4b084cd1ac
+  Yoga: d4d200896f40c3b84d1393e8083c08f8c78ecbfb
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: b5e05b0a0133f1b3b298e54fd1e61aea5bfd8ba7
+PODFILE CHECKSUM: 1ea344ef690aa1d6d06b5688b87a58e5dbc197d2
 
 COCOAPODS: 1.16.2

--- a/apps/expo-go/ios/Exponent.xcodeproj/project.pbxproj
+++ b/apps/expo-go/ios/Exponent.xcodeproj/project.pbxproj
@@ -136,6 +136,8 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Supporting/Info.plist,
+				Info.plist,
+				"Exponent-Prefix.pch",
 			);
 			target = 78CEE2BF1ACD07D70095B124 /* Expo Go */;
 		};

--- a/apps/expo-go/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.m
@@ -54,7 +54,6 @@ if (params[@"fileSystemDirectories"]) {
 
 #if __has_include(<ExpoModulesCore/EXPermissionsService.h>)
   EXScopedPermissions *permissionsModule = [[EXScopedPermissions alloc] initWithScopeKey:scopeKey andConstantsBinding:constantsBinding];
-  [moduleRegistry registerExportedModule:permissionsModule];
   [moduleRegistry registerInternalModule:permissionsModule];
 #endif
 

--- a/apps/expo-go/ios/Exponent/Versioned/Core/UniversalModules/Permissions/EXScopedPermissions.m
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/UniversalModules/Permissions/EXScopedPermissions.m
@@ -28,7 +28,6 @@
 
 - (void)setModuleRegistry:(EXModuleRegistry *)moduleRegistry
 {
-  [super setModuleRegistry:moduleRegistry];
   _utils = [moduleRegistry getModuleImplementingProtocol:@protocol(EXUtilitiesInterface)];
   _permissionsService = [moduleRegistry getSingletonModuleForName:@"Permissions"];
 }
@@ -46,7 +45,7 @@
   if (!_permissionsService) {
     return [[self class] permissionStringForStatus:EXPermissionStatusGranted];
   }
-  
+
   return [[self class] permissionStringForStatus:[_permissionsService getPermission:permissionType forExperience:_scopeKey]];
 }
 
@@ -55,7 +54,7 @@
   if (!_permissionsService || ![self shouldVerifyScopedPermission:permissionType]) {
     return YES;
   }
-  
+
   return [_permissionsService getPermission:permissionType forExperience:_scopeKey] == EXPermissionStatusGranted;
 }
 
@@ -77,7 +76,7 @@
       }
       resolve(permission);
     };
-    
+
     return [self askForGlobalPermissionUsingRequesterClass:requesterClass withResolver:customOnResults withRejecter:reject];
   } else if (![self hasGrantedScopedPermission:permissionType]) {
     // second group
@@ -92,7 +91,7 @@
       }
       resolve(permission);
     }];
-    
+
     UIAlertAction *denyAction = [UIAlertAction actionWithTitle:@"Deny" style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
       EX_ENSURE_STRONGIFY(self);
       NSMutableDictionary *permission = [globalPermissions mutableCopy];
@@ -100,10 +99,10 @@
       permission[@"granted"] = @(NO);
       resolve([NSDictionary dictionaryWithDictionary:permission]);
     }];
-    
+
     return [self showPermissionRequestAlert:permissionType withAllowAction:allowAction withDenyAction:denyAction];
   }
-  
+
   resolve(globalPermissions); // third group
 }
 
@@ -115,7 +114,7 @@
     return nil;
   }
   NSMutableDictionary *permission = [NSMutableDictionary dictionaryWithDictionary:globalPermission];
-  
+
   if ([self shouldVerifyScopedPermission:permissionType]
       && [EXPermissionsService statusForPermission:permission] == EXPermissionStatusGranted) {
     permission[@"status"] = [self getScopedPermissionStatus:permissionType];
@@ -154,7 +153,7 @@
   } else if ([type isEqualToString:@"cameraRoll"]) {
     return @"photos";
   }
-  
+
   return type;
 }
 

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -466,7 +466,7 @@ PODS:
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.83.0-rc.3)
+  - FBLazyVector (0.83.0-rc.5)
   - FirebaseAnalytics (11.11.0):
     - FirebaseAnalytics/AdIdSupport (= 11.11.0)
     - FirebaseCore (~> 11.11.0)
@@ -677,31 +677,31 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.83.0-rc.3)
-  - RCTRequired (0.83.0-rc.3)
-  - RCTSwiftUI (0.83.0-rc.3)
-  - RCTSwiftUIWrapper (0.83.0-rc.3):
+  - RCTDeprecation (0.83.0-rc.5)
+  - RCTRequired (0.83.0-rc.5)
+  - RCTSwiftUI (0.83.0-rc.5)
+  - RCTSwiftUIWrapper (0.83.0-rc.5):
     - RCTSwiftUI
-  - RCTTypeSafety (0.83.0-rc.3):
-    - FBLazyVector (= 0.83.0-rc.3)
-    - RCTRequired (= 0.83.0-rc.3)
-    - React-Core (= 0.83.0-rc.3)
+  - RCTTypeSafety (0.83.0-rc.5):
+    - FBLazyVector (= 0.83.0-rc.5)
+    - RCTRequired (= 0.83.0-rc.5)
+    - React-Core (= 0.83.0-rc.5)
   - ReachabilitySwift (5.2.4)
-  - React (0.83.0-rc.3):
-    - React-Core (= 0.83.0-rc.3)
-    - React-Core/DevSupport (= 0.83.0-rc.3)
-    - React-Core/RCTWebSocket (= 0.83.0-rc.3)
-    - React-RCTActionSheet (= 0.83.0-rc.3)
-    - React-RCTAnimation (= 0.83.0-rc.3)
-    - React-RCTBlob (= 0.83.0-rc.3)
-    - React-RCTImage (= 0.83.0-rc.3)
-    - React-RCTLinking (= 0.83.0-rc.3)
-    - React-RCTNetwork (= 0.83.0-rc.3)
-    - React-RCTSettings (= 0.83.0-rc.3)
-    - React-RCTText (= 0.83.0-rc.3)
-    - React-RCTVibration (= 0.83.0-rc.3)
-  - React-callinvoker (0.83.0-rc.3)
-  - React-Core (0.83.0-rc.3):
+  - React (0.83.0-rc.5):
+    - React-Core (= 0.83.0-rc.5)
+    - React-Core/DevSupport (= 0.83.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.83.0-rc.5)
+    - React-RCTActionSheet (= 0.83.0-rc.5)
+    - React-RCTAnimation (= 0.83.0-rc.5)
+    - React-RCTBlob (= 0.83.0-rc.5)
+    - React-RCTImage (= 0.83.0-rc.5)
+    - React-RCTLinking (= 0.83.0-rc.5)
+    - React-RCTNetwork (= 0.83.0-rc.5)
+    - React-RCTSettings (= 0.83.0-rc.5)
+    - React-RCTText (= 0.83.0-rc.5)
+    - React-RCTVibration (= 0.83.0-rc.5)
+  - React-callinvoker (0.83.0-rc.5)
+  - React-Core (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -711,7 +711,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.83.0-rc.3)
+    - React-Core/Default (= 0.83.0-rc.5)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -726,82 +726,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.83.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.83.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.83.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.83.0-rc.3)
-    - React-Core/RCTWebSocket (= 0.83.0-rc.3)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.83.0-rc.3):
+  - React-Core/CoreModulesHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -826,7 +751,57 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.83.0-rc.3):
+  - React-Core/Default (0.83.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.83.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.83.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.83.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -851,7 +826,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.83.0-rc.3):
+  - React-Core/RCTAnimationHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -876,7 +851,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.83.0-rc.3):
+  - React-Core/RCTBlobHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -901,7 +876,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.83.0-rc.3):
+  - React-Core/RCTImageHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -926,7 +901,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.83.0-rc.3):
+  - React-Core/RCTLinkingHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -951,7 +926,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.83.0-rc.3):
+  - React-Core/RCTNetworkHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -976,7 +951,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.83.0-rc.3):
+  - React-Core/RCTSettingsHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1001,7 +976,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.83.0-rc.3):
+  - React-Core/RCTTextHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1026,7 +1001,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.83.0-rc.3):
+  - React-Core/RCTVibrationHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1036,7 +1011,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.83.0-rc.3)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -1051,7 +1026,32 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.83.0-rc.3):
+  - React-Core/RCTWebSocket (0.83.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.83.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1059,22 +1059,22 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.83.0-rc.3)
-    - React-Core/CoreModulesHeaders (= 0.83.0-rc.3)
+    - RCTTypeSafety (= 0.83.0-rc.5)
+    - React-Core/CoreModulesHeaders (= 0.83.0-rc.5)
     - React-debug
-    - React-jsi (= 0.83.0-rc.3)
+    - React-jsi (= 0.83.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.83.0-rc.3)
+    - React-RCTImage (= 0.83.0-rc.5)
     - React-runtimeexecutor
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.83.0-rc.3):
+  - React-cxxreact (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1083,20 +1083,20 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.83.0-rc.3)
-    - React-debug (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
+    - React-callinvoker (= 0.83.0-rc.5)
+    - React-debug (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.83.0-rc.3)
-    - React-perflogger (= 0.83.0-rc.3)
+    - React-logger (= 0.83.0-rc.5)
+    - React-perflogger (= 0.83.0-rc.5)
     - React-runtimeexecutor
-    - React-timing (= 0.83.0-rc.3)
+    - React-timing (= 0.83.0-rc.5)
     - React-utils
     - SocketRocket
-  - React-debug (0.83.0-rc.3)
-  - React-defaultsnativemodule (0.83.0-rc.3):
+  - React-debug (0.83.0-rc.5)
+  - React-defaultsnativemodule (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1117,7 +1117,7 @@ PODS:
     - React-webperformancenativemodule
     - SocketRocket
     - Yoga
-  - React-domnativemodule (0.83.0-rc.3):
+  - React-domnativemodule (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1137,7 +1137,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.83.0-rc.3):
+  - React-Fabric (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1151,25 +1151,25 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animated (= 0.83.0-rc.3)
-    - React-Fabric/animationbackend (= 0.83.0-rc.3)
-    - React-Fabric/animations (= 0.83.0-rc.3)
-    - React-Fabric/attributedstring (= 0.83.0-rc.3)
-    - React-Fabric/bridging (= 0.83.0-rc.3)
-    - React-Fabric/componentregistry (= 0.83.0-rc.3)
-    - React-Fabric/componentregistrynative (= 0.83.0-rc.3)
-    - React-Fabric/components (= 0.83.0-rc.3)
-    - React-Fabric/consistency (= 0.83.0-rc.3)
-    - React-Fabric/core (= 0.83.0-rc.3)
-    - React-Fabric/dom (= 0.83.0-rc.3)
-    - React-Fabric/imagemanager (= 0.83.0-rc.3)
-    - React-Fabric/leakchecker (= 0.83.0-rc.3)
-    - React-Fabric/mounting (= 0.83.0-rc.3)
-    - React-Fabric/observers (= 0.83.0-rc.3)
-    - React-Fabric/scheduler (= 0.83.0-rc.3)
-    - React-Fabric/telemetry (= 0.83.0-rc.3)
-    - React-Fabric/templateprocessor (= 0.83.0-rc.3)
-    - React-Fabric/uimanager (= 0.83.0-rc.3)
+    - React-Fabric/animated (= 0.83.0-rc.5)
+    - React-Fabric/animationbackend (= 0.83.0-rc.5)
+    - React-Fabric/animations (= 0.83.0-rc.5)
+    - React-Fabric/attributedstring (= 0.83.0-rc.5)
+    - React-Fabric/bridging (= 0.83.0-rc.5)
+    - React-Fabric/componentregistry (= 0.83.0-rc.5)
+    - React-Fabric/componentregistrynative (= 0.83.0-rc.5)
+    - React-Fabric/components (= 0.83.0-rc.5)
+    - React-Fabric/consistency (= 0.83.0-rc.5)
+    - React-Fabric/core (= 0.83.0-rc.5)
+    - React-Fabric/dom (= 0.83.0-rc.5)
+    - React-Fabric/imagemanager (= 0.83.0-rc.5)
+    - React-Fabric/leakchecker (= 0.83.0-rc.5)
+    - React-Fabric/mounting (= 0.83.0-rc.5)
+    - React-Fabric/observers (= 0.83.0-rc.5)
+    - React-Fabric/scheduler (= 0.83.0-rc.5)
+    - React-Fabric/telemetry (= 0.83.0-rc.5)
+    - React-Fabric/templateprocessor (= 0.83.0-rc.5)
+    - React-Fabric/uimanager (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1181,32 +1181,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animated (0.83.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/animationbackend (0.83.0-rc.3):
+  - React-Fabric/animated (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1231,7 +1206,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.83.0-rc.3):
+  - React-Fabric/animationbackend (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1256,7 +1231,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/attributedstring (0.83.0-rc.3):
+  - React-Fabric/animations (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1281,7 +1256,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/bridging (0.83.0-rc.3):
+  - React-Fabric/attributedstring (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1306,7 +1281,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.83.0-rc.3):
+  - React-Fabric/bridging (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1331,7 +1306,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.83.0-rc.3):
+  - React-Fabric/componentregistry (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1356,36 +1331,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.83.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.83.0-rc.3)
-    - React-Fabric/components/root (= 0.83.0-rc.3)
-    - React-Fabric/components/scrollview (= 0.83.0-rc.3)
-    - React-Fabric/components/view (= 0.83.0-rc.3)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.83.0-rc.3):
+  - React-Fabric/componentregistrynative (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1410,7 +1356,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.83.0-rc.3):
+  - React-Fabric/components (0.83.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.83.0-rc.5)
+    - React-Fabric/components/root (= 0.83.0-rc.5)
+    - React-Fabric/components/scrollview (= 0.83.0-rc.5)
+    - React-Fabric/components/view (= 0.83.0-rc.5)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1435,7 +1410,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.83.0-rc.3):
+  - React-Fabric/components/root (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1460,7 +1435,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.83.0-rc.3):
+  - React-Fabric/components/scrollview (0.83.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1487,7 +1487,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.83.0-rc.3):
+  - React-Fabric/consistency (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1512,7 +1512,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.83.0-rc.3):
+  - React-Fabric/core (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1537,7 +1537,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.83.0-rc.3):
+  - React-Fabric/dom (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1562,7 +1562,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.83.0-rc.3):
+  - React-Fabric/imagemanager (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1587,7 +1587,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.83.0-rc.3):
+  - React-Fabric/leakchecker (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1612,7 +1612,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.83.0-rc.3):
+  - React-Fabric/mounting (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1637,7 +1637,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.83.0-rc.3):
+  - React-Fabric/observers (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1651,8 +1651,8 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.83.0-rc.3)
-    - React-Fabric/observers/intersection (= 0.83.0-rc.3)
+    - React-Fabric/observers/events (= 0.83.0-rc.5)
+    - React-Fabric/observers/intersection (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1664,32 +1664,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.83.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/observers/intersection (0.83.0-rc.3):
+  - React-Fabric/observers/events (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1714,7 +1689,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.83.0-rc.3):
+  - React-Fabric/observers/intersection (0.83.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/scheduler (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1742,7 +1742,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.83.0-rc.3):
+  - React-Fabric/telemetry (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1767,7 +1767,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.83.0-rc.3):
+  - React-Fabric/templateprocessor (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1792,7 +1792,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.83.0-rc.3):
+  - React-Fabric/uimanager (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1806,7 +1806,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.83.0-rc.3)
+    - React-Fabric/uimanager/consistency (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1819,7 +1819,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager/consistency (0.83.0-rc.3):
+  - React-Fabric/uimanager/consistency (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1845,7 +1845,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.83.0-rc.3):
+  - React-FabricComponents (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1860,8 +1860,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.83.0-rc.3)
-    - React-FabricComponents/textlayoutmanager (= 0.83.0-rc.3)
+    - React-FabricComponents/components (= 0.83.0-rc.5)
+    - React-FabricComponents/textlayoutmanager (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1874,7 +1874,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.83.0-rc.3):
+  - React-FabricComponents/components (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1889,18 +1889,18 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.83.0-rc.3)
-    - React-FabricComponents/components/iostextinput (= 0.83.0-rc.3)
-    - React-FabricComponents/components/modal (= 0.83.0-rc.3)
-    - React-FabricComponents/components/rncore (= 0.83.0-rc.3)
-    - React-FabricComponents/components/safeareaview (= 0.83.0-rc.3)
-    - React-FabricComponents/components/scrollview (= 0.83.0-rc.3)
-    - React-FabricComponents/components/switch (= 0.83.0-rc.3)
-    - React-FabricComponents/components/text (= 0.83.0-rc.3)
-    - React-FabricComponents/components/textinput (= 0.83.0-rc.3)
-    - React-FabricComponents/components/unimplementedview (= 0.83.0-rc.3)
-    - React-FabricComponents/components/virtualview (= 0.83.0-rc.3)
-    - React-FabricComponents/components/virtualviewexperimental (= 0.83.0-rc.3)
+    - React-FabricComponents/components/inputaccessory (= 0.83.0-rc.5)
+    - React-FabricComponents/components/iostextinput (= 0.83.0-rc.5)
+    - React-FabricComponents/components/modal (= 0.83.0-rc.5)
+    - React-FabricComponents/components/rncore (= 0.83.0-rc.5)
+    - React-FabricComponents/components/safeareaview (= 0.83.0-rc.5)
+    - React-FabricComponents/components/scrollview (= 0.83.0-rc.5)
+    - React-FabricComponents/components/switch (= 0.83.0-rc.5)
+    - React-FabricComponents/components/text (= 0.83.0-rc.5)
+    - React-FabricComponents/components/textinput (= 0.83.0-rc.5)
+    - React-FabricComponents/components/unimplementedview (= 0.83.0-rc.5)
+    - React-FabricComponents/components/virtualview (= 0.83.0-rc.5)
+    - React-FabricComponents/components/virtualviewexperimental (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1913,34 +1913,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.83.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.83.0-rc.3):
+  - React-FabricComponents/components/inputaccessory (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1967,7 +1940,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/modal (0.83.0-rc.3):
+  - React-FabricComponents/components/iostextinput (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1994,7 +1967,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.83.0-rc.3):
+  - React-FabricComponents/components/modal (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2021,7 +1994,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.83.0-rc.3):
+  - React-FabricComponents/components/rncore (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2048,7 +2021,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.83.0-rc.3):
+  - React-FabricComponents/components/safeareaview (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2075,7 +2048,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/switch (0.83.0-rc.3):
+  - React-FabricComponents/components/scrollview (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2102,7 +2075,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.83.0-rc.3):
+  - React-FabricComponents/components/switch (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2129,7 +2102,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.83.0-rc.3):
+  - React-FabricComponents/components/text (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2156,7 +2129,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.83.0-rc.3):
+  - React-FabricComponents/components/textinput (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2183,7 +2156,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualview (0.83.0-rc.3):
+  - React-FabricComponents/components/unimplementedview (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2210,7 +2183,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualviewexperimental (0.83.0-rc.3):
+  - React-FabricComponents/components/virtualview (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2237,7 +2210,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.83.0-rc.3):
+  - React-FabricComponents/components/virtualviewexperimental (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2264,7 +2237,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.83.0-rc.3):
+  - React-FabricComponents/textlayoutmanager (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2273,21 +2246,48 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.83.0-rc.3)
-    - RCTTypeSafety (= 0.83.0-rc.3)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.83.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.83.0-rc.5)
+    - RCTTypeSafety (= 0.83.0-rc.5)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.83.0-rc.3)
+    - React-jsiexecutor (= 0.83.0-rc.5)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.83.0-rc.3):
+  - React-featureflags (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2296,7 +2296,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.83.0-rc.3):
+  - React-featureflagsnativemodule (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2311,7 +2311,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.83.0-rc.3):
+  - React-graphics (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2324,7 +2324,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.83.0-rc.3):
+  - React-hermes (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2333,17 +2333,17 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.83.0-rc.3)
+    - React-cxxreact (= 0.83.0-rc.5)
     - React-jsi
-    - React-jsiexecutor (= 0.83.0-rc.3)
+    - React-jsiexecutor (= 0.83.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.83.0-rc.3)
+    - React-perflogger (= 0.83.0-rc.5)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.83.0-rc.3):
+  - React-idlecallbacksnativemodule (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2359,7 +2359,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.83.0-rc.3):
+  - React-ImageManager (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2374,7 +2374,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-intersectionobservernativemodule (0.83.0-rc.3):
+  - React-intersectionobservernativemodule (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2395,7 +2395,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-jserrorhandler (0.83.0-rc.3):
+  - React-jserrorhandler (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2410,7 +2410,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.83.0-rc.3):
+  - React-jsi (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2420,7 +2420,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.83.0-rc.3):
+  - React-jsiexecutor (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2439,7 +2439,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-jsinspector (0.83.0-rc.3):
+  - React-jsinspector (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2454,11 +2454,11 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.83.0-rc.3)
+    - React-perflogger (= 0.83.0-rc.5)
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-jsinspectorcdp (0.83.0-rc.3):
+  - React-jsinspectorcdp (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2467,7 +2467,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.83.0-rc.3):
+  - React-jsinspectornetwork (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2477,7 +2477,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-jsinspectorcdp
     - SocketRocket
-  - React-jsinspectortracing (0.83.0-rc.3):
+  - React-jsinspectortracing (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2491,7 +2491,7 @@ PODS:
     - React-oscompat
     - React-timing
     - SocketRocket
-  - React-jsitooling (0.83.0-rc.3):
+  - React-jsitooling (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2499,18 +2499,18 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.83.0-rc.3)
+    - React-cxxreact (= 0.83.0-rc.5)
     - React-debug
-    - React-jsi (= 0.83.0-rc.3)
+    - React-jsi (= 0.83.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-jsitracing (0.83.0-rc.3):
+  - React-jsitracing (0.83.0-rc.5):
     - React-jsi
-  - React-logger (0.83.0-rc.3):
+  - React-logger (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2519,7 +2519,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.83.0-rc.3):
+  - React-Mapbuffer (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2529,7 +2529,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.83.0-rc.3):
+  - React-microtasksnativemodule (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2868,7 +2868,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-NativeModulesApple (0.83.0-rc.3):
+  - React-NativeModulesApple (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2889,7 +2889,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-networking (0.83.0-rc.3):
+  - React-networking (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2903,8 +2903,8 @@ PODS:
     - React-performancetimeline
     - React-timing
     - SocketRocket
-  - React-oscompat (0.83.0-rc.3)
-  - React-perflogger (0.83.0-rc.3):
+  - React-oscompat (0.83.0-rc.5)
+  - React-perflogger (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2913,7 +2913,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancecdpmetrics (0.83.0-rc.3):
+  - React-performancecdpmetrics (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2927,7 +2927,7 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - SocketRocket
-  - React-performancetimeline (0.83.0-rc.3):
+  - React-performancetimeline (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2940,9 +2940,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.83.0-rc.3):
-    - React-Core/RCTActionSheetHeaders (= 0.83.0-rc.3)
-  - React-RCTAnimation (0.83.0-rc.3):
+  - React-RCTActionSheet (0.83.0-rc.5):
+    - React-Core/RCTActionSheetHeaders (= 0.83.0-rc.5)
+  - React-RCTAnimation (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2958,7 +2958,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.83.0-rc.3):
+  - React-RCTAppDelegate (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2992,7 +2992,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.83.0-rc.3):
+  - React-RCTBlob (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3011,7 +3011,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.83.0-rc.3):
+  - React-RCTFabric (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3048,7 +3048,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.83.0-rc.3):
+  - React-RCTFBReactNativeSpec (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3062,10 +3062,10 @@ PODS:
     - React-Core
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.83.0-rc.3)
+    - React-RCTFBReactNativeSpec/components (= 0.83.0-rc.5)
     - ReactCommon
     - SocketRocket
-  - React-RCTFBReactNativeSpec/components (0.83.0-rc.3):
+  - React-RCTFBReactNativeSpec/components (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3088,7 +3088,7 @@ PODS:
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-RCTImage (0.83.0-rc.3):
+  - React-RCTImage (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3104,14 +3104,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.83.0-rc.3):
-    - React-Core/RCTLinkingHeaders (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
+  - React-RCTLinking (0.83.0-rc.5):
+    - React-Core/RCTLinkingHeaders (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.83.0-rc.3)
-  - React-RCTNetwork (0.83.0-rc.3):
+    - ReactCommon/turbomodule/core (= 0.83.0-rc.5)
+  - React-RCTNetwork (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3131,7 +3131,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.83.0-rc.3):
+  - React-RCTRuntime (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3153,7 +3153,7 @@ PODS:
     - React-RuntimeHermes
     - React-utils
     - SocketRocket
-  - React-RCTSettings (0.83.0-rc.3):
+  - React-RCTSettings (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3168,10 +3168,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.83.0-rc.3):
-    - React-Core/RCTTextHeaders (= 0.83.0-rc.3)
+  - React-RCTText (0.83.0-rc.5):
+    - React-Core/RCTTextHeaders (= 0.83.0-rc.5)
     - Yoga
-  - React-RCTVibration (0.83.0-rc.3):
+  - React-RCTVibration (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3185,11 +3185,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.83.0-rc.3)
-  - React-renderercss (0.83.0-rc.3):
+  - React-rendererconsistency (0.83.0-rc.5)
+  - React-renderercss (0.83.0-rc.5):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.83.0-rc.3):
+  - React-rendererdebug (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3199,7 +3199,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-RuntimeApple (0.83.0-rc.3):
+  - React-RuntimeApple (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3228,7 +3228,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.83.0-rc.3):
+  - React-RuntimeCore (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3250,7 +3250,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.83.0-rc.3):
+  - React-runtimeexecutor (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3260,10 +3260,10 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.83.0-rc.3)
+    - React-jsi (= 0.83.0-rc.5)
     - React-utils
     - SocketRocket
-  - React-RuntimeHermes (0.83.0-rc.3):
+  - React-RuntimeHermes (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3284,7 +3284,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.83.0-rc.3):
+  - React-runtimescheduler (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3306,9 +3306,9 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.83.0-rc.3):
+  - React-timing (0.83.0-rc.5):
     - React-debug
-  - React-utils (0.83.0-rc.3):
+  - React-utils (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3318,9 +3318,9 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - React-debug
-    - React-jsi (= 0.83.0-rc.3)
+    - React-jsi (= 0.83.0-rc.5)
     - SocketRocket
-  - React-webperformancenativemodule (0.83.0-rc.3):
+  - React-webperformancenativemodule (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3337,9 +3337,9 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactAppDependencyProvider (0.83.0-rc.3):
+  - ReactAppDependencyProvider (0.83.0-rc.5):
     - ReactCodegen
-  - ReactCodegen (0.83.0-rc.3):
+  - ReactCodegen (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3365,7 +3365,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.83.0-rc.3):
+  - ReactCommon (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3373,9 +3373,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.83.0-rc.3)
+    - ReactCommon/turbomodule (= 0.83.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule (0.83.0-rc.3):
+  - ReactCommon/turbomodule (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3384,15 +3384,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.83.0-rc.3)
-    - React-cxxreact (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
-    - React-logger (= 0.83.0-rc.3)
-    - React-perflogger (= 0.83.0-rc.3)
-    - ReactCommon/turbomodule/bridging (= 0.83.0-rc.3)
-    - ReactCommon/turbomodule/core (= 0.83.0-rc.3)
+    - React-callinvoker (= 0.83.0-rc.5)
+    - React-cxxreact (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
+    - React-logger (= 0.83.0-rc.5)
+    - React-perflogger (= 0.83.0-rc.5)
+    - ReactCommon/turbomodule/bridging (= 0.83.0-rc.5)
+    - ReactCommon/turbomodule/core (= 0.83.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.83.0-rc.3):
+  - ReactCommon/turbomodule/bridging (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3401,13 +3401,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.83.0-rc.3)
-    - React-cxxreact (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
-    - React-logger (= 0.83.0-rc.3)
-    - React-perflogger (= 0.83.0-rc.3)
+    - React-callinvoker (= 0.83.0-rc.5)
+    - React-cxxreact (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
+    - React-logger (= 0.83.0-rc.5)
+    - React-perflogger (= 0.83.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.83.0-rc.3):
+  - ReactCommon/turbomodule/core (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3416,14 +3416,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.83.0-rc.3)
-    - React-cxxreact (= 0.83.0-rc.3)
-    - React-debug (= 0.83.0-rc.3)
-    - React-featureflags (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
-    - React-logger (= 0.83.0-rc.3)
-    - React-perflogger (= 0.83.0-rc.3)
-    - React-utils (= 0.83.0-rc.3)
+    - React-callinvoker (= 0.83.0-rc.5)
+    - React-cxxreact (= 0.83.0-rc.5)
+    - React-debug (= 0.83.0-rc.5)
+    - React-featureflags (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
+    - React-logger (= 0.83.0-rc.5)
+    - React-perflogger (= 0.83.0-rc.5)
+    - React-utils (= 0.83.0-rc.5)
     - SocketRocket
   - RNCAsyncStorage (2.2.0):
     - boost
@@ -4643,7 +4643,7 @@ SPEC CHECKSUMS:
   EXUpdates: a318472f1671f936208c26ef71955415a1b2e279
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: d7f74537f87b148a7bb047c690036ce7a52c7590
+  FBLazyVector: 5f1d154c17cb9158e4becc24719b2d937f4945fd
   FirebaseAnalytics: acfa848bf81e1a4dbf60ef1f0eddd7328fe6673e
   FirebaseCore: 2321536f9c423b1f857e047a82b8a42abc6d9e2c
   FirebaseCoreExtension: 3a64994969dd05f4bcb7e6896c654eded238e75b
@@ -4659,7 +4659,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 53f8aecd4b137eb7013a4a3620db4c2b57f03a3e
+  hermes-engine: 2853aea4922d43f84b721631947e9b25da43eabd
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -4672,42 +4672,42 @@ SPEC CHECKSUMS:
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
-  RCTDeprecation: fd7dda582e035270b441eec37e0d59f9a93f4cd1
-  RCTRequired: 8769adc104cdfa26af6a42152b3d355d62cd016f
-  RCTSwiftUI: d32a6cb82941045710ec3b4ae68dbb6cccf7e6db
-  RCTSwiftUIWrapper: e0fbc4c1aa47bed80a63602ba0f32cadb90a8377
-  RCTTypeSafety: 7ee27a91354aa8b6f4e2668f92c8a0f5c95ef35a
+  RCTDeprecation: ebbf9e4405e6ff9c1d2db992a3494572c8305198
+  RCTRequired: 758e5b53140d72879317104fb43e19ab1a1193ba
+  RCTSwiftUI: 890ac28774f2fde5cebe1ebbe037e41b0b0c7d18
+  RCTSwiftUIWrapper: 5be2ebb69cf9160438447579ebf5b123cfb0e877
+  RCTTypeSafety: 15292827a8cb22172d657eed0eccd42320687562
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 444caa11c2b83e3b1ed6fa6182102c557c940b99
-  React-callinvoker: 870ebac0b6f228e96144e1d75f4c997b2b9a57af
-  React-Core: a72fc4cd2c28a52b1da63e60891bb6b5c3607f9e
-  React-CoreModules: 01fa71d36c590129d3f70c175b4a8f5aee806606
-  React-cxxreact: bff823e34f270c93f2dc85917aab5d4c5aff7241
-  React-debug: ded5c26d859893b9a1bbb2fc5c690129b567aba7
-  React-defaultsnativemodule: ad6e94fdb56d518642b04ce53df63afa7bd8bf2d
-  React-domnativemodule: c4e8285adc1f230b7dedfa0f99346b25fd781060
-  React-Fabric: 293af299cd2c67627d4e4f51d347a617ba62f6c6
-  React-FabricComponents: 63c7d5bbd3d2eed1a5d2e3864026f276998ef6b9
-  React-FabricImage: bff3c65498ce1e2750d35637c2b10395299ce5ac
-  React-featureflags: a73670b1b54e6054feb1123c607d40998a5dfe89
-  React-featureflagsnativemodule: c7901fbf1d0ecb45a4067eef44918c9ac7c08bb3
-  React-graphics: 0d2c17c289b0b1dd5907f46d996e2b5977e2c5d3
-  React-hermes: b04d1fdbcd891c43b67ca6386e43ea7b95282f0c
-  React-idlecallbacksnativemodule: fe2bc0f22774b409a2e8cc21e66174fbb25d6a5b
-  React-ImageManager: 095bb64f067dd2b72fe3741bf551f803c3fe2c0e
-  React-intersectionobservernativemodule: ca6d045a0bc5d86d71839b3e5f8750e04e88879e
-  React-jserrorhandler: 2c172461ccd791dfcdf43e3e0c07dcf525c7b27f
-  React-jsi: b7c3619ec34d573d59dbd12a66dbd221a9d95263
-  React-jsiexecutor: 381f0bba11eeabb85220392c43f81ff61cc0eb9b
-  React-jsinspector: 56eae8b1872e6f6ff2b847358f88a6af8dc2b44a
-  React-jsinspectorcdp: 99bcb1f7a85f3bf49a69dc4de7673b519e3e404f
-  React-jsinspectornetwork: 26ea72d65831a9de5184434a455174a1e226c743
-  React-jsinspectortracing: 1a89b2d8c21d05031f13815d175a7e07b0c1790a
-  React-jsitooling: 228f862fff62c28135ac8fa23baa2c5aaddce561
-  React-jsitracing: aa63a0ec9ab0cd70ca26bf150245535d889907b6
-  React-logger: ff158f3ec4a6cadbd2b668ff7c60dab5245926c5
-  React-Mapbuffer: c2b016c7c73b70c11250907c97f9bedb6ad726b0
-  React-microtasksnativemodule: cdb701591390d2c08e9770f0f49feeb7d126ad12
+  React: 8896aeaee7431bbbbee8b85592672c2742be80c9
+  React-callinvoker: d64342e47a435565ef0f29d3be649f4fa2c2900b
+  React-Core: 424a8b9734c342ce6405cc7d114e717bebf871d8
+  React-CoreModules: bca5cc57ff1903626235e65852a4a13bb9b743c4
+  React-cxxreact: 2bbb9ee8e9ecf2cdf21f4945a6cdd74cfc7221b0
+  React-debug: 40ce3603f7acf8ce536fbd1b2256d7dde1924267
+  React-defaultsnativemodule: d116bd9b3f372e549c7df94b631b83f67a233219
+  React-domnativemodule: f68417863aa944859d4a8435c68a70240739138e
+  React-Fabric: 36b4f85870edf0a97c91bcb351da60b88888924f
+  React-FabricComponents: c58866b1a6a29cbb90743c7664995fad44de7615
+  React-FabricImage: 739fa870ba9f3a64e115f83438ca62612a172eaf
+  React-featureflags: 2254fdf2554fa6efa41212c0d3adab4e6dc71e51
+  React-featureflagsnativemodule: bb0996bafaf35fdcc9721e8a5c0a423adc18c73d
+  React-graphics: 3ffe759fad74fa962cdd0542f69656bab54141f2
+  React-hermes: 83e6689841c012647450b7d8a38f520a3eeec712
+  React-idlecallbacksnativemodule: c39f4384458074f7e8d801238616b66596d0bcb4
+  React-ImageManager: b8895816803e62edac8e17fc9a8a35e146a02510
+  React-intersectionobservernativemodule: e6bd3ae82d726bb2bc3a5bcf238689932f20aebd
+  React-jserrorhandler: abf4353171d170398254ab83de8e5945dc8163cc
+  React-jsi: 6c2be0fad70db93d9ea3677d35a26e979297180c
+  React-jsiexecutor: b87463dfcffd85b766f96ae262de3935c87111bd
+  React-jsinspector: ca69c2b99d7c6dcdb83f98ae811a3ce6b8302737
+  React-jsinspectorcdp: dfe02915051f543fb62af5724c1c3b5e61f0db13
+  React-jsinspectornetwork: e4ac4c32423c9adb50d29954b656be4fdff0ffe9
+  React-jsinspectortracing: 96b7b3311e0057cff68a3b441810aed6a4536997
+  React-jsitooling: a295b9db2182ca9d368365c685a98fcebca0afe9
+  React-jsitracing: ded1b9591f05f3966f783e79dfb338acc8cc98c9
+  React-logger: d924cbdb1ca5b8201e0e75e61bcf533ab8ba500d
+  React-Mapbuffer: d5b8757899fa4235d2ce0140a2651ef8dcf327b0
+  React-microtasksnativemodule: 0204c4180fddfb125918b464787d04b7bd78f700
   react-native-google-maps: 7cc1184afe41fbd15a3dffd53c924819f6587b69
   react-native-keyboard-controller: 5e209d13d4c5355ddf8c36be3d41b8dfc879cd91
   react-native-maps: ee1e65647460c3d41e778071be5eda10e3da6225
@@ -4719,39 +4719,39 @@ SPEC CHECKSUMS:
   react-native-slider: 30cea7008de785564de2f4fd064f2deb38614a4a
   react-native-view-shot: aac285cd08144be29c19ab659930172836f0067f
   react-native-webview: 183e0d1f10b3c61c5ddd70f4ecd46488856a3573
-  React-NativeModulesApple: 3342e3a9f273c8b38dbf8139ffcb421c26b763fc
-  React-networking: 995d83889b062ebd36cf87345abc05b406413d08
-  React-oscompat: ca07088cee072dd44730c6d6fb7df965aac9d12b
-  React-perflogger: 4ffe3568c3868ebb087801e69cd000c53337f2e5
-  React-performancecdpmetrics: 9c8814933d1ffb333eb0092e486cc5638d3e667a
-  React-performancetimeline: 23e25b5f595007313dcbe328865b12d3bf584b62
-  React-RCTActionSheet: c99e4aec86b4d96df58f0886de1295f0a3d8fcdb
-  React-RCTAnimation: f3f423ccc8d509bbee8d58ef48501cced88d779f
-  React-RCTAppDelegate: 760a29a3f5d619d671ff660ca15ff732aa4d91e1
-  React-RCTBlob: f6eb42ebf2a1a61499d1ab9ad4881c5312688b39
-  React-RCTFabric: f0da54bb97ada23db824400e3baf566d0c9ed2bd
-  React-RCTFBReactNativeSpec: b6f18d253867d1f08569f20aa6d997d7ccd008c5
-  React-RCTImage: 414d115a056530d5513d5dcf9726829bf04b5e5b
-  React-RCTLinking: 216b5fae7687fd142701ce7b4ac31ac806348f7a
-  React-RCTNetwork: aebf36d12ff12d25847fab9547e7d8bcbe11b3b4
-  React-RCTRuntime: f7d487670363ff6ab54ec97fe8c2043d20aa7db0
-  React-RCTSettings: e4cb8087443fd1a97a19f5b6a2925aceae909417
-  React-RCTText: e1efc422d7f33561f851e59e1aa85bbc2fa37a0c
-  React-RCTVibration: 7353bce6ad10f536d69c9b536194bc8f68cb74b1
-  React-rendererconsistency: 0f52c08979513533defc3567a877bf5b81f055a7
-  React-renderercss: d08dfda709c5c3a41b060526665f42d245a47049
-  React-rendererdebug: 01d39f8b29c81c49bc57b72e63fd184bdc2b5bbb
-  React-RuntimeApple: 4680334ae798eb855d9a0353ef52312a43307500
-  React-RuntimeCore: 8fd660d8f929b336d034c6a4600ad37da17b8c4d
-  React-runtimeexecutor: d1bd03f649816f52be6bbb37cf40a723dbf96493
-  React-RuntimeHermes: 52d6fb2d360eb497472e28e722a6a88b5f0cd069
-  React-runtimescheduler: 5c6698437e6b8cf41ab33af6725bcbfa3dc54d88
-  React-timing: b9c9e523117bbd4622d3c2e14b0594e5698f4412
-  React-utils: 83d8f8ec38fb08ec28f0f1ab64a8a9f3cecde9f1
-  React-webperformancenativemodule: 73fb7c9b5b9e55a323f8a7108b9b83e82785685e
-  ReactAppDependencyProvider: 9ca54963f57b9d01b93b4014ebabf5b39bc61773
-  ReactCodegen: 4b6cecbef7c12d27ecaff17f301a4eb83d6bc513
-  ReactCommon: 186521d964be2b0c76daaa031d0916953a60ceb2
+  React-NativeModulesApple: 70e48ed2223d19f8464a34b415673a857ef41d87
+  React-networking: 79a1c0f75ab745981a05db45b8a9042d0f946fb9
+  React-oscompat: 288833c6a87f07dfe80c723d16d5eb893ced5b16
+  React-perflogger: 270d4df0eb451c7c4ee240b005ca7099d087bf8c
+  React-performancecdpmetrics: a890cba394b7bb01b46dbc14088ea1ce9e68cb7b
+  React-performancetimeline: 9f82677bd40a0b383cdb3a4e964d07e06880cb3c
+  React-RCTActionSheet: 617f2ea407dcc8031af58b4edf1ab23267d9fcb4
+  React-RCTAnimation: d005d9e7f7925dc58bae7a4836a1e98abd6b3b74
+  React-RCTAppDelegate: 522d3975f5cf2b92ae9f845c7e72859f647c9543
+  React-RCTBlob: e53bfec9080ca133920e7f1844503abbe72c0dd9
+  React-RCTFabric: 9c477e0c90313ea1967d22f6c900abc3127e778e
+  React-RCTFBReactNativeSpec: fa4089fc8178d0db81b20d8795ec2475ece16e15
+  React-RCTImage: ac182b3d6fb16529225a5fae1d2ea2026cefaa1b
+  React-RCTLinking: 1a08a5d6d4194f6a98810bc0ed75ace51a1aa781
+  React-RCTNetwork: ecb749b8f1b49c93a34374b42c6f6671a12e6c6a
+  React-RCTRuntime: 17dd45929b38c7d15733eceda4db7edfd53ddd08
+  React-RCTSettings: 02fc9e5747b0d3b9365ff564141052d90e315a72
+  React-RCTText: 69207b5b01b7fecd04c31fedbdb882f11614fe09
+  React-RCTVibration: 825060f86f8cc5bc3e8631782eb71e66607266c5
+  React-rendererconsistency: c1771076d441d78c31f0ff7ce8317aae7e44d12c
+  React-renderercss: c4eef5e3dc6bad6687dc0ff9f2f50cb8a76c7ce8
+  React-rendererdebug: 522bd3d58a4826af80bcb9e32611555ada20c640
+  React-RuntimeApple: 55b7dacfd957956c910b2d3c00755009d89930e6
+  React-RuntimeCore: 85284e027c2a33cef289a7b3a143d290c70c0351
+  React-runtimeexecutor: e7db211787f560f955824f263d79499d6afdb859
+  React-RuntimeHermes: c64502edabb96874c3498fb9a5958577e7fb5a50
+  React-runtimescheduler: 60bc9573c7e072b963f1a477426875dc682ee33a
+  React-timing: c2e83bba103ec949371698481f1f2bf75b43e71a
+  React-utils: da1fd1ea9c36f20d86b7e3acb373c9999b57a8b6
+  React-webperformancenativemodule: 8e9272ba6aca935306c8afc488fa226174b8ed30
+  ReactAppDependencyProvider: 07461dc99cceeca991cece80447fd21345113f16
+  ReactCodegen: 78c3cfe0b91f5496545f88e4547fdddd2553a9b7
+  ReactCommon: c93e2d89edf5832fe95ec4eae5bfa8e6e428bd09
   RNCAsyncStorage: 302f2fac014fd450046c120567ca364632da682b
   RNCMaskedView: 63268de1986a098b5f4d1fb5b1bc1e97fade0aee
   RNCPicker: 51992b3407f6b70ddb8e417ec5714c3f2d48d8a4
@@ -4776,7 +4776,7 @@ SPEC CHECKSUMS:
   StripePaymentsUI: 05d4be35b34f821d5ddc8617dee04219f3646253
   StripeUICore: d07bd63a4b53dee8cab4d6f81ce5a7ab3e28511e
   UMAppLoader: e1234c45d2b7da239e9e90fc4bbeacee12afd5b6
-  Yoga: cec68ad2cff7afc3e8f47ad6a056aa4b084cd1ac
+  Yoga: d4d200896f40c3b84d1393e8083c08f8c78ecbfb
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 742e8f741f69382578860d1bf3542a2909c81f37

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -69,7 +69,7 @@
     "prop-types": "^15.7.2",
     "querystring": "^0.2.0",
     "react": "19.2.0",
-    "react-native": "0.83.0-rc.3",
+    "react-native": "0.83.0-rc.5",
     "react-native-edge-to-edge": "1.6.0",
     "react-native-fade-in-image": "^1.6.1",
     "react-native-gesture-handler": "~2.28.0",

--- a/apps/jest-expo-mock-generator/package.json
+++ b/apps/jest-expo-mock-generator/package.json
@@ -9,6 +9,6 @@
     "expo": "~54.0.8",
     "expo-clipboard": "~8.0.7",
     "react": "19.2.0",
-    "react-native": "0.83.0-rc.3"
+    "react-native": "0.83.0-rc.5"
   }
 }

--- a/apps/minimal-tester/ios/Podfile.lock
+++ b/apps/minimal-tester/ios/Podfile.lock
@@ -322,7 +322,7 @@ PODS:
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.83.0-rc.3)
+  - FBLazyVector (0.83.0-rc.5)
   - fmt (11.0.2)
   - glog (0.3.5)
   - hermes-engine (0.14.0):
@@ -364,31 +364,31 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.83.0-rc.3)
-  - RCTRequired (0.83.0-rc.3)
-  - RCTSwiftUI (0.83.0-rc.3)
-  - RCTSwiftUIWrapper (0.83.0-rc.3):
+  - RCTDeprecation (0.83.0-rc.5)
+  - RCTRequired (0.83.0-rc.5)
+  - RCTSwiftUI (0.83.0-rc.5)
+  - RCTSwiftUIWrapper (0.83.0-rc.5):
     - RCTSwiftUI
-  - RCTTypeSafety (0.83.0-rc.3):
-    - FBLazyVector (= 0.83.0-rc.3)
-    - RCTRequired (= 0.83.0-rc.3)
-    - React-Core (= 0.83.0-rc.3)
+  - RCTTypeSafety (0.83.0-rc.5):
+    - FBLazyVector (= 0.83.0-rc.5)
+    - RCTRequired (= 0.83.0-rc.5)
+    - React-Core (= 0.83.0-rc.5)
   - ReachabilitySwift (5.2.4)
-  - React (0.83.0-rc.3):
-    - React-Core (= 0.83.0-rc.3)
-    - React-Core/DevSupport (= 0.83.0-rc.3)
-    - React-Core/RCTWebSocket (= 0.83.0-rc.3)
-    - React-RCTActionSheet (= 0.83.0-rc.3)
-    - React-RCTAnimation (= 0.83.0-rc.3)
-    - React-RCTBlob (= 0.83.0-rc.3)
-    - React-RCTImage (= 0.83.0-rc.3)
-    - React-RCTLinking (= 0.83.0-rc.3)
-    - React-RCTNetwork (= 0.83.0-rc.3)
-    - React-RCTSettings (= 0.83.0-rc.3)
-    - React-RCTText (= 0.83.0-rc.3)
-    - React-RCTVibration (= 0.83.0-rc.3)
-  - React-callinvoker (0.83.0-rc.3)
-  - React-Core (0.83.0-rc.3):
+  - React (0.83.0-rc.5):
+    - React-Core (= 0.83.0-rc.5)
+    - React-Core/DevSupport (= 0.83.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.83.0-rc.5)
+    - React-RCTActionSheet (= 0.83.0-rc.5)
+    - React-RCTAnimation (= 0.83.0-rc.5)
+    - React-RCTBlob (= 0.83.0-rc.5)
+    - React-RCTImage (= 0.83.0-rc.5)
+    - React-RCTLinking (= 0.83.0-rc.5)
+    - React-RCTNetwork (= 0.83.0-rc.5)
+    - React-RCTSettings (= 0.83.0-rc.5)
+    - React-RCTText (= 0.83.0-rc.5)
+    - React-RCTVibration (= 0.83.0-rc.5)
+  - React-callinvoker (0.83.0-rc.5)
+  - React-Core (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -398,7 +398,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.83.0-rc.3)
+    - React-Core/Default (= 0.83.0-rc.5)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -413,82 +413,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.83.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.83.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.83.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.83.0-rc.3)
-    - React-Core/RCTWebSocket (= 0.83.0-rc.3)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.83.0-rc.3):
+  - React-Core/CoreModulesHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -513,7 +438,57 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.83.0-rc.3):
+  - React-Core/Default (0.83.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.83.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.83.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.83.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -538,7 +513,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.83.0-rc.3):
+  - React-Core/RCTAnimationHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -563,7 +538,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.83.0-rc.3):
+  - React-Core/RCTBlobHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -588,7 +563,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.83.0-rc.3):
+  - React-Core/RCTImageHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -613,7 +588,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.83.0-rc.3):
+  - React-Core/RCTLinkingHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -638,7 +613,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.83.0-rc.3):
+  - React-Core/RCTNetworkHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -663,7 +638,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.83.0-rc.3):
+  - React-Core/RCTSettingsHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -688,7 +663,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.83.0-rc.3):
+  - React-Core/RCTTextHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -713,7 +688,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.83.0-rc.3):
+  - React-Core/RCTVibrationHeaders (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -723,7 +698,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.83.0-rc.3)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -738,7 +713,32 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.83.0-rc.3):
+  - React-Core/RCTWebSocket (0.83.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.83.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -746,22 +746,22 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.83.0-rc.3)
-    - React-Core/CoreModulesHeaders (= 0.83.0-rc.3)
+    - RCTTypeSafety (= 0.83.0-rc.5)
+    - React-Core/CoreModulesHeaders (= 0.83.0-rc.5)
     - React-debug
-    - React-jsi (= 0.83.0-rc.3)
+    - React-jsi (= 0.83.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.83.0-rc.3)
+    - React-RCTImage (= 0.83.0-rc.5)
     - React-runtimeexecutor
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.83.0-rc.3):
+  - React-cxxreact (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -770,20 +770,20 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.83.0-rc.3)
-    - React-debug (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
+    - React-callinvoker (= 0.83.0-rc.5)
+    - React-debug (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.83.0-rc.3)
-    - React-perflogger (= 0.83.0-rc.3)
+    - React-logger (= 0.83.0-rc.5)
+    - React-perflogger (= 0.83.0-rc.5)
     - React-runtimeexecutor
-    - React-timing (= 0.83.0-rc.3)
+    - React-timing (= 0.83.0-rc.5)
     - React-utils
     - SocketRocket
-  - React-debug (0.83.0-rc.3)
-  - React-defaultsnativemodule (0.83.0-rc.3):
+  - React-debug (0.83.0-rc.5)
+  - React-defaultsnativemodule (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -804,7 +804,7 @@ PODS:
     - React-webperformancenativemodule
     - SocketRocket
     - Yoga
-  - React-domnativemodule (0.83.0-rc.3):
+  - React-domnativemodule (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -824,7 +824,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.83.0-rc.3):
+  - React-Fabric (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -838,25 +838,25 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animated (= 0.83.0-rc.3)
-    - React-Fabric/animationbackend (= 0.83.0-rc.3)
-    - React-Fabric/animations (= 0.83.0-rc.3)
-    - React-Fabric/attributedstring (= 0.83.0-rc.3)
-    - React-Fabric/bridging (= 0.83.0-rc.3)
-    - React-Fabric/componentregistry (= 0.83.0-rc.3)
-    - React-Fabric/componentregistrynative (= 0.83.0-rc.3)
-    - React-Fabric/components (= 0.83.0-rc.3)
-    - React-Fabric/consistency (= 0.83.0-rc.3)
-    - React-Fabric/core (= 0.83.0-rc.3)
-    - React-Fabric/dom (= 0.83.0-rc.3)
-    - React-Fabric/imagemanager (= 0.83.0-rc.3)
-    - React-Fabric/leakchecker (= 0.83.0-rc.3)
-    - React-Fabric/mounting (= 0.83.0-rc.3)
-    - React-Fabric/observers (= 0.83.0-rc.3)
-    - React-Fabric/scheduler (= 0.83.0-rc.3)
-    - React-Fabric/telemetry (= 0.83.0-rc.3)
-    - React-Fabric/templateprocessor (= 0.83.0-rc.3)
-    - React-Fabric/uimanager (= 0.83.0-rc.3)
+    - React-Fabric/animated (= 0.83.0-rc.5)
+    - React-Fabric/animationbackend (= 0.83.0-rc.5)
+    - React-Fabric/animations (= 0.83.0-rc.5)
+    - React-Fabric/attributedstring (= 0.83.0-rc.5)
+    - React-Fabric/bridging (= 0.83.0-rc.5)
+    - React-Fabric/componentregistry (= 0.83.0-rc.5)
+    - React-Fabric/componentregistrynative (= 0.83.0-rc.5)
+    - React-Fabric/components (= 0.83.0-rc.5)
+    - React-Fabric/consistency (= 0.83.0-rc.5)
+    - React-Fabric/core (= 0.83.0-rc.5)
+    - React-Fabric/dom (= 0.83.0-rc.5)
+    - React-Fabric/imagemanager (= 0.83.0-rc.5)
+    - React-Fabric/leakchecker (= 0.83.0-rc.5)
+    - React-Fabric/mounting (= 0.83.0-rc.5)
+    - React-Fabric/observers (= 0.83.0-rc.5)
+    - React-Fabric/scheduler (= 0.83.0-rc.5)
+    - React-Fabric/telemetry (= 0.83.0-rc.5)
+    - React-Fabric/templateprocessor (= 0.83.0-rc.5)
+    - React-Fabric/uimanager (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -868,32 +868,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animated (0.83.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/animationbackend (0.83.0-rc.3):
+  - React-Fabric/animated (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -918,7 +893,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.83.0-rc.3):
+  - React-Fabric/animationbackend (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -943,7 +918,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/attributedstring (0.83.0-rc.3):
+  - React-Fabric/animations (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -968,7 +943,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/bridging (0.83.0-rc.3):
+  - React-Fabric/attributedstring (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -993,7 +968,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.83.0-rc.3):
+  - React-Fabric/bridging (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1018,7 +993,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.83.0-rc.3):
+  - React-Fabric/componentregistry (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1043,36 +1018,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.83.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.83.0-rc.3)
-    - React-Fabric/components/root (= 0.83.0-rc.3)
-    - React-Fabric/components/scrollview (= 0.83.0-rc.3)
-    - React-Fabric/components/view (= 0.83.0-rc.3)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.83.0-rc.3):
+  - React-Fabric/componentregistrynative (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1097,7 +1043,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.83.0-rc.3):
+  - React-Fabric/components (0.83.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.83.0-rc.5)
+    - React-Fabric/components/root (= 0.83.0-rc.5)
+    - React-Fabric/components/scrollview (= 0.83.0-rc.5)
+    - React-Fabric/components/view (= 0.83.0-rc.5)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1122,7 +1097,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.83.0-rc.3):
+  - React-Fabric/components/root (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1147,7 +1122,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.83.0-rc.3):
+  - React-Fabric/components/scrollview (0.83.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1174,7 +1174,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.83.0-rc.3):
+  - React-Fabric/consistency (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1199,7 +1199,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.83.0-rc.3):
+  - React-Fabric/core (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1224,7 +1224,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.83.0-rc.3):
+  - React-Fabric/dom (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1249,7 +1249,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.83.0-rc.3):
+  - React-Fabric/imagemanager (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1274,7 +1274,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.83.0-rc.3):
+  - React-Fabric/leakchecker (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1299,7 +1299,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.83.0-rc.3):
+  - React-Fabric/mounting (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1324,7 +1324,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.83.0-rc.3):
+  - React-Fabric/observers (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1338,8 +1338,8 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.83.0-rc.3)
-    - React-Fabric/observers/intersection (= 0.83.0-rc.3)
+    - React-Fabric/observers/events (= 0.83.0-rc.5)
+    - React-Fabric/observers/intersection (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1351,32 +1351,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.83.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/observers/intersection (0.83.0-rc.3):
+  - React-Fabric/observers/events (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1401,7 +1376,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.83.0-rc.3):
+  - React-Fabric/observers/intersection (0.83.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/scheduler (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1429,7 +1429,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.83.0-rc.3):
+  - React-Fabric/telemetry (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1454,7 +1454,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.83.0-rc.3):
+  - React-Fabric/templateprocessor (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1479,7 +1479,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.83.0-rc.3):
+  - React-Fabric/uimanager (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1493,7 +1493,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.83.0-rc.3)
+    - React-Fabric/uimanager/consistency (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1506,7 +1506,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager/consistency (0.83.0-rc.3):
+  - React-Fabric/uimanager/consistency (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1532,7 +1532,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.83.0-rc.3):
+  - React-FabricComponents (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1547,8 +1547,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.83.0-rc.3)
-    - React-FabricComponents/textlayoutmanager (= 0.83.0-rc.3)
+    - React-FabricComponents/components (= 0.83.0-rc.5)
+    - React-FabricComponents/textlayoutmanager (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1561,7 +1561,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.83.0-rc.3):
+  - React-FabricComponents/components (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1576,18 +1576,18 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.83.0-rc.3)
-    - React-FabricComponents/components/iostextinput (= 0.83.0-rc.3)
-    - React-FabricComponents/components/modal (= 0.83.0-rc.3)
-    - React-FabricComponents/components/rncore (= 0.83.0-rc.3)
-    - React-FabricComponents/components/safeareaview (= 0.83.0-rc.3)
-    - React-FabricComponents/components/scrollview (= 0.83.0-rc.3)
-    - React-FabricComponents/components/switch (= 0.83.0-rc.3)
-    - React-FabricComponents/components/text (= 0.83.0-rc.3)
-    - React-FabricComponents/components/textinput (= 0.83.0-rc.3)
-    - React-FabricComponents/components/unimplementedview (= 0.83.0-rc.3)
-    - React-FabricComponents/components/virtualview (= 0.83.0-rc.3)
-    - React-FabricComponents/components/virtualviewexperimental (= 0.83.0-rc.3)
+    - React-FabricComponents/components/inputaccessory (= 0.83.0-rc.5)
+    - React-FabricComponents/components/iostextinput (= 0.83.0-rc.5)
+    - React-FabricComponents/components/modal (= 0.83.0-rc.5)
+    - React-FabricComponents/components/rncore (= 0.83.0-rc.5)
+    - React-FabricComponents/components/safeareaview (= 0.83.0-rc.5)
+    - React-FabricComponents/components/scrollview (= 0.83.0-rc.5)
+    - React-FabricComponents/components/switch (= 0.83.0-rc.5)
+    - React-FabricComponents/components/text (= 0.83.0-rc.5)
+    - React-FabricComponents/components/textinput (= 0.83.0-rc.5)
+    - React-FabricComponents/components/unimplementedview (= 0.83.0-rc.5)
+    - React-FabricComponents/components/virtualview (= 0.83.0-rc.5)
+    - React-FabricComponents/components/virtualviewexperimental (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1600,34 +1600,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.83.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.83.0-rc.3):
+  - React-FabricComponents/components/inputaccessory (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1654,7 +1627,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/modal (0.83.0-rc.3):
+  - React-FabricComponents/components/iostextinput (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1681,7 +1654,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.83.0-rc.3):
+  - React-FabricComponents/components/modal (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1708,7 +1681,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.83.0-rc.3):
+  - React-FabricComponents/components/rncore (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1735,7 +1708,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.83.0-rc.3):
+  - React-FabricComponents/components/safeareaview (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1762,7 +1735,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/switch (0.83.0-rc.3):
+  - React-FabricComponents/components/scrollview (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1789,7 +1762,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.83.0-rc.3):
+  - React-FabricComponents/components/switch (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1816,7 +1789,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.83.0-rc.3):
+  - React-FabricComponents/components/text (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1843,7 +1816,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.83.0-rc.3):
+  - React-FabricComponents/components/textinput (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1870,7 +1843,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualview (0.83.0-rc.3):
+  - React-FabricComponents/components/unimplementedview (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1897,7 +1870,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualviewexperimental (0.83.0-rc.3):
+  - React-FabricComponents/components/virtualview (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1924,7 +1897,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.83.0-rc.3):
+  - React-FabricComponents/components/virtualviewexperimental (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1951,7 +1924,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.83.0-rc.3):
+  - React-FabricComponents/textlayoutmanager (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1960,21 +1933,48 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.83.0-rc.3)
-    - RCTTypeSafety (= 0.83.0-rc.3)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.83.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.83.0-rc.5)
+    - RCTTypeSafety (= 0.83.0-rc.5)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.83.0-rc.3)
+    - React-jsiexecutor (= 0.83.0-rc.5)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.83.0-rc.3):
+  - React-featureflags (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1983,7 +1983,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.83.0-rc.3):
+  - React-featureflagsnativemodule (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1998,7 +1998,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.83.0-rc.3):
+  - React-graphics (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2011,7 +2011,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.83.0-rc.3):
+  - React-hermes (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2020,17 +2020,17 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.83.0-rc.3)
+    - React-cxxreact (= 0.83.0-rc.5)
     - React-jsi
-    - React-jsiexecutor (= 0.83.0-rc.3)
+    - React-jsiexecutor (= 0.83.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.83.0-rc.3)
+    - React-perflogger (= 0.83.0-rc.5)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.83.0-rc.3):
+  - React-idlecallbacksnativemodule (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2046,7 +2046,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.83.0-rc.3):
+  - React-ImageManager (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2061,7 +2061,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-intersectionobservernativemodule (0.83.0-rc.3):
+  - React-intersectionobservernativemodule (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2082,7 +2082,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-jserrorhandler (0.83.0-rc.3):
+  - React-jserrorhandler (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2097,7 +2097,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.83.0-rc.3):
+  - React-jsi (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2107,7 +2107,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.83.0-rc.3):
+  - React-jsiexecutor (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2126,7 +2126,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-jsinspector (0.83.0-rc.3):
+  - React-jsinspector (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2141,11 +2141,11 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.83.0-rc.3)
+    - React-perflogger (= 0.83.0-rc.5)
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-jsinspectorcdp (0.83.0-rc.3):
+  - React-jsinspectorcdp (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2154,7 +2154,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.83.0-rc.3):
+  - React-jsinspectornetwork (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2164,7 +2164,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-jsinspectorcdp
     - SocketRocket
-  - React-jsinspectortracing (0.83.0-rc.3):
+  - React-jsinspectortracing (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2178,7 +2178,7 @@ PODS:
     - React-oscompat
     - React-timing
     - SocketRocket
-  - React-jsitooling (0.83.0-rc.3):
+  - React-jsitooling (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2186,18 +2186,18 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.83.0-rc.3)
+    - React-cxxreact (= 0.83.0-rc.5)
     - React-debug
-    - React-jsi (= 0.83.0-rc.3)
+    - React-jsi (= 0.83.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-jsitracing (0.83.0-rc.3):
+  - React-jsitracing (0.83.0-rc.5):
     - React-jsi
-  - React-logger (0.83.0-rc.3):
+  - React-logger (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2206,7 +2206,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.83.0-rc.3):
+  - React-Mapbuffer (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2216,7 +2216,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.83.0-rc.3):
+  - React-microtasksnativemodule (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2230,7 +2230,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-NativeModulesApple (0.83.0-rc.3):
+  - React-NativeModulesApple (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2251,7 +2251,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-networking (0.83.0-rc.3):
+  - React-networking (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2265,8 +2265,8 @@ PODS:
     - React-performancetimeline
     - React-timing
     - SocketRocket
-  - React-oscompat (0.83.0-rc.3)
-  - React-perflogger (0.83.0-rc.3):
+  - React-oscompat (0.83.0-rc.5)
+  - React-perflogger (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2275,7 +2275,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancecdpmetrics (0.83.0-rc.3):
+  - React-performancecdpmetrics (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2289,7 +2289,7 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - SocketRocket
-  - React-performancetimeline (0.83.0-rc.3):
+  - React-performancetimeline (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2302,9 +2302,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.83.0-rc.3):
-    - React-Core/RCTActionSheetHeaders (= 0.83.0-rc.3)
-  - React-RCTAnimation (0.83.0-rc.3):
+  - React-RCTActionSheet (0.83.0-rc.5):
+    - React-Core/RCTActionSheetHeaders (= 0.83.0-rc.5)
+  - React-RCTAnimation (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2320,7 +2320,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.83.0-rc.3):
+  - React-RCTAppDelegate (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2354,7 +2354,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.83.0-rc.3):
+  - React-RCTBlob (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2373,7 +2373,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.83.0-rc.3):
+  - React-RCTFabric (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2410,7 +2410,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.83.0-rc.3):
+  - React-RCTFBReactNativeSpec (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2424,10 +2424,10 @@ PODS:
     - React-Core
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.83.0-rc.3)
+    - React-RCTFBReactNativeSpec/components (= 0.83.0-rc.5)
     - ReactCommon
     - SocketRocket
-  - React-RCTFBReactNativeSpec/components (0.83.0-rc.3):
+  - React-RCTFBReactNativeSpec/components (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2450,7 +2450,7 @@ PODS:
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-RCTImage (0.83.0-rc.3):
+  - React-RCTImage (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2466,14 +2466,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.83.0-rc.3):
-    - React-Core/RCTLinkingHeaders (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
+  - React-RCTLinking (0.83.0-rc.5):
+    - React-Core/RCTLinkingHeaders (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.83.0-rc.3)
-  - React-RCTNetwork (0.83.0-rc.3):
+    - ReactCommon/turbomodule/core (= 0.83.0-rc.5)
+  - React-RCTNetwork (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2493,7 +2493,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.83.0-rc.3):
+  - React-RCTRuntime (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2515,7 +2515,7 @@ PODS:
     - React-RuntimeHermes
     - React-utils
     - SocketRocket
-  - React-RCTSettings (0.83.0-rc.3):
+  - React-RCTSettings (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2530,10 +2530,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.83.0-rc.3):
-    - React-Core/RCTTextHeaders (= 0.83.0-rc.3)
+  - React-RCTText (0.83.0-rc.5):
+    - React-Core/RCTTextHeaders (= 0.83.0-rc.5)
     - Yoga
-  - React-RCTVibration (0.83.0-rc.3):
+  - React-RCTVibration (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2547,11 +2547,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.83.0-rc.3)
-  - React-renderercss (0.83.0-rc.3):
+  - React-rendererconsistency (0.83.0-rc.5)
+  - React-renderercss (0.83.0-rc.5):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.83.0-rc.3):
+  - React-rendererdebug (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2561,7 +2561,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-RuntimeApple (0.83.0-rc.3):
+  - React-RuntimeApple (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2590,7 +2590,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.83.0-rc.3):
+  - React-RuntimeCore (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2612,7 +2612,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.83.0-rc.3):
+  - React-runtimeexecutor (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2622,10 +2622,10 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.83.0-rc.3)
+    - React-jsi (= 0.83.0-rc.5)
     - React-utils
     - SocketRocket
-  - React-RuntimeHermes (0.83.0-rc.3):
+  - React-RuntimeHermes (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2646,7 +2646,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.83.0-rc.3):
+  - React-runtimescheduler (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2668,9 +2668,9 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.83.0-rc.3):
+  - React-timing (0.83.0-rc.5):
     - React-debug
-  - React-utils (0.83.0-rc.3):
+  - React-utils (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2680,9 +2680,9 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - React-debug
-    - React-jsi (= 0.83.0-rc.3)
+    - React-jsi (= 0.83.0-rc.5)
     - SocketRocket
-  - React-webperformancenativemodule (0.83.0-rc.3):
+  - React-webperformancenativemodule (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2699,9 +2699,9 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactAppDependencyProvider (0.83.0-rc.3):
+  - ReactAppDependencyProvider (0.83.0-rc.5):
     - ReactCodegen
-  - ReactCodegen (0.83.0-rc.3):
+  - ReactCodegen (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2727,7 +2727,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.83.0-rc.3):
+  - ReactCommon (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2735,9 +2735,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.83.0-rc.3)
+    - ReactCommon/turbomodule (= 0.83.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule (0.83.0-rc.3):
+  - ReactCommon/turbomodule (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2746,15 +2746,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.83.0-rc.3)
-    - React-cxxreact (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
-    - React-logger (= 0.83.0-rc.3)
-    - React-perflogger (= 0.83.0-rc.3)
-    - ReactCommon/turbomodule/bridging (= 0.83.0-rc.3)
-    - ReactCommon/turbomodule/core (= 0.83.0-rc.3)
+    - React-callinvoker (= 0.83.0-rc.5)
+    - React-cxxreact (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
+    - React-logger (= 0.83.0-rc.5)
+    - React-perflogger (= 0.83.0-rc.5)
+    - ReactCommon/turbomodule/bridging (= 0.83.0-rc.5)
+    - ReactCommon/turbomodule/core (= 0.83.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.83.0-rc.3):
+  - ReactCommon/turbomodule/bridging (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2763,13 +2763,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.83.0-rc.3)
-    - React-cxxreact (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
-    - React-logger (= 0.83.0-rc.3)
-    - React-perflogger (= 0.83.0-rc.3)
+    - React-callinvoker (= 0.83.0-rc.5)
+    - React-cxxreact (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
+    - React-logger (= 0.83.0-rc.5)
+    - React-perflogger (= 0.83.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.83.0-rc.3):
+  - ReactCommon/turbomodule/core (0.83.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2778,14 +2778,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.83.0-rc.3)
-    - React-cxxreact (= 0.83.0-rc.3)
-    - React-debug (= 0.83.0-rc.3)
-    - React-featureflags (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
-    - React-logger (= 0.83.0-rc.3)
-    - React-perflogger (= 0.83.0-rc.3)
-    - React-utils (= 0.83.0-rc.3)
+    - React-callinvoker (= 0.83.0-rc.5)
+    - React-cxxreact (= 0.83.0-rc.5)
+    - React-debug (= 0.83.0-rc.5)
+    - React-featureflags (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
+    - React-logger (= 0.83.0-rc.5)
+    - React-perflogger (= 0.83.0-rc.5)
+    - React-utils (= 0.83.0-rc.5)
     - SocketRocket
   - SDWebImage (5.21.0):
     - SDWebImage/Core (= 5.21.0)
@@ -3146,10 +3146,10 @@ SPEC CHECKSUMS:
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
   EXManifests: 7469efed75d694ce3c43a6da9c6f3886f66d3c26
   Expo: 446942b564f6fa3f855457d1f1678a9d5c5f3741
-  expo-dev-client: b0363ce1f16a248d7c9b67ceaee2dbee058c1e05
-  expo-dev-launcher: 66cb3e6dc99d85b33b74c3ce60a376bfdf26fbea
-  expo-dev-menu: 5cb7b596faa72b1134ccf05e183006a867b704e3
-  expo-dev-menu-interface: 600df12ea01efecdd822daaf13cc0ac091775533
+  expo-dev-client: b8c16c699a35787e1ac38c6d44ef7552fe3f0334
+  expo-dev-launcher: 617152822493adda0848170557a79d6bc585e6fe
+  expo-dev-menu: ae1feaf51f47590afc4527c6a75165beb7aed0dd
+  expo-dev-menu-interface: 30d9aa2fbca275a1335ca7e076273dac1d42d40a
   ExpoAppleAuthentication: 414e4316f8e25a2afbc3943cf725579c910f24b8
   ExpoAsset: 4375a46b45b12bbfcf6efac8c8a33aebdb8ba12b
   ExpoBlur: b5b7a26572b3c33a11f0b2aa2f95c17c4c393b76
@@ -3169,7 +3169,7 @@ SPEC CHECKSUMS:
   EXUpdates: d1cc88b95f08b41151c1b07edf8b08fdddf7e3bb
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: d7f74537f87b148a7bb047c690036ce7a52c7590
+  FBLazyVector: 5f1d154c17cb9158e4becc24719b2d937f4945fd
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 9a270294aaec03556862ee83edd0f490710bfbb2
@@ -3177,83 +3177,83 @@ SPEC CHECKSUMS:
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
-  RCTDeprecation: fd7dda582e035270b441eec37e0d59f9a93f4cd1
-  RCTRequired: 8769adc104cdfa26af6a42152b3d355d62cd016f
-  RCTSwiftUI: d32a6cb82941045710ec3b4ae68dbb6cccf7e6db
-  RCTSwiftUIWrapper: e0fbc4c1aa47bed80a63602ba0f32cadb90a8377
-  RCTTypeSafety: 7ee27a91354aa8b6f4e2668f92c8a0f5c95ef35a
+  RCTDeprecation: ebbf9e4405e6ff9c1d2db992a3494572c8305198
+  RCTRequired: 758e5b53140d72879317104fb43e19ab1a1193ba
+  RCTSwiftUI: 890ac28774f2fde5cebe1ebbe037e41b0b0c7d18
+  RCTSwiftUIWrapper: 5be2ebb69cf9160438447579ebf5b123cfb0e877
+  RCTTypeSafety: 15292827a8cb22172d657eed0eccd42320687562
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 444caa11c2b83e3b1ed6fa6182102c557c940b99
-  React-callinvoker: 870ebac0b6f228e96144e1d75f4c997b2b9a57af
-  React-Core: a72fc4cd2c28a52b1da63e60891bb6b5c3607f9e
-  React-CoreModules: 01fa71d36c590129d3f70c175b4a8f5aee806606
-  React-cxxreact: bff823e34f270c93f2dc85917aab5d4c5aff7241
-  React-debug: ded5c26d859893b9a1bbb2fc5c690129b567aba7
-  React-defaultsnativemodule: ad6e94fdb56d518642b04ce53df63afa7bd8bf2d
-  React-domnativemodule: c4e8285adc1f230b7dedfa0f99346b25fd781060
-  React-Fabric: 293af299cd2c67627d4e4f51d347a617ba62f6c6
-  React-FabricComponents: 63c7d5bbd3d2eed1a5d2e3864026f276998ef6b9
-  React-FabricImage: bff3c65498ce1e2750d35637c2b10395299ce5ac
-  React-featureflags: a73670b1b54e6054feb1123c607d40998a5dfe89
-  React-featureflagsnativemodule: c7901fbf1d0ecb45a4067eef44918c9ac7c08bb3
-  React-graphics: 0d2c17c289b0b1dd5907f46d996e2b5977e2c5d3
-  React-hermes: b04d1fdbcd891c43b67ca6386e43ea7b95282f0c
-  React-idlecallbacksnativemodule: fe2bc0f22774b409a2e8cc21e66174fbb25d6a5b
-  React-ImageManager: 095bb64f067dd2b72fe3741bf551f803c3fe2c0e
-  React-intersectionobservernativemodule: ca6d045a0bc5d86d71839b3e5f8750e04e88879e
-  React-jserrorhandler: 2c172461ccd791dfcdf43e3e0c07dcf525c7b27f
-  React-jsi: b7c3619ec34d573d59dbd12a66dbd221a9d95263
-  React-jsiexecutor: 381f0bba11eeabb85220392c43f81ff61cc0eb9b
-  React-jsinspector: 56eae8b1872e6f6ff2b847358f88a6af8dc2b44a
-  React-jsinspectorcdp: 99bcb1f7a85f3bf49a69dc4de7673b519e3e404f
-  React-jsinspectornetwork: 26ea72d65831a9de5184434a455174a1e226c743
-  React-jsinspectortracing: 1a89b2d8c21d05031f13815d175a7e07b0c1790a
-  React-jsitooling: 228f862fff62c28135ac8fa23baa2c5aaddce561
-  React-jsitracing: aa63a0ec9ab0cd70ca26bf150245535d889907b6
-  React-logger: ff158f3ec4a6cadbd2b668ff7c60dab5245926c5
-  React-Mapbuffer: c2b016c7c73b70c11250907c97f9bedb6ad726b0
-  React-microtasksnativemodule: cdb701591390d2c08e9770f0f49feeb7d126ad12
-  React-NativeModulesApple: 3342e3a9f273c8b38dbf8139ffcb421c26b763fc
-  React-networking: 995d83889b062ebd36cf87345abc05b406413d08
-  React-oscompat: ca07088cee072dd44730c6d6fb7df965aac9d12b
-  React-perflogger: 4ffe3568c3868ebb087801e69cd000c53337f2e5
-  React-performancecdpmetrics: 9c8814933d1ffb333eb0092e486cc5638d3e667a
-  React-performancetimeline: 23e25b5f595007313dcbe328865b12d3bf584b62
-  React-RCTActionSheet: c99e4aec86b4d96df58f0886de1295f0a3d8fcdb
-  React-RCTAnimation: f3f423ccc8d509bbee8d58ef48501cced88d779f
-  React-RCTAppDelegate: 760a29a3f5d619d671ff660ca15ff732aa4d91e1
-  React-RCTBlob: f6eb42ebf2a1a61499d1ab9ad4881c5312688b39
-  React-RCTFabric: f0da54bb97ada23db824400e3baf566d0c9ed2bd
-  React-RCTFBReactNativeSpec: b6f18d253867d1f08569f20aa6d997d7ccd008c5
-  React-RCTImage: 414d115a056530d5513d5dcf9726829bf04b5e5b
-  React-RCTLinking: 216b5fae7687fd142701ce7b4ac31ac806348f7a
-  React-RCTNetwork: aebf36d12ff12d25847fab9547e7d8bcbe11b3b4
-  React-RCTRuntime: f7d487670363ff6ab54ec97fe8c2043d20aa7db0
-  React-RCTSettings: e4cb8087443fd1a97a19f5b6a2925aceae909417
-  React-RCTText: e1efc422d7f33561f851e59e1aa85bbc2fa37a0c
-  React-RCTVibration: 7353bce6ad10f536d69c9b536194bc8f68cb74b1
-  React-rendererconsistency: 0f52c08979513533defc3567a877bf5b81f055a7
-  React-renderercss: d08dfda709c5c3a41b060526665f42d245a47049
-  React-rendererdebug: 01d39f8b29c81c49bc57b72e63fd184bdc2b5bbb
-  React-RuntimeApple: 4680334ae798eb855d9a0353ef52312a43307500
-  React-RuntimeCore: 8fd660d8f929b336d034c6a4600ad37da17b8c4d
-  React-runtimeexecutor: d1bd03f649816f52be6bbb37cf40a723dbf96493
-  React-RuntimeHermes: 52d6fb2d360eb497472e28e722a6a88b5f0cd069
-  React-runtimescheduler: 5c6698437e6b8cf41ab33af6725bcbfa3dc54d88
-  React-timing: b9c9e523117bbd4622d3c2e14b0594e5698f4412
-  React-utils: 83d8f8ec38fb08ec28f0f1ab64a8a9f3cecde9f1
-  React-webperformancenativemodule: 73fb7c9b5b9e55a323f8a7108b9b83e82785685e
-  ReactAppDependencyProvider: 9ca54963f57b9d01b93b4014ebabf5b39bc61773
-  ReactCodegen: 90f6850a6e5261a537859f5fec729c505ff9b530
-  ReactCommon: 186521d964be2b0c76daaa031d0916953a60ceb2
+  React: 8896aeaee7431bbbbee8b85592672c2742be80c9
+  React-callinvoker: d64342e47a435565ef0f29d3be649f4fa2c2900b
+  React-Core: 424a8b9734c342ce6405cc7d114e717bebf871d8
+  React-CoreModules: bca5cc57ff1903626235e65852a4a13bb9b743c4
+  React-cxxreact: 2bbb9ee8e9ecf2cdf21f4945a6cdd74cfc7221b0
+  React-debug: 40ce3603f7acf8ce536fbd1b2256d7dde1924267
+  React-defaultsnativemodule: d116bd9b3f372e549c7df94b631b83f67a233219
+  React-domnativemodule: f68417863aa944859d4a8435c68a70240739138e
+  React-Fabric: 36b4f85870edf0a97c91bcb351da60b88888924f
+  React-FabricComponents: c58866b1a6a29cbb90743c7664995fad44de7615
+  React-FabricImage: 739fa870ba9f3a64e115f83438ca62612a172eaf
+  React-featureflags: 2254fdf2554fa6efa41212c0d3adab4e6dc71e51
+  React-featureflagsnativemodule: bb0996bafaf35fdcc9721e8a5c0a423adc18c73d
+  React-graphics: 3ffe759fad74fa962cdd0542f69656bab54141f2
+  React-hermes: 83e6689841c012647450b7d8a38f520a3eeec712
+  React-idlecallbacksnativemodule: c39f4384458074f7e8d801238616b66596d0bcb4
+  React-ImageManager: b8895816803e62edac8e17fc9a8a35e146a02510
+  React-intersectionobservernativemodule: e6bd3ae82d726bb2bc3a5bcf238689932f20aebd
+  React-jserrorhandler: abf4353171d170398254ab83de8e5945dc8163cc
+  React-jsi: 6c2be0fad70db93d9ea3677d35a26e979297180c
+  React-jsiexecutor: b87463dfcffd85b766f96ae262de3935c87111bd
+  React-jsinspector: ca69c2b99d7c6dcdb83f98ae811a3ce6b8302737
+  React-jsinspectorcdp: dfe02915051f543fb62af5724c1c3b5e61f0db13
+  React-jsinspectornetwork: e4ac4c32423c9adb50d29954b656be4fdff0ffe9
+  React-jsinspectortracing: 96b7b3311e0057cff68a3b441810aed6a4536997
+  React-jsitooling: a295b9db2182ca9d368365c685a98fcebca0afe9
+  React-jsitracing: ded1b9591f05f3966f783e79dfb338acc8cc98c9
+  React-logger: d924cbdb1ca5b8201e0e75e61bcf533ab8ba500d
+  React-Mapbuffer: d5b8757899fa4235d2ce0140a2651ef8dcf327b0
+  React-microtasksnativemodule: 0204c4180fddfb125918b464787d04b7bd78f700
+  React-NativeModulesApple: 70e48ed2223d19f8464a34b415673a857ef41d87
+  React-networking: 79a1c0f75ab745981a05db45b8a9042d0f946fb9
+  React-oscompat: 288833c6a87f07dfe80c723d16d5eb893ced5b16
+  React-perflogger: 270d4df0eb451c7c4ee240b005ca7099d087bf8c
+  React-performancecdpmetrics: a890cba394b7bb01b46dbc14088ea1ce9e68cb7b
+  React-performancetimeline: 9f82677bd40a0b383cdb3a4e964d07e06880cb3c
+  React-RCTActionSheet: 617f2ea407dcc8031af58b4edf1ab23267d9fcb4
+  React-RCTAnimation: d005d9e7f7925dc58bae7a4836a1e98abd6b3b74
+  React-RCTAppDelegate: 522d3975f5cf2b92ae9f845c7e72859f647c9543
+  React-RCTBlob: e53bfec9080ca133920e7f1844503abbe72c0dd9
+  React-RCTFabric: 9c477e0c90313ea1967d22f6c900abc3127e778e
+  React-RCTFBReactNativeSpec: fa4089fc8178d0db81b20d8795ec2475ece16e15
+  React-RCTImage: ac182b3d6fb16529225a5fae1d2ea2026cefaa1b
+  React-RCTLinking: 1a08a5d6d4194f6a98810bc0ed75ace51a1aa781
+  React-RCTNetwork: ecb749b8f1b49c93a34374b42c6f6671a12e6c6a
+  React-RCTRuntime: 17dd45929b38c7d15733eceda4db7edfd53ddd08
+  React-RCTSettings: 02fc9e5747b0d3b9365ff564141052d90e315a72
+  React-RCTText: 69207b5b01b7fecd04c31fedbdb882f11614fe09
+  React-RCTVibration: 825060f86f8cc5bc3e8631782eb71e66607266c5
+  React-rendererconsistency: c1771076d441d78c31f0ff7ce8317aae7e44d12c
+  React-renderercss: c4eef5e3dc6bad6687dc0ff9f2f50cb8a76c7ce8
+  React-rendererdebug: 522bd3d58a4826af80bcb9e32611555ada20c640
+  React-RuntimeApple: 55b7dacfd957956c910b2d3c00755009d89930e6
+  React-RuntimeCore: 85284e027c2a33cef289a7b3a143d290c70c0351
+  React-runtimeexecutor: e7db211787f560f955824f263d79499d6afdb859
+  React-RuntimeHermes: c64502edabb96874c3498fb9a5958577e7fb5a50
+  React-runtimescheduler: 60bc9573c7e072b963f1a477426875dc682ee33a
+  React-timing: c2e83bba103ec949371698481f1f2bf75b43e71a
+  React-utils: da1fd1ea9c36f20d86b7e3acb373c9999b57a8b6
+  React-webperformancenativemodule: 8e9272ba6aca935306c8afc488fa226174b8ed30
+  ReactAppDependencyProvider: 07461dc99cceeca991cece80447fd21345113f16
+  ReactCodegen: 2105594ab480614fa28e464435f0905781540826
+  ReactCommon: c93e2d89edf5832fe95ec4eae5bfa8e6e428bd09
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: cec68ad2cff7afc3e8f47ad6a056aa4b084cd1ac
+  Yoga: d4d200896f40c3b84d1393e8083c08f8c78ecbfb
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: 3d26d20fc75a5b3e209d9b88282589121a9ef56d
+PODFILE CHECKSUM: 7d8a30763a5483760de31b98b1bd5dd615b82985
 
 COCOAPODS: 1.16.2

--- a/apps/minimal-tester/package.json
+++ b/apps/minimal-tester/package.json
@@ -22,7 +22,7 @@
     "expo-video": "~3.0.11",
     "react": "19.2.0",
     "react-dom": "19.2.0",
-    "react-native": "0.83.0-rc.3",
+    "react-native": "0.83.0-rc.5",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -140,7 +140,7 @@
     "processing-js": "^1.6.6",
     "react": "19.2.0",
     "react-dom": "19.2.0",
-    "react-native": "0.83.0-rc.3",
+    "react-native": "0.83.0-rc.5",
     "react-native-dropdown-picker": "^5.3.0",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-keyboard-controller": "^1.18.5",

--- a/apps/native-tests/ios/Podfile.lock
+++ b/apps/native-tests/ios/Podfile.lock
@@ -444,7 +444,7 @@ PODS:
     - Yoga
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
-  - FBLazyVector (0.83.0-rc.3)
+  - FBLazyVector (0.83.0-rc.5)
   - hermes-engine (0.14.0):
     - hermes-engine/Pre-built (= 0.14.0)
   - hermes-engine/Pre-built (0.14.0)
@@ -480,35 +480,35 @@ PODS:
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (9.1.0)
   - Quick (7.3.0)
-  - RCTDeprecation (0.83.0-rc.3)
-  - RCTRequired (0.83.0-rc.3)
-  - RCTSwiftUI (0.83.0-rc.3)
-  - RCTSwiftUIWrapper (0.83.0-rc.3):
+  - RCTDeprecation (0.83.0-rc.5)
+  - RCTRequired (0.83.0-rc.5)
+  - RCTSwiftUI (0.83.0-rc.5)
+  - RCTSwiftUIWrapper (0.83.0-rc.5):
     - RCTSwiftUI
-  - RCTTypeSafety (0.83.0-rc.3):
-    - FBLazyVector (= 0.83.0-rc.3)
-    - RCTRequired (= 0.83.0-rc.3)
-    - React-Core (= 0.83.0-rc.3)
+  - RCTTypeSafety (0.83.0-rc.5):
+    - FBLazyVector (= 0.83.0-rc.5)
+    - RCTRequired (= 0.83.0-rc.5)
+    - React-Core (= 0.83.0-rc.5)
   - ReachabilitySwift (5.2.4)
-  - React (0.83.0-rc.3):
-    - React-Core (= 0.83.0-rc.3)
-    - React-Core/DevSupport (= 0.83.0-rc.3)
-    - React-Core/RCTWebSocket (= 0.83.0-rc.3)
-    - React-RCTActionSheet (= 0.83.0-rc.3)
-    - React-RCTAnimation (= 0.83.0-rc.3)
-    - React-RCTBlob (= 0.83.0-rc.3)
-    - React-RCTImage (= 0.83.0-rc.3)
-    - React-RCTLinking (= 0.83.0-rc.3)
-    - React-RCTNetwork (= 0.83.0-rc.3)
-    - React-RCTSettings (= 0.83.0-rc.3)
-    - React-RCTText (= 0.83.0-rc.3)
-    - React-RCTVibration (= 0.83.0-rc.3)
-  - React-callinvoker (0.83.0-rc.3)
-  - React-Core (0.83.0-rc.3):
+  - React (0.83.0-rc.5):
+    - React-Core (= 0.83.0-rc.5)
+    - React-Core/DevSupport (= 0.83.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.83.0-rc.5)
+    - React-RCTActionSheet (= 0.83.0-rc.5)
+    - React-RCTAnimation (= 0.83.0-rc.5)
+    - React-RCTBlob (= 0.83.0-rc.5)
+    - React-RCTImage (= 0.83.0-rc.5)
+    - React-RCTLinking (= 0.83.0-rc.5)
+    - React-RCTNetwork (= 0.83.0-rc.5)
+    - React-RCTSettings (= 0.83.0-rc.5)
+    - React-RCTText (= 0.83.0-rc.5)
+    - React-RCTVibration (= 0.83.0-rc.5)
+  - React-callinvoker (0.83.0-rc.5)
+  - React-Core (0.83.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.83.0-rc.3)
+    - React-Core/Default (= 0.83.0-rc.5)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -523,66 +523,9 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core-prebuilt (0.83.0-rc.3):
+  - React-Core-prebuilt (0.83.0-rc.5):
     - ReactNativeDependencies
-  - React-Core/CoreModulesHeaders (0.83.0-rc.3):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/Default (0.83.0-rc.3):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/DevSupport (0.83.0-rc.3):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default (= 0.83.0-rc.3)
-    - React-Core/RCTWebSocket (= 0.83.0-rc.3)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.83.0-rc.3):
+  - React-Core/CoreModulesHeaders (0.83.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -601,7 +544,45 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.83.0-rc.3):
+  - React-Core/Default (0.83.0-rc.5):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/DevSupport (0.83.0-rc.5):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-Core/Default (= 0.83.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.83.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.83.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -620,7 +601,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTBlobHeaders (0.83.0-rc.3):
+  - React-Core/RCTAnimationHeaders (0.83.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -639,7 +620,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTImageHeaders (0.83.0-rc.3):
+  - React-Core/RCTBlobHeaders (0.83.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -658,7 +639,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.83.0-rc.3):
+  - React-Core/RCTImageHeaders (0.83.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -677,7 +658,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.83.0-rc.3):
+  - React-Core/RCTLinkingHeaders (0.83.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -696,7 +677,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.83.0-rc.3):
+  - React-Core/RCTNetworkHeaders (0.83.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -715,7 +696,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTTextHeaders (0.83.0-rc.3):
+  - React-Core/RCTSettingsHeaders (0.83.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -734,7 +715,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.83.0-rc.3):
+  - React-Core/RCTTextHeaders (0.83.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -753,11 +734,11 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTWebSocket (0.83.0-rc.3):
+  - React-Core/RCTVibrationHeaders (0.83.0-rc.5):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.83.0-rc.3)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -772,40 +753,59 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-CoreModules (0.83.0-rc.3):
-    - RCTTypeSafety (= 0.83.0-rc.3)
+  - React-Core/RCTWebSocket (0.83.0-rc.5):
+    - hermes-engine
+    - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/CoreModulesHeaders (= 0.83.0-rc.3)
+    - React-Core/Default (= 0.83.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-CoreModules (0.83.0-rc.5):
+    - RCTTypeSafety (= 0.83.0-rc.5)
+    - React-Core-prebuilt
+    - React-Core/CoreModulesHeaders (= 0.83.0-rc.5)
     - React-debug
-    - React-jsi (= 0.83.0-rc.3)
+    - React-jsi (= 0.83.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.83.0-rc.3)
+    - React-RCTImage (= 0.83.0-rc.5)
     - React-runtimeexecutor
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
-  - React-cxxreact (0.83.0-rc.3):
+  - React-cxxreact (0.83.0-rc.5):
     - hermes-engine
-    - React-callinvoker (= 0.83.0-rc.3)
+    - React-callinvoker (= 0.83.0-rc.5)
     - React-Core-prebuilt
-    - React-debug (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
+    - React-debug (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.83.0-rc.3)
-    - React-perflogger (= 0.83.0-rc.3)
+    - React-logger (= 0.83.0-rc.5)
+    - React-perflogger (= 0.83.0-rc.5)
     - React-runtimeexecutor
-    - React-timing (= 0.83.0-rc.3)
+    - React-timing (= 0.83.0-rc.5)
     - React-utils
     - ReactNativeDependencies
-  - React-debug (0.83.0-rc.3)
-  - React-defaultsnativemodule (0.83.0-rc.3):
+  - React-debug (0.83.0-rc.5)
+  - React-defaultsnativemodule (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-domnativemodule
@@ -820,7 +820,7 @@ PODS:
     - React-webperformancenativemodule
     - ReactNativeDependencies
     - Yoga
-  - React-domnativemodule (0.83.0-rc.3):
+  - React-domnativemodule (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-Fabric
@@ -834,7 +834,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric (0.83.0-rc.3):
+  - React-Fabric (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -842,25 +842,25 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/animated (= 0.83.0-rc.3)
-    - React-Fabric/animationbackend (= 0.83.0-rc.3)
-    - React-Fabric/animations (= 0.83.0-rc.3)
-    - React-Fabric/attributedstring (= 0.83.0-rc.3)
-    - React-Fabric/bridging (= 0.83.0-rc.3)
-    - React-Fabric/componentregistry (= 0.83.0-rc.3)
-    - React-Fabric/componentregistrynative (= 0.83.0-rc.3)
-    - React-Fabric/components (= 0.83.0-rc.3)
-    - React-Fabric/consistency (= 0.83.0-rc.3)
-    - React-Fabric/core (= 0.83.0-rc.3)
-    - React-Fabric/dom (= 0.83.0-rc.3)
-    - React-Fabric/imagemanager (= 0.83.0-rc.3)
-    - React-Fabric/leakchecker (= 0.83.0-rc.3)
-    - React-Fabric/mounting (= 0.83.0-rc.3)
-    - React-Fabric/observers (= 0.83.0-rc.3)
-    - React-Fabric/scheduler (= 0.83.0-rc.3)
-    - React-Fabric/telemetry (= 0.83.0-rc.3)
-    - React-Fabric/templateprocessor (= 0.83.0-rc.3)
-    - React-Fabric/uimanager (= 0.83.0-rc.3)
+    - React-Fabric/animated (= 0.83.0-rc.5)
+    - React-Fabric/animationbackend (= 0.83.0-rc.5)
+    - React-Fabric/animations (= 0.83.0-rc.5)
+    - React-Fabric/attributedstring (= 0.83.0-rc.5)
+    - React-Fabric/bridging (= 0.83.0-rc.5)
+    - React-Fabric/componentregistry (= 0.83.0-rc.5)
+    - React-Fabric/componentregistrynative (= 0.83.0-rc.5)
+    - React-Fabric/components (= 0.83.0-rc.5)
+    - React-Fabric/consistency (= 0.83.0-rc.5)
+    - React-Fabric/core (= 0.83.0-rc.5)
+    - React-Fabric/dom (= 0.83.0-rc.5)
+    - React-Fabric/imagemanager (= 0.83.0-rc.5)
+    - React-Fabric/leakchecker (= 0.83.0-rc.5)
+    - React-Fabric/mounting (= 0.83.0-rc.5)
+    - React-Fabric/observers (= 0.83.0-rc.5)
+    - React-Fabric/scheduler (= 0.83.0-rc.5)
+    - React-Fabric/telemetry (= 0.83.0-rc.5)
+    - React-Fabric/templateprocessor (= 0.83.0-rc.5)
+    - React-Fabric/uimanager (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -872,26 +872,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/animated (0.83.0-rc.3):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/animationbackend (0.83.0-rc.3):
+  - React-Fabric/animated (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -910,7 +891,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/animations (0.83.0-rc.3):
+  - React-Fabric/animationbackend (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -929,7 +910,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/attributedstring (0.83.0-rc.3):
+  - React-Fabric/animations (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -948,7 +929,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/bridging (0.83.0-rc.3):
+  - React-Fabric/attributedstring (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -967,7 +948,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistry (0.83.0-rc.3):
+  - React-Fabric/bridging (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -986,7 +967,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistrynative (0.83.0-rc.3):
+  - React-Fabric/componentregistry (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1005,30 +986,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components (0.83.0-rc.3):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.83.0-rc.3)
-    - React-Fabric/components/root (= 0.83.0-rc.3)
-    - React-Fabric/components/scrollview (= 0.83.0-rc.3)
-    - React-Fabric/components/view (= 0.83.0-rc.3)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/components/legacyviewmanagerinterop (0.83.0-rc.3):
+  - React-Fabric/componentregistrynative (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1047,7 +1005,30 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/root (0.83.0-rc.3):
+  - React-Fabric/components (0.83.0-rc.5):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.83.0-rc.5)
+    - React-Fabric/components/root (= 0.83.0-rc.5)
+    - React-Fabric/components/scrollview (= 0.83.0-rc.5)
+    - React-Fabric/components/view (= 0.83.0-rc.5)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/legacyviewmanagerinterop (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1066,7 +1047,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/scrollview (0.83.0-rc.3):
+  - React-Fabric/components/root (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1085,7 +1066,26 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/view (0.83.0-rc.3):
+  - React-Fabric/components/scrollview (0.83.0-rc.5):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/view (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1106,7 +1106,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric/consistency (0.83.0-rc.3):
+  - React-Fabric/consistency (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1125,7 +1125,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/core (0.83.0-rc.3):
+  - React-Fabric/core (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1144,7 +1144,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/dom (0.83.0-rc.3):
+  - React-Fabric/dom (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1163,7 +1163,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/imagemanager (0.83.0-rc.3):
+  - React-Fabric/imagemanager (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1182,7 +1182,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/leakchecker (0.83.0-rc.3):
+  - React-Fabric/leakchecker (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1201,7 +1201,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/mounting (0.83.0-rc.3):
+  - React-Fabric/mounting (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1220,7 +1220,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers (0.83.0-rc.3):
+  - React-Fabric/observers (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1228,8 +1228,8 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.83.0-rc.3)
-    - React-Fabric/observers/intersection (= 0.83.0-rc.3)
+    - React-Fabric/observers/events (= 0.83.0-rc.5)
+    - React-Fabric/observers/intersection (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1241,26 +1241,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers/events (0.83.0-rc.3):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/observers/intersection (0.83.0-rc.3):
+  - React-Fabric/observers/events (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1279,7 +1260,26 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/scheduler (0.83.0-rc.3):
+  - React-Fabric/observers/intersection (0.83.0-rc.5):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/scheduler (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1301,7 +1301,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/telemetry (0.83.0-rc.3):
+  - React-Fabric/telemetry (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1320,7 +1320,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/templateprocessor (0.83.0-rc.3):
+  - React-Fabric/templateprocessor (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1339,7 +1339,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager (0.83.0-rc.3):
+  - React-Fabric/uimanager (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1347,7 +1347,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.83.0-rc.3)
+    - React-Fabric/uimanager/consistency (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1360,7 +1360,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager/consistency (0.83.0-rc.3):
+  - React-Fabric/uimanager/consistency (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1380,7 +1380,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-FabricComponents (0.83.0-rc.3):
+  - React-FabricComponents (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1389,8 +1389,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.83.0-rc.3)
-    - React-FabricComponents/textlayoutmanager (= 0.83.0-rc.3)
+    - React-FabricComponents/components (= 0.83.0-rc.5)
+    - React-FabricComponents/textlayoutmanager (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1403,7 +1403,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components (0.83.0-rc.3):
+  - React-FabricComponents/components (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1412,18 +1412,18 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.83.0-rc.3)
-    - React-FabricComponents/components/iostextinput (= 0.83.0-rc.3)
-    - React-FabricComponents/components/modal (= 0.83.0-rc.3)
-    - React-FabricComponents/components/rncore (= 0.83.0-rc.3)
-    - React-FabricComponents/components/safeareaview (= 0.83.0-rc.3)
-    - React-FabricComponents/components/scrollview (= 0.83.0-rc.3)
-    - React-FabricComponents/components/switch (= 0.83.0-rc.3)
-    - React-FabricComponents/components/text (= 0.83.0-rc.3)
-    - React-FabricComponents/components/textinput (= 0.83.0-rc.3)
-    - React-FabricComponents/components/unimplementedview (= 0.83.0-rc.3)
-    - React-FabricComponents/components/virtualview (= 0.83.0-rc.3)
-    - React-FabricComponents/components/virtualviewexperimental (= 0.83.0-rc.3)
+    - React-FabricComponents/components/inputaccessory (= 0.83.0-rc.5)
+    - React-FabricComponents/components/iostextinput (= 0.83.0-rc.5)
+    - React-FabricComponents/components/modal (= 0.83.0-rc.5)
+    - React-FabricComponents/components/rncore (= 0.83.0-rc.5)
+    - React-FabricComponents/components/safeareaview (= 0.83.0-rc.5)
+    - React-FabricComponents/components/scrollview (= 0.83.0-rc.5)
+    - React-FabricComponents/components/switch (= 0.83.0-rc.5)
+    - React-FabricComponents/components/text (= 0.83.0-rc.5)
+    - React-FabricComponents/components/textinput (= 0.83.0-rc.5)
+    - React-FabricComponents/components/unimplementedview (= 0.83.0-rc.5)
+    - React-FabricComponents/components/virtualview (= 0.83.0-rc.5)
+    - React-FabricComponents/components/virtualviewexperimental (= 0.83.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1436,28 +1436,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.83.0-rc.3):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.83.0-rc.3):
+  - React-FabricComponents/components/inputaccessory (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1478,7 +1457,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/modal (0.83.0-rc.3):
+  - React-FabricComponents/components/iostextinput (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1499,7 +1478,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/rncore (0.83.0-rc.3):
+  - React-FabricComponents/components/modal (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1520,7 +1499,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.83.0-rc.3):
+  - React-FabricComponents/components/rncore (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1541,7 +1520,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/scrollview (0.83.0-rc.3):
+  - React-FabricComponents/components/safeareaview (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1562,7 +1541,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/switch (0.83.0-rc.3):
+  - React-FabricComponents/components/scrollview (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1583,7 +1562,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/text (0.83.0-rc.3):
+  - React-FabricComponents/components/switch (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1604,7 +1583,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/textinput (0.83.0-rc.3):
+  - React-FabricComponents/components/text (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1625,7 +1604,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.83.0-rc.3):
+  - React-FabricComponents/components/textinput (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1646,7 +1625,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/virtualview (0.83.0-rc.3):
+  - React-FabricComponents/components/unimplementedview (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1667,7 +1646,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/virtualviewexperimental (0.83.0-rc.3):
+  - React-FabricComponents/components/virtualview (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1688,7 +1667,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.83.0-rc.3):
+  - React-FabricComponents/components/virtualviewexperimental (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1709,27 +1688,48 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricImage (0.83.0-rc.3):
+  - React-FabricComponents/textlayoutmanager (0.83.0-rc.5):
     - hermes-engine
-    - RCTRequired (= 0.83.0-rc.3)
-    - RCTTypeSafety (= 0.83.0-rc.3)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
+  - React-FabricImage (0.83.0-rc.5):
+    - hermes-engine
+    - RCTRequired (= 0.83.0-rc.5)
+    - RCTTypeSafety (= 0.83.0-rc.5)
     - React-Core-prebuilt
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.83.0-rc.3)
+    - React-jsiexecutor (= 0.83.0-rc.5)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-featureflags (0.83.0-rc.3):
+  - React-featureflags (0.83.0-rc.5):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-featureflagsnativemodule (0.83.0-rc.3):
+  - React-featureflagsnativemodule (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1738,27 +1738,27 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-graphics (0.83.0-rc.3):
+  - React-graphics (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
     - React-jsiexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-hermes (0.83.0-rc.3):
+  - React-hermes (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
-    - React-cxxreact (= 0.83.0-rc.3)
+    - React-cxxreact (= 0.83.0-rc.5)
     - React-jsi
-    - React-jsiexecutor (= 0.83.0-rc.3)
+    - React-jsiexecutor (= 0.83.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.83.0-rc.3)
+    - React-perflogger (= 0.83.0-rc.5)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-idlecallbacksnativemodule (0.83.0-rc.3):
+  - React-idlecallbacksnativemodule (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1768,7 +1768,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-ImageManager (0.83.0-rc.3):
+  - React-ImageManager (0.83.0-rc.5):
     - React-Core-prebuilt
     - React-Core/Default
     - React-debug
@@ -1777,7 +1777,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - ReactNativeDependencies
-  - React-intersectionobservernativemodule (0.83.0-rc.3):
+  - React-intersectionobservernativemodule (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1792,7 +1792,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-jserrorhandler (0.83.0-rc.3):
+  - React-jserrorhandler (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1801,11 +1801,11 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - ReactNativeDependencies
-  - React-jsi (0.83.0-rc.3):
+  - React-jsi (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsiexecutor (0.83.0-rc.3):
+  - React-jsiexecutor (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1818,7 +1818,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-jsinspector (0.83.0-rc.3):
+  - React-jsinspector (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1827,18 +1827,18 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.83.0-rc.3)
+    - React-perflogger (= 0.83.0-rc.5)
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-jsinspectorcdp (0.83.0-rc.3):
+  - React-jsinspectorcdp (0.83.0-rc.5):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsinspectornetwork (0.83.0-rc.3):
+  - React-jsinspectornetwork (0.83.0-rc.5):
     - React-Core-prebuilt
     - React-jsinspectorcdp
     - ReactNativeDependencies
-  - React-jsinspectortracing (0.83.0-rc.3):
+  - React-jsinspectortracing (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1846,27 +1846,27 @@ PODS:
     - React-oscompat
     - React-timing
     - ReactNativeDependencies
-  - React-jsitooling (0.83.0-rc.3):
+  - React-jsitooling (0.83.0-rc.5):
     - React-Core-prebuilt
-    - React-cxxreact (= 0.83.0-rc.3)
+    - React-cxxreact (= 0.83.0-rc.5)
     - React-debug
-    - React-jsi (= 0.83.0-rc.3)
+    - React-jsi (= 0.83.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-jsitracing (0.83.0-rc.3):
+  - React-jsitracing (0.83.0-rc.5):
     - React-jsi
-  - React-logger (0.83.0-rc.3):
+  - React-logger (0.83.0-rc.5):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-Mapbuffer (0.83.0-rc.3):
+  - React-Mapbuffer (0.83.0-rc.5):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-microtasksnativemodule (0.83.0-rc.3):
+  - React-microtasksnativemodule (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1874,7 +1874,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-NativeModulesApple (0.83.0-rc.3):
+  - React-NativeModulesApple (0.83.0-rc.5):
     - hermes-engine
     - React-callinvoker
     - React-Core
@@ -1889,7 +1889,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-networking (0.83.0-rc.3):
+  - React-networking (0.83.0-rc.5):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspectornetwork
@@ -1897,11 +1897,11 @@ PODS:
     - React-performancetimeline
     - React-timing
     - ReactNativeDependencies
-  - React-oscompat (0.83.0-rc.3)
-  - React-perflogger (0.83.0-rc.3):
+  - React-oscompat (0.83.0-rc.5)
+  - React-perflogger (0.83.0-rc.5):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-performancecdpmetrics (0.83.0-rc.3):
+  - React-performancecdpmetrics (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1909,16 +1909,16 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - ReactNativeDependencies
-  - React-performancetimeline (0.83.0-rc.3):
+  - React-performancetimeline (0.83.0-rc.5):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspectortracing
     - React-perflogger
     - React-timing
     - ReactNativeDependencies
-  - React-RCTActionSheet (0.83.0-rc.3):
-    - React-Core/RCTActionSheetHeaders (= 0.83.0-rc.3)
-  - React-RCTAnimation (0.83.0-rc.3):
+  - React-RCTActionSheet (0.83.0-rc.5):
+    - React-Core/RCTActionSheetHeaders (= 0.83.0-rc.5)
+  - React-RCTAnimation (0.83.0-rc.5):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTAnimationHeaders
@@ -1928,7 +1928,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTAppDelegate (0.83.0-rc.3):
+  - React-RCTAppDelegate (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1956,7 +1956,7 @@ PODS:
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTBlob (0.83.0-rc.3):
+  - React-RCTBlob (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-Core/RCTBlobHeaders
@@ -1969,7 +1969,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFabric (0.83.0-rc.3):
+  - React-RCTFabric (0.83.0-rc.5):
     - hermes-engine
     - RCTSwiftUIWrapper
     - React-Core
@@ -2000,7 +2000,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-RCTFBReactNativeSpec (0.83.0-rc.3):
+  - React-RCTFBReactNativeSpec (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2008,10 +2008,10 @@ PODS:
     - React-Core-prebuilt
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.83.0-rc.3)
+    - React-RCTFBReactNativeSpec/components (= 0.83.0-rc.5)
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFBReactNativeSpec/components (0.83.0-rc.3):
+  - React-RCTFBReactNativeSpec/components (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2028,7 +2028,7 @@ PODS:
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-RCTImage (0.83.0-rc.3):
+  - React-RCTImage (0.83.0-rc.5):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTImageHeaders
@@ -2038,14 +2038,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTLinking (0.83.0-rc.3):
-    - React-Core/RCTLinkingHeaders (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
+  - React-RCTLinking (0.83.0-rc.5):
+    - React-Core/RCTLinkingHeaders (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.83.0-rc.3)
-  - React-RCTNetwork (0.83.0-rc.3):
+    - ReactCommon/turbomodule/core (= 0.83.0-rc.5)
+  - React-RCTNetwork (0.83.0-rc.5):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTNetworkHeaders
@@ -2059,7 +2059,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTRuntime (0.83.0-rc.3):
+  - React-RCTRuntime (0.83.0-rc.5):
     - hermes-engine
     - React-Core
     - React-Core-prebuilt
@@ -2075,7 +2075,7 @@ PODS:
     - React-RuntimeHermes
     - React-utils
     - ReactNativeDependencies
-  - React-RCTSettings (0.83.0-rc.3):
+  - React-RCTSettings (0.83.0-rc.5):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTSettingsHeaders
@@ -2084,10 +2084,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTText (0.83.0-rc.3):
-    - React-Core/RCTTextHeaders (= 0.83.0-rc.3)
+  - React-RCTText (0.83.0-rc.5):
+    - React-Core/RCTTextHeaders (= 0.83.0-rc.5)
     - Yoga
-  - React-RCTVibration (0.83.0-rc.3):
+  - React-RCTVibration (0.83.0-rc.5):
     - React-Core-prebuilt
     - React-Core/RCTVibrationHeaders
     - React-jsi
@@ -2095,15 +2095,15 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-rendererconsistency (0.83.0-rc.3)
-  - React-renderercss (0.83.0-rc.3):
+  - React-rendererconsistency (0.83.0-rc.5)
+  - React-renderercss (0.83.0-rc.5):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.83.0-rc.3):
+  - React-rendererdebug (0.83.0-rc.5):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-RuntimeApple (0.83.0-rc.3):
+  - React-RuntimeApple (0.83.0-rc.5):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -2126,7 +2126,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeCore (0.83.0-rc.3):
+  - React-RuntimeCore (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -2142,14 +2142,14 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-runtimeexecutor (0.83.0-rc.3):
+  - React-runtimeexecutor (0.83.0-rc.5):
     - React-Core-prebuilt
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.83.0-rc.3)
+    - React-jsi (= 0.83.0-rc.5)
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeHermes (0.83.0-rc.3):
+  - React-RuntimeHermes (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -2164,7 +2164,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-runtimescheduler (0.83.0-rc.3):
+  - React-runtimescheduler (0.83.0-rc.5):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -2180,15 +2180,15 @@ PODS:
     - React-timing
     - React-utils
     - ReactNativeDependencies
-  - React-timing (0.83.0-rc.3):
+  - React-timing (0.83.0-rc.5):
     - React-debug
-  - React-utils (0.83.0-rc.3):
+  - React-utils (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-debug
-    - React-jsi (= 0.83.0-rc.3)
+    - React-jsi (= 0.83.0-rc.5)
     - ReactNativeDependencies
-  - React-webperformancenativemodule (0.83.0-rc.3):
+  - React-webperformancenativemodule (0.83.0-rc.5):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -2199,9 +2199,9 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - ReactAppDependencyProvider (0.83.0-rc.3):
+  - ReactAppDependencyProvider (0.83.0-rc.5):
     - ReactCodegen
-  - ReactCodegen (0.83.0-rc.3):
+  - ReactCodegen (0.83.0-rc.5):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2221,43 +2221,43 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - ReactCommon (0.83.0-rc.3):
+  - ReactCommon (0.83.0-rc.5):
     - React-Core-prebuilt
-    - ReactCommon/turbomodule (= 0.83.0-rc.3)
+    - ReactCommon/turbomodule (= 0.83.0-rc.5)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule (0.83.0-rc.3):
+  - ReactCommon/turbomodule (0.83.0-rc.5):
     - hermes-engine
-    - React-callinvoker (= 0.83.0-rc.3)
+    - React-callinvoker (= 0.83.0-rc.5)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
-    - React-logger (= 0.83.0-rc.3)
-    - React-perflogger (= 0.83.0-rc.3)
-    - ReactCommon/turbomodule/bridging (= 0.83.0-rc.3)
-    - ReactCommon/turbomodule/core (= 0.83.0-rc.3)
+    - React-cxxreact (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
+    - React-logger (= 0.83.0-rc.5)
+    - React-perflogger (= 0.83.0-rc.5)
+    - ReactCommon/turbomodule/bridging (= 0.83.0-rc.5)
+    - ReactCommon/turbomodule/core (= 0.83.0-rc.5)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/bridging (0.83.0-rc.3):
+  - ReactCommon/turbomodule/bridging (0.83.0-rc.5):
     - hermes-engine
-    - React-callinvoker (= 0.83.0-rc.3)
+    - React-callinvoker (= 0.83.0-rc.5)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
-    - React-logger (= 0.83.0-rc.3)
-    - React-perflogger (= 0.83.0-rc.3)
+    - React-cxxreact (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
+    - React-logger (= 0.83.0-rc.5)
+    - React-perflogger (= 0.83.0-rc.5)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/core (0.83.0-rc.3):
+  - ReactCommon/turbomodule/core (0.83.0-rc.5):
     - hermes-engine
-    - React-callinvoker (= 0.83.0-rc.3)
+    - React-callinvoker (= 0.83.0-rc.5)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.83.0-rc.3)
-    - React-debug (= 0.83.0-rc.3)
-    - React-featureflags (= 0.83.0-rc.3)
-    - React-jsi (= 0.83.0-rc.3)
-    - React-logger (= 0.83.0-rc.3)
-    - React-perflogger (= 0.83.0-rc.3)
-    - React-utils (= 0.83.0-rc.3)
+    - React-cxxreact (= 0.83.0-rc.5)
+    - React-debug (= 0.83.0-rc.5)
+    - React-featureflags (= 0.83.0-rc.5)
+    - React-jsi (= 0.83.0-rc.5)
+    - React-logger (= 0.83.0-rc.5)
+    - React-perflogger (= 0.83.0-rc.5)
+    - React-utils (= 0.83.0-rc.5)
     - ReactNativeDependencies
-  - ReactNativeDependencies (0.83.0-rc.3)
+  - ReactNativeDependencies (0.83.0-rc.5)
   - SDWebImage (5.21.0):
     - SDWebImage/Core (= 5.21.0)
   - SDWebImage/Core (5.21.0)
@@ -2608,90 +2608,90 @@ SPEC CHECKSUMS:
   EXStructuredHeaders: c951e77f2d936f88637421e9588c976da5827368
   EXUpdates: 83e4d666a085b44149f3b21d5bd057ad37b2c3e5
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
-  FBLazyVector: 14b0edddf1446bafe25388fcafb8e752f01c9876
-  hermes-engine: e33c73080ec31b854de9f4c025d453cbcdfb10df
+  FBLazyVector: a9d42cd9acb1b6e87eaef82916d91ad23136e4bb
+  hermes-engine: 9a270294aaec03556862ee83edd0f490710bfbb2
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: d32871931c05547cb4e0bc9009d66a18b50d8558
-  RCTDeprecation: 743787dda2b5197524c82143ce048738f722b9d1
-  RCTRequired: c095f5258e0c4a723653a42cd0bd63b7bacfabfd
-  RCTSwiftUI: d32a6cb82941045710ec3b4ae68dbb6cccf7e6db
-  RCTSwiftUIWrapper: e0fbc4c1aa47bed80a63602ba0f32cadb90a8377
-  RCTTypeSafety: a5ed9aeb43feb848a4043e72dbc20d29c9632ad0
+  RCTDeprecation: cc0af08b1e51c1d3b07c4fe9cd0b9163df475154
+  RCTRequired: c0cb29582513beb094acd06e0566ace3ce3b15a1
+  RCTSwiftUI: 890ac28774f2fde5cebe1ebbe037e41b0b0c7d18
+  RCTSwiftUIWrapper: 5be2ebb69cf9160438447579ebf5b123cfb0e877
+  RCTTypeSafety: 6f2136f534016f0891d9d39679c1b464eb91f628
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 444caa11c2b83e3b1ed6fa6182102c557c940b99
-  React-callinvoker: 86f02ac20583228911bf903a451b677d802c5863
-  React-Core: 4c30624c61366a085ea0665701137723bbf9d792
-  React-Core-prebuilt: 2efd2b200002cd48164b16ed3506726ef201d708
-  React-CoreModules: fdb45864a5bb6cca3720dbac2659fa8dcf40aed2
-  React-cxxreact: 2fc01174c4a114d4517a739c982d1e594df280e2
-  React-debug: 4ee7c16e085c26584151f98bdf6c23fc350d4cf5
-  React-defaultsnativemodule: 45655eb7cac341e9fe454410fff22165a4be3882
-  React-domnativemodule: 9a73bfb08cded64fe28992efb548c1619e2aa07a
-  React-Fabric: cb6a1540dc8e54a06cbcdd0cc60c4516a535c021
-  React-FabricComponents: cd93c1b85558ea7218272c8202bb9b2f5a94b770
-  React-FabricImage: 5fb1b7c79c3c898506f99c4634dbd13a6eedebde
-  React-featureflags: 21ecfce9ba53bfe99817e8e9be8a89e1ab1df9df
-  React-featureflagsnativemodule: 90e8757fdf1f17d093b85a24f1988064daea6670
-  React-graphics: 52a09ab44d1feeab567e6b58fe1538b3d8ff8500
-  React-hermes: 5b528c756543650c0c61e43eb8878f38afd19dc2
-  React-idlecallbacksnativemodule: d4be8061a122e9b331f036b1236117a4d09588f1
-  React-ImageManager: ec43eeac34d09b0de01a2dfcfa72502510c4f08f
-  React-intersectionobservernativemodule: f49285534fa0283cdaf4d9458225cfe89b954698
-  React-jserrorhandler: 0c865633d6b03119aaa0f4b85ccd453d9329bbdd
-  React-jsi: 5ae7ce9f8669a3b26b915c7c2dcf227a8309c252
-  React-jsiexecutor: ec0953b503a685b00747f7fa3b6dbb3711f46efd
-  React-jsinspector: 32b5f4bc217a45e48f2d8e73528b98f55bdee743
-  React-jsinspectorcdp: 1563321232fa3b698a185e090522535f255e2940
-  React-jsinspectornetwork: 72614b2460f4d1798e86db6e412c5ec086595566
-  React-jsinspectortracing: c51071aad909d8e150fde60e22534f0b5dbfc0ee
-  React-jsitooling: b18310b006a2d3b5b36ee865e345d3da7cb9d09b
-  React-jsitracing: 3a93a6bd35081253c47639dfd234e0631ad308f2
-  React-logger: 52ef6553fc16d12e1abb41de0c3d262b28331ea7
-  React-Mapbuffer: 8c2c21804c1fece13af5572e62cbfcfa355657bf
-  React-microtasksnativemodule: 848bfe62eaa333b0495711d6a59c96d1b56a69f0
-  React-NativeModulesApple: 80ad1b2c0f297ddf09018e5539cc5d7c5bc9b4b2
-  React-networking: d8619e04a3d3590798d2bd560815f50307f23579
-  React-oscompat: 5c2b58647e220321355cf15809edfa186c35a07f
-  React-perflogger: ee2278145c48ea3a3de877af7077fe3f0eedf013
-  React-performancecdpmetrics: 366499895db4c8f650ca04928d417b2bbf95c84e
-  React-performancetimeline: a003c7b7c6be2a79bc2ffed461d450daa730c7a8
-  React-RCTActionSheet: e175bdb52bdee7ea507e2a30cd200a115b690215
-  React-RCTAnimation: bf7bf75d9d773f7a10a9cf8123e337d5e2cfc90e
-  React-RCTAppDelegate: 165af38f104fc09978fd689d0ddd98171fb0309c
-  React-RCTBlob: 89345a4768efa9dbf564b302011b164d79def62b
-  React-RCTFabric: 0bbbd3e83aabc29962751697b262e957a8516214
-  React-RCTFBReactNativeSpec: 1cc8b89614d0a04de54b448c9df1364e593bb181
-  React-RCTImage: 2223d4602af59c7fc0ee9592029dfc18391b6949
-  React-RCTLinking: 4d4aa6358872d1c757e497d3c4d349c4d8618b90
-  React-RCTNetwork: a511a9ddb70c9a29815561accc559176a0f48a6c
-  React-RCTRuntime: 529c6113daef13822d1648f1d306780c48caadf7
-  React-RCTSettings: 7dc0750219fc02919d35cdc2b100635219643de7
-  React-RCTText: b581c0bf877f927aa171d671aa51d41c740b3913
-  React-RCTVibration: 34de1a4888e5a827f39a4d10eb0e4c8352dc151b
-  React-rendererconsistency: d7a9a7bcc6eb0c5fd705aff01df878d2c1b009dd
-  React-renderercss: 0e2dc78de58eb0e94e100828d12666066f648642
-  React-rendererdebug: 24e1e3248859c66d71823921f3644768598b8465
-  React-RuntimeApple: ba89590d6a6857bcd709c47d24c54e1f8ec57602
-  React-RuntimeCore: f99adca09ea8a51eb7712f2c45881075196ad8bb
-  React-runtimeexecutor: ac5add875f8e76baae535024eb1e6ded4b33d960
-  React-RuntimeHermes: bf9c7bbf954e9288305f8d15d4c66d621f40b737
-  React-runtimescheduler: cd73c0c169181e6cb026fe73ce7f8468e2bd73ae
-  React-timing: 444b1b4d7a55a4696e42bbaca49e73c0947cffc6
-  React-utils: 592b56a766a3638089316668fe0ff16f64384643
-  React-webperformancenativemodule: 200d840520aa1c9a51ed1040ee810e0310ae8acc
-  ReactAppDependencyProvider: 9ca54963f57b9d01b93b4014ebabf5b39bc61773
-  ReactCodegen: 8df8c5cf06c16e63f2cba093e906278e36c65b19
-  ReactCommon: 5c22adade7e11913a9a72b3c420c0071553b572f
-  ReactNativeDependencies: 0b9a84436883441f75d28ac6462c8aa1fa5401b7
+  React: 8896aeaee7431bbbbee8b85592672c2742be80c9
+  React-callinvoker: 2b6eadc2850579c424c4b1bc3ad7f4452d3e48ce
+  React-Core: 66ae91bab722380ad0bb1f0dc1b12bebef20e1fd
+  React-Core-prebuilt: 9f67b21058b39d96c70d4d19ebfde66424eef197
+  React-CoreModules: 772a8edd6d3e070410864fec6db5b7714edec5d9
+  React-cxxreact: 81daeec52c0629719a1d7fdd59bcb5b414d72377
+  React-debug: e8441fe272552c7687003906ac065f1067b607ee
+  React-defaultsnativemodule: 3817acd3f32dfe0e15c61ff824655f512a15355e
+  React-domnativemodule: 038bf94e8aa31b90e0c430dcaacdbc705545f5e0
+  React-Fabric: 9007f4fcc2963cbb3450b508ee8cb8595b8a18ae
+  React-FabricComponents: c18f56571b8fb756aa64ede97661b8fb6bc089bd
+  React-FabricImage: 7a6acbdfdf7859edbdc70c76d932fe558c19320f
+  React-featureflags: 9df96cbceeca5d6223953b26a2674db87c1a18b5
+  React-featureflagsnativemodule: a968abaef928d87ada59af07e6bd2f09900bbd82
+  React-graphics: 905f5c1c5956e3a193bbe08bcf7982d605fe63e1
+  React-hermes: a0f0d165074993c7847d933015fb682b01ed2cce
+  React-idlecallbacksnativemodule: eefca67a72d06c1ef52add41cb0379c0a624521c
+  React-ImageManager: dcbc712f96612e9f52454736fedf9f058f481c86
+  React-intersectionobservernativemodule: e5ff32a8f8a9dca060cd082a1a3d6a820ce3aef5
+  React-jserrorhandler: 08dafdd6baef94686f5b4d48eb68e38df2065c51
+  React-jsi: 8e57af579384ef5768b0239b9dfa3da62d9d38e1
+  React-jsiexecutor: 0c95d7412d8a6a8555ec28d067b5e0e3950b6a36
+  React-jsinspector: c7a6ad41569f76154109ef80ad5d677e528ea552
+  React-jsinspectorcdp: 43d44f2f5b54e7bc4d409ee6ed294a7526aefc8a
+  React-jsinspectornetwork: 5bfa398781cec973c4bd4ef2c7f6c689370c91ab
+  React-jsinspectortracing: 627ebe604268690c53a990863cab3fcc7943511b
+  React-jsitooling: 7849ee1596c332a5230679f52fd1beb4f47f9d9c
+  React-jsitracing: ba8d57ef74d3ffc3d9bc15547134b8f4d366360e
+  React-logger: 7fbc64214aab6c3bb3997345038e553937983592
+  React-Mapbuffer: 2f408e3e0c2b7961742d19cb6968ef6fd783a8ab
+  React-microtasksnativemodule: 2631260c7d842dc8fbcdd33189d25b8dbcf06235
+  React-NativeModulesApple: 703c3cffcf3a88a977312b7aff9373f320d47b41
+  React-networking: 5d7e03f512935d0a5a2daa1dcf4951851a40fbf5
+  React-oscompat: 326c21cd206db353bb2b716b7ed6e967e53f4270
+  React-perflogger: 6c93378ad8b86f147b4b521bfd7fe4e15528be7b
+  React-performancecdpmetrics: 68987dc00db6c0194fa0b4626c06c485dca5ccca
+  React-performancetimeline: 60012da450aa8c1324bf95f4d9a59e7f6d204166
+  React-RCTActionSheet: b972aa9d319cf3001482804a3137ee11c8a89620
+  React-RCTAnimation: 03bc83ca17fe82f07f903c65f2af6605de0a08a7
+  React-RCTAppDelegate: 5973b6bc18aba3c5f0432c9b937eb108be087a96
+  React-RCTBlob: 2f29fa294dcb8666ae1123926accc03c653ca025
+  React-RCTFabric: 480b8af9e3eca542265d8cdfa128a965ea8840f8
+  React-RCTFBReactNativeSpec: f857e00f108b9b925e117a00e6080cf5dee2afb7
+  React-RCTImage: 2c7bc6f51894fd60d2c6a9983834a03d1f318ba7
+  React-RCTLinking: 32b7df2a5de9c7399891c90c7898f28eb368cbe5
+  React-RCTNetwork: 93b5814fd29be4248fb06cc7c416832f017705f3
+  React-RCTRuntime: 5e0ef6e30fb3c25b810456d6159bffc2b31baeec
+  React-RCTSettings: 95e8fc667242496a927f873d93a7def4e50ed485
+  React-RCTText: dd7b7e20ca7f142bfa1419738e21a09838cf7997
+  React-RCTVibration: 1fce77e5829e27747c2615f94bcba88cd1e95aed
+  React-rendererconsistency: fcba6a533c4f8883ebec40a97ed91b640006c1e3
+  React-renderercss: b3db1263258e9a94ad5e8bf75ef8306887769928
+  React-rendererdebug: 36f0dd428026d944cf9996a92da406ec2fd85753
+  React-RuntimeApple: d0693c7a0774067b7694fce6e2bfd82a8bec9131
+  React-RuntimeCore: ea2818cce7a39e5704ad16c43ede95afb4998f49
+  React-runtimeexecutor: 342d82e5a127c8aadb8339456899422bf4393403
+  React-RuntimeHermes: 2839515edc95bf8c3fdf7268a42bc883d262db59
+  React-runtimescheduler: 0e16cee26cc89c9908da4aa940a54ca3f131ccc6
+  React-timing: 2da67c8d3c5dba510c12be6500e19eff5449e150
+  React-utils: 67ec8a01ed4cae43072d490c54b08d518b266224
+  React-webperformancenativemodule: c85feb7f62a8e5d1665a2e46045a164bb0485131
+  ReactAppDependencyProvider: 07461dc99cceeca991cece80447fd21345113f16
+  ReactCodegen: dbf7b3bda2e7f0e8aea9d4cec17b5b034fa9f510
+  ReactCommon: 95e0bc81ddbc0460fca25e0e9ea8323fc44fd84a
+  ReactNativeDependencies: 95d7635f07837c67f1dcb7f3c9029278e0e70162
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
-  Yoga: 67d1653c9d28e838e7682451b47bed2d2b3fca9d
+  Yoga: e0eab070104b3e31f025ab4c82a94e076e0cf700
 
 PODFILE CHECKSUM: 529f4f814d5854f9650d1358752caf314ca5bfaa
 

--- a/apps/native-tests/package.json
+++ b/apps/native-tests/package.json
@@ -19,7 +19,7 @@
     "expo-updates": "29.0.10",
     "react": "19.2.0",
     "react-dom": "19.2.0",
-    "react-native": "0.83.0-rc.3"
+    "react-native": "0.83.0-rc.5"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -31,7 +31,7 @@
     "expo-task-manager": "14.0.7",
     "react-native-gesture-handler": "~2.28.0",
     "react": "19.2.0",
-    "react-native": "0.83.0-rc.3",
+    "react-native": "0.83.0-rc.5",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.19.0-nightly-20251203-1746a584e"
   },

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -58,7 +58,7 @@
     "expo-symbols": "~1.0.7",
     "jose": "^5",
     "react": "19.2.0",
-    "react-native": "0.83.0-rc.3",
+    "react-native": "0.83.0-rc.5",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.19.0-nightly-20251203-1746a584e",
     "react-native-webview": "13.15.0"

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -15,7 +15,7 @@
     "expo-router": "^6.0.6",
     "expo-splash-screen": "~31.0.10",
     "react": "19.1.1",
-    "react-native": "0.83.0-nightly-20251030-26ad9492b",
+    "react-native": "0.83.0-rc.5",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.11.1-nightly-20250611-8b82e081e"
   },

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -51,7 +51,7 @@
     "jasmine-core": "^2.4.1",
     "lodash": "^4.17.19",
     "react": "19.2.0",
-    "react-native": "0.83.0-rc.3",
+    "react-native": "0.83.0-rc.5",
     "react-native-gesture-handler": "~2.28.0",
     "sinon": "^7.1.1"
   },

--- a/packages/@expo/cli/e2e/fixtures/with-assets/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-assets/package.json
@@ -6,7 +6,7 @@
     "expo": "^52",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-native": "0.83.0-rc.3",
+    "react-native": "0.83.0-rc.5",
     "react-native-web": "~0.20.0"
   },
   "devDependencies": {

--- a/packages/@expo/cli/e2e/fixtures/with-circular-async-imports/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-circular-async-imports/package.json
@@ -6,7 +6,7 @@
     "expo": "^52",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-native": "0.83.0-rc.3",
+    "react-native": "0.83.0-rc.5",
     "react-native-web": "~0.20.0"
   },
   "devDependencies": {

--- a/packages/@expo/cli/e2e/fixtures/with-dom/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-dom/package.json
@@ -6,7 +6,7 @@
     "expo": "^52",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-native": "0.83.0-rc.3",
+    "react-native": "0.83.0-rc.5",
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.15.0"
   },

--- a/packages/@expo/cli/e2e/fixtures/with-hmr-env-vars/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-hmr-env-vars/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "expo": "^52",
     "react": "18.3.1",
-    "react-native": "0.83.0-rc.3",
+    "react-native": "0.83.0-rc.5",
     "react-dom": "18.3.1",
     "react-native-web": "~0.20.0"
   },

--- a/packages/@expo/cli/e2e/fixtures/with-monorepo/apps/app-b/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-monorepo/apps/app-b/package.json
@@ -11,7 +11,7 @@
     "expo-status-bar": "~3.0.8",
     "react": "19.2.0",
     "react-dom": "19.2.0",
-    "react-native": "0.83.0-rc.3",
+    "react-native": "0.83.0-rc.5",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.18.0",
     "react-native-web": "~0.21.0"

--- a/packages/@expo/cli/e2e/fixtures/with-router-typed-routes/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-router-typed-routes/package.json
@@ -11,7 +11,7 @@
     "expo-status-bar": "~2.0.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-native": "0.83.0-rc.3",
+    "react-native": "0.83.0-rc.5",
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0"
   },

--- a/packages/@expo/cli/e2e/fixtures/with-router/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-router/package.json
@@ -10,7 +10,7 @@
     "expo-status-bar": "~3.0.8",
     "react": "19.2.0",
     "react-dom": "19.2.0",
-    "react-native": "0.83.0-rc.3",
+    "react-native": "0.83.0-rc.5",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.18.0",
     "react-native-web": "~0.21.0"

--- a/packages/@expo/cli/e2e/fixtures/with-web/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-web/package.json
@@ -5,7 +5,7 @@
     "expo": "^52",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-native": "0.83.0-rc.3",
+    "react-native": "0.83.0-rc.5",
     "react-native-web": "~0.20.0"
   },
   "devDependencies": {

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -61,7 +61,7 @@
     "@expo/spawn-async": "^1.7.2",
     "@expo/ws-tunnel": "^1.0.1",
     "@expo/xcpretty": "^4.3.0",
-    "@react-native/dev-middleware": "0.83.0-rc.3",
+    "@react-native/dev-middleware": "0.83.0-rc.5",
     "@urql/core": "^5.0.6",
     "@urql/exchange-retry": "^1.3.0",
     "accepts": "^1.3.8",

--- a/packages/@expo/log-box/package.json
+++ b/packages/@expo/log-box/package.json
@@ -30,7 +30,7 @@
     "glob": "^13.0.0",
     "npm-run-all2": "^8.0.4",
     "react": "19.2.0",
-    "react-native": "0.83.0-rc.3",
+    "react-native": "0.83.0-rc.5",
     "rimraf": "^6.1.2",
     "typescript": "~5.9.2",
     "typescript-plugin-css-modules": "^5.2.0"

--- a/packages/@expo/prebuild-config/package.json
+++ b/packages/@expo/prebuild-config/package.json
@@ -45,7 +45,7 @@
     "@expo/config-types": "^54.0.8",
     "@expo/image-utils": "^0.8.7",
     "@expo/json-file": "^10.0.7",
-    "@react-native/normalize-colors": "0.83.0-rc.3",
+    "@react-native/normalize-colors": "0.83.0-rc.5",
     "debug": "^4.3.1",
     "resolve-from": "^5.0.0",
     "semver": "^7.6.0",

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -69,7 +69,7 @@
     "@babel/plugin-transform-parameters": "^7.24.7",
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.23.0",
-    "@react-native/babel-preset": "0.83.0-rc.3",
+    "@react-native/babel-preset": "0.83.0-rc.5",
     "babel-plugin-react-compiler": "^1.0.0",
     "babel-plugin-react-native-web": "~0.21.0",
     "babel-plugin-transform-flow-enums": "^0.0.2",

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -42,7 +42,7 @@
     "babel-preset-expo": "~54.0.1",
     "expo-module-scripts": "^5.0.7",
     "react": "19.2.0",
-    "react-native": "0.83.0-rc.3"
+    "react-native": "0.83.0-rc.5"
   },
   "peerDependencies": {
     "expo": "*"

--- a/packages/expo-navigation-bar/package.json
+++ b/packages/expo-navigation-bar/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/navigation-bar",
   "dependencies": {
-    "@react-native/normalize-colors": "0.83.0-rc.3",
+    "@react-native/normalize-colors": "0.83.0-rc.5",
     "debug": "^4.3.2",
     "react-native-is-edge-to-edge": "^1.2.1"
   },

--- a/packages/expo-system-ui/package.json
+++ b/packages/expo-system-ui/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/system-ui",
   "dependencies": {
-    "@react-native/normalize-colors": "0.83.0-rc.3",
+    "@react-native/normalize-colors": "0.83.0-rc.5",
     "debug": "^4.3.2"
   },
   "jest": {

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -109,7 +109,7 @@
     "expo-module-scripts": "^5.0.7",
     "react": "19.2.0",
     "react-dom": "19.2.0",
-    "react-native": "0.83.0-rc.3",
+    "react-native": "0.83.0-rc.5",
     "web-streams-polyfill": "^3.3.2"
   },
   "peerDependencies": {

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -14,6 +14,6 @@
     "expo": "~54.0.8",
     "expo-status-bar": "~3.0.8",
     "react": "19.2.0",
-    "react-native": "0.83.0-rc.3"
+    "react-native": "0.83.0-rc.5"
   }
 }

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -14,7 +14,7 @@
     "expo": "~54.0.8",
     "expo-status-bar": "~3.0.8",
     "react": "19.2.0",
-    "react-native": "0.83.0-rc.3"
+    "react-native": "0.83.0-rc.5"
   },
   "devDependencies": {
     "@types/react": "~19.1.1",

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -14,6 +14,6 @@
     "expo": "~54.0.8",
     "expo-status-bar": "~3.0.8",
     "react": "19.2.0",
-    "react-native": "0.83.0-rc.3"
+    "react-native": "0.83.0-rc.5"
   }
 }

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -29,7 +29,7 @@
     "expo-web-browser": "~15.0.7",
     "react": "19.2.0",
     "react-dom": "19.2.0",
-    "react-native": "0.83.0-rc.3",
+    "react-native": "0.83.0-rc.5",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-worklets": "0.6.1",
     "react-native-reanimated": "~4.1.1",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -23,7 +23,7 @@
     "expo-web-browser": "~15.0.7",
     "react": "19.2.0",
     "react-dom": "19.2.0",
-    "react-native": "0.83.0-rc.3",
+    "react-native": "0.83.0-rc.5",
     "react-native-worklets": "0.6.1",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3628,28 +3628,23 @@
   resolved "https://registry.yarnpkg.com/@react-native-segmented-control/segmented-control/-/segmented-control-2.5.7.tgz#7c91ef7dede8752796a234321fafa2c604fc82af"
   integrity sha512-l84YeVX8xAU3lvOJSvV4nK/NbGhIm2gBfveYolwaoCbRp+/SLXtc6mYrQmM9ScXNwU14mnzjQTpTHWl5YPnkzQ==
 
-"@react-native/assets-registry@0.83.0-nightly-20251030-26ad9492b":
-  version "0.83.0-nightly-20251030-26ad9492b"
-  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.83.0-nightly-20251030-26ad9492b.tgz#0699ef4f4f555a2366a301d8b6386c0320de661a"
-  integrity sha512-Lp6/zfkuZKy++ULslivCXhrx87cZIENQ1Iddl/BuVeD84fmjM9bVBvhAoTzVEpX2wCOWqr+2orZyw6JDhse6nA==
+"@react-native/assets-registry@0.83.0-rc.5":
+  version "0.83.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.83.0-rc.5.tgz#369712b0a45df0d1f38f4e291e03fee1f3ddadc7"
+  integrity sha512-FJjVT/ZQvqSKfatSusuzBLVfseNxg3NBKQfmbDyTP5xefNW+liGk5rmyfkjQbgnEyC7/bBXWnF+eB/MtvnMZ0Q==
 
-"@react-native/assets-registry@0.83.0-rc.3":
-  version "0.83.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.83.0-rc.3.tgz#d1e447eb80ec778df26d2a74893d4edb63e0802c"
-  integrity sha512-wDk0L+xgD9rwwZCq6ttxwY088elywcXeJmL1XFQTr+iU6S7k0IYWRAdNVIy3GSVdKsbWREO5wrBzPwdE1xWoxg==
-
-"@react-native/babel-plugin-codegen@0.83.0-rc.3":
-  version "0.83.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.83.0-rc.3.tgz#efe3211349226e5db9e619b0d18e48d1a0ecd555"
-  integrity sha512-oM4POAUUGHl+ha7dQU/ncxNFTEXCavk4eONXG96f90WJX5FlZhZBssKM4bqdwNH5TM54xyPEDRYJHYljvyBCEA==
+"@react-native/babel-plugin-codegen@0.83.0-rc.5":
+  version "0.83.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.83.0-rc.5.tgz#fb80c9e8b10f710b3e1018f3b1d40b749e1a9fe4"
+  integrity sha512-rvSkQdWU8pgqbncYcQXM2cy6xCCBWJv6DU8qGnkxKbsOobTgcP50fiF/TakwoQGW9+ughCndduigQ5Sgs08XxA==
   dependencies:
     "@babel/traverse" "^7.25.3"
-    "@react-native/codegen" "0.83.0-rc.3"
+    "@react-native/codegen" "0.83.0-rc.5"
 
-"@react-native/babel-preset@0.83.0-rc.3":
-  version "0.83.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.83.0-rc.3.tgz#804354b8aa496bb348924dd7b33ee2b5a8daabb0"
-  integrity sha512-015WusxDTJrQ9YA0cpOoJ9JGqHbnR3XytZY/XQNqWuH8i8Zw2OOU6a2CIOd77+MO+XqUH5g5YA89lP+02LY56Q==
+"@react-native/babel-preset@0.83.0-rc.5":
+  version "0.83.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.83.0-rc.5.tgz#faaef188cfd55ba56e7189f0c007f58734f400ac"
+  integrity sha512-UbJSGUPHRbdafWADJgI8YuhT4evEIlO0POQDKyT1+UzP/NN7VwmNfQgrDp6JYByA+hyHW9dSUY5rcpYtCi0KYg==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/plugin-proposal-export-default-from" "^7.24.7"
@@ -3692,15 +3687,15 @@
     "@babel/plugin-transform-typescript" "^7.25.2"
     "@babel/plugin-transform-unicode-regex" "^7.24.7"
     "@babel/template" "^7.25.0"
-    "@react-native/babel-plugin-codegen" "0.83.0-rc.3"
+    "@react-native/babel-plugin-codegen" "0.83.0-rc.5"
     babel-plugin-syntax-hermes-parser "0.32.0"
     babel-plugin-transform-flow-enums "^0.0.2"
     react-refresh "^0.14.0"
 
-"@react-native/codegen@0.83.0-nightly-20251030-26ad9492b":
-  version "0.83.0-nightly-20251030-26ad9492b"
-  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.83.0-nightly-20251030-26ad9492b.tgz#070d86fcc03c98c7cab154c7a9b2b0427d0e7426"
-  integrity sha512-PYek39uxBK/VwwQlukrlCWUyJwn+XZheDjDIrJSgiFV4z3FAWCNySvh/D2Rato11tUIRwCYJtqcYpJESX/lp1Q==
+"@react-native/codegen@0.83.0-rc.5":
+  version "0.83.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.83.0-rc.5.tgz#e4dec3dd8c53c12e237348f46aec8571d36e7eb4"
+  integrity sha512-MADDyzuFuAOVfdLzTH4DKXrb239Czu77x9GlYmG4ZqqM/h1AxeYO4D1/YElvYdKZhpI/yTD7IIiBoFvh2ibNTQ==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/parser" "^7.25.3"
@@ -3710,25 +3705,12 @@
     nullthrows "^1.1.1"
     yargs "^17.6.2"
 
-"@react-native/codegen@0.83.0-rc.3":
-  version "0.83.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.83.0-rc.3.tgz#7d87c321d9611989c00f1bbf0d1a9b9a19da93f4"
-  integrity sha512-Bgb7aIbIUYtL/DOuQ80H3PH7/GLn7BahIKwb+4NpTOsY9DKeInFvoULxYgBS4sRyLW2be/loL8iyBgAh/rrZQw==
+"@react-native/community-cli-plugin@0.83.0-rc.5":
+  version "0.83.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.83.0-rc.5.tgz#55453849ae5c8dc2970f7422dd02de26478dc9f8"
+  integrity sha512-DpZGrki3DJA9ix5nk8X+bv1XK10xl0LLXZTSRY8w4n4NXteJ8BeDttE+92YH15ZybgS4RQEfIh3BSeUZFK3djQ==
   dependencies:
-    "@babel/core" "^7.25.2"
-    "@babel/parser" "^7.25.3"
-    glob "^7.1.1"
-    hermes-parser "0.32.0"
-    invariant "^2.2.4"
-    nullthrows "^1.1.1"
-    yargs "^17.6.2"
-
-"@react-native/community-cli-plugin@0.83.0-nightly-20251030-26ad9492b":
-  version "0.83.0-nightly-20251030-26ad9492b"
-  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.83.0-nightly-20251030-26ad9492b.tgz#a1df7c6a0007643dc9400f651ea57e29359d64f6"
-  integrity sha512-zf3BCiqJMtKmL/TyuVoZwIbmYBk3omfFfGQvdByssYBBF5hozxk1nhpRubuETMH14bRykoFmu1ZuXqN+GrK0GQ==
-  dependencies:
-    "@react-native/dev-middleware" "0.83.0-nightly-20251030-26ad9492b"
+    "@react-native/dev-middleware" "0.83.0-rc.5"
     debug "^4.4.0"
     invariant "^2.2.4"
     metro "^0.83.3"
@@ -3736,53 +3718,27 @@
     metro-core "^0.83.3"
     semver "^7.1.3"
 
-"@react-native/community-cli-plugin@0.83.0-rc.3":
-  version "0.83.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.83.0-rc.3.tgz#163b09b1d68964d634a2b21eb6c984731283d9b8"
-  integrity sha512-n+F6Kxpgiym/XTZQmETz7s6WOtm9pVMbRb/JkLX9/rc6qYJAQORpwDMe4xHnPE1Xk/s1V+cG50tYYjaVWBt86w==
-  dependencies:
-    "@react-native/dev-middleware" "0.83.0-rc.3"
-    debug "^4.4.0"
-    invariant "^2.2.4"
-    metro "^0.83.3"
-    metro-config "^0.83.3"
-    metro-core "^0.83.3"
-    semver "^7.1.3"
+"@react-native/debugger-frontend@0.83.0-rc.5":
+  version "0.83.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.83.0-rc.5.tgz#22c86d515d0800566a2c96986303a9d28b7bce84"
+  integrity sha512-s2DHrSgy1SmB73xgAhjIm5ukiiLjQP0dYFWhRTll4sLkWa9aTlzbHaHHyLpyoNyVxrikoiMpSsA5xNuyJURCzQ==
 
-"@react-native/debugger-frontend@0.83.0-nightly-20251030-26ad9492b":
-  version "0.83.0-nightly-20251030-26ad9492b"
-  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.83.0-nightly-20251030-26ad9492b.tgz#ccfd1cd5d0459096e167eaadec626e0102ec34d5"
-  integrity sha512-42mPfvdmSqDspDMDlkOvI+8CUncwqM9nKv0nf3oFGPtzcyr63sNmD8O3YkaqFIjYahdkJepEtF48aey7Byxrgg==
-
-"@react-native/debugger-frontend@0.83.0-rc.3":
-  version "0.83.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.83.0-rc.3.tgz#29c83b9df3c13393793e52e5132aac44fa7389a8"
-  integrity sha512-PwXzJZHwM4mcraNMPPSODpr7CKSUr2JhovUj4/Gi02jftDENUmikxBEP3EfJAI4OzM/FpQPODRa+maskolJaiA==
-
-"@react-native/debugger-shell@0.83.0-nightly-20251030-26ad9492b":
-  version "0.83.0-nightly-20251030-26ad9492b"
-  resolved "https://registry.yarnpkg.com/@react-native/debugger-shell/-/debugger-shell-0.83.0-nightly-20251030-26ad9492b.tgz#25c7e8286d2b7a2d002b62cd75ed7686e79b655b"
-  integrity sha512-cmucPY+yuS3D+5n63pA0lDS70ZkkdUoYxqFUpIe913CKzXY/jLM/yOyPiuhT5eGs2BvdPQSs+oPH9HDPNnCjxg==
+"@react-native/debugger-shell@0.83.0-rc.5":
+  version "0.83.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/debugger-shell/-/debugger-shell-0.83.0-rc.5.tgz#dd2a0f78738a4b225820836f253c055856e63e7f"
+  integrity sha512-4scqp8z30fx+YmtE5ZKp+fEW5NHc+f6n/ilLmKtVm0gzFkQTOtoTEXAVQG32+INU57Nt4Ur8Ku5YPIm5l0qH7g==
   dependencies:
     cross-spawn "^7.0.6"
     fb-dotslash "0.5.8"
 
-"@react-native/debugger-shell@0.83.0-rc.3":
-  version "0.83.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/debugger-shell/-/debugger-shell-0.83.0-rc.3.tgz#a5f7a21fbff588b8a62f3f997b6c6859a6f1a5b8"
-  integrity sha512-NIdRO/OAswE0/1VXXSygYlztASkQ72ZGO+XAW4mag/X1Nw0stbPUTK3bCL3U48apNsfUS9I485/qrwLNiDa0qw==
-  dependencies:
-    cross-spawn "^7.0.6"
-    fb-dotslash "0.5.8"
-
-"@react-native/dev-middleware@0.83.0-nightly-20251030-26ad9492b":
-  version "0.83.0-nightly-20251030-26ad9492b"
-  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.83.0-nightly-20251030-26ad9492b.tgz#652faa11b30b6f86b030668e4a39ae924443d0d9"
-  integrity sha512-7grJpBxXTmx/6v/fCMTupAFAGGUu3YoYznO0p9bVJBecgzzY26KT+BorpRcioh4RH+DqhBVEoFMxBXPkwBYzRg==
+"@react-native/dev-middleware@0.83.0-rc.5":
+  version "0.83.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.83.0-rc.5.tgz#20c7543c06af3ffb20228a387b9d7b2aedd1766b"
+  integrity sha512-7ip84qZuPM+7XXGAZgsaBOWwqRAq518VvQA56HB951Jqpjh/naytKk/rSOER/YktSu7k2/aNKMQUzbqj1d09Dw==
   dependencies:
     "@isaacs/ttlcache" "^1.4.1"
-    "@react-native/debugger-frontend" "0.83.0-nightly-20251030-26ad9492b"
-    "@react-native/debugger-shell" "0.83.0-nightly-20251030-26ad9492b"
+    "@react-native/debugger-frontend" "0.83.0-rc.5"
+    "@react-native/debugger-shell" "0.83.0-rc.5"
     chrome-launcher "^0.15.2"
     chromium-edge-launcher "^0.2.0"
     connect "^3.6.5"
@@ -3793,71 +3749,30 @@
     serve-static "^1.16.2"
     ws "^7.5.10"
 
-"@react-native/dev-middleware@0.83.0-rc.3":
-  version "0.83.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.83.0-rc.3.tgz#755e5e663910136557dbe9855c7cb0b80b15cb37"
-  integrity sha512-h2Uhq9GLPdS69cSW7rC4g0/dQmJhDJEeAhj6bEUGREBvGnjwdcd5uRO9qnlWt4PjJbngkyPSyfjjTXl75X6+6A==
-  dependencies:
-    "@isaacs/ttlcache" "^1.4.1"
-    "@react-native/debugger-frontend" "0.83.0-rc.3"
-    "@react-native/debugger-shell" "0.83.0-rc.3"
-    chrome-launcher "^0.15.2"
-    chromium-edge-launcher "^0.2.0"
-    connect "^3.6.5"
-    debug "^4.4.0"
-    invariant "^2.2.4"
-    nullthrows "^1.1.1"
-    open "^7.0.3"
-    serve-static "^1.16.2"
-    ws "^7.5.10"
+"@react-native/gradle-plugin@0.83.0-rc.5":
+  version "0.83.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.83.0-rc.5.tgz#2ad60e9c955cc12297f1d52935e75070189f1ece"
+  integrity sha512-QjmkvFrNDkvl+ubj+NPj8PzApoWIY+gri9CJdLvm/WJEiv85I/ukqMYaWeU5CV8i8r+vZTDW0e/dFkDh6TxQIg==
 
-"@react-native/gradle-plugin@0.83.0-nightly-20251030-26ad9492b":
-  version "0.83.0-nightly-20251030-26ad9492b"
-  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.83.0-nightly-20251030-26ad9492b.tgz#e15e650268698cb46250747e20d5aad25f8878e6"
-  integrity sha512-Hx3CBSsBoCW7CxQkHWhq4Io3AT3OrJRiyfLT2t77xaKuwqBHOr8mY/li6z35Q8uM3g79yeYXdm2b/cwKYR0a3A==
+"@react-native/js-polyfills@0.83.0-rc.5":
+  version "0.83.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.83.0-rc.5.tgz#c5dbc29e12d43672eecb131d8c81d98bee3a2cee"
+  integrity sha512-igakbyY6o036DVH682V8S+77MZAq4HOj/ln5NZgoysAFt5/7bEVzNnkWWP1sAzJMN7cC8cQ0+YxrITv80F+UVg==
 
-"@react-native/gradle-plugin@0.83.0-rc.3":
-  version "0.83.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.83.0-rc.3.tgz#a3d3c678f480a6d219978ddac7fae40b28783f41"
-  integrity sha512-bppDSEXRZcEpwSLuuMaKxXOGDvoCW2KlzCV6wA47MAKVa2/BHT4LJTku+R1hk85dtJwSP7AngoTstcXq6cSHPQ==
-
-"@react-native/js-polyfills@0.83.0-nightly-20251030-26ad9492b":
-  version "0.83.0-nightly-20251030-26ad9492b"
-  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.83.0-nightly-20251030-26ad9492b.tgz#7e2f9279341c0a986b925a0bacd0b1d93c989cce"
-  integrity sha512-E6+WFModgogHStMNWeInvwC5QPmC7OqESrvrWMhBt6OzHw5bf4bBqxblP6UmKcIxq6clZYV+YAq9VqO7WgsSzg==
-
-"@react-native/js-polyfills@0.83.0-rc.3":
-  version "0.83.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.83.0-rc.3.tgz#c2aa8f1925539f2961d61fa3af32111bcd67853d"
-  integrity sha512-0gRv0NKZNGHzXuLYBqAYLQWROmkCSQhGpwP+UvpjMIj0zi9L/4s6b+X7S1T5R3Qx7zN9ASu6E5YX7gvkpJaNDA==
-
-"@react-native/normalize-colors@0.83.0-nightly-20251030-26ad9492b":
-  version "0.83.0-nightly-20251030-26ad9492b"
-  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.83.0-nightly-20251030-26ad9492b.tgz#6526c67789c059753c4f51f3e67c65288fa8f28b"
-  integrity sha512-RbN8uZqTeda2PL6hlczytWbCzuWxBDa4gWwjoT7VOeeo5iKqFOWegyK8TRJ46NoCf4hqbs0Fgsz8kFcPROPXcg==
-
-"@react-native/normalize-colors@0.83.0-rc.3":
-  version "0.83.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.83.0-rc.3.tgz#c4cad59ad02ce3b57ebded3fd6ca144ce70d0c48"
-  integrity sha512-zUY+wgNvkhYWOl+dS5acm/fUAVENEgE0hSkDvRrKq1DT1jCA6IW+dJR1DNrdvWRzgrF4yF5nnG0D6aQYk5fyPA==
+"@react-native/normalize-colors@0.83.0-rc.5":
+  version "0.83.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.83.0-rc.5.tgz#d6c09574204221748e722bf92bf0a678dfd34ad0"
+  integrity sha512-OxyK7aHXGq+PVdlDSHHd7BCqUsoARS+KG4XFEaaSSt9TG1/elV5rDx7+ugLtN9J7U/kTq38DSLVsBEk7Tw+kXg==
 
 "@react-native/normalize-colors@^0.74.1":
   version "0.74.88"
   resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.74.88.tgz#46f4c7270c8e6853281d7dd966e0eb362068e41a"
   integrity sha512-He5oTwPBxvXrxJ91dZzpxR7P+VYmc9IkJfhuH8zUiU50ckrt+xWNjtVugPdUv4LuVjmZ36Vk2EX8bl1gVn2dVA==
 
-"@react-native/virtualized-lists@0.83.0-nightly-20251030-26ad9492b":
-  version "0.83.0-nightly-20251030-26ad9492b"
-  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.83.0-nightly-20251030-26ad9492b.tgz#96009329feaa164a90ab64f1ecc5c7bd4ccbb405"
-  integrity sha512-vIflRX89lgLLep9xD2WUiq/ql1wrq8n5qEubHUtmEFa/omUHBjrGcS8yxl6jyvOj6lr6ykDC3sxm/3gZ20stag==
-  dependencies:
-    invariant "^2.2.4"
-    nullthrows "^1.1.1"
-
-"@react-native/virtualized-lists@0.83.0-rc.3":
-  version "0.83.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.83.0-rc.3.tgz#10072178e3b52a21579ef42aa0bdde9efabd7084"
-  integrity sha512-77jIhCbJXmrdcwEu+4OkUpuRUocgdYXJLBJEbdAdUhCZ9tP7Uju7+L9KhDVpqTXOKaascsg0qwTDWOMgrF3+jg==
+"@react-native/virtualized-lists@0.83.0-rc.5":
+  version "0.83.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.83.0-rc.5.tgz#0a3404bf7415d5e35c5296ce7c0d4b09da66d18d"
+  integrity sha512-yxKkmXbOPVfssNateE7h2a4iaCM7T2x3uKZxuhRFWuM9OGnBm0DVoPZdcQMEzI5D+oq+1W0tKxh/pBHjdckArg==
   dependencies:
     invariant "^2.2.4"
     nullthrows "^1.1.1"
@@ -9359,11 +9274,6 @@ hermes-compiler@0.14.0:
   resolved "https://registry.yarnpkg.com/hermes-compiler/-/hermes-compiler-0.14.0.tgz#ec0ec83132ab5954e7bd2c74e6331752742f188f"
   integrity sha512-clxa193o+GYYwykWVFfpHduCATz8fR5jvU7ngXpfKHj+E9hr9vjLNtdLSEe8MUbObvVexV3wcyxQ00xTPIrB1Q==
 
-hermes-compiler@0.14.0-commitly-202510291853-2edc19af3:
-  version "0.14.0-commitly-202510291853-2edc19af3"
-  resolved "https://registry.yarnpkg.com/hermes-compiler/-/hermes-compiler-0.14.0-commitly-202510291853-2edc19af3.tgz#c1cc7caecdeccb43418fff67a7baf2dac0ab7df4"
-  integrity sha512-k9M/efmZO2qT3bmd8YngAuijIYc99E2nML8e1EhgXom9eHjFmIIVK4NdAmn3HkZcXSZ36n1kznt8EPDg1aYXMA==
-
 hermes-estree@0.29.1:
   version "0.29.1"
   resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.29.1.tgz#043c7db076e0e8ef8c5f6ed23828d1ba463ebcc5"
@@ -13742,60 +13652,19 @@ react-native-worklets@0.6.1:
     convert-source-map "^2.0.0"
     semver "7.7.2"
 
-react-native@0.83.0-nightly-20251030-26ad9492b:
-  version "0.83.0-nightly-20251030-26ad9492b"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.83.0-nightly-20251030-26ad9492b.tgz#f7b2bfb481f27ef9978a5de9e691f5d4101ccfea"
-  integrity sha512-6TxGJVc8EYbSoDKc9EZzhB12foryeMu5uaSc8dfj7/uIN6AGR/2oPA1Di+tE30BLxDUg4pUhRKvDe5ZJXbfFPw==
+react-native@0.83.0-rc.5:
+  version "0.83.0-rc.5"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.83.0-rc.5.tgz#2e9c4ad1d57b06b39df3bc518e70fcdf0549bc03"
+  integrity sha512-PRjcXR2k++pIepjWL/VEcKuAu07XHCJzhDVPKCiltgQcFfkKCcTZqhA8CloniV0dM98rUadX8Grqhoj0t4/7dQ==
   dependencies:
     "@jest/create-cache-key-function" "^29.7.0"
-    "@react-native/assets-registry" "0.83.0-nightly-20251030-26ad9492b"
-    "@react-native/codegen" "0.83.0-nightly-20251030-26ad9492b"
-    "@react-native/community-cli-plugin" "0.83.0-nightly-20251030-26ad9492b"
-    "@react-native/gradle-plugin" "0.83.0-nightly-20251030-26ad9492b"
-    "@react-native/js-polyfills" "0.83.0-nightly-20251030-26ad9492b"
-    "@react-native/normalize-colors" "0.83.0-nightly-20251030-26ad9492b"
-    "@react-native/virtualized-lists" "0.83.0-nightly-20251030-26ad9492b"
-    abort-controller "^3.0.0"
-    anser "^1.4.9"
-    ansi-regex "^5.0.0"
-    babel-jest "^29.7.0"
-    babel-plugin-syntax-hermes-parser "0.32.0"
-    base64-js "^1.5.1"
-    commander "^12.0.0"
-    flow-enums-runtime "^0.0.6"
-    glob "^7.1.1"
-    hermes-compiler "0.14.0-commitly-202510291853-2edc19af3"
-    invariant "^2.2.4"
-    jest-environment-node "^29.7.0"
-    memoize-one "^5.0.0"
-    metro-runtime "^0.83.3"
-    metro-source-map "^0.83.3"
-    nullthrows "^1.1.1"
-    pretty-format "^29.7.0"
-    promise "^8.3.0"
-    react-devtools-core "^6.1.5"
-    react-refresh "^0.14.0"
-    regenerator-runtime "^0.13.2"
-    scheduler "0.27.0"
-    semver "^7.1.3"
-    stacktrace-parser "^0.1.10"
-    whatwg-fetch "^3.0.0"
-    ws "^7.5.10"
-    yargs "^17.6.2"
-
-react-native@0.83.0-rc.3:
-  version "0.83.0-rc.3"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.83.0-rc.3.tgz#fb63ad7fec34196c0a530b9d63d99e9b4a5a63f5"
-  integrity sha512-SBlf9nTYSZRZ0AE4+oRTMYr1EhY5achBwHEBIEA2GUSqz8dcsJzix7b/kXpeuKHey3nXwaYgN0NHORatckEYgw==
-  dependencies:
-    "@jest/create-cache-key-function" "^29.7.0"
-    "@react-native/assets-registry" "0.83.0-rc.3"
-    "@react-native/codegen" "0.83.0-rc.3"
-    "@react-native/community-cli-plugin" "0.83.0-rc.3"
-    "@react-native/gradle-plugin" "0.83.0-rc.3"
-    "@react-native/js-polyfills" "0.83.0-rc.3"
-    "@react-native/normalize-colors" "0.83.0-rc.3"
-    "@react-native/virtualized-lists" "0.83.0-rc.3"
+    "@react-native/assets-registry" "0.83.0-rc.5"
+    "@react-native/codegen" "0.83.0-rc.5"
+    "@react-native/community-cli-plugin" "0.83.0-rc.5"
+    "@react-native/gradle-plugin" "0.83.0-rc.5"
+    "@react-native/js-polyfills" "0.83.0-rc.5"
+    "@react-native/normalize-colors" "0.83.0-rc.5"
+    "@react-native/virtualized-lists" "0.83.0-rc.5"
     abort-controller "^3.0.0"
     anser "^1.4.9"
     ansi-regex "^5.0.0"


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/expo/pull/41219

# How

- update package versions
  - `react-native  0.83.0-rc.3-> 0.83.0-rc.5`  
  - `@react-native/normalize-colors 0.83.0-rc.3 ->  0.83.0-rc.5` 
  - `@react-native/babel-preset 0.83.0-rc.3 ->  0.83.0-rc.5` 
  - `@react-native/dev-middleware 0.83.0-rc.3 ->  0.83.0-rc.5`    

# Test Plan
 
bare-expo ios / android
paper-tester ios / android
ci passed

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
