### PR TITLE
[docs][expotools] fix docs tests run, fix expotools "add-changelog" command, fix expotools run on windows

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
     "lint-links": "remark -u validate-links ./pages",
     "lint-prose": "yarn vale --glob='!pages/versions/latest/**' .",
     "watch": "tsc --noEmit -w",
-    "test": "yarn generate-static-resources && yarn node --experimental-vm-modules $(yarn bin jest)",
+    "test": "yarn generate-static-resources && yarn node --experimental-vm-modules \"$(yarn bin jest)\"",
     "remove-version": "node --unhandled-rejections=strict ./scripts/remove-version.js",
     "copy-latest": "node ./scripts/copy-latest.js",
     "generate-llms": "node ./scripts/generate-llms/index.js",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "lint": "eslint .",
     "tsc": "echo 'You are trying to run \"tsc\" in the workspace root. Run it from an individual package instead.' && exit 1"
   },
+  "bin": {
+    "et": "./bin/expotools"
+  },
   "workspaces": {
     "packages": [
       "apps/*",

--- a/tools/src/commands/AddChangelog.ts
+++ b/tools/src/commands/AddChangelog.ts
@@ -22,20 +22,23 @@ type ActionOptions = {
 
 async function checkOrAskForOptions(options: ActionOptions): Promise<ActionOptions> {
   const lengthValidator = (x: { length: number }) => x.length !== 0;
-  const stringValidator = {
-    filter: (s: string) => s.trim(),
-    validate: lengthValidator,
-  };
 
   const questions: QuestionCollection[] = [];
+
   if (options.packageNames.length === 0) {
     questions.push({
       type: 'input',
-      name: 'package',
-      message: 'What are the packages that you want to add a changelog entry?',
-      ...stringValidator,
-      transformer(input) {
-        return input.split(/\s+/g);
+      name: 'packageNames',
+      message:
+        'What are the packages that you want to add a changelog entry (separate by space or comma)?',
+      filter: (packageNames) =>
+        packageNames
+          .split(/[, ]/g)
+          .map((packageName) => packageName.trim())
+          .filter(Boolean),
+      validate: lengthValidator,
+      transformer(input, answers, { isFinal }) {
+        return isFinal ? input : input.split(/\s+/g);
       },
     });
   }
@@ -73,7 +76,8 @@ async function checkOrAskForOptions(options: ActionOptions): Promise<ActionOptio
       type: 'input',
       name: 'entry',
       message: 'What is the changelog message?',
-      ...stringValidator,
+      filter: (s: string) => s.trim(),
+      validate: lengthValidator,
     });
   }
 


### PR DESCRIPTION
# Why

- **`docs`**
  - Fixed launch of `test` script on **windows** if path to expo have spaces like `my folder/expo`

- **`Expotools`**
  - Fixed launch on windows, now `et ...` commands can be run as `npx et ...`
  - Fixed broken generation of `CHANGELOG.md` files (`et add-changelog`) via console **UI** (was incorrectly handled "package names" property)

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
