### PR TITLE
[expo-gl] remove support of `GIF` image format in image decoding in `texImage2D` expo wrapper

### DIFF
--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### ⚠️ Notices
 
+- **Performance optimization**: remove support of **GIF** image format in image decoding in `texImage2D` expo wrapper. ([#41499](https://github.com/expo/expo/pull/41499) by [@psnet](https://github.com/psnet))
 - **Performance optimization**: reduce supported old image formats in lib `stb_image.h` used for image decoding in `texImage2D` expo wrapper to support only **JPEG, PNG, GIF** image formats. Formats **BMP, PSD, TGA, HDR, PIC, PNM** are no longer supported. ([#41001](https://github.com/expo/expo/pull/41001) by [@psnet](https://github.com/psnet))
 - Updated library `stb_image.h` used for image decoding in `texImage2D` expo wraper method. A lot of fixes and performance improvements, see related PR. ([#41000](https://github.com/expo/expo/pull/41000) by [@psnet](https://github.com/psnet))
 - Added support for React Native 0.82.x. ([#39678](https://github.com/expo/expo/pull/39678) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo-gl/common/EXGLImageUtils.cpp
+++ b/packages/expo-gl/common/EXGLImageUtils.cpp
@@ -2,7 +2,6 @@
 
 #define STBI_ONLY_JPEG
 #define STBI_ONLY_PNG
-#define STBI_ONLY_GIF
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
 


### PR DESCRIPTION
# Why

Performance optimization
---

There is no any chance to use **GIF** image format for 3D rendering as source for **textures**. This format has a lots of **limitations** and it doesnt have any logic to be used instead of JPEG or PNG which are good for all possible cases.

Removing this format makes compiled `.so` lib smaller in size (up to ~100 KiB depending on arch), which takes less RAM memory and quicker image loading as lib needs to check less image formats to support.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Disabled support in underlying library `stb_image.h`

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

I tested this case in my another RN project, it works correctly.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
