### PR TITLE
[docs] Adds release statuses

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -689,6 +689,7 @@ const versionsReference = VERSIONS.reduce(
           makePage('more/expo-cli.mdx'),
           makePage('more/create-expo.mdx'),
           makePage('more/qr-codes.mdx'),
+          makePage('more/release-statuses.mdx'),
           makePage('more/glossary-of-terms.mdx'),
         ],
         {

--- a/docs/pages/eas/workflows/limitations.mdx
+++ b/docs/pages/eas/workflows/limitations.mdx
@@ -6,14 +6,6 @@ description: Learn about the current limitations of EAS Workflows.
 
 EAS Workflows is designed to help you automate your development and release processes. However, it is good to be aware of certain limitations that we plan to address since they could affect your workflow automation strategy.
 
-## Maestro tests are experimental
-
-Maestro tests are currently in an experimental phase. While you can use them in your workflows, you may experience some flakiness in test results. We're actively working to improve the stability and reliability of Maestro test integration.
-
-## No programmatic job status access
-
-Currently, it's not possible to programmatically get the status of jobs for use in other CI workflows. This feature is on our roadmap and will be implemented in future updates.
-
 ## No shared workflow configurations
 
 At this time, it's not possible to define shared workflow configurations. Each workflow needs to be defined independently, which may lead to some configuration duplication.

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -812,7 +812,7 @@ jobs:
 
 Run Maestro tests on a Android emulator or iOS Simulator build.
 
-> **important** Maestro tests are in [preview](/more/release-statuses/#preview).
+> **important** Maestro tests are in [alpha](/more/release-statuses/#alpha).
 
 ### Syntax
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -812,7 +812,7 @@ jobs:
 
 Run Maestro tests on a Android emulator or iOS Simulator build.
 
-> **important** Maestro tests are experimental and may experience flakiness.
+> **important** Maestro tests are in [preview](/more/release-statuses/#preview).
 
 ### Syntax
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -1059,7 +1059,7 @@ This job outputs the following properties:
 
 Runs [Maestro](https://maestro.dev/) tests on a build. See [Maestro job documentation](/eas/workflows/pre-packaged-jobs#maestro) for detailed information and examples.
 
-> **important** Maestro tests are in [preview](/more/release-statuses/#preview).
+> **important** Maestro tests are in [alhpa](/more/release-statuses/#alpha).
 
 ```yaml
 jobs:

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -1059,7 +1059,7 @@ This job outputs the following properties:
 
 Runs [Maestro](https://maestro.dev/) tests on a build. See [Maestro job documentation](/eas/workflows/pre-packaged-jobs#maestro) for detailed information and examples.
 
-> **important** Maestro tests are experimental and may experience flakiness.
+> **important** Maestro tests are in [preview](/more/release-statuses/#preview).
 
 ```yaml
 jobs:

--- a/docs/pages/more/release-statuses.mdx
+++ b/docs/pages/more/release-statuses.mdx
@@ -1,13 +1,13 @@
 ---
 title: Release statuses
-description: Learn about early access, preview, and stable release statuses and how they affect feature stability.
+description: Learn about alpha, beta, and stable release statuses and how they affect feature stability.
 ---
 
 Expo uses different release statuses to indicate the stability and readiness of its tools and services. Understanding these statuses can help you make informed decisions about which features and versions to use in your projects.
 
-## Early access
+## Alpha
 
-Early access features are available for early testing but may have significant limitations. These features are in the earliest stage of development and are shared with the community to gather feedback and shape their direction.
+Alpha features are available for early testing but may have significant limitations. These features are in the earliest stage of development and are shared with the community to gather feedback and shape their direction.
 
 **What to expect:**
 
@@ -16,11 +16,11 @@ Early access features are available for early testing but may have significant l
 - May have known bugs or performance issues
 - Not recommended for production apps
 
-Early access features are opportunities to influence the future of Expo. We encourage you to test these features in development environments and [provide feedback](https://expo.dev/contact) to help us refine them before they reach a wider audience.
+Alpha features are opportunities to influence the future of Expo. We encourage you to test these features in development environments and [provide feedback](https://expo.dev/contact) to help us refine them before they reach a wider audience.
 
-## Preview
+## Beta
 
-Preview features are feature-complete and undergoing final validation. These features have core functionality implemented and are being prepared for stable release.
+Beta features are feature-complete and undergoing final validation. These features have core functionality implemented and are being prepared for stable release.
 
 **What to expect:**
 
@@ -29,7 +29,7 @@ Preview features are feature-complete and undergoing final validation. These fea
 - Breaking changes are possible but unlikely unless critical issues are found
 - Can be used in production with thorough testing
 
-Preview features are ready for real-world testing. While we don't expect major changes, we recommend testing thoroughly if you plan to use them in production. [Your feedback](https://expo.dev/contact) during this stage helps us catch any remaining issues before the stable release.
+Beta features are ready for real-world testing. While we don't expect major changes, we recommend testing thoroughly if you plan to use them in production. [Your feedback](https://expo.dev/contact) during this stage helps us catch any remaining issues before the stable release.
 
 ## Stable
 
@@ -43,3 +43,15 @@ Features without any status badge are considered stable and are fully released f
 - Documentation and examples available
 
 Stable features are ready for use in any application. You can rely on them following semantic versioning principles, meaning breaking changes will only occur in major version updates.
+
+## Deprecated
+
+Deprecated features are those that are no longer recommended for use and will be removed in future releases. We provide deprecation warnings to give developers time to transition away from these features.
+
+**What to expect:**
+
+- Warnings in documentation and code when using deprecated features
+- No new features or improvements will be made
+- Removal in future major releases
+
+When you encounter a deprecated feature, we recommend planning to migrate to the suggested alternatives as soon as possible to ensure your projects remain up-to-date and maintainable.

--- a/docs/pages/more/release-statuses.mdx
+++ b/docs/pages/more/release-statuses.mdx
@@ -1,0 +1,45 @@
+---
+title: Release statuses
+description: Learn about early access, preview, and stable release statuses and how they affect feature stability.
+---
+
+Expo uses different release statuses to indicate the stability and readiness of its tools and services. Understanding these statuses can help you make informed decisions about which features and versions to use in your projects.
+
+## Early access
+
+Early access features are available for early testing but may have significant limitations. These features are in the earliest stage of development and are shared with the community to gather feedback and shape their direction.
+
+**What to expect:**
+
+- APIs are subject to breaking changes without major version bumps
+- Implementation may change substantially based on feedback
+- May have known bugs or performance issues
+- Not recommended for production apps
+
+Early access features are opportunities to influence the future of Expo. We encourage you to test these features in development environments and [provide feedback](https://expo.dev/contact) to help us refine them before they reach a wider audience.
+
+## Preview
+
+Preview features are feature-complete and undergoing final validation. These features have core functionality implemented and are being prepared for stable release.
+
+**What to expect:**
+
+- Core functionality is complete and API shape is mostly settled
+- May have minor bugs or edge cases that are being addressed
+- Breaking changes are possible but unlikely unless critical issues are found
+- Can be used in production with thorough testing
+
+Preview features are ready for real-world testing. While we don't expect major changes, we recommend testing thoroughly if you plan to use them in production. [Your feedback](https://expo.dev/contact) during this stage helps us catch any remaining issues before the stable release.
+
+## Stable
+
+Features without any status badge are considered stable and are fully released for production use. These features have been thoroughly tested and follow semantic versioning for any future changes.
+
+**What to expect:**
+
+- Production-ready with full support
+- Breaking changes only occur in major version releases
+- Performance and stability have been validated
+- Documentation and examples available
+
+Stable features are ready for use in any application. You can rely on them following semantic versioning principles, meaning breaking changes will only occur in major version updates.

--- a/docs/pages/more/release-statuses.mdx
+++ b/docs/pages/more/release-statuses.mdx
@@ -1,6 +1,6 @@
 ---
 title: Release statuses
-description: Learn about alpha, beta, and stable release statuses and how they affect feature stability.
+description: Learn about alpha, beta, and stable release statuses and how they affect feature stability when using Expo SDK and Expo Application Services (EAS).
 ---
 
 Expo uses different release statuses to indicate the stability and readiness of its tools and services. Understanding these statuses can help you make informed decisions about which features and versions to use in your projects.


### PR DESCRIPTION
# Why

We often label new features or APIs with a variety of different statuses that mean many different things, like:
- Experimental
- Preview
- Alpha
- Beta

Sometimes these mean that something is new and we don't have enough validation yet to feel confident recommending them. Sometimes it means that we know of significant or minor issues. Sometimes we leave labels on features permanently because we're not sure when to promote a feature to the next release status.

This is confusing for developers and customers, because you have to ask us directly what we mean by any of these terms.

This PR creates release statuses and defines them in a doc. The release statuses are:
- Alpha (Could be "experimental" or "early access")
- Beta (Could be "preview")
- Stable
- Deprecated

This PR also links the "alpha" state to the Maestro test jobs documentation, so users can see exactly what that means. The expectation would be that going forward, any feature or API would link to this doc to better describe where it is in our release sequence.

# Test Plan

Check out /more/release-statuses for the definition doc. Then check out the pre-packaged jobs doc (the maestro job section) for a link to the preview header.

<img width="1718" height="1440" alt="Screenshot 2025-12-08 at 12 57 47 PM" src="https://github.com/user-attachments/assets/29d8f59c-5f43-4b7e-add0-cebbf7080844" />
<img width="1718" height="1440" alt="Screenshot 2025-12-08 at 12 57 37 PM" src="https://github.com/user-attachments/assets/fdcfbc5c-635c-448b-9158-0578180bd8d4" />


