### PR TITLE
refactor(config-types): force-enable and deprecate `android.edgeToEdgeEnabled` for SDK 54+

### DIFF
--- a/packages/@expo/config-types/build/ExpoConfig.d.ts
+++ b/packages/@expo/config-types/build/ExpoConfig.d.ts
@@ -830,9 +830,10 @@ export interface Android {
      */
     version?: string;
     /**
-     * Enable your app to run in [edge-to-edge](https://developer.android.com/develop/ui/views/layout/edge-to-edge) mode. Default to false.
+     * Enable your app to run in [edge-to-edge](https://developer.android.com/develop/ui/views/layout/edge-to-edge) mode. Default to true.
+     * @deprecated Android 16+ (API level 36) requires edge-to-edge to be enabled. This feature can't be disabled anymore. [learn more](https://developer.android.com/about/versions/16/behavior-changes-16#edge-to-edge)
      */
-    edgeToEdgeEnabled?: boolean;
+    edgeToEdgeEnabled?: true;
     /**
      * Enable your app to use the [predictive back gesture](https://developer.android.com/guide/navigation/custom-back/predictive-back-gesture) on Android 13 (API level 33) and later. Default to false.
      */

--- a/packages/@expo/config-types/src/ExpoConfig.ts
+++ b/packages/@expo/config-types/src/ExpoConfig.ts
@@ -838,9 +838,10 @@ export interface Android {
    */
   version?: string;
   /**
-   * Enable your app to run in [edge-to-edge](https://developer.android.com/develop/ui/views/layout/edge-to-edge) mode. Default to false.
+   * Enable your app to run in [edge-to-edge](https://developer.android.com/develop/ui/views/layout/edge-to-edge) mode. Default to true.
+   * @deprecated Android 16+ (API level 36) requires edge-to-edge to be enabled. This feature can't be disabled anymore. [learn more](https://developer.android.com/about/versions/16/behavior-changes-16#edge-to-edge)
    */
-  edgeToEdgeEnabled?: boolean;
+  edgeToEdgeEnabled?: true;
   /**
    * Enable your app to use the [predictive back gesture](https://developer.android.com/guide/navigation/custom-back/predictive-back-gesture) on Android 13 (API level 33) and later. Default to false.
    */


### PR DESCRIPTION
# Why

Due to Expo SDK 54 targeting Android 16+, this can't be disabled anymore as [Google now requires edge-to-edge](https://developer.android.com/about/versions/16/behavior-changes-16#edge-to-edge) for Androdi 16+.

We should also likely drop this property for SDK 55+, but this would at least be backportable to `sdk-54`. We can create a new PR dropping this fully from `main`.

# How

- Forced `edgeToEdgeEnabled?: true`
- XDL schema change: https://github.com/expo/universe/pull/23257

# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
