### PR TITLE
[templates][tabs] Remove unnecessary ts-expect-error from ExternalLink

### DIFF
--- a/templates/expo-template-tabs/components/ExternalLink.tsx
+++ b/templates/expo-template-tabs/components/ExternalLink.tsx
@@ -10,7 +10,6 @@ export function ExternalLink(
     <Link
       target="_blank"
       {...props}
-      // @ts-expect-error: External URLs are not typed.
       href={props.href}
       onPress={(e) => {
         if (Platform.OS !== 'web') {


### PR DESCRIPTION
# Why

When we backported the template changes on https://github.com/expo/expo/pull/28473 we forgot to remove the ts-expect-error comment in ExternalLink from the tabs template

# How

Remove unnecessary ts-expect-error from `ExternalLink` in the tabs template

# Test Plan

Ts check should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
