### PR TITLE
[expo-router][ios] improve native warning logging

### DIFF
--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeModule.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeModule.swift
@@ -2,7 +2,7 @@ import ExpoModulesCore
 
 public class LinkPreviewNativeModule: Module {
   static let moduleName: String = "ExpoRouterNativeLinkPreview"
-  lazy var zoomSourceRepository = LinkZoomTransitionsSourceRepository()
+  lazy var zoomSourceRepository = LinkZoomTransitionsSourceRepository(logger: appContext?.jsLogger)
   lazy var zoomAlignmentViewRepository = LinkZoomTransitionsAlignmentViewRepository()
 
   public func definition() -> ModuleDefinition {


### PR DESCRIPTION
# Why

The native warnings were only printed to swift console.

# How

1. Log warnings to jsLogger
2. Fix unmounting issues

# Test Plan

1. Manual testing - you can test the logger by passing `Fragment` with multiple children to `AppleZoom` or `AppleZoomTarget`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
