### PR TITLE
[ui][ios] - rename RNHostProtocol to RNHostViewProtocol

### DIFF
--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewHost.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewHost.swift
@@ -58,7 +58,7 @@ extension ExpoSwiftUI {
     }
   }
 
-  public protocol RNHostProtocol {
+  public protocol RNHostViewProtocol {
     var matchContents: Bool { get set }
   }
 }
@@ -76,7 +76,7 @@ private struct ViewSizeWrapper: View {
   }
 
   var body: some View {
-    if let rnHost = viewHost.view as? ExpoSwiftUI.RNHostProtocol, rnHost.matchContents {
+    if let rnHost = viewHost.view as? ExpoSwiftUI.RNHostViewProtocol, rnHost.matchContents {
       viewHost
         .frame(width: viewSizeModel.viewFrame.width, height: viewSizeModel.viewFrame.height)
     } else {

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewHost.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewHost.swift
@@ -76,7 +76,7 @@ private struct ViewSizeWrapper: View {
   }
 
   var body: some View {
-    if let rnHost = viewHost.view as? ExpoSwiftUI.RNHostViewProtocol, rnHost.matchContents {
+    if let rnHostView = viewHost.view as? ExpoSwiftUI.RNHostViewProtocol, rnHostView.matchContents {
       viewHost
         .frame(width: viewSizeModel.viewFrame.width, height: viewSizeModel.viewFrame.height)
     } else {

--- a/packages/expo-ui/ios/RNHostView.swift
+++ b/packages/expo-ui/ios/RNHostView.swift
@@ -2,7 +2,7 @@
 
 import ExpoModulesCore
 
-public final class RNHostView: ExpoView, ExpoSwiftUI.RNHostProtocol {
+public final class RNHostView: ExpoView, ExpoSwiftUI.RNHostViewProtocol {
   public required init(appContext: AppContext? = nil) {
     super.init(appContext: appContext)
     ExpoUITouchHandlerHelper.createAndAttachTouchHandler(for: self)


### PR DESCRIPTION
# Why
Missed this renaming in https://github.com/expo/expo/pull/41509

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
