### PR TITLE
feat(metro-config): add assetPrefix option for CDN support

### DIFF
--- a/apps/router-e2e/app.config.js
+++ b/apps/router-e2e/app.config.js
@@ -31,6 +31,7 @@ module.exports = {
   experiments: {
     autolinkingModuleResolution: true,
     baseUrl: process.env.EXPO_E2E_BASE_PATH || undefined,
+    assetPrefix: process.env.EXPO_E2E_ASSET_PREFIX || undefined,
     tsconfigPaths: process.env.EXPO_USE_PATH_ALIASES,
     typedRoutes: true,
     reactCompiler: process.env.E2E_ROUTER_COMPILER,

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Support Bundler-managed CocoaPods installations ([#43605](https://github.com/expo/expo/pull/43605) by [@tiwari91](https://github.com/tiwari91), [@kitten](https://github.com/kitten))
+- Add `experiments.assetPrefix` config option to serve static assets from a CDN while keeping the app URL unchanged. ([#41520](https://github.com/expo/expo/pull/41520) by [@jtomaszewski](https://github.com/jtomaszewski))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/e2e/__tests__/export/asset-prefix.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/asset-prefix.test.ts
@@ -1,0 +1,159 @@
+/* eslint-env jest */
+import fs from 'fs';
+import path from 'path';
+
+import { runExportSideEffects } from './export-side-effects';
+import { executeExpoAsync } from '../../utils/expo';
+import { findProjectFiles, getPageHtml, getRouterE2ERoot } from '../utils';
+
+runExportSideEffects();
+
+describe('static-rendering with asset prefix for CDN', () => {
+  const projectRoot = getRouterE2ERoot();
+  const outputName = 'dist-static-rendering-asset-prefix';
+  const outputDir = path.join(projectRoot, outputName);
+
+  beforeAll(async () => {
+    const assetPrefix = 'https://cdn.example.com';
+    await executeExpoAsync(projectRoot, ['export', '-p', 'web', '--output-dir', outputName], {
+      env: {
+        NODE_ENV: 'production',
+        EXPO_E2E_ASSET_PREFIX: assetPrefix,
+        EXPO_USE_STATIC: 'static',
+        E2E_ROUTER_SRC: 'static-rendering',
+        E2E_ROUTER_ASYNC: 'development',
+      },
+    });
+  });
+
+  it('has expected files', async () => {
+    const files = findProjectFiles(outputDir);
+
+    expect(files.find((file) => file?.match(/_expo\/static\/js\/web\/entry-.*\.js/))).toBeDefined();
+
+    expect(files).not.toContain('+html.html');
+    expect(files).not.toContain('_layout.html');
+
+    expect(files).toContain('_sitemap.html');
+    expect(files).toContain('+not-found.html');
+
+    expect(files).toContain('about.html');
+    expect(files).toContain('index.html');
+    expect(files).toContain('styled.html');
+    expect(files).toContain('links.html');
+  });
+
+  it('writes JS assets with CDN prefix', async () => {
+    const indexHtml = await getPageHtml(outputDir, 'index.html');
+
+    const jsFiles = indexHtml
+      .querySelectorAll('script')
+      .filter((script) => !!script.attributes.src)
+      .map((script) => script.attributes.src);
+
+    expect(jsFiles).toEqual([
+      expect.stringMatching(/^https:\/\/cdn\.example\.com\/_expo\/static\/js\/web\/entry-.*\.js$/),
+    ]);
+  });
+
+  it('writes CSS assets with CDN prefix', async () => {
+    const indexHtml = await getPageHtml(outputDir, 'index.html');
+
+    const links = indexHtml.querySelectorAll('html > head > link').filter((link) => {
+      return link.attributes.as !== 'font';
+    });
+
+    const cssFiles = links.map((link) => link.attributes.href);
+
+    cssFiles.forEach((src) => {
+      expect(src).toMatch(/^https:\/\/cdn\.example\.com\/_expo\/static\/css\/.*\.css$/);
+    });
+  });
+
+  it('asset files exist locally (without CDN prefix)', async () => {
+    const indexHtml = await getPageHtml(outputDir, 'index.html');
+
+    const jsFiles = indexHtml
+      .querySelectorAll('script')
+      .filter((script) => !!script.attributes.src)
+      .map((script) => script.attributes.src);
+
+    const links = indexHtml.querySelectorAll('html > head > link').filter((link) => {
+      return link.attributes.as !== 'font';
+    });
+
+    const cssFiles = links.map((link) => link.attributes.href);
+
+    for (const file of [...cssFiles, ...jsFiles]) {
+      expect(
+        fs.existsSync(
+          path.join(
+            outputDir,
+            file.replace(/^https:\/\/cdn\.example\.com/, '')
+          )
+        )
+      ).toBe(true);
+    }
+  });
+});
+
+describe('static-rendering with asset prefix and base path', () => {
+  const projectRoot = getRouterE2ERoot();
+  const outputName = 'dist-static-rendering-asset-prefix-base-path';
+  const outputDir = path.join(projectRoot, outputName);
+
+  beforeAll(async () => {
+    const baseUrl = '/my-app';
+    const assetPrefix = 'https://cdn.example.com/assets';
+    await executeExpoAsync(projectRoot, ['export', '-p', 'web', '--output-dir', outputName], {
+      env: {
+        NODE_ENV: 'production',
+        EXPO_E2E_BASE_PATH: baseUrl,
+        EXPO_E2E_ASSET_PREFIX: assetPrefix,
+        EXPO_USE_STATIC: 'static',
+        E2E_ROUTER_SRC: 'static-rendering',
+        E2E_ROUTER_ASYNC: 'development',
+      },
+    });
+  });
+
+  it('writes JS assets with CDN prefix (not base path)', async () => {
+    const indexHtml = await getPageHtml(outputDir, 'index.html');
+
+    const jsFiles = indexHtml
+      .querySelectorAll('script')
+      .filter((script) => !!script.attributes.src)
+      .map((script) => script.attributes.src);
+
+    expect(jsFiles).toEqual([
+      expect.stringMatching(/^https:\/\/cdn\.example\.com\/assets\/_expo\/static\/js\/web\/entry-.*\.js$/),
+    ]);
+
+    jsFiles.forEach((src) => {
+      expect(src).not.toMatch(/\/my-app\//);
+    });
+  });
+
+  it('writes CSS assets with CDN prefix (not base path)', async () => {
+    const indexHtml = await getPageHtml(outputDir, 'index.html');
+
+    const links = indexHtml.querySelectorAll('html > head > link').filter((link) => {
+      return link.attributes.as !== 'font';
+    });
+
+    const cssFiles = links.map((link) => link.attributes.href);
+
+    cssFiles.forEach((src) => {
+      expect(src).toMatch(/^https:\/\/cdn\.example\.com\/assets\/_expo\/static\/css\/.*\.css$/);
+      expect(src).not.toMatch(/\/my-app\//);
+    });
+  });
+
+  it('links still use base path', async () => {
+    expect(
+      (await getPageHtml(outputDir, 'links.html')).querySelector(
+        'body > #root a[data-testid="links-one"]'
+      )?.attributes.href
+    ).toBe('/my-app/about');
+  });
+});

--- a/packages/@expo/cli/e2e/__tests__/export/export-side-effects.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/export-side-effects.ts
@@ -11,6 +11,7 @@ declare const process: {
     EXPO_USE_STATIC?: string;
     E2E_ROUTER_SRC?: string;
     EXPO_E2E_BASE_PATH?: string;
+    EXPO_E2E_ASSET_PREFIX?: string;
   };
   [key: string]: any;
 };
@@ -24,6 +25,7 @@ export function clearEnv() {
   process.env.EXPO_USE_PATH_ALIASES = '1';
   delete process.env.EXPO_USE_STATIC;
   delete process.env.EXPO_E2E_BASE_PATH;
+  delete process.env.EXPO_E2E_ASSET_PREFIX;
 }
 
 export function restoreEnv() {

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -30,7 +30,10 @@ import { DevServerManager } from '../start/server/DevServerManager';
 import { MetroBundlerDevServer } from '../start/server/metro/MetroBundlerDevServer';
 import { getRouterDirectoryModuleIdWithManifest } from '../start/server/metro/router';
 import { serializeHtmlWithAssets } from '../start/server/metro/serializeHtml';
-import { getBaseUrlFromExpoConfig } from '../start/server/middleware/metroOptions';
+import {
+  getAssetPrefixFromExpoConfig,
+  getBaseUrlFromExpoConfig,
+} from '../start/server/middleware/metroOptions';
 import { createTemplateHtmlFromExpoConfigAsync } from '../start/server/webTemplate';
 import { env } from '../utils/env';
 import { CommandError } from '../utils/errors';
@@ -90,6 +93,7 @@ export async function exportAppAsync(
   }
 
   const baseUrl = getBaseUrlFromExpoConfig(exp);
+  const assetPrefix = getAssetPrefixFromExpoConfig(exp) || undefined;
 
   if (!bytecode && (platforms.includes('ios') || platforms.includes('android'))) {
     Log.warn(
@@ -277,6 +281,7 @@ export async function exportAppAsync(
                 exp: projectConfig.exp,
               }),
               baseUrl,
+              assetPrefix,
             });
 
             // Add the favicon assets to the HTML.
@@ -387,6 +392,7 @@ export async function exportAppAsync(
           outputDir: outputPath,
           minify,
           baseUrl,
+          assetPrefix,
           includeSourceMaps: sourceMaps,
           routerRoot: getRouterDirectoryModuleIdWithManifest(projectRoot, exp),
           reactCompiler: !!exp.experiments?.reactCompiler,

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -47,6 +47,8 @@ type Options = {
   minify: boolean;
   exportServer: boolean;
   baseUrl: string;
+  /** URL prefix for static assets (JS, CSS). Falls back to baseUrl if not set. */
+  assetPrefix?: string;
   includeSourceMaps: boolean;
   entryPoint?: string;
   clear: boolean;
@@ -203,6 +205,7 @@ export async function exportFromServerAsync(
   {
     outputDir,
     baseUrl,
+    assetPrefix,
     exportServer,
     includeSourceMaps,
     routerRoot,
@@ -281,6 +284,7 @@ export async function exportFromServerAsync(
         resources: resources.artifacts,
         template,
         baseUrl,
+        assetPrefix,
         route,
         hydrate: true,
       });

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -93,6 +93,7 @@ import {
   convertPathToModuleSpecifier,
   createBundleUrlPath,
   createBundleOsPath,
+  getAssetPrefixFromExpoConfig,
   getAsyncRoutesFromExpoConfig,
   getBaseUrlFromExpoConfig,
   getMetroDirectBundleOptions,
@@ -674,8 +675,16 @@ export class MetroBundlerDevServer extends BundlerDevServer {
     request?: ImmutableRequest
   ): Promise<{ content: string | ReadableStream<Uint8Array>; resources?: SerialAsset[] }> {
     const { exp } = getConfig(this.projectRoot);
-    const { mode, isExporting, clientBoundaries, baseUrl, reactCompiler, routerRoot, asyncRoutes } =
-      this.instanceMetroOptions;
+    const {
+      mode,
+      isExporting,
+      clientBoundaries,
+      baseUrl,
+      assetPrefix,
+      reactCompiler,
+      routerRoot,
+      asyncRoutes,
+    } = this.instanceMetroOptions;
     assert(
       mode != null &&
         isExporting != null &&
@@ -783,6 +792,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       template: staticHtml,
       devBundleUrl: devBundleUrlPathname,
       baseUrl,
+      assetPrefix,
       hydrate: env.EXPO_WEB_DEV_HYDRATE,
     });
     return {
@@ -1280,6 +1290,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
     const useServerRendering = ['static', 'server'].includes(exp.web?.output ?? '');
     const hasApiRoutes = isReactServerComponentsEnabled || exp.web?.output === 'server';
     const baseUrl = getBaseUrlFromExpoConfig(exp);
+    const assetPrefix = getAssetPrefixFromExpoConfig(exp) || undefined;
     const asyncRoutes = getAsyncRoutesFromExpoConfig(exp, options.mode ?? 'development', 'web');
     const routerRoot = getRouterDirectoryModuleIdWithManifest(this.projectRoot, exp);
     const reactCompiler = !!exp.experiments?.reactCompiler;
@@ -1306,6 +1317,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
     const instanceMetroOptions = {
       isExporting: !!options.isExporting,
       baseUrl,
+      assetPrefix,
       mode,
       routerRoot,
       reactCompiler,

--- a/packages/@expo/cli/src/start/server/metro/__tests__/__snapshots__/serializeHtml.test.ts.snap
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/__snapshots__/serializeHtml.test.ts.snap
@@ -1,5 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`falls back to baseUrl when assetPrefix is not provided 1`] = `
+"<!DOCTYPE html><html><head></head><body><div id="root"></div><script src="/app/_expo/static/js/web/entry-abc123.js" defer></script>
+</body></html>"
+`;
+
 exports[`injects hydration flag 1`] = `
 "<!DOCTYPE html><html><head><script type="module">globalThis.__EXPO_ROUTER_HYDRATE__=true;</script></head><body><div id="root"></div><script src="/dist/entry.js" defer></script>
 </body></html>"
@@ -22,5 +27,10 @@ exports[`serializes development static html 1`] = `
 
 exports[`serializes production static html for export 1`] = `
 "<!DOCTYPE html><html><head></head><body><div id="root"></div><script src="/dist/entry.js" defer></script>
+</body></html>"
+`;
+
+exports[`uses assetPrefix for static assets when provided 1`] = `
+"<!DOCTYPE html><html><head><link rel="preload" href="https://cdn.example.com/_expo/static/css/styles-def456.css" as="style"><link rel="stylesheet" href="https://cdn.example.com/_expo/static/css/styles-def456.css"></head><body><div id="root"></div><script src="https://cdn.example.com/_expo/static/js/web/entry-abc123.js" defer></script>
 </body></html>"
 `;

--- a/packages/@expo/cli/src/start/server/metro/__tests__/serializeHtml.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/serializeHtml.test.ts
@@ -154,6 +154,57 @@ it('serializes HTML with async chunks in correct order for dynamic routes', () =
   );
 });
 
+it('uses assetPrefix for static assets when provided', () => {
+  const res = serializeHtmlWithAssets({
+    resources: [
+      {
+        filename: '_expo/static/js/web/entry-abc123.js',
+        originFilename: 'entry.js',
+        type: 'js',
+        metadata: { isAsync: false, requires: [], modulePaths: [] },
+        source: '',
+      },
+      {
+        filename: '_expo/static/css/styles-def456.css',
+        originFilename: 'styles.css',
+        type: 'css',
+        metadata: { hmrId: 'styles' },
+        source: '.test { color: red; }',
+      },
+    ],
+    template: '<!DOCTYPE html><html><head></head><body><div id="root"></div></body></html>',
+    baseUrl: '/app',
+    assetPrefix: 'https://cdn.example.com',
+    isExporting: true,
+  });
+  expect(res).toMatchSnapshot();
+  expect(res).toMatch(
+    /<script src="https:\/\/cdn\.example\.com\/_expo\/static\/js\/web\/entry-abc123\.js" defer>/
+  );
+  expect(res).toMatch(
+    /<link rel="stylesheet" href="https:\/\/cdn\.example\.com\/_expo\/static\/css\/styles-def456\.css">/
+  );
+});
+
+it('falls back to baseUrl when assetPrefix is not provided', () => {
+  const res = serializeHtmlWithAssets({
+    resources: [
+      {
+        filename: '_expo/static/js/web/entry-abc123.js',
+        originFilename: 'entry.js',
+        type: 'js',
+        metadata: { isAsync: false, requires: [], modulePaths: [] },
+        source: '',
+      },
+    ],
+    template: '<!DOCTYPE html><html><head></head><body><div id="root"></div></body></html>',
+    baseUrl: '/app',
+    isExporting: true,
+  });
+  expect(res).toMatchSnapshot();
+  expect(res).toMatch(/<script src="\/app\/_expo\/static\/js\/web\/entry-abc123\.js" defer>/);
+});
+
 it('sorts assets based on requires tree', () => {
   const assets: SerialAsset[] = [
     {

--- a/packages/@expo/cli/src/start/server/metro/serializeHtml.ts
+++ b/packages/@expo/cli/src/start/server/metro/serializeHtml.ts
@@ -13,6 +13,7 @@ export function serializeHtmlWithAssets({
   template,
   devBundleUrl,
   baseUrl,
+  assetPrefix,
   route,
   isExporting,
   hydrate,
@@ -21,6 +22,8 @@ export function serializeHtmlWithAssets({
   template: string;
   /** asset prefix used for deploying to non-standard origins like GitHub pages. */
   baseUrl: string;
+  /** URL prefix for static assets (JS, CSS). Falls back to baseUrl if not set. */
+  assetPrefix?: string;
   devBundleUrl?: string;
   route?: RouteNode;
   isExporting: boolean;
@@ -33,6 +36,7 @@ export function serializeHtmlWithAssets({
     isExporting,
     template,
     baseUrl,
+    assetPrefix,
     bundleUrl: isExporting ? undefined : devBundleUrl,
     route,
     hydrate,
@@ -61,6 +65,7 @@ function htmlFromSerialAssets(
     isExporting,
     template,
     baseUrl,
+    assetPrefix,
     bundleUrl,
     route,
     hydrate,
@@ -68,19 +73,24 @@ function htmlFromSerialAssets(
     isExporting: boolean;
     template: string;
     baseUrl: string;
+    /** URL prefix for static assets (JS, CSS). Falls back to baseUrl if not set. */
+    assetPrefix?: string;
     /** This is dev-only. */
     bundleUrl?: string;
     route?: RouteNode;
     hydrate?: boolean;
   }
 ) {
+  // Use assetPrefix for static assets if provided, otherwise fall back to baseUrl
+  const staticAssetPrefix = assetPrefix ?? baseUrl;
+
   // Combine the CSS modules into tags that have hot refresh data attributes.
   const styleString = assets
     .filter((asset) => asset.type.startsWith('css'))
     .map(({ type, metadata, filename, source }) => {
       if (type === 'css') {
         if (isExporting) {
-          return createInjectedCssAsString([combineUrlPath(baseUrl, filename)]);
+          return createInjectedCssAsString([combineUrlPath(staticAssetPrefix, filename)]);
         } else {
           return `<style data-expo-css-hmr="${metadata.hmrId}">` + source + '\n</style>';
         }
@@ -127,10 +137,10 @@ function htmlFromSerialAssets(
               return '';
             }
             // Mark async chunks as defer so they don't block the page load.
-            // return `<script src="${combineUrlPath(baseUrl, filename)" defer></script>`;
+            // return `<script src="${combineUrlPath(staticAssetPrefix, filename)" defer></script>`;
           }
 
-          return createInjectedScriptsAsString([combineUrlPath(baseUrl, filename)]);
+          return createInjectedScriptsAsString([combineUrlPath(staticAssetPrefix, filename)]);
         })
         .join('');
 

--- a/packages/@expo/cli/src/start/server/middleware/metroOptions.ts
+++ b/packages/@expo/cli/src/start/server/middleware/metroOptions.ts
@@ -38,6 +38,8 @@ export type ExpoMetroOptions = {
   /** Enable React compiler support in Babel. */
   reactCompiler?: boolean;
   baseUrl?: string;
+  /** URL prefix for static assets (JS, CSS, fonts). Falls back to baseUrl if not set. */
+  assetPrefix?: string;
   isExporting: boolean;
   /** Is bundling a DOM Component ("use dom"). Requires the entry dom component file path. */
   domRoot?: string;
@@ -120,6 +122,10 @@ export function getBaseUrlFromExpoConfig(exp: ExpoConfig) {
   return exp.experiments?.baseUrl?.trim().replace(/\/+$/, '') ?? '';
 }
 
+export function getAssetPrefixFromExpoConfig(exp: ExpoConfig) {
+  return exp.experiments?.assetPrefix?.trim().replace(/\/+$/, '') ?? '';
+}
+
 export function getAsyncRoutesFromExpoConfig(exp: ExpoConfig, mode: string, platform: string) {
   let asyncRoutesSetting;
 
@@ -138,12 +144,13 @@ export function getAsyncRoutesFromExpoConfig(exp: ExpoConfig, mode: string, plat
 export function getMetroDirectBundleOptionsForExpoConfig(
   projectRoot: string,
   exp: ExpoConfig,
-  options: Omit<ExpoMetroOptions, 'baseUrl' | 'reactCompiler' | 'routerRoot' | 'asyncRoutes'>
+  options: Omit<ExpoMetroOptions, 'baseUrl' | 'assetPrefix' | 'reactCompiler' | 'routerRoot' | 'asyncRoutes'>
 ) {
   return getMetroDirectBundleOptions({
     ...options,
     reactCompiler: !!exp.experiments?.reactCompiler,
     baseUrl: getBaseUrlFromExpoConfig(exp),
+    assetPrefix: getAssetPrefixFromExpoConfig(exp),
     routerRoot: getRouterDirectoryModuleIdWithManifest(projectRoot, exp),
     asyncRoutes: getAsyncRoutesFromExpoConfig(exp, options.mode, options.platform),
   });
@@ -164,6 +171,7 @@ export function getMetroDirectBundleOptions(options: ExpoMetroOptions) {
     preserveEnvVars,
     asyncRoutes,
     baseUrl,
+    assetPrefix,
     routerRoot,
     isExporting,
     inlineSourceMap,
@@ -214,6 +222,7 @@ export function getMetroDirectBundleOptions(options: ExpoMetroOptions) {
     asyncRoutes: asyncRoutes ? toBoolStr(asyncRoutes) : undefined,
     environment,
     baseUrl: baseUrl || undefined,
+    assetPrefix: assetPrefix || undefined,
     routerRoot,
     bytecode: bytecode ? '1' : undefined,
     reactCompiler: reactCompiler ? toBoolStr(reactCompiler) : undefined,
@@ -307,6 +316,7 @@ export function createBundleUrlSearchParams(options: ExpoMetroOptions): URLSearc
     preserveEnvVars,
     asyncRoutes,
     baseUrl,
+    assetPrefix,
     routerRoot,
     reactCompiler,
     inlineSourceMap,
@@ -360,6 +370,9 @@ export function createBundleUrlSearchParams(options: ExpoMetroOptions): URLSearc
   }
   if (baseUrl) {
     queryParams.append('transform.baseUrl', baseUrl);
+  }
+  if (assetPrefix) {
+    queryParams.append('transform.assetPrefix', assetPrefix);
   }
   if (clientBoundaries?.length) {
     queryParams.append('transform.clientBoundaries', JSON.stringify(clientBoundaries));
@@ -460,6 +473,7 @@ export function getMetroOptionsFromUrl(urlFragment: string) {
     reactCompiler: isTruthy(getStringParam('transform.reactCompiler') ?? 'false'),
     asyncRoutes: isTruthy(getStringParam('transform.asyncRoutes') ?? 'false'),
     baseUrl: getStringParam('transform.baseUrl') ?? undefined,
+    assetPrefix: getStringParam('transform.assetPrefix') ?? undefined,
     // clientBoundaries: JSON.parse(getStringParam('transform.clientBoundaries') ?? '[]'),
     engine: assertEngine(getStringParam('transform.engine')),
     runModule: isTruthy(getStringParam('runModule') ?? 'true'),

--- a/packages/@expo/config-types/build/ExpoConfig.d.ts
+++ b/packages/@expo/config-types/build/ExpoConfig.d.ts
@@ -218,6 +218,10 @@ export interface ExpoConfig {
          */
         baseUrl?: string;
         /**
+         * URL prefix for static assets (JS, CSS, fonts, images). Use this to serve assets from a CDN while keeping the app URL unchanged. Similar to Next.js assetPrefix. Example: 'https://cdn.example.com'. If not specified, defaults to the value of `baseUrl`.
+         */
+        assetPrefix?: string;
+        /**
          * @deprecated This field is not longer marked as experimental and will be removed in a future release, use the `buildCacheProvider` field instead.
          */
         buildCacheProvider?: 'eas' | {

--- a/packages/@expo/config-types/src/ExpoConfig.ts
+++ b/packages/@expo/config-types/src/ExpoConfig.ts
@@ -230,6 +230,10 @@ export interface ExpoConfig {
      */
     baseUrl?: string;
     /**
+     * URL prefix for static assets (JS, CSS, fonts, images). Use this to serve assets from a CDN while keeping the app URL unchanged. Similar to Next.js assetPrefix. Example: 'https://cdn.example.com'. If not specified, defaults to the value of `baseUrl`.
+     */
+    assetPrefix?: string;
+    /**
      * @deprecated This field is not longer marked as experimental and will be removed in a future release, use the `buildCacheProvider` field instead.
      */
     buildCacheProvider?:

--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `experiments.assetPrefix` config option to serve static assets from a CDN while keeping the app URL unchanged. ([#41520](https://github.com/expo/expo/pull/41520) by [@jtomaszewski](https://github.com/jtomaszewski))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/@expo/metro-config/src/serializer/fork/__tests__/baseJSBundle.test.ts
+++ b/packages/@expo/metro-config/src/serializer/fork/__tests__/baseJSBundle.test.ts
@@ -1,4 +1,4 @@
-import { getBaseUrlOption } from '../baseJSBundle';
+import { getAssetPrefixOption, getBaseUrlOption } from '../baseJSBundle';
 
 describe(getBaseUrlOption, () => {
   it(`returns the expected base url from dev server options`, () => {
@@ -39,6 +39,76 @@ describe(getBaseUrlOption, () => {
               customTransformOptions: {
                 __proto__: null,
                 baseUrl: input,
+              },
+            },
+          },
+          {
+            serializerOptions: {},
+          }
+        )
+      ).toBe(expected);
+    });
+  });
+});
+
+describe(getAssetPrefixOption, () => {
+  it(`returns null when assetPrefix is not set`, () => {
+    expect(
+      getAssetPrefixOption(
+        {
+          // @ts-expect-error
+          transformOptions: {
+            customTransformOptions: {
+              __proto__: null,
+            },
+          },
+        },
+        {}
+      )
+    ).toBe(null);
+  });
+
+  it(`returns the expected asset prefix from dev server options`, () => {
+    [
+      ['https%3A%2F%2Fcdn.example.com', 'https://cdn.example.com'],
+      ['https://cdn.example.com', 'https://cdn.example.com'],
+      ['https://cdn.example.com/', 'https://cdn.example.com'],
+      ['/cdn', '/cdn'],
+      ['/cdn/', '/cdn'],
+    ].forEach(([input, expected]) => {
+      expect(
+        getAssetPrefixOption(
+          {
+            // @ts-expect-error
+            transformOptions: {
+              customTransformOptions: {
+                __proto__: null,
+                assetPrefix: input,
+              },
+            },
+          },
+          {}
+        )
+      ).toBe(expected);
+    });
+  });
+
+  it(`returns the expected asset prefix from direct API usage`, () => {
+    [
+      ['https%3A%2F%2Fcdn.example.com', 'https%3A%2F%2Fcdn.example.com'],
+      ['https://cdn.example.com', 'https://cdn.example.com'],
+      ['https://cdn.example.com/', 'https://cdn.example.com'],
+      ['/cdn', '/cdn'],
+      ['/cdn/', '/cdn'],
+    ].forEach(([input, expected]) => {
+      expect(
+        getAssetPrefixOption(
+          {
+            // @ts-expect-error
+            transformOptions: {
+              customTransformOptions: {
+                __proto__: null,
+                assetPrefix: input,
               },
             },
           },

--- a/packages/@expo/metro-config/src/serializer/fork/baseJSBundle.ts
+++ b/packages/@expo/metro-config/src/serializer/fork/baseJSBundle.ts
@@ -86,6 +86,21 @@ export function getBaseUrlOption(
   return '/';
 }
 
+export function getAssetPrefixOption(
+  graph: Pick<ReadOnlyGraph, 'transformOptions'>,
+  options: Pick<ExpoSerializerOptions, 'serializerOptions'>
+): string | null {
+  const assetPrefix = graph.transformOptions?.customTransformOptions?.assetPrefix;
+  if (typeof assetPrefix === 'string') {
+    // This tells us that the value came over a URL and may be encoded.
+    const mayBeEncoded = options.serializerOptions == null;
+    const option = mayBeEncoded ? decodeURIComponent(assetPrefix) : assetPrefix;
+
+    return option.replace(/\/+$/, '');
+  }
+  return null;
+}
+
 export function baseJSBundle(
   entryPoint: string,
   preModules: readonly Module[],

--- a/packages/@expo/metro-config/src/serializer/serializeChunks.ts
+++ b/packages/@expo/metro-config/src/serializer/serializeChunks.ts
@@ -65,6 +65,16 @@ function getPlatformOption(
   return _getPlatformOption(...args);
 }
 
+let _getAssetPrefixOption: typeof import('./fork/baseJSBundle').getAssetPrefixOption;
+function getAssetPrefixOption(
+  ...args: Parameters<typeof import('./fork/baseJSBundle').getAssetPrefixOption>
+) {
+  if (!_getAssetPrefixOption) {
+    _getAssetPrefixOption = require('./fork/baseJSBundle').getAssetPrefixOption;
+  }
+  return _getAssetPrefixOption(...args);
+}
+
 type Serializer = NonNullable<ConfigT['serializer']['customSerializer']>;
 type SerializerParameters = Parameters<Serializer>;
 
@@ -139,7 +149,8 @@ export async function graphToSerialAssetsAsync(
   // TODO: Can this be anything besides true?
   const isExporting = true;
   const baseUrl = getBaseUrlOption(graph, { serializerOptions: serializeChunkOptions });
-  const assetPublicUrl = (baseUrl.replace(/\/+$/, '') ?? '') + '/assets';
+  const assetPrefix = getAssetPrefixOption(graph, { serializerOptions: serializeChunkOptions });
+  const assetPublicUrl = ((assetPrefix ?? baseUrl.replace(/\/+$/, '')) ?? '') + '/assets';
   const platform = getPlatformOption(graph, options) ?? 'web';
   const isHosted =
     platform === 'web' || (graph.transformOptions?.customTransformOptions?.hosted && isExporting);


### PR DESCRIPTION
## Summary

Adds `experiments.assetPrefix` config option to serve static assets (JS, CSS, fonts, images) from a CDN while keeping the app URL unchanged. Similar to Next.js's [`assetPrefix`](https://nextjs.org/docs/app/api-reference/config/next-config-js/assetPrefix) feature.

This addresses the use case described in #28649 where you want to deploy your app at one URL but serve assets from a separate CDN for better performance.

### Usage in app.config.js:

```js
{
  experiments: {
    baseUrl: '/my-app',
    assetPrefix: 'https://cdn.example.com'
  }
}
```

With this configuration:
- Page links use `baseUrl`: `/my-app/about`
- Static assets use `assetPrefix`: `https://cdn.example.com/_expo/static/js/...`

If `assetPrefix` is not specified, it defaults to `baseUrl` behavior (maintaining backward compatibility).

Related: https://github.com/expo/expo/issues/28649#issuecomment-2103336069

## Test plan

- Added unit tests for `getAssetPrefixOption` in `baseJSBundle.test.ts`
- Added unit tests for assetPrefix in `serializeHtml.test.ts`
- Added e2e tests in `asset-prefix.test.ts`:
  - Tests assetPrefix with CDN URL
  - Tests assetPrefix combined with baseUrl (verifies assets use CDN while links use basePath)

🤖 Generated with [Claude Code](https://claude.com/claude-code)