### PR TITLE
[docs] Add React Native Survey 2025 banner

### DIFF
--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -9,6 +9,7 @@ import {
   JoinTheCommunity,
 } from '~/ui/components/Home/sections';
 import { ExploreExamples } from '~/ui/components/Home/sections/ExploreExamples';
+import { StateOfRNBanner } from '~/ui/components/StateOfRNBanner';
 
 function Home() {
   return (
@@ -19,6 +20,7 @@ function Home() {
       <div className="h-0">
         <DevicesImageMasks />
       </div>
+      <StateOfRNBanner />
       <QuickStart />
       <CommandLineTools />
       <DiscoverMore />

--- a/docs/ui/components/StateOfRNBanner/index.tsx
+++ b/docs/ui/components/StateOfRNBanner/index.tsx
@@ -9,7 +9,7 @@ import { ReactLogo } from './ReactLogo';
 
 export function StateOfRNBanner() {
   const router = useRouter();
-  const stateOfRNEndDate = new Date('2025-01-08');
+  const stateOfRNEndDate = new Date('2026-01-08');
   const showShoutout = isBefore(new Date(), stateOfRNEndDate);
   const isHomePage = router?.pathname === '/';
 
@@ -32,7 +32,7 @@ export function StateOfRNBanner() {
         </div>
         <div className="relative grid grid-cols-1 gap-1">
           <HEADLINE className="text-[#001a72] dark:text-[#b1dfd0]">
-            State of React Native 2024
+            State of React Native 2025
           </HEADLINE>
           <CALLOUT className="text-[#001a72] dark:text-[#b1dfd0]">
             Have a few minutes and want to shape the future of React Native?

--- a/docs/ui/components/StateOfRNBanner/index.tsx
+++ b/docs/ui/components/StateOfRNBanner/index.tsx
@@ -9,7 +9,7 @@ import { ReactLogo } from './ReactLogo';
 
 export function StateOfRNBanner() {
   const router = useRouter();
-  const stateOfRNEndDate = new Date('2026-01-08');
+  const stateOfRNEndDate = new Date('2026-01-10');
   const showShoutout = isBefore(new Date(), stateOfRNEndDate);
   const isHomePage = router?.pathname === '/';
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

https://survey.stateofreactnative.com/ is live.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Enable `StateOfRNBanner` in docs index page.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

<img width="4112" height="2458" alt="CleanShot 2025-12-09 at 23 27 08@2x" src="https://github.com/user-attachments/assets/ab7a08c3-e788-4442-9093-59bbbbbd5920" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
