### PR TITLE
[cli] Fix running iOS builds on device without available simulators

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -21,6 +21,7 @@
 - only skip dependency validation for `EXPO_NO_DEPENDENCY_VALIDATION=1` ([#40043](https://github.com/expo/expo/pull/40043) by [@kitten](https://github.com/kitten))
 - Report stack traces on unexpected `TransformerError`s and `SyntaxError`s from Metro ([#41468](https://github.com/expo/expo/pull/41468) by [@kitten](https://github.com/kitten))
 - resolve "Illegal invocation" errors in `workerd` runtime ([#41502](https://github.com/expo/expo/pull/41502) by [@hassankhan](https://github.com/hassankhan))
+- Fix running iOS builds on device without available simulators ([#41524](https://github.com/expo/expo/pull/41524) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/platforms/ios/getBestSimulator.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/getBestSimulator.ts
@@ -103,5 +103,13 @@ export async function getBestSimulatorAsync({ osType }: DeviceContext): Promise<
     return simulatorOpenedByApp.udid;
   }
 
-  return await getBestUnbootedSimulatorAsync({ osType });
+  try {
+    return await getBestUnbootedSimulatorAsync({ osType });
+  } catch (error) {
+    // Instead of throwing, return null if no simulators are found
+    if (error instanceof CommandError && error.code === 'UNSUPPORTED_OS_TYPE') {
+      return null;
+    }
+    throw error;
+  }
 }


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/41403
Closes DVT-77
<img width="650" height="108" alt="image" src="https://github.com/user-attachments/assets/c829e101-dcbb-4049-a1d5-6aff059bd46c" />

 ### How 

When listing iOS devices in the CLI, we sorted available simulators so the most recently opened one (the user’s default) appeared first. However, we didn’t account for situations where the user has no available simulators, but does have a physical iOS device connected. In that scenario, the current logic would throw an error. This PR updates `getBestUnbootedSimulatorAsync` to return `null` instead of throwing when no simulators are available.

# Test Plan

1. Delete all iOS simulators 
2. Connect an iOS device to the computer
3. Run `npx expo run:ios --device <uuid>`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
