### PR TITLE
[docs] Fix FileTree parsing for llms.txt generation

### DIFF
--- a/docs/scripts/generate-llms/utils.js
+++ b/docs/scripts/generate-llms/utils.js
@@ -334,7 +334,7 @@ function renderFileTreeAscii(structure) {
 
   renderNodes(structure, '');
 
-  return lines.map(line => line.replace(/^(├── |└── )/, ''));
+  return lines;
 }
 
 function generateItemMarkdown(item) {

--- a/docs/scripts/generate-llms/utils.js
+++ b/docs/scripts/generate-llms/utils.js
@@ -268,6 +268,7 @@ function parseFileTreeFilesLiteral(literal) {
 
   try {
     return parse(literal);
+    // eslint-disable-next-line no-unused-vars
   } catch (error) {
     try {
       return parse(sanitizeFileTreeFilesLiteral(literal));


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

`FileTree` blocks with JSX notes (fragments, links, icons) were causing “Unexpected identifier” parse errors in llms-*.txt outputs.

I noticed this locally and in one of the recently merged PR's Build docs website for deploy step: https://github.com/expo/expo/actions/runs/20070918823/job/57572431255#step:5:16

<img width="943" height="863" alt="CleanShot 2025-12-10 at 02 15 16" src="https://github.com/user-attachments/assets/4b4fbea3-7b7c-4b3b-bed4-34a42f4b47c1" />

<br />
<br />

**This disables parsing the `FileTree` components in `llms-*.txt` files to ASCII representations such as the following:**

```
├── app.config.ts  # import "./my-config-plugin"
└── my-config-plugin.ts  # Imported from config
```

# How

<!--
How did you build this feature or fix this bug and why?
-->

Sanitize `FileTree` files literals by stripping tags, normalizing whitespace, and converting fragments/inline elements to quoted text before evaluation in `generate-llms/utils.js`.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Locally, run `yarn run generate-llms` and there should be no parsing errors:

<img width="721" height="245" alt="CleanShot 2025-12-10 at 02 12 47" src="https://github.com/user-attachments/assets/6e29d0c0-8c9d-4930-9817-fc5db97fd18f" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
