### PR TITLE
[video][android] Set property values on calling thread.

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [Android] Remove @UnstableReactNativeAPI annotations. ([#39921](https://github.com/expo/expo/pull/39921) by [@jakex7](https://github.com/jakex7))
 - [iOS] Load track information for events in asynchronous context. ([#40355](https://github.com/expo/expo/pull/40355) by [@behenate](https://github.com/behenate))
 - Add extract the object `VideoSource` type into separate `VideoSourceObject` type. ([#41514](https://github.com/expo/expo/pull/41514) by [@behenate](https://github.com/behenate))
+- [Android] Set property values on calling thread. ([#41533](https://github.com/expo/expo/pull/41533) by [@behenate](https://github.com/behenate))
 
 ## 3.0.15 - 2025-12-05
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
@@ -85,9 +85,7 @@ class VideoModule : Module() {
           ref.muted
         }
         .set { ref: VideoPlayer, muted: Boolean ->
-          appContext.mainQueue.launch {
-            ref.muted = muted
-          }
+          ref.muted = muted
         }
 
       Property("volume")
@@ -95,10 +93,8 @@ class VideoModule : Module() {
           ref.volume
         }
         .set { ref: VideoPlayer, volume: Float ->
-          appContext.mainQueue.launch {
-            ref.userVolume = volume
-            ref.volume = volume
-          }
+          ref.userVolume = volume
+          ref.volume = volume
         }
 
       Property("currentTime")
@@ -180,10 +176,8 @@ class VideoModule : Module() {
           ref.playbackParameters.speed
         }
         .set { ref: VideoPlayer, playbackRate: Float ->
-          appContext.mainQueue.launch {
-            val pitch = if (ref.preservesPitch) 1f else playbackRate
-            ref.playbackParameters = PlaybackParameters(playbackRate, pitch)
-          }
+          val pitch = if (ref.preservesPitch) 1f else playbackRate
+          ref.playbackParameters = PlaybackParameters(playbackRate, pitch)
         }
 
       Property("isLive")
@@ -196,9 +190,7 @@ class VideoModule : Module() {
           ref.preservesPitch
         }
         .set { ref: VideoPlayer, preservesPitch: Boolean ->
-          appContext.mainQueue.launch {
-            ref.preservesPitch = preservesPitch
-          }
+          ref.preservesPitch = preservesPitch
         }
 
       Property("showNowPlayingNotification")
@@ -206,9 +198,7 @@ class VideoModule : Module() {
           ref.showNowPlayingNotification
         }
         .set { ref: VideoPlayer, showNotification: Boolean ->
-          appContext.mainQueue.launch {
-            ref.showNowPlayingNotification = showNotification
-          }
+          ref.showNowPlayingNotification = showNotification
         }
 
       Property("status")
@@ -287,9 +277,7 @@ class VideoModule : Module() {
           ref.audioMixingMode
         }
         .set { ref: VideoPlayer, audioMixingMode: AudioMixingMode ->
-          appContext.mainQueue.launch {
-            ref.audioMixingMode = audioMixingMode
-          }
+          ref.audioMixingMode = audioMixingMode
         }
 
       Property("keepScreenOnWhilePlaying")

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
@@ -101,24 +101,32 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
   var preservesPitch = false
     set(preservesPitch) {
       field = preservesPitch
-      playbackParameters = applyPitchCorrection(playbackParameters)
+      appContext?.mainQueue?.launch {
+        playbackParameters = applyPitchCorrection(playbackParameters)
+      }
     }
   var showNowPlayingNotification = false
     set(value) {
       field = value
-      serviceSetShowNotification(value)
+      appContext?.mainQueue?.launch {
+        serviceSetShowNotification(value)
+      }
     }
   var duration = 0f
   var isLive = false
 
   var volume: Float by IgnoreSameSet(1f) { new: Float, old: Float ->
-    player.volume = if (muted) 0f else new
+    appContext.mainQueue.launch {
+      player.volume = if (muted) 0f else new
+    }
     userVolume = volume
     sendEvent(PlayerEvent.VolumeChanged(new, old))
   }
 
   var muted: Boolean by IgnoreSameSet(false) { new: Boolean, old: Boolean ->
-    player.volume = if (new) 0f else userVolume
+    appContext.mainQueue.launch {
+      player.volume = if (new) 0f else userVolume
+    }
     sendEvent(PlayerEvent.MutedChanged(new, old))
   }
 
@@ -126,7 +134,9 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
     PlaybackParameters.DEFAULT,
     propertyMapper = { applyPitchCorrection(it) }
   ) { new: PlaybackParameters, old: PlaybackParameters ->
-    player.playbackParameters = new
+    appContext.mainQueue.launch {
+      player.playbackParameters = new
+    }
 
     if (old.speed != new.speed) {
       sendEvent(PlayerEvent.PlaybackRateChanged(new.speed, old.speed))


### PR DESCRIPTION
# Why

For most player properties, we have to schedule the ExoPlayer setter on the main thread, since it has to be modified on the main thread.

So far we have also been scheduling our property setter on the main thread for the sake of simplicity. 
This introduces an issue though. Doing the following:
```
// Default player volume is 1
player.volume = 0.5
print(player.volume) // Will usually print 1
```

In normal use cases this didn't cause any issues, but it does in property testers in `test-suite`, since they usually do the pattern mentioned above.

# How

Set our property value on the calling thread, and schedule the ExoPlayer property setting on the main thread.

# Test Plan

Tested in BareExpo on Android
