### PR TITLE
[video-thumbnails][docs] Add deprecation notice for the library

### DIFF
--- a/docs/pages/versions/unversioned/sdk/video-thumbnails.mdx
+++ b/docs/pages/versions/unversioned/sdk/video-thumbnails.mdx
@@ -4,11 +4,14 @@ description: A library that allows you to generate an image to serve as a thumbn
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-video-thumbnails'
 packageName: 'expo-video-thumbnails'
 platforms: ['android', 'ios', 'tvos']
+isDeprecated: true
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
+
+> **warning** **Deprecated:** Video Thumbnails library has been deprecated in favor of [`generateThumbnailsAsync`](video.mdx/#generatethumbnailsasynctimes-options) from [`expo-video`](video.mdx). `expo-video-thumbnails` is not receiving patches and will be removed in SDK 56.
 
 `expo-video-thumbnails` allows you to generate an image to serve as a thumbnail from a video file.
 


### PR DESCRIPTION
# Why

We are ending support for `expo-video-thumbnails` in favour of the same feature in `expo-video`. We need to add a note to the docs for the SDK 55 release cycle and then remove the library from the SDK in SDK 56.

# How

Add the depreciation notice.

# Test Plan

Tested in locally hosted docs
