### PR TITLE
[docs] fix link in notification docs

### DIFF
--- a/docs/pages/push-notifications/what-you-need-to-know.mdx
+++ b/docs/pages/push-notifications/what-you-need-to-know.mdx
@@ -101,6 +101,6 @@ You may also come across the term "silent notification", which is yet another na
 
 This is a non-exhaustive list of official resources for push notifications on Android and iOS:
 
-- [Android - About FCM messages](https://firebase.google.com/docs/cloud-messaging/concept-options)
+- [Android - Firebase Cloud Messaging message types](https://firebase.google.com/docs/cloud-messaging/customize-messages/set-message-type)
 - [iOS - Generating a remote notification](https://developer.apple.com/documentation/usernotifications/generating-a-remote-notification)
 - [iOS - Pushing background updates to your app](https://developer.apple.com/documentation/usernotifications/pushing-background-updates-to-your-app)


### PR DESCRIPTION
# Why

the old link is a 404

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
