### PR TITLE
[docs] Fix custom EAS dashboard section ordering in search ui

### DIFF
--- a/docs/ui/components/Search/Search.tsx
+++ b/docs/ui/components/Search/Search.tsx
@@ -35,7 +35,7 @@ export const Search = () => {
             heading: 'EAS dashboard',
             items: expoDashboardItems,
             getItemsAsync: getExpoItemsAsync,
-            sectionIndex: 2,
+            sectionIndex: Number.MAX_SAFE_INTEGER,
           },
         ]}
       />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The “EAS dashboard” custom section was injected at index 2, causing it to appear second in the results, ahead of core sections.

<img width="1946" height="2136" alt="CleanShot 2025-12-11 at 14 47 53@2x" src="https://github.com/user-attachments/assets/64ea523d-4d42-4788-8b25-4689efd7c61a" />


<img width="2064" height="1980" alt="CleanShot 2025-12-11 at 14 47 56@2x" src="https://github.com/user-attachments/assets/a02e848b-261a-43f5-8a0e-fb13eb78f255" />


# How

<!--
How did you build this feature or fix this bug and why?
-->

Set the custom section’s sectionIndex to `Number.MAX_SAFE_INTEGER` in `ui/components/Search/Search.tsx`, effectively appending it after the built-in groups.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2134" height="1982" alt="CleanShot 2025-12-11 at 14 48 29@2x" src="https://github.com/user-attachments/assets/9f255fed-c211-4cb7-ad97-648adc89108a" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
