### PR TITLE
[core][Android] Deprecated `executeOnJavaScriptThread` in favor of `runtime.schedule`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -49,8 +49,7 @@
 - Remove old REACT_NATIVE_TARGET_VERSION checks ([#40843](https://github.com/expo/expo/pull/40843) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Moved the implementation of the constants provider (`EXConstantsService`) from `expo-constants`. ([#41339](https://github.com/expo/expo/pull/41339) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Replaced `appContext.fileSystem`, `appContext.utilities`, `appContext.imageLoader` and `appContext.permissions` with the core implementations. ([#41350](https://github.com/expo/expo/pull/41350), [#41370](https://github.com/expo/expo/pull/41370), [#41396](https://github.com/expo/expo/pull/41396) by [@tsapeta](https://github.com/tsapeta))
-- [iOS] Deprecated `executeOnJavaScriptThread` in favor of `runtime.schedule`. ([#41478](https://github.com/expo/expo/pull/41478) by [@tsapeta](https://github.com/tsapeta))
-- [Android] Deprecated `executeOnJavaScriptThread` in favor of `runtime.schedule`.
+- Deprecated `executeOnJavaScriptThread` in favor of `runtime.schedule`. ([#41478](https://github.com/expo/expo/pull/41478) by [@tsapeta](https://github.com/tsapeta) & [#41551](https://github.com/expo/expo/pull/41551) by [@lukmccall](https://github.com/lukmccall))
 
 ## 3.0.28 - 2025-12-05
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -50,6 +50,7 @@
 - [iOS] Moved the implementation of the constants provider (`EXConstantsService`) from `expo-constants`. ([#41339](https://github.com/expo/expo/pull/41339) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Replaced `appContext.fileSystem`, `appContext.utilities`, `appContext.imageLoader` and `appContext.permissions` with the core implementations. ([#41350](https://github.com/expo/expo/pull/41350), [#41370](https://github.com/expo/expo/pull/41370), [#41396](https://github.com/expo/expo/pull/41396) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Deprecated `executeOnJavaScriptThread` in favor of `runtime.schedule`. ([#41478](https://github.com/expo/expo/pull/41478) by [@tsapeta](https://github.com/tsapeta))
+- [Android] Deprecated `executeOnJavaScriptThread` in favor of `runtime.schedule`.
 
 ## 3.0.28 - 2025-12-05
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
@@ -38,6 +38,7 @@ private fun defaultAppContextMock(): Pair<AppContext, RuntimeContext> {
   every { runtimeContext.appContext } answers { appContextMock }
   every { appContextMock.findView<View>(capture(slot())) } answers { mockk() }
   every { appContextMock.hostingRuntimeContext } answers { runtimeContext }
+  every { appContextMock.runtime } answers { runtimeContext }
 
   return appContextMock to runtimeContext
 }
@@ -96,7 +97,7 @@ internal inline fun withJSIInterop(
         register(it, null)
       }
     }
-    val sharedObjectRegistry = SharedObjectRegistry(appContextMock.hostingRuntimeContext)
+    val sharedObjectRegistry = SharedObjectRegistry(appContextMock.runtime)
     every { appContextMock.registry } answers { registry }
     every { runtimeContext.sharedObjectRegistry } answers { sharedObjectRegistry }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -57,7 +57,11 @@ class AppContext(
 
   // The main context used in the app.
   // Modules attached to this context will be available on the main js context.
+  @Deprecated("Use AppContext.runtimeContext instead", ReplaceWith("runtime"))
   val hostingRuntimeContext = RuntimeContext(this, reactContextHolder)
+
+  val runtime: RuntimeContext
+    get() = hostingRuntimeContext
 
   private val reactLifecycleDelegate = ReactLifecycleDelegate(this)
 
@@ -355,6 +359,7 @@ class AppContext(
   /**
    * Runs a code block on the JavaScript thread.
    */
+  @Deprecated("Use RuntimeContext.schedule instead", ReplaceWith("runtime.schedule(runnable)"))
   fun executeOnJavaScriptThread(runnable: Runnable) {
     hostingRuntimeContext.reactContext?.runOnJSQueueThread(runnable)
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/RuntimeContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/RuntimeContext.kt
@@ -42,6 +42,14 @@ class RuntimeContext(
   }
 
   /**
+   * Runs a code block on the JavaScript thread.
+   */
+  fun schedule(block: () -> Unit) {
+    // TODO(@lukmccall): start using RuntimeScheduler
+    reactContext?.runOnJSQueueThread(block)
+  }
+
+  /**
    * The core module that defines the `expo` object in the global scope of the JS runtime.
    *
    * Note: in current implementation this module won't receive any events.
@@ -52,7 +60,7 @@ class RuntimeContext(
     ModuleHolder(module, null)
   }
 
-  val jniDeallocator: JNIDeallocator = JNIDeallocator()
+  internal val jniDeallocator: JNIDeallocator = JNIDeallocator()
 
   internal val sharedObjectRegistry = SharedObjectRegistry(this)
 
@@ -63,7 +71,7 @@ class RuntimeContext(
    * It will be a NOOP if the remote debugging was activated.
    */
   @OptIn(FrameworkAPI::class)
-  fun installJSIContext() = synchronized(this) {
+  internal fun installJSIContext() = synchronized(this) {
     if (isJSIContextInitialized()) {
       logger.warn("⚠️ JSI interop was already installed")
       return
@@ -102,7 +110,7 @@ class RuntimeContext(
     }
   }
 
-  fun deallocate() {
+  internal fun deallocate() {
     jniDeallocator.deallocate()
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/RuntimeContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/RuntimeContext.kt
@@ -60,6 +60,7 @@ class RuntimeContext(
     ModuleHolder(module, null)
   }
 
+  @PublishedApi
   internal val jniDeallocator: JNIDeallocator = JNIDeallocator()
 
   internal val sharedObjectRegistry = SharedObjectRegistry(this)


### PR DESCRIPTION
# Why

A follow-up to the https://github.com/expo/expo/pull/41478.

# How

- Deprecated `executeOnJavaScriptThread` in favor of `runtime.schedule`.
- Made some functions inside `RuntimeContext` internal as it will be used as a public API.

# Test Plan

- tests ✅ 