### PR TITLE
[docs] Improve search ordering by passing main section context  in Search UI

### DIFF
--- a/docs/ui/components/Search/Search.tsx
+++ b/docs/ui/components/Search/Search.tsx
@@ -7,10 +7,14 @@ import versions from '~/public/static/constants/versions.json';
 import { ExpoDashboardItem } from './ExpoDashboardItem';
 import { entries } from './expoEntries';
 
+type SearchProps = {
+  mainSection?: string;
+};
+
 const { LATEST_VERSION } = versions;
 const isDev = process.env.NODE_ENV === 'development';
 
-export const Search = () => {
+export const Search = ({ mainSection }: SearchProps) => {
   const { version } = usePageApiVersion();
   const [open, setOpen] = useState(false);
   const [expoDashboardItems, setExpoDashboardItems] = useState<ReactNode[]>([]);
@@ -29,7 +33,11 @@ export const Search = () => {
       <CommandMenu
         open={open}
         setOpen={setOpen}
-        config={{ docsVersion: version, docsTransformUrl: transformDocsUrl }}
+        config={{
+          docsVersion: version,
+          docsTransformUrl: transformDocsUrl,
+          ...(mainSection && { docsSectionContext: { mainSection } }),
+        }}
         customSections={[
           {
             heading: 'EAS dashboard',

--- a/docs/ui/components/Sidebar/SidebarHead.tsx
+++ b/docs/ui/components/Sidebar/SidebarHead.tsx
@@ -18,6 +18,14 @@ type SidebarHeadProps = {
 
 export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
   const isPreviewVisible = shouldShowFeaturePreviewLink();
+  const mainSectionMap: Record<string, string> = {
+    home: 'Home',
+    general: 'Guides',
+    eas: 'Expo Application Services',
+    reference: 'Reference',
+    learn: 'Learn',
+  };
+  const mainSection = mainSectionMap[sidebarActiveGroup];
 
   if (sidebarActiveGroup === 'archive') {
     return (
@@ -35,7 +43,7 @@ export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
   return (
     <>
       <div className="flex flex-col gap-0.5 border-b border-default bg-default p-4 compact-height:pb-3">
-        <Search />
+        <Search mainSection={mainSection} />
         <div
           className={mergeClasses(
             'contents',


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Dynamic search should prioritize the active docs main section (Home, Guides, EAS, Reference, Learn) so results from the current context surface first.

Examples:

<img width="4108" height="2382" alt="CleanShot 2025-12-11 at 14 56 12@2x" src="https://github.com/user-attachments/assets/993e3c0d-9d67-4060-a420-dec75bcf7eae" />

<img width="4112" height="2392" alt="CleanShot 2025-12-11 at 14 56 17@2x" src="https://github.com/user-attachments/assets/5d07776d-25fc-45ba-bfe9-b76c80a16dc0" />

<img width="4112" height="2384" alt="CleanShot 2025-12-11 at 14 56 25@2x" src="https://github.com/user-attachments/assets/ba7936b2-b471-429b-bdd6-7cdb4d4754fb" />


# How

<!--
How did you build this feature or fix this bug and why?
-->

Added an optional `mainSection` prop to `Search.tsx` and threaded the current main section from `SidebarHead.tsx` based on the active group, passing it to `CommandMenu` via `docsSectionContext` to bias ordering toward the active section.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview


https://github.com/user-attachments/assets/796f2664-9461-46f9-84b8-41823a7ebd33



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
