### PR TITLE
[ios][dev-launcher] Fix dev server scanning cancellation

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -3818,7 +3818,7 @@ SPEC CHECKSUMS:
   EXUpdates: 83e4d666a085b44149f3b21d5bd057ad37b2c3e5
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   FBLazyVector: a9d42cd9acb1b6e87eaef82916d91ad23136e4bb
-  hermes-engine: fa9b621ba90dcc147916c1da7383dc4f42790cce
+  hermes-engine: 6bb3000824be2770010ae038914fa26721255c8e
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -3836,7 +3836,7 @@ SPEC CHECKSUMS:
   React: 8896aeaee7431bbbbee8b85592672c2742be80c9
   React-callinvoker: 2b6eadc2850579c424c4b1bc3ad7f4452d3e48ce
   React-Core: 66ae91bab722380ad0bb1f0dc1b12bebef20e1fd
-  React-Core-prebuilt: ccf108a0491869242e2444a8b4b032f56ca30cfc
+  React-Core-prebuilt: 674b9753b697f8ee65bb81177dfa880c70611292
   React-CoreModules: 772a8edd6d3e070410864fec6db5b7714edec5d9
   React-cxxreact: 81daeec52c0629719a1d7fdd59bcb5b414d72377
   React-debug: e8441fe272552c7687003906ac065f1067b607ee
@@ -3906,7 +3906,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 07461dc99cceeca991cece80447fd21345113f16
   ReactCodegen: 924af208e62aaae2696e480188cbfa1f565a6e6b
   ReactCommon: 95e0bc81ddbc0460fca25e0e9ea8323fc44fd84a
-  ReactNativeDependencies: 4e6eca9c31e342f4b732a542730f616a4b581c8a
+  ReactNativeDependencies: 9a4a42586d9419b06992f2746d1aa9755265047b
   RNCAsyncStorage: e85a99325df9eb0191a6ee2b2a842644c7eb29f4
   RNCMaskedView: 3c9d7586e2b9bbab573591dcb823918bc4668005
   RNCPicker: 38a9deb903d9a8ae18b598bac727e6c84b3cf0fa

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Restore config plugin `launchMode` support ([#41363](https://github.com/expo/expo/pull/41363) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Prevent some debug only artifacts from being included in release builds. ([#41378](https://github.com/expo/expo/pull/41378) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Fix `DevLauncherWrapperView` in SwiftUI brownfield apps ([#41431](https://github.com/expo/expo/pull/41431) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Fix dev server discovery cancellation.
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Restore config plugin `launchMode` support ([#41363](https://github.com/expo/expo/pull/41363) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Prevent some debug only artifacts from being included in release builds. ([#41378](https://github.com/expo/expo/pull/41378) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Fix `DevLauncherWrapperView` in SwiftUI brownfield apps ([#41431](https://github.com/expo/expo/pull/41431) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- [iOS] Fix dev server discovery cancellation.
+- [iOS] Fix dev server discovery cancellation. ([#41555](https://github.com/expo/expo/pull/41555) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewController.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewController.swift
@@ -57,7 +57,7 @@ import ExpoModulesCore
     hostingController.view.frame = view.frame
     hostingController.view.autoresizingMask = [.width, .height]
 #endif
-    
+
   }
 
 #if os(iOS) || os(tvOS)

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
@@ -41,6 +41,7 @@ class DevLauncherViewModel: ObservableObject {
   @Published var user: User?
   @Published var selectedAccountId: String?
   @Published var isLoadingServer: Bool = false
+  private var discoveryTask: Task<Void, Never>?
 
   #if !os(tvOS)
   private let presentationContext = DevLauncherAuthPresentationContext()
@@ -64,7 +65,6 @@ class DevLauncherViewModel: ObservableObject {
 
   init() {
     loadData()
-    discoverDevServers()
     checkAuthenticationStatus()
     checkForStoredCrashes()
   }
@@ -126,35 +126,60 @@ class DevLauncherViewModel: ObservableObject {
     return runtimeVersion == structuredBuildInfo.runtimeVersion
   }
 
-  func discoverDevServers() {
-    Task {
-      var discoveredServers: [DevServer] = []
-
-      // swiftlint:disable number_separator
-      let portsToCheck = [8081, 8082, 8_083, 8084, 8085, 19000, 19001, 19002]
-      // swiftlint:enable number_separator
-
-      let ipsToScan = NetworkUtilities.getIPAddressesToScan()
-      await withTaskGroup(of: DevServer?.self) { group in
-        for ip in ipsToScan {
-          for port in portsToCheck {
-            group.addTask {
-              let baseAddress = ip == "localhost" ? "http://localhost" : "http://\(ip)"
-              return await self.checkDevServer(url: "\(baseAddress):\(port)")
-            }
-          }
+  func startServerDiscovery() {
+    discoveryTask?.cancel()
+    discoveryTask = Task {
+      await discoverDevServers()
+      while !Task.isCancelled {
+        try? await Task.sleep(nanoseconds: 2_000_000_000)
+        if Task.isCancelled {
+          break
         }
+        await discoverDevServers()
+      }
+    }
+  }
 
-        for await server in group {
-          if let server = server {
-            discoveredServers.append(server)
+  func stopServerDiscovery() {
+    discoveryTask?.cancel()
+    discoveryTask = nil
+  }
+
+  private func discoverDevServers() async {
+    guard !Task.isCancelled else {
+      return
+    }
+
+    var discoveredServers: [DevServer] = []
+
+    // swiftlint:disable number_separator
+    let portsToCheck = [8081, 8082, 8_083, 8084, 8085, 19000, 19001, 19002]
+    // swiftlint:enable number_separator
+
+    let ipsToScan = NetworkUtilities.getIPAddressesToScan()
+    await withTaskGroup(of: DevServer?.self) { group in
+      for ip in ipsToScan {
+        for port in portsToCheck {
+          group.addTask {
+            let baseAddress = ip == "localhost" ? "http://localhost" : "http://\(ip)"
+            return await self.checkDevServer(url: "\(baseAddress):\(port)")
           }
         }
       }
 
-      await MainActor.run {
-        self.devServers = discoveredServers.sorted { $0.url < $1.url }
+      for await server in group {
+        if let server {
+          discoveredServers.append(server)
+        }
       }
+    }
+
+    guard !Task.isCancelled else {
+      return
+    }
+
+    await MainActor.run {
+      self.devServers = discoveredServers.sorted { $0.url < $1.url }
     }
   }
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
@@ -1,7 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 import SwiftUI
-import Combine
 
 // swiftlint:disable closure_body_length
 
@@ -28,7 +27,6 @@ struct DevServersView: View {
   @Binding var showingInfoDialog: Bool
   @State private var showingURLInput = false
   @State private var urlText = ""
-  @State private var cancellables = Set<AnyCancellable>()
 
   private func connectToURL() {
     if !urlText.isEmpty {
@@ -65,10 +63,10 @@ struct DevServersView: View {
       }
     }
     .onAppear {
-      startServerDiscovery()
+      viewModel.startServerDiscovery()
     }
     .onDisappear {
-      cancellables.removeAll()
+      viewModel.stopServerDiscovery()
     }
   }
 
@@ -156,16 +154,6 @@ struct DevServersView: View {
     }
     .disabled(urlText.isEmpty)
     .buttonStyle(PlainButtonStyle())
-  }
-
-  private func startServerDiscovery() {
-    Timer.publish(every: 2.0, on: .main, in: .common)
-      .autoconnect()
-      .receive(on: DispatchQueue.global(qos: .background))
-      .sink { [weak viewModel] _ in
-        viewModel?.discoverDevServers()
-      }
-      .store(in: &cancellables)
   }
 }
 


### PR DESCRIPTION
# Why
Dev server scanning was not cancelling correctly when the view disappeared.

# How
The issue was mixing combine and swift concurrency. The publisher was correctly cancelled but the async tasks were not causing them to continue indefinitely. I've removed combine and now handle scanning entirely with swift concurrency and manage task cancellation ourselves.

# Test Plan
Bare-expo. The warnings from scanning failures are now gone when the app is loaded.

