### PR TITLE
[max-sdk-override-plugin][Android] Fix plugin not working with custom flavours

### DIFF
--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-max-sdk-override-plugin/src/main/kotlin/expo/modules/plugin/ExpoMaxSdkOverridePlugin.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-max-sdk-override-plugin/src/main/kotlin/expo/modules/plugin/ExpoMaxSdkOverridePlugin.kt
@@ -7,6 +7,7 @@ import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import expo.modules.plugin.text.Colors
 import expo.modules.plugin.text.Emojis
 import expo.modules.plugin.text.withColor
+import expo.modules.plugin.utils.camelToKebab
 import org.gradle.internal.cc.base.logger
 
 /**
@@ -23,7 +24,7 @@ class ExpoMaxSdkOverridePlugin : Plugin<Project> {
 
     androidComponents.onVariants(androidComponents.selector().all()) { variant ->
       val taskName = "expo${variant.name.replaceFirstChar { it.uppercase() }}OverrideMaxSdkConflicts"
-      val blameReportPath = "outputs/logs/manifest-merger-${variant.name}-report.txt"
+      val blameReportPath = "outputs/logs/manifest-merger-${variant.name.camelToKebab()}-report.txt"
       val reportFile = project.layout.buildDirectory.file(blameReportPath)
       val fixTaskProvider = project.tasks.register(
         taskName,

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-max-sdk-override-plugin/src/main/kotlin/expo/modules/plugin/utils/CamelToKebab.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-max-sdk-override-plugin/src/main/kotlin/expo/modules/plugin/utils/CamelToKebab.kt
@@ -1,0 +1,14 @@
+package expo.modules.plugin.utils
+
+fun String.camelToKebab(): String {
+  val builder = StringBuilder()
+  for (char in this) {
+    if (char.isUpperCase()) {
+      builder.append("-")
+      builder.append(char.lowercaseChar())
+    } else {
+      builder.append(char)
+    }
+  }
+  return builder.toString()
+}


### PR DESCRIPTION
# Why

Fix `ExpoMaxSdkOverridePlugin` plugin not working with custom flavours.

# How

The file name of the manifest merger report is written in kebab case, which we didn't handle correctly. 

# Test Plan

- run `ExpoMaxSdkOverridePlugin` in Expo Go where we have custom flavors. 