### PR TITLE
[ui] remove AutoSizingComposable

### DIFF
--- a/apps/native-component-list/src/screens/UI/DateTimePickerScreen.android.tsx
+++ b/apps/native-component-list/src/screens/UI/DateTimePickerScreen.android.tsx
@@ -1,7 +1,7 @@
 import { DateTimePicker, DateTimePickerProps, Picker, Column } from '@expo/ui/jetpack-compose';
 import { Host } from '@expo/ui/swift-ui';
 import * as React from 'react';
-import { ScrollView, Text, View } from 'react-native';
+import { ScrollView, Text } from 'react-native';
 
 import { Page, Section } from '../../components/Page';
 
@@ -29,42 +29,40 @@ export default function DatePickerScreen() {
           <Text>{selectedDate.toTimeString()}</Text>
         </Section>
         <Section title={getPickerType()}>
-          <View style={{ gap: 20 }}>
-            <Host>
-              <Column>
-                <DateTimePicker
-                  onDateSelected={(date) => {
-                    setSelectedDate(date);
-                  }}
-                  displayedComponents={
-                    typeOptions[typeIndex] as DateTimePickerProps['displayedComponents']
-                  }
-                  initialDate={selectedDate.toISOString()}
-                  variant={displayOptions[selectedIndex] as DateTimePickerProps['variant']}
-                  showVariantToggle
-                  is24Hour
-                />
+          <Host matchContents={{ vertical: true }}>
+            <Column>
+              <Picker
+                options={displayOptions}
+                selectedIndex={selectedIndex}
+                onOptionSelected={({ nativeEvent: { index } }) => {
+                  setSelectedIndex(index);
+                }}
+                variant="segmented"
+              />
 
-                <Picker
-                  options={displayOptions}
-                  selectedIndex={selectedIndex}
-                  onOptionSelected={({ nativeEvent: { index } }) => {
-                    setSelectedIndex(index);
-                  }}
-                  variant="segmented"
-                />
+              <Picker
+                options={typeOptions}
+                selectedIndex={typeIndex}
+                onOptionSelected={({ nativeEvent: { index } }) => {
+                  setTypeIndex(index);
+                }}
+                variant="segmented"
+              />
 
-                <Picker
-                  options={typeOptions}
-                  selectedIndex={typeIndex}
-                  onOptionSelected={({ nativeEvent: { index } }) => {
-                    setTypeIndex(index);
-                  }}
-                  variant="segmented"
-                />
-              </Column>
-            </Host>
-          </View>
+              <DateTimePicker
+                onDateSelected={(date) => {
+                  setSelectedDate(date);
+                }}
+                displayedComponents={
+                  typeOptions[typeIndex] as DateTimePickerProps['displayedComponents']
+                }
+                initialDate={selectedDate.toISOString()}
+                variant={displayOptions[selectedIndex] as DateTimePickerProps['variant']}
+                showVariantToggle
+                is24Hour
+              />
+            </Column>
+          </Host>
         </Section>
       </Page>
     </ScrollView>

--- a/apps/native-component-list/src/screens/UI/PickerScreen.android.tsx
+++ b/apps/native-component-list/src/screens/UI/PickerScreen.android.tsx
@@ -14,7 +14,7 @@ export default function PickerScreen() {
           <Text>{[...options, 'unset'][selectedIndex ?? options.length]}</Text>
         </Section>
         <Section title="Segmented picker">
-          <Host>
+          <Host matchContents={{ vertical: true }}>
             <Picker
               options={options}
               selectedIndex={selectedIndex}
@@ -26,7 +26,7 @@ export default function PickerScreen() {
           </Host>
         </Section>
         <Section title="Tinted picker">
-          <Host>
+          <Host matchContents={{ vertical: true }}>
             <Picker
               options={options}
               selectedIndex={selectedIndex}
@@ -38,7 +38,7 @@ export default function PickerScreen() {
           </Host>
         </Section>
         <Section title="Radio picker">
-          <Host>
+          <Host matchContents={{ vertical: true }}>
             <Picker
               options={options}
               selectedIndex={selectedIndex}

--- a/apps/native-component-list/src/screens/UI/ProgressScreen.android.tsx
+++ b/apps/native-component-list/src/screens/UI/ProgressScreen.android.tsx
@@ -26,66 +26,66 @@ export default function ProgressScreen() {
     <Page>
       <ScrollView>
         <Section title="Indeterminate progress" gap={16}>
-          <Host style={{ width: 30, height: 30 }}>
+          <Host matchContents>
             <CircularProgress />
           </Host>
-          <Host>
+          <Host matchContents={{ vertical: true }}>
             <LinearProgress />
           </Host>
         </Section>
         <Section title="Determinate progress" gap={16}>
-          <Host style={{ width: 30, height: 30 }}>
+          <Host matchContents>
             <CircularProgress progress={progress} />
           </Host>
-          <Host>
+          <Host matchContents={{ vertical: true }}>
             <LinearProgress progress={progress} />
           </Host>
         </Section>
         <Section title="Color" gap={16}>
-          <Host style={{ width: 30, height: 30 }}>
+          <Host matchContents>
             <CircularProgress progress={progress} color="red" />
           </Host>
-          <Host>
+          <Host matchContents={{ vertical: true }}>
             <LinearProgress progress={progress} color="red" />
           </Host>
         </Section>
         <Section title="Track color" gap={16}>
-          <Host style={{ width: 30, height: 30 }}>
+          <Host matchContents>
             <CircularProgress elementColors={{ trackColor: '#cccccc' }} />
           </Host>
-          <Host>
+          <Host matchContents={{ vertical: true }}>
             <LinearProgress elementColors={{ trackColor: '#cccccc' }} />
           </Host>
         </Section>
         <Section title="Wavy - Indeterminate progress" gap={16}>
-          <Host style={{ width: 30, height: 30 }}>
+          <Host matchContents>
             <CircularWavyProgress />
           </Host>
-          <Host>
+          <Host matchContents={{ vertical: true }}>
             <LinearWavyProgress />
           </Host>
         </Section>
         <Section title="Wavy - Determinate progress" gap={16}>
-          <Host style={{ width: 30, height: 30 }}>
+          <Host matchContents>
             <CircularWavyProgress progress={progress} />
           </Host>
-          <Host>
+          <Host matchContents={{ vertical: true }}>
             <LinearWavyProgress progress={progress} />
           </Host>
         </Section>
         <Section title="Wavy - Color" gap={16}>
-          <Host style={{ width: 30, height: 30 }}>
+          <Host matchContents>
             <CircularWavyProgress progress={progress} color="red" />
           </Host>
-          <Host>
+          <Host matchContents={{ vertical: true }}>
             <LinearWavyProgress progress={progress} color="red" />
           </Host>
         </Section>
         <Section title="Wavy - Track color" gap={16}>
-          <Host style={{ width: 30, height: 30 }}>
+          <Host matchContents>
             <CircularWavyProgress elementColors={{ trackColor: '#cccccc' }} />
           </Host>
-          <Host>
+          <Host matchContents={{ vertical: true }}>
             <LinearWavyProgress elementColors={{ trackColor: '#cccccc' }} />
           </Host>
         </Section>

--- a/apps/native-component-list/src/screens/UI/SwitchScreen.android.tsx
+++ b/apps/native-component-list/src/screens/UI/SwitchScreen.android.tsx
@@ -8,7 +8,7 @@ export default function SwitchScreen() {
   return (
     <Page>
       <Section title="Switch">
-        <Host>
+        <Host matchContents>
           <Switch
             value={checked}
             onValueChange={setChecked}
@@ -19,7 +19,7 @@ export default function SwitchScreen() {
         </Host>
       </Section>
       <Section title="Checkbox Switch">
-        <Host>
+        <Host matchContents>
           <Switch
             value={checked}
             onValueChange={setChecked}
@@ -30,7 +30,7 @@ export default function SwitchScreen() {
         </Host>
       </Section>
       <Section title="Button Switch">
-        <Host>
+        <Host matchContents>
           <Switch
             value={checked}
             onValueChange={setChecked}

--- a/apps/native-component-list/src/screens/UI/TextInputScreen.android.tsx
+++ b/apps/native-component-list/src/screens/UI/TextInputScreen.android.tsx
@@ -19,7 +19,7 @@ export default function TextInputScreen() {
         Set text
       </Button>
       <Section title="Text Input">
-        <Host>
+        <Host matchContents>
           <TextInput
             ref={textRef}
             autocorrection={false}
@@ -29,7 +29,7 @@ export default function TextInputScreen() {
         </Host>
       </Section>
       <Section title="Multiline Text Input">
-        <Host>
+        <Host matchContents>
           <TextInput
             multiline
             numberOfLines={5}
@@ -40,7 +40,7 @@ export default function TextInputScreen() {
         </Host>
       </Section>
       <Section title="Phone Text Input">
-        <Host>
+        <Host matchContents>
           <TextInput
             multiline
             numberOfLines={5}
@@ -53,7 +53,7 @@ export default function TextInputScreen() {
       </Section>
 
       <Section title="Capitalization">
-        <Host>
+        <Host matchContents>
           <TextInput
             multiline
             numberOfLines={5}

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### 💡 Others
 
 - [jetpack-compose] Replaced `DynamicTheme` as `Host.colorScheme` prop. ([#41413](https://github.com/expo/expo/pull/41413) by [@kudo](https://github.com/kudo))
+- [jetpack-compose] Removed coupled `AutoSizingComposable`. ([#41595](https://github.com/expo/expo/pull/41595) by [@kudo](https://github.com/kudo))
 
 ## 0.2.0-beta.10 — 2025-12-09
 

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/PickerView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/PickerView.kt
@@ -25,7 +25,6 @@ import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.viewevent.EventDispatcher
-import expo.modules.kotlin.views.AutoSizingComposable
 import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.ExpoComposeView
@@ -91,68 +90,64 @@ class PickerView(context: Context, appContext: AppContext) :
 
     @Composable
     fun SegmentedComposable() {
-      AutoSizingComposable(shadowNodeProxy) {
-        SingleChoiceSegmentedButtonRow(
-          modifier = Modifier.fromExpoModifiers(props.modifiers.value, this@Content)
-        ) {
-          options.forEachIndexed { index, label ->
-            SegmentedButton(
-              shape = SegmentedButtonDefaults.itemShape(
-                index = index,
-                count = options.size
-              ),
-              onClick = {
-                onOptionSelected(mapOf("index" to index, "label" to label))
-              },
-              modifier = Modifier.fromExpoModifiers(props.buttonModifiers.value, this@Content),
-              selected = index == selectedIndex,
-              label = { Text(label) },
-              colors = SegmentedButtonDefaults.colors(
-                activeBorderColor = colors.activeBorderColor.compose,
-                activeContentColor = colors.activeContentColor.compose,
-                inactiveBorderColor = colors.inactiveBorderColor.compose,
-                inactiveContentColor = colors.inactiveContentColor.compose,
-                disabledActiveBorderColor = colors.disabledActiveBorderColor.compose,
-                disabledActiveContentColor = colors.disabledActiveContentColor.compose,
-                disabledInactiveBorderColor = colors.disabledInactiveBorderColor.compose,
-                disabledInactiveContentColor = colors.disabledInactiveContentColor.compose,
-                activeContainerColor = colors.activeContainerColor.compose,
-                inactiveContainerColor = colors.inactiveContainerColor.compose,
-                disabledActiveContainerColor = colors.disabledActiveContainerColor.compose,
-                disabledInactiveContainerColor = colors.disabledInactiveContainerColor.compose
-              )
+      SingleChoiceSegmentedButtonRow(
+        modifier = Modifier.fromExpoModifiers(props.modifiers.value, this@Content)
+      ) {
+        options.forEachIndexed { index, label ->
+          SegmentedButton(
+            shape = SegmentedButtonDefaults.itemShape(
+              index = index,
+              count = options.size
+            ),
+            onClick = {
+              onOptionSelected(mapOf("index" to index, "label" to label))
+            },
+            modifier = Modifier.fromExpoModifiers(props.buttonModifiers.value, this@Content),
+            selected = index == selectedIndex,
+            label = { Text(label) },
+            colors = SegmentedButtonDefaults.colors(
+              activeBorderColor = colors.activeBorderColor.compose,
+              activeContentColor = colors.activeContentColor.compose,
+              inactiveBorderColor = colors.inactiveBorderColor.compose,
+              inactiveContentColor = colors.inactiveContentColor.compose,
+              disabledActiveBorderColor = colors.disabledActiveBorderColor.compose,
+              disabledActiveContentColor = colors.disabledActiveContentColor.compose,
+              disabledInactiveBorderColor = colors.disabledInactiveBorderColor.compose,
+              disabledInactiveContentColor = colors.disabledInactiveContentColor.compose,
+              activeContainerColor = colors.activeContainerColor.compose,
+              inactiveContainerColor = colors.inactiveContainerColor.compose,
+              disabledActiveContainerColor = colors.disabledActiveContainerColor.compose,
+              disabledInactiveContainerColor = colors.disabledInactiveContainerColor.compose
             )
-          }
+          )
         }
       }
     }
 
     @Composable
     fun RadioComposable() {
-      AutoSizingComposable(shadowNodeProxy) {
-        Column(Modifier.selectableGroup()) {
-          options.forEachIndexed { index, label ->
-            Row(
-              Modifier.fillMaxWidth()
-                .height(28.dp)
-                .selectable(
-                  selected = index == selectedIndex,
-                  onClick = {
-                    onOptionSelected(mapOf("index" to index, "label" to label))
-                  },
-                  role = Role.RadioButton
-                ),
-              verticalAlignment = Alignment.CenterVertically
-            ) {
-              RadioButton(
+      Column(Modifier.selectableGroup()) {
+        options.forEachIndexed { index, label ->
+          Row(
+            Modifier.fillMaxWidth()
+              .height(28.dp)
+              .selectable(
                 selected = index == selectedIndex,
-                onClick = null
-              )
-              Text(
-                text = label,
-                modifier = Modifier.padding(start = 12.dp)
-              )
-            }
+                onClick = {
+                  onOptionSelected(mapOf("index" to index, "label" to label))
+                },
+                role = Role.RadioButton
+              ),
+            verticalAlignment = Alignment.CenterVertically
+          ) {
+            RadioButton(
+              selected = index == selectedIndex,
+              onClick = null
+            )
+            Text(
+              text = label,
+              modifier = Modifier.padding(start = 12.dp)
+            )
           }
         }
       }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ProgressView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ProgressView.kt
@@ -18,12 +18,9 @@ import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
-import expo.modules.kotlin.views.AutoSizingComposable
 import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
-import expo.modules.kotlin.views.Direction
 import expo.modules.kotlin.views.ExpoComposeView
-import java.util.EnumSet
 
 enum class ProgressVariant(val value: String) : Enumerable {
   CIRCULAR("circular"),
@@ -57,8 +54,7 @@ class ProgressView(context: Context, appContext: AppContext) :
     val (colors) = props.elementColors
 
     when (variant) {
-      ProgressVariant.LINEAR ->
-        AutoSizingComposable(shadowNodeProxy, axis = EnumSet.of(Direction.VERTICAL)) {
+      ProgressVariant.LINEAR -> {
           val composeColor = color.composeOrNull ?: ProgressIndicatorDefaults.linearColor
           val trackColor = colors.trackColor.composeOrNull ?: ProgressIndicatorDefaults.linearTrackColor
           if (progress != null) {
@@ -77,8 +73,7 @@ class ProgressView(context: Context, appContext: AppContext) :
             )
           }
         }
-      ProgressVariant.CIRCULAR ->
-        AutoSizingComposable(shadowNodeProxy) {
+      ProgressVariant.CIRCULAR -> {
           val composeColor = color.composeOrNull ?: ProgressIndicatorDefaults.circularColor
           if (progress != null) {
             CircularProgressIndicator(
@@ -95,8 +90,7 @@ class ProgressView(context: Context, appContext: AppContext) :
             )
           }
         }
-      ProgressVariant.LINEAR_WAVY ->
-        AutoSizingComposable(shadowNodeProxy, axis = EnumSet.of(Direction.VERTICAL)) {
+      ProgressVariant.LINEAR_WAVY -> {
           val composeColor = color.composeOrNull ?: ProgressIndicatorDefaults.linearColor
           val trackColor = colors.trackColor.composeOrNull ?: ProgressIndicatorDefaults.linearTrackColor
           if (progress != null) {
@@ -114,8 +108,7 @@ class ProgressView(context: Context, appContext: AppContext) :
             )
           }
         }
-      ProgressVariant.CIRCULAR_WAVY ->
-        AutoSizingComposable(shadowNodeProxy) {
+      ProgressVariant.CIRCULAR_WAVY -> {
           val composeColor = color.composeOrNull ?: ProgressIndicatorDefaults.circularColor
           if (progress != null) {
             CircularWavyProgressIndicator(

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SwitchView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SwitchView.kt
@@ -14,7 +14,6 @@ import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.viewevent.EventDispatcher
-import expo.modules.kotlin.views.AutoSizingComposable
 import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.ExpoComposeView
@@ -128,8 +127,8 @@ class SwitchView(context: Context, appContext: AppContext) :
       onValueChange(ValueChangeEvent(checked))
     }
 
-    AutoSizingComposable(shadowNodeProxy) {
-      ThemedHybridSwitch(variant, checked, onCheckedChange, colors, Modifier.fromExpoModifiers(props.modifiers.value, this@Content))
-    }
+    ThemedHybridSwitch(variant, checked, onCheckedChange, colors,
+      Modifier.fromExpoModifiers(props.modifiers.value,
+        this@Content))
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/TextInputView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/TextInputView.kt
@@ -2,28 +2,19 @@ package expo.modules.ui
 
 import android.content.Context
 import androidx.compose.foundation.text.KeyboardOptions
-
-import expo.modules.kotlin.viewevent.EventDispatcher
-import expo.modules.kotlin.views.ExpoComposeView
-
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
-
-import expo.modules.kotlin.AppContext
-import expo.modules.kotlin.views.ComposeProps
-
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.KeyboardCapitalization
-import expo.modules.kotlin.views.AutoSizingComposable
-import expo.modules.kotlin.views.Direction
+import androidx.compose.ui.text.input.KeyboardType
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.views.ComposableScope
-import java.util.EnumSet
+import expo.modules.kotlin.views.ComposeProps
+import expo.modules.kotlin.views.ExpoComposeView
 
 data class TextInputProps(
   val defaultValue: MutableState<String> = mutableStateOf(""),
@@ -78,23 +69,21 @@ class TextInputView(context: Context, appContext: AppContext) :
 
   @Composable
   override fun ComposableScope.Content() {
-    AutoSizingComposable(shadowNodeProxy, axis = EnumSet.of(Direction.VERTICAL)) {
-      TextField(
-        value = requireNotNull(textState.value),
-        onValueChange = {
-          textState.value = it
-          onValueChanged(mapOf("value" to it))
-        },
-        placeholder = { Text(props.placeholder.value) },
-        maxLines = if (props.multiline.value) props.numberOfLines.value ?: Int.MAX_VALUE else 1,
-        singleLine = !props.multiline.value,
-        keyboardOptions = KeyboardOptions.Default.copy(
-          keyboardType = props.keyboardType.value.keyboardType(),
-          autoCorrectEnabled = props.autocorrection.value,
-          capitalization = props.autoCapitalize.value.autoCapitalize()
-        ),
-        modifier = Modifier.fromExpoModifiers(props.modifiers.value, composableScope = this@Content)
-      )
-    }
+    TextField(
+      value = requireNotNull(textState.value),
+      onValueChange = {
+        textState.value = it
+        onValueChanged(mapOf("value" to it))
+      },
+      placeholder = { Text(props.placeholder.value) },
+      maxLines = if (props.multiline.value) props.numberOfLines.value ?: Int.MAX_VALUE else 1,
+      singleLine = !props.multiline.value,
+      keyboardOptions = KeyboardOptions.Default.copy(
+        keyboardType = props.keyboardType.value.keyboardType(),
+        autoCorrectEnabled = props.autocorrection.value,
+        capitalization = props.autoCapitalize.value.autoCapitalize()
+      ),
+      modifier = Modifier.fromExpoModifiers(props.modifiers.value, composableScope = this@Content)
+    )
   }
 }


### PR DESCRIPTION
# Why

close ENG-18108

# How

remove AutoSizingComposable and replace with Host and matchContents

# Test Plan

verify with NCL screens

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
