### PR TITLE
[cli] fix auto add config plugin for scoped packages

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Report stack traces on unexpected `TransformerError`s and `SyntaxError`s from Metro ([#41468](https://github.com/expo/expo/pull/41468) by [@kitten](https://github.com/kitten))
 - resolve "Illegal invocation" errors in `workerd` runtime ([#41502](https://github.com/expo/expo/pull/41502) by [@hassankhan](https://github.com/hassankhan))
 - Fix running iOS builds on device without available simulators ([#41524](https://github.com/expo/expo/pull/41524) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Fix auto add config plugin for scoped packages ([#41599](https://github.com/expo/expo/pull/41599) by [@pawicao](https://github.com/pawicao))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/install/applyPlugins.ts
+++ b/packages/@expo/cli/src/install/applyPlugins.ts
@@ -17,7 +17,14 @@ export async function applyPluginsAsync(projectRoot: string, packages: string[])
       projectRoot,
       exp,
       // Split any possible NPM tags. i.e. `expo@latest` -> `expo`
-      packages.map((pkg) => pkg.split('@')[0]).filter(Boolean)
+      packages
+        .map((pkg) => {
+          if (pkg[0] === '@') {
+            return '@' + pkg.slice(1).split('@')[0];
+          }
+          return pkg.split('@')[0];
+        })
+        .filter(Boolean)
     );
   } catch (error: any) {
     // If we fail to apply plugins, the log a warning and continue.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
While adding libraries to my applications with `npx expo install`, I realised that some of them are not getting their config plugins added automatically to `app.json`. After trying things out for a bit, I noticed that the problem only happens for scoped packages (`@scope/package-name`). This situation added the need for users of such libraries to always manually add the config plugins to `app.json`.

# How

<!--
How did you build this feature or fix this bug and why?
-->
Turned out that the code in `applyPlugins.ts` responsible for removing versions tags from the provided packages using `split('@')[0]` was working incorrectly for scoped packages as it passed further empty string as a result, leading to no auto-add of such config plugins. I modified that code to take into account the cases of scoped packages.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

I tested it by applying the changes to the installed instance of `@expo/cli` and comparing the results.

Before:
```
my-app % npx expo install @rnrepo/expo-config-plugin
› Installing 1 other package using npm
> npm install --save @rnrepo/expo-config-plugin

up to date, audited 1004 packages in 985ms

166 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

After:
```
my-app % npx expo install @rnrepo/expo-config-plugin
› Installing 1 other package using npm
> npm install --save @rnrepo/expo-config-plugin

up to date, audited 1004 packages in 985ms

166 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
› Added config plugin: @rnrepo/expo-config-plugin
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
