### PR TITLE
[video][android] Fix rare crashes related to VideoPlayer listeners

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [Web] Fix crash on older versions of Safari. ([#41101](https://github.com/expo/expo/pull/41101) by [@CamWass](https://github.com/CamWass))
 - [Web] Fix video pausing when entering fullscreen in electron apps. ([#40989](https://github.com/expo/expo/pull/40989) by [@behenate](https://github.com/behenate))
 - [Android] Fix crashes when exiting PiP with one than more `VideoView` present on the screen. ([#41090](https://github.com/expo/expo/pull/41090) by [@behenate](https://github.com/behenate))
+- [Android] Fix rare crashes related to VideoPlayer listeners. ([#41608](https://github.com/expo/expo/pull/41608) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

It's possible for the player to remove a player from the listeners list while `listeners.mapNotNull` is running. This results in a `NullPointerException` where the `it` from `it.get()` is null. 

This happens because the listeners can be registered and unregistered from any thread.

This issue seems to be rare and I don't think we had any reports, but I've experienced it when writing the `test-suite` tests, where we create and then relatively quickly release a lot of players. 

I didn't have a reliable repro, but I believe this should fix it. 

# How

Synchronise the listener list access.

# Test Plan

Tested in Bare expo in Android 16 emulator and a physical device
