### PR TITLE
[video][android] Fix player duration property refreshing too late

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [Android] Fix crashes when exiting PiP with one than more `VideoView` present on the screen. ([#41090](https://github.com/expo/expo/pull/41090) by [@behenate](https://github.com/behenate))
 - [Android] Fix rare crashes related to VideoPlayer listeners. ([#41608](https://github.com/expo/expo/pull/41608) by [@behenate](https://github.com/behenate))
 - Fix `fullscreenOptions.enable` and `allowsFullscreen` props issues. ([#41600](https://github.com/expo/expo/pull/41600) by [@behenate](https://github.com/behenate))
+- [Android] Fix player duration property refreshing too late. ([#41609](https://github.com/expo/expo/pull/41609) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
@@ -239,12 +239,13 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
       val newCurrentSubtitleTrack = subtitles.currentSubtitleTrack
       val newCurrentAudioTrack = audioTracks.currentAudioTrack
       availableVideoTracks = tracks.toVideoTracks()
+      refreshPlaybackInfo()
 
       if (isLoadingNewSource) {
         sendEvent(
           PlayerEvent.VideoSourceLoaded(
             commitedSource,
-            this@VideoPlayer.player.duration / 1000.0,
+            duration.toDouble(),
             availableVideoTracks,
             newSubtitleTracks,
             newAudioTracks


### PR DESCRIPTION
# Why

We refresh the player duration and isLive properties when the player becomes ready to play. 
This is kinda late, we can refresh this information just before emitting the `sourceLoad` event, which is the earliest point at which we have this information.

# How

Update the `duration` just before emitting the `sourceLoad` event.

# Test Plan

Tested in BareExpo on Android
