### PR TITLE
[docs] Better support function overloads in generated API docs

### DIFF
--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -1,4 +1,5 @@
 import { mergeClasses } from '@expo/styleguide';
+import { BracketsEllipsesDuotoneIcon } from '@expo/styleguide-icons/duotone/BracketsEllipsesDuotoneIcon';
 import { CornerDownRightIcon } from '@expo/styleguide-icons/outline/CornerDownRightIcon';
 
 import { APIBoxHeader } from '~/components/plugins/api/components/APIBoxHeader';
@@ -97,6 +98,12 @@ export const renderMethod = (
           hideInSidebar={overloadIndex > 0}
           tags={hasOverloads ? ['overload'] : undefined}
         />
+        {hasOverloads && (
+          <div className="px-4 text-tertiary">
+            <BracketsEllipsesDuotoneIcon className="icon-xs mr-1 inline shrink-0" />
+            <span className="text-3xs">Overload #{overloadIndex + 1}</span>
+          </div>
+        )}
         {parameters && parameters.length > 0 && (
           <>
             <APIMethodParamRows parameters={parameters} sdkVersion={sdkVersion} />

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -99,7 +99,7 @@ export const renderMethod = (
           tags={hasOverloads ? ['overload'] : undefined}
         />
         {hasOverloads && (
-          <div className="px-4 text-tertiary">
+          <div className="px-4 pb-2 text-tertiary">
             <BracketsEllipsesDuotoneIcon className="icon-xs mr-1 inline shrink-0" />
             <span className="text-3xs">Overload #{overloadIndex + 1}</span>
           </div>

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -70,7 +70,7 @@ export const renderMethod = (
   const signatures = getMethodRootSignatures(method);
   const baseNestingLevel = options.baseNestingLevel ?? (exposeInSidebar ? 3 : 4);
 
-  return signatures.map(({ name, parameters, comment, type, typeParameter }) => {
+  return signatures.map(({ name, parameters, comment, type, typeParameter }, overloadIndex) => {
     const returnComment = getTagData('returns', comment);
     const platforms = getAllTagData('platform', comment);
     return (
@@ -92,6 +92,8 @@ export const renderMethod = (
           )}
           platforms={platforms.length > 0 ? platforms : parentPlatforms}
           baseNestingLevel={baseNestingLevel}
+          // only show first overload in sidebar to avoid duplicates
+          hideInSidebar={overloadIndex > 0}
         />
         {parameters && parameters.length > 0 && (
           <>
@@ -128,7 +130,6 @@ export const renderMethod = (
             ) : undefined
           }
         />
-        {}
       </div>
     );
   });

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -69,6 +69,7 @@ export const renderMethod = (
 ) => {
   const signatures = getMethodRootSignatures(method);
   const baseNestingLevel = options.baseNestingLevel ?? (exposeInSidebar ? 3 : 4);
+  const hasOverloads = signatures.length > 1;
 
   return signatures.map(({ name, parameters, comment, type, typeParameter }, overloadIndex) => {
     const returnComment = getTagData('returns', comment);
@@ -94,6 +95,7 @@ export const renderMethod = (
           baseNestingLevel={baseNestingLevel}
           // only show first overload in sidebar to avoid duplicates
           hideInSidebar={overloadIndex > 0}
+          tags={hasOverloads ? ['overload'] : undefined}
         />
         {parameters && parameters.length > 0 && (
           <>

--- a/docs/components/plugins/api/components/APIBoxHeader.tsx
+++ b/docs/components/plugins/api/components/APIBoxHeader.tsx
@@ -1,12 +1,13 @@
 import { mergeClasses } from '@expo/styleguide';
 
+import { AdditionalProps } from '~/common/headingManager';
 import { MONOSPACE, RawH3 } from '~/ui/components/Text';
 
 import { CommentData, CommentTagData } from '../APIDataTypes';
 import { getCodeHeadingWithBaseNestingLevel, getTagNamesList } from '../APISectionUtils';
 import { APISectionPlatformTags } from './APISectionPlatformTags';
 
-type Props = {
+type Props = AdditionalProps & {
   name: string;
   comment?: CommentData;
   baseNestingLevel?: number;
@@ -20,8 +21,10 @@ export function APIBoxHeader({
   platforms,
   baseNestingLevel = 3,
   deprecated = false,
+  ...additionalProps
 }: Props) {
   const HeaderComponent = getCodeHeadingWithBaseNestingLevel(baseNestingLevel, RawH3);
+  const tags = [...(getTagNamesList(comment) ?? []), ...(additionalProps?.tags ?? [])];
   return (
     <div
       className={mergeClasses(
@@ -29,7 +32,7 @@ export function APIBoxHeader({
         'max-md-gutters:flex-col max-md-gutters:gap-y-1.5',
         '[&_h3]:!mb-0'
       )}>
-      <HeaderComponent tags={getTagNamesList(comment)}>
+      <HeaderComponent {...additionalProps} tags={tags}>
         <MONOSPACE
           weight="medium"
           className={mergeClasses(

--- a/docs/ui/components/TableOfContents/TableOfContentsLink.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContentsLink.tsx
@@ -1,4 +1,5 @@
 import { mergeClasses } from '@expo/styleguide';
+import { BracketsEllipsesDuotoneIcon } from '@expo/styleguide-icons/duotone/BracketsEllipsesDuotoneIcon';
 import Link from 'next/link';
 import { forwardRef, useState, type MouseEvent } from 'react';
 
@@ -25,6 +26,7 @@ export const TableOfContentsLink = forwardRef<HTMLAnchorElement, SidebarLinkProp
     const TitleElement = isCodeOrFilePath ? MONOSPACE : CALLOUT;
     const displayTitle = shortenCode && isCode ? trimCodedTitle(title) : title;
     const isDeprecated = tags && tags.length > 0 ? tags.find(tag => tag === 'deprecated') : null;
+    const hasOverloads = tags && tags.length > 0 ? tags.find(tag => tag === 'overload') : null;
 
     function onMouseOver(event: MouseEvent<HTMLAnchorElement>) {
       setTooltipVisible(isOverflowing(event.currentTarget));
@@ -56,6 +58,12 @@ export const TableOfContentsLink = forwardRef<HTMLAnchorElement, SidebarLinkProp
                 isDeprecated && 'line-through opacity-80'
               )}>
               {displayTitle}
+              {hasOverloads && (
+                <>
+                  <BracketsEllipsesDuotoneIcon className="icon-xs ml-1 inline text-icon-secondary" />
+                  <span className="sr-only">Has overloads</span>
+                </>
+              )}
               {isDeprecated && <span className="sr-only">Deprecated section</span>}
             </TitleElement>
           </Link>


### PR DESCRIPTION
# Why

Follow-up discussion from https://github.com/expo/expo/pull/41249#discussion_r2598280144

Implemented solution 1 from there

# How

- When a function has more than one signature, display only one item in the sidebar
  - For overloaded functions, display a small icon next to the sidebar item (+ screen-reader a11y text) indicating that it is overloaded. I used `BracketsEllipsesDuotoneIcon` from [expo-stylegiude](https://styleguide.expo.dev/icons).
  - Sidebar links to the first overload of the function. However, all overloads are permalinkable (links can be copied and shared).

- For overloaded functions, display a small text above the arguments table indicating that the function has other overloads.
  - Alternatively, the text can be moved above the signature header (see below). I'll implement this approach if requested.

# Test Plan

<details>
<summary>Screenshot of overloaded example</summary>
This is using APIs from #41249 

<img width="1177" height="705" alt="Screenshot 2025-12-12 at 18 11 01" src="https://github.com/user-attachments/assets/adbbf1e3-86eb-419d-84ff-a05da68e5943" />

Not sure if it should be moved slightly to the right to better fit with the table's round corners

</details>

<details>
<summary>Alternative text placement</summary>

The platform pills should probably be moved to the top, rather than being aligned with the signature, not sure.

Dark mode:
<img width="1155" height="706" alt="Screenshot 2025-12-12 at 18 18 38" src="https://github.com/user-attachments/assets/253fe554-9677-4b9a-8f66-1e18b9b3b509" />

Light mode:
<img width="1180" height="705" alt="Screenshot 2025-12-12 at 18 19 08" src="https://github.com/user-attachments/assets/26033ad9-fb5a-4d4d-a5f3-a0ce0bedc3f1" />

</details>

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
