### PR TITLE
[docs] Fix warning from `Select` component about uncontrolled component

### DIFF
--- a/docs/ui/components/Header/ThemeSelector.tsx
+++ b/docs/ui/components/Header/ThemeSelector.tsx
@@ -2,6 +2,7 @@ import { Themes, useTheme } from '@expo/styleguide';
 import { Contrast02SolidIcon } from '@expo/styleguide-icons/solid/Contrast02SolidIcon';
 import { Moon01SolidIcon } from '@expo/styleguide-icons/solid/Moon01SolidIcon';
 import { SunSolidIcon } from '@expo/styleguide-icons/solid/SunSolidIcon';
+
 import { Select } from '~/ui/components/Select';
 
 const options = [

--- a/docs/ui/components/Header/ThemeSelector.tsx
+++ b/docs/ui/components/Header/ThemeSelector.tsx
@@ -2,8 +2,6 @@ import { Themes, useTheme } from '@expo/styleguide';
 import { Contrast02SolidIcon } from '@expo/styleguide-icons/solid/Contrast02SolidIcon';
 import { Moon01SolidIcon } from '@expo/styleguide-icons/solid/Moon01SolidIcon';
 import { SunSolidIcon } from '@expo/styleguide-icons/solid/SunSolidIcon';
-import { useEffect, useState } from 'react';
-
 import { Select } from '~/ui/components/Select';
 
 const options = [
@@ -27,12 +25,6 @@ const options = [
 export function ThemeSelector() {
   const { themeName, setAutoMode, setDarkMode, setLightMode } = useTheme();
 
-  const [loaded, setLoaded] = useState(false);
-
-  useEffect(function didMount() {
-    setLoaded(true);
-  }, []);
-
   function onThemeSelect(value: string) {
     if (value === Themes.AUTO) {
       setAutoMode();
@@ -48,7 +40,7 @@ export function ThemeSelector() {
   return (
     <Select
       className="min-w-[108px]"
-      value={loaded ? (themeName ?? Themes.AUTO) : undefined}
+      value={themeName ?? Themes.AUTO}
       onValueChange={onThemeSelect}
       options={options}
       optionsLabel="Theme"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18333

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix theme dropdown controlled state by removing the mount guard in `ThemeSelector` so the `Select` is controlled on first render. This eliminates the warning while keeping the same theme-switch behavior.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Run the docs app locally: `yarn run dev`
- Open http://localhost:3002
- Open Developer Tools in browser > Console
- There shouldn't be a warning about the controlled/uncontrolled component

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
