### PR TITLE
fix(cli): Fix scoped packages w/ config plugins not being auto-added to app config

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Report stack traces on unexpected `TransformerError`s and `SyntaxError`s from Metro ([#41468](https://github.com/expo/expo/pull/41468) by [@kitten](https://github.com/kitten))
 - resolve "Illegal invocation" errors in `workerd` runtime ([#41502](https://github.com/expo/expo/pull/41502) by [@hassankhan](https://github.com/hassankhan))
 - Fix running iOS builds on device without available simulators ([#41524](https://github.com/expo/expo/pull/41524) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Fix `expo install` not auto-adding config plugins for scoped packages ([#41613](https://github.com/expo/expo/pull/41613) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/install/applyPlugins.ts
+++ b/packages/@expo/cli/src/install/applyPlugins.ts
@@ -1,6 +1,7 @@
 import { getConfig } from '@expo/config';
 
 import * as Log from '../log';
+import { parsePackageSpecifier } from './utils/parsePackageSpecifier';
 
 /**
  * A convenience feature for automatically applying Expo Config Plugins to the `app.json` after installing them.
@@ -17,7 +18,7 @@ export async function applyPluginsAsync(projectRoot: string, packages: string[])
       projectRoot,
       exp,
       // Split any possible NPM tags. i.e. `expo@latest` -> `expo`
-      packages.map((pkg) => pkg.split('@')[0]).filter(Boolean)
+      packages.map(parsePackageSpecifier).filter((x) => x != null)
     );
   } catch (error: any) {
     // If we fail to apply plugins, the log a warning and continue.

--- a/packages/@expo/cli/src/install/fixPackages.ts
+++ b/packages/@expo/cli/src/install/fixPackages.ts
@@ -72,7 +72,10 @@ export async function fixPackagesAsync(
 
     await packageManager.addAsync([...packageManagerArguments, ...versionedPackages]);
 
-    await applyPluginsAsync(projectRoot, versionedPackages);
+    await applyPluginsAsync(
+      projectRoot,
+      dependencies.map((dep) => dep.packageName)
+    );
   }
 
   if (devDependencies.length) {

--- a/packages/@expo/cli/src/install/installAsync.ts
+++ b/packages/@expo/cli/src/install/installAsync.ts
@@ -211,5 +211,5 @@ function findPackageByName(packages: string[], name: string) {
 
 /** Determine if a specific version is requested for a package */
 function packageHasVersion(name = '') {
-  return name.indexOf('@') > 0; // Scoped packages may start with `@`
+  return name.indexOf('@', 1) > 0; // Scoped packages may start with `@`
 }

--- a/packages/@expo/cli/src/install/installAsync.ts
+++ b/packages/@expo/cli/src/install/installAsync.ts
@@ -211,5 +211,5 @@ function findPackageByName(packages: string[], name: string) {
 
 /** Determine if a specific version is requested for a package */
 function packageHasVersion(name = '') {
-  return name.includes('@');
+  return name.indexOf('@') > 0; // Scoped packages may start with `@`
 }

--- a/packages/@expo/cli/src/install/utils/__tests__/parsePackageSpecifier-test.ts
+++ b/packages/@expo/cli/src/install/utils/__tests__/parsePackageSpecifier-test.ts
@@ -1,0 +1,17 @@
+import { parsePackageSpecifier } from '../parsePackageSpecifier';
+
+describe(parsePackageSpecifier, () => {
+  it('parses names', () => {
+    expect(parsePackageSpecifier('test')).toBe('test');
+    expect(parsePackageSpecifier('test@test')).toBe('test');
+    expect(parsePackageSpecifier('')).toBe(null);
+    expect(parsePackageSpecifier('@test')).toBe(null);
+  });
+
+  it('parses scoped names', () => {
+    expect(parsePackageSpecifier('@a/b')).toBe('@a/b');
+    expect(parsePackageSpecifier('@a/b@test')).toBe('@a/b');
+    expect(parsePackageSpecifier('@a/')).toBe(null);
+    expect(parsePackageSpecifier('@a')).toBe(null);
+  });
+});

--- a/packages/@expo/cli/src/install/utils/parsePackageSpecifier.ts
+++ b/packages/@expo/cli/src/install/utils/parsePackageSpecifier.ts
@@ -1,0 +1,13 @@
+/** Accepts a package name (scoped or unscoped) and optionally with a specifier */
+export function parsePackageSpecifier(specifier: string): string | null {
+  let idx = -1;
+  if (specifier[0] === '@') {
+    idx = specifier.indexOf('/', 1);
+    if (idx === -1 || specifier.length - 1 <= idx) {
+      return null;
+    }
+  }
+  idx = specifier.indexOf('@', idx + 1);
+  const packageName = idx > -1 ? specifier.slice(0, idx) : specifier;
+  return packageName.length > 0 ? packageName : null;
+}


### PR DESCRIPTION
# Why

When installing scoped packages, the leading `@` is treated as a specifier which is then filtering the package name out itself. The strictness of inputs into `applyPluginsAsync` wasn't as high as it could be.

Supersedes #41599
Supersedes #41463

# How

- Add normalisation function to check for scoped packages
  - This was intended to increase clarity around the accepted formats (scoped, unscoped, optionally with specifier) and be clearer around what to filter out (returns `null` for invalid inputs, as needed)
- We don't want to pass on empty strings, since the resolver may treat this unfavourably as a `node_modules` read
- Updated dependent functions for clarity

# Test Plan

- Unit tests added for package specifier
- Can be reproduced by installing `expo install @rnrepo/expo-config-plugin` (see related PRs)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
