### PR TITLE
[docs] Development mode only: Highlight missing link targets in API docs

### DIFF
--- a/docs/common/utilities.ts
+++ b/docs/common/utilities.ts
@@ -146,10 +146,36 @@ export function listMissingHashLinkTargets(apiName?: string) {
     link.setAttribute('title', `Missing hash target: #${hash}`);
   });
 
-  /* eslint-disable no-console */
-  console.group(`🚨 The following links targets are missing in the ${apiName} API reference:`);
-  console.table(missingEntries);
-  console.groupEnd();
+  const isDevToolsOpen = () => {
+    const gap = 160;
+    return (
+      Math.abs(window.outerWidth - window.innerWidth) > gap ||
+      Math.abs(window.outerHeight - window.innerHeight) > gap
+    );
+  };
+
+  const logAsTable = () => {
+    /* eslint-disable no-console */
+    console.group(`🚨 The following links targets are missing in the ${apiName} API reference:`);
+    console.table(missingEntries);
+    console.groupEnd();
+  };
+
+  const logWhenDevToolsReady = () => {
+    if (isDevToolsOpen()) {
+      logAsTable();
+      return;
+    }
+
+    const handleFirstResize = () => {
+      setTimeout(logAsTable, 0);
+      window.removeEventListener('resize', handleFirstResize);
+    };
+
+    window.addEventListener('resize', handleFirstResize);
+  };
+
+  logWhenDevToolsReady();
 }
 
 export function versionToText(version: string): string {

--- a/docs/common/utilities.ts
+++ b/docs/common/utilities.ts
@@ -73,7 +73,9 @@ export const stripVersionFromPath = (path?: string) => {
   return path.replace(/\/versions\/[\w.]+/, '');
 };
 
-export const pathStartsWith = (name: string, path: string) => path.startsWith(`/${name}`);
+export const pathStartsWith = (name: string, path: string) => {
+  return path.startsWith(`/${name}`);
+};
 
 const missingHashStyleId = 'missing-hash-target-style';
 const ensureMissingHashStyle = () => {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Recent feedback from @jonsamp on highlighting the missing link targets (broken internal links). Currently, for SDK pages, the missing link targets are reported under Developer Tools (browser) > Console tabs as a table:

<img width="4112" height="2658" alt="CleanShot 2025-12-13 at 16 57 25@2x" src="https://github.com/user-attachments/assets/138ec545-63ca-4c5a-9a55-85c5c06c12f4" />

Jon mentioned that we should highlight these links within the page since this will be faster than opening the Console tab in the browser. Hopefully, this change will allow us to catch these issues immediately.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Added development-only highlight for missing hash targets in API docs. The `listMissingHashLinkTargets` now early-returns outside development, injects a single style tag, and marks missing-anchor links with a red underline.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Run docs locally and visit: http://localhost:3002/versions/v54.0.0/sdk/audio/#using-the-audioplayer-directly.
- You will see the missing link targer in the section for `createAudioPlayer`:

<img width="1784" height="776" alt="CleanShot 2025-12-13 at 16 57 12@2x" src="https://github.com/user-attachments/assets/6628aee3-2ca2-4ce0-b264-3a3fd73cd652" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
