### PR TITLE
[core][iOS] Create new AppContext instance on full reload

### DIFF
--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
@@ -11,17 +11,6 @@
   EXAppContext *_appContext;
 }
 
-// TODO: Remove check when react-native-macos 0.81 is released (this init was not available before)
-#if !TARGET_OS_OSX
-- (instancetype)initWithDelegate:(id<RCTReactNativeFactoryDelegate>)delegate releaseLevel:(RCTReleaseLevel)releaseLevel
-{
-  if (self = [super initWithDelegate:delegate releaseLevel:releaseLevel]) {
-    _appContext = [[EXAppContext alloc] init];
-  }
-  return self;
-}
-#endif
-
 #pragma mark - RCTHostDelegate
 
 // [main thread]
@@ -40,6 +29,8 @@
 // [JS thread]
 - (void)host:(nonnull RCTHost *)host didInitializeRuntime:(jsi::Runtime &)runtime
 {
+  _appContext = [[EXAppContext alloc] init];
+
   // Inject and decorate the `global.expo` object
   _appContext._runtime = [[EXRuntime alloc] initWithRuntime:runtime];
 


### PR DESCRIPTION
# Why

#41311 introduced a regression – modules were not found after full reload. `AppContext` can be used with only one runtime, meaning that we should not reassign it. Currently we're creating only one instance in `ExpoReactNativeFactory` initializer and reuse it with a new runtime created after reload.

# How

Instead of creating a single `AppContext` in `ExpoReactNativeFactory` initializer, we should recreate it when the app reloads. This can be done only from `host:didInitializeRuntime:`.

In the future, I think we should pass the runtime to `AppContext`'s initializer instead of assigning it. The setup through `ExpoBridgeModule` is a bit more complicated so for now it's better to keep it as is.

# Test Plan

bare-expo reloads correctly without errors