### PR TITLE
fix(expo-router): use typed icon props for native tabs (react-native-screens 4.18)

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix native tabs icon prop shape for react-native-screens 4.18 on iOS ([#41626](https://github.com/expo/expo/pull/41626) by [@RobJacobson](https://github.com/RobJacobson))
 ### 💡 Others
 
 ## 6.0.19 — 2025-12-12

--- a/packages/expo-router/src/native-tabs/NativeBottomTabs/NativeTabsView.tsx
+++ b/packages/expo-router/src/native-tabs/NativeBottomTabs/NativeTabsView.tsx
@@ -201,7 +201,7 @@ function Screen(props: {
       iconResourceName={getAndroidIconResourceName(icon)}
       iconResource={getAndroidIconResource(icon)}
       icon={convertOptionsIconToPropsIcon(icon)}
-      selectedIcon={convertOptionsIconToPropsIcon(selectedIcon)}
+      selectedIcon={convertOptionsIconToIOSPropsIcon(selectedIcon)}
       title={title}
       freezeContents={false}
       tabKey={routeKey}
@@ -255,11 +255,56 @@ function convertOptionsIconToPropsIcon(
   if (!icon) {
     return undefined;
   }
-  if ('sf' in icon && icon.sf) {
-    return { sfSymbolName: icon.sf };
-  } else if ('src' in icon && icon.src) {
-    return { templateSource: icon.src };
+
+  const ios = convertOptionsIconToIOSPropsIcon(icon);
+  const android = convertOptionsIconToAndroidPropsIcon(icon);
+
+  if (!ios && !android) {
+    return undefined;
   }
+
+  // react-native-screens@4.18 expects the typed icon format:
+  // - iOS: { type: 'sfSymbol' | 'imageSource' | 'templateSource', ... }
+  // - Android: { type: 'imageSource' | 'drawableResource', ... }
+  const result: NonNullable<BottomTabsScreenProps['icon']> = {};
+  if (ios) result.ios = ios;
+  if (android) result.android = android;
+  return result;
+}
+
+function convertOptionsIconToIOSPropsIcon(
+  icon: AwaitedIcon | undefined
+): BottomTabsScreenProps['selectedIcon'] {
+  if (!icon) {
+    return undefined;
+  }
+
+  if ('sf' in icon && icon.sf) {
+    return { type: 'sfSymbol', name: icon.sf };
+  }
+
+  if ('src' in icon && icon.src) {
+    return { type: 'templateSource', templateSource: icon.src };
+  }
+
+  return undefined;
+}
+
+function convertOptionsIconToAndroidPropsIcon(
+  icon: AwaitedIcon | undefined
+): { type: 'drawableResource'; name: string } | { type: 'imageSource'; imageSource: ImageSourcePropType } | undefined {
+  if (!icon) {
+    return undefined;
+  }
+
+  if ('drawable' in icon && icon.drawable) {
+    return { type: 'drawableResource', name: icon.drawable };
+  }
+
+  if ('src' in icon && icon.src) {
+    return { type: 'imageSource', imageSource: icon.src };
+  }
+
   return undefined;
 }
 

--- a/packages/expo-router/src/native-tabs/NativeBottomTabs/__tests__/options.test.ios.tsx
+++ b/packages/expo-router/src/native-tabs/NativeBottomTabs/__tests__/options.test.ios.tsx
@@ -70,7 +70,7 @@ it('can pass options via elements', () => {
   expect(screen.getByTestId('index')).toBeVisible();
   expect(BottomTabsScreen).toHaveBeenCalledTimes(1);
   expect(BottomTabsScreen.mock.calls[0][0]).toMatchObject({
-    icon: { sfSymbolName: 'homepod.2.fill' },
+    icon: { ios: { type: 'sfSymbol', name: 'homepod.2.fill' } },
     selectedIcon: undefined,
   } as NativeTabOptions);
 });
@@ -117,7 +117,7 @@ describe('Icons', () => {
     expect(screen.getByTestId('index')).toBeVisible();
     expect(BottomTabsScreen).toHaveBeenCalledTimes(1);
     expect(BottomTabsScreen.mock.calls[0][0]).toMatchObject({
-      icon: { sfSymbolName: 'homepod.2.fill' },
+      icon: { ios: { type: 'sfSymbol', name: 'homepod.2.fill' } },
     } as NativeTabOptions);
   });
 
@@ -136,7 +136,7 @@ describe('Icons', () => {
     expect(screen.getByTestId('index')).toBeVisible();
     expect(BottomTabsScreen).toHaveBeenCalledTimes(1);
     expect(BottomTabsScreen.mock.calls[0][0]).toMatchObject({
-      selectedIcon: { sfSymbolName: 'homepod.2.fill' },
+      selectedIcon: { type: 'sfSymbol', name: 'homepod.2.fill' },
     } as NativeTabOptions);
   });
 
@@ -155,8 +155,8 @@ describe('Icons', () => {
     expect(screen.getByTestId('index')).toBeVisible();
     expect(BottomTabsScreen).toHaveBeenCalledTimes(1);
     expect(BottomTabsScreen.mock.calls[0][0]).toMatchObject({
-      selectedIcon: { sfSymbolName: 'star.bubble' },
-      icon: { sfSymbolName: 'stairs' },
+      selectedIcon: { type: 'sfSymbol', name: 'star.bubble' },
+      icon: { ios: { type: 'sfSymbol', name: 'stairs' } },
     } as NativeTabOptions);
   });
 
@@ -195,7 +195,7 @@ describe('Icons', () => {
     expect(screen.getByTestId('index')).toBeVisible();
     expect(BottomTabsScreen).toHaveBeenCalledTimes(1);
     expect(BottomTabsScreen.mock.calls[0][0]).toMatchObject({
-      icon: { sfSymbolName: 'homepod.2.fill' },
+      icon: { ios: { type: 'sfSymbol', name: 'homepod.2.fill' } },
       selectedIcon: undefined,
     } as NativeTabOptions);
   });
@@ -216,7 +216,7 @@ describe('Icons', () => {
     expect(screen.getByTestId('index')).toBeVisible();
     expect(BottomTabsScreen).toHaveBeenCalledTimes(1);
     expect(BottomTabsScreen.mock.calls[0][0]).toMatchObject({
-      selectedIcon: { sfSymbolName: 'homepod.2.fill' },
+      selectedIcon: { type: 'sfSymbol', name: 'homepod.2.fill' },
     } as NativeTabOptions);
   });
 
@@ -238,7 +238,7 @@ describe('Icons', () => {
     expect(BottomTabsScreen).toHaveBeenCalledTimes(1);
     expect(BottomTabsScreen.mock.calls[0][0]).toMatchObject({
       selectedIcon: undefined,
-      icon: { sfSymbolName: '0.circle.ar' },
+      icon: { ios: { type: 'sfSymbol', name: '0.circle.ar' } },
     } as NativeTabOptions);
   });
 
@@ -259,7 +259,7 @@ describe('Icons', () => {
     expect(screen.getByTestId('index')).toBeVisible();
     expect(BottomTabsScreen).toHaveBeenCalledTimes(1);
     expect(BottomTabsScreen.mock.calls[0][0]).toMatchObject({
-      selectedIcon: { sfSymbolName: '0.circle.ar' },
+      selectedIcon: { type: 'sfSymbol', name: '0.circle.ar' },
       icon: undefined,
     } as NativeTabOptions);
   });
@@ -827,7 +827,7 @@ describe('Dynamic options', () => {
     expect(BottomTabsScreen.mock.calls[0][0]).toMatchObject({
       title: 'Initial Title',
       badgeValue: '3',
-      icon: { sfSymbolName: '0.circle' },
+      icon: { ios: { type: 'sfSymbol', name: '0.circle' } },
       hidden: false,
       specialEffects: {},
       tabKey: expect.stringMatching(/^index-[-\w]+/),
@@ -872,7 +872,7 @@ describe('Dynamic options', () => {
     expect(BottomTabsScreen.mock.calls[0][0]).toMatchObject({
       title: 'Initial Title',
       badgeValue: '3',
-      icon: { sfSymbolName: '0.circle' },
+      icon: { ios: { type: 'sfSymbol', name: '0.circle' } },
       hidden: false,
       specialEffects: {},
       tabKey: expect.stringMatching(/^index-[-\w]+/),


### PR DESCRIPTION
# Why

Native tabs in `expo-router@6.0.19` (SDK 54) pass a legacy icon object shape into `react-native-screens@4.18.0`, which can crash on iOS with:

`[RNScreens] Incorrect icon format for iOS. You must provide sfSymbol, imageSource or templateSource.`

Related: expo/expo#41049

# How

- Update `NativeTabsView` to pass the typed icon objects expected by `react-native-screens`:
  - `icon` prop: `{ ios: { type: 'sfSymbol' | 'templateSource', ... }, android: { type: 'imageSource' | 'drawableResource', ... } }`
  - `selectedIcon` prop (iOS-only): `{ type: 'sfSymbol' | 'templateSource', ... }`
- Update `options.test.ios.tsx` expectations accordingly.

# Test Plan

- Automated: updated Jest expectations in `packages/expo-router/src/native-tabs/NativeBottomTabs/__tests__/options.test.ios.tsx`.
- Manual: reproduced crash in an SDK 54 dev-client app using `expo-router/unstable-native-tabs` + `Icon src`/`VectorIcon`, and confirmed it no longer throws.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources.
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build.
- [ ] Conforms with the Documentation Writing Style Guide.