### PR TITLE
[ios][core] Add `RCTHost` wrapper

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -3818,7 +3818,7 @@ SPEC CHECKSUMS:
   EXUpdates: 83e4d666a085b44149f3b21d5bd057ad37b2c3e5
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   FBLazyVector: 7c1d69992204c5ec452eeefa4a24b0ff311709c8
-  hermes-engine: 9a270294aaec03556862ee83edd0f490710bfbb2
+  hermes-engine: 6bb3000824be2770010ae038914fa26721255c8e
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -3836,7 +3836,7 @@ SPEC CHECKSUMS:
   React: f6f8fc5c01e77349cdfaf49102bcb928ac31d8ed
   React-callinvoker: 3e62a849bda1522c6422309c02f5dc3210bc5359
   React-Core: 0b765bc7c2b83dff178c2b03ed8a0390df26f18c
-  React-Core-prebuilt: e654a2eee526d66aacce0daf22d4b10e0a469dfc
+  React-Core-prebuilt: 620fa7df017f9663e0e8b96c68d2441fb6770c49
   React-CoreModules: 55b932564ba696301cb683a86385be6a6f137e57
   React-cxxreact: 5bfb95256fde56cc0f9ce425f38cfaa085e71ad2
   React-debug: f9dda2791d3ebe2078bc6102641edab77917efb7
@@ -3906,7 +3906,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 23e2bca1661f8781e55fcc05a151fc1df97bc1fb
   ReactCodegen: ed5e30a49f34630c4bf9fc339b8ace492d80f9e5
   ReactCommon: 89ccc6cb100ca5a0303b46483037ef8f3e06e2e0
-  ReactNativeDependencies: f0e046869967ed18d43b1f95caff7c3c266d51b5
+  ReactNativeDependencies: b050dc3d4b087c93c8b61da7cf660d2da08a4739
   RNCAsyncStorage: e85a99325df9eb0191a6ee2b2a842644c7eb29f4
   RNCMaskedView: 3c9d7586e2b9bbab573591dcb823918bc4668005
   RNCPicker: 38a9deb903d9a8ae18b598bac727e6c84b3cf0fa

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -54,7 +54,7 @@
 - [iOS] Replaced `appContext.fileSystem`, `appContext.utilities`, `appContext.imageLoader` and `appContext.permissions` with the core implementations. ([#41350](https://github.com/expo/expo/pull/41350), [#41370](https://github.com/expo/expo/pull/41370), [#41396](https://github.com/expo/expo/pull/41396) by [@tsapeta](https://github.com/tsapeta))
 - Deprecated `executeOnJavaScriptThread` in favor of `runtime.schedule`. ([#41478](https://github.com/expo/expo/pull/41478) by [@tsapeta](https://github.com/tsapeta) & [#41551](https://github.com/expo/expo/pull/41551) by [@lukmccall](https://github.com/lukmccall))
 - Added `ShadowNodeProxy.setStyleSize()` for Jetpack Compose integration. ([#41553](https://github.com/expo/expo/pull/41553) by [@kudo](https://github.com/kudo))
-- [iOS] Create wrapper for `RCTHost`.
+- [iOS] Create wrapper for `RCTHost`. ([#41632](https://github.com/expo/expo/pull/41632) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 3.0.28 - 2025-12-05
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -54,6 +54,7 @@
 - [iOS] Replaced `appContext.fileSystem`, `appContext.utilities`, `appContext.imageLoader` and `appContext.permissions` with the core implementations. ([#41350](https://github.com/expo/expo/pull/41350), [#41370](https://github.com/expo/expo/pull/41370), [#41396](https://github.com/expo/expo/pull/41396) by [@tsapeta](https://github.com/tsapeta))
 - Deprecated `executeOnJavaScriptThread` in favor of `runtime.schedule`. ([#41478](https://github.com/expo/expo/pull/41478) by [@tsapeta](https://github.com/tsapeta) & [#41551](https://github.com/expo/expo/pull/41551) by [@lukmccall](https://github.com/lukmccall))
 - Added `ShadowNodeProxy.setStyleSize()` for Jetpack Compose integration. ([#41553](https://github.com/expo/expo/pull/41553) by [@kudo](https://github.com/kudo))
+- [iOS] Create wrapper for `RCTHost`.
 
 ## 3.0.28 - 2025-12-05
 

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -57,6 +57,12 @@ public final class AppContext: NSObject, @unchecked Sendable {
   public weak var reactBridge: RCTBridge?
 
   /**
+   RCTHost wrapper. This is set by ``ExpoReactNativeFactory`` in `didInitializeRuntime`.
+   */
+  @objc
+  public var hostWrapper: ExpoHostWrapper?
+
+  /**
    Underlying JSI runtime of the running app.
    */
   @objc
@@ -158,6 +164,10 @@ public final class AppContext: NSObject, @unchecked Sendable {
   // MARK: - UI
 
   public func findView<ViewType>(withTag viewTag: Int, ofType type: ViewType.Type) -> ViewType? {
+    if let view = hostWrapper?.findView(withTag: viewTag) as? ViewType {
+      return view
+    }
+    
     return reactBridge?.uiManager.view(forReactTag: NSNumber(value: viewTag)) as? ViewType
   }
 

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -162,12 +162,8 @@ public final class AppContext: NSObject, @unchecked Sendable {
 
   // MARK: - UI
 
-  public func findView<ViewType>(withTag viewTag: Int, ofType type: ViewType.Type) -> ViewType? {
-    if let view = hostWrapper?.findView(withTag: viewTag) as? ViewType {
-      return view
-    }
-    
-    return reactBridge?.uiManager.view(forReactTag: NSNumber(value: viewTag)) as? ViewType
+  public func findView<ViewType>(withTag viewTag: Int, ofType type: ViewType.Type) -> ViewType? {    
+    return hostWrapper?.findView(withTag: viewTag) as? ViewType
   }
 
   // MARK: - Running on specific queues

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -59,8 +59,7 @@ public final class AppContext: NSObject, @unchecked Sendable {
   /**
    RCTHost wrapper. This is set by ``ExpoReactNativeFactory`` in `didInitializeRuntime`.
    */
-  @objc
-  public var hostWrapper: ExpoHostWrapper?
+  private var hostWrapper: ExpoHostWrapper?
 
   /**
    Underlying JSI runtime of the running app.
@@ -532,6 +531,11 @@ public final class AppContext: NSObject, @unchecked Sendable {
     if isModuleRegistryInitialized {
       moduleRegistry.post(event: .appContextDestroys)
     }
+  }
+  
+  @objc
+  public func setHostWrapper(_ wrapper: ExpoHostWrapper) {
+    self.hostWrapper = wrapper
   }
 
   // MARK: - Statics

--- a/packages/expo-modules-core/ios/ExpoModulesCore.h
+++ b/packages/expo-modules-core/ios/ExpoModulesCore.h
@@ -12,6 +12,7 @@
 #import <ExpoModulesCore/ExpoModulesCore.h>
 #import <ExpoModulesCore/ExpoModulesCore.h>
 #import <ExpoModulesCore/ExpoFabricViewObjC.h>
+#import <ExpoModulesCore/EXHostWrapper.h>
 #import <ExpoModulesCore/EXCameraInterface.h>
 #import <ExpoModulesCore/EXConstantsInterface.h>
 #import <ExpoModulesCore/EXFaceDetectorManagerInterface.h>

--- a/packages/expo-modules-core/ios/Fabric/EXHostWrapper.h
+++ b/packages/expo-modules-core/ios/Fabric/EXHostWrapper.h
@@ -1,0 +1,20 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ A wrapper around RCTHost.
+ RCTHost isn't directly available in Swift, so this wrapper provides a typed interface.
+ */
+NS_SWIFT_NAME(ExpoHostWrapper)
+@interface EXHostWrapper : NSObject
+
+- (instancetype)initWithHost:(id)host;
+
+- (nullable UIView *)findViewWithTag:(NSInteger)tag;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-modules-core/ios/Fabric/EXHostWrapper.h
+++ b/packages/expo-modules-core/ios/Fabric/EXHostWrapper.h
@@ -2,13 +2,19 @@
 
 #import <ExpoModulesCore/Platform.h>
 
+#ifdef __cplusplus
+#import <ReactCommon/RCTHost.h>
+#endif
+
 /**
  A wrapper around RCTHost. RCTHost isn't directly available in Swift.
  */
 NS_SWIFT_NAME(ExpoHostWrapper)
 @interface EXHostWrapper : NSObject
 
-- (instancetype _Nonnull)initWithHost:(id _Nonnull)host;
+#ifdef __cplusplus
+- (instancetype _Nonnull)initWithHost:(RCTHost * _Nonnull)host;
+#endif
 
 - (nullable UIView *)findViewWithTag:(NSInteger)tag;
 

--- a/packages/expo-modules-core/ios/Fabric/EXHostWrapper.h
+++ b/packages/expo-modules-core/ios/Fabric/EXHostWrapper.h
@@ -5,8 +5,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- A wrapper around RCTHost.
- RCTHost isn't directly available in Swift, so this wrapper provides a typed interface.
+ A wrapper around RCTHost. RCTHost isn't directly available in Swift.
  */
 NS_SWIFT_NAME(ExpoHostWrapper)
 @interface EXHostWrapper : NSObject

--- a/packages/expo-modules-core/ios/Fabric/EXHostWrapper.h
+++ b/packages/expo-modules-core/ios/Fabric/EXHostWrapper.h
@@ -1,8 +1,6 @@
 // Copyright 2024-present 650 Industries. All rights reserved.
 
-#import <UIKit/UIKit.h>
-
-NS_ASSUME_NONNULL_BEGIN
+#import <ExpoModulesCore/Platform.h>
 
 /**
  A wrapper around RCTHost. RCTHost isn't directly available in Swift.
@@ -10,10 +8,9 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(ExpoHostWrapper)
 @interface EXHostWrapper : NSObject
 
-- (instancetype)initWithHost:(id)host;
+- (instancetype _Nonnull)initWithHost:(id _Nonnull)host;
 
 - (nullable UIView *)findViewWithTag:(NSInteger)tag;
 
 @end
 
-NS_ASSUME_NONNULL_END

--- a/packages/expo-modules-core/ios/Fabric/EXHostWrapper.mm
+++ b/packages/expo-modules-core/ios/Fabric/EXHostWrapper.mm
@@ -15,7 +15,7 @@
 #endif
 }
 
-- (instancetype)initWithHost:(id)host
+- (instancetype)initWithHost:(RCTHost *)host
 {
   if (self = [super init]) {
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/packages/expo-modules-core/ios/Fabric/EXHostWrapper.mm
+++ b/packages/expo-modules-core/ios/Fabric/EXHostWrapper.mm
@@ -2,37 +2,27 @@
 
 #import <ExpoModulesCore/EXHostWrapper.h>
 
-#ifdef RCT_NEW_ARCH_ENABLED
 #import <ReactCommon/RCTHost.h>
 #import <React/RCTSurfacePresenter.h>
 #import <React/RCTMountingManager.h>
 #import <React/RCTComponentViewRegistry.h>
-#endif
 
 @implementation EXHostWrapper {
-#ifdef RCT_NEW_ARCH_ENABLED
   __weak RCTHost *_host;
-#endif
 }
 
 - (instancetype)initWithHost:(RCTHost *)host
 {
   if (self = [super init]) {
-#ifdef RCT_NEW_ARCH_ENABLED
     _host = host;
-#endif
   }
   return self;
 }
 
 - (nullable UIView *)findViewWithTag:(NSInteger)tag
 {
-#ifdef RCT_NEW_ARCH_ENABLED
   RCTComponentViewRegistry *componentViewRegistry = _host.surfacePresenter.mountingManager.componentViewRegistry;
   return [componentViewRegistry findComponentViewWithTag:tag];
-#else
-  return nil;
-#endif
 }
 
 @end

--- a/packages/expo-modules-core/ios/Fabric/EXHostWrapper.mm
+++ b/packages/expo-modules-core/ios/Fabric/EXHostWrapper.mm
@@ -1,0 +1,38 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+#import <ExpoModulesCore/EXHostWrapper.h>
+
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <ReactCommon/RCTHost.h>
+#import <React/RCTSurfacePresenter.h>
+#import <React/RCTMountingManager.h>
+#import <React/RCTComponentViewRegistry.h>
+#endif
+
+@implementation EXHostWrapper {
+#ifdef RCT_NEW_ARCH_ENABLED
+  __weak RCTHost *_host;
+#endif
+}
+
+- (instancetype)initWithHost:(id)host
+{
+  if (self = [super init]) {
+#ifdef RCT_NEW_ARCH_ENABLED
+    _host = host;
+#endif
+  }
+  return self;
+}
+
+- (nullable UIView *)findViewWithTag:(NSInteger)tag
+{
+#ifdef RCT_NEW_ARCH_ENABLED
+  RCTComponentViewRegistry *componentViewRegistry = _host.surfacePresenter.mountingManager.componentViewRegistry;
+  return [componentViewRegistry findComponentViewWithTag:tag];
+#else
+  return nil;
+#endif
+}
+
+@end

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
@@ -33,7 +33,7 @@
 
   // Inject and decorate the `global.expo` object
   _appContext._runtime = [[EXRuntime alloc] initWithRuntime:runtime];
-  _appContext.hostWrapper = [[EXHostWrapper alloc] initWithHost:host];
+  [_appContext setHostWrapper:[[EXHostWrapper alloc] initWithHost:host]];
   
   [_appContext registerNativeModules];
 }

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
@@ -33,7 +33,8 @@
 
   // Inject and decorate the `global.expo` object
   _appContext._runtime = [[EXRuntime alloc] initWithRuntime:runtime];
-
+  _appContext.hostWrapper = [[EXHostWrapper alloc] initWithHost:host];
+  
   [_appContext registerNativeModules];
 }
 


### PR DESCRIPTION
# Why
Without the bridge we need a way to lookup views when calling view functions. 

# How
Create a wrapper around `RCTHost` so we can access `RCTComponentViewRegistry` to look up views. May also be useful in the future if we need anything else on the host. 

# Test Plan
Bare-expo. View functions had been failing, now working correctly.

