### PR TITLE
[maps] - map resets camera position on re-appear.

### DIFF
--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix MapKit built-in buttons not responding ([#41151](https://github.com/expo/expo/pull/41151) by [@nishan](https://github.com/intergalacticspacehighway))
+- [iOS] Fix Map resets camera position on navigation tab switch. ([#41639](https://github.com/expo/expo/pull/41639) by [@nishan](https://github.com/intergalacticspacehighway))
 
 ### 💡 Others
 

--- a/packages/expo-maps/ios/AppleMapsViewState.swift
+++ b/packages/expo-maps/ios/AppleMapsViewState.swift
@@ -10,6 +10,7 @@ public class AppleMapsViewiOS18State: ObservableObject {
   @Published var selection: MapSelection<MKMapItem>?
   @Published var lookAroundScene: MKLookAroundScene?
   @Published var lookAroundPresented: Bool = false
+  var hasInitializedCamera: Bool = false
 }
 
 @available(iOS 17.0, *)
@@ -17,4 +18,5 @@ public class AppleMapsViewiOS17State: ObservableObject {
   @Published var mapCameraPosition: MapCameraPosition = .automatic
   @Published var lookAroundScene: MKLookAroundScene?
   @Published var lookAroundPresented: Bool = false
+  var hasInitializedCamera: Bool = false
 }

--- a/packages/expo-maps/ios/AppleMapsViewiOS17.swift
+++ b/packages/expo-maps/ios/AppleMapsViewiOS17.swift
@@ -140,7 +140,10 @@ struct AppleMapsViewiOS17: View, AppleMapsViewProtocol {
         }
       )
       .onAppear {
-        state.mapCameraPosition = convertToMapCamera(position: props.cameraPosition)
+        if !state.hasInitializedCamera {
+          state.mapCameraPosition = convertToMapCamera(position: props.cameraPosition)
+          state.hasInitializedCamera = true
+        }
       }
     }
   }

--- a/packages/expo-maps/ios/AppleMapsViewiOS18.swift
+++ b/packages/expo-maps/ios/AppleMapsViewiOS18.swift
@@ -228,7 +228,10 @@ struct AppleMapsViewiOS18: View, AppleMapsViewProtocol {
         }
       )
       .onAppear {
-        state.mapCameraPosition = convertToMapCamera(position: props.cameraPosition)
+        if !state.hasInitializedCamera {
+          state.mapCameraPosition = convertToMapCamera(position: props.cameraPosition)
+          state.hasInitializedCamera = true
+        }
       }
     }
   }


### PR DESCRIPTION
# Why

https://github.com/expo/expo/issues/41634

As demonstrated in the [repro](https://github.com/matinzd/expo-maps-repro), when an uncontrolled state map is mounted, it gets mounted with a default coordinates of (0, 0). This location currently gets set on `onAppear`. `onAppear` can also get called on tab navigation events where map disappears and re-appears while the component is still mounted. We need to preserve the state if user has moved the map and the map is still mounted.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Initialise the position from prop only once. 
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested the fix in the repro.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
