### PR TITLE
[go][Android] Migrate apollo client from js to kotlin

### DIFF
--- a/apps/expo-go/android/expoview/build.gradle
+++ b/apps/expo-go/android/expoview/build.gradle
@@ -208,7 +208,8 @@ dependencies {
   api(libs.okio)
   api(libs.javax.inject)
 
-  implementation 'com.apollographql.apollo:apollo-runtime:4.3.1'
+  implementation expoLibs.apollo
+  implementation expoLibs.apollo.normalized.cache
 
   // Our dependencies
   compileOnly 'org.glassfish:javax.annotation:3.1.1'

--- a/apps/expo-go/android/expoview/build.gradle
+++ b/apps/expo-go/android/expoview/build.gradle
@@ -11,7 +11,7 @@ buildscript {
   }
 
   dependencies {
-    classpath("com.apollographql.apollo:apollo-gradle-plugin:4.3.1")
+    classpath(expoLibs.apollo.gradle)
   }
 }
 
@@ -209,7 +209,7 @@ dependencies {
   api(libs.javax.inject)
 
   implementation expoLibs.apollo
-  implementation expoLibs.apollo.normalized.cache
+  implementation expoLibs.apollo.cache
 
   // Our dependencies
   compileOnly 'org.glassfish:javax.annotation:3.1.1'

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/apollo/AuthInterceptor.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/apollo/AuthInterceptor.kt
@@ -1,0 +1,24 @@
+package host.exp.exponent.apollo
+
+import com.apollographql.apollo.api.http.HttpRequest
+import com.apollographql.apollo.api.http.HttpResponse
+import com.apollographql.apollo.network.http.HttpInterceptor
+import com.apollographql.apollo.network.http.HttpInterceptorChain
+
+// TODO(@lukmccall): Replace with actual session management implementation
+fun interface SessionManager {
+  fun getSessionSecret(): String?
+}
+
+class AuthInterceptor(private val sessionManager: SessionManager) : HttpInterceptor {
+  override suspend fun intercept(request: HttpRequest, chain: HttpInterceptorChain): HttpResponse {
+    val sessionSecret = sessionManager.getSessionSecret()
+      ?: return chain.proceed(request)
+
+    val newRequest = request.newBuilder()
+      .addHeader("expo-session", sessionSecret)
+      .build()
+
+    return chain.proceed(newRequest)
+  }
+}

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/apollo/Paginator.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/apollo/Paginator.kt
@@ -1,0 +1,41 @@
+package host.exp.exponent.apollo
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+typealias Query<T> = suspend (limit: Int, offset: Int) -> List<T>
+
+class Paginator<Data>(
+  private val defaultLimit: Int = 15,
+  private val fetch: Query<Data>
+) {
+  private val _data = MutableStateFlow<List<Data>>(emptyList())
+
+  val data: StateFlow<List<Data>> = _data.asStateFlow()
+  private var currentOffset = 0
+
+  var isLastPage = false
+    private set
+  var isFetching = false
+    private set
+
+  suspend fun loadMore() {
+    if (isFetching || isLastPage) {
+      return
+    }
+
+    isFetching = true
+    val data = fetch(defaultLimit, currentOffset)
+    currentOffset += data.size
+
+    if (data.size < defaultLimit || data.isEmpty()) {
+      isLastPage = true
+    }
+
+    currentOffset += data.size
+    _data.update { oldData -> oldData + data }
+    isFetching = false
+  }
+}

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/services/ApolloClientService.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/services/ApolloClientService.kt
@@ -61,7 +61,7 @@ class ApolloClientService(
   }
 
   fun branches(
-    appId : String
+    appId: String
   ): Paginator<BranchesForProjectQuery.UpdateBranch> {
     return Paginator(
       fetch = { limit, offset ->
@@ -140,7 +140,7 @@ class ApolloClientService(
     )
   }
 
- suspend fun primaryAccount(): Home_ViewerPrimaryAccountNameQuery.PrimaryAccount? {
+  suspend fun primaryAccount(): Home_ViewerPrimaryAccountNameQuery.PrimaryAccount? {
     return apolloClient.query(
       Home_ViewerPrimaryAccountNameQuery()
     )

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/services/ApolloClientService.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/services/ApolloClientService.kt
@@ -1,0 +1,152 @@
+package host.exp.exponent.services
+
+import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.cache.normalized.FetchPolicy
+import com.apollographql.apollo.cache.normalized.api.MemoryCacheFactory
+import com.apollographql.apollo.cache.normalized.fetchPolicy
+import com.apollographql.apollo.cache.normalized.normalizedCache
+import com.apollographql.apollo.network.okHttpClient
+import host.exp.exponent.apollo.AuthInterceptor
+import host.exp.exponent.apollo.Paginator
+import host.exp.exponent.graphql.BranchDetailsQuery
+import host.exp.exponent.graphql.BranchesForProjectQuery
+import host.exp.exponent.graphql.Home_AccountAppsQuery
+import host.exp.exponent.graphql.Home_AccountSnacksQuery
+import host.exp.exponent.graphql.Home_CurrentUserActorQuery
+import host.exp.exponent.graphql.Home_ViewerPrimaryAccountNameQuery
+import host.exp.exponent.graphql.ProjectsQuery
+import host.exp.exponent.graphql.fragment.CurrentUserActorData
+import host.exp.exponent.graphql.type.AppPlatform
+import okhttp3.OkHttpClient
+
+class ApolloClientService(
+  httpClient: OkHttpClient
+) {
+  private val normalizedCacheFactory = MemoryCacheFactory(maxSizeBytes = 10 * 1024 * 1024)
+
+  private val apolloClient = ApolloClient
+    .Builder()
+    .serverUrl("https://exp.host/--/graphql")
+    .okHttpClient(httpClient)
+    .normalizedCache(normalizedCacheFactory)
+    .addHttpInterceptor(AuthInterceptor { null })
+    .fetchPolicy(FetchPolicy.CacheAndNetwork)
+    .build()
+
+  suspend fun currentUser(): CurrentUserActorData? {
+    return apolloClient.query(
+      Home_CurrentUserActorQuery()
+    )
+      .execute()
+      .dataOrThrow()
+      .meUserActor
+      ?.currentUserActorData
+  }
+
+  suspend fun branchDetails(
+    name: String,
+    appId: String
+  ): BranchDetailsQuery.ById {
+    return apolloClient.query(
+      BranchDetailsQuery(
+        name = name,
+        appId = appId,
+        platform = AppPlatform.ANDROID
+      )
+    )
+      .execute()
+      .dataOrThrow()
+      .app
+      .byId
+  }
+
+  fun branches(
+    appId : String
+  ): Paginator<BranchesForProjectQuery.UpdateBranch> {
+    return Paginator(
+      fetch = { limit, offset ->
+        apolloClient.query(
+          BranchesForProjectQuery(
+            appId = appId,
+            platform = AppPlatform.ANDROID,
+            limit = limit,
+            offset = offset
+          )
+        )
+          .execute()
+          .dataOrThrow()
+          .app
+          .byId
+          .updateBranches
+      }
+    )
+  }
+
+  fun apps(
+    accountName: String
+  ): Paginator<Home_AccountAppsQuery.App> {
+    return Paginator(
+      fetch = { limit, offset ->
+        apolloClient.query(
+          Home_AccountAppsQuery(
+            accountName = accountName,
+            platform = AppPlatform.ANDROID,
+            limit = limit,
+            offset = offset
+          )
+        )
+          .execute()
+          .dataOrThrow()
+          .account
+          .byName
+          .apps
+      }
+    )
+  }
+
+  suspend fun app(
+    appId: String
+  ): ProjectsQuery.ById {
+    return apolloClient.query(
+      ProjectsQuery(
+        appId = appId,
+        platform = AppPlatform.ANDROID
+      )
+    )
+      .execute()
+      .dataOrThrow()
+      .app
+      .byId
+  }
+
+  fun snacks(
+    accountName: String
+  ): Paginator<Home_AccountSnacksQuery.Snack> {
+    return Paginator(
+      fetch = { limit, offset ->
+        apolloClient.query(
+          Home_AccountSnacksQuery(
+            accountName = accountName,
+            limit = limit,
+            offset = offset
+          )
+        )
+          .execute()
+          .dataOrThrow()
+          .account
+          .byName
+          .snacks
+      }
+    )
+  }
+
+ suspend fun primaryAccount(): Home_ViewerPrimaryAccountNameQuery.PrimaryAccount? {
+    return apolloClient.query(
+      Home_ViewerPrimaryAccountNameQuery()
+    )
+      .execute()
+      .dataOrThrow()
+      .meUserActor
+      ?.primaryAccount
+  }
+}

--- a/apps/expo-go/android/gradle/libs.versions.toml
+++ b/apps/expo-go/android/gradle/libs.versions.toml
@@ -7,13 +7,17 @@ buildTools = "36.0.0"
 # Dependencies versions
 agp = "8.11.0"
 fresco = "3.6.0"
+apollo = "4.3.3"
 
 [libraries]
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 
+apollo-normalized-cache = { module = "com.apollographql.apollo:apollo-normalized-cache", version.ref = "apollo" }
 fresco = { module = "com.facebook.fresco:fresco", version.ref = "fresco" }
 fresco-middleware = { module = "com.facebook.fresco:middleware", version.ref = "fresco" }
 fresco-animated-gif  = { module = "com.facebook.fresco:animated-gif", version.ref = "fresco" }
 fresco-animated-webp = { module = "com.facebook.fresco:animated-webp", version.ref = "fresco" }
 fresco-webpsupport = { module = "com.facebook.fresco:webpsupport", version.ref = "fresco" }
 
+apollo =  { module = "com.apollographql.apollo:apollo-runtime", version.ref = "apollo" }
+apollo-cache = { module = "com.apollographql.apollo:apollo-cache-normalized", version.ref = "apollo" }

--- a/apps/expo-go/android/gradle/libs.versions.toml
+++ b/apps/expo-go/android/gradle/libs.versions.toml
@@ -12,7 +12,6 @@ apollo = "4.3.3"
 [libraries]
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 
-apollo-normalized-cache = { module = "com.apollographql.apollo:apollo-normalized-cache", version.ref = "apollo" }
 fresco = { module = "com.facebook.fresco:fresco", version.ref = "fresco" }
 fresco-middleware = { module = "com.facebook.fresco:middleware", version.ref = "fresco" }
 fresco-animated-gif  = { module = "com.facebook.fresco:animated-gif", version.ref = "fresco" }
@@ -21,3 +20,4 @@ fresco-webpsupport = { module = "com.facebook.fresco:webpsupport", version.ref =
 
 apollo =  { module = "com.apollographql.apollo:apollo-runtime", version.ref = "apollo" }
 apollo-cache = { module = "com.apollographql.apollo:apollo-cache-normalized", version.ref = "apollo" }
+apollo-gradle = { module = "com.apollographql.apollo:apollo-gradle-plugin", version.ref = "apollo" }

--- a/apps/expo-go/android/gradle/libs.versions.toml
+++ b/apps/expo-go/android/gradle/libs.versions.toml
@@ -19,5 +19,5 @@ fresco-animated-webp = { module = "com.facebook.fresco:animated-webp", version.r
 fresco-webpsupport = { module = "com.facebook.fresco:webpsupport", version.ref = "fresco" }
 
 apollo =  { module = "com.apollographql.apollo:apollo-runtime", version.ref = "apollo" }
-apollo-cache = { module = "com.apollographql.apollo:apollo-cache-normalized", version.ref = "apollo" }
+apollo-cache = { module = "com.apollographql.apollo:apollo-normalized-cache", version.ref = "apollo" }
 apollo-gradle = { module = "com.apollographql.apollo:apollo-gradle-plugin", version.ref = "apollo" }


### PR DESCRIPTION
# Why

Migrates the Apollo client from JS to Kotlin. 

# How

- Added in-memory cache 
- Added authentication 
- Added a wrapper for paginated data
- Exposed public interface 

# Test Plan
 
- I've tested it by running it manually. We should invest some time in adding tests ✅ 