### PR TITLE
[ios][camera] fix returned pictureRef dimensions

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [Android] Fix certain exif keys being dropped because of invalid values. ([#41043](https://github.com/expo/expo/pull/41043) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix camera not being recreated on the old architecture. ([#41405](https://github.com/expo/expo/pull/41405) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix `takePictureAsync` with `pictureRef` returning swapped width/height that didn't account for EXIF orientation. ([#41647](https://github.com/expo/expo/pull/41647) by [@martinezleoml](https://github.com/martinezleoml))
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/CameraViewModule.swift
+++ b/packages/expo-camera/ios/CameraViewModule.swift
@@ -307,11 +307,11 @@ public final class CameraViewModule: Module, ScannerResultHandler {
 
     Class("Picture", PictureRef.self) {
       Property("width") { (image: PictureRef) -> Int in
-        return image.ref.cgImage?.width ?? 0
+        return Int(image.ref.size.width)
       }
 
       Property("height") { (image: PictureRef) -> Int in
-        return image.ref.cgImage?.height ?? 0
+        return Int(image.ref.size.height)
       }
 
       AsyncFunction("savePictureAsync") { (image: PictureRef, options: SavePictureOptions?) -> [String: Any?] in


### PR DESCRIPTION
# Why

Fixes #41646.

In `CameraViewModule.swift`, the Picture class exposes width/height using `CGImage` dimensions:

```swift
Property("width") { (image: PictureRef) -> Int in
  return image.ref.cgImage?.width ?? 0
}

Property("height") { (image: PictureRef) -> Int in
  return image.ref.cgImage?.height ?? 0
}
```

`CGImage.width` and `CGImage.height` return the raw pixel buffer dimensions, which don't account for EXIF orientation metadata. On iOS, the camera sensor captures in landscape orientation regardless of device orientation, and the correct orientation is stored as metadata in `UIImage.imageOrientation`.

# How

Use `UIImage.size` instead, which correctly interprets the orientation metadata:

```swift
Property("width") { (image: PictureRef) -> Int in
  return Int(image.ref.size.width)
}

Property("height") { (image: PictureRef) -> Int in
  return Int(image.ref.size.height)
}
```

This is consistent with how the regular `takePicture` (non-ref) method handles dimensions in CameraPhotoCapture.swift, where it correctly uses `takenImage.size.width` and `takenImage.size.height`.

# Test Plan

See original issue and https://github.com/martinezleoml/expo-camera-picture-ref-dimensions for a full repro.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
