### PR TITLE
[docs] Convert all `diff` blocks to use `DiffBlock` component for better UX

### DIFF
--- a/docs/pages/archive/classic-updates/hosting-your-app.mdx
+++ b/docs/pages/archive/classic-updates/hosting-your-app.mdx
@@ -3,7 +3,7 @@ title: Hosting Updates on Your Servers
 ---
 
 import { FileTree } from '~/ui/components/FileTree';
-import { Terminal } from '~/ui/components/Snippet';
+import { DiffBlock, Terminal } from '~/ui/components/Snippet';
 
 > This doc was archived in August 2022 and will not receive any further updates. Use EAS Update instead. [Learn more](/eas-update/introduction)
 
@@ -50,12 +50,16 @@ On some hosting services such as [AWS](https://aws.amazon.com/) and [Firebase](h
 
 Here's an example of **firebase.json** configuration, with a [deploy target](https://firebase.google.com/docs/cli/targets) named "native".
 
-```diff
-{
-  "hosting": [
-    {
-      "target": "native",
-      "public": "dist",
+<DiffBlock
+  raw={`diff --git a/firebase.json b/firebase.json
+index 0000000..1111111 100644
+--- a/firebase.json
++++ b/firebase.json
+@@ -1,7 +1,18 @@
+   "hosting": [
+     {
+       "target": "native",
+       "public": "dist",
 +      "headers": [
 +        {
 +          "source": "**/*.js",
@@ -65,12 +69,12 @@ Here's an example of **firebase.json** configuration, with a [deploy target](htt
 +              "value": "application/javascript"
 +            }
 +          ]
-        }
-      ]
-    }
-  ]
-}
-```
++        }
++      ]
+     }
+   ]
+ }`}
+/>
 
 <Terminal
   cmd={[

--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -126,7 +126,12 @@ fi
 
 And add support the `"main"` field in **package.json** by making the following change to **AppDelegate.swift**:
 
-```diff AppDelegate.swift
+<DiffBlock
+  raw={`diff --git a/ios/AppDelegate.swift b/ios/AppDelegate.swift
+index 0000000..1111111 100644
+--- a/ios/AppDelegate.swift
++++ b/ios/AppDelegate.swift
+@@ -1,7 +1,7 @@
    override func bundleURL() -> URL? {
  #if DEBUG
 -    RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
@@ -134,7 +139,8 @@ And add support the `"main"` field in **package.json** by making the following c
  #else
      Bundle.main.url(forResource: "main", withExtension: "jsbundle")
  #endif
-```
+   }`}
+/>
 
 </Collapsible>
 

--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -47,20 +47,23 @@ Modify the `expo` section of **app.json**. If you created your project using `np
 
 If you want to set up a [custom `expo-updates` server](https://github.com/expo/custom-expo-updates-server) instead, add your URL to `updates.url` in **app.json**.
 
-```diff app.json
- {
-   "name": "MyApp",
-   "displayName": "MyApp",
+<DiffBlock
+  raw={`diff --git a/app.json b/app.json
+index 0000000..1111111 100644
+--- a/app.json
++++ b/app.json
+@@ -1,7 +1,7 @@
    "expo": {
      "name": "MyApp",
-      ...
-     "updates": {
+-    "updates": {
 -      "url": "https://u.expo.dev/[your-project-id]"
+-    }
++    "updates": {
 +      "url": "http://localhost:3000/api/manifest"
-     }
++    }
    }
- }
-```
+ }`}
+/>
 
 ### Android
 
@@ -74,21 +77,7 @@ Modify **android/app/src/main/AndroidManifest.xml** to add the `expo-updates` co
 
 If using the updates server URL (a custom non-HTTPS update server running on the same machine), you will need to modify **android/app/src/main/AndroidManifest.xml** to add the update server URL and enable `usesCleartextTraffic`:
 
-```diff android/app/src/main/AndroidManifest.xml
- <application
-  android:name=".MainApplication"
-  android:label="@string/app_name"
-  android:icon="@mipmap/ic_launcher"
-  android:roundIcon="@mipmap/ic_launcher_round"
-  android:allowBackup="false"
-  android:theme="@style/AppTheme"
-+ android:usesCleartextTraffic="true"
- >
-
-- <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="https://u.expo.dev/[your-project-id]"/>
-+ <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="http://localhost:3000/api/manifest"/>
- </application>
-```
+<DiffBlock source="/static/diffs/expo-updates-android-manifest-cleartext.diff" />
 
 Add the Expo runtime version string key to **android/app/src/main/res/values/strings.xml**:
 

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -57,23 +57,20 @@ We recommend that apps using EAS Update use Expo's [`registerRootComponent`](/ve
 
 In a simple app created with React Native Community CLI, the diff would look like this:
 
-```diff
-diff --git a/index.js b/index.js
-index a850d03..8fb69fd 100644
+<DiffBlock
+  raw={`diff --git a/index.js b/index.js
+index 0000000..1111111 100644
 --- a/index.js
 +++ b/index.js
-@@ -2,8 +2,7 @@
-  * @forma
-  */
-
+@@ -1,5 +1,4 @@
 -import {AppRegistry} from 'react-native';
+-import {name as appName} from './app.json';
 +import {registerRootComponent} from 'expo';
  import App from './App';
--import {name as appName} from './app.json';
-
+-
 -AppRegistry.registerComponent(appName, () => App);
-+export default registerRootComponent(App);
-```
++export default registerRootComponent(App);`}
+ />
 
 After making that change, update your [`MainActivity`](/versions/latest/sdk/expo/#rootregistercomponent-setup-for-existing-react-native-projects) and [`AppDelegate`](/versions/latest//sdk/expo/#rootregistercomponent-setup-for-existing-react-native-projects) to use the module name `"main"` instead of your app name.
 

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -70,7 +70,7 @@ index 0000000..1111111 100644
 -
 -AppRegistry.registerComponent(appName, () => App);
 +export default registerRootComponent(App);`}
- />
+/>
 
 After making that change, update your [`MainActivity`](/versions/latest/sdk/expo/#rootregistercomponent-setup-for-existing-react-native-projects) and [`AppDelegate`](/versions/latest//sdk/expo/#rootregistercomponent-setup-for-existing-react-native-projects) to use the module name `"main"` instead of your app name.
 

--- a/docs/pages/guides/adopting-prebuild.mdx
+++ b/docs/pages/guides/adopting-prebuild.mdx
@@ -36,7 +36,7 @@ index 0000000..1111111 100644
 -
 -AppRegistry.registerComponent(appName, () => App);
 +registerRootComponent(App);`}
- />
+/>
 
 > Learn more about [`registerRootComponent`](/versions/latest/sdk/expo/#registerrootcomponentcomponent).
 
@@ -90,7 +90,7 @@ index 0000000..1111111 100644
 +    "name": "myapp"
 +  }
  }`}
- />
+/>
 
 **metro.config.js**
 
@@ -113,7 +113,7 @@ index 0000000..1111111 100644
 +    "android": "expo run:android",
 +    "ios": "expo run:ios",
    },`}
- />
+/>
 
 These commands have better logging, auto code signing, better simulator handling, and they ensure you run `npx expo start` to serve files.
 

--- a/docs/pages/guides/adopting-prebuild.mdx
+++ b/docs/pages/guides/adopting-prebuild.mdx
@@ -3,7 +3,7 @@ title: Adopt Prebuild
 description: Learn how to adopt Expo Prebuild in a project that was bootstrapped with React Native CLI.
 ---
 
-import { Terminal } from '~/ui/components/Snippet';
+import { DiffBlock, Terminal } from '~/ui/components/Snippet';
 
 There are [many advantages](/workflow/prebuild#pitch) of using [Expo Prebuild][prebuild] to [continuously generate your native projects](/workflow/continuous-native-generation). This guide will show you how to adopt Expo Prebuild in a project that was bootstrapped with `npx @react-native-community/cli@latest init`. The amount of time it will take to convert your project depends on the amount of custom native changes that you have made to your Android and iOS native projects. This may take a minute or two on a brand new project, and on a large project, it will be much longer.
 
@@ -23,16 +23,20 @@ Ensure you install the version of `expo` that works for your currently installed
 
 Modify the entry file to use [`registerRootComponent`](/versions/latest/sdk/expo/#registerrootcomponentcomponent) instead of `AppRegistry.registerComponent`:
 
-```diff
-+ import {registerRootComponent} from 'expo';
-
-- import {AppRegistry} from 'react-native';
-import App from './App';
-- import {name as appName} from './app.json';
-
-- AppRegistry.registerComponent(appName, () => App);
-+ registerRootComponent(App);
-```
+<DiffBlock
+  raw={`diff --git a/index.js b/index.js
+index 0000000..1111111 100644
+--- a/index.js
++++ b/index.js
+@@ -1,5 +1,4 @@
+-import {AppRegistry} from 'react-native';
+-import {name as appName} from './app.json';
++import {registerRootComponent} from 'expo';
+ import App from './App';
+-
+-AppRegistry.registerComponent(appName, () => App);
++registerRootComponent(App);`}
+ />
 
 > Learn more about [`registerRootComponent`](/versions/latest/sdk/expo/#registerrootcomponentcomponent).
 
@@ -74,15 +78,19 @@ The **android** and **ios** directories are automatically added to **.gitignore*
 
 Remove all fields that are outside the top-level `expo` object as these will not be used in `npx expo prebuild`.
 
-```diff
-{
+<DiffBlock
+  raw={`diff --git a/app.json b/app.json
+index 0000000..1111111 100644
+--- a/app.json
++++ b/app.json
+@@
 -  "name": "myapp",
 -  "displayName": "myapp"
 +  "expo": {
 +    "name": "myapp"
 +  }
-}
-```
+ }`}
+ />
 
 **metro.config.js**
 
@@ -92,15 +100,20 @@ See [Customizing Metro](/guides/customizing-metro/).
 
 You may want to change the scripts to use the [Expo CLI](/more/expo-cli/#compiling) run commands:
 
-```diff
-  "scripts": {
-    "start": "expo start",
+<DiffBlock
+  raw={`diff --git a/package.json b/package.json
+index 0000000..1111111 100644
+--- a/package.json
++++ b/package.json
+@@
+   "scripts": {
+     "start": "expo start",
 -    "android": "react-native run-android",
 -    "ios": "react-native run-ios",
 +    "android": "expo run:android",
 +    "ios": "expo run:ios",
-  },
-```
+   },`}
+ />
 
 These commands have better logging, auto code signing, better simulator handling, and they ensure you run `npx expo start` to serve files.
 

--- a/docs/pages/modules/additional-platform-support.mdx
+++ b/docs/pages/modules/additional-platform-support.mdx
@@ -4,6 +4,7 @@ description: Learn how to add support for macOS and tvOS platforms.
 ---
 
 import { Step } from '~/ui/components/Step';
+import { DiffBlock } from '~/ui/components/Snippet';
 
 Expo Modules API provides first-class support for Android and iOS. However, since all Apple platforms are based on the same foundation and use the same programming language, targeting other [Out-of-Tree platforms](https://reactnative.dev/docs/out-of-tree-platforms) in the Expo module is possible.
 
@@ -15,18 +16,22 @@ Currently, only **macOS** and **tvOS** platforms are supported. This guide will 
 
 To provide seamless support for other Apple platforms, Expo SDK introduced a universal `"apple"` platform to instruct the [autolinking](/modules/autolinking/) that the module may support any of the Apple platform and whether to link the module in the specific CocoaPods target is moved off to the podspec. If you have used `"ios"` before, you can safely replace it:
 
-```diff expo-module.config.json
-{
--   "platforms": ["ios"],
--   "ios": {
--     "modules": ["MyModule"]
--   }
-+   "platforms": ["apple"],
-+   "apple": {
-+     "modules": ["MyModule"]
-+   }
-}
-```
+<DiffBlock
+  raw={`diff --git a/expo-module.config.json b/expo-module.config.json
+index 0000000..1111111 100644
+--- a/expo-module.config.json
++++ b/expo-module.config.json
+@@ -1,5 +1,5 @@
+-  "platforms": ["ios"],
+-  "ios": {
+-    "modules": ["MyModule"]
+-  }
++  "platforms": ["apple"],
++  "apple": {
++    "modules": ["MyModule"]
++  }
+ }`}
+/>
 
 </Step>
 
@@ -36,14 +41,19 @@ To provide seamless support for other Apple platforms, Expo SDK introduced a uni
 
 The module's podspec needs to be updated with a list of the supported platforms. Otherwise, CocoaPods would fail to install the pod on targets for the other platforms. As mentioned in the first step, this part of the spec is the source of truth for autolinking when the module is configured with a universal `"apple"` platform.
 
-```diff Module's podspec
+<DiffBlock
+  raw={`diff --git a/YourModule.podspec b/YourModule.podspec
+index 0000000..1111111 100644
+--- a/YourModule.podspec
++++ b/YourModule.podspec
+@@ -1,5 +1,5 @@
 - s.platform       = :ios, '13.4'
 + s.platforms = {
 +   :ios => '13.4',
 +   :tvos => '13.4',
 +   :osx => '10.15'
-+ }
-```
++ }`}
+/>
 
 Any changes in the podspec require running `pod install` to have an effect.
 

--- a/docs/pages/modules/additional-platform-support.mdx
+++ b/docs/pages/modules/additional-platform-support.mdx
@@ -3,8 +3,8 @@ title: Additional platform support
 description: Learn how to add support for macOS and tvOS platforms.
 ---
 
-import { Step } from '~/ui/components/Step';
 import { DiffBlock } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
 
 Expo Modules API provides first-class support for Android and iOS. However, since all Apple platforms are based on the same foundation and use the same programming language, targeting other [Out-of-Tree platforms](https://reactnative.dev/docs/out-of-tree-platforms) in the Expo module is possible.
 

--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -10,7 +10,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { FileTree } from '~/ui/components/FileTree';
-import { Terminal } from '~/ui/components/Snippet';
+import { DiffBlock, Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { TabsGroup, Tabs, Tab } from '~/ui/components/Tabs';
 import { CODE } from '~/ui/components/Text';
@@ -130,22 +130,9 @@ In another terminal window, compile and run the example app:
 
 Add the native dependencies to the module by editing the **expo-radial-chart/android/build.gradle** and **expo-radial-chart/ios/ExpoRadialChart.podspec** files:
 
-```diff android/build.gradle
-dependencies {
-  implementation project(':expo-modules-core')
-  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-+ implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0'
-}
-```
+<DiffBlock source="/static/diffs/third-party-library/android-mpandroidchart-dependency.diff" />
 
-```diff ios/ExpoRadialChart.podspec
-  s.static_framework = true
-
-  s.dependency 'ExpoModulesCore'
-+ s.dependency 'DGCharts', '~> 5.1.0'
-
-  # Swift/Objective-C compatibility
-```
+<DiffBlock source="/static/diffs/third-party-library/ios-dgcharts-dependency.diff" />
 
 <Collapsible summary={<>Are you trying to use a <CODE>.aar</CODE> dependency?</>}>
 
@@ -153,49 +140,21 @@ dependencies {
   <Tab label="SDK 52 and later">
     Inside the **android** directory, create another directory called **libs** and place the **.aar** file inside it. Then, add the file as a Gradle project from autolinking:
 
-```diff expo-module.config.json
-    "android": {
-+     "gradleAarProjects": [
-+       {
-+         "name": "test-aar",
-+         "aarFilePath": "android/libs/test.aar"
-+       }
-+     ],
-    "modules": [
-```
+<DiffBlock source="/static/diffs/third-party-library/expo-module-config-gradle-aar.diff" />
 
     Finally, add the dependency to the `dependencies` list in the **android/build.gradle** file, using the dependency's specified name with `${project.name}$` prefix:
 
-```diff android/build.gradle
-dependencies {
-  implementation project(':expo-modules-core')
-  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-+ implementation project(":${project.name}\$test-aar")
-}
-```
+<DiffBlock source="/static/diffs/third-party-library/android-build-gradle-aar-project.diff" />
 
   </Tab>
   <Tab label="SDK 51 and earlier">
     Inside the **android** directory, create another directory called **libs** and place the **.aar** file inside it. Then, add the directory as a repository:
 
-```diff android/build.gradle
-  repositories {
-    mavenCentral()
-+   flatDir {
-+       dirs 'libs'
-+   }
-  }
-```
+<DiffBlock source="/static/diffs/third-party-library/android-build-gradle-flatdir.diff" />
 
 Finally, add the dependency to the `dependencies` list. Instead of the filename, use the package path, which includes the `@aar` at the end:
 
-```diff android/build.gradle
-dependencies {
-  implementation project(':expo-modules-core')
-  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-+ implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0@aar'
-}
-```
+<DiffBlock source="/static/diffs/third-party-library/android-build-gradle-mpandroidchart-aar.diff" />
 
   </Tab>
 </Tabs>
@@ -206,12 +165,7 @@ dependencies {
 
 On iOS, you can also use dependencies bundled as a framework by using the `vendored_frameworks` config option.
 
-```diff ios/ExpoRadialChart.podspec
-    s.static_framework = true
-    s.dependency 'ExpoModulesCore'
-+   s.vendored_frameworks = 'Frameworks/MyFramework.framework'
-    # Swift/Objective-C compatibility
-```
+<DiffBlock source="/static/diffs/third-party-library/ios-podspec-vendored-framework.diff" />
 
 > **info** **Note**: The file pattern used to specify the path to the framework is relative to the podspec file,
 > and doesn't support traversing the parent directory (`..`), meaning you need to place the framework inside the **ios** directory
@@ -219,10 +173,7 @@ On iOS, you can also use dependencies bundled as a framework by using the `vendo
 
 Once the framework is added, make sure that the `source_files` option file pattern doesn't match any files inside the framework. One way to achieve this is to move your iOS source Swift files (that is `ExpoRadialChartView.swift` and `ExpoRadialChartModule.swift`) into a **src** directory separate from where you placed your framework(s) and update the `source_files` option to only match the **src** directory:
 
-```diff ios/ExpoRadialChart.podspec
-- s.source_files = '**/*.{h,m,mm,swift,hpp,cpp}'
-+ s.source_files = 'src/**/*.{h,m,mm,swift,hpp,cpp}'
-```
+<DiffBlock source="/static/diffs/third-party-library/ios-podspec-source-files-src.diff" />
 
 Your **ios** directory should end up with a file structure similar to this:
 

--- a/docs/pages/push-notifications/sending-notifications-custom.mdx
+++ b/docs/pages/push-notifications/sending-notifications-custom.mdx
@@ -4,6 +4,8 @@ hideFromSearch: true
 description: Learn how to send notifications with FCM and APNs.
 ---
 
+import { DiffBlock } from '~/ui/components/Snippet';
+
 You may need finer-grained control over your notifications, in which case communicating directly with FCM and APNs may be necessary. The Expo platform does not lock you into using Expo Application Services, and the `expo-notifications` API is push-service agnostic.
 
 > **Note**: This guide does not aim to be a comprehensive resource for sending notifications via FCM or APNs. We recommend you read the official documentation to make sure you're following the latest instructions.
@@ -14,13 +16,18 @@ When using Expo notification service, you use the `ExpoPushToken` obtained with 
 
 If you instead want to send notifications via FCM or APNs, you need to obtain the native device token with [`getDevicePushTokenAsync`](/versions/latest/sdk/notifications/#getdevicepushtokenasync-devicepushtoken).
 
-```diff
-import * as Notifications from 'expo-notifications';
-...
-- const token = (await Notifications.getExpoPushTokenAsync()).data;
-+ const token = (await Notifications.getDevicePushTokenAsync()).data;
-// send token to your server
-```
+<DiffBlock
+  raw={`diff --git a/App.js b/App.js
+index 0000000..1111111 100644
+--- a/App.js
++++ b/App.js
+@@ -1,4 +1,4 @@
+ import * as Notifications from 'expo-notifications';
+ // ...
+-const token = (await Notifications.getExpoPushTokenAsync()).data;
++const token = (await Notifications.getDevicePushTokenAsync()).data;
+ // send token to your server`}
+/>
 
 ## FCMv1 server
 

--- a/docs/pages/router/advanced/custom-tabs.mdx
+++ b/docs/pages/router/advanced/custom-tabs.mdx
@@ -9,6 +9,7 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { FileTree } from '~/ui/components/FileTree';
+import { DiffBlock } from '~/ui/components/Snippet';
 
 > **important** Experimentally available in SDK 52 and later.
 
@@ -255,13 +256,7 @@ export function TabButton({ icon, children, isFocused, ...props }: TabButtonProp
 
 In Expo SDK 52 and earlier (React 18), use the legacy `forwardRef` function to access the `ref` handle.
 
-```diff
-- import { ComponentProps, Ref } from 'react';
-+ import { ComponentProps, Ref, forwardRef } from 'react';
-
-- export function TabButton({ ref }) {
-+ export const TabButton = forwardRef((props: TabButtonProps, ref: Ref<View>) => {
-```
+<DiffBlock source="/static/diffs/router/custom-tabs/forward-ref-tab-button.diff" />
 
 </Collapsible>
 

--- a/docs/pages/router/advanced/native-tabs.mdx
+++ b/docs/pages/router/advanced/native-tabs.mdx
@@ -9,6 +9,7 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { FileTree } from '~/ui/components/FileTree';
+import { DiffBlock } from '~/ui/components/Snippet';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 <VideoBoxLink
@@ -462,14 +463,7 @@ Native tabs are not designed to be a drop-in replacement for [JavaScript tabs](/
 
 `NativeTabs` has a React-first API that opts to use components for defining UI in favor of props objects.
 
-```diff
-- options={{
--   tabBarIcon: ({ focused, color, size }) => (
--     <Icon name="home" color={color} size={size} />
--   ),
-- }}
-+ <Icon sf="house" drawable="home_drawable" />
-```
+<DiffBlock source="/static/diffs/router/native-tabs/trigger-icon-component.diff" />
 
 ### Use Stacks inside tabs
 

--- a/docs/pages/router/migrate/from-react-navigation.mdx
+++ b/docs/pages/router/migrate/from-react-navigation.mdx
@@ -6,7 +6,7 @@ description: Learn how to migrate a project using React Navigation to Expo Route
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { FileTree } from '~/ui/components/FileTree';
-import { Terminal } from '~/ui/components/Snippet';
+import { Terminal, DiffBlock } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
 Both React Navigation and Expo Router are Expo frameworks for routing and navigation. Expo Router is a wrapper around React Navigation and many of the concepts are the same.
@@ -65,17 +65,7 @@ On web, returning `null` from the root will cause [static rendering](/router/web
 
 Expo Router automatically adds `react-native-safe-area-context` support.
 
-```diff
-- import { SafeAreaProvider } from 'react-native-safe-area-context';
-
-export default function App() {
-  return (
--    <SafeAreaProvider>
-      <MyApp />
--    </SafeAreaProvider>
-  )
-}
-```
+<DiffBlock source="/static/diffs/router/migrate-from-react-navigation/remove-safe-area-provider.diff" />
 
 Expo Router **does not** add `react-native-gesture-handler` (as of v3), so you'll have to add this yourself if you are using Gesture Handler or `<Drawer />` layout. Avoid using this package on web since it adds a lot of JavaScript that is often unused.
 
@@ -182,46 +172,15 @@ React Navigation v6 and lower will pass the props `{ navigation, route }` to eve
 
 Instead, migrate `navigation` to the `useRouter` hook.
 
-```diff
-+ import { useRouter } from 'expo-router';
-
-export default function Page({
--  navigation
-}) {
--  navigation.push('User', { user: 'bacon' });
-
-+  const router = useRouter();
-+  router.push('/users/bacon');
-}
-```
+<DiffBlock source="/static/diffs/router/migrate-from-react-navigation/use-router-hook.diff" />
 
 Similarly, migrate from the `route` prop to the [`useLocalSearchParams`](/router/reference/hooks/#uselocalsearchparams) hook.
 
-```diff
-+ import { useLocalSearchParams } from 'expo-router';
-
-export default function Page({
--  route
-}) {
--  const user = route?.params?.user;
-
-+  const { user } = useLocalSearchParams();
-}
-```
+<DiffBlock source="/static/diffs/router/migrate-from-react-navigation/use-local-search-params.diff" />
 
 To access the [`navigation.navigate`](https://reactnavigation.org/docs/navigation-object/#navigate), import the `navigation` prop from [`useNavigation`](/router/reference/hooks/#usenavigation) hook.
 
-```diff
-+ import { useNavigation } from 'expo-router';
-
-export default function Page({
-+  const navigation = useNavigation();
-
-  return (
-    <Button onPress={navigation.navigate('screenName')}>
-  )
-})
-```
+<DiffBlock source="/static/diffs/router/migrate-from-react-navigation/use-navigation-hook.diff" />
 
 ### Migrate the Link component
 

--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -7,7 +7,7 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { FileTree } from '~/ui/components/FileTree';
-import { Terminal } from '~/ui/components/Snippet';
+import { DiffBlock, Terminal } from '~/ui/components/Snippet';
 
 See more information about **metro.config.js** in the [customizing Metro guide](/guides/customizing-metro/).
 
@@ -127,11 +127,7 @@ In Expo, CSS Modules are defined by creating a file with the `.module.css` exten
 
 CSS Modules support platform extensions to allow you to define different styles for different platforms. For example, you can define a `module.ios.css` and `module.android.css` file to define styles for Android and iOS respectively. You'll need to import without the extension, for example:
 
-```diff App.js
-// Importing `./App.module.ios.css`:
-- import styles from './App.module.css';
-+ import styles from './App.module';
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/css-modules-import.diff" />
 
 Flipping the extension, for example, `App.ios.module.css` will not work and result in a universal module named `App.ios.module`.
 
@@ -663,15 +659,7 @@ module.exports = config;
 
 The Android **app/build.gradle** must be configured to use Expo CLI for production bundling. Modify the `react` config object:
 
-```diff android/app/build.gradle
-react {
-  ...
-+     // Use Expo CLI to bundle the app, this ensures the Metro config
-+     // works correctly with Expo projects.
-+     cliFile = new File(["node", "--print", "require.resolve('@expo/cli')"].execute(null, rootDir).text.trim())
-+     bundleCommand = "export:embed"
-}
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/android-use-expo-cli-bundling.diff" />
 
 ### `ios/<Project>.xcodeproj/project.pbxproj`
 
@@ -681,67 +669,15 @@ In your **ios/&lt;Project&gt;.xcodeproj/project.pbxproj** file, replace the foll
 
 Remove the **"Start Packager"** script. The dev server must be started with `npx expo` before/after running the app.
 
-```diff Start Packager
--    FD10A7F022414F080027D42C /* Start Packager */ = {
--			isa = PBXShellScriptBuildPhase;
--			alwaysOutOfDate = 1;
--			buildActionMask = 2147483647;
--			files = (
--			);
--			inputFileListPaths = (
--			);
--			inputPaths = (
--			);
--			name = "Start Packager";
--			outputFileListPaths = (
--			);
--			outputPaths = (
--			);
--			runOnlyForDeploymentPostprocessing = 0;
--			shellPath = /bin/sh;
--			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.updates\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.updates\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\nexport RCT_METRO_PORT=\"${RCT_METRO_PORT:=8081}\"\necho \"export RCT_METRO_PORT=${RCT_METRO_PORT}\" > `$NODE_BINARY --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/.packager.env'\"`\nif [ -z \"${RCT_NO_LAUNCH_PACKAGER+xxx}\" ] ; then\n  if nc -w 5 -z localhost ${RCT_METRO_PORT} ; then\n    if ! curl -s \"http://localhost:${RCT_METRO_PORT}/status\" | grep -q \"packager-status:running\" ; then\n      echo \"Port ${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\"\n      exit 2\n    fi\n  else\n    open `$NODE_BINARY --print \"require('path').dirname(require.resolve('expo/package.json')) + '/scripts/launchPackager.command'\"` || echo \"Can't start packager automatically\"\n  fi\nfi\n";
--			showEnvVarsInLog = 0;
--		};
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/ios-remove-start-packager.diff" />
 
 #### "Bundle React Native code and images" script
 
-```diff Bundle React Native code and images
-+			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n# The project root by default is one level up from the ios directory\nexport PROJECT_ROOT=\"$PROJECT_DIR\"/..\n\nif [[ \"$CONFIGURATION\" = *Debug* ]]; then\n  export SKIP_BUNDLING=1\nfi\nif [[ -z \"$ENTRY_FILE\" ]]; then\n  # Set the entry JS file using the bundler's entry resolution.\n  export ENTRY_FILE=\"$(\"$NODE_BINARY\" -e \"require('expo/scripts/resolveAppEntry')\" \"$PROJECT_ROOT\" ios absolute | tail -n 1)\"\nfi\n\nif [[ -z \"$CLI_PATH\" ]]; then\n  # Use Expo CLI\n  export CLI_PATH=\"$(\"$NODE_BINARY\" --print \"require.resolve('@expo/cli')\")\"\nfi\nif [[ -z \"$BUNDLE_COMMAND\" ]]; then\n  # Default Expo CLI command for bundling\n  export BUNDLE_COMMAND=\"export:embed\"\nfi\n\n`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\n\n";
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/ios-bundle-script.diff" />
 
 Alternatively, in the Xcode project, select the **"Bundle React Native code and images"** build phase and add the following modifications:
 
-```diff Bundle React Native code and images
-if [[ -f "$PODS_ROOT/../.xcode.env" ]]; then
-  source "$PODS_ROOT/../.xcode.env"
-fi
-if [[ -f "$PODS_ROOT/../.xcode.env.local" ]]; then
-  source "$PODS_ROOT/../.xcode.env.local"
-fi
-
-# The project root by default is one level up from the ios directory
-export PROJECT_ROOT="$PROJECT_DIR"/..
-
-if [[ "$CONFIGURATION" = *Debug* ]]; then
-  export SKIP_BUNDLING=1
-fi
-+ if [[ -z "$ENTRY_FILE" ]]; then
-+   # Set the entry JS file using the bundler's entry resolution.
-+   export ENTRY_FILE="$("$NODE_BINARY" -e "require('expo/scripts/resolveAppEntry')" "$PROJECT_ROOT" ios absolute | tail -n 1)"
-+ fi
-
-+ if [[ -z "$CLI_PATH" ]]; then
-+   # Use Expo CLI
-+   export CLI_PATH="$("$NODE_BINARY" --print "require.resolve('@expo/cli')")"
-+ fi
-+ if [[ -z "$BUNDLE_COMMAND" ]]; then
-+   # Default Expo CLI command for bundling
-+   export BUNDLE_COMMAND="export:embed"
-+ fi
-
-`"$NODE_BINARY" --print "require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'"`
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/ios-bundle-script-inline.diff" />
 
 > You can set `CLI_PATH`, `BUNDLE_COMMAND`, and `ENTRY_FILE` environment variables to overwrite these defaults.
 
@@ -753,40 +689,16 @@ By default, React Native only supports using a root `index.js` file as the entry
 
 Development mode entry files can be enabled by using the [`expo-dev-client`](../sdk/dev-client/) package. Alternatively you can add the following configuration:
 
-```diff ios/<Project>/AppDelegate.mm
-- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
-{
-#if DEBUG
--  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
-+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@".expo/.virtual-metro-entry"];
-#else
-  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
-#endif
-}
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/ios-appdelegate-entry.diff" />
 
-```diff android/app/src/main/java/<Project>/MainApplication.java
-@Override
-protected String getJSMainModuleName() {
--  return "index";
-+  return ".expo/.virtual-metro-entry";
-}
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/android-mainapplication-entry.diff" />
 
 #### Production
 
 In your **ios/&lt;Project&gt;.xcodeproj/project.pbxproj** file, replace the **"Bundle React Native code and images"** script to set `$ENTRY_FILE` according using Metro:
 
-```diff ios/<Project>/project.pbxproj
-+			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n# The project root by default is one level up from the ios directory\nexport PROJECT_ROOT=\"$PROJECT_DIR\"/..\n\nif [[ \"$CONFIGURATION\" = *Debug* ]]; then\n  export SKIP_BUNDLING=1\nfi\nif [[ -z \"$ENTRY_FILE\" ]]; then\n  # Set the entry JS file using the bundler's entry resolution.\n  export ENTRY_FILE=\"$(\"$NODE_BINARY\" -e \"require('expo/scripts/resolveAppEntry')\" \"$PROJECT_ROOT\" ios absolute | tail -n 1)\"\nfi\n\nif [[ -z \"$CLI_PATH\" ]]; then\n  # Use Expo CLI\n  export CLI_PATH=\"$(\"$NODE_BINARY\" --print \"require.resolve('@expo/cli')\")\"\nfi\nif [[ -z \"$BUNDLE_COMMAND\" ]]; then\n  # Default Expo CLI command for bundling\n  export BUNDLE_COMMAND=\"export:embed\"\nfi\n\n`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\n\n";
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/ios-bundle-script.diff" />
 
 The Android **app/build.gradle** must be configured to use Metro module resolution to find the root entry file. Modify the `react` config object:
 
-```diff app/build.gradle
-+ def projectRoot = rootDir.getAbsoluteFile().getParentFile().getAbsolutePath()
-
-react {
-+    entryFile = file(["node", "-e", "require('expo/scripts/resolveAppEntry')", projectRoot, "android", "absolute"].execute(null, rootDir).text.trim())
-}
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/android-entry-file.diff" />

--- a/docs/pages/versions/v52.0.0/config/metro.mdx
+++ b/docs/pages/versions/v52.0.0/config/metro.mdx
@@ -7,7 +7,7 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { FileTree } from '~/ui/components/FileTree';
-import { Terminal } from '~/ui/components/Snippet';
+import { DiffBlock, Terminal } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
 See more information about **metro.config.js** in the [customizing Metro guide](/guides/customizing-metro/).
@@ -149,11 +149,7 @@ In Expo, CSS Modules are defined by creating a file with the `.module.css` exten
 
 CSS Modules support platform extensions to allow you to define different styles for different platforms. For example, you can define a `module.ios.css` and `module.android.css` file to define styles for Android and iOS respectively. You'll need to import without the extension, for example:
 
-```diff App.js
-// Importing `./App.module.ios.css`:
-- import styles from './App.module.css';
-+ import styles from './App.module';
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/css-modules-import.diff" />
 
 Flipping the extension, for example, `App.ios.module.css` will not work and result in a universal module named `App.ios.module`.
 
@@ -537,15 +533,7 @@ module.exports = config;
 
 The Android `app/build.gradle` must be configured to use Expo CLI for production bundling. Modify the `react` config object:
 
-```diff
-react {
-  ...
-+     // Use Expo CLI to bundle the app, this ensures the Metro config
-+     // works correctly with Expo projects.
-+     cliFile = new File(["node", "--print", "require.resolve('@expo/cli')"].execute(null, rootDir).text.trim())
-+     bundleCommand = "export:embed"
-}
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/android-use-expo-cli-bundling.diff" />
 
 ### `ios/<Project>.xcodeproj/project.pbxproj`
 
@@ -555,67 +543,15 @@ In your `ios/<Project>.xcodeproj/project.pbxproj` file, replace the following sc
 
 Remove the "Start Packager" script in SDK 50 and later. The dev server must be started with `npx expo` before/after running the app.
 
-```diff
--    FD10A7F022414F080027D42C /* Start Packager */ = {
--			isa = PBXShellScriptBuildPhase;
--			alwaysOutOfDate = 1;
--			buildActionMask = 2147483647;
--			files = (
--			);
--			inputFileListPaths = (
--			);
--			inputPaths = (
--			);
--			name = "Start Packager";
--			outputFileListPaths = (
--			);
--			outputPaths = (
--			);
--			runOnlyForDeploymentPostprocessing = 0;
--			shellPath = /bin/sh;
--			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.updates\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.updates\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\nexport RCT_METRO_PORT=\"${RCT_METRO_PORT:=8081}\"\necho \"export RCT_METRO_PORT=${RCT_METRO_PORT}\" > `$NODE_BINARY --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/.packager.env'\"`\nif [ -z \"${RCT_NO_LAUNCH_PACKAGER+xxx}\" ] ; then\n  if nc -w 5 -z localhost ${RCT_METRO_PORT} ; then\n    if ! curl -s \"http://localhost:${RCT_METRO_PORT}/status\" | grep -q \"packager-status:running\" ; then\n      echo \"Port ${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\"\n      exit 2\n    fi\n  else\n    open `$NODE_BINARY --print \"require('path').dirname(require.resolve('expo/package.json')) + '/scripts/launchPackager.command'\"` || echo \"Can't start packager automatically\"\n  fi\nfi\n";
--			showEnvVarsInLog = 0;
--		};
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/ios-remove-start-packager.diff" />
 
 #### "Bundle React Native code and images"
 
-```diff
-+			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n# The project root by default is one level up from the ios directory\nexport PROJECT_ROOT=\"$PROJECT_DIR\"/..\n\nif [[ \"$CONFIGURATION\" = *Debug* ]]; then\n  export SKIP_BUNDLING=1\nfi\nif [[ -z \"$ENTRY_FILE\" ]]; then\n  # Set the entry JS file using the bundler's entry resolution.\n  export ENTRY_FILE=\"$(\"$NODE_BINARY\" -e \"require('expo/scripts/resolveAppEntry')\" \"$PROJECT_ROOT\" ios absolute | tail -n 1)\"\nfi\n\nif [[ -z \"$CLI_PATH\" ]]; then\n  # Use Expo CLI\n  export CLI_PATH=\"$(\"$NODE_BINARY\" --print \"require.resolve('@expo/cli')\")\"\nfi\nif [[ -z \"$BUNDLE_COMMAND\" ]]; then\n  # Default Expo CLI command for bundling\n  export BUNDLE_COMMAND=\"export:embed\"\nfi\n\n`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\n\n";
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/ios-bundle-script.diff" />
 
 **Alternatively**, in the Xcode project, select the "Bundle React Native code and images" build phase and add the following modifications:
 
-```diff
-if [[ -f "$PODS_ROOT/../.xcode.env" ]]; then
-  source "$PODS_ROOT/../.xcode.env"
-fi
-if [[ -f "$PODS_ROOT/../.xcode.env.local" ]]; then
-  source "$PODS_ROOT/../.xcode.env.local"
-fi
-
-# The project root by default is one level up from the ios directory
-export PROJECT_ROOT="$PROJECT_DIR"/..
-
-if [[ "$CONFIGURATION" = *Debug* ]]; then
-  export SKIP_BUNDLING=1
-fi
-+ if [[ -z "$ENTRY_FILE" ]]; then
-+   # Set the entry JS file using the bundler's entry resolution.
-+   export ENTRY_FILE="$("$NODE_BINARY" -e "require('expo/scripts/resolveAppEntry')" "$PROJECT_ROOT" ios absolute | tail -n 1)"
-+ fi
-
-+ if [[ -z "$CLI_PATH" ]]; then
-+   # Use Expo CLI
-+   export CLI_PATH="$("$NODE_BINARY" --print "require.resolve('@expo/cli')")"
-+ fi
-+ if [[ -z "$BUNDLE_COMMAND" ]]; then
-+   # Default Expo CLI command for bundling
-+   export BUNDLE_COMMAND="export:embed"
-+ fi
-
-`"$NODE_BINARY" --print "require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'"`
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/ios-bundle-script-inline.diff" />
 
 > You can set `CLI_PATH`, `BUNDLE_COMMAND`, and `ENTRY_FILE` environment variables to overwrite these defaults.
 
@@ -629,42 +565,18 @@ Development mode entry files can be enabled by using the [`expo-dev-client`](../
 
 In the `ios/[project]/AppDelegate.mm` file:
 
-```diff
-- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
-{
-#if DEBUG
--  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
-+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@".expo/.virtual-metro-entry"];
-#else
-  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
-#endif
-}
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/ios-appdelegate-entry.diff" />
 
 In the `android/app/src/main/java/**/MainApplication.java`:
 
-```diff
-@Override
-protected String getJSMainModuleName() {
--  return "index";
-+  return ".expo/.virtual-metro-entry";
-}
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/android-mainapplication-entry.diff" />
 
 #### Production
 
 In your `ios/<Project>.xcodeproj/project.pbxproj` file, replace the `"Bundle React Native code and images"` script to set `$ENTRY_FILE` according using Metro:
 
-```diff
-+			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n# The project root by default is one level up from the ios directory\nexport PROJECT_ROOT=\"$PROJECT_DIR\"/..\n\nif [[ \"$CONFIGURATION\" = *Debug* ]]; then\n  export SKIP_BUNDLING=1\nfi\nif [[ -z \"$ENTRY_FILE\" ]]; then\n  # Set the entry JS file using the bundler's entry resolution.\n  export ENTRY_FILE=\"$(\"$NODE_BINARY\" -e \"require('expo/scripts/resolveAppEntry')\" \"$PROJECT_ROOT\" ios absolute | tail -n 1)\"\nfi\n\nif [[ -z \"$CLI_PATH\" ]]; then\n  # Use Expo CLI\n  export CLI_PATH=\"$(\"$NODE_BINARY\" --print \"require.resolve('@expo/cli')\")\"\nfi\nif [[ -z \"$BUNDLE_COMMAND\" ]]; then\n  # Default Expo CLI command for bundling\n  export BUNDLE_COMMAND=\"export:embed\"\nfi\n\n`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\n\n";
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/ios-bundle-script.diff" />
 
 The Android `app/build.gradle` must be configured to use Metro module resolution to find the root entry file. Modify the `react` config object:
 
-```diff
-+ def projectRoot = rootDir.getAbsoluteFile().getParentFile().getAbsolutePath()
-
-react {
-+    entryFile = file(["node", "-e", "require('expo/scripts/resolveAppEntry')", projectRoot, "android", "absolute"].execute(null, rootDir).text.trim())
-}
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/android-entry-file.diff" />

--- a/docs/pages/versions/v53.0.0/config/metro.mdx
+++ b/docs/pages/versions/v53.0.0/config/metro.mdx
@@ -7,7 +7,7 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { FileTree } from '~/ui/components/FileTree';
-import { Terminal } from '~/ui/components/Snippet';
+import { DiffBlock, Terminal } from '~/ui/components/Snippet';
 
 See more information about **metro.config.js** in the [customizing Metro guide](/guides/customizing-metro/).
 
@@ -127,11 +127,7 @@ In Expo, CSS Modules are defined by creating a file with the `.module.css` exten
 
 CSS Modules support platform extensions to allow you to define different styles for different platforms. For example, you can define a `module.ios.css` and `module.android.css` file to define styles for Android and iOS respectively. You'll need to import without the extension, for example:
 
-```diff App.js
-// Importing `./App.module.ios.css`:
-- import styles from './App.module.css';
-+ import styles from './App.module';
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/css-modules-import.diff" />
 
 Flipping the extension, for example, `App.ios.module.css` will not work and result in a universal module named `App.ios.module`.
 
@@ -651,15 +647,7 @@ module.exports = config;
 
 The Android **app/build.gradle** must be configured to use Expo CLI for production bundling. Modify the `react` config object:
 
-```diff android/app/build.gradle
-react {
-  ...
-+     // Use Expo CLI to bundle the app, this ensures the Metro config
-+     // works correctly with Expo projects.
-+     cliFile = new File(["node", "--print", "require.resolve('@expo/cli')"].execute(null, rootDir).text.trim())
-+     bundleCommand = "export:embed"
-}
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/android-use-expo-cli-bundling.diff" />
 
 ### `ios/<Project>.xcodeproj/project.pbxproj`
 
@@ -669,67 +657,15 @@ In your **ios/&lt;Project&gt;.xcodeproj/project.pbxproj** file, replace the foll
 
 Remove the **"Start Packager"** script. The dev server must be started with `npx expo` before/after running the app.
 
-```diff Start Packager
--    FD10A7F022414F080027D42C /* Start Packager */ = {
--			isa = PBXShellScriptBuildPhase;
--			alwaysOutOfDate = 1;
--			buildActionMask = 2147483647;
--			files = (
--			);
--			inputFileListPaths = (
--			);
--			inputPaths = (
--			);
--			name = "Start Packager";
--			outputFileListPaths = (
--			);
--			outputPaths = (
--			);
--			runOnlyForDeploymentPostprocessing = 0;
--			shellPath = /bin/sh;
--			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.updates\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.updates\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\nexport RCT_METRO_PORT=\"${RCT_METRO_PORT:=8081}\"\necho \"export RCT_METRO_PORT=${RCT_METRO_PORT}\" > `$NODE_BINARY --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/.packager.env'\"`\nif [ -z \"${RCT_NO_LAUNCH_PACKAGER+xxx}\" ] ; then\n  if nc -w 5 -z localhost ${RCT_METRO_PORT} ; then\n    if ! curl -s \"http://localhost:${RCT_METRO_PORT}/status\" | grep -q \"packager-status:running\" ; then\n      echo \"Port ${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\"\n      exit 2\n    fi\n  else\n    open `$NODE_BINARY --print \"require('path').dirname(require.resolve('expo/package.json')) + '/scripts/launchPackager.command'\"` || echo \"Can't start packager automatically\"\n  fi\nfi\n";
--			showEnvVarsInLog = 0;
--		};
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/ios-remove-start-packager.diff" />
 
 #### "Bundle React Native code and images" script
 
-```diff Bundle React Native code and images
-+			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n# The project root by default is one level up from the ios directory\nexport PROJECT_ROOT=\"$PROJECT_DIR\"/..\n\nif [[ \"$CONFIGURATION\" = *Debug* ]]; then\n  export SKIP_BUNDLING=1\nfi\nif [[ -z \"$ENTRY_FILE\" ]]; then\n  # Set the entry JS file using the bundler's entry resolution.\n  export ENTRY_FILE=\"$(\"$NODE_BINARY\" -e \"require('expo/scripts/resolveAppEntry')\" \"$PROJECT_ROOT\" ios absolute | tail -n 1)\"\nfi\n\nif [[ -z \"$CLI_PATH\" ]]; then\n  # Use Expo CLI\n  export CLI_PATH=\"$(\"$NODE_BINARY\" --print \"require.resolve('@expo/cli')\")\"\nfi\nif [[ -z \"$BUNDLE_COMMAND\" ]]; then\n  # Default Expo CLI command for bundling\n  export BUNDLE_COMMAND=\"export:embed\"\nfi\n\n`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\n\n";
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/ios-bundle-script.diff" />
 
 Alternatively, in the Xcode project, select the **"Bundle React Native code and images"** build phase and add the following modifications:
 
-```diff Bundle React Native code and images
-if [[ -f "$PODS_ROOT/../.xcode.env" ]]; then
-  source "$PODS_ROOT/../.xcode.env"
-fi
-if [[ -f "$PODS_ROOT/../.xcode.env.local" ]]; then
-  source "$PODS_ROOT/../.xcode.env.local"
-fi
-
-# The project root by default is one level up from the ios directory
-export PROJECT_ROOT="$PROJECT_DIR"/..
-
-if [[ "$CONFIGURATION" = *Debug* ]]; then
-  export SKIP_BUNDLING=1
-fi
-+ if [[ -z "$ENTRY_FILE" ]]; then
-+   # Set the entry JS file using the bundler's entry resolution.
-+   export ENTRY_FILE="$("$NODE_BINARY" -e "require('expo/scripts/resolveAppEntry')" "$PROJECT_ROOT" ios absolute | tail -n 1)"
-+ fi
-
-+ if [[ -z "$CLI_PATH" ]]; then
-+   # Use Expo CLI
-+   export CLI_PATH="$("$NODE_BINARY" --print "require.resolve('@expo/cli')")"
-+ fi
-+ if [[ -z "$BUNDLE_COMMAND" ]]; then
-+   # Default Expo CLI command for bundling
-+   export BUNDLE_COMMAND="export:embed"
-+ fi
-
-`"$NODE_BINARY" --print "require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'"`
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/ios-bundle-script-inline.diff" />
 
 > You can set `CLI_PATH`, `BUNDLE_COMMAND`, and `ENTRY_FILE` environment variables to overwrite these defaults.
 
@@ -741,40 +677,16 @@ By default, React Native only supports using a root `index.js` file as the entry
 
 Development mode entry files can be enabled by using the [`expo-dev-client`](../sdk/dev-client/) package. Alternatively you can add the following configuration:
 
-```diff ios/<Project>/AppDelegate.mm
-- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
-{
-#if DEBUG
--  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
-+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@".expo/.virtual-metro-entry"];
-#else
-  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
-#endif
-}
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/ios-appdelegate-entry.diff" />
 
-```diff android/app/src/main/java/<Project>/MainApplication.java
-@Override
-protected String getJSMainModuleName() {
--  return "index";
-+  return ".expo/.virtual-metro-entry";
-}
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/android-mainapplication-entry.diff" />
 
 #### Production
 
 In your **ios/&lt;Project&gt;.xcodeproj/project.pbxproj** file, replace the **"Bundle React Native code and images"** script to set `$ENTRY_FILE` according using Metro:
 
-```diff ios/<Project>/project.pbxproj
-+			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n# The project root by default is one level up from the ios directory\nexport PROJECT_ROOT=\"$PROJECT_DIR\"/..\n\nif [[ \"$CONFIGURATION\" = *Debug* ]]; then\n  export SKIP_BUNDLING=1\nfi\nif [[ -z \"$ENTRY_FILE\" ]]; then\n  # Set the entry JS file using the bundler's entry resolution.\n  export ENTRY_FILE=\"$(\"$NODE_BINARY\" -e \"require('expo/scripts/resolveAppEntry')\" \"$PROJECT_ROOT\" ios absolute | tail -n 1)\"\nfi\n\nif [[ -z \"$CLI_PATH\" ]]; then\n  # Use Expo CLI\n  export CLI_PATH=\"$(\"$NODE_BINARY\" --print \"require.resolve('@expo/cli')\")\"\nfi\nif [[ -z \"$BUNDLE_COMMAND\" ]]; then\n  # Default Expo CLI command for bundling\n  export BUNDLE_COMMAND=\"export:embed\"\nfi\n\n`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\n\n";
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/ios-bundle-script.diff" />
 
 The Android **app/build.gradle** must be configured to use Metro module resolution to find the root entry file. Modify the `react` config object:
 
-```diff app/build.gradle
-+ def projectRoot = rootDir.getAbsoluteFile().getParentFile().getAbsolutePath()
-
-react {
-+    entryFile = file(["node", "-e", "require('expo/scripts/resolveAppEntry')", projectRoot, "android", "absolute"].execute(null, rootDir).text.trim())
-}
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/android-entry-file.diff" />

--- a/docs/pages/versions/v54.0.0/config/metro.mdx
+++ b/docs/pages/versions/v54.0.0/config/metro.mdx
@@ -7,7 +7,7 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { FileTree } from '~/ui/components/FileTree';
-import { Terminal } from '~/ui/components/Snippet';
+import { DiffBlock, Terminal } from '~/ui/components/Snippet';
 
 See more information about **metro.config.js** in the [customizing Metro guide](/guides/customizing-metro/).
 
@@ -127,11 +127,7 @@ In Expo, CSS Modules are defined by creating a file with the `.module.css` exten
 
 CSS Modules support platform extensions to allow you to define different styles for different platforms. For example, you can define a `module.ios.css` and `module.android.css` file to define styles for Android and iOS respectively. You'll need to import without the extension, for example:
 
-```diff App.js
-// Importing `./App.module.ios.css`:
-- import styles from './App.module.css';
-+ import styles from './App.module';
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/css-modules-import.diff" />
 
 Flipping the extension, for example, `App.ios.module.css` will not work and result in a universal module named `App.ios.module`.
 
@@ -663,15 +659,7 @@ module.exports = config;
 
 The Android **app/build.gradle** must be configured to use Expo CLI for production bundling. Modify the `react` config object:
 
-```diff android/app/build.gradle
-react {
-  ...
-+     // Use Expo CLI to bundle the app, this ensures the Metro config
-+     // works correctly with Expo projects.
-+     cliFile = new File(["node", "--print", "require.resolve('@expo/cli')"].execute(null, rootDir).text.trim())
-+     bundleCommand = "export:embed"
-}
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/android-use-expo-cli-bundling.diff" />
 
 ### `ios/<Project>.xcodeproj/project.pbxproj`
 
@@ -681,67 +669,15 @@ In your **ios/&lt;Project&gt;.xcodeproj/project.pbxproj** file, replace the foll
 
 Remove the **"Start Packager"** script. The dev server must be started with `npx expo` before/after running the app.
 
-```diff Start Packager
--    FD10A7F022414F080027D42C /* Start Packager */ = {
--			isa = PBXShellScriptBuildPhase;
--			alwaysOutOfDate = 1;
--			buildActionMask = 2147483647;
--			files = (
--			);
--			inputFileListPaths = (
--			);
--			inputPaths = (
--			);
--			name = "Start Packager";
--			outputFileListPaths = (
--			);
--			outputPaths = (
--			);
--			runOnlyForDeploymentPostprocessing = 0;
--			shellPath = /bin/sh;
--			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.updates\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.updates\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\nexport RCT_METRO_PORT=\"${RCT_METRO_PORT:=8081}\"\necho \"export RCT_METRO_PORT=${RCT_METRO_PORT}\" > `$NODE_BINARY --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/.packager.env'\"`\nif [ -z \"${RCT_NO_LAUNCH_PACKAGER+xxx}\" ] ; then\n  if nc -w 5 -z localhost ${RCT_METRO_PORT} ; then\n    if ! curl -s \"http://localhost:${RCT_METRO_PORT}/status\" | grep -q \"packager-status:running\" ; then\n      echo \"Port ${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\"\n      exit 2\n    fi\n  else\n    open `$NODE_BINARY --print \"require('path').dirname(require.resolve('expo/package.json')) + '/scripts/launchPackager.command'\"` || echo \"Can't start packager automatically\"\n  fi\nfi\n";
--			showEnvVarsInLog = 0;
--		};
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/ios-remove-start-packager.diff" />
 
 #### "Bundle React Native code and images" script
 
-```diff Bundle React Native code and images
-+			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n# The project root by default is one level up from the ios directory\nexport PROJECT_ROOT=\"$PROJECT_DIR\"/..\n\nif [[ \"$CONFIGURATION\" = *Debug* ]]; then\n  export SKIP_BUNDLING=1\nfi\nif [[ -z \"$ENTRY_FILE\" ]]; then\n  # Set the entry JS file using the bundler's entry resolution.\n  export ENTRY_FILE=\"$(\"$NODE_BINARY\" -e \"require('expo/scripts/resolveAppEntry')\" \"$PROJECT_ROOT\" ios absolute | tail -n 1)\"\nfi\n\nif [[ -z \"$CLI_PATH\" ]]; then\n  # Use Expo CLI\n  export CLI_PATH=\"$(\"$NODE_BINARY\" --print \"require.resolve('@expo/cli')\")\"\nfi\nif [[ -z \"$BUNDLE_COMMAND\" ]]; then\n  # Default Expo CLI command for bundling\n  export BUNDLE_COMMAND=\"export:embed\"\nfi\n\n`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\n\n";
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/ios-bundle-script.diff" />
 
 Alternatively, in the Xcode project, select the **"Bundle React Native code and images"** build phase and add the following modifications:
 
-```diff Bundle React Native code and images
-if [[ -f "$PODS_ROOT/../.xcode.env" ]]; then
-  source "$PODS_ROOT/../.xcode.env"
-fi
-if [[ -f "$PODS_ROOT/../.xcode.env.local" ]]; then
-  source "$PODS_ROOT/../.xcode.env.local"
-fi
-
-# The project root by default is one level up from the ios directory
-export PROJECT_ROOT="$PROJECT_DIR"/..
-
-if [[ "$CONFIGURATION" = *Debug* ]]; then
-  export SKIP_BUNDLING=1
-fi
-+ if [[ -z "$ENTRY_FILE" ]]; then
-+   # Set the entry JS file using the bundler's entry resolution.
-+   export ENTRY_FILE="$("$NODE_BINARY" -e "require('expo/scripts/resolveAppEntry')" "$PROJECT_ROOT" ios absolute | tail -n 1)"
-+ fi
-
-+ if [[ -z "$CLI_PATH" ]]; then
-+   # Use Expo CLI
-+   export CLI_PATH="$("$NODE_BINARY" --print "require.resolve('@expo/cli')")"
-+ fi
-+ if [[ -z "$BUNDLE_COMMAND" ]]; then
-+   # Default Expo CLI command for bundling
-+   export BUNDLE_COMMAND="export:embed"
-+ fi
-
-`"$NODE_BINARY" --print "require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'"`
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/ios-bundle-script-inline.diff" />
 
 > You can set `CLI_PATH`, `BUNDLE_COMMAND`, and `ENTRY_FILE` environment variables to overwrite these defaults.
 
@@ -753,40 +689,16 @@ By default, React Native only supports using a root `index.js` file as the entry
 
 Development mode entry files can be enabled by using the [`expo-dev-client`](../sdk/dev-client/) package. Alternatively you can add the following configuration:
 
-```diff ios/<Project>/AppDelegate.mm
-- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
-{
-#if DEBUG
--  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
-+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@".expo/.virtual-metro-entry"];
-#else
-  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
-#endif
-}
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/ios-appdelegate-entry.diff" />
 
-```diff android/app/src/main/java/<Project>/MainApplication.java
-@Override
-protected String getJSMainModuleName() {
--  return "index";
-+  return ".expo/.virtual-metro-entry";
-}
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/android-mainapplication-entry.diff" />
 
 #### Production
 
 In your **ios/&lt;Project&gt;.xcodeproj/project.pbxproj** file, replace the **"Bundle React Native code and images"** script to set `$ENTRY_FILE` according using Metro:
 
-```diff ios/<Project>/project.pbxproj
-+			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n# The project root by default is one level up from the ios directory\nexport PROJECT_ROOT=\"$PROJECT_DIR\"/..\n\nif [[ \"$CONFIGURATION\" = *Debug* ]]; then\n  export SKIP_BUNDLING=1\nfi\nif [[ -z \"$ENTRY_FILE\" ]]; then\n  # Set the entry JS file using the bundler's entry resolution.\n  export ENTRY_FILE=\"$(\"$NODE_BINARY\" -e \"require('expo/scripts/resolveAppEntry')\" \"$PROJECT_ROOT\" ios absolute | tail -n 1)\"\nfi\n\nif [[ -z \"$CLI_PATH\" ]]; then\n  # Use Expo CLI\n  export CLI_PATH=\"$(\"$NODE_BINARY\" --print \"require.resolve('@expo/cli')\")\"\nfi\nif [[ -z \"$BUNDLE_COMMAND\" ]]; then\n  # Default Expo CLI command for bundling\n  export BUNDLE_COMMAND=\"export:embed\"\nfi\n\n`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\n\n";
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/ios-bundle-script.diff" />
 
 The Android **app/build.gradle** must be configured to use Metro module resolution to find the root entry file. Modify the `react` config object:
 
-```diff app/build.gradle
-+ def projectRoot = rootDir.getAbsoluteFile().getParentFile().getAbsolutePath()
-
-react {
-+    entryFile = file(["node", "-e", "require('expo/scripts/resolveAppEntry')", projectRoot, "android", "absolute"].execute(null, rootDir).text.trim())
-}
-```
+<DiffBlock source="/static/diffs/config/metro-unversioned/android-entry-file.diff" />

--- a/docs/pages/workflow/web.mdx
+++ b/docs/pages/workflow/web.mdx
@@ -82,7 +82,7 @@ If you haven't added Expo to your React Native app yet, you can either [install 
 -import {name as appName} from './app.json';
 +import {registerRootComponent} from 'expo';
 import App from './App';
--
+
 -AppRegistry.registerComponent(appName, () => App);
 +registerRootComponent(App);`}
 />

--- a/docs/pages/workflow/web.mdx
+++ b/docs/pages/workflow/web.mdx
@@ -11,7 +11,7 @@ import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
-import { Terminal } from '~/ui/components/Snippet';
+import { DiffBlock, Terminal } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { CODE } from '~/ui/components/Text';
 
@@ -73,16 +73,19 @@ If you haven't added Expo to your React Native app yet, you can either [install 
 
 2. Modify the entry file to use [`registerRootComponent`](/versions/latest/sdk/expo/#registerrootcomponentcomponent) instead of `AppRegistry.registerComponent`:
 
-```diff
-+ import {registerRootComponent} from 'expo';
-
+<DiffBlock
+  raw={`diff --git a/index.js b/index.js
+--- a/index.js
++++ b/index.js
+@@ -1,5 +1,4 @@
+-import {AppRegistry} from 'react-native';
+-import {name as appName} from './app.json';
++import {registerRootComponent} from 'expo';
 import App from './App';
-- import {AppRegistry} from 'react-native';
-- import {name as appName} from './app.json';
-
-- AppRegistry.registerComponent(appName, () => App);
-+ registerRootComponent(App);
-```
+-
+-AppRegistry.registerComponent(appName, () => App);
++registerRootComponent(App);`}
+/>
 
 </Collapsible>
 

--- a/docs/public/static/diffs/config/metro-unversioned/android-entry-file.diff
+++ b/docs/public/static/diffs/config/metro-unversioned/android-entry-file.diff
@@ -1,0 +1,11 @@
+diff --git a/android/app/build.gradle b/android/app/build.gradle
+index 0000000..1111111 100644
+--- a/android/app/build.gradle
++++ b/android/app/build.gradle
+@@ -1,4 +1,5 @@
++def projectRoot = rootDir.getAbsoluteFile().getParentFile().getAbsolutePath()
+
+react {
+
++  entryFile = file(["node", "-e", "require('expo/scripts/resolveAppEntry')", projectRoot, "android", "absolute"].execute(null, rootDir).text.trim())
+}

--- a/docs/public/static/diffs/config/metro-unversioned/android-mainapplication-entry.diff
+++ b/docs/public/static/diffs/config/metro-unversioned/android-mainapplication-entry.diff
@@ -1,0 +1,10 @@
+diff --git a/android/app/src/main/java/<Project>/MainApplication.java b/android/app/src/main/java/<Project>/MainApplication.java
+index 0000000..1111111 100644
+--- a/android/app/src/main/java/<Project>/MainApplication.java
++++ b/android/app/src/main/java/<Project>/MainApplication.java
+@@ -1,4 +1,4 @@
+ @Override
+ protected String getJSMainModuleName() {
+-  return "index";
++  return ".expo/.virtual-metro-entry";
+ }

--- a/docs/public/static/diffs/config/metro-unversioned/android-use-expo-cli-bundling.diff
+++ b/docs/public/static/diffs/config/metro-unversioned/android-use-expo-cli-bundling.diff
@@ -1,0 +1,15 @@
+diff --git a/android/app/build.gradle b/android/app/build.gradle
+index 0000000..1111111 100644
+--- a/android/app/build.gradle
++++ b/android/app/build.gradle
+@@ -1,3 +1,7 @@
+-react {
+-  ...
+-}
++react {
++  // ...
++  // Use Expo CLI to bundle the app, this ensures the Metro config
++  // works correctly with Expo projects.
++  cliFile = new File(["node", "--print", "require.resolve('@expo/cli')"].execute(null, rootDir).text.trim())
++  bundleCommand = "export:embed"
++}

--- a/docs/public/static/diffs/config/metro-unversioned/css-modules-import.diff
+++ b/docs/public/static/diffs/config/metro-unversioned/css-modules-import.diff
@@ -1,0 +1,9 @@
+diff --git a/App.js b/App.js
+index 0000000..1111111 100644
+--- a/App.js
++++ b/App.js
+@@ -1,2 +1,2 @@
+-// Importing `./App.module.ios.css`:
+-import styles from './App.module.css';
++// Importing `./App.module.ios.css`:
++import styles from './App.module';

--- a/docs/public/static/diffs/config/metro-unversioned/ios-appdelegate-entry.diff
+++ b/docs/public/static/diffs/config/metro-unversioned/ios-appdelegate-entry.diff
@@ -1,0 +1,14 @@
+diff --git a/ios/<Project>/AppDelegate.mm b/ios/<Project>/AppDelegate.mm
+index 0000000..1111111 100644
+--- a/ios/<Project>/AppDelegate.mm
++++ b/ios/<Project>/AppDelegate.mm
+@@ -1,7 +1,7 @@
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+ {
+ #if DEBUG
+-  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
++  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@".expo/.virtual-metro-entry"];
+ #else
+   return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+ #endif
+ }

--- a/docs/public/static/diffs/config/metro-unversioned/ios-bundle-script-inline.diff
+++ b/docs/public/static/diffs/config/metro-unversioned/ios-bundle-script-inline.diff
@@ -1,0 +1,33 @@
+diff --git a/ios/<Project>.xcodeproj/project.pbxproj b/ios/<Project>.xcodeproj/project.pbxproj
+index 0000000..1111111 100644
+--- a/ios/<Project>.xcodeproj/project.pbxproj
++++ b/ios/<Project>.xcodeproj/project.pbxproj
+@@ -1,12 +1,19 @@
+ if [[ -f "$PODS_ROOT/../.xcode.env" ]]; then
+   source "$PODS_ROOT/../.xcode.env"
+ fi
+ if [[ -f "$PODS_ROOT/../.xcode.env.local" ]]; then
+   source "$PODS_ROOT/../.xcode.env.local"
+ fi
+
+ # The project root by default is one level up from the ios directory
+ export PROJECT_ROOT="$PROJECT_DIR"/..
+
+ if [[ "$CONFIGURATION" = *Debug* ]]; then
+  export SKIP_BUNDLING=1
+ fi
++if [[ -z "$ENTRY_FILE" ]]; then
++  # Set the entry JS file using the bundler's entry resolution.
++  export ENTRY_FILE="$($NODE_BINARY -e \"require('expo/scripts/resolveAppEntry')\" \"$PROJECT_ROOT\" ios absolute | tail -n 1)"
++fi
++
++if [[ -z "$CLI_PATH" ]]; then
++  # Use Expo CLI
++  export CLI_PATH="$($NODE_BINARY --print \"require.resolve('@expo/cli')\")"
++fi
++if [[ -z "$BUNDLE_COMMAND" ]]; then
++  # Default Expo CLI command for bundling
++  export BUNDLE_COMMAND="export:embed"
++fi
+
+ `"$NODE_BINARY" --print "require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'"`

--- a/docs/public/static/diffs/config/metro-unversioned/ios-bundle-script.diff
+++ b/docs/public/static/diffs/config/metro-unversioned/ios-bundle-script.diff
@@ -1,0 +1,6 @@
+diff --git a/ios/<Project>.xcodeproj/project.pbxproj b/ios/<Project>.xcodeproj/project.pbxproj
+index 0000000..1111111 100644
+--- a/ios/<Project>.xcodeproj/project.pbxproj
++++ b/ios/<Project>.xcodeproj/project.pbxproj
+@@ -0,0 +1,1 @@
++      shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n# The project root by default is one level up from the ios directory\nexport PROJECT_ROOT=\"$PROJECT_DIR\"/..\n\nif [[ \"$CONFIGURATION\" = *Debug* ]]; then\n  export SKIP_BUNDLING=1\nfi\nif [[ -z \"$ENTRY_FILE\" ]]; then\n  # Set the entry JS file using the bundler's entry resolution.\n  export ENTRY_FILE=\"$(\"$NODE_BINARY\" -e \"require('expo/scripts/resolveAppEntry')\" \"$PROJECT_ROOT\" ios absolute | tail -n 1)\"\nfi\n\nif [[ -z \"$CLI_PATH\" ]]; then\n  # Use Expo CLI\n  export CLI_PATH=\"$(\"$NODE_BINARY\" --print \"require.resolve('@expo/cli')\")\"\nfi\nif [[ -z \"$BUNDLE_COMMAND\" ]]; then\n  # Default Expo CLI command for bundling\n  export BUNDLE_COMMAND=\"export:embed\"\nfi\n\n`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\n\n";

--- a/docs/public/static/diffs/config/metro-unversioned/ios-remove-start-packager.diff
+++ b/docs/public/static/diffs/config/metro-unversioned/ios-remove-start-packager.diff
@@ -1,0 +1,25 @@
+diff --git a/ios/<Project>.xcodeproj/project.pbxproj b/ios/<Project>.xcodeproj/project.pbxproj
+index 0000000..1111111 100644
+--- a/ios/<Project>.xcodeproj/project.pbxproj
++++ b/ios/<Project>.xcodeproj/project.pbxproj
+@@ -1,15 +1,0 @@
+-    FD10A7F022414F080027D42C /* Start Packager */ = {
+-      isa = PBXShellScriptBuildPhase;
+-      alwaysOutOfDate = 1;
+-      buildActionMask = 2147483647;
+-      files = (
+-      );
+-      inputFileListPaths = (
+-      );
+-      inputPaths = (
+-      );
+-      name = "Start Packager";
+-      outputFileListPaths = (
+-      );
+-      outputPaths = (
+-      );
+-      runOnlyForDeploymentPostprocessing = 0;
+-      shellPath = /bin/sh;
+-      shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.updates\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.updates\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\nexport RCT_METRO_PORT=\"${RCT_METRO_PORT:=8081}\"\necho \"export RCT_METRO_PORT=${RCT_METRO_PORT}\" > `$NODE_BINARY --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/.packager.env'\"`\nif [ -z \"${RCT_NO_LAUNCH_PACKAGER+xxx}\" ] ; then\n  if nc -w 5 -z localhost ${RCT_METRO_PORT} ; then\n    if ! curl -s \"http://localhost:${RCT_METRO_PORT}/status\" | grep -q \"packager-status:running\" ; then\n      echo \"Port ${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\"\n      exit 2\n    fi\n  else\n    open `$NODE_BINARY --print \"require('path').dirname(require.resolve('expo/package.json')) + '/scripts/launchPackager.command'\"` || echo \"Can't start packager automatically\"\n  fi\nfi\n";
+-      showEnvVarsInLog = 0;
+-    };

--- a/docs/public/static/diffs/expo-updates-android-manifest-cleartext.diff
+++ b/docs/public/static/diffs/expo-updates-android-manifest-cleartext.diff
@@ -1,0 +1,17 @@
+diff --git a/android/app/src/main/AndroidManifest.xml b/android/app/src/main/AndroidManifest.xml
+index 0000000..1111111 100644
+--- a/android/app/src/main/AndroidManifest.xml
++++ b/android/app/src/main/AndroidManifest.xml
+@@ -1,5 +1,6 @@
+ <application
+   android:name=".MainApplication"
+   android:label="@string/app_name"
+   android:icon="@mipmap/ic_launcher"
+   android:roundIcon="@mipmap/ic_launcher_round"
+   android:allowBackup="false"
+   android:theme="@style/AppTheme"
++  android:usesCleartextTraffic="true"
+ >
+-  <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="https://u.expo.dev/[your-project-id]" />
++  <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="http://localhost:3000/api/manifest"/>
+ </application>

--- a/docs/public/static/diffs/router/custom-tabs/forward-ref-tab-button.diff
+++ b/docs/public/static/diffs/router/custom-tabs/forward-ref-tab-button.diff
@@ -1,0 +1,12 @@
+diff --git a/components/TabButton.tsx b/components/TabButton.tsx
+index 0000000..1111111 100644
+--- a/components/TabButton.tsx
++++ b/components/TabButton.tsx
+@@ -1,5 +1,5 @@
+-import { ComponentProps, Ref } from 'react';
++import { ComponentProps, Ref, forwardRef } from 'react';
+
+-export function TabButton({ icon, children, isFocused, ...props }: TabButtonProps) {
++export const TabButton = forwardRef((props: TabButtonProps, ref: Ref<View>) => {
+  // ...
+}

--- a/docs/public/static/diffs/router/migrate-from-react-navigation/remove-safe-area-provider.diff
+++ b/docs/public/static/diffs/router/migrate-from-react-navigation/remove-safe-area-provider.diff
@@ -1,0 +1,14 @@
+diff --git a/App.tsx b/App.tsx
+index 0000000..1111111 100644
+--- a/App.tsx
++++ b/App.tsx
+@@ -1,9 +1,6 @@
+-import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+ export default function App() {
+   return (
+-    <SafeAreaProvider>
+       <MyApp />
+-    </SafeAreaProvider>
+   )
+ }

--- a/docs/public/static/diffs/router/migrate-from-react-navigation/use-local-search-params.diff
+++ b/docs/public/static/diffs/router/migrate-from-react-navigation/use-local-search-params.diff
@@ -1,0 +1,12 @@
+diff --git a/app/index.tsx b/app/index.tsx
+index 0000000..1111111 100644
+--- a/app/index.tsx
++++ b/app/index.tsx
+@@ -1,5 +1,6 @@
++import { useLocalSearchParams } from 'expo-router';
+
+-export default function Page({ route }) {
+-  const user = route?.params?.user;
++export default function Page() {
++  const { user } = useLocalSearchParams();
+}

--- a/docs/public/static/diffs/router/migrate-from-react-navigation/use-navigation-hook.diff
+++ b/docs/public/static/diffs/router/migrate-from-react-navigation/use-navigation-hook.diff
@@ -1,0 +1,14 @@
+diff --git a/app/index.tsx b/app/index.tsx
+index 0000000..1111111 100644
+--- a/app/index.tsx
++++ b/app/index.tsx
+@@ -1,4 +1,6 @@
++import { useNavigation } from 'expo-router';
+
+export default function Page() {
++ const navigation = useNavigation();
+
+  return (
+    <Button onPress={navigation.navigate('screenName')}>
+  )
+}

--- a/docs/public/static/diffs/router/migrate-from-react-navigation/use-router-hook.diff
+++ b/docs/public/static/diffs/router/migrate-from-react-navigation/use-router-hook.diff
@@ -1,0 +1,13 @@
+diff --git a/app/index.tsx b/app/index.tsx
+index 0000000..1111111 100644
+--- a/app/index.tsx
++++ b/app/index.tsx
+@@ -1,6 +1,7 @@
++import { useRouter } from 'expo-router';
+
+-export default function Page({ navigation }) {
+-  navigation.push('User', { user: 'bacon' });
++export default function Page() {
++  const router = useRouter();
++  router.push('/users/bacon');
+}

--- a/docs/public/static/diffs/router/native-tabs/trigger-icon-component.diff
+++ b/docs/public/static/diffs/router/native-tabs/trigger-icon-component.diff
@@ -1,0 +1,13 @@
+diff --git a/app/_layout.tsx b/app/_layout.tsx
+index 0000000..1111111 100644
+--- a/app/_layout.tsx
++++ b/app/_layout.tsx
+@@ -1,5 +1,3 @@
+- <NativeTabs.Trigger name="index" options={{
+-   tabBarIcon: ({ color, size }) => (
+-     <Icon name="home" color={color} size={size} />
+-   ),
+- }}>
++ <NativeTabs.Trigger name="index">
++   <Icon sf="house" drawable="home_drawable" />
++ </NativeTabs.Trigger>

--- a/docs/public/static/diffs/third-party-library/android-build-gradle-aar-project.diff
+++ b/docs/public/static/diffs/third-party-library/android-build-gradle-aar-project.diff
@@ -1,0 +1,10 @@
+diff --git a/android/build.gradle b/android/build.gradle
+index 0000000..1111111 100644
+--- a/android/build.gradle
++++ b/android/build.gradle
+@@ -1,4 +1,5 @@
+  dependencies {
+   implementation project(':expo-modules-core')
+   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
++  implementation project(":${project.name}$test-aar")
+  }

--- a/docs/public/static/diffs/third-party-library/android-build-gradle-flatdir.diff
+++ b/docs/public/static/diffs/third-party-library/android-build-gradle-flatdir.diff
@@ -1,0 +1,11 @@
+diff --git a/android/build.gradle b/android/build.gradle
+index 0000000..1111111 100644
+--- a/android/build.gradle
++++ b/android/build.gradle
+@@ -1,3 +1,6 @@
+  repositories {
+    mavenCentral()
++   flatDir {
++      dirs 'libs'
++   }
+  }

--- a/docs/public/static/diffs/third-party-library/android-build-gradle-mpandroidchart-aar.diff
+++ b/docs/public/static/diffs/third-party-library/android-build-gradle-mpandroidchart-aar.diff
@@ -1,0 +1,10 @@
+diff --git a/android/build.gradle b/android/build.gradle
+index 0000000..1111111 100644
+--- a/android/build.gradle
++++ b/android/build.gradle
+@@ -1,5 +1,6 @@
+  dependencies {
+   implementation project(':expo-modules-core')
+   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
++  implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0@aar'
+  }

--- a/docs/public/static/diffs/third-party-library/android-mpandroidchart-dependency.diff
+++ b/docs/public/static/diffs/third-party-library/android-mpandroidchart-dependency.diff
@@ -1,0 +1,10 @@
+diff --git a/android/build.gradle b/android/build.gradle
+index 0000000..1111111 100644
+--- a/android/build.gradle
++++ b/android/build.gradle
+@@ -1,5 +1,6 @@
+  dependencies {
+   implementation project(':expo-modules-core')
+   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
++  implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0'
+  }

--- a/docs/public/static/diffs/third-party-library/expo-module-config-gradle-aar.diff
+++ b/docs/public/static/diffs/third-party-library/expo-module-config-gradle-aar.diff
@@ -1,0 +1,13 @@
+diff --git a/expo-module.config.json b/expo-module.config.json
+index 0000000..1111111 100644
+--- a/expo-module.config.json
++++ b/expo-module.config.json
+@@ -1,3 +1,9 @@
+    "android": {
++     "gradleAarProjects": [
++       {
++         "name": "test-aar",
++         "aarFilePath": "android/libs/test.aar"
++       }
++     ],
+     "modules": [

--- a/docs/public/static/diffs/third-party-library/ios-dgcharts-dependency.diff
+++ b/docs/public/static/diffs/third-party-library/ios-dgcharts-dependency.diff
@@ -1,0 +1,11 @@
+diff --git a/ios/ExpoRadialChart.podspec b/ios/ExpoRadialChart.podspec
+index 0000000..1111111 100644
+--- a/ios/ExpoRadialChart.podspec
++++ b/ios/ExpoRadialChart.podspec
+@@ -1,5 +1,6 @@
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
++ s.dependency 'DGCharts', '~> 5.1.0'
+
+   # Swift/Objective-C compatibility

--- a/docs/public/static/diffs/third-party-library/ios-podspec-source-files-src.diff
+++ b/docs/public/static/diffs/third-party-library/ios-podspec-source-files-src.diff
@@ -1,0 +1,7 @@
+diff --git a/ios/ExpoRadialChart.podspec b/ios/ExpoRadialChart.podspec
+index 0000000..1111111 100644
+--- a/ios/ExpoRadialChart.podspec
++++ b/ios/ExpoRadialChart.podspec
+@@ -1,1 +1,1 @@
+- s.source_files = '**/*.{h,m,mm,swift,hpp,cpp}'
++ s.source_files = 'src/**/*.{h,m,mm,swift,hpp,cpp}'

--- a/docs/public/static/diffs/third-party-library/ios-podspec-vendored-framework.diff
+++ b/docs/public/static/diffs/third-party-library/ios-podspec-vendored-framework.diff
@@ -1,0 +1,9 @@
+diff --git a/ios/ExpoRadialChart.podspec b/ios/ExpoRadialChart.podspec
+index 0000000..1111111 100644
+--- a/ios/ExpoRadialChart.podspec
++++ b/ios/ExpoRadialChart.podspec
+@@ -1,3 +1,4 @@
+   s.static_framework = true
+   s.dependency 'ExpoModulesCore'
++  s.vendored_frameworks = 'Frameworks/MyFramework.framework'
+   # Swift/Objective-C compatibility

--- a/docs/ui/components/Snippet/blocks/DiffBlock.tsx
+++ b/docs/ui/components/Snippet/blocks/DiffBlock.tsx
@@ -90,7 +90,9 @@ export const DiffBlock = ({
   SnippetHeaderComponent = SnippetHeader,
 }: Props) => {
   const initialRaw = typeof raw === 'string' && raw.trim().length > 0 ? normalizeDiff(raw) : null;
-  const [diff, setDiff] = useState<RenderLine[] | null>(initialRaw ? safeParseDiff(initialRaw) : null);
+  const [diff, setDiff] = useState<RenderLine[] | null>(
+    initialRaw ? safeParseDiff(initialRaw) : null
+  );
   useEffect(() => {
     if (source) {
       const fetchDiffAsync = async () => {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18264

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Convert all `diff` blocks to use the `DiffBlock` component for better. Most conversion in documents refers to using diff files rather than parsing the raw data directly with `DiffBlock`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
