### PR TITLE
[docs] Display `StackHeaderItemSharedProps` in Expo Router reference

### DIFF
--- a/docs/components/plugins/APISection.tsx
+++ b/docs/components/plugins/APISection.tsx
@@ -49,11 +49,14 @@ const isHook = ({ name }: { name: string }) => name.startsWith('use');
 const isListener = ({ name }: GeneratedData) =>
   name.endsWith('Listener') || name.endsWith('Listeners');
 
+const PROP_EXCEPTIONS = new Set(['StackHeaderItemSharedProps']);
+
 const isProp = ({ name }: GeneratedData) =>
   name.includes('Props') &&
   name !== 'ErrorRecoveryProps' &&
   name !== 'WebAnchorProps' &&
-  name !== 'ScreenProps';
+  name !== 'ScreenProps' &&
+  !PROP_EXCEPTIONS.has(name);
 
 const componentTypeNames = new Set(['React.FC', 'ForwardRefExoticComponent', 'ComponentType']);
 
@@ -185,7 +188,7 @@ const renderAPI = (
     const interfaces = filterDataByKind(
       data,
       TypeDocKind.Interface,
-      entry => !entry.name.includes('Props')
+      entry => !entry.name.includes('Props') || PROP_EXCEPTIONS.has(entry.name)
     );
     const constants = filterDataByKind(data, TypeDocKind.Variable, entry => isConstant(entry));
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18472

- Interfaces with names containing "Props" were filtered out, hiding shared props like `StackHeaderItemSharedProps` even after excluding them from the "Props" bucket.
- We need a maintainable way to whitelist shared prop interfaces without scattering inline checks.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Added a `PROP_EXCEPTIONS` list and reused it in isProp and the interfaces filter, so whitelisted interfaces aren’t classified as props and aren’t filtered out of the Interfaces section.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Run `yarn run dev`
- Visit: http://localhost:3002/versions/unversioned/sdk/router/#stackheaderitemsharedprops

## Preview

<img width="1824" height="1139" alt="CleanShot 2025-12-16 at 00 38 12" src="https://github.com/user-attachments/assets/3f87c87a-be9b-4912-9bf4-da024f032072" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
