### PR TITLE
 [docs] Update font.mdx to clarify font loading methods

### DIFF
--- a/docs/pages/versions/unversioned/sdk/font.mdx
+++ b/docs/pages/versions/unversioned/sdk/font.mdx
@@ -26,7 +26,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 There are two ways to add fonts to your app: using the `expo-font` config plugin (recommended for native builds but has no effect on web) or loading them at runtime (which works across all platforms including web).
 
-The plugin allows you to embed font files at build time (config plugin doesn't work on web) which is more efficient than [`useFonts`](#usefontsmap) or [`loadAsync`](#loadasyncfontfamilyorfontmap-source). After you set up the config plugin and run [prebuild](/workflow/continuous-native-generation/#usage), you can render custom fonts right away. The plugin can be configured in different ways, see the [Fonts](/develop/user-interface/fonts/#with-expo-font-config-plugin) guide on how to use it.
+On native platforms, the plugin allows you to embed font files at build time which is more efficient than [`useFonts`](#usefontsmap) or [`loadAsync`](#loadasyncfontfamilyorfontmap-source). After you set up the config plugin and run [prebuild](/workflow/continuous-native-generation/#usage), you can render custom fonts right away. The plugin can be configured in different ways, see the [Fonts](/develop/user-interface/fonts/#with-expo-font-config-plugin) guide on how to use it.
 
 <ConfigPluginExample>
 

--- a/docs/pages/versions/unversioned/sdk/font.mdx
+++ b/docs/pages/versions/unversioned/sdk/font.mdx
@@ -24,9 +24,9 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 ## Configuration in app config
 
-There are two ways to add fonts to your app: using the `expo-font` config plugin (recommended) or loading them at runtime.
+There are two ways to add fonts to your app: using the `expo-font` config plugin (recommended for native builds but has no effect on web) or loading them at runtime (which works across all platforms including web).
 
-The plugin allows you to embed font files at build time which is more efficient than [`useFonts`](#usefontsmap) or [`loadAsync`](#loadasyncfontfamilyorfontmap-source). After you set up the config plugin and run [prebuild](/workflow/continuous-native-generation/#usage), you can render custom fonts right away. The plugin can be configured in different ways, see the [Fonts](/develop/user-interface/fonts/#with-expo-font-config-plugin) guide on how to use it.
+The plugin allows you to embed font files at build time (config plugin doesn't work on web) which is more efficient than [`useFonts`](#usefontsmap) or [`loadAsync`](#loadasyncfontfamilyorfontmap-source). After you set up the config plugin and run [prebuild](/workflow/continuous-native-generation/#usage), you can render custom fonts right away. The plugin can be configured in different ways, see the [Fonts](/develop/user-interface/fonts/#with-expo-font-config-plugin) guide on how to use it.
 
 <ConfigPluginExample>
 


### PR DESCRIPTION
Clarified the usage of the expo-font config plugin and its limitations on web.

# Why

The expo-font config plugin simplifies the inclusion of custom fonts in Expo projects. However, its behavior differs between native platforms and web, which can lead to confusion. This PR clarifies its usage and explicitly notes its limitations on web.

Related issue: [expo/expo#27562](https://github.com/expo/expo/issues/27562)


# How

Updated the documentation to explain that the expo-font config plugin automatically links fonts for native builds but does not automatically load fonts for web.


# Test Plan


Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
