### PR TITLE
[docs] Improve `DiffBlock` styles

### DIFF
--- a/docs/styles/global.css
+++ b/docs/styles/global.css
@@ -172,11 +172,11 @@ div.tippy-box {
 }
 
 .diff-gutter-col {
-  @apply w-10 bg-element;
+  @apply w-6 bg-element;
 }
 
 .diff-gutter {
-  @apply px-2 text-3xs;
+  @apply px-1 text-3xs;
   text-align: right;
   user-select: none;
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #41650

Based on recent feedback from @kadikraman, where she mentioned that `DiffBlock` for small blocks looks misaligned with the rest of the content around it, in its current state.

# How

<!--
How did you build this feature or fix this bug and why?
-->

  * Reduced the width of `.diff-gutter-col` from `w-10` to `w-6` and decreased the horizontal padding of `.diff-gutter` from `px-2` to `px-1` in `docs/styles/global.css`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

**Before**


<img width="2400" height="432" alt="CleanShot 2025-12-16 at 01 23 16@2x" src="https://github.com/user-attachments/assets/ad2c3acd-f80d-42cb-bf0b-aa75310d7166" />

<img width="2450" height="906" alt="CleanShot 2025-12-16 at 01 24 03@2x" src="https://github.com/user-attachments/assets/465782c7-b2ee-4309-9ab9-464965725233" />



**After**

<img width="2420" height="506" alt="CleanShot 2025-12-16 at 01 21 54@2x" src="https://github.com/user-attachments/assets/cf5e80e8-4104-4378-a88d-63e9890cd6c9" />

<img width="2478" height="810" alt="CleanShot 2025-12-16 at 01 24 26@2x" src="https://github.com/user-attachments/assets/75ced40b-5189-4897-bb2b-d8485a4897de" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
