### PR TITLE
[ios][camera] Fix `pictureRef` dimensions

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - [Android] Fix certain exif keys being dropped because of invalid values. ([#41043](https://github.com/expo/expo/pull/41043) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix camera not being recreated on the old architecture. ([#41405](https://github.com/expo/expo/pull/41405) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Return correct size information when using image refs.
+- [iOS] Return correct size information when using image refs. ([#41658](https://github.com/expo/expo/pull/41658) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [Android] Fix certain exif keys being dropped because of invalid values. ([#41043](https://github.com/expo/expo/pull/41043) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix camera not being recreated on the old architecture. ([#41405](https://github.com/expo/expo/pull/41405) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Return correct size information when using image refs.
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/CameraViewModule.swift
+++ b/packages/expo-camera/ios/CameraViewModule.swift
@@ -306,12 +306,12 @@ public final class CameraViewModule: Module, ScannerResultHandler {
     }
 
     Class("Picture", PictureRef.self) {
-      Property("width") { (image: PictureRef) -> Int in
-        return image.ref.cgImage?.width ?? 0
+      Property("width") { (image: PictureRef) -> CGFloat in
+        return image.ref.size.width
       }
 
-      Property("height") { (image: PictureRef) -> Int in
-        return image.ref.cgImage?.height ?? 0
+      Property("height") { (image: PictureRef) -> CGFloat in
+        return image.ref.size.height
       }
 
       AsyncFunction("savePictureAsync") { (image: PictureRef, options: SavePictureOptions?) -> [String: Any?] in

--- a/packages/expo-camera/ios/Common/ExpoCameraUtils.swift
+++ b/packages/expo-camera/ios/Common/ExpoCameraUtils.swift
@@ -249,8 +249,8 @@ struct ExpoCameraUtils {
     }
 
     result["url"] = fileUrl.absoluteString
-    result["width"] = image.cgImage?.width ?? 0
-    result["height"] = image.cgImage?.height ?? 0
+    result["width"] = image.size.width
+    result["height"] = image.size.height
     result["base64"] = options.base64 ? data.base64EncodedString() : nil
 
     do {


### PR DESCRIPTION
# Why
Closes #41646

# How
Image dimensions should not be taken from `cgImage` as these don't account for image orientation. 

# Test Plan
Bare-expo