### PR TITLE
fix(expo-location): Report location updates immediately in foreground on Android

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixed deferred location updates being applied in foreground due to incorrect `mIsHostPaused` initialization. Location updates are now delivered immediately when app is in foreground, matching iOS behavior. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@tyrauber](https://github.com/tyrauber)) ([#41659](https://github.com/expo/expo/pull/41659) by [@tyrauber](https://github.com/tyrauber))
+- [Android] Fixed deferred location updates being applied in foreground due to incorrect `mIsHostPaused` initialization. Location updates are now delivered immediately when app is in foreground, matching iOS behavior. ([#41659](https://github.com/expo/expo/pull/41659) by [@tyrauber](https://github.com/tyrauber))
 - use WGS 84 as reference for altitude on iOS ([#41318](https://github.com/expo/expo/pull/41318) by [@vonovak](https://github.com/vonovak))
 - fix position of the `scope` field in a permissions request result ([#41328](https://github.com/expo/expo/pull/41328) by [@vonovak](https://github.com/vonovak))
 - [Web] Stop using legacy event emitter. ([#41680](https://github.com/expo/expo/pull/41680) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixed deferred location updates being applied in foreground due to incorrect `mIsHostPaused` initialization. Location updates are now delivered immediately when app is in foreground, matching iOS behavior. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@tyrauber](https://github.com/tyrauber))
+- [Android] Fixed deferred location updates being applied in foreground due to incorrect `mIsHostPaused` initialization. Location updates are now delivered immediately when app is in foreground, matching iOS behavior. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@tyrauber](https://github.com/tyrauber)) ([#41659](https://github.com/expo/expo/pull/41659) by [@tyrauber](https://github.com/tyrauber))
 - use WGS 84 as reference for altitude on iOS ([#41318](https://github.com/expo/expo/pull/41318) by [@vonovak](https://github.com/vonovak))
 - fix position of the `scope` field in a permissions request result ([#41328](https://github.com/expo/expo/pull/41328) by [@vonovak](https://github.com/vonovak))
 - [Web] Stop using legacy event emitter. ([#41680](https://github.com/expo/expo/pull/41680) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed deferred location updates being applied in foreground due to incorrect `mIsHostPaused` initialization. Location updates are now delivered immediately when app is in foreground, matching iOS behavior. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@tyrauber](https://github.com/tyrauber))
 - use WGS 84 as reference for altitude on iOS ([#41318](https://github.com/expo/expo/pull/41318) by [@vonovak](https://github.com/vonovak))
 - fix position of the `scope` field in a permissions request result ([#41328](https://github.com/expo/expo/pull/41328) by [@vonovak](https://github.com/vonovak))
 - [Web] Stop using legacy event emitter. ([#41680](https://github.com/expo/expo/pull/41680) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/LocationTaskConsumer.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/LocationTaskConsumer.kt
@@ -43,6 +43,7 @@ class LocationTaskConsumer(context: Context, taskManagerUtils: TaskManagerUtilsI
   private var mLastReportedLocation: Location? = null
   private var mDeferredDistance = 0.0
   private val mDeferredLocations: MutableList<Location> = ArrayList()
+
   // Apps start in foreground state; lifecycle callbacks update this after initialization
   private var mIsHostPaused = false
   private val mLocationClient: FusedLocationProviderClient by lazy {
@@ -101,13 +102,13 @@ class LocationTaskConsumer(context: Context, taskManagerUtils: TaskManagerUtilsI
    */
   private fun handleLocationUpdate(locations: List<Location>) {
     if (locations.isEmpty()) return
-    
+
     // Foreground: report immediately for responsive UI (matches iOS behavior)
     if (!mIsHostPaused) {
       reportLocationsImmediately(locations)
       return
     }
-    
+
     // Background: use deferred buffer for battery optimization
     deferLocations(locations)
     maybeReportDeferredLocations()


### PR DESCRIPTION
# Why

On Android, deferredUpdates were being applied to foreground operations due to incorrect mIsHostPaused initialization. Unlike iOS, where distanceInterval and timeInterval are respected in foreground, Android was batching all location
updates using the deferred updates logic regardless of app state.

This caused significant delays before location updates appeared on screen, resulting in poor UX for location tracking apps.

# How

Root Cause:

The mIsHostPaused flag was initialized to true. Since apps start in foreground (lifecycle callbacks fire after initialization), all location updates were routed through the deferred updates path from the start.

Solution:
1. Initialize mIsHostPaused = false since apps start in foreground state
2. Add reportLocationsImmediately() method that bypasses the deferred buffer
3. Route location updates based on foreground/background state:
   - Foreground: report immediately (matches iOS behavior)
   - Background: use deferred buffer for battery optimization

This brings Android behavior in line with iOS, respecting distanceInterval and timeInterval in foreground while preserving deferred batching in background.

# Test Plan

- Verified immediate location delivery in foreground (matches iOS)
- Confirmed background deferred batching still works for battery optimization
- Validated foreground/background transitions work correctly

# Checklist


- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
