### PR TITLE
fix(expo-modules-core): Fix race condition in native module initialization

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix race condition where `ensureNativeModulesAreInstalled` returns early before `NativeModule` class is installed. ([#41660](https://github.com/expo/expo/pull/41660) by [@kimchi-developer](https://github.com/kimchi-developer))
 - [iOS] Fix throwing `InvalidArgsNumberException` when declaring `AsyncFunction` with optional arguments and `Promise`. ([#41054](https://github.com/expo/expo/pull/41054) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] fix queue assertion crash ([#41296](https://github.com/expo/expo/pull/41296) by [@vonovak](https://github.com/vonovak))
 - [Android] check if `AppContextActivityResultLauncher` coroutine continuation is active before resuming ([#41319](https://github.com/expo/expo/pull/41319) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-modules-core/src/ensureNativeModulesAreInstalled.native.ts
+++ b/packages/expo-modules-core/src/ensureNativeModulesAreInstalled.native.ts
@@ -5,7 +5,10 @@ import { TurboModuleRegistry } from 'react-native';
  * Otherwise, it synchronously calls a native function that installs them.
  */
 export function ensureNativeModulesAreInstalled(): void {
-  if (globalThis.expo || typeof window === 'undefined') {
+  // Check that NativeModule class is installed, not just globalThis.expo.
+  // globalThis.expo gets created before NativeModule/EventEmitter classes are installed,
+  // which can cause race conditions where modules exist but methods like addListener are undefined.
+  if (globalThis.expo?.NativeModule || typeof window === 'undefined') {
     return;
   }
 


### PR DESCRIPTION
# Summary

Fix race condition where `ensureNativeModulesAreInstalled()` returns early before `NativeModule`/`EventEmitter` classes are installed, causing runtime errors.

## Problem

After PR #41311 changed iOS runtime access, there's a timing window where:

1. `AppContext.prepareRuntime()` calls `initializeCoreObject()` → creates `globalThis.expo`
2. JS bundle starts executing (race condition window)
3. `installEventEmitterClass()` → installs EventEmitter prototype
4. `installNativeModuleClass()` → installs NativeModule prototype  
5. `installExpoModulesHostObject()` → installs modules

If JS executes between steps 1 and 4, modules exist but their prototypes (like `addListener`) are undefined:

```
TypeError: NativeJSLogger.addListener is not a function (it is undefined)
```

This happens intermittently because it depends on timing.

## Solution

Change the check from:
```typescript
if (globalThis.expo || typeof window === 'undefined') {
```

To:
```typescript
if (globalThis.expo?.NativeModule || typeof window === 'undefined') {
```

This ensures we wait until `NativeModule` class is actually installed, not just until `globalThis.expo` exists.

## Test Plan

- [x] Verified fix resolves the `addListener is not a function` error
- [ ] Existing tests pass