### PR TITLE
Bump @react-native-picker/picker.

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -49,7 +49,7 @@
     "@react-native-community/netinfo": "11.4.1",
     "@react-native-community/slider": "5.0.1",
     "@react-native-masked-view/masked-view": "0.3.2",
-    "@react-native-picker/picker": "2.11.1",
+    "@react-native-picker/picker": "2.11.3",
     "@react-native-segmented-control/segmented-control": "2.5.7",
     "@shopify/flash-list": "2.0.2",
     "@shopify/react-native-skia": "2.2.12",

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -32,7 +32,7 @@
     "@react-native-community/netinfo": "11.4.1",
     "@react-native-community/slider": "5.0.1",
     "@react-native-masked-view/masked-view": "0.3.2",
-    "@react-native-picker/picker": "2.11.1",
+    "@react-native-picker/picker": "2.11.3",
     "@react-native-segmented-control/segmented-control": "2.5.7",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -44,7 +44,7 @@
     "@react-native-community/netinfo": "11.4.1",
     "@react-native-community/slider": "5.0.1",
     "@react-native-masked-view/masked-view": "0.3.2",
-    "@react-native-picker/picker": "2.11.1",
+    "@react-native-picker/picker": "2.11.3",
     "@react-native-segmented-control/segmented-control": "2.5.7",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/drawer": "^7.5.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -9,7 +9,7 @@
   "@react-native-community/netinfo": "11.4.1",
   "@react-native-community/slider": "5.0.1",
   "@react-native-community/viewpager": "5.0.11",
-  "@react-native-picker/picker": "2.11.1",
+  "@react-native-picker/picker": "2.11.3",
   "@react-native-segmented-control/segmented-control": "2.5.7",
   "@stripe/stripe-react-native": "0.50.3",
   "eslint-config-expo": "~10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3477,10 +3477,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-masked-view/masked-view/-/masked-view-0.3.2.tgz#7064533a573e3539ec912f59c1f457371bf49dd9"
   integrity sha512-XwuQoW7/GEgWRMovOQtX3A4PrXhyaZm0lVUiY8qJDvdngjLms9Cpdck6SmGAUNqQwcj2EadHC1HwL0bEyoa/SQ==
 
-"@react-native-picker/picker@2.11.1":
-  version "2.11.1"
-  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.11.1.tgz#d8884440abc5f75579d82f9888e50ca047c9ec14"
-  integrity sha512-ThklnkK4fV3yynnIIRBkxxjxR4IFbdMNJVF6tlLdOJ/zEFUEFUEdXY0KmH0iYzMwY8W4/InWsLiA7AkpAbnexA==
+"@react-native-picker/picker@2.11.3":
+  version "2.11.3"
+  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.11.3.tgz#60ed5d55de430136dcfa1c8a9d0194ad09d1c58d"
+  integrity sha512-aknxi+6dmNrSk0Bev+cnhsUAwi3Iz7KTj8lSHnGNcU+P9VkCGN6QQDcU0e2gnWLY3zhS3HzV+DBTmzR9ia6kTg==
 
 "@react-native-segmented-control/segmented-control@2.5.7":
   version "2.5.7"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Including a picker with `@react-native-picker/picker` on React Native 0.81 and navigating away causes a crash. 

See react-native-picker/picker#647

# How

<!--
How did you build this feature or fix this bug and why?
-->

Upgrading `@react-native-picker/picker` to `2.11.3` fixes the crash on React Native 0.81. 

See react-native-picker/picker#648

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

I noticed this bug while working on my app that includes a picker, and upgrading fixed the problem. 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
