### PR TITLE
Do not overwrite TextDecoder if it already exists

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### 🎉 New features
 
-- Add `skipIfExists` option to `installGlobal` to preserve preexisting globals like `TextDecoder`. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@greentriangle](https://github.com/greentriangle))
+- Add `skipIfExists` option to `installGlobal` to preserve preexisting globals like `TextDecoder`. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@greentriangle](https://github.com/greentriangle)) ([#41672](https://github.com/expo/expo/pull/41672) by [@savv](https://github.com/savv))
 - Add `process.env.EXPO_DOM_HOST_OS` for detecting the original platform of a DOM Component. ([#40382](https://github.com/expo/expo/pull/40382) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove `ExpoAppDelegate` inheritance requirement in ExpoReactNativeFactory ([#39417](https://github.com/expo/expo/pull/39417) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Remove bindReactNativeFactory function ([#39418](https://github.com/expo/expo/pull/39418) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### 🎉 New features
 
+- Add `skipIfExists` option to `installGlobal` to preserve preexisting globals like `TextDecoder`. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@greentriangle](https://github.com/greentriangle))
 - Add `process.env.EXPO_DOM_HOST_OS` for detecting the original platform of a DOM Component. ([#40382](https://github.com/expo/expo/pull/40382) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove `ExpoAppDelegate` inheritance requirement in ExpoReactNativeFactory ([#39417](https://github.com/expo/expo/pull/39417) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Remove bindReactNativeFactory function ([#39418](https://github.com/expo/expo/pull/39418) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo/src/winter/installGlobal.ts
+++ b/packages/expo/src/winter/installGlobal.ts
@@ -77,10 +77,20 @@ function defineLazyObjectProperty<T>(
  *
  * @see https://github.com/facebook/react-native/issues/934
  */
-export function installGlobal<T extends object>(name: string, getValue: () => T): void {
+export function installGlobal<T extends object>(
+  name: string,
+  getValue: () => T,
+  { skipIfExists = false }: { skipIfExists?: boolean } = {}
+): void {
   // @ts-ignore: globalThis is not defined in all environments
   const object = typeof global !== 'undefined' ? global : globalThis;
   const descriptor = Object.getOwnPropertyDescriptor(object, name);
+
+  // Skip installation if the property already exists and skipIfExists is true
+  if (skipIfExists && descriptor) {
+    return;
+  }
+
   if (__DEV__ && descriptor) {
     const backupName = `original${name[0].toUpperCase()}${name.slice(1)}`;
     Object.defineProperty(object, backupName, descriptor);

--- a/packages/expo/src/winter/runtime.native.ts
+++ b/packages/expo/src/winter/runtime.native.ts
@@ -5,7 +5,7 @@ import { installFormDataPatch } from './FormData';
 import { installGlobal as install } from './installGlobal';
 
 // https://encoding.spec.whatwg.org/#textdecoder
-install('TextDecoder', () => require('./TextDecoder').TextDecoder);
+install('TextDecoder', () => require('./TextDecoder').TextDecoder, { skipIfExists: true });
 // https://encoding.spec.whatwg.org/#interface-textdecoderstream
 install('TextDecoderStream', () => require('./TextDecoderStream').TextDecoderStream);
 // https://encoding.spec.whatwg.org/#interface-textencoderstream


### PR DESCRIPTION
# Why

expo's TextDecoder overwrites other polyfills that may be preferable to whoever is using expo (e.g. support for more encodings than utf8, better performance, etc). This will also be necessary so as not to overwrite RN's upcoming TextDecoder: https://github.com/facebook/hermes/pull/1855


# How

We do not overwrite a TextDecoder if it already exists.

# Test Plan

I tested this as part of the PR above.

# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
