### PR TITLE
fix(ncl): Remove remaining `fs-extra` usage in `native-component-list`

### DIFF
--- a/apps/native-component-list/plugins/withGradleProperties.js
+++ b/apps/native-component-list/plugins/withGradleProperties.js
@@ -1,6 +1,6 @@
 const { withDangerousMod } = require('@expo/config-plugins');
 const assert = require('assert');
-const fs = require('fs-extra');
+const fs = require('fs/promises');
 const path = require('path');
 
 // Use this improve gradle builds


### PR DESCRIPTION
Extracted from https://github.com/expo/expo/pull/41288/commits/07763c77fb117a6103f390beec080b3cc1c67198