### PR TITLE
fix(expo): Add explicit cast for onLayout in WebviewWrapper

### DIFF
--- a/packages/expo/src/dom/webview-wrapper.tsx
+++ b/packages/expo/src/dom/webview-wrapper.tsx
@@ -137,7 +137,7 @@ const RawWebView = React.forwardRef<object, Props>((props, ref) => {
     },
     ...domProps,
     containerStyle: [containerStyle, debugZeroHeightStyle, dom?.containerStyle],
-    onLayout: __DEV__ ? debugOnLayout : dom?.onLayout,
+    onLayout: (__DEV__ ? debugOnLayout : dom?.onLayout) as RawWebViewProps['onLayout'],
     injectedJavaScriptBeforeContentLoaded: [
       // Inject the top-most OS for the DOM component to read.
       `window.$$EXPO_DOM_HOST_OS = ${JSON.stringify(process.env.EXPO_OS)};true;`,


### PR DESCRIPTION
Extracted from https://github.com/expo/expo/pull/41288/commits/df4b2fb16787a1cb2aa787b8c5d175c9f31f34d1

Only needed for version drift on webview, which came up in the pnpm migration.

No changelog entry needed since this is internal-types-only.