### PR TITLE
fix(expo-task-manager): Fix Android job scheduling ANR and duplicate data

### DIFF
--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix job scheduling ANR caused by cancel/reschedule pattern that prevented jobs from executing and accumulated data until exceeding Binder transaction limit. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@tyrauber](https://github.com/tyrauber))
+
 ### 💡 Others
 
 - [iOS] Migrated the native module to Swift. ([#41911](https://github.com/expo/expo/pull/41911) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix job scheduling ANR caused by cancel/reschedule pattern that prevented jobs from executing and accumulated data until exceeding Binder transaction limit. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@tyrauber](https://github.com/tyrauber))
+- [Android] Fix job scheduling ANR caused by cancel/reschedule pattern that prevented jobs from executing and accumulated data until exceeding Binder transaction limit. ([#41688](https://github.com/expo/expo/pull/41688) by [@tyrauber](https://github.com/tyrauber))
 
 ### 💡 Others
 

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
@@ -200,11 +200,24 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
   }
 
   private JobInfo createJobInfo(int jobId, ComponentName jobService, PersistableBundle extras) {
-    return new JobInfo.Builder(jobId, jobService)
-      .setExtras(extras)
-      .setMinimumLatency(0)
-      .setOverrideDeadline(DEFAULT_OVERRIDE_DEADLINE)
-      .build();
+    JobInfo.Builder jobBuilder = new JobInfo.Builder(jobId, jobService)
+        .setExtras(extras)
+        .setPersisted(true)
+        .setRequiresDeviceIdle(false);
+
+    if (Build.VERSION.SDK_INT < 28) {
+      // For Android versions below 28 (Android 9 and below)
+      jobBuilder.setMinimumLatency(0)
+          .setOverrideDeadline(DEFAULT_OVERRIDE_DEADLINE);
+    } else if (Build.VERSION.SDK_INT < 31) {
+      // For Android 9 (API 28) to Android 11 (API 30)
+      jobBuilder.setImportantWhileForeground(true);
+    } else {
+      // For Android 12 (API 31) and above
+      jobBuilder.setExpedited(true);
+    }
+
+    return jobBuilder.build();
   }
 
   private JobInfo createJobInfo(Context context, TaskInterface task, int jobId, List<PersistableBundle> data) {

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskService.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskService.java
@@ -349,10 +349,7 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
 
     TaskInterface task = getTask(taskName, appScopeKey);
 
-    // `notifyTaskJobCancelled` notifies TaskManagerUtils about a job for task being cancelled.
-    // It returns `true` if the job has been intentionally cancelled to be rescheduled,
-    // in that case we don't want to inform the consumer about cancellation.
-    if (task != null && !TaskManagerUtils.notifyTaskJobCancelled(task)) {
+    if (task != null) {
       TaskConsumerInterface consumer = task.getConsumer();
 
       if (consumer == null) {
@@ -361,7 +358,6 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
 
       Log.i(TAG, "Job for task '" + taskName + "' has been cancelled by the system.");
 
-      // cancels task
       return consumer.didCancelJob(jobService, params);
     }
 

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/Utils.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/Utils.java
@@ -103,7 +103,10 @@ public class Utils {
       for (int i = 0; i < json.length(); i++) {
         Object value = json.get(i);
 
-        if (value instanceof JSONArray) {
+        // Handle JSONObject.NULL - convert to actual Java null
+        if (value == JSONObject.NULL) {
+          value = null;
+        } else if (value instanceof JSONArray) {
           value = jsonToList((JSONArray) value);
         } else if (value instanceof JSONObject) {
           value = jsonToMap((JSONObject) value);
@@ -117,6 +120,12 @@ public class Utils {
   }
 
   public static Object jsonObjectToObject(Object json) {
+    // Handle JSONObject.NULL - convert to actual Java null
+    // JSONObject.NULL is returned when a JSON key has a null value
+    // and it's an instance of a special singleton class (JSONObject$1)
+    if (json == null || json == JSONObject.NULL) {
+      return null;
+    }
     if (json instanceof JSONObject) {
       return jsonToMap((JSONObject) json);
     }


### PR DESCRIPTION
# Why

The original implementation merged new data into existing pending jobs, then cancelled and rescheduled them. This caused two critical issues:

1. Duplicate data: Jobs already in flight could deliver data, then the merged/rescheduled job would deliver it again.

2. ANR crashes: Cancel/reschedule resets Android's job scheduling priority, preventing jobs from ever becoming "old enough" to execute. Data accumulated until exceeding the Binder transaction limit (~1MB).

# How

The fix: Schedule each data batch as a separate job with its own ID. Each batch is delivered exactly once, and jobs stay small enough to avoid Binder limits.

To stay within Android's per-app job limit (100 for API <31, 150 for API 31+), we monitor total pending jobs. When approaching the limit (with a 10-job buffer), new data merges into the newest existing job for that task rather than being dropped—merge is better than drop.

Changes:

- Schedule new jobs instead of merging into existing ones
- Merge only when approaching Android's job limit
- Remove cancel/reschedule tracking (no longer needed)
- Use Build.VERSION.SDK_INT to determine version-appropriate limit

# Test Plan

We have this patch running in a release build and seeing 10+ hours straight of background location tracking on Android (with patched expo-location), with no duplicate data and no ANR.

# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
