### PR TITLE
feat(babel-preset-expo): optimize expo-router babel plugins

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Improve performance of Expo Router babel plugins.
 - Ensure `loader()` functions are stripped from client bundles ([#40670](https://github.com/expo/expo/pull/40670) by [@hassankhan](https://github.com/hassankhan))
 
 ### 🐛 Bug fixes

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Improve performance of Expo Router babel plugins.
+- Improve performance of Expo Router babel plugins. ([#41693](https://github.com/expo/expo/pull/41693) by [@EvanBacon](https://github.com/EvanBacon))
 - Ensure `loader()` functions are stripped from client bundles ([#40670](https://github.com/expo/expo/pull/40670) by [@hassankhan](https://github.com/hassankhan))
 
 ### 🐛 Bug fixes

--- a/packages/babel-preset-expo/build/define-plugin.d.ts
+++ b/packages/babel-preset-expo/build/define-plugin.d.ts
@@ -5,6 +5,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type { ConfigAPI, PluginObj } from '@babel/core';
-declare function definePlugin({ types: t }: ConfigAPI & typeof import('@babel/core')): PluginObj;
+import type { ConfigAPI, PluginObj, PluginPass } from '@babel/core';
+declare function definePlugin({ types: t, }: ConfigAPI & typeof import('@babel/core')): PluginObj<PluginPass & {
+    opts: Record<string, null | boolean | string>;
+}>;
 export default definePlugin;

--- a/packages/babel-preset-expo/build/define-plugin.js
+++ b/packages/babel-preset-expo/build/define-plugin.js
@@ -7,28 +7,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 Object.defineProperty(exports, "__esModule", { value: true });
-/**
- * Checks if the given identifier is an ES module import
- * @param  {babelNode} identifierNodePath The node to check
- * @return {boolean} Indicates if the provided node is an import specifier or references one
- */
-const isImportIdentifier = (identifierNodePath) => {
-    if (identifierNodePath.container &&
-        !Array.isArray(identifierNodePath.container) &&
-        'type' in identifierNodePath.container) {
-        return (identifierNodePath.container.type === 'ImportDefaultSpecifier' ||
-            identifierNodePath.container.type === 'ImportSpecifier');
-    }
-    return false;
-};
-const memberExpressionComparator = (nodePath, value) => nodePath.matchesPattern(value);
-const identifierComparator = (nodePath, value) => 'name' in nodePath.node && nodePath.node.name === value;
-const unaryExpressionComparator = (nodePath, value) => {
-    if ('argument' in nodePath.node && nodePath.node.argument && 'name' in nodePath.node?.argument) {
-        return nodePath.node.argument.name === value;
-    }
-    return false;
-};
 const TYPEOF_PREFIX = 'typeof ';
 function definePlugin({ types: t }) {
     /**
@@ -38,79 +16,124 @@ function definePlugin({ types: t }) {
      */
     function replaceAndEvaluateNode(nodePath, replacement) {
         nodePath.replaceWith(t.valueToNode(replacement));
-        if (nodePath.parentPath && nodePath.parentPath.isBinaryExpression()) {
+        if (nodePath.parentPath?.isBinaryExpression()) {
             const result = nodePath.parentPath.evaluate();
             if (result.confident) {
                 nodePath.parentPath.replaceWith(t.valueToNode(result.value));
             }
         }
     }
-    const isLeftHandSideOfAssignmentExpression = (node, parent) => t.isAssignmentExpression(parent) && parent.left === node;
-    const processNode = (replacements, nodePath, comparator) => {
-        const replacementKey = Object.keys(replacements).find((value) => comparator(nodePath, value));
-        if (typeof replacementKey === 'string' &&
-            replacements != null &&
-            replacementKey in replacements) {
-            replaceAndEvaluateNode(nodePath, replacements[replacementKey]);
+    /** Get the root identifier name from a member expression (e.g., "process" from "process.env.NODE_ENV") */
+    function getMemberExpressionRoot(node) {
+        let current = node;
+        while (t.isMemberExpression(current)) {
+            current = current.object;
         }
-    };
+        return t.isIdentifier(current) ? current.name : null;
+    }
     return {
         name: 'expo-define-globals',
+        pre() {
+            const opts = this.opts;
+            if (opts == null || typeof opts !== 'object') {
+                throw new Error('define plugin expects an object as options');
+            }
+            // Pre-process replacements once per file
+            const identifiers = new Map();
+            const memberPatterns = [];
+            const typeofValues = new Map();
+            const memberRoots = new Set();
+            for (const key of Object.keys(opts)) {
+                const value = opts[key];
+                if (key.startsWith(TYPEOF_PREFIX)) {
+                    // "typeof window" -> typeofValues["window"]
+                    typeofValues.set(key.slice(TYPEOF_PREFIX.length), value);
+                }
+                else if (key.includes('.')) {
+                    // "process.env.NODE_ENV" -> memberPatterns, extract "process" as root
+                    memberPatterns.push([key, value]);
+                    const root = key.split('.')[0];
+                    memberRoots.add(root);
+                }
+                else {
+                    // "__DEV__" -> identifiers
+                    identifiers.set(key, value);
+                }
+            }
+            this.processed = {
+                identifiers,
+                memberPatterns,
+                typeofValues,
+                memberRoots,
+            };
+        },
         visitor: {
             // process.env.NODE_ENV;
             MemberExpression(nodePath, state) {
-                if (
                 // Prevent rewriting if the member expression is on the left-hand side of an assignment
-                isLeftHandSideOfAssignmentExpression(nodePath.node, nodePath.parent)) {
+                if (t.isAssignmentExpression(nodePath.parent) && nodePath.parent.left === nodePath.node) {
                     return;
                 }
-                const replacements = state.opts;
-                assertOptions(replacements);
-                processNode(replacements, nodePath, memberExpressionComparator);
+                const { memberPatterns, memberRoots } = state.processed;
+                if (memberPatterns.length === 0)
+                    return;
+                // Quick filter: check if root matches any known pattern root
+                const root = getMemberExpressionRoot(nodePath.node);
+                if (!root || !memberRoots.has(root))
+                    return;
+                // Check against patterns
+                for (const [pattern, replacement] of memberPatterns) {
+                    if (nodePath.matchesPattern(pattern)) {
+                        replaceAndEvaluateNode(nodePath, replacement);
+                        return;
+                    }
+                }
             },
             // const x = { version: VERSION };
             ReferencedIdentifier(nodePath, state) {
-                const binding = nodePath.scope?.getBinding(nodePath.node.name);
-                if (binding ||
-                    // Don't transform import identifiers. This is meant to mimic webpack's
-                    // DefinePlugin behavior.
-                    isImportIdentifier(nodePath) ||
-                    // Do not transform Object keys / properties unless they are computed like {[key]: value}
-                    (nodePath.key === 'key' &&
-                        nodePath.parent &&
-                        'computed' in nodePath.parent &&
-                        nodePath.parent.computed === false) ||
-                    (nodePath.key === 'property' &&
-                        nodePath.parent &&
-                        'computed' in nodePath.parent &&
-                        nodePath.parent.computed === false)) {
+                const { identifiers } = state.processed;
+                if (identifiers.size === 0)
+                    return;
+                const name = nodePath.node.name;
+                // Quick check: is this identifier in our replacements?
+                if (!identifiers.has(name))
+                    return;
+                // Check for binding (locally defined variable shadows replacement)
+                if (nodePath.scope?.getBinding(name))
+                    return;
+                // Don't transform import identifiers (mimics webpack's DefinePlugin behavior)
+                const container = nodePath.container;
+                if (container &&
+                    !Array.isArray(container) &&
+                    'type' in container &&
+                    (container.type === 'ImportDefaultSpecifier' || container.type === 'ImportSpecifier')) {
                     return;
                 }
-                const replacements = state.opts;
-                assertOptions(replacements);
-                processNode(replacements, nodePath, identifierComparator);
+                // Do not transform Object keys / properties unless they are computed like {[key]: value}
+                if ((nodePath.key === 'key' || nodePath.key === 'property') &&
+                    nodePath.parent &&
+                    'computed' in nodePath.parent &&
+                    nodePath.parent.computed === false) {
+                    return;
+                }
+                replaceAndEvaluateNode(nodePath, identifiers.get(name));
             },
             // typeof window
             UnaryExpression(nodePath, state) {
-                if (nodePath.node.operator !== 'typeof') {
+                if (nodePath.node.operator !== 'typeof')
                     return;
+                const { typeofValues } = state.processed;
+                if (typeofValues.size === 0)
+                    return;
+                const argument = nodePath.node.argument;
+                if (!t.isIdentifier(argument))
+                    return;
+                const replacement = typeofValues.get(argument.name);
+                if (replacement !== undefined) {
+                    replaceAndEvaluateNode(nodePath, replacement);
                 }
-                const replacements = state.opts;
-                assertOptions(replacements);
-                const typeofValues = {};
-                Object.keys(replacements).forEach((key) => {
-                    if (key.substring(0, TYPEOF_PREFIX.length) === TYPEOF_PREFIX) {
-                        typeofValues[key.substring(TYPEOF_PREFIX.length)] = replacements[key];
-                    }
-                });
-                processNode(typeofValues, nodePath, unaryExpressionComparator);
             },
         },
     };
-}
-function assertOptions(opts) {
-    if (opts == null || typeof opts !== 'object') {
-        throw new Error('define plugin expects an object as options');
-    }
 }
 exports.default = definePlugin;

--- a/packages/babel-preset-expo/build/define-plugin.js
+++ b/packages/babel-preset-expo/build/define-plugin.js
@@ -8,7 +8,7 @@
  */
 Object.defineProperty(exports, "__esModule", { value: true });
 const TYPEOF_PREFIX = 'typeof ';
-function definePlugin({ types: t }) {
+function definePlugin({ types: t, }) {
     /**
      * Replace a node with a given value. If the replacement results in a BinaryExpression, it will be
      * evaluated. For example, if the result of the replacement is `var x = "production" === "production"`
@@ -34,17 +34,13 @@ function definePlugin({ types: t }) {
     return {
         name: 'expo-define-globals',
         pre() {
-            const opts = this.opts;
-            if (opts == null || typeof opts !== 'object') {
-                throw new Error('define plugin expects an object as options');
-            }
             // Pre-process replacements once per file
             const identifiers = new Map();
             const memberPatterns = [];
             const typeofValues = new Map();
             const memberRoots = new Set();
-            for (const key of Object.keys(opts)) {
-                const value = opts[key];
+            for (const key of Object.keys(this.opts)) {
+                const value = this.opts[key];
                 if (key.startsWith(TYPEOF_PREFIX)) {
                     // "typeof window" -> typeofValues["window"]
                     typeofValues.set(key.slice(TYPEOF_PREFIX.length), value);

--- a/packages/babel-preset-expo/build/expo-inline-manifest-plugin.d.ts
+++ b/packages/babel-preset-expo/build/expo-inline-manifest-plugin.d.ts
@@ -1,2 +1,6 @@
-import type { ConfigAPI, PluginObj } from '@babel/core';
-export declare function expoInlineManifestPlugin(api: ConfigAPI & typeof import('@babel/core')): PluginObj;
+import type { ConfigAPI, PluginObj, PluginPass } from '@babel/core';
+interface InlineManifestState extends PluginPass {
+    projectRoot: string;
+}
+export declare function expoInlineManifestPlugin(api: ConfigAPI & typeof import('@babel/core')): PluginObj<InlineManifestState>;
+export {};

--- a/packages/babel-preset-expo/build/expo-inline-manifest-plugin.js
+++ b/packages/babel-preset-expo/build/expo-inline-manifest-plugin.js
@@ -154,8 +154,7 @@ function expoInlineManifestPlugin(api) {
     return {
         name: 'expo-inline-manifest-plugin',
         pre() {
-            this.projectRoot =
-                possibleProjectRoot || this.file.opts.root || '';
+            this.projectRoot = possibleProjectRoot || this.file.opts.root || '';
         },
         visitor: {
             MemberExpression(path, state) {

--- a/packages/babel-preset-expo/build/expo-inline-manifest-plugin.js
+++ b/packages/babel-preset-expo/build/expo-inline-manifest-plugin.js
@@ -4,7 +4,7 @@ exports.expoInlineManifestPlugin = expoInlineManifestPlugin;
 const common_1 = require("./common");
 const debug = require('debug')('expo:babel:inline-manifest');
 // Convert expo value to PWA value
-function ensurePWAorientation(orientation) {
+function ensurePWAOrientation(orientation) {
     if (orientation) {
         const webOrientation = orientation.toLowerCase();
         if (webOrientation !== 'default') {
@@ -52,7 +52,7 @@ function applyWebDefaults({ config, appName, webName }) {
     const startUrl = webManifest.startUrl;
     const { scope, crossorigin } = webManifest;
     const barStyle = webManifest.barStyle;
-    const orientation = ensurePWAorientation(webManifest.orientation || appJSON.orientation);
+    const orientation = ensurePWAOrientation(webManifest.orientation || appJSON.orientation);
     /**
      * **Splash screen background color**
      * `https://developers.google.com/web/fundamentals/web-app-manifest/#splash-screen`

--- a/packages/babel-preset-expo/build/expo-router-plugin.js
+++ b/packages/babel-preset-expo/build/expo-router-plugin.js
@@ -8,11 +8,19 @@ const node_path_1 = __importDefault(require("node:path"));
 const resolve_from_1 = __importDefault(require("resolve-from"));
 const common_1 = require("./common");
 const debug = require('debug')('expo:babel:router');
+// Cache for getExpoRouterAppRoot results (projectRoot -> appRoot)
+const appRootCache = new Map();
 function getExpoRouterAppRoot(projectRoot, appFolder) {
+    const cacheKey = `${projectRoot}:${appFolder}`;
+    const cached = appRootCache.get(cacheKey);
+    if (cached !== undefined) {
+        return cached;
+    }
     // TODO: We should have cache invalidation if the expo-router/entry file location changes.
     const routerEntry = (0, resolve_from_1.default)(projectRoot, 'expo-router/entry');
     const appRoot = node_path_1.default.relative(node_path_1.default.dirname(routerEntry), appFolder);
     debug('routerEntry', routerEntry, appFolder, appRoot);
+    appRootCache.set(cacheKey, appRoot);
     return appRoot;
 }
 /**
@@ -28,36 +36,53 @@ function expoRouterBabelPlugin(api) {
     const possibleProjectRoot = api.caller(common_1.getPossibleProjectRoot);
     const asyncRoutes = api.caller(common_1.getAsyncRoutes);
     const routerAbsoluteRoot = api.caller(common_1.getExpoRouterAbsoluteAppRoot);
-    function isFirstInAssign(path) {
-        return t.isAssignmentExpression(path.parent) && path.parent.left === path.node;
-    }
+    const importMode = asyncRoutes ? 'lazy' : 'sync';
     return {
         name: 'expo-router',
+        pre() {
+            const state = this;
+            state.projectRoot = possibleProjectRoot || this.file.opts.root || '';
+            // Check test env at transform time, not module load time
+            state.isTestEnv = process.env.NODE_ENV === 'test';
+        },
         visitor: {
             MemberExpression(path, state) {
-                const projectRoot = possibleProjectRoot || state.file.opts.root || '';
-                if (path.get('object').matchesPattern('process.env')) {
-                    const key = path.toComputedKey();
-                    if (t.isStringLiteral(key) && !isFirstInAssign(path)) {
-                        // Used for log box on web.
-                        if (key.value.startsWith('EXPO_PROJECT_ROOT')) {
-                            path.replaceWith(t.stringLiteral(projectRoot));
-                        }
-                        else if (key.value.startsWith('EXPO_ROUTER_IMPORT_MODE')) {
-                            path.replaceWith(t.stringLiteral(asyncRoutes ? 'lazy' : 'sync'));
-                        }
-                        if (
-                        // Skip loading the app root in tests.
-                        // This is handled by the testing-library utils
-                        process.env.NODE_ENV !== 'test') {
-                            if (key.value.startsWith('EXPO_ROUTER_ABS_APP_ROOT')) {
-                                path.replaceWith(t.stringLiteral(routerAbsoluteRoot));
-                            }
-                            else if (key.value.startsWith('EXPO_ROUTER_APP_ROOT')) {
-                                path.replaceWith(t.stringLiteral(getExpoRouterAppRoot(projectRoot, routerAbsoluteRoot)));
-                            }
-                        }
-                    }
+                // Quick check: skip if not accessing something on an object named 'process'
+                const object = path.node.object;
+                if (!t.isMemberExpression(object))
+                    return;
+                const objectOfObject = object.object;
+                if (!t.isIdentifier(objectOfObject) || objectOfObject.name !== 'process')
+                    return;
+                // Now check if it's process.env
+                if (!t.isIdentifier(object.property) || object.property.name !== 'env')
+                    return;
+                // Skip if this is an assignment target
+                if (t.isAssignmentExpression(path.parent) && path.parent.left === path.node)
+                    return;
+                // Get the property key
+                const key = path.toComputedKey();
+                if (!t.isStringLiteral(key))
+                    return;
+                const keyValue = key.value;
+                // Check each possible env var
+                if (keyValue.startsWith('EXPO_PROJECT_ROOT')) {
+                    path.replaceWith(t.stringLiteral(state.projectRoot));
+                    return;
+                }
+                if (keyValue.startsWith('EXPO_ROUTER_IMPORT_MODE')) {
+                    path.replaceWith(t.stringLiteral(importMode));
+                    return;
+                }
+                // Skip app root transforms in tests (handled by testing-library utils)
+                if (state.isTestEnv)
+                    return;
+                if (keyValue.startsWith('EXPO_ROUTER_ABS_APP_ROOT')) {
+                    path.replaceWith(t.stringLiteral(routerAbsoluteRoot));
+                    return;
+                }
+                if (keyValue.startsWith('EXPO_ROUTER_APP_ROOT')) {
+                    path.replaceWith(t.stringLiteral(getExpoRouterAppRoot(state.projectRoot, routerAbsoluteRoot)));
                 }
             },
         },

--- a/packages/babel-preset-expo/build/expo-router-plugin.js
+++ b/packages/babel-preset-expo/build/expo-router-plugin.js
@@ -66,23 +66,25 @@ function expoRouterBabelPlugin(api) {
                     return;
                 const keyValue = key.value;
                 // Check each possible env var
-                if (keyValue.startsWith('EXPO_PROJECT_ROOT')) {
-                    path.replaceWith(t.stringLiteral(state.projectRoot));
-                    return;
-                }
-                if (keyValue.startsWith('EXPO_ROUTER_IMPORT_MODE')) {
-                    path.replaceWith(t.stringLiteral(importMode));
-                    return;
+                switch (keyValue) {
+                    case 'EXPO_PROJECT_ROOT':
+                        path.replaceWith(t.stringLiteral(state.projectRoot));
+                        return;
+                    case 'EXPO_ROUTER_IMPORT_MODE':
+                        path.replaceWith(t.stringLiteral(importMode));
+                        return;
+                    default:
+                        break;
                 }
                 // Skip app root transforms in tests (handled by testing-library utils)
                 if (state.isTestEnv)
                     return;
-                if (keyValue.startsWith('EXPO_ROUTER_ABS_APP_ROOT')) {
-                    path.replaceWith(t.stringLiteral(routerAbsoluteRoot));
-                    return;
-                }
-                if (keyValue.startsWith('EXPO_ROUTER_APP_ROOT')) {
-                    path.replaceWith(t.stringLiteral(getExpoRouterAppRoot(state.projectRoot, routerAbsoluteRoot)));
+                switch (keyValue) {
+                    case 'EXPO_ROUTER_ABS_APP_ROOT':
+                        path.replaceWith(t.stringLiteral(routerAbsoluteRoot));
+                        return;
+                    case 'EXPO_ROUTER_APP_ROOT':
+                        path.replaceWith(t.stringLiteral(getExpoRouterAppRoot(state.projectRoot, routerAbsoluteRoot)));
                 }
             },
         },

--- a/packages/babel-preset-expo/src/define-plugin.ts
+++ b/packages/babel-preset-expo/src/define-plugin.ts
@@ -6,42 +6,24 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type { ConfigAPI, PluginObj, NodePath, types as t } from '@babel/core';
-
-/**
- * Checks if the given identifier is an ES module import
- * @param  {babelNode} identifierNodePath The node to check
- * @return {boolean} Indicates if the provided node is an import specifier or references one
- */
-const isImportIdentifier = (
-  identifierNodePath: NodePath<t.Identifier | t.JSXIdentifier>
-): boolean => {
-  if (
-    identifierNodePath.container &&
-    !Array.isArray(identifierNodePath.container) &&
-    'type' in identifierNodePath.container
-  ) {
-    return (
-      identifierNodePath.container.type === 'ImportDefaultSpecifier' ||
-      identifierNodePath.container.type === 'ImportSpecifier'
-    );
-  }
-
-  return false;
-};
-
-const memberExpressionComparator = (nodePath: NodePath, value: string): boolean =>
-  nodePath.matchesPattern(value);
-const identifierComparator = (nodePath: NodePath, value: string): boolean =>
-  'name' in nodePath.node && nodePath.node.name === value;
-const unaryExpressionComparator = (nodePath: NodePath, value: string): boolean => {
-  if ('argument' in nodePath.node && nodePath.node.argument && 'name' in nodePath.node?.argument) {
-    return nodePath.node.argument.name === value;
-  }
-  return false;
-};
+import type { ConfigAPI, PluginObj, PluginPass, NodePath, types as t } from '@babel/core';
 
 const TYPEOF_PREFIX = 'typeof ';
+
+interface ProcessedReplacements {
+  /** Identifier name -> replacement value (e.g., "__DEV__" -> false) */
+  identifiers: Map<string, unknown>;
+  /** Member expression pattern -> replacement value (e.g., "process.env.NODE_ENV" -> "production") */
+  memberPatterns: Array<[string, unknown]>;
+  /** typeof argument name -> replacement value (e.g., "window" -> "object") */
+  typeofValues: Map<string, unknown>;
+  /** Set of root object names from member patterns for quick filtering (e.g., "process", "Platform") */
+  memberRoots: Set<string>;
+}
+
+interface DefinePluginState extends PluginPass {
+  processed?: ProcessedReplacements;
+}
 
 function definePlugin({ types: t }: ConfigAPI & typeof import('@babel/core')): PluginObj {
   /**
@@ -49,10 +31,10 @@ function definePlugin({ types: t }: ConfigAPI & typeof import('@babel/core')): P
    * evaluated. For example, if the result of the replacement is `var x = "production" === "production"`
    * The evaluation will make a second replacement resulting in `var x = true`
    */
-  function replaceAndEvaluateNode(nodePath: NodePath, replacement: string) {
+  function replaceAndEvaluateNode(nodePath: NodePath, replacement: unknown) {
     nodePath.replaceWith(t.valueToNode(replacement));
 
-    if (nodePath.parentPath && nodePath.parentPath.isBinaryExpression()) {
+    if (nodePath.parentPath?.isBinaryExpression()) {
       const result = nodePath.parentPath.evaluate();
 
       if (result.confident) {
@@ -61,93 +43,133 @@ function definePlugin({ types: t }: ConfigAPI & typeof import('@babel/core')): P
     }
   }
 
-  const isLeftHandSideOfAssignmentExpression = (node: t.MemberExpression, parent: t.Node) =>
-    t.isAssignmentExpression(parent) && parent.left === node;
-
-  const processNode = (
-    replacements: Record<string, string>,
-    nodePath: NodePath,
-    comparator: (nodePath: NodePath, value: string) => boolean
-  ): void => {
-    const replacementKey = Object.keys(replacements).find((value) => comparator(nodePath, value));
-    if (
-      typeof replacementKey === 'string' &&
-      replacements != null &&
-      replacementKey in replacements
-    ) {
-      replaceAndEvaluateNode(nodePath, replacements[replacementKey]);
+  /** Get the root identifier name from a member expression (e.g., "process" from "process.env.NODE_ENV") */
+  function getMemberExpressionRoot(node: t.MemberExpression): string | null {
+    let current: t.Expression = node;
+    while (t.isMemberExpression(current)) {
+      current = current.object;
     }
-  };
+    return t.isIdentifier(current) ? current.name : null;
+  }
 
   return {
     name: 'expo-define-globals',
+
+    pre() {
+      const opts = this.opts;
+      if (opts == null || typeof opts !== 'object') {
+        throw new Error('define plugin expects an object as options');
+      }
+
+      // Pre-process replacements once per file
+      const identifiers = new Map<string, unknown>();
+      const memberPatterns: Array<[string, unknown]> = [];
+      const typeofValues = new Map<string, unknown>();
+      const memberRoots = new Set<string>();
+
+      for (const key of Object.keys(opts)) {
+        const value = (opts as Record<string, unknown>)[key];
+
+        if (key.startsWith(TYPEOF_PREFIX)) {
+          // "typeof window" -> typeofValues["window"]
+          typeofValues.set(key.slice(TYPEOF_PREFIX.length), value);
+        } else if (key.includes('.')) {
+          // "process.env.NODE_ENV" -> memberPatterns, extract "process" as root
+          memberPatterns.push([key, value]);
+          const root = key.split('.')[0];
+          memberRoots.add(root);
+        } else {
+          // "__DEV__" -> identifiers
+          identifiers.set(key, value);
+        }
+      }
+
+      (this as DefinePluginState).processed = {
+        identifiers,
+        memberPatterns,
+        typeofValues,
+        memberRoots,
+      };
+    },
+
     visitor: {
       // process.env.NODE_ENV;
-      MemberExpression(nodePath, state): void {
-        if (
-          // Prevent rewriting if the member expression is on the left-hand side of an assignment
-          isLeftHandSideOfAssignmentExpression(nodePath.node, nodePath.parent)
-        ) {
+      MemberExpression(nodePath, state: DefinePluginState): void {
+        // Prevent rewriting if the member expression is on the left-hand side of an assignment
+        if (t.isAssignmentExpression(nodePath.parent) && nodePath.parent.left === nodePath.node) {
           return;
         }
-        const replacements = state.opts;
-        assertOptions(replacements);
-        processNode(replacements, nodePath, memberExpressionComparator);
+
+        const { memberPatterns, memberRoots } = state.processed!;
+        if (memberPatterns.length === 0) return;
+
+        // Quick filter: check if root matches any known pattern root
+        const root = getMemberExpressionRoot(nodePath.node);
+        if (!root || !memberRoots.has(root)) return;
+
+        // Check against patterns
+        for (const [pattern, replacement] of memberPatterns) {
+          if (nodePath.matchesPattern(pattern)) {
+            replaceAndEvaluateNode(nodePath, replacement);
+            return;
+          }
+        }
       },
 
       // const x = { version: VERSION };
-      ReferencedIdentifier(nodePath, state) {
-        const binding = nodePath.scope?.getBinding(nodePath.node.name);
+      ReferencedIdentifier(nodePath, state: DefinePluginState) {
+        const { identifiers } = state.processed!;
+        if (identifiers.size === 0) return;
 
+        const name = nodePath.node.name;
+
+        // Quick check: is this identifier in our replacements?
+        if (!identifiers.has(name)) return;
+
+        // Check for binding (locally defined variable shadows replacement)
+        if (nodePath.scope?.getBinding(name)) return;
+
+        // Don't transform import identifiers (mimics webpack's DefinePlugin behavior)
+        const container = nodePath.container;
         if (
-          binding ||
-          // Don't transform import identifiers. This is meant to mimic webpack's
-          // DefinePlugin behavior.
-          isImportIdentifier(nodePath) ||
-          // Do not transform Object keys / properties unless they are computed like {[key]: value}
-          (nodePath.key === 'key' &&
-            nodePath.parent &&
-            'computed' in nodePath.parent &&
-            nodePath.parent.computed === false) ||
-          (nodePath.key === 'property' &&
-            nodePath.parent &&
-            'computed' in nodePath.parent &&
-            nodePath.parent.computed === false)
+          container &&
+          !Array.isArray(container) &&
+          'type' in container &&
+          (container.type === 'ImportDefaultSpecifier' || container.type === 'ImportSpecifier')
         ) {
           return;
         }
-        const replacements = state.opts;
-        assertOptions(replacements);
-        processNode(replacements, nodePath, identifierComparator);
-      },
 
-      // typeof window
-      UnaryExpression(nodePath, state) {
-        if (nodePath.node.operator !== 'typeof') {
+        // Do not transform Object keys / properties unless they are computed like {[key]: value}
+        if (
+          (nodePath.key === 'key' || nodePath.key === 'property') &&
+          nodePath.parent &&
+          'computed' in nodePath.parent &&
+          nodePath.parent.computed === false
+        ) {
           return;
         }
 
-        const replacements = state.opts;
-        assertOptions(replacements);
+        replaceAndEvaluateNode(nodePath, identifiers.get(name));
+      },
 
-        const typeofValues: { [key: string]: any } = {};
+      // typeof window
+      UnaryExpression(nodePath, state: DefinePluginState) {
+        if (nodePath.node.operator !== 'typeof') return;
 
-        Object.keys(replacements).forEach((key) => {
-          if (key.substring(0, TYPEOF_PREFIX.length) === TYPEOF_PREFIX) {
-            typeofValues[key.substring(TYPEOF_PREFIX.length)] = replacements[key];
-          }
-        });
+        const { typeofValues } = state.processed!;
+        if (typeofValues.size === 0) return;
 
-        processNode(typeofValues, nodePath, unaryExpressionComparator);
+        const argument = nodePath.node.argument;
+        if (!t.isIdentifier(argument)) return;
+
+        const replacement = typeofValues.get(argument.name);
+        if (replacement !== undefined) {
+          replaceAndEvaluateNode(nodePath, replacement);
+        }
       },
     },
   };
-}
-
-function assertOptions(opts: any): asserts opts is Record<string, string> {
-  if (opts == null || typeof opts !== 'object') {
-    throw new Error('define plugin expects an object as options');
-  }
 }
 
 export default definePlugin;

--- a/packages/babel-preset-expo/src/define-plugin.ts
+++ b/packages/babel-preset-expo/src/define-plugin.ts
@@ -25,7 +25,11 @@ interface DefinePluginState extends PluginPass {
   processed?: ProcessedReplacements;
 }
 
-function definePlugin({ types: t }: ConfigAPI & typeof import('@babel/core')): PluginObj {
+function definePlugin({
+  types: t,
+}: ConfigAPI & typeof import('@babel/core')): PluginObj<
+  PluginPass & { opts: Record<string, null | boolean | string> }
+> {
   /**
    * Replace a node with a given value. If the replacement results in a BinaryExpression, it will be
    * evaluated. For example, if the result of the replacement is `var x = "production" === "production"`
@@ -56,19 +60,14 @@ function definePlugin({ types: t }: ConfigAPI & typeof import('@babel/core')): P
     name: 'expo-define-globals',
 
     pre() {
-      const opts = this.opts;
-      if (opts == null || typeof opts !== 'object') {
-        throw new Error('define plugin expects an object as options');
-      }
-
       // Pre-process replacements once per file
       const identifiers = new Map<string, unknown>();
       const memberPatterns: [string, unknown][] = [];
       const typeofValues = new Map<string, unknown>();
       const memberRoots = new Set<string>();
 
-      for (const key of Object.keys(opts)) {
-        const value = (opts as Record<string, unknown>)[key];
+      for (const key of Object.keys(this.opts)) {
+        const value = (this.opts as Record<string, unknown>)[key];
 
         if (key.startsWith(TYPEOF_PREFIX)) {
           // "typeof window" -> typeofValues["window"]

--- a/packages/babel-preset-expo/src/define-plugin.ts
+++ b/packages/babel-preset-expo/src/define-plugin.ts
@@ -14,7 +14,7 @@ interface ProcessedReplacements {
   /** Identifier name -> replacement value (e.g., "__DEV__" -> false) */
   identifiers: Map<string, unknown>;
   /** Member expression pattern -> replacement value (e.g., "process.env.NODE_ENV" -> "production") */
-  memberPatterns: Array<[string, unknown]>;
+  memberPatterns: [string, unknown][];
   /** typeof argument name -> replacement value (e.g., "window" -> "object") */
   typeofValues: Map<string, unknown>;
   /** Set of root object names from member patterns for quick filtering (e.g., "process", "Platform") */
@@ -63,7 +63,7 @@ function definePlugin({ types: t }: ConfigAPI & typeof import('@babel/core')): P
 
       // Pre-process replacements once per file
       const identifiers = new Map<string, unknown>();
-      const memberPatterns: Array<[string, unknown]> = [];
+      const memberPatterns: [string, unknown][] = [];
       const typeofValues = new Map<string, unknown>();
       const memberRoots = new Set<string>();
 

--- a/packages/babel-preset-expo/src/expo-inline-manifest-plugin.ts
+++ b/packages/babel-preset-expo/src/expo-inline-manifest-plugin.ts
@@ -174,8 +174,7 @@ export function expoInlineManifestPlugin(api: ConfigAPI & typeof import('@babel/
     name: 'expo-inline-manifest-plugin',
 
     pre() {
-      (this as InlineManifestState).projectRoot =
-        possibleProjectRoot || this.file.opts.root || '';
+      (this as InlineManifestState).projectRoot = possibleProjectRoot || this.file.opts.root || '';
     },
 
     visitor: {

--- a/packages/babel-preset-expo/src/expo-inline-manifest-plugin.ts
+++ b/packages/babel-preset-expo/src/expo-inline-manifest-plugin.ts
@@ -6,7 +6,7 @@ import { getIsReactServer, getPlatform, getPossibleProjectRoot } from './common'
 const debug = require('debug')('expo:babel:inline-manifest');
 
 // Convert expo value to PWA value
-function ensurePWAorientation(orientation?: string) {
+function ensurePWAOrientation(orientation?: string) {
   if (orientation) {
     const webOrientation = orientation.toLowerCase();
     if (webOrientation !== 'default') {
@@ -55,7 +55,7 @@ function applyWebDefaults({ config, appName, webName }: ConfigMemo) {
   const startUrl = webManifest.startUrl;
   const { scope, crossorigin } = webManifest;
   const barStyle = webManifest.barStyle;
-  const orientation = ensurePWAorientation(webManifest.orientation || appJSON.orientation);
+  const orientation = ensurePWAOrientation(webManifest.orientation || appJSON.orientation);
   /**
    * **Splash screen background color**
    * `https://developers.google.com/web/fundamentals/web-app-manifest/#splash-screen`
@@ -150,11 +150,13 @@ function getConfigMemo(projectRoot: string): ConfigMemo | null {
 }
 
 interface InlineManifestState extends PluginPass {
-  projectRoot?: string;
+  projectRoot: string;
 }
 
 // Convert `process.env.APP_MANIFEST` to a modified web-specific variation of the app.json public manifest.
-export function expoInlineManifestPlugin(api: ConfigAPI & typeof import('@babel/core')): PluginObj {
+export function expoInlineManifestPlugin(
+  api: ConfigAPI & typeof import('@babel/core')
+): PluginObj<InlineManifestState> {
   const { types: t } = api;
 
   const isReactServer = api.caller(getIsReactServer);
@@ -174,7 +176,7 @@ export function expoInlineManifestPlugin(api: ConfigAPI & typeof import('@babel/
     name: 'expo-inline-manifest-plugin',
 
     pre() {
-      (this as InlineManifestState).projectRoot = possibleProjectRoot || this.file.opts.root || '';
+      this.projectRoot = possibleProjectRoot || this.file.opts.root || '';
     },
 
     visitor: {
@@ -202,7 +204,7 @@ export function expoInlineManifestPlugin(api: ConfigAPI & typeof import('@babel/
 
         // Surfaces the `app.json` (config) as an environment variable which is then parsed by
         // `expo-constants` https://docs.expo.dev/versions/latest/sdk/constants/
-        const manifest = getExpoAppManifest(state.projectRoot!);
+        const manifest = getExpoAppManifest(state.projectRoot);
         if (manifest !== null) {
           parent.replaceWith(t.stringLiteral(manifest));
         }

--- a/packages/babel-preset-expo/src/expo-inline-manifest-plugin.ts
+++ b/packages/babel-preset-expo/src/expo-inline-manifest-plugin.ts
@@ -1,4 +1,4 @@
-import type { ConfigAPI, PluginObj } from '@babel/core';
+import type { ConfigAPI, PluginObj, PluginPass } from '@babel/core';
 import type { ExpoConfig, ProjectConfig } from 'expo/config';
 
 import { getIsReactServer, getPlatform, getPossibleProjectRoot } from './common';
@@ -149,6 +149,10 @@ function getConfigMemo(projectRoot: string): ConfigMemo | null {
   return configMemo;
 }
 
+interface InlineManifestState extends PluginPass {
+  projectRoot?: string;
+}
+
 // Convert `process.env.APP_MANIFEST` to a modified web-specific variation of the app.json public manifest.
 export function expoInlineManifestPlugin(api: ConfigAPI & typeof import('@babel/core')): PluginObj {
   const { types: t } = api;
@@ -157,41 +161,51 @@ export function expoInlineManifestPlugin(api: ConfigAPI & typeof import('@babel/
   const platform = api.caller(getPlatform);
   const possibleProjectRoot = api.caller(getPossibleProjectRoot);
   const shouldInline = platform === 'web' || isReactServer;
+
+  // Early exit: return a no-op plugin if we're not going to inline anything
+  if (!shouldInline) {
+    return {
+      name: 'expo-inline-manifest-plugin',
+      visitor: {},
+    };
+  }
+
   return {
     name: 'expo-inline-manifest-plugin',
+
+    pre() {
+      (this as InlineManifestState).projectRoot =
+        possibleProjectRoot || this.file.opts.root || '';
+    },
+
     visitor: {
-      MemberExpression(path: any, state: any) {
-        // Web-only/React Server-only feature: the native manifest is provided dynamically by the client.
-        if (!shouldInline) {
-          return;
-        }
+      MemberExpression(path, state: InlineManifestState) {
+        // We're looking for: process.env.APP_MANIFEST
+        // This visitor is called on every MemberExpression, so we need fast checks
 
-        if (
-          !t.isIdentifier(path.node.object, { name: 'process' }) ||
-          !t.isIdentifier(path.node.property, { name: 'env' })
-        ) {
-          return;
-        }
-
+        // Quick check: the property we're looking for is 'APP_MANIFEST'
+        // The parent must be a MemberExpression with property 'APP_MANIFEST'
         const parent = path.parentPath;
-        if (!t.isMemberExpression(parent.node)) {
-          return;
-        }
+        if (!parent?.isMemberExpression()) return;
 
-        const projectRoot = possibleProjectRoot || state.file.opts.root || '';
+        // Check if parent's property is APP_MANIFEST (most selective check first)
+        const parentProp = parent.node.property;
+        if (!t.isIdentifier(parentProp) || parentProp.name !== 'APP_MANIFEST') return;
 
-        if (
-          // Surfaces the `app.json` (config) as an environment variable which is then parsed by
-          // `expo-constants` https://docs.expo.dev/versions/latest/sdk/constants/
-          t.isIdentifier(parent.node.property, {
-            name: 'APP_MANIFEST',
-          }) &&
-          !parent.parentPath.isAssignmentExpression()
-        ) {
-          const manifest = getExpoAppManifest(projectRoot);
-          if (manifest !== null) {
-            parent.replaceWith(t.stringLiteral(manifest));
-          }
+        // Now verify this is process.env
+        const obj = path.node.object;
+        const prop = path.node.property;
+        if (!t.isIdentifier(obj) || obj.name !== 'process') return;
+        if (!t.isIdentifier(prop) || prop.name !== 'env') return;
+
+        // Skip if this is an assignment target
+        if (parent.parentPath?.isAssignmentExpression()) return;
+
+        // Surfaces the `app.json` (config) as an environment variable which is then parsed by
+        // `expo-constants` https://docs.expo.dev/versions/latest/sdk/constants/
+        const manifest = getExpoAppManifest(state.projectRoot!);
+        if (manifest !== null) {
+          parent.replaceWith(t.stringLiteral(manifest));
         }
       },
     },

--- a/packages/babel-preset-expo/src/expo-router-plugin.ts
+++ b/packages/babel-preset-expo/src/expo-router-plugin.ts
@@ -1,7 +1,7 @@
 /**
  * Copyright © 2024 650 Industries.
  */
-import type { ConfigAPI, PluginObj, NodePath, types as t } from '@babel/core';
+import type { ConfigAPI, PluginObj, PluginPass } from '@babel/core';
 import nodePath from 'node:path';
 import resolveFrom from 'resolve-from';
 
@@ -9,14 +9,29 @@ import { getExpoRouterAbsoluteAppRoot, getPossibleProjectRoot, getAsyncRoutes } 
 
 const debug = require('debug')('expo:babel:router');
 
+// Cache for getExpoRouterAppRoot results (projectRoot -> appRoot)
+const appRootCache = new Map<string, string>();
+
 function getExpoRouterAppRoot(projectRoot: string, appFolder: string) {
+  const cacheKey = `${projectRoot}:${appFolder}`;
+  const cached = appRootCache.get(cacheKey);
+  if (cached !== undefined) {
+    return cached;
+  }
+
   // TODO: We should have cache invalidation if the expo-router/entry file location changes.
   const routerEntry = resolveFrom(projectRoot, 'expo-router/entry');
 
   const appRoot = nodePath.relative(nodePath.dirname(routerEntry), appFolder);
 
   debug('routerEntry', routerEntry, appFolder, appRoot);
+  appRootCache.set(cacheKey, appRoot);
   return appRoot;
+}
+
+interface ExpoRouterPluginState extends PluginPass {
+  projectRoot?: string;
+  isTestEnv?: boolean;
 }
 
 /**
@@ -32,41 +47,62 @@ export function expoRouterBabelPlugin(api: ConfigAPI & typeof import('@babel/cor
   const possibleProjectRoot = api.caller(getPossibleProjectRoot);
   const asyncRoutes = api.caller(getAsyncRoutes);
   const routerAbsoluteRoot = api.caller(getExpoRouterAbsoluteAppRoot);
-
-  function isFirstInAssign(path: NodePath<t.MemberExpression>) {
-    return t.isAssignmentExpression(path.parent) && path.parent.left === path.node;
-  }
+  const importMode = asyncRoutes ? 'lazy' : 'sync';
 
   return {
     name: 'expo-router',
+
+    pre() {
+      const state = this as ExpoRouterPluginState;
+      state.projectRoot = possibleProjectRoot || this.file.opts.root || '';
+      // Check test env at transform time, not module load time
+      state.isTestEnv = process.env.NODE_ENV === 'test';
+    },
+
     visitor: {
-      MemberExpression(path: any, state: any) {
-        const projectRoot = possibleProjectRoot || state.file.opts.root || '';
+      MemberExpression(path, state: ExpoRouterPluginState) {
+        // Quick check: skip if not accessing something on an object named 'process'
+        const object = path.node.object;
+        if (!t.isMemberExpression(object)) return;
 
-        if (path.get('object').matchesPattern('process.env')) {
-          const key = path.toComputedKey();
-          if (t.isStringLiteral(key) && !isFirstInAssign(path)) {
-            // Used for log box on web.
-            if (key.value.startsWith('EXPO_PROJECT_ROOT')) {
-              path.replaceWith(t.stringLiteral(projectRoot));
-            } else if (key.value.startsWith('EXPO_ROUTER_IMPORT_MODE')) {
-              path.replaceWith(t.stringLiteral(asyncRoutes ? 'lazy' : 'sync'));
-            }
+        const objectOfObject = object.object;
+        if (!t.isIdentifier(objectOfObject) || objectOfObject.name !== 'process') return;
 
-            if (
-              // Skip loading the app root in tests.
-              // This is handled by the testing-library utils
-              process.env.NODE_ENV !== 'test'
-            ) {
-              if (key.value.startsWith('EXPO_ROUTER_ABS_APP_ROOT')) {
-                path.replaceWith(t.stringLiteral(routerAbsoluteRoot));
-              } else if (key.value.startsWith('EXPO_ROUTER_APP_ROOT')) {
-                path.replaceWith(
-                  t.stringLiteral(getExpoRouterAppRoot(projectRoot, routerAbsoluteRoot))
-                );
-              }
-            }
-          }
+        // Now check if it's process.env
+        if (!t.isIdentifier(object.property) || object.property.name !== 'env') return;
+
+        // Skip if this is an assignment target
+        if (t.isAssignmentExpression(path.parent) && path.parent.left === path.node) return;
+
+        // Get the property key
+        const key = path.toComputedKey();
+        if (!t.isStringLiteral(key)) return;
+
+        const keyValue = key.value;
+
+        // Check each possible env var
+        if (keyValue.startsWith('EXPO_PROJECT_ROOT')) {
+          path.replaceWith(t.stringLiteral(state.projectRoot!));
+          return;
+        }
+
+        if (keyValue.startsWith('EXPO_ROUTER_IMPORT_MODE')) {
+          path.replaceWith(t.stringLiteral(importMode));
+          return;
+        }
+
+        // Skip app root transforms in tests (handled by testing-library utils)
+        if (state.isTestEnv) return;
+
+        if (keyValue.startsWith('EXPO_ROUTER_ABS_APP_ROOT')) {
+          path.replaceWith(t.stringLiteral(routerAbsoluteRoot));
+          return;
+        }
+
+        if (keyValue.startsWith('EXPO_ROUTER_APP_ROOT')) {
+          path.replaceWith(
+            t.stringLiteral(getExpoRouterAppRoot(state.projectRoot!, routerAbsoluteRoot))
+          );
         }
       },
     },

--- a/packages/babel-preset-expo/src/expo-router-plugin.ts
+++ b/packages/babel-preset-expo/src/expo-router-plugin.ts
@@ -81,28 +81,32 @@ export function expoRouterBabelPlugin(api: ConfigAPI & typeof import('@babel/cor
         const keyValue = key.value;
 
         // Check each possible env var
-        if (keyValue.startsWith('EXPO_PROJECT_ROOT')) {
-          path.replaceWith(t.stringLiteral(state.projectRoot!));
-          return;
-        }
 
-        if (keyValue.startsWith('EXPO_ROUTER_IMPORT_MODE')) {
-          path.replaceWith(t.stringLiteral(importMode));
-          return;
+        switch (keyValue) {
+          case 'EXPO_PROJECT_ROOT':
+            path.replaceWith(t.stringLiteral(state.projectRoot!));
+            return;
+          case 'EXPO_ROUTER_IMPORT_MODE':
+            path.replaceWith(t.stringLiteral(importMode));
+            return;
+          default:
+            break;
         }
 
         // Skip app root transforms in tests (handled by testing-library utils)
         if (state.isTestEnv) return;
 
-        if (keyValue.startsWith('EXPO_ROUTER_ABS_APP_ROOT')) {
-          path.replaceWith(t.stringLiteral(routerAbsoluteRoot));
-          return;
-        }
-
-        if (keyValue.startsWith('EXPO_ROUTER_APP_ROOT')) {
-          path.replaceWith(
-            t.stringLiteral(getExpoRouterAppRoot(state.projectRoot!, routerAbsoluteRoot))
-          );
+        switch (keyValue) {
+          case 'EXPO_ROUTER_ABS_APP_ROOT':
+            path.replaceWith(t.stringLiteral(routerAbsoluteRoot));
+            return;
+          case 'EXPO_ROUTER_APP_ROOT':
+            path.replaceWith(
+              t.stringLiteral(getExpoRouterAppRoot(state.projectRoot!, routerAbsoluteRoot))
+            );
+            return;
+          default:
+            break;
         }
       },
     },

--- a/packages/babel-preset-expo/src/expo-router-plugin.ts
+++ b/packages/babel-preset-expo/src/expo-router-plugin.ts
@@ -104,9 +104,6 @@ export function expoRouterBabelPlugin(api: ConfigAPI & typeof import('@babel/cor
             path.replaceWith(
               t.stringLiteral(getExpoRouterAppRoot(state.projectRoot!, routerAbsoluteRoot))
             );
-            return;
-          default:
-            break;
         }
       },
     },


### PR DESCRIPTION
# Why

I setup `babel-timing` on a different branch to understand where we could optimize. Noticed that some of the plugins I wrote previously were doing extraneous passes and extra work.  

- expo-define-globals - 342.19ms
- expo-router - 78.79ms 
- expo-inline-manifest-plugin - 45.28ms 

Now:

- expo-define-globals - 174.96ms
- expo-router - 28.45ms
- expo-inline-manifest-plugin - 33.48ms

The changes aren't massive as this is only tested against a base project.


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Existing behavior should be covered in the tests.