### PR TITLE
fix(create-expo/e2e): Update `node-linker` setting location

### DIFF
--- a/packages/create-expo/e2e/__tests__/index-test.ts
+++ b/packages/create-expo/e2e/__tests__/index-test.ts
@@ -104,7 +104,6 @@ it('uses pnpm', async () => {
   expectFileNotExists(projectName, 'node_modules');
 
   // Check if `pnpm` node linker is set
-  expectFileExists(projectName, '.npmrc');
   const { stdout } = expectExecutePassing(
     await spawnAsync('pnpm', ['config', 'get', 'node-linker'], { cwd: getTestPath(projectName) })
   );


### PR DESCRIPTION
This was failing on `main`. The `node-linker` setting is now placed into `pnpm-workspace.yaml` by default rather than an `.npmrc`. This depends on the version of `pnpm` that's installed