### PR TITLE
[expo] Upgrade `react-native-screen` to `4.19.0`

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2919,7 +2919,7 @@ PODS:
     - ReactNativeDependencies
     - RNWorklets
     - Yoga
-  - RNScreens (4.19.0-nightly-20251203-1746a584e):
+  - RNScreens (4.19.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2941,9 +2941,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNScreens/common (= 4.19.0-nightly-20251203-1746a584e)
+    - RNScreens/common (= 4.19.0)
     - Yoga
-  - RNScreens/common (4.19.0-nightly-20251203-1746a584e):
+  - RNScreens/common (4.19.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3818,7 +3818,7 @@ SPEC CHECKSUMS:
   EXUpdates: 83e4d666a085b44149f3b21d5bd057ad37b2c3e5
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   FBLazyVector: 7c1d69992204c5ec452eeefa4a24b0ff311709c8
-  hermes-engine: 6bb3000824be2770010ae038914fa26721255c8e
+  hermes-engine: 67894097e90a25b73f8b0f0c999e239f12b1842e
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -3836,7 +3836,7 @@ SPEC CHECKSUMS:
   React: f6f8fc5c01e77349cdfaf49102bcb928ac31d8ed
   React-callinvoker: 3e62a849bda1522c6422309c02f5dc3210bc5359
   React-Core: 0b765bc7c2b83dff178c2b03ed8a0390df26f18c
-  React-Core-prebuilt: 620fa7df017f9663e0e8b96c68d2441fb6770c49
+  React-Core-prebuilt: 41379a76b354a39ee48aa47d21fc161eee052d0e
   React-CoreModules: 55b932564ba696301cb683a86385be6a6f137e57
   React-cxxreact: 5bfb95256fde56cc0f9ce425f38cfaa085e71ad2
   React-debug: f9dda2791d3ebe2078bc6102641edab77917efb7
@@ -3906,14 +3906,14 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 23e2bca1661f8781e55fcc05a151fc1df97bc1fb
   ReactCodegen: ed5e30a49f34630c4bf9fc339b8ace492d80f9e5
   ReactCommon: 89ccc6cb100ca5a0303b46483037ef8f3e06e2e0
-  ReactNativeDependencies: b050dc3d4b087c93c8b61da7cf660d2da08a4739
+  ReactNativeDependencies: 5366e8d6d45f6add60da05aa112051f32641d5c6
   RNCAsyncStorage: e85a99325df9eb0191a6ee2b2a842644c7eb29f4
   RNCMaskedView: 3c9d7586e2b9bbab573591dcb823918bc4668005
   RNCPicker: 38a9deb903d9a8ae18b598bac727e6c84b3cf0fa
   RNDateTimePicker: 6fdd63f5d1e0f21faf4cc8674957c52958a7efae
   RNGestureHandler: 72efe2ab9d5d1b1d25b96f3ad3d174992f3bad87
   RNReanimated: 03e066b9967a8ccd8ff28aa88c098d8117b4d860
-  RNScreens: 23072e49d81e27f08b9451f63ac81fa33237c48f
+  RNScreens: 08ec2d3a35cbeeb9ddd063e5aa8fb6da5bf3a978
   RNSVG: 595d31b6cd45e92424c6b623bd93e1e9b6aa8b79
   RNWorklets: 78d1eb5df6aa27c762c1466aaaffba8774d807a8
   SDWebImage: f29024626962457f3470184232766516dee8dfea
@@ -3924,6 +3924,6 @@ SPEC CHECKSUMS:
   Yoga: 90687fcd1ebd927341caed917696d692813c0b24
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: 293433137ea62a126033703d9237390c4ab6c393
+PODFILE CHECKSUM: a51febb16165299188befc91ca5c5f5412219590
 
 COCOAPODS: 1.16.2

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -74,7 +74,7 @@
     "react-native-pager-view": "6.9.1",
     "react-native-reanimated": "4.2.0",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.19.0-nightly-20251203-1746a584e",
+    "react-native-screens": "4.19.0",
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.15.0",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3657,7 +3657,7 @@ PODS:
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNScreens (4.19.0-nightly-20251203-1746a584e):
+  - RNScreens (4.19.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3684,10 +3684,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.19.0-nightly-20251203-1746a584e)
+    - RNScreens/common (= 4.19.0)
     - SocketRocket
     - Yoga
-  - RNScreens/common (4.19.0-nightly-20251203-1746a584e):
+  - RNScreens/common (4.19.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -4570,78 +4570,78 @@ SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
-  EASClient: 68127f1248d2b25fdc82dbbfb17be95d1c4700be
-  EXApplication: 296622817d459f46b6c5fe8691f4aac44d2b79e7
-  EXAV: e3fefaca88f14624bca01d9a128562a5f8e738f8
-  EXConstants: a95804601ee4a6aa7800645f9b070d753b1142b3
+  EASClient: de38c20c1dd9af7ff435afdc8b2c9b7c20d46767
+  EXApplication: a9d1c46d473d36f61302a9a81db2379441f3f094
+  EXAV: f33ecd2d85522045cb1f0cc2fae3aa53e4e0c3c0
+  EXConstants: 59d46d25b89f88cc38291a56dbce4d550758f72d
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
-  EXManifests: 224345a575fca389073c416297b6348163f28d1a
-  EXNotifications: 7a2975f4e282b827a0bc78bb1d232650cb569bbd
-  Expo: 893f285c89da2145c740d723cb48824705fced04
-  expo-dev-menu: 565b34d448aeb44c007ea28f7eed4b9f84099c80
+  EXManifests: 7469efed75d694ce3c43a6da9c6f3886f66d3c26
+  EXNotifications: a9eb811deeb51fb8e50ef45569be6ffab3994648
+  Expo: 446942b564f6fa3f855457d1f1678a9d5c5f3741
+  expo-dev-menu: ae1feaf51f47590afc4527c6a75165beb7aed0dd
   expo-dev-menu-interface: 30d9aa2fbca275a1335ca7e076273dac1d42d40a
-  ExpoAgeRange: b1d5dcc89405adae714b7713cdc5689ff9e19f4d
-  ExpoAppleAuthentication: bc9de6e9ff3340604213ab9031d4c4f7f802623e
-  ExpoAsset: 84810d6fed8179f04d4a7a4a6b37028bbd726e26
-  ExpoAudio: b04c4ae65e0174a8f4b097b2aa4040441c49fbd5
-  ExpoBackgroundFetch: ed6e4bf58cab43d3d3fa29ece1661d88a08c882d
-  ExpoBackgroundTask: 22ed53b129d4d5e15c39be9fa68e45d25f6781a1
-  ExpoBattery: a5d7037bbdc0ecf6619ce23a92b8d74d470ac54f
-  ExpoBlur: 2dd8f64aa31f5d405652c21d3deb2d2588b1852f
-  ExpoBrightness: 32672952bf8b152d0cceaf8ec9f1def3a9a5e0d9
-  ExpoCalendar: 34fe3956dab6278057a8ad04c648fe43bd642ef5
-  ExpoCamera: a5ef3d199495c8d61e0544b06a130c67e98189bb
-  ExpoCellular: 29d1b3e065cb85c585297e9f75e23e3a965f2301
-  ExpoClipboard: af650d14765f19c60ce2a1eaf9dfe6445eff7365
-  ExpoContacts: f39087ad6b85f388184a52f9858393b2800b0d2e
-  ExpoCrypto: c1fbce112d1b6b79652bbe380b4fd4cc91676595
-  ExpoDevice: 2f01090a3115ae223988134a70bf96a2e59dbbfd
-  ExpoDocumentPicker: 2200eefc2817f19315fa18f0147e0b80ece86926
-  ExpoDomWebView: b05849dc0f139754f914db14beb7822215e48c36
-  ExpoFileSystem: 4fb06865906e781329eb67166bd64fc4749c3019
-  ExpoFont: 86ceec09ffed1c99cfee36ceb79ba149074901b5
-  ExpoGL: 08e3c61191e39b9b67b964b78f55337165ec02df
-  ExpoGlassEffect: e48c949ee7dcf2072cca31389bf8fa776c1727a0
-  ExpoHaptics: 807476b0c39e9d82b7270349d6487928ce32df84
-  ExpoImage: c6246a2fe19dd28522e8ddedf3ab6c23993c163a
-  ExpoImageManipulator: 3c771ab212ad53f9b97f85200d41ea089bd9b758
-  ExpoImagePicker: d251aab45a1b1857e4156fed88511b278b4eee1c
-  ExpoKeepAwake: 1a2e820692e933c94a565ec3fbbe38ac31658ffe
-  ExpoLinearGradient: a464898cb95153125e3b81894fd479bcb1c7dd27
-  ExpoLinking: f051f28e50ea9269ff539317c166adec81d9342d
-  ExpoLivePhoto: 023cb9092676fd545018c095af0aeade53d9544f
-  ExpoLocalAuthentication: ea7b9878fefac9ae38dc5766af00b52cac55c51b
-  ExpoLocalization: b852a5d8ec14c5349c1593eca87896b5b3ebfcca
-  ExpoLocation: 93d7faa0c2adbd5a04686af0c1a61bc6ed3ee2f7
-  ExpoLogBox: 07180e5ecd27974a5549266065d0258e78ea14d8
-  ExpoMailComposer: f513efa3833a7dbd64065e54d5d61585b43fd9b2
-  ExpoMediaLibrary: 641a6952299b395159ccd459bd8f5f6764bf55fe
-  ExpoMeshGradient: c732e71dc4ba7323d09a6a6360321bcb2cc249ae
-  ExpoModulesCore: edb1cafd5bad55a7ec0a93542ad14cb2649596f7
-  ExpoModulesJSI: 7f289ef5df7f2608ca453f8fd34f861eef66fc6a
-  ExpoModulesTestCore: be5073c51ffe7c2db9f14aedfce7d8cdc141f55a
-  ExpoNetwork: b87392dcc24d49a595f186ca25cdcf7293d30275
-  ExpoPrint: 3fa0bd322ea8effa81893a099803c914e59ad46f
-  ExpoRouter: e4269ca6e4083b1e671474ad65bb6a7f51fe642d
-  ExpoScreenCapture: d3bf63d48c87f8dad3f0874412ce9d47b6ddf709
-  ExpoScreenOrientation: 6d5996b4de4e5d464fff470949404ec4d91567b7
-  ExpoSecureStore: 9c6571fe3fcb045a671c4011c451546eaaab98fd
-  ExpoSensors: c420123b1c0c2a49e86908055742caaefb1f687e
-  ExpoSharing: 032c01bb034319e2374badf082ae935be866d2e9
-  ExpoSMS: 10cd15976285c7e42f91790d6584eea53dc4e026
-  ExpoSpeech: 18a7f92a932028e16d3df1891377a8b626ab5cc0
-  ExpoSQLite: 81d4359265bd7a8ce0a492ecf74895d97dcf92e4
-  ExpoStoreReview: fd420d7a5745b3111735abac551b5d2853547f9e
-  ExpoSymbols: 1ae04ce686de719b9720453b988d8bc5bf776c68
-  ExpoSystemUI: 6cd74248a2282adf6dec488a75fa532d69dee314
-  ExpoTrackingTransparency: 95602afd451d5e3a3fb3628d0afc2e63e8fcf8dd
-  ExpoVideo: 6ffaf450d18b2ca33bdf92acaea80271b4a06c92
-  ExpoVideoThumbnails: cadd91e1e71794cc3be76f815b46db33fa8e2fc6
-  ExpoWebBrowser: 533bc2a1b188eec1c10e4926decf658f1687b5e5
+  ExpoAgeRange: 294504c50f493b0b5da2107fd47126486164ec09
+  ExpoAppleAuthentication: 414e4316f8e25a2afbc3943cf725579c910f24b8
+  ExpoAsset: 4375a46b45b12bbfcf6efac8c8a33aebdb8ba12b
+  ExpoAudio: 80c3cce8e252081c24837ef4c7bedda78f3ce8de
+  ExpoBackgroundFetch: e0a8fba22cb21473f667eb8220cab7feef18e63c
+  ExpoBackgroundTask: c6f9ddfb624d9b5ec548d69fd7195745e08ff987
+  ExpoBattery: da883ecca2a79507916edd00836ef6a50afecac2
+  ExpoBlur: b5b7a26572b3c33a11f0b2aa2f95c17c4c393b76
+  ExpoBrightness: 7c3c86da46b847aadf44401bd28fb6d67050f324
+  ExpoCalendar: 46ad51c48d2cb1a95439c2215b182428919a0c3d
+  ExpoCamera: 442bbbbd75d73d17f3a972b269efe7595b9b6933
+  ExpoCellular: 539c6092e755f7b2c37d80f18d9c1f3d7f09e4ab
+  ExpoClipboard: 99109306a2d9ed2fbd16f6b856e6267b2afa8472
+  ExpoContacts: 82f80ddc812c85548b8edab4153fbc3e8a39212e
+  ExpoCrypto: 4c50a152f5939e16a2ca10be77b002a3a391c4d3
+  ExpoDevice: 205f817268e7cc1acdbc354a425626bf328d0004
+  ExpoDocumentPicker: dbe4eeeb771891209fee044a6b0bafbd1fdcc4fa
+  ExpoDomWebView: f8d74b970eede6e02ca2f215742812472f046817
+  ExpoFileSystem: adffad7d1f57f768ca7a5e3bf450312fb9ebd27a
+  ExpoFont: d3e56c7cc03d9fd113b90a5513ad32b4bf46b0ff
+  ExpoGL: 39262a8c3d4c36d48a28bc412e3392c25c5391c9
+  ExpoGlassEffect: 02d9577dfe05a6b6c9856fd71514120e96792052
+  ExpoHaptics: b48d913e7e5f23816c6f130e525c9a6501b160b5
+  ExpoImage: 0fc185a4a4e462fedfe877ae66204a7c541dfee0
+  ExpoImageManipulator: d6ebf77518412c40d9837d72bf043fd95edec643
+  ExpoImagePicker: bd0a5c81d7734548f6908a480609257e85d19ea8
+  ExpoKeepAwake: 3f5e3ac53627849174f3603271df8e08f174ed4a
+  ExpoLinearGradient: f9e7182e5253d53b2de4134b69d70bbfc2d50588
+  ExpoLinking: f5c171877e118e792cb9a77e5ade0b080d899b14
+  ExpoLivePhoto: 3b9d71033932eb0202034ee11445b72fa187674a
+  ExpoLocalAuthentication: 8f11d958b956fa372c0a49975f54ed1dc617ae1d
+  ExpoLocalization: 6c6f0f89ad2822001ab0bc2eb6d4d980c77f080c
+  ExpoLocation: 1dc9e4c06ef66ed081348a11eb637d1dfecc7d61
+  ExpoLogBox: b4c81de3f21bbe2e9467a26455563c76c7709efb
+  ExpoMailComposer: 8771121c8d5e6e0e194537fab79360d0f443f70d
+  ExpoMediaLibrary: 648cee3f5dcba13410ec9cc8ac9a426e89a61a31
+  ExpoMeshGradient: 763087d3b1e6e9a0974e9700ea24cb598816d93c
+  ExpoModulesCore: d843eb08a3bc89716cd4eb517f89e17afa451ffc
+  ExpoModulesJSI: b5e87deda640f9710d08446db5d110e91db64cc9
+  ExpoModulesTestCore: e65555b75a4ed7dd3bcf421ad01d7748bd372c88
+  ExpoNetwork: 97073786edfe405aba5d0987a544617ed0671ad1
+  ExpoPrint: ad836bb90da10793509651c0ea1f39e120db001e
+  ExpoRouter: 84268c2b41722697cb02cd6c377d588b4f71c9b5
+  ExpoScreenCapture: 0c785ab7e1fa38943f04b16060d54ae8f886544a
+  ExpoScreenOrientation: 3d7f279ae28b395ba6d313768735cfba40710c49
+  ExpoSecureStore: f44dee1354536bdb3d7fab8cc451ee737c41beca
+  ExpoSensors: 4e9582fe20b9829a3a1d276e07ecd7916ee1ca84
+  ExpoSharing: 6f52a070c3083c11717cf2236ae8fd6ac45bf028
+  ExpoSMS: 429edbe5911e7899bc9a0a1a2c106677f552dc33
+  ExpoSpeech: 0b515130c96898789e72e8d0aac82b7e9123e88b
+  ExpoSQLite: e22c4e298016e658454527ec7dbda5a237b293a3
+  ExpoStoreReview: 142af4a031b0a7ad99e70e1de8675da03be4ff40
+  ExpoSymbols: ef7b8ac77ac2d496b1bc3f0f7daf5e19c3a9933a
+  ExpoSystemUI: 5e7fbe4b716edb9e3a7bc0441e4a3b6b1f9eb1ea
+  ExpoTrackingTransparency: 92e731b9b9b09353c3ef48e0fc9f82b89a1957c6
+  ExpoVideo: 7e39a5933892dc640b1b83013f3f9d9d37072151
+  ExpoVideoThumbnails: c951ae8c6ed9974dd3ae5f79b2dd1d9b6e8ab266
+  ExpoWebBrowser: 4f0dc52a559027cc0fba6920adc19a7604e2733d
   EXStructuredHeaders: c951e77f2d936f88637421e9588c976da5827368
-  EXTaskManager: cf225704fab8de8794a6f57f7fa41a90c0e2cd47
-  EXUpdates: ea916b08e3fdb82b7d5d36c77abe9c47eb313900
-  EXUpdatesInterface: 5adf50cb41e079c861da6d9b4b954c3db9a50734
+  EXTaskManager: 7d80cb59c1faa3dcfa42035b185bcb5209ca7b1b
+  EXUpdates: a318472f1671f936208c26ef71955415a1b2e279
+  EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: a293a88992c4c33f0aee184acab0b64a08ff9458
   FirebaseAnalytics: acfa848bf81e1a4dbf60ef1f0eddd7328fe6673e
@@ -4659,115 +4659,115 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: d7f7fb1a27f66786d3ff4a911c81178eb7703bd7
+  hermes-engine: 184fc6b3c638036331cd1ab4e2d94ee375a262d7
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
-  lottie-react-native: 86fa7488b1476563f41071244aa73d5b738faf19
+  lottie-react-native: d849be4292d467c0e13fd4ca5042bb352b7d1a61
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
-  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
+  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: 2b70c6e3abe00396cefd8913efbf6a2db01a2b36
   RCTRequired: f3540eee8094231581d40c5c6d41b0f170237a81
   RCTSwiftUI: 5928f7ca7e9e2f1a82d85d4c79ea3065137ad81c
-  RCTSwiftUIWrapper: 8ff2f9da84b47db66d11ece1589d8e5515c0ab8b
+  RCTSwiftUIWrapper: 1d538f86a38b18a6d5f70a94afa696242f46f5e5
   RCTTypeSafety: 6359ff3fcbe18c52059f4d4ce301e47f9da5f0d5
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
   React: f6f8fc5c01e77349cdfaf49102bcb928ac31d8ed
   React-callinvoker: 032b6d1d03654b9fb7de9e2b3b978d3cb1a893ad
-  React-Core: 418c9278f8a071b44a88a87be9a4943234cc2e77
-  React-CoreModules: 925b8cb677649f967f6000f9b1ef74dc4ff60c30
-  React-cxxreact: 21f6f0cb2a7d26fbed4d09e04482e5c75662beaf
+  React-Core: ce3dea95f8ae196e9bfba71e3a5ef6057385890b
+  React-CoreModules: 78916168da700dfe90ecba15734e0e9c5b726814
+  React-cxxreact: 04f73d81cfe783a57a88ef8683c76edc5bda3af8
   React-debug: 8fc21f2fecd3d6244e988dc55d60cb117d122588
-  React-defaultsnativemodule: 05c6115a2d3a7f4a2cc3f96022261570700dbfa5
-  React-domnativemodule: f19d7fd59facf19a4e6cb75bf48357c329acaea7
-  React-Fabric: 94acdbc0b889bdcec2d5b1a90ae48f1032c5a5a1
-  React-FabricComponents: 9754fb783979b88fb82ed3d0c50ae5f5d775a86f
-  React-FabricImage: d8f5bcb5006eafc0e2262c11bf4dedaa610fd66c
-  React-featureflags: 8bd4abaf8adf3cf5cc115f128e8761fd3d95b848
-  React-featureflagsnativemodule: 0062ca1dc92cb5aae22df8aed4e8f261759cb3bd
-  React-graphics: 318048b8f98e040c093adcb77ffeb46d78961c30
-  React-hermes: 05ca52f53557a31b8ef8bac8f94c3f9db1ff00ed
-  React-idlecallbacksnativemodule: d3c5ba0150555ce9b7db85008aeb170a02bbf2d8
-  React-ImageManager: 225b19fcb16fd353851d664c344025a6d4d79870
-  React-intersectionobservernativemodule: d490ebd28572754dfdad4a8d0771573345b1ec92
-  React-jserrorhandler: caafb9c1d42c24422829e71e8178de3dd1c7ea12
-  React-jsi: 749de748ad3b760011255326c63bf7b7dd6f8f9d
-  React-jsiexecutor: 02a5ee45bffcae98197eaa253fbf13b65c95073d
-  React-jsinspector: 4a031b0605009d4bcd079c99df85eb55d142cd12
-  React-jsinspectorcdp: 6d25166ec876053b7b6e290eb57f41a9f9496846
-  React-jsinspectornetwork: 5c481d208eade7a338f545b2645a2cf134fdf265
-  React-jsinspectortracing: b4d2404ecd64a0dd65e2746d9867fbc3a7cd0927
-  React-jsitooling: e0d93e78a5a231e4089459ddbed8d4844be9e238
-  React-jsitracing: f3c4aae144b86799e9e23eb5ef16bae6b474d4e2
-  React-logger: 9e597cbeda7b8cc8aa8fb93860dade97190f69cc
-  React-Mapbuffer: 20046c0447efaa7aace0b76085aa9bb35b0e8105
-  React-microtasksnativemodule: 0e837de56519c92d8a2e3097717df9497feb33cb
-  react-native-google-maps: c4f5c5b2dda17e7cb2cb2b37a81f140b039b3e7e
-  react-native-keyboard-controller: 8bd5f5572b6d5d402a2f77987a17492f869e5d62
-  react-native-maps: 9febd31278b35cd21e4fad2cf6fa708993be5dab
-  react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
-  react-native-pager-view: a0516effb17ca5120ac2113bfd21b91130ad5748
-  react-native-safe-area-context: a72764e0eb5d6b79b7450e5d0ae919eb1a4567b4
-  react-native-segmented-control: bf6e0032726727498e18dd437ae88afcdbc18e99
-  react-native-skia: 665cd52db7ad3d41e2a59c84e9c097343745c088
-  react-native-slider: 663776e5683e257de8df8091abc2d93ff6ec67db
-  react-native-view-shot: 6c008e58f4720de58370848201c5d4a082c6d4ca
-  react-native-webview: 4cbb7f05f2c50671a7dcff4012d3e85faad271e4
-  React-NativeModulesApple: 1a378198515f8e825c5931a7613e98da69320cee
-  React-networking: bfd1695ada5a57023006ce05823ac5391c3ce072
+  React-defaultsnativemodule: 7e39a67ea846a0c28fa1f8f3b7eb9c8d182cb519
+  React-domnativemodule: 94500ffaa0e79ac9365bd239c1081bbeae76c5e1
+  React-Fabric: bf43f81647dbb4760b38e8e54ff4734bcf3c3b2b
+  React-FabricComponents: 3dac7ea7ec199495b1b8bc57698ce2d215c8df4f
+  React-FabricImage: c0a883774156e295a58e2658584ba7b744728749
+  React-featureflags: 57a5e07572451ec5c3fdfef5ec38e8f168aeba74
+  React-featureflagsnativemodule: c43443be3e3f29b4d02a8ed1c5b823159e990f52
+  React-graphics: e1a6995d70dd81db0c1d6f48fa9d5746cff23a57
+  React-hermes: c15f47e27ebc5b5a4879a662192a2b5a2dbb121c
+  React-idlecallbacksnativemodule: e02e937ad0b76431e41cd4c0c4a964e2171df9a6
+  React-ImageManager: db5557eb93bebef31bf846c6125b5a721a1315d9
+  React-intersectionobservernativemodule: f45124cc5344500c862c1ea98386fe7f2e5ec214
+  React-jserrorhandler: 2e42cbfcfa1fe5def2b386bb88579d88a793b305
+  React-jsi: f93d4c647cb3c8668619a3217154627f22b3ba93
+  React-jsiexecutor: 4b53a61c342a7e4df1271e45b72eebb0c7537b5c
+  React-jsinspector: 6601404af388513573ce330248fba1951f374a06
+  React-jsinspectorcdp: edae3e229f9232156598e07765915ea153bb93a8
+  React-jsinspectornetwork: 9c2bf9c45bdd3a53b6fafa3c92057d3267056500
+  React-jsinspectortracing: f3132ce1e23f0b0a4e70b4f07ced6e766dbb3e00
+  React-jsitooling: 93f0b858d38f4c3e1231ff3a9ad3880ee1807776
+  React-jsitracing: b444d2d4aee3707d2838981a1ba6d9d859089da6
+  React-logger: 3fc17afd62cdb87324a345b107b06a90b3e2dea0
+  React-Mapbuffer: d690542fbbded9d9526a0a883c439aa82e4cede3
+  React-microtasksnativemodule: b908076184179c0fd0db8713b5140f6e6e0e56c7
+  react-native-google-maps: 7cc1184afe41fbd15a3dffd53c924819f6587b69
+  react-native-keyboard-controller: 5e209d13d4c5355ddf8c36be3d41b8dfc879cd91
+  react-native-maps: ee1e65647460c3d41e778071be5eda10e3da6225
+  react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
+  react-native-pager-view: 899989dd025d219d3ac0d386b2bc162f81ae8330
+  react-native-safe-area-context: 2249e17382bd5a97cbccaa89e22af8756188c0fb
+  react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
+  react-native-skia: 6fe142fbe7f93579e6205d4045abdf5d6574b942
+  react-native-slider: 30cea7008de785564de2f4fd064f2deb38614a4a
+  react-native-view-shot: aac285cd08144be29c19ab659930172836f0067f
+  react-native-webview: 183e0d1f10b3c61c5ddd70f4ecd46488856a3573
+  React-NativeModulesApple: 153a3effe2df7d35881f3f0c126c8182b8643e5a
+  React-networking: 236c494a8d26fc5a776b3cfec7795a3e55143c91
   React-oscompat: aedc0afbded67280de6bb6bfac8cfde0389e2b33
-  React-perflogger: c174462de00c0b7d768f0b2d61b8e2240717a667
-  React-performancecdpmetrics: 2607a034407d55049f1820b7ec86db1efd3d22e1
-  React-performancetimeline: 6ebdcdf745dbe372508ad7164e732362e7eeae6f
+  React-perflogger: 65e40e7afec4f9d2b1934baf8223f8ff73d4ce6d
+  React-performancecdpmetrics: 5f221a5581f34959707a5153bcdb6775fcfd5b77
+  React-performancetimeline: df0ec4aa60217aa71d178ad90b93b4318ab2ed31
   React-RCTActionSheet: 175c74d343e92793d3187b3a819d565f534e0b1d
-  React-RCTAnimation: d67919cddb7da39c949b8010b4fd4ea39815fe4e
-  React-RCTAppDelegate: 5f7b1e4b7ee5a44faf5f9518a7d3cabafb801adf
-  React-RCTBlob: 7ceb93e0918511163f036cfd295973f132a2bc57
-  React-RCTFabric: f2250d34e1143c659b845af7e369b3f8f015950c
-  React-RCTFBReactNativeSpec: b0fc0c9c8adaf8b9183f9e9fb5455ca5deedc7a0
-  React-RCTImage: d6297035168312fc3089f8ca0ee7a75216f21715
-  React-RCTLinking: 619a2553c4ef83acaccfb551ada1b7d45cf1cce3
-  React-RCTNetwork: 7df41788a194dc5b628f58db6a765224b6b37eac
-  React-RCTRuntime: f75ec08d991c611f1d74154dfeb852e30b1825dd
-  React-RCTSettings: fa7882ce3d73f1e3482fe05f9cb3167a35a60869
-  React-RCTText: 4d659598d9b7730343d465c43d97b3f4aad13938
-  React-RCTVibration: 968c3184bfe5005bedd86c913a3b52438222e3a4
+  React-RCTAnimation: 4056aa1dd854167164563d4cfaecaa932a8ba999
+  React-RCTAppDelegate: 59e920b73759d31ebcd9d6e3b9816de3ed8206b4
+  React-RCTBlob: d154413584f959bc96303bfe9e0d59ef88bbe590
+  React-RCTFabric: 4047481287f5db88210e9770fddfcd0992365b1c
+  React-RCTFBReactNativeSpec: 81c4e73677c31fd88d087117ca15c3699fab753e
+  React-RCTImage: 3b944bfe431f0bd74fad0b0b0af7c375c44f1edf
+  React-RCTLinking: 45c05cdd58f5fa1006d94e93da2f35c080f423b2
+  React-RCTNetwork: c1aca7f6c18fe305254d48c5f6cda2e92ff43607
+  React-RCTRuntime: bd9afe3a2a2a2ea4172533fcb1a96c60e17f32e2
+  React-RCTSettings: d4a6492bd9502bf239ec16b24858cecfa908ace4
+  React-RCTText: 0c507cfb9dbb9ae10685ec47e1db1759600f75bb
+  React-RCTVibration: 011035bf5753761355c070af58ad05f5d7674372
   React-rendererconsistency: 1204c62facf6168b69bc5022e0020f19c92f138e
-  React-renderercss: 36c02a3c55402fdb06226c2ef04d82fc06c4e2fc
-  React-rendererdebug: 11b54233498d961d939d2f2ec6c640d44efa3c12
-  React-RuntimeApple: 5287d92680f4b08c8e882afe9791a41eab69d4a7
-  React-RuntimeCore: 402b658d8e9cefb44824624e39a0804f2237e205
-  React-runtimeexecutor: a1ce75c4e153ede11be957ef31bb72eef9cc4daf
-  React-RuntimeHermes: c987b19a1284c685062d3eaad79fd9300a3aa82f
-  React-runtimescheduler: a12722da46f562626f5897edf9b8fa02219de065
-  React-timing: a453a65192dbe400d61d299024e95a302e726661
-  React-utils: 43479e74f806f6633ee04c212c48811530041170
-  React-webperformancenativemodule: bd1ad71ea9e217e55f66233e99d02581ee3d5cb7
-  ReactAppDependencyProvider: ebcf3a78dc1bcdf054c9e8d309244bade6b31568
-  ReactCodegen: 21e28a112d96c89473567f2852ed445d575178c6
-  ReactCommon: 424cc34cf5055d69a3dcf02f3436481afb8b0f6f
-  RNCAsyncStorage: 29f0230e1a25f36c20b05f65e2eb8958d6526e82
-  RNCMaskedView: 5ef8c95cbab95334a32763b72896a7b7d07e6299
-  RNCPicker: a7e5555ebf53e17e06c1fde62195cf07b685d26c
-  RNDateTimePicker: cda4c045beca864cebb3209ef9cc4094f974864c
-  RNGestureHandler: be7148bc663eac98c0ad6474b4b105f8cadd56be
-  RNReanimated: 715e5661739c6649b918153fd2ce9b8cbbf03bc6
-  RNScreens: 9ac872bb794dca4b685a3fef0e77ccc3bb80008f
-  RNSVG: 4e9e2409faeec5d16b75ab5231d572b8d6739110
-  RNWorklets: f2ed333c600377955ac5ab798a14210805de846d
+  React-renderercss: 77e9d118c0026cdb093c522d5e9cb7669d5d0cf4
+  React-rendererdebug: 8a355bb7c619cdc4d38b7ec7912f185026dc447e
+  React-RuntimeApple: 297e55eda9aec96d108611a7df51a6045e4e87ac
+  React-RuntimeCore: c4fbc07d2cbf3c9cf34cc0ca416c054dfc7feb80
+  React-runtimeexecutor: 0ba49c1979f7881e97426f593a0147c1c5be992c
+  React-RuntimeHermes: 3729990da73339d95b536797753f3e20e61f4a3a
+  React-runtimescheduler: df0f89b264cb24b16d224f9b524d8b2333270e66
+  React-timing: ae03268dceeb18e6c94becb2648e1cb093d3250d
+  React-utils: 16ee6a8ad7f6be49bca27e42f3fe9603e0f04e2a
+  React-webperformancenativemodule: 2e06a8c4c84da4777c56603db36f6a6915d1991d
+  ReactAppDependencyProvider: 23e2bca1661f8781e55fcc05a151fc1df97bc1fb
+  ReactCodegen: 0c6def52d0d29c97b85d4e269b247b6a9709a10a
+  ReactCommon: c6cd81778336e767e27fe63c6707dd6b735fff5c
+  RNCAsyncStorage: 302f2fac014fd450046c120567ca364632da682b
+  RNCMaskedView: 63268de1986a098b5f4d1fb5b1bc1e97fade0aee
+  RNCPicker: 51992b3407f6b70ddb8e417ec5714c3f2d48d8a4
+  RNDateTimePicker: c4a42c6a77d474f05162d61a4ab4253d13008277
+  RNGestureHandler: afae32614741017de0f813f74586eee29773f31a
+  RNReanimated: ef851cdf95ca947de3199fb05b863be9596a9a91
+  RNScreens: 69f68c95d395bc4261d27c3aae7b4a458b947b7e
+  RNSVG: 6e742388ed2c7bfe7c9f5baf42b8eb850adc0442
+  RNWorklets: 4e3230b74c2e466e608458b7f665a41825bca6c1
   SDWebImage: f29024626962457f3470184232766516dee8dfea
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Stripe: d1824162e4bcb6ead10401a0dc8e8a3d5ffee41f
-  stripe-react-native: f2af1d3769363ae90b2a6c4bb9642232c2c4d2c9
+  stripe-react-native: fd628fd2cd45a6d06700cdf499f23dbcb4d5f8d9
   StripeApplePay: eb64705d3c919492b1b28876652fd0aca2db38cc
   StripeCore: b5bee05167f0c8ccce936244a031a9972fdeade8
   StripeFinancialConnections: fd6c661f86f47b1d26a32f588b3a0b09826aba84

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -78,7 +78,7 @@
     "react-native-paper": "^5.12.5",
     "react-native-reanimated": "4.2.0",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.19.0-nightly-20251203-1746a584e",
+    "react-native-screens": "4.19.0",
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.15.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -150,7 +150,7 @@
     "react-native-worklets": "0.7.1",
     "react-native-reanimated": "4.2.0",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.19.0-nightly-20251203-1746a584e",
+    "react-native-screens": "4.19.0",
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-web": "~0.21.0",

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -33,7 +33,7 @@
     "react": "19.2.0",
     "react-native": "0.83.0",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.19.0-nightly-20251203-1746a584e"
+    "react-native-screens": "4.19.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -62,7 +62,7 @@
     "react": "19.2.0",
     "react-native": "0.83.0",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.19.0-nightly-20251203-1746a584e",
+    "react-native-screens": "4.19.0",
     "react-native-webview": "13.15.0"
   },
   "devDependencies": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -103,7 +103,7 @@
   "react-native-pager-view": "6.9.1",
   "react-native-worklets": "0.7.1",
   "react-native-reanimated": "~4.2.0",
-  "react-native-screens": "~4.19.0-nightly-20251203-1746a584e",
+  "react-native-screens": "~4.19.0",
   "react-native-safe-area-context": "~5.6.0",
   "react-native-svg": "15.12.1",
   "react-native-view-shot": "4.0.3",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -34,7 +34,7 @@
     "react-native-worklets": "0.7.1",
     "react-native-reanimated": "~4.2.0",
     "react-native-safe-area-context": "~5.6.0",
-    "react-native-screens": "~4.18.0",
+    "react-native-screens": "~4.19.0",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -27,7 +27,7 @@
     "react-native-worklets": "0.7.1",
     "react-native-reanimated": "~4.2.0",
     "react-native-safe-area-context": "~5.6.0",
-    "react-native-screens": "~4.18.0",
+    "react-native-screens": "~4.19.0",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13376,10 +13376,10 @@ react-native-screens@4.11.1-nightly-20250611-8b82e081e:
     react-native-is-edge-to-edge "^1.1.7"
     warn-once "^0.1.0"
 
-react-native-screens@4.19.0-nightly-20251203-1746a584e:
-  version "4.19.0-nightly-20251203-1746a584e"
-  resolved "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.19.0-nightly-20251203-1746a584e.tgz#024435ea96f82b9c7d76beb941075bfd7af52a7a"
-  integrity sha512-V/Wg9Opua4WMFHDG/ybfsDVwX02MHCI6Qe+gd8P2FdGDw9mileQP9f6f8l7FAMFW47SCVs8E1bowGpBA5Dpq1w==
+react-native-screens@4.19.0:
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.19.0.tgz#d00f2ec070d7426204eaf34ef6c64396a6871e1d"
+  integrity sha512-qSDAO3AL5bti0Ri7KZRSVmWlhDr8MV86N5GruiKVQfEL7Zx2nUi3Dl62lqHUAD/LnDvOPuDDsMHCfIpYSv3hPQ==
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"


### PR DESCRIPTION
# Why

Upgrades `react-native-screen` to `4.19.0`.
I've decided to do it now, as the app reloading on Android doesn't work. It was fixed https://github.com/software-mansion/react-native-screens/pull/3475 and released in `4.19.0`


# Test Plan

- bare-expo ✅ 