### PR TITLE
[docs] Update EAS dashboard entries in Search UI

### DIFF
--- a/docs/ui/components/Search/expoEntries.ts
+++ b/docs/ui/components/Search/expoEntries.ts
@@ -4,6 +4,8 @@ import { BuildIcon } from '@expo/styleguide-icons/custom/BuildIcon';
 import { CredentialIcon } from '@expo/styleguide-icons/custom/CredentialIcon';
 import { EasSubmitIcon } from '@expo/styleguide-icons/custom/EasSubmitIcon';
 import { Smartphone01Icon } from '@expo/styleguide-icons/custom/Smartphone01Icon';
+import { Cloud01DuotoneIcon } from '@expo/styleguide-icons/duotone/Cloud01DuotoneIcon';
+import { Fingerprint03DuotoneIcon } from '@expo/styleguide-icons/duotone/Fingerprint03DuotoneIcon';
 import { BracketsXIcon } from '@expo/styleguide-icons/outline/BracketsXIcon';
 import { Cube02Icon } from '@expo/styleguide-icons/outline/Cube02Icon';
 import { DataIcon } from '@expo/styleguide-icons/outline/DataIcon';
@@ -13,7 +15,6 @@ import { Grid01Icon } from '@expo/styleguide-icons/outline/Grid01Icon';
 import { LayersTwo02Icon } from '@expo/styleguide-icons/outline/LayersTwo02Icon';
 import { NotificationBoxIcon } from '@expo/styleguide-icons/outline/NotificationBoxIcon';
 import { Settings01Icon } from '@expo/styleguide-icons/outline/Settings01Icon';
-import { Tag03Icon } from '@expo/styleguide-icons/outline/Tag03Icon';
 import type { ComponentType, HTMLAttributes } from 'react';
 
 export type ExpoItemType = {
@@ -59,9 +60,9 @@ export const entries: ExpoItemType[] = [
     Icon: DataIcon,
   },
   {
-    label: 'Project Native Deployments',
-    url: 'https://expo.dev/accounts/[account]/projects/[project]/deployments',
-    Icon: Tag03Icon,
+    label: 'Project Workflows',
+    url: 'https://expo.dev/accounts/[account]/projects/[project]/workflows',
+    Icon: Dataflow03Icon,
   },
   {
     label: 'Project Development Builds',
@@ -89,19 +90,14 @@ export const entries: ExpoItemType[] = [
     Icon: BranchIcon,
   },
   {
-    label: 'Project Updates',
+    label: 'Project Updates Groups',
     url: 'https://expo.dev/accounts/[account]/projects/[project]/updates',
     Icon: LayersTwo02Icon,
   },
   {
-    label: 'Project Credentials',
-    url: 'https://expo.dev/accounts/[account]/projects/[project]/credentials',
-    Icon: CredentialIcon,
-  },
-  {
-    label: 'Project Workflows',
-    url: 'https://expo.dev/accounts/[account]/projects/[project]/workflows',
-    Icon: Dataflow03Icon,
+    label: 'Project Hosting',
+    url: 'https://expo.dev/accounts/[account]/projects/[project]/hosting',
+    Icon: Cloud01DuotoneIcon,
   },
   {
     label: 'Project Push Notifications',
@@ -109,13 +105,23 @@ export const entries: ExpoItemType[] = [
     Icon: NotificationBoxIcon,
   },
   {
-    label: 'Project Environment Variables',
-    url: 'https://expo.dev/accounts/[account]/projects/[project]/environment-variables',
-    Icon: BracketsXIcon,
+    label: 'Project Fingerprints',
+    url: 'https://expo.dev/accounts/[account]/projects/[project]/distribution',
+    Icon: Fingerprint03DuotoneIcon,
   },
   {
     label: 'Project Settings',
     url: 'https://expo.dev/accounts/[account]/projects/[project]/settings',
     Icon: Settings01Icon,
+  },
+  {
+    label: 'Project Credentials',
+    url: 'https://expo.dev/accounts/[account]/projects/[project]/credentials',
+    Icon: CredentialIcon,
+  },
+  {
+    label: 'Project Environment Variables',
+    url: 'https://expo.dev/accounts/[account]/projects/[project]/environment-variables',
+    Icon: BracketsXIcon,
   },
 ];


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

EAS dashboard entries in Search UI are outdated. For example:
- Hosting and Fingerprints are not linked
- Workflows, Environment variables have wrong order
- Update channels are called Native deployments

<img width="1802" height="1666" alt="CleanShot 2025-12-17 at 18 24 41@2x" src="https://github.com/user-attachments/assets/376b6df9-f434-4adb-92e1-bbb2565d3241" />

From EAS dashboard on Update channels mapping:
<img width="2622" height="732" alt="CleanShot 2025-12-17 at 18 16 47@2x" src="https://github.com/user-attachments/assets/9a39b2df-41e7-4624-92b9-084712d3c545" />


# How

<!--
How did you build this feature or fix this bug and why?
-->

Update entries and their order in EAS dashboard.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview


<img width="1986" height="1952" alt="CleanShot 2025-12-17 at 18 23 25@2x" src="https://github.com/user-attachments/assets/4e7ede13-bca7-4120-92f1-b56268442c4a" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
