### PR TITLE
fix(cli): Pass empty `nodeModulesPaths` for autolinking & fallback resolution

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -25,6 +25,7 @@
 - resolve "Illegal invocation" errors in `workerd` runtime ([#41502](https://github.com/expo/expo/pull/41502) by [@hassankhan](https://github.com/hassankhan))
 - Fix running iOS builds on device without available simulators ([#41524](https://github.com/expo/expo/pull/41524) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fix `expo install` not auto-adding config plugins for scoped packages ([#41613](https://github.com/expo/expo/pull/41613) by [@kitten](https://github.com/kitten))
+- Pass empty `nodeModulesPaths` when applying autolinking and fallback resolution to Metro resolver ([#41703](https://github.com/expo/expo/pull/41703) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
@@ -1042,7 +1042,7 @@ describe(withExtendedResolver, () => {
         3,
         expect.objectContaining({
           originModulePath: '/node_modules/expo/index.js',
-          nodeModulesPaths: ['/node_modules/expo'],
+          nodeModulesPaths: [],
         }),
         '@babel/runtime/helpers/interopRequireDefault',
         platform
@@ -1120,7 +1120,7 @@ describe(withExtendedResolver, () => {
         4,
         expect.objectContaining({
           originModulePath: '/node_modules/expo-router/index.js',
-          nodeModulesPaths: ['/node_modules/expo-router'],
+          nodeModulesPaths: [],
         }),
         'example',
         platform

--- a/packages/@expo/cli/src/start/server/metro/createExpoAutolinkingResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoAutolinkingResolver.ts
@@ -141,7 +141,7 @@ export function createAutolinkingModuleResolver(
       // We instead resolve as if it was a dependency from within the module (self-require/import)
       const context: ResolutionContext = {
         ...immutableContext,
-        nodeModulesPaths: [resolvedModulePath],
+        nodeModulesPaths: [],
         originModulePath: resolvedModulePath,
       };
       const res = getStrictResolver(context, platform)(moduleName);

--- a/packages/@expo/cli/src/start/server/metro/createExpoFallbackResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoFallbackResolver.ts
@@ -178,7 +178,7 @@ export function createFallbackModuleResolver({
         // We instead resolve as if it was depended on by the `originModulePath` (the module named in `originModuleNames`)
         const context: ResolutionContext = {
           ...immutableContext,
-          nodeModulesPaths: [moduleDescription.originModulePath],
+          nodeModulesPaths: [],
           // NOTE(@kitten): We need to add a fake filename here. Metro performs a `path.dirname` on this path
           // and then searches `${path.dirname(originModulePath)}/node_modules`. If we don't add it, we miss
           // fallback resolution for packages that failed to hoist


### PR DESCRIPTION
# Why

The `nodeModulesPaths` passed aren't actually `node_modules` paths. `nodeModulesPaths` is the fallback when no default resolution matches. However, we weren't passing actual paths here and instead passing "mock" paths.

We should rely on self-resolution (as per the `doSelfResolve` algorithm definition in Node.js) and/or rely on cascading upwards to the enclosing `node_modules` folder. Even if there's edge-cases that aren't handled, this wouldn't be a problem for these resolvers to fix/workaround

Without this we may see warnings from `resolvePackageTargetFromExports`, which makes it quite obvious that if resolution has failed, the fallback `nodeModulesPaths` aren't right.

# How

- Empty out `nodeModulesPaths` in autolinking/fallback resolvers

# Test Plan

- CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
