### PR TITLE
chore(fingerprint): Replace undeclared rimraf usage with `fs.promises.rm` in fingerprint E2E tests

### DIFF
--- a/packages/@expo/fingerprint/e2e/__tests__/bare-test.ts
+++ b/packages/@expo/fingerprint/e2e/__tests__/bare-test.ts
@@ -1,7 +1,6 @@
 import spawnAsync from '@expo/spawn-async';
 import fs from 'fs/promises';
 import path from 'path';
-import rimraf from 'rimraf';
 
 import { getFingerprintHashFromCLIAsync } from './utils/CLIUtils';
 import { createProjectHashAsync } from '../../src/Fingerprint';
@@ -20,7 +19,8 @@ describe('bare project test', () => {
   const projectRoot = path.join(tmpDir, projectName);
 
   beforeAll(async () => {
-    rimraf.sync(projectRoot);
+    await fs.rm(projectRoot, { force: true, recursive: true });
+
     await spawnAsync('bunx', ['create-expo-app', '-t', 'bare-minimum', projectName], {
       stdio: 'inherit',
       cwd: tmpDir,
@@ -33,7 +33,7 @@ describe('bare project test', () => {
   });
 
   afterAll(async () => {
-    rimraf.sync(projectRoot);
+    await fs.rm(projectRoot, { force: true, recursive: true });
   });
 
   it('should have same hash after adding js only library', async () => {

--- a/packages/@expo/fingerprint/e2e/__tests__/default-ignore-paths-test.ts
+++ b/packages/@expo/fingerprint/e2e/__tests__/default-ignore-paths-test.ts
@@ -2,7 +2,6 @@ import spawnAsync from '@expo/spawn-async';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
-import rimraf from 'rimraf';
 
 import { createFingerprintAsync } from '../../src/Fingerprint';
 
@@ -22,7 +21,7 @@ describe('default template ignore paths', () => {
   const projectRoot = path.join(tmpDir, projectName);
 
   beforeAll(async () => {
-    rimraf.sync(projectRoot);
+    await fs.rm(projectRoot, { force: true, recursive: true });
     await spawnAsync('bunx', ['create-expo-app', '-t', 'default', projectName], {
       stdio: 'inherit',
       cwd: tmpDir,
@@ -35,7 +34,7 @@ describe('default template ignore paths', () => {
   });
 
   afterAll(async () => {
-    rimraf.sync(projectRoot);
+    await fs.rm(projectRoot, { force: true, recursive: true });
   });
 
   it('should not contain non-native node modules', async () => {
@@ -89,7 +88,7 @@ macosDescribe('CocoaPods generated files', () => {
   const projectRoot = path.join(tmpDir, projectName);
 
   beforeAll(async () => {
-    rimraf.sync(projectRoot);
+    await fs.rm(projectRoot, { force: true, recursive: true });
     await spawnAsync('bunx', ['create-expo-app', '-t', 'default', projectName], {
       stdio: 'inherit',
       cwd: tmpDir,
@@ -114,7 +113,7 @@ ios/**/*
   });
 
   afterAll(async () => {
-    rimraf.sync(projectRoot);
+    await fs.rm(projectRoot, { force: true, recursive: true });
   });
 
   it('should ignore pod install generated files', async () => {

--- a/packages/@expo/fingerprint/e2e/__tests__/managed-test.ts
+++ b/packages/@expo/fingerprint/e2e/__tests__/managed-test.ts
@@ -2,7 +2,6 @@ import spawnAsync from '@expo/spawn-async';
 import { randomUUID } from 'crypto';
 import fs from 'fs/promises';
 import path from 'path';
-import rimraf from 'rimraf';
 
 import { getFingerprintHashFromCLIAsync } from './utils/CLIUtils';
 import {
@@ -28,7 +27,8 @@ describe('managed project test', () => {
   let originalConfig: any;
 
   beforeAll(async () => {
-    rimraf.sync(projectRoot);
+    await fs.rm(projectRoot, { force: true, recursive: true });
+
     // Pin the SDK version to prevent the latest version breaking snapshots
     await spawnAsync('bunx', ['create-expo-app', '-t', 'blank@sdk-49', projectName], {
       stdio: 'inherit',
@@ -48,7 +48,7 @@ describe('managed project test', () => {
   });
 
   afterAll(async () => {
-    rimraf.sync(projectRoot);
+    await fs.rm(projectRoot, { force: true, recursive: true });
   });
 
   it('should have same hash after adding js only library', async () => {
@@ -221,7 +221,8 @@ describe(`getHashSourcesAsync - managed project`, () => {
   const projectRoot = path.join(tmpDir, projectName);
 
   beforeAll(async () => {
-    rimraf.sync(projectRoot);
+    await fs.rm(projectRoot, { force: true, recursive: true });
+
     // Pin the SDK version to prevent the latest version breaking snapshots
     await spawnAsync('bunx', ['create-expo-app', '-t', 'blank@sdk-49', projectName], {
       stdio: 'inherit',
@@ -241,7 +242,7 @@ describe(`getHashSourcesAsync - managed project`, () => {
   });
 
   afterAll(async () => {
-    rimraf.sync(projectRoot);
+    await fs.rm(projectRoot, { force: true, recursive: true });
   });
 
   it('should match snapshot', async () => {

--- a/packages/@expo/fingerprint/e2e/__tests__/relative-paths-test.ts
+++ b/packages/@expo/fingerprint/e2e/__tests__/relative-paths-test.ts
@@ -1,16 +1,6 @@
-import spawnAsync from '@expo/spawn-async';
-import fs from 'fs/promises';
 import path from 'path';
-import rimraf from 'rimraf';
 
 import { getFingerprintFromCLIAsync } from './utils/CLIUtils';
-import {
-  createFingerprintAsync,
-  createProjectHashAsync,
-  diffFingerprintChangesAsync,
-} from '../../src/Fingerprint';
-import { normalizeOptionsAsync } from '../../src/Options';
-import { getHashSourcesAsync } from '../../src/sourcer/Sourcer';
 
 jest.mock('../../src/ExpoConfigLoader', () => ({
   // Mock the getExpoConfigLoaderPath to use the built version rather than the typescript version from src

--- a/packages/@expo/fingerprint/e2e/__tests__/updates-test.ts
+++ b/packages/@expo/fingerprint/e2e/__tests__/updates-test.ts
@@ -1,7 +1,6 @@
 import spawnAsync from '@expo/spawn-async';
 import fs from 'fs/promises';
 import path from 'path';
-import rimraf from 'rimraf';
 
 import { getFingerprintHashFromCLIAsync } from './utils/CLIUtils';
 import { createProjectHashAsync } from '../../src/Fingerprint';
@@ -20,7 +19,7 @@ describe('updates managed support', () => {
   const projectRoot = path.join(tmpDir, projectName);
 
   beforeAll(async () => {
-    rimraf.sync(projectRoot);
+    await fs.rm(projectRoot, { force: true, recursive: true });
     // Pin the SDK version to prevent the latest version breaking snapshots
     await spawnAsync('bunx', ['create-expo-app', '-t', 'blank@sdk-51', projectName], {
       stdio: 'inherit',
@@ -41,7 +40,7 @@ describe('updates managed support', () => {
   });
 
   afterAll(async () => {
-    rimraf.sync(projectRoot);
+    await fs.rm(projectRoot, { force: true, recursive: true });
   });
 
   it('should have same hash before and after prebuild', async () => {


### PR DESCRIPTION
# Why

Extracted from https://github.com/expo/expo/pull/41288/commits/d813c195183c0558e46cbb5975d68887e1042dfc (#41288)

# How

- Remove `rimraf` usage

# Test Plan

- E2E CI run

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
