### PR TITLE
chore(updates): Replace undeclared rimraf usage with `fs.promises.rm` in updates E2E-CLI tests

### DIFF
--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-cli.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-cli.yml
@@ -6,10 +6,12 @@ on:
     paths:
       - apps/expo-workflow-testing/.eas/workflows/updates-e2e-cli.yml
       - packages/expo-updates/cli/**
+      - packages/expo-updates/e2e-cli/**
   pull_request:
     paths:
       - apps/expo-workflow-testing/.eas/workflows/updates-e2e-cli.yml
       - packages/expo-updates/cli/**
+      - packages/expo-updates/e2e-cli/**
   schedule:
     - cron: '0 18 * * SUN' # 18:00 UTC every Sunday
 

--- a/packages/expo-updates/e2e-cli/__tests__/cli-test.ts
+++ b/packages/expo-updates/e2e-cli/__tests__/cli-test.ts
@@ -1,6 +1,6 @@
 import spawnAsync from '@expo/spawn-async';
+import fs from 'fs/promises';
 import path from 'path';
-import rimraf from 'rimraf';
 
 import runCLIAsync from './utils/CLIUtils';
 
@@ -11,7 +11,7 @@ describe('CLI', () => {
   const projectRoot = path.join(tmpDir, projectName);
 
   beforeAll(async () => {
-    rimraf.sync(projectRoot);
+    await fs.rm(projectRoot, { force: true, recursive: true });
     await spawnAsync('yarn', ['create', 'expo-app', '-t', 'bare-minimum', projectName], {
       stdio: 'inherit',
       cwd: tmpDir,
@@ -24,7 +24,7 @@ describe('CLI', () => {
   });
 
   afterAll(async () => {
-    rimraf.sync(projectRoot);
+    await fs.rm(projectRoot, { force: true, recursive: true });
   });
 
   test('fingerprint:generate basic case', async () => {


### PR DESCRIPTION
# Why

Related to #41710
Extracted from https://github.com/expo/expo/pull/41288/commits/4e32f50d8065c7011f2c1456110648e93f081eed (#41288)

# How

- Remove `rimraf` usage

# Test Plan

- E2E CI run

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
