### PR TITLE
chore(bare-expo): Update outdated resolutions in `android/app/build.gradle`

### DIFF
--- a/apps/bare-expo/android/app/build.gradle
+++ b/apps/bare-expo/android/app/build.gradle
@@ -17,14 +17,14 @@ react {
     hermesCommand = new File(["node", "--print", "require.resolve('hermes-compiler/package.json', { paths: [require.resolve('react-native/package.json')] })"].execute(null, rootDir).text.trim()).getParentFile().getAbsolutePath() + "/hermesc/%OS-BIN%/hermesc"
     codegenDir = file(providers.exec {
       workingDir(rootDir)
-      commandLine("node", "--print", "require.resolve('@react-native/codegen/package.json')")
+      commandLine("node", "--print", "require.resolve('@react-native/codegen/package.json', { paths: [require.resolve('react-native/package.json')] })")
     }.standardOutput.asText.get().trim()).getParentFile().getAbsoluteFile()
 
 
     // Use Expo CLI to bundle the JS code
     cliFile = file(providers.exec {
       workingDir(rootDir)
-      commandLine("node", "--print", "require.resolve('@expo/cli')")
+      commandLine("node", "--print", "require.resolve('expo/bin/cli')")
     }.standardOutput.asText.get().trim())
 
     bundleCommand = "export:embed"


### PR DESCRIPTION
# Why

Extracted from https://github.com/expo/expo/pull/41288/commits/15d12f3be135f1d07a4fd755fa5f02d69e0911a5 (#41288)

Pulling this out since we can have a separate CI run for it, just to make sure it's fine. The resolutions here seemingly haven't been updated in a bit and can fail the build (not sure if they're used though). These were likely just missed in past changes/updates.

# How

- Resolve codegen from `react-native` via `react-native` module
- Resolve `@expo/cli` via `expo` (chose to go for `bin/cli` instead of the `paths` resolution)

# Test Plan

- CI run

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
