### PR TITLE
[core] fix comment typo

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/providers/AppContextProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/providers/AppContextProvider.kt
@@ -3,12 +3,12 @@ package expo.modules.kotlin.providers
 import expo.modules.kotlin.AppContext
 
 /**
- * Provider that allows accessing [AppContext] and all it's public parts (e.g. [AppContext.reactContext]).
+ * Provider that allows accessing [AppContext] and all its public parts (e.g. [AppContext.reactContext]).
  */
 interface AppContextProvider {
   /**
    * [AppContext] reference. If it's not possible to access the [AppContext], because it's null
-   * then it's an invalid situation and should result in throwing descriptive error.
+   * then it's an invalid situation and should result in throwing a descriptive error.
    */
   val appContext: AppContext
 }


### PR DESCRIPTION
# Why

This PR fixes grammatical errors in the documentation comments of the `AppContextProvider` interface. Specifically, it corrects "it's" to "its" when used as a possessive and adds a missing article "a" before "descriptive error".

# How

Updated the documentation comments in `AppContextProvider.kt`

# Test Plan

No functional changes were made, only documentation comments were updated. The code compiles successfully with the updated comments.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)