### PR TITLE
[docs] Add Clerk and overview pages under authentication integration category

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -345,6 +345,8 @@ export const general = [
       makePage('guides/using-vexo.mdx'),
     ]),
     makeGroup('Authentication', [
+      makePage('guides/using-authentication.mdx'),
+      makePage('guides/using-clerk.mdx'),
       makePage('guides/facebook-authentication.mdx'),
       makePage('guides/google-authentication.mdx'),
     ]),

--- a/docs/pages/guides/using-authentication.mdx
+++ b/docs/pages/guides/using-authentication.mdx
@@ -10,7 +10,7 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { CODE } from '~/ui/components/Text';
 
-Authentication in mobile apps refers to how you identify who a user is, manage sign up or sign in flows, and maintain their authenticated session across app launches and across multiple devices. Authentication SDKs and libraries help you add these flows so you do not need to build your own custom auth backend. The guides below highlight popular SDKs and providers for your Expo and React Native projects.
+Authentication in mobile apps refers to how you identify who a user is, manage sign-up or sign-in flows, and maintain their authenticated session across app launches and across multiple devices. Authentication SDKs and libraries help you add these flows, so you do not need to build your own custom auth backend. The guides below highlight popular SDKs and providers for your Expo and React Native projects.
 
 > **warning** Some providers require custom native code and aren't supported in Expo Go. Use a [development build](/develop/development-builds/introduction/) when needed.
 

--- a/docs/pages/guides/using-authentication.mdx
+++ b/docs/pages/guides/using-authentication.mdx
@@ -1,0 +1,46 @@
+---
+title: Using authentication SDKs and libraries
+sidebar_title: Overview
+description: An overview of authentication integrations available in the Expo and React Native ecosystem.
+hideTOC: true
+---
+
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { CODE } from '~/ui/components/Text';
+
+Authentication in mobile apps is how you identify who a user is, let them sign up or sign in, and keep their session securely connected across launches and devices. Authentication SDKs and libraries help you add these flows without building a custom auth backend. The guides below highlight popular SDKs and providers for your Expo and React Native projects.
+
+> **warning** Some providers require custom native code and aren't supported in Expo Go. Use a [development build](/develop/development-builds/introduction/) when needed.
+
+<BoxLink
+  title="Using Clerk"
+  description="Add Clerk authentication and user management to your Expo and React Native projects."
+  href="/guides/using-clerk/"
+  Icon={BookOpen02Icon}
+/>
+
+<BoxLink
+  title="Using Facebook authentication"
+  description={
+    <>
+      Configure <CODE>react-native-fbsdk-next</CODE> to add Facebook authentication in your Expo
+      project.
+    </>
+  }
+  href="/guides/facebook-authentication/"
+  Icon={BookOpen02Icon}
+/>
+
+<BoxLink
+  title="Using Google authentication"
+  description={
+    <>
+      Configure <CODE>@react-native-google-signin/google-signin</CODE> to add Google authentication
+      in your Expo project.
+    </>
+  }
+  href="/guides/google-authentication/"
+  Icon={BookOpen02Icon}
+/>

--- a/docs/pages/guides/using-authentication.mdx
+++ b/docs/pages/guides/using-authentication.mdx
@@ -10,7 +10,7 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { CODE } from '~/ui/components/Text';
 
-Authentication in mobile apps is how you identify who a user is, let them sign up or sign in, and keep their session securely connected across launches and devices. Authentication SDKs and libraries help you add these flows without building a custom auth backend. The guides below highlight popular SDKs and providers for your Expo and React Native projects.
+Authentication in mobile apps refers to how you identify who a user is, manage sign up or sign in flows, and maintain their authenticated session across app launches and across multiple devices. Authentication SDKs and libraries help you add these flows so you do not need to build your own custom auth backend. The guides below highlight popular SDKs and providers for your Expo and React Native projects.
 
 > **warning** Some providers require custom native code and aren't supported in Expo Go. Use a [development build](/develop/development-builds/introduction/) when needed.
 

--- a/docs/pages/guides/using-clerk.mdx
+++ b/docs/pages/guides/using-clerk.mdx
@@ -15,7 +15,7 @@ For Expo and React Native projects, Clerk provides hooks, UI, and control compon
 
 ## Features
 
-- **Authentication flows:** Email and password sign-up/sign-in plus other strategies like social providers and enterprise connections.
+- **Authentication flows:** Email and password sign-up/sign-in and other strategies like social providers.
 - **Session management:** Secure token handling with [`expo-secure-store`](/versions/latest/sdk/secure-store/).
 - **User management:** Profile data, account settings, and organization membership for multi-tenant apps.
 

--- a/docs/pages/guides/using-clerk.mdx
+++ b/docs/pages/guides/using-clerk.mdx
@@ -1,0 +1,31 @@
+---
+title: Using Clerk
+description: Learn how to integrate Clerk authentication in your Expo and React Native projects.
+---
+
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+
+[Clerk](https://clerk.com/) is a full-stack authentication and user management platform that helps you add sign-up, sign-in, and account management without building your own auth backend. It supports multiple authentication strategies, session management, and organizations for multi-tenant apps.
+
+For Expo and React Native projects, Clerk provides hooks, UI, and control components so you can build custom authentication screens. Pair it with `expo-secure-store` to keep session tokens encrypted on device, and configure your projects's providers and policies in the Clerk Dashboard.
+
+> **Note:** Clerk's [prebuilt UI components](https://clerk.com/docs/expo/reference/components/overview) are available for web. For native platforms, Clerk recommends building custom flows.
+
+## Features
+
+- **Authentication flows:** Email and password sign-up/sign-in plus other strategies like social providers and enterprise connections.
+- **Session management:** Secure token handling with [`expo-secure-store`](/versions/latest/sdk/secure-store/).
+- **User management:** Profile data, account settings, and organization membership for multi-tenant apps.
+
+## Get started
+
+To get started, follow the instructions in the Clerk's documentation:
+
+<BoxLink
+  title="Clerk Expo quickstart"
+  description="Follow the official quickstart for installing the Expo SDK, configuring secure token storage, and building sign-in and sign-up flows."
+  href="https://clerk.com/docs/expo/getting-started/quickstart"
+  Icon={BookOpen02Icon}
+/>

--- a/docs/pages/guides/using-clerk.mdx
+++ b/docs/pages/guides/using-clerk.mdx
@@ -9,13 +9,13 @@ import { BoxLink } from '~/ui/components/BoxLink';
 
 [Clerk](https://clerk.com/) is a full stack authentication and user management platform that helps you add sign-up, sign-in, and account management without building your own auth backend. It supports multiple authentication strategies, session management, and organizations for multi-tenant apps.
 
-For Expo and React Native projects, Clerk provides hooks, UI, and control components so you can build custom authentication screens. Pair it with `expo-secure-store` to keep session tokens encrypted on device, and configure your projects's providers and policies in the Clerk's dashboard.
+Clerk provides hooks, UI, and control components so you can build completely custom authentication screens. Pair it with `expo-secure-store` to keep session tokens encrypted on device, and configure your projects's providers and policies in the Clerk's dashboard.
 
-> **Note:** Clerk's [prebuilt UI components](https://clerk.com/docs/expo/reference/components/overview) are available for web. For native platforms, Clerk recommends building custom flows.
+> **Note:** Clerk's [prebuilt UI components](https://clerk.com/docs/expo/reference/components/overview) are available for web only. For native platforms, Clerk recommends building custom flows.
 
 ## Features
 
-- **Authentication flows:** Email and password sign-up/sign-in and other strategies like social providers.
+- **Authentication flows:** Sign-up and sign-in with email verification code, magic links, passwords, social providers (20+), passkeys, phone number verification, SAML, OpenID Connect, Web3 (MetaMask), and authenticator apps for multi-factor authentication.
 - **Session management:** Secure token handling with [`expo-secure-store`](/versions/latest/sdk/secure-store/).
 - **User management:** Profile data, account settings, and organization membership for multi-tenant apps.
 

--- a/docs/pages/guides/using-clerk.mdx
+++ b/docs/pages/guides/using-clerk.mdx
@@ -7,7 +7,7 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 
-[Clerk](https://clerk.com/) is a full-stack authentication and user management platform that helps you add sign-up, sign-in, and account management without building your own auth backend. It supports multiple authentication strategies, session management, and organizations for multi-tenant apps.
+[Clerk](https://clerk.com/) is a full stack authentication and user management platform that helps you add sign-up, sign-in, and account management without building your own auth backend. It supports multiple authentication strategies, session management, and organizations for multi-tenant apps.
 
 For Expo and React Native projects, Clerk provides hooks, UI, and control components so you can build custom authentication screens. Pair it with `expo-secure-store` to keep session tokens encrypted on device, and configure your projects's providers and policies in the Clerk Dashboard.
 

--- a/docs/pages/guides/using-clerk.mdx
+++ b/docs/pages/guides/using-clerk.mdx
@@ -9,7 +9,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 
 [Clerk](https://clerk.com/) is a full stack authentication and user management platform that helps you add sign-up, sign-in, and account management without building your own auth backend. It supports multiple authentication strategies, session management, and organizations for multi-tenant apps.
 
-For Expo and React Native projects, Clerk provides hooks, UI, and control components so you can build custom authentication screens. Pair it with `expo-secure-store` to keep session tokens encrypted on device, and configure your projects's providers and policies in the Clerk Dashboard.
+For Expo and React Native projects, Clerk provides hooks, UI, and control components so you can build custom authentication screens. Pair it with `expo-secure-store` to keep session tokens encrypted on device, and configure your projects's providers and policies in the Clerk's dashboard.
 
 > **Note:** Clerk's [prebuilt UI components](https://clerk.com/docs/expo/reference/components/overview) are available for web. For native platforms, Clerk recommends building custom flows.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18501

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add Clerk and overview pages under authentication integration category.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally and visit: 
- http://localhost:3002/guides/using-clerk/
- http://localhost:3002/guides/using-authentication/

## Preview

<img width="1244" height="702" alt="CleanShot 2025-12-18 at 21 55 33" src="https://github.com/user-attachments/assets/e6496130-96c1-475c-94dc-713ad136049a" />

<img width="1263" height="728" alt="CleanShot 2025-12-18 at 22 00 45" src="https://github.com/user-attachments/assets/c856ab0f-199f-4ca7-b4d1-705f1f5d31ff" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
