### PR TITLE
[CI] Fix ios-test-e2e

### DIFF
--- a/apps/bare-expo/e2e/_nested-flows/screenshot-comparison.yaml
+++ b/apps/bare-expo/e2e/_nested-flows/screenshot-comparison.yaml
@@ -21,6 +21,9 @@ appId: dev.expo.Payments
       diffOutputPath: ~/.maestro/tests/${screenshotOutputPath}
       similarityThreshold: ${similarityThreshold}
       resizingFactor: ${resizingFactor}
+      # Explicitly unset testID and mode to prevent them from persisting from previous flows
+      testID: ''
+      mode: ''
 
 - assertTrue:
     condition: ${output.comparisonResult.success}


### PR DESCRIPTION
# Why
The image comparison tests are currently failing. Seems that there is a bug in [maestro](https://github.com/mobile-dev-inc/maestro/issues/2694) where the env from one `runScript` persists in the next run. This causes an issue because `viewshot-comparison.yaml` runs first creating `testID: 'image-comparison-list'` and `mode: 'keep-originals'` that persist in the `screenshot-comparison.yaml` causing problems like bad paths for the image (`.base.ios.ios.png`) and receiving a testId means we attempt to crop the image when we want a full screen comparison.

# How
Explicitly clear the variables in screenshot-comparison.yaml

# Test Plan
Tests pass locally

