### PR TITLE
[ios][expo-router] Add zoomDismissGestureTopZoneHeight option for zoom transitions

### DIFF
--- a/apps/router-e2e/__e2e__/native-tabs/app/_layout.tsx
+++ b/apps/router-e2e/__e2e__/native-tabs/app/_layout.tsx
@@ -40,6 +40,10 @@ export default function Layout() {
           <NativeTabs.Trigger.Badge>9</NativeTabs.Trigger.Badge>
           <NativeTabs.Trigger.Label>Dynamic</NativeTabs.Trigger.Label>
         </NativeTabs.Trigger>
+        <NativeTabs.Trigger name="zoom-demo">
+          <NativeTabs.Trigger.Icon sf="arrow.down.app" drawable="ic_zoom" />
+          <NativeTabs.Trigger.Label>Zoom Demo</NativeTabs.Trigger.Label>
+        </NativeTabs.Trigger>
         <NativeTabs.BottomAccessory>
           <MiniPlayer isPlaying={isPlaying} setIsPlaying={setIsPlaying} />
         </NativeTabs.BottomAccessory>

--- a/apps/router-e2e/__e2e__/native-tabs/app/zoom-demo/_layout.tsx
+++ b/apps/router-e2e/__e2e__/native-tabs/app/zoom-demo/_layout.tsx
@@ -1,0 +1,10 @@
+import { Stack } from 'expo-router';
+
+export default function ZoomDemoLayout() {
+  return (
+    <Stack screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="index" />
+      <Stack.Screen name="player" options={{ presentation: 'transparentModal' }} />
+    </Stack>
+  );
+}

--- a/apps/router-e2e/__e2e__/native-tabs/app/zoom-demo/index.tsx
+++ b/apps/router-e2e/__e2e__/native-tabs/app/zoom-demo/index.tsx
@@ -1,0 +1,63 @@
+import FontAwesomeIcons from '@expo/vector-icons/FontAwesome5';
+import { Link } from 'expo-router';
+import { useState } from 'react';
+import { View, Text, Pressable, Platform, ColorValue, DynamicColorIOS } from 'react-native';
+
+export default function ZoomDemoIndex() {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const textColor = Platform.select<ColorValue>({
+    ios: DynamicColorIOS({ light: 'black', dark: 'white' }),
+    default: 'black',
+  });
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'flex-end', alignItems: 'center', paddingBottom: 150, paddingHorizontal: 20 }}>
+      <Link href="/zoom-demo/player" asChild>
+        <Link.Trigger>
+          <Link.AppleZoom>
+            <Pressable
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                paddingVertical: 12,
+                paddingHorizontal: 16,
+                gap: 12,
+                backgroundColor: Platform.OS === 'ios' ? 'rgba(255,255,255,0.9)' : '#fff',
+                borderRadius: 12,
+                shadowColor: '#000',
+                shadowOffset: { width: 0, height: 2 },
+                shadowOpacity: 0.1,
+                shadowRadius: 8,
+                elevation: 4,
+              }}>
+              <View
+                style={{
+                  width: 50,
+                  height: 50,
+                  backgroundColor: 'blue',
+                  borderRadius: 8,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}>
+                <FontAwesomeIcons name="music" size={20} color="white" />
+              </View>
+              <View style={{ flex: 1 }}>
+                <Text style={{ fontSize: 16, fontWeight: '600', color: textColor }}>
+                  Zoom Demo Song
+                </Text>
+                <Text style={{ fontSize: 14, color: '#666' }}>Tap to test dismiss zone</Text>
+              </View>
+              <Pressable
+                onPress={(e) => {
+                  e.stopPropagation();
+                  setIsPlaying(!isPlaying);
+                }}>
+                <FontAwesomeIcons name={isPlaying ? 'pause' : 'play'} size={20} color={textColor} />
+              </Pressable>
+            </Pressable>
+          </Link.AppleZoom>
+        </Link.Trigger>
+      </Link>
+    </View>
+  );
+}

--- a/apps/router-e2e/__e2e__/native-tabs/app/zoom-demo/player.tsx
+++ b/apps/router-e2e/__e2e__/native-tabs/app/zoom-demo/player.tsx
@@ -1,0 +1,234 @@
+import FontAwesomeIcons from '@expo/vector-icons/FontAwesome5';
+import { Stack, router } from 'expo-router';
+import { useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  Platform,
+  ColorValue,
+  DynamicColorIOS,
+  ScrollView,
+} from 'react-native';
+
+const DISMISS_GESTURE_TOP_ZONE_HEIGHT = 150;
+
+export default function PlayerScreen() {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const textColor = Platform.select<ColorValue>({
+    ios: DynamicColorIOS({ light: 'black', dark: 'white' }),
+    default: 'black',
+  });
+
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          headerShown: false,
+          // presentation: 'transparentModal',
+          // @ts-expect-error
+          zoomDismissGestureTopZoneHeight: DISMISS_GESTURE_TOP_ZONE_HEIGHT,
+        }}
+      />
+      <View style={styles.container}>
+        <View style={[styles.dismissZone, { height: DISMISS_GESTURE_TOP_ZONE_HEIGHT }]}>
+          <View style={styles.handle} />
+          <Text style={styles.dismissZoneText}>
+            Dismiss Gesture Zone ({DISMISS_GESTURE_TOP_ZONE_HEIGHT}px)
+          </Text>
+          <Text style={styles.dismissZoneSubtext}>Swipe down here to dismiss</Text>
+        </View>
+
+        <ScrollView style={styles.content} contentContainerStyle={styles.scrollContent}>
+          <View style={styles.header}>
+            <View style={styles.albumArt}>
+              <FontAwesomeIcons name="music" size={80} color="white" />
+            </View>
+            <Text style={[styles.nowPlaying, { color: textColor }]}>NOW PLAYING</Text>
+            <Text style={[styles.songTitle, { color: textColor }]}>Zoom Demo Song</Text>
+            <Text style={[styles.artistName, { color: textColor }]}>Test Artist</Text>
+          </View>
+
+          <View style={styles.controls}>
+            <Pressable style={styles.controlButton}>
+              <FontAwesomeIcons name="step-backward" size={32} color={textColor} />
+            </Pressable>
+            <Pressable style={styles.playButton} onPress={() => setIsPlaying(!isPlaying)}>
+              <FontAwesomeIcons name={isPlaying ? 'pause' : 'play'} size={32} color="white" />
+            </Pressable>
+            <Pressable style={styles.controlButton}>
+              <FontAwesomeIcons name="step-forward" size={32} color={textColor} />
+            </Pressable>
+          </View>
+
+          <View style={styles.infoSection}>
+            <View style={styles.infoBox}>
+              <FontAwesomeIcons name="check-circle" size={20} color="#4CAF50" />
+              <View style={styles.infoContent}>
+                <Text style={[styles.infoTitle, { color: textColor }]}>Zoom Transition</Text>
+                <Text style={styles.infoDescription}>
+                  Opened with Apple zoom animation
+                </Text>
+              </View>
+            </View>
+
+            <View style={styles.infoBox}>
+              <FontAwesomeIcons name="hand-pointer" size={20} color="#2196F3" />
+              <View style={styles.infoContent}>
+                <Text style={[styles.infoTitle, { color: textColor }]}>Restricted Dismiss</Text>
+                <Text style={styles.infoDescription}>
+                  Only top {DISMISS_GESTURE_TOP_ZONE_HEIGHT}px allows dismiss
+                </Text>
+              </View>
+            </View>
+          </View>
+
+          <View style={styles.trySection}>
+            <Text style={[styles.tryTitle, { color: textColor }]}>Try it:</Text>
+            <Text style={styles.tryText}>
+              1. Swipe down from green zone → dismisses{'\n'}
+              2. Swipe down below green → blocked
+            </Text>
+          </View>
+
+          <Pressable style={styles.closeButton} onPress={() => router.back()}>
+            <Text style={styles.closeButtonText}>Close</Text>
+          </Pressable>
+        </ScrollView>
+      </View>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  dismissZone: {
+    backgroundColor: '#4CAF50',
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingTop: 50,
+  },
+  handle: {
+    width: 40,
+    height: 5,
+    backgroundColor: 'rgba(255,255,255,0.7)',
+    borderRadius: 3,
+    marginBottom: 8,
+  },
+  dismissZoneText: {
+    color: 'white',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  dismissZoneSubtext: {
+    color: 'rgba(255,255,255,0.8)',
+    fontSize: 12,
+    marginTop: 4,
+  },
+  content: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: 20,
+  },
+  header: {
+    alignItems: 'center',
+    marginBottom: 40,
+  },
+  albumArt: {
+    width: 200,
+    height: 200,
+    backgroundColor: 'blue',
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 24,
+  },
+  nowPlaying: {
+    fontSize: 12,
+    fontWeight: '500',
+    letterSpacing: 2,
+    marginBottom: 8,
+  },
+  songTitle: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    marginBottom: 4,
+  },
+  artistName: {
+    fontSize: 18,
+    opacity: 0.7,
+  },
+  controls: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 40,
+    marginBottom: 40,
+  },
+  controlButton: {
+    padding: 10,
+  },
+  playButton: {
+    width: 80,
+    height: 80,
+    backgroundColor: 'blue',
+    borderRadius: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  infoSection: {
+    gap: 12,
+    marginBottom: 24,
+  },
+  infoBox: {
+    flexDirection: 'row',
+    backgroundColor: '#f5f5f5',
+    padding: 16,
+    borderRadius: 12,
+    gap: 12,
+  },
+  infoContent: {
+    flex: 1,
+  },
+  infoTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginBottom: 4,
+  },
+  infoDescription: {
+    fontSize: 13,
+    color: '#666',
+  },
+  trySection: {
+    backgroundColor: '#e3f2fd',
+    padding: 16,
+    borderRadius: 12,
+    marginBottom: 24,
+  },
+  tryTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 8,
+  },
+  tryText: {
+    fontSize: 14,
+    color: '#1565c0',
+    lineHeight: 22,
+  },
+  closeButton: {
+    backgroundColor: '#FF3B30',
+    padding: 16,
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  closeButtonText: {
+    color: 'white',
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+});

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -31,6 +31,7 @@
 - add hidden prop to native tabs ([#41375](https://github.com/expo/expo/pull/41375) by [@Ubax](https://github.com/Ubax))
 - [iOS] add withAppleZoom prop to Link.Trigger ([#41371](https://github.com/expo/expo/pull/41371) by [@Ubax](https://github.com/Ubax))
 - [iOS] prevent dismissal for zoom transition, when gestureEnabled is false ([#41356](https://github.com/expo/expo/pull/41356) by [@Ubax](https://github.com/Ubax))
+- [iOS] add `zoomDismissGestureTopZoneHeight` option to restrict zoom transition dismiss gesture to top region of screen by [@AmaanMohd](https://github.com/AmaanMohd))
 - [iOS] add Link.AppleZoomTarget ([#41352](https://github.com/expo/expo/pull/41352) by [@Ubax](https://github.com/Ubax))
 - add header items components API ([#40842](https://github.com/expo/expo/pull/40842) by [@Ubax](https://github.com/Ubax))
 - allow for standalone usage of Stack.Header and Stack.Header.Left/Right ([#41649](https://github.com/expo/expo/pull/41649) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/build/link/zoom/ZoomTransitionEnabler.ios.js
+++ b/packages/expo-router/build/link/zoom/ZoomTransitionEnabler.ios.js
@@ -38,7 +38,8 @@ function ZoomTransitionEnabler({ route }) {
             const descriptorsMap = (0, react_1.use)(descriptors_context_1.DescriptorsContext);
             const currentDescriptor = descriptorsMap[route.key];
             const preventInteractiveDismissal = currentDescriptor?.options?.gestureEnabled === false;
-            return (<native_1.LinkZoomTransitionEnabler zoomTransitionSourceIdentifier={zoomTransitionId} preventInteractiveDismissal={preventInteractiveDismissal}/>);
+            const dismissGestureTopZoneHeight = currentDescriptor?.options?.zoomDismissGestureTopZoneHeight ?? 0;
+            return (<native_1.LinkZoomTransitionEnabler zoomTransitionSourceIdentifier={zoomTransitionId} preventInteractiveDismissal={preventInteractiveDismissal} dismissGestureTopZoneHeight={dismissGestureTopZoneHeight}/>);
         }
     }
     return null;

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeModule.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeModule.swift
@@ -119,6 +119,10 @@ public class LinkPreviewNativeModule: Module {
       Prop("preventInteractiveDismissal") { (view: LinkZoomTransitionEnabler, prevent: Bool) in
         view.isPreventingInteractiveDismissal = prevent
       }
+
+      Prop("dismissGestureTopZoneHeight") { (view: LinkZoomTransitionEnabler, height: Double) in
+        view.dismissGestureTopZoneHeight = CGFloat(height)
+      }
     }
 
     View(LinkZoomTransitionAlignmentRectDetector.self) {

--- a/packages/expo-router/ios/LinkPreview/LinkZoomTransition.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkZoomTransition.swift
@@ -274,11 +274,11 @@ class LinkZoomTransitionAlignmentRectDetector: LinkZoomExpoView {
 class LinkZoomTransitionEnabler: LinkZoomExpoView {
   var zoomTransitionSourceIdentifier: String = ""
   var isPreventingInteractiveDismissal: Bool = false
+  var dismissGestureTopZoneHeight: CGFloat = 0
 
   override func didMoveToSuperview() {
     super.didMoveToSuperview()
     if superview != nil {
-      // Need to run this async. Otherwise the view has no view controller yet
       DispatchQueue.main.async {
         self.setupZoomTransition()
       }
@@ -318,8 +318,14 @@ class LinkZoomTransitionEnabler: LinkZoomExpoView {
           }
           return rect
         }
-        options.interactiveDismissShouldBegin = { _ in
-          !self.isPreventingInteractiveDismissal
+        options.interactiveDismissShouldBegin = { context in
+          if self.isPreventingInteractiveDismissal {
+            return false
+          }
+          if self.dismissGestureTopZoneHeight > 0 {
+            return context.location.y <= self.dismissGestureTopZoneHeight
+          }
+          return true
         }
         controller.preferredTransition = .zoom(options: options) { _ in
           let sourceInfo = self.sourceRepository?.getSource(

--- a/packages/expo-router/src/link/preview/native.tsx
+++ b/packages/expo-router/src/link/preview/native.tsx
@@ -100,13 +100,19 @@ export function NativeLinkPreviewContent(props: NativeLinkPreviewContentProps) {
 
 // #region Zoom transition enabler
 const LinkZoomTransitionEnablerNativeView: React.ComponentType<
-  ViewProps & { zoomTransitionSourceIdentifier: string; disableForceFlatten?: boolean }
+  ViewProps & {
+    zoomTransitionSourceIdentifier: string;
+    disableForceFlatten?: boolean;
+    preventInteractiveDismissal?: boolean;
+    dismissGestureTopZoneHeight?: number;
+  }
 > | null = areNativeViewsAvailable
   ? requireNativeView('ExpoRouterNativeLinkPreview', 'LinkZoomTransitionEnabler')
   : null;
 export function LinkZoomTransitionEnabler(props: {
   zoomTransitionSourceIdentifier: string;
   preventInteractiveDismissal?: boolean;
+  dismissGestureTopZoneHeight?: number;
 }) {
   if (!LinkZoomTransitionEnablerNativeView) {
     return null;

--- a/packages/expo-router/src/link/zoom/ZoomTransitionEnabler.ios.tsx
+++ b/packages/expo-router/src/link/zoom/ZoomTransitionEnabler.ios.tsx
@@ -50,10 +50,13 @@ export function ZoomTransitionEnabler({ route }: ZoomTransitionEnablerProps) {
       const descriptorsMap = use(DescriptorsContext);
       const currentDescriptor = descriptorsMap[route.key];
       const preventInteractiveDismissal = currentDescriptor?.options?.gestureEnabled === false;
+      // @ts-expect-error
+      const dismissGestureTopZoneHeight = currentDescriptor?.options?.zoomDismissGestureTopZoneHeight ?? 0;
       return (
         <LinkZoomTransitionEnabler
           zoomTransitionSourceIdentifier={zoomTransitionId}
           preventInteractiveDismissal={preventInteractiveDismissal}
+          dismissGestureTopZoneHeight={dismissGestureTopZoneHeight}
         />
       );
     }


### PR DESCRIPTION
## Summary

Adds `zoomDismissGestureTopZoneHeight` screen option to restrict the interactive dismiss gesture for zoom transitions to a specific height from the top of the screen. This is useful for media player interfaces where you want users to be able to interact with content below the header without accidentally dismissing the modal. Note that this is for the ```<Stack.Screen>``` with ```presentation: transparentModal``` which are fullscreen.

https://github.com/user-attachments/assets/fd8d9119-c4c9-4775-873e-4413435acbc3

## Changes

- Added `dismissGestureTopZoneHeight` prop to `LinkZoomTransitionEnabler` native view
- Updated `interactiveDismissShouldBegin` in Swift to check gesture location against the zone height
- Added `zoomDismissGestureTopZoneHeight` screen option support in expo-router
- Added zoom-demo tab in native-tabs e2e example

## Test Plan

1. Run the `native-tabs` e2e example:
   ```bash
   cd apps/router-e2e
   yarn start:native-tabs
   ```
2. Navigate to the "Zoom Demo" tab
3. Tap the mini player card to open the modal with zoom transition
4. Verify:
   - Swiping down from the **green zone** (top 150px) dismisses the modal
   - Swiping down from **below the green zone** does NOT dismiss the modal
   - The zoom animation works correctly on open and close

## Usage

```tsx
<Stack.Screen
  name="player"
  options={{
    zoomDismissGestureTopZoneHeight: 150,
  }}
/>
```