### PR TITLE
chore(cli,pkcs12): Bump `node-forge` range to `^1.3.3`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Skip adding unnecessary CORS response header for `localhost` requests ([#41542](https://github.com/expo/expo/pull/41542) by [@kitten](https://github.com/kitten))
 - Embed `/_expo/touch` templates ([#41541](https://github.com/expo/expo/pull/41541) by [@kitten](https://github.com/kitten))
 - Bump to `@expo/metro@54.2.0` and `metro@0.83.3` ([#41142](https://github.com/expo/expo/pull/41142) by [@kitten](https://github.com/kitten))
+- Bump `node-forge` dependency range to `^1.3.3` ([#41753](https://github.com/expo/expo/pull/41753) by [@kitten](https://github.com/kitten))
 
 ### ⚠️ Notices
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -81,7 +81,7 @@
     "glob": "^13.0.0",
     "lan-network": "^0.1.6",
     "minimatch": "^9.0.0",
-    "node-forge": "^1.3.1",
+    "node-forge": "^1.3.3",
     "npm-package-arg": "^11.0.0",
     "ora": "^3.4.0",
     "picomatch": "^3.0.1",

--- a/packages/@expo/pkcs12/CHANGELOG.md
+++ b/packages/@expo/pkcs12/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bump `node-forge` dependency range to `^1.3.3` ([#41753](https://github.com/expo/expo/pull/41753) by [@kitten](https://github.com/kitten))
+
 ## 0.3.8 - 2025-12-05
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/pkcs12/package.json
+++ b/packages/@expo/pkcs12/package.json
@@ -30,7 +30,7 @@
     "directory": "packages/@expo/pkcs12"
   },
   "dependencies": {
-    "node-forge": "^1.2.1"
+    "node-forge": "^1.3.3"
   },
   "devDependencies": {
     "expo-module-scripts": "^5.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12039,10 +12039,10 @@ node-fetch@^2.6.1:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-forge@^1.2.1, node-forge@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
-  integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
+node-forge@^1.2.1, node-forge@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.3.tgz#0ad80f6333b3a0045e827ac20b7f735f93716751"
+  integrity sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==
 
 node-html-parser@^6.1.5:
   version "6.1.5"


### PR DESCRIPTION
# Why

While `node-forge@1.3.2` resolving a security notice is in range, and Expo is not affected by the vulnerability in how certificates are used, generated, and validated, we should explicitly bump on `main` to the latest range.

# How

- Bump to `node-forge@^1.3.3` in `@expo/cli` and `@expo/pkcs12`

# Test Plan

- CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
