### PR TITLE
[notifications] avoid crash in new token event when module destroyed

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- avoid crash emitting new token event when module is destroyed ([#41754](https://github.com/expo/expo/pull/41754) by [@vonovak](https://github.com/vonovak))
 - fix completion handler never called for background notifications ([#41300](https://github.com/expo/expo/pull/41300) by [@vonovak](https://github.com/vonovak))
 
 ### 💡 Others

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/tokens/PushTokenModule.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/tokens/PushTokenModule.kt
@@ -21,12 +21,16 @@ class PushTokenModule : Module(), FirebaseTokenListener {
    * @param token New push token.
    */
   override fun onNewToken(token: String) {
-    sendEvent(
-      NEW_TOKEN_EVENT_NAME,
-      mapOf(
-        NEW_TOKEN_EVENT_TOKEN_KEY to token
+    runCatching {
+      // onNewToken is emitted asynchronously and the module may be destroyed by the time sendEvent is called
+      // that would result in an exception
+      sendEvent(
+        NEW_TOKEN_EVENT_NAME,
+        mapOf(
+          NEW_TOKEN_EVENT_TOKEN_KEY to token
+        )
       )
-    )
+    }
   }
 
   override fun definition() = ModuleDefinition {


### PR DESCRIPTION
# Why

closes #41040 - there are conditions when new token event is emitted after the module got destroyed: see stacktrace in https://github.com/expo/expo/issues/41040#issuecomment-3670907313

# How

- swallow exceptions when thrown

# Test Plan

- manual

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
