### PR TITLE
[expo-router][ios] replace print with jsLog in native components

### DIFF
--- a/apps/router-e2e/__e2e__/native-navigation/app/tabs/index.tsx
+++ b/apps/router-e2e/__e2e__/native-navigation/app/tabs/index.tsx
@@ -42,7 +42,7 @@ export default function Index() {
         <Link.Trigger>
           <Pressable>
             <Link.AppleZoom>
-              <View style={{ width: 170 }}>
+              <View style={{ width: 170 }} collapsable={false}>
                 <StaticFaces numberOfFaces={9} size={50} />
               </View>
             </Link.AppleZoom>

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -83,6 +83,7 @@
 - Bump `react-server-dom-webpack` ([#41574](https://github.com/expo/expo/pull/41574) by [@kitten](https://github.com/kitten)) ([#41589](https://github.com/expo/expo/pull/41589) by [@kitten](https://github.com/kitten))
 - [ios] add internal animateAspectRatioChange prop ([#41511](https://github.com/expo/expo/pull/41511) by [@Ubax](https://github.com/Ubax))
 - Add unstable_navigationEvents to expose global navigation events ([#41706](https://github.com/expo/expo/pull/41706) by [@Ubax](https://github.com/Ubax))
+- [ios] replace print with jsLog in native components ([#41757](https://github.com/expo/expo/pull/41757) by [@Ubax](https://github.com/Ubax))
 
 ## 6.0.17 - 2025-12-05
 

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeActionView.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeActionView.swift
@@ -1,8 +1,8 @@
 import ExpoModulesCore
-import WebKit
 
-class LinkPreviewNativeActionView: ExpoView, LinkPreviewMenuUpdatable {
+class LinkPreviewNativeActionView: RouterViewWithLogger, LinkPreviewMenuUpdatable {
   var identifier: String = ""
+  // TODO(@ubax): Add @ReactiveProp similar to RouterToolbar to reduce repetition
   // MARK: - Shared props
   var title: String = "" {
     didSet {
@@ -235,8 +235,8 @@ class LinkPreviewNativeActionView: ExpoView, LinkPreviewMenuUpdatable {
         subActions.insert(childActionView, at: index)
         childActionView.parentMenuUpdatable = self
       } else {
-        print(
-          "ExpoRouter: Unknown child component view (\(childComponentView)) mounted to NativeLinkPreviewActionView"
+        logger?.warn(
+          "[expo-router] Unknown child component view (\(childComponentView)) mounted to NativeLinkPreviewActionView. This is most likely a bug in expo-router."
         )
       }
     }
@@ -245,8 +245,8 @@ class LinkPreviewNativeActionView: ExpoView, LinkPreviewMenuUpdatable {
       if let childActionView = child as? LinkPreviewNativeActionView {
         subActions.removeAll(where: { $0 == childActionView })
       } else {
-        print(
-          "ExpoRouter: Unknown child component view (\(child)) unmounted from NativeLinkPreviewActionView"
+        logger?.warn(
+          "ExpoRouter: Unknown child component view (\(child)) unmounted from NativeLinkPreviewActionView. This is most likely a bug in expo-router."
         )
       }
     }

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeModule.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeModule.swift
@@ -37,7 +37,7 @@ public class LinkPreviewNativeModule: Module {
         let height = size["height", default: 0]
 
         guard width >= 0, height >= 0 else {
-          print("Preferred content size cannot be negative (\(width), \(height))")
+          view.logger?.warn("[expo-router] Preferred content size cannot be negative (\(width), \(height))")
           return
         }
 

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativePreviewView.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativePreviewView.swift
@@ -1,12 +1,7 @@
 import ExpoModulesCore
-import WebKit
 
-class NativeLinkPreviewContentView: ExpoView {
+class NativeLinkPreviewContentView: RouterViewWithLogger {
   var preferredContentSize: CGSize = .zero
-
-  required init(appContext: AppContext? = nil) {
-    super.init(appContext: appContext)
-  }
 
   func setInitialSize(bounds: CGRect) {
 #if RCT_NEW_ARCH_ENABLED

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeView.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeView.swift
@@ -1,7 +1,7 @@
 import ExpoModulesCore
 import RNScreens
 
-class NativeLinkPreviewView: ExpoView, UIContextMenuInteractionDelegate,
+class NativeLinkPreviewView: RouterViewWithLogger, UIContextMenuInteractionDelegate,
   RNSDismissibleModalProtocol, LinkPreviewMenuUpdatable {
   private var preview: NativeLinkPreviewContentView?
   private var interaction: UIContextMenuInteraction?
@@ -19,7 +19,7 @@ class NativeLinkPreviewView: ExpoView, UIContextMenuInteractionDelegate,
   private var actions: [LinkPreviewNativeActionView] = []
 
   private lazy var linkPreviewNativeNavigation: LinkPreviewNativeNavigation = {
-    return LinkPreviewNativeNavigation(logger: appContext?.jsLogger)
+    return LinkPreviewNativeNavigation(logger: logger)
   }()
 
   let onPreviewTapped = EventDispatcher()
@@ -62,7 +62,7 @@ class NativeLinkPreviewView: ExpoView, UIContextMenuInteractionDelegate,
         actions.append(actionView)
       } else {
         if directChild != nil {
-          print(
+          logger?.warn(
             "[expo-router] Found a second child of <Link.Trigger>. Only one is allowed. This is most likely a bug in expo-router."
           )
           return
@@ -89,7 +89,7 @@ class NativeLinkPreviewView: ExpoView, UIContextMenuInteractionDelegate,
       } else {
         if let directChild = directChild {
           if directChild != child {
-            print(
+            logger?.warn(
               "[expo-router] Unmounting unexpected child from <Link.Trigger>. This is most likely a bug in expo-router."
             )
             return
@@ -103,7 +103,7 @@ class NativeLinkPreviewView: ExpoView, UIContextMenuInteractionDelegate,
           }
           super.unmountChildComponentView(child, index: index)
         } else {
-          print(
+          logger?.warn(
             "[expo-router] No link child found to unmount. This is most likely a bug in expo-router."
           )
           return

--- a/packages/expo-router/ios/LinkPreview/LinkZoomTransition.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkZoomTransition.swift
@@ -244,7 +244,7 @@ class LinkZoomTransitionAlignmentRectDetector: LinkZoomExpoView {
   ) {
     guard child == nil else {
       logger?.warn(
-        "[expo-router] Link.AppleZoomTarget can only have a single native child."
+        "[expo-router] Link.AppleZoomTarget can only have a single native child. If you passed a single child, consider adding collapsible={false} to your component"
       )
       return
     }
@@ -287,7 +287,7 @@ class LinkZoomTransitionEnabler: LinkZoomExpoView {
 
   private func setupZoomTransition() {
     if self.zoomTransitionSourceIdentifier.isEmpty {
-      print("[expo-router] No zoomTransitionSourceIdentifier passed to LinkZoomTransitionEnabler")
+      logger?.warn("[expo-router] No zoomTransitionSourceIdentifier passed to LinkZoomTransitionEnabler. This is most likely a bug in expo-router.")
       return
     }
     if let controller = self.findViewController() {
@@ -329,8 +329,8 @@ class LinkZoomTransitionEnabler: LinkZoomExpoView {
             view = linkPreviewView.directChild
           }
           guard let view else {
-            print(
-              "[expo-router] No source view found for identifier \(self.zoomTransitionSourceIdentifier) to enable zoom transition"
+            self.logger?.warn(
+              "[expo-router] No source view found for identifier \(self.zoomTransitionSourceIdentifier) to enable zoom transition. This is most likely a bug in expo-router."
             )
             return nil
           }
@@ -339,7 +339,7 @@ class LinkZoomTransitionEnabler: LinkZoomExpoView {
         return
       }
     } else {
-      print("[expo-router] No navigation controller found to enable zoom transition")
+      logger?.warn("[expo-router] No navigation controller found to enable zoom transition. This is most likely a bug in expo-router.")
     }
   }
 
@@ -390,7 +390,7 @@ class LinkZoomTransitionEnabler: LinkZoomExpoView {
   }
 }
 
-class LinkZoomExpoView: ExpoView {
+class LinkZoomExpoView: RouterViewWithLogger {
   var module: LinkPreviewNativeModule? {
     return appContext?.moduleRegistry.get(moduleWithName: LinkPreviewNativeModule.moduleName)
       as? LinkPreviewNativeModule
@@ -398,7 +398,7 @@ class LinkZoomExpoView: ExpoView {
 
   var sourceRepository: LinkZoomTransitionsSourceRepository? {
     guard let module else {
-      print("[expo-router] LinkPreviewNativeModule not loaded")
+      logger?.warn("[expo-router] LinkPreviewNativeModule not loaded. Make sure expo-router is properly configured.")
       return nil
     }
     return module.zoomSourceRepository
@@ -406,11 +406,9 @@ class LinkZoomExpoView: ExpoView {
 
   var alignmentViewRepository: LinkZoomTransitionsAlignmentViewRepository? {
     guard let module else {
-      print("[expo-router] LinkPreviewNativeModule not loaded")
+      logger?.warn("[expo-router] LinkPreviewNativeModule not loaded.  Make sure expo-router is properly configured.")
       return nil
     }
     return module.zoomAlignmentViewRepository
   }
-
-  lazy var logger = appContext?.jsLogger
 }

--- a/packages/expo-router/ios/RouterViewWithLogger.swift
+++ b/packages/expo-router/ios/RouterViewWithLogger.swift
@@ -1,0 +1,5 @@
+import ExpoModulesCore
+
+class RouterViewWithLogger: ExpoView {
+  lazy var logger = appContext?.jsLogger
+}

--- a/packages/expo-router/ios/Toolbar/RouterToolbarHostView.swift
+++ b/packages/expo-router/ios/Toolbar/RouterToolbarHostView.swift
@@ -2,15 +2,11 @@ import ExpoModulesCore
 import RNScreens
 import UIKit
 
-class RouterToolbarHostView: ExpoView, LinkPreviewMenuUpdatable {
+class RouterToolbarHostView: RouterViewWithLogger, LinkPreviewMenuUpdatable {
   // Mutable map of toolbar items
   var toolbarItemsArray: [String] = []
   var toolbarItemsMap: [String: RouterToolbarItemView] = [:]
   var menuItemsMap: [String: LinkPreviewNativeActionView] = [:]
-
-  required init(appContext: AppContext? = nil) {
-    super.init(appContext: appContext)
-  }
 
   private func addRouterToolbarItemAtIndex(
     _ item: RouterToolbarItemView,
@@ -56,6 +52,7 @@ class RouterToolbarHostView: ExpoView, LinkPreviewMenuUpdatable {
             if let item = toolbarItemsMap[$0] {
               return item.barButtonItem
             }
+            // TODO: Extract this logic to separate function
             if let menu = menuItemsMap[$0] {
               let item = UIBarButtonItem(
                 title: menu.title,
@@ -92,8 +89,8 @@ class RouterToolbarHostView: ExpoView, LinkPreviewMenuUpdatable {
               }
               return item
             }
-            print(
-              "[expo-router] Warning: Could not find toolbar item or menu for identifier \($0)"
+            logger?.warn(
+              "[expo-router] Warning: Could not find toolbar item or menu for identifier \($0). This is most likely a bug in expo-router."
             )
             return nil
           }, animated: true)
@@ -101,16 +98,15 @@ class RouterToolbarHostView: ExpoView, LinkPreviewMenuUpdatable {
           false, animated: true)
         return
       }
-    } else {
-      print(
-        "[expo-router] Warning: Could not find owning UIViewController for RouterToolbarHostView")
     }
   }
 
   override func mountChildComponentView(_ childComponentView: UIView, index: Int) {
     if let toolbarItem = childComponentView as? RouterToolbarItemView {
       if toolbarItem.identifier.isEmpty {
-        print("[expo-router] RouterToolbarItemView identifier is empty")
+        logger?.warn(
+          "[expo-router] RouterToolbarItemView identifier is empty. This is most likely a bug in expo-router."
+        )
         return
       }
       addRouterToolbarItemAtIndex(toolbarItem, index: index)
@@ -118,8 +114,8 @@ class RouterToolbarHostView: ExpoView, LinkPreviewMenuUpdatable {
       menu.parentMenuUpdatable = self
       addMenuToolbarItemAtIndex(menu, index: index)
     } else {
-      print(
-        "ExpoRouter: Unknown child component view (\(childComponentView)) mounted to RouterToolbarHost"
+      logger?.warn(
+        "[expo-router] Unknown child component view (\(childComponentView)) mounted to RouterToolbarHost. This is most likely a bug in expo-router."
       )
     }
     updateToolbarItems()
@@ -128,19 +124,22 @@ class RouterToolbarHostView: ExpoView, LinkPreviewMenuUpdatable {
   override func unmountChildComponentView(_ childComponentView: UIView, index: Int) {
     if let toolbarItem = childComponentView as? RouterToolbarItemView {
       if toolbarItem.identifier.isEmpty {
-        print("[expo-router] RouterToolbarItemView identifier is empty")
+        logger?.warn(
+          "[expo-router] RouterToolbarItemView identifier is empty. This is most likely a bug in expo-router."
+        )
         return
       }
       removeToolbarItemWithId(toolbarItem.identifier)
     } else if let menu = childComponentView as? LinkPreviewNativeActionView {
       if menu.identifier.isEmpty {
-        print("[expo-router] Menu identifier is empty")
+        logger?.warn(
+          "[expo-router] Menu identifier is empty. This is most likely a bug in expo-router.")
         return
       }
       removeToolbarItemWithId(menu.identifier)
     } else {
-      print(
-        "ExpoRouter: Unknown child component view (\(childComponentView)) unmounted from RouterToolbarHost"
+      logger?.warn(
+        "[expo-router] Unknown child component view (\(childComponentView)) unmounted from RouterToolbarHost. This is most likely a bug in expo-router."
       )
     }
     updateToolbarItems()

--- a/packages/expo-router/ios/Toolbar/RouterToolbarItemView.swift
+++ b/packages/expo-router/ios/Toolbar/RouterToolbarItemView.swift
@@ -1,7 +1,7 @@
 import ExpoModulesCore
 import UIKit
 
-class RouterToolbarItemView: ExpoView {
+class RouterToolbarItemView: RouterViewWithLogger {
   var identifier: String = ""
   @ReactiveProp var type: ItemType?
   @ReactiveProp var title: String?
@@ -115,8 +115,8 @@ class RouterToolbarItemView: ExpoView {
 
   override func mountChildComponentView(_ childComponentView: UIView, index: Int) {
     if customView != nil {
-      print(
-        "[expo-router] Warning: RouterToolbarItemView can only have one child view"
+      logger?.warn(
+        "[expo-router] RouterToolbarItemView can only have one child view. This is most likely a bug in expo-router."
       )
       return
     }


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-18357/use-jslogger-in-routes-native-components

Most of the native warnings in router were logged using `print`. Thus it's unlikely they would surface in most cases. This PR replaces `print` with `jsLogger` in order to make the warnings more visible.

Follow-up task: https://linear.app/expo/issue/ENG-18487/refactor-linkpreivewactionview-native-components-to-use-similar

# How

1. Create lazy variable `logger`
2. Replace print with `logger?.warn`
3. Rewrite warnings to be easier to understand
4. Remove unnecessary warnings

# Test Plan

Manual testing

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
