### PR TITLE
[docs] fix typo in mestro workflows

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -1072,7 +1072,7 @@ This job outputs the following properties:
 
 Runs [Maestro](https://maestro.dev/) tests on a build. See [Maestro job documentation](/eas/workflows/pre-packaged-jobs#maestro) for detailed information and examples.
 
-> **important** Maestro tests are in [alhpa](/more/release-statuses/#alpha).
+> **important** Maestro tests are in [alpha](/more/release-statuses/#alpha).
 
 ```yaml
 jobs:


### PR DESCRIPTION
# Why

Fixed a typo in the Maestro tests documentation where "alpha" was misspelled as "alhpa".

# How

Corrected the spelling of "alpha" in the Maestro tests section of the workflows syntax documentation.

# Test Plan



# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)