### PR TITLE
[expo-router][ios] add NativeActionProp to reduce repetition in LinkPreviewNativeActionView

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -85,6 +85,7 @@
 - [ios] add internal animateAspectRatioChange prop ([#41511](https://github.com/expo/expo/pull/41511) by [@Ubax](https://github.com/Ubax))
 - Add unstable_navigationEvents to expose global navigation events ([#41706](https://github.com/expo/expo/pull/41706) by [@Ubax](https://github.com/Ubax))
 - [ios] replace print with jsLog in native components ([#41757](https://github.com/expo/expo/pull/41757) by [@Ubax](https://github.com/Ubax))
+- [ios] add NativeActionProp to reduce repetition in LinkPreviewNativeActionView ([#41763](https://github.com/expo/expo/pull/41763) by [@Ubax](https://github.com/Ubax))
 
 ## 6.0.17 - 2025-12-05
 

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeActionView.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeActionView.swift
@@ -2,150 +2,33 @@ import ExpoModulesCore
 
 class LinkPreviewNativeActionView: RouterViewWithLogger, LinkPreviewMenuUpdatable {
   var identifier: String = ""
-  // TODO(@ubax): Add @ReactiveProp similar to RouterToolbar to reduce repetition
   // MARK: - Shared props
-  var title: String = "" {
-    didSet {
-      updateUiAction()
-      if isMenuAction {
-        updateMenu()
-      }
-    }
-  }
-  var icon: String? {
-    didSet {
-      updateUiAction()
-      if isMenuAction {
-        updateMenu()
-      }
-    }
-  }
-  var destructive: Bool? {
-    didSet {
-      updateUiAction()
-      if isMenuAction {
-        updateMenu()
-      }
-    }
-  }
-  var disabled: Bool = false {
-    didSet {
-      updateUiAction()
-      if isMenuAction {
-        updateMenu()
-      }
-    }
-  }
+  @NativeActionProp(updateAction: true, updateMenu: true) var title: String = ""
+  @NativeActionProp(updateAction: true, updateMenu: true) var icon: String?
+  @NativeActionProp(updateAction: true, updateMenu: true) var destructive: Bool?
+  @NativeActionProp(updateAction: true, updateMenu: true) var disabled: Bool = false
 
   // MARK: - Action only props
-  var isOn: Bool? {
-    didSet {
-      updateUiAction()
-    }
-  }
-  var keepPresented: Bool? {
-    didSet {
-      updateUiAction()
-    }
-  }
-  var discoverabilityLabel: String? {
-    didSet {
-      updateUiAction()
-    }
-  }
-  var subtitle: String? {
-    didSet {
-      updateUiAction()
-    }
-  }
+  @NativeActionProp(updateAction: true) var isOn: Bool?
+  @NativeActionProp(updateAction: true) var keepPresented: Bool?
+  @NativeActionProp(updateAction: true) var discoverabilityLabel: String?
+  @NativeActionProp(updateAction: true) var subtitle: String?
 
   // MARK: - Menu only props
-  var singleSelection: Bool = false {
-    didSet {
-      if isMenuAction {
-        updateMenu()
-      }
-    }
-  }
-  var displayAsPalette: Bool = false {
-    didSet {
-      if isMenuAction {
-        updateMenu()
-      }
-    }
-  }
-  var displayInline: Bool = false {
-    didSet {
-      if isMenuAction {
-        updateMenu()
-      }
-    }
-  }
+  @NativeActionProp(updateMenu: true) var singleSelection: Bool = false
+  @NativeActionProp(updateMenu: true) var displayAsPalette: Bool = false
+  @NativeActionProp(updateMenu: true) var displayInline: Bool = false
 
   // MARK: - UIBarButtonItem props
-  var routerHidden: Bool = false {
-    didSet {
-      updateUiAction()
-      if isMenuAction {
-        updateMenu()
-      }
-    }
-  }
-  var titleStyle: TitleStyle? {
-    didSet {
-      if isMenuAction {
-        updateMenu()
-      }
-    }
-  }
-  var sharesBackground: Bool? {
-    didSet {
-      if isMenuAction {
-        updateMenu()
-      }
-    }
-  }
-  var hidesSharedBackground: Bool? {
-    didSet {
-      if isMenuAction {
-        updateMenu()
-      }
-    }
-  }
-  var customTintColor: UIColor? {
-    didSet {
-      updateUiAction()
-      if isMenuAction {
-        updateMenu()
-      }
-    }
-  }
-  var barButtonItemStyle: UIBarButtonItem.Style? {
-    didSet {
-      if isMenuAction {
-        updateMenu()
-      }
-    }
-  }
-  var subActions: [LinkPreviewNativeActionView] = [] {
-    didSet {
-      updateMenu()
-    }
-  }
-  var accessibilityLabelForMenu: String? {
-    didSet {
-      if isMenuAction {
-        updateMenu()
-      }
-    }
-  }
-  var accessibilityHintForMenu: String? {
-    didSet {
-      if isMenuAction {
-        updateMenu()
-      }
-    }
-  }
+  @NativeActionProp(updateAction: true, updateMenu: true) var routerHidden: Bool = false
+  @NativeActionProp(updateMenu: true) var titleStyle: TitleStyle?
+  @NativeActionProp(updateMenu: true) var sharesBackground: Bool?
+  @NativeActionProp(updateMenu: true) var hidesSharedBackground: Bool?
+  @NativeActionProp(updateAction: true, updateMenu: true) var customTintColor: UIColor?
+  @NativeActionProp(updateMenu: true) var barButtonItemStyle: UIBarButtonItem.Style?
+  @NativeActionProp(updateMenu: true) var subActions: [LinkPreviewNativeActionView] = []
+  @NativeActionProp(updateMenu: true) var accessibilityLabelForMenu: String?
+  @NativeActionProp(updateMenu: true) var accessibilityHintForMenu: String?
 
   // MARK: - Events
   let onSelected = EventDispatcher()
@@ -202,7 +85,7 @@ class LinkPreviewNativeActionView: RouterViewWithLogger, LinkPreviewMenuUpdatabl
     parentMenuUpdatable?.updateMenu()
   }
 
-  private func updateUiAction() {
+  func updateUiAction() {
     var attributes: UIMenuElement.Attributes = []
     if destructive == true { attributes.insert(.destructive) }
     if disabled == true { attributes.insert(.disabled) }
@@ -248,6 +131,55 @@ class LinkPreviewNativeActionView: RouterViewWithLogger, LinkPreviewMenuUpdatabl
         "ExpoRouter: Unknown child component view (\(child)) unmounted from NativeLinkPreviewActionView. This is most likely a bug in expo-router."
       )
     }
+  }
+
+  @propertyWrapper
+  struct NativeActionProp<Value: Equatable> {
+    var value: Value
+    let updateAction: Bool
+    let updateMenu: Bool
+
+    init(wrappedValue: Value, updateAction: Bool = false, updateMenu: Bool = false) {
+      self.value = wrappedValue
+      self.updateAction = updateAction
+      self.updateMenu = updateMenu
+    }
+
+    static subscript<EnclosingSelf: LinkPreviewNativeActionView>(
+      _enclosingInstance instance: EnclosingSelf,
+      wrapped wrappedKeyPath: ReferenceWritableKeyPath<EnclosingSelf, Value>,
+      storage storageKeyPath: ReferenceWritableKeyPath<EnclosingSelf, NativeActionProp<Value>>
+    ) -> Value {
+      get {
+        instance[keyPath: storageKeyPath].value
+      }
+      set {
+        let oldValue = instance[keyPath: storageKeyPath].value
+        if oldValue != newValue {
+          instance[keyPath: storageKeyPath].value = newValue
+          if instance[keyPath: storageKeyPath].updateAction {
+            instance.updateUiAction()
+          }
+          if instance[keyPath: storageKeyPath].updateMenu {
+            instance.updateMenu()
+          }
+        }
+      }
+    }
+
+    var wrappedValue: Value {
+      get { value }
+      set { value = newValue }
+    }
+  }
+}
+
+// Needed to allow optional properties without default `= nil` to avoid repetition
+extension LinkPreviewNativeActionView.NativeActionProp where Value: ExpressibleByNilLiteral {
+  init(updateAction: Bool = false, updateMenu: Bool = false) {
+    self.value = nil
+    self.updateAction = updateAction
+    self.updateMenu = updateMenu
   }
 }
 


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-18487/refactor-linkpreivewactionview-native-components-to-use-similar

There was a lot of repetition in the link preview code. This PR replaces `didSet` with `@propertyWrapper` in order to apply DRY rule.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
