### PR TITLE
[ios][splashscreen] Remove new arch checks

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -747,7 +747,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core-prebuilt (0.83.0):
+  - React-Core-prebuilt (0.83.1):
     - ReactNativeDependencies
   - React-Core/CoreModulesHeaders (0.83.1):
     - hermes-engine
@@ -3836,7 +3836,7 @@ SPEC CHECKSUMS:
   React: 4bc1f928568ad4bcfd147260f907b4ea5873a03b
   React-callinvoker: 8dd44c31888a314694efd0ef5f19ab7e0e855ef8
   React-Core: 0c1f3042e1204c0512b2e4263062c66550d7e6a3
-  React-Core-prebuilt: 620fa7df017f9663e0e8b96c68d2441fb6770c49
+  React-Core-prebuilt: 7894b037a2f0fa699a44de6c88d20acd4235b255
   React-CoreModules: f6a626221d52f21b5eb8df2d79780b96f20240e5
   React-cxxreact: 2e3990595049d43dd1d59ccd6cb35545f0dc6f03
   React-debug: 60be0767f5672afc81bfd6a50d996507430f7906

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -747,7 +747,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core-prebuilt (0.83.1):
+  - React-Core-prebuilt (0.83.0):
     - ReactNativeDependencies
   - React-Core/CoreModulesHeaders (0.83.1):
     - hermes-engine
@@ -3803,7 +3803,7 @@ SPEC CHECKSUMS:
   ExpoSharing: 6f52a070c3083c11717cf2236ae8fd6ac45bf028
   ExpoSMS: 429edbe5911e7899bc9a0a1a2c106677f552dc33
   ExpoSpeech: 0b515130c96898789e72e8d0aac82b7e9123e88b
-  ExpoSplashScreen: 9d2ff8fa08f2c00336a83f93bebffed3a8312519
+  ExpoSplashScreen: 896f624f2e9e98c5de938bf59a62a061f383164d
   ExpoSQLite: e22c4e298016e658454527ec7dbda5a237b293a3
   ExpoStoreReview: 142af4a031b0a7ad99e70e1de8675da03be4ff40
   ExpoSymbols: ef7b8ac77ac2d496b1bc3f0f7daf5e19c3a9933a
@@ -3818,7 +3818,7 @@ SPEC CHECKSUMS:
   EXUpdates: 83e4d666a085b44149f3b21d5bd057ad37b2c3e5
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   FBLazyVector: 3a7ea85f6009224ad89f7daeda516f189e6b5759
-  hermes-engine: 9a270294aaec03556862ee83edd0f490710bfbb2
+  hermes-engine: 6bb3000824be2770010ae038914fa26721255c8e
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -3836,7 +3836,7 @@ SPEC CHECKSUMS:
   React: 4bc1f928568ad4bcfd147260f907b4ea5873a03b
   React-callinvoker: 8dd44c31888a314694efd0ef5f19ab7e0e855ef8
   React-Core: 0c1f3042e1204c0512b2e4263062c66550d7e6a3
-  React-Core-prebuilt: 77dc6b8896f979084f259440ae631ff66ec5caf8
+  React-Core-prebuilt: 620fa7df017f9663e0e8b96c68d2441fb6770c49
   React-CoreModules: f6a626221d52f21b5eb8df2d79780b96f20240e5
   React-cxxreact: 2e3990595049d43dd1d59ccd6cb35545f0dc6f03
   React-debug: 60be0767f5672afc81bfd6a50d996507430f7906
@@ -3906,7 +3906,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: bfb12ead469222b022a2024f32aba47ce50de512
   ReactCodegen: b9b0ea5c72e425fa5a89a031ada3e64dfd839771
   ReactCommon: 0084791d25c4deae3d8b77efd4440fb2d5c38746
-  ReactNativeDependencies: c489f425742a360f0c51e45ddbfe43572e754c89
+  ReactNativeDependencies: 17a617edb4d5883a4c48339514ccb8b765f8af4f
   RNCAsyncStorage: e85a99325df9eb0191a6ee2b2a842644c7eb29f4
   RNCMaskedView: 3c9d7586e2b9bbab573591dcb823918bc4668005
   RNCPicker: 38a9deb903d9a8ae18b598bac727e6c84b3cf0fa

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -4660,7 +4660,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 2853aea4922d43f84b721631947e9b25da43eabd
+  hermes-engine: 452f2dd7422b2fd7973ae9ca103898d28d7744f0
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [iOS] Remove new architecture checks.
+- [iOS] Remove new architecture checks. ([#41767](https://github.com/expo/expo/pull/41767) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 31.0.12 - 2025-12-05
 

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [iOS] Remove new architecture checks.
+
 ## 31.0.12 - 2025-12-05
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-splash-screen/ios/ExpoSplashScreen.podspec
+++ b/packages/expo-splash-screen/ios/ExpoSplashScreen.podspec
@@ -2,14 +2,6 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
 
-new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
-new_arch_compiler_flags = '-DRCT_NEW_ARCH_ENABLED'
-compiler_flags = ''
-
-if new_arch_enabled
-  compiler_flags << ' ' << new_arch_compiler_flags
-end
-
 Pod::Spec.new do |s|
   s.name           = 'ExpoSplashScreen'
   s.version        = package['version']
@@ -28,8 +20,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
     'SWIFT_COMPILATION_MODE' => 'wholemodule',
-    'OTHER_SWIFT_FLAGS' => "$(inherited) #{new_arch_enabled ? new_arch_compiler_flags : ''}",
   }
 
-  s.source_files = "**/*.{h,m,swift}"
+  s.source_files = "**/*.swift"
 end

--- a/packages/expo-splash-screen/ios/SplashScreenManager.swift
+++ b/packages/expo-splash-screen/ios/SplashScreenManager.swift
@@ -67,16 +67,10 @@ public class SplashScreenManager: NSObject, RCTReloadListener {
         loadingView?.center = CGPoint(x: bounds.midX, y: bounds.midY)
       }
       loadingView?.isHidden = false
-#if RCT_NEW_ARCH_ENABLED
       if let hostView = rootView as? RCTSurfaceHostingProxyRootView, let loadingView {
         hostView.disableActivityIndicatorAutoHide(true)
         hostView.loadingView = loadingView
       }
-#else
-      if let loadingView {
-        self.rootView?.addSubview(loadingView)
-      }
-#endif
     }
   }
 


### PR DESCRIPTION
# Why
SDK 55 won't support the old architecture so we can remove these checks

# How

# Test Plan
Bare-expo

