### PR TITLE
[core][Android] Move coreModule from JSIContext to installer

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
@@ -12,7 +12,6 @@ import com.google.common.truth.Truth
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.ModuleHolder
 import expo.modules.kotlin.ModuleRegistry
-import expo.modules.kotlin.runtime.RuntimeContext
 import expo.modules.kotlin.defaultmodules.CoreModule
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.jni.tests.RuntimeHolder
@@ -30,7 +29,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 
-private fun defaultAppContextMock(): Pair<AppContext, RuntimeContext> {
+private fun defaultAppContextMock(): Pair<AppContext, MainRuntimeContext> {
   val appContextMock = mockk<AppContext>()
   val runtimeContext = mockk<MainRuntimeContext>()
   val classRegistry = ClassRegistry()

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
@@ -85,19 +85,6 @@ JSIContext::callGetJavaScriptModuleObjectMethod(const std::string &moduleName) c
   return jni::adopt_local(static_cast<JavaScriptModuleObject::javaobject>(result));
 }
 
-jni::local_ref<JavaScriptModuleObject::javaobject>
-JSIContext::callGetCoreModuleObject() const {
-  if (javaPart_ == nullptr) {
-    throw std::runtime_error("getCoreModule: JSIContext was prepared to be deallocated.");
-  }
-
-  const static auto method = expo::JSIContext::javaClassLocal()
-    ->getMethod<jni::local_ref<JavaScriptModuleObject::javaobject>()>(
-      "getCoreModuleObject"
-    );
-  return method(javaPart_);
-}
-
 jni::local_ref<jni::JArrayClass<jni::JString>>
 JSIContext::callGetJavaScriptModulesNames() const {
   if (javaPart_ == nullptr) {
@@ -133,10 +120,6 @@ bool JSIContext::callHasModule(const std::string &moduleName) const {
 jni::local_ref<JavaScriptModuleObject::javaobject>
 JSIContext::getModule(const std::string &moduleName) const {
   return callGetJavaScriptModuleObjectMethod(moduleName);
-}
-
-jni::local_ref<JavaScriptModuleObject::javaobject> JSIContext::getCoreModule() const {
-  return callGetCoreModuleObject();
 }
 
 bool JSIContext::hasModule(const std::string &moduleName) const {

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
@@ -91,11 +91,6 @@ public:
   jni::local_ref<JavaScriptObject::javaobject> createObject() noexcept;
 
   /**
-  * Gets a core module.
-  */
-  [[nodiscard]] jni::local_ref<JavaScriptModuleObject::javaobject> getCoreModule() const;
-
-  /**
    * Adds a shared object to the internal registry
    * @param native part of the shared object
    * @param js part of the shared object
@@ -155,8 +150,6 @@ private:
   callGetJavaScriptModuleObjectMethod(const std::string &moduleName) const;
 
   [[nodiscard]] inline jni::local_ref<jni::JArrayClass<jni::JString>> callGetJavaScriptModulesNames() const;
-
-  [[nodiscard]] inline jni::local_ref<JavaScriptModuleObject::javaobject> callGetCoreModuleObject() const;
 
   [[nodiscard]] inline bool callHasModule(const std::string &moduleName) const;
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -20,7 +20,7 @@ class JavaScriptModuleObject;
 
 class JSDecoratorsBridgingObject;
 
-class JavaScriptRuntime;
+class MainRuntimeInstaller;
 
 /**
  * A CPP part of the module.
@@ -54,7 +54,7 @@ public:
 
 private:
   friend HybridBase;
-  friend JavaScriptRuntime;
+  friend MainRuntimeInstaller;
 
   /**
    * A reference to the `jsi::Object`.

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
@@ -86,32 +86,4 @@ void JavaScriptRuntime::drainJSEventLoop() {
   while (!runtime->drainMicrotasks()) {}
 }
 
-void JavaScriptRuntime::installMainObject() {
-  auto coreModule = getJSIContext(get())->getCoreModule();
-
-  // As opposed to other modules, the core module is represented by a raw JS object instead of an instance of NativeModule class.
-  mainObject = std::make_shared<jsi::Object>(*runtime);
-
-  // Decorate the core object based on the module definition.
-  for (const auto &decorator : coreModule->cthis()->decorators) {
-    decorator->decorate(*runtime, *mainObject);
-  }
-
-  auto global = runtime->global();
-
-  jsi::Object descriptor = JavaScriptObject::preparePropertyDescriptor(*runtime, 1 << 1);
-
-  descriptor.setProperty(*runtime, "value", jsi::Value(*runtime, *mainObject));
-
-  common::defineProperty(
-    *runtime,
-    &global,
-    "expo",
-    std::move(descriptor)
-  );
-}
-
-std::shared_ptr<jsi::Object> JavaScriptRuntime::getMainObject() noexcept {
-  return mainObject;
-}
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
@@ -73,14 +73,9 @@ public:
    */
   void drainJSEventLoop();
 
-  void installMainObject();
-
   std::shared_ptr<react::CallInvoker> jsInvoker;
-
-  std::shared_ptr<jsi::Object> getMainObject() noexcept;
 
 private:
   std::shared_ptr<jsi::Runtime> runtime;
-  std::shared_ptr<jsi::Object> mainObject;
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/installers/MainRuntimeInstaller.h
+++ b/packages/expo-modules-core/android/src/main/cpp/installers/MainRuntimeInstaller.h
@@ -53,14 +53,32 @@ public:
   ) noexcept;
 
   static void prepareRuntime(
+    jni::alias_ref<MainRuntimeInstaller::javaobject> self,
     jni::local_ref<JSIContext::javaobject> jsiContext
   ) noexcept;
 
   static void installClasses(
     jsi::Runtime &runtime,
-    expo::SharedObject::ObjectReleaser releaser
+    JSIContext *jsiContext
   ) noexcept;
 
+  static std::shared_ptr<jsi::Object> installMainObject(
+    jsi::Runtime &runtime,
+    std::vector<std::unique_ptr<JSDecorator>> &decorators
+  ) noexcept;
+
+  static void installModules(
+    jsi::Runtime &runtime,
+    JSIContext *jsiContext,
+    const std::shared_ptr<jsi::Object> &hostObject
+  ) noexcept;
+
+  /**
+  * Gets a core module.
+  */
+  [[nodiscard]] static jni::local_ref<JavaScriptModuleObject::javaobject> getCoreModule(
+    jni::alias_ref<MainRuntimeInstaller::javaobject> self
+  );
 };
 
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/installers/WorkletRuntimeInstaller.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/installers/WorkletRuntimeInstaller.cpp
@@ -16,7 +16,7 @@ namespace expo {
 void WorkletRuntimeInstaller::registerNatives() {
   javaClassLocal()->registerNatives({
                                       makeNativeMethod("install", WorkletRuntimeInstaller::install)
-  });
+                                    });
 }
 
 jni::local_ref<JSIContext::javaobject> WorkletRuntimeInstaller::install(
@@ -26,21 +26,56 @@ jni::local_ref<JSIContext::javaobject> WorkletRuntimeInstaller::install(
   jni::alias_ref<JNIDeallocator::javaobject> jniDeallocator
 ) noexcept {
 #if WORKLETS_ENABLED
-  jsi::Runtime* jsRuntime = reinterpret_cast<jsi::Runtime *>(jsRuntimePointer);
+  auto *jsRuntime = reinterpret_cast<jsi::Runtime *>(jsRuntimePointer);
   auto workletRuntime = worklets::WorkletRuntime::getWeakRuntimeFromJSIRuntime(*jsRuntime);
 
   auto jsiContext = MainRuntimeInstaller::createJSIContext(
-    std::move(runtimeContextHolder),
+    runtimeContextHolder,
     jsRuntimePointer,
-    std::move(jniDeallocator),
+    jniDeallocator,
     std::make_shared<WorkletJSCallInvoker>(workletRuntime)
   );
 
-  MainRuntimeInstaller::prepareRuntime(jsiContext);
+  WorkletRuntimeInstaller::prepareRuntime(jsiContext);
 
   return jsiContext;
 #else
   return nullptr;
+#endif
+}
+
+void WorkletRuntimeInstaller::prepareRuntime(
+  jni::local_ref<JSIContext::javaobject> jsiContext
+) noexcept {
+#if WORKLETS_ENABLED
+  auto cxxPart = jsiContext->cthis();
+  auto runtimeHolder = cxxPart->runtimeHolder;
+  jsi::Runtime &runtime = runtimeHolder->get();
+
+  bindJSIContext(runtime, cxxPart);
+
+  auto mainObject = std::make_shared<jsi::Object>(runtime);
+
+  auto global = runtime.global();
+  jsi::Object descriptor = JavaScriptObject::preparePropertyDescriptor(runtime, 1 << 1);
+  descriptor.setProperty(runtime, "value", jsi::Value(runtime, *mainObject));
+  common::defineProperty(
+    runtime,
+    &global,
+    "expo",
+    std::move(descriptor)
+  );
+
+  MainRuntimeInstaller::installClasses(
+    runtime,
+    cxxPart
+  );
+
+  MainRuntimeInstaller::installModules(
+    runtime,
+    cxxPart,
+    mainObject
+  );
 #endif
 }
 

--- a/packages/expo-modules-core/android/src/main/cpp/installers/WorkletRuntimeInstaller.h
+++ b/packages/expo-modules-core/android/src/main/cpp/installers/WorkletRuntimeInstaller.h
@@ -17,6 +17,10 @@ public:
     jlong jsRuntimePointer,
     jni::alias_ref<JNIDeallocator::javaobject> jniDeallocator
   ) noexcept;
+
+  static void prepareRuntime(
+    jni::local_ref<JSIContext::javaobject> jsiContext
+  ) noexcept;
 };
 
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
@@ -122,12 +122,6 @@ class JSIContext @DoNotStrip internal constructor(
       ?.toJavaScriptObject(native)
   }
 
-  @Suppress("unused")
-  @DoNotStrip
-  fun getCoreModuleObject(): JavaScriptModuleObject? {
-    return runtimeContextHolder.get()?.coreModule?.jsObject
-  }
-
   @Throws(Throwable::class)
   protected fun finalize() {
     deallocate()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/MainRuntimeInstaller.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/MainRuntimeInstaller.kt
@@ -6,7 +6,6 @@ import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
 import com.facebook.soloader.SoLoader
 import expo.modules.core.interfaces.DoNotStrip
 import expo.modules.kotlin.runtime.MainRuntimeContext
-import expo.modules.kotlin.runtime.RuntimeContext
 import expo.modules.kotlin.weak
 import java.lang.ref.WeakReference
 
@@ -38,7 +37,6 @@ class MainRuntimeInstaller(
       runtimeExecutor
     )
   }
-
 
   @Suppress("unused")
   @DoNotStrip

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/MainRuntimeInstaller.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/MainRuntimeInstaller.kt
@@ -4,13 +4,15 @@ import com.facebook.react.bridge.RuntimeExecutor
 import com.facebook.react.common.annotations.FrameworkAPI
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl
 import com.facebook.soloader.SoLoader
+import expo.modules.core.interfaces.DoNotStrip
+import expo.modules.kotlin.runtime.MainRuntimeContext
 import expo.modules.kotlin.runtime.RuntimeContext
 import expo.modules.kotlin.weak
 import java.lang.ref.WeakReference
 
 @OptIn(FrameworkAPI::class)
 class MainRuntimeInstaller(
-  val runtimeContext: RuntimeContext
+  val runtimeContext: MainRuntimeContext
 ) {
   // TODO(@lukmccall): Migrate tests to use bridgeless JSI installation and remove this method.
   fun install(
@@ -35,6 +37,13 @@ class MainRuntimeInstaller(
       runtimeContext.deallocator,
       runtimeExecutor
     )
+  }
+
+
+  @Suppress("unused")
+  @DoNotStrip
+  fun getCoreModuleObject(): JavaScriptModuleObject {
+    return runtimeContext.coreModule.jsObject
   }
 
   private external fun install(

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/runtime/MainRuntimeContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/runtime/MainRuntimeContext.kt
@@ -2,14 +2,12 @@ package expo.modules.kotlin.runtime
 
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.common.annotations.FrameworkAPI
-import expo.modules.core.interfaces.DoNotStrip
 import expo.modules.core.utilities.ifNull
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.ModuleHolder
 import expo.modules.kotlin.defaultmodules.CoreModule
 import expo.modules.kotlin.jni.JNIDeallocator
 import expo.modules.kotlin.jni.JSIContext
-import expo.modules.kotlin.jni.JavaScriptModuleObject
 import expo.modules.kotlin.jni.JavaScriptValue
 import expo.modules.kotlin.jni.MainRuntimeInstaller
 import expo.modules.kotlin.logger

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/runtime/MainRuntimeContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/runtime/MainRuntimeContext.kt
@@ -2,12 +2,14 @@ package expo.modules.kotlin.runtime
 
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.common.annotations.FrameworkAPI
+import expo.modules.core.interfaces.DoNotStrip
 import expo.modules.core.utilities.ifNull
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.ModuleHolder
 import expo.modules.kotlin.defaultmodules.CoreModule
 import expo.modules.kotlin.jni.JNIDeallocator
 import expo.modules.kotlin.jni.JSIContext
+import expo.modules.kotlin.jni.JavaScriptModuleObject
 import expo.modules.kotlin.jni.JavaScriptValue
 import expo.modules.kotlin.jni.MainRuntimeInstaller
 import expo.modules.kotlin.logger
@@ -58,7 +60,7 @@ class MainRuntimeContext(
    *
    * Note: in current implementation this module won't receive any events.
    */
-  override val coreModule = run {
+  internal val coreModule = run {
     val module = CoreModule()
     module._appContextHolder = appContextHolder
     ModuleHolder(module, null)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/runtime/RuntimeContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/runtime/RuntimeContext.kt
@@ -2,7 +2,6 @@ package expo.modules.kotlin.runtime
 
 import com.facebook.react.bridge.ReactApplicationContext
 import expo.modules.kotlin.AppContext
-import expo.modules.kotlin.ModuleHolder
 import expo.modules.kotlin.jni.JNIDeallocator
 import expo.modules.kotlin.jni.JSIContext
 import expo.modules.kotlin.jni.JavaScriptValue
@@ -16,7 +15,6 @@ abstract class RuntimeContext {
 
   @PublishedApi
   internal abstract val deallocator: JNIDeallocator
-  internal abstract val coreModule: ModuleHolder<*>
   internal abstract val sharedObjectRegistry: SharedObjectRegistry
   internal abstract val classRegistry: ClassRegistry
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/runtime/WorkletRuntimeContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/runtime/WorkletRuntimeContext.kt
@@ -2,14 +2,11 @@ package expo.modules.kotlin.runtime
 
 import com.facebook.react.bridge.ReactApplicationContext
 import expo.modules.kotlin.AppContext
-import expo.modules.kotlin.ModuleHolder
 import expo.modules.kotlin.jni.JNIDeallocator
 import expo.modules.kotlin.jni.JSIContext
 import expo.modules.kotlin.jni.JavaScriptValue
 import expo.modules.kotlin.jni.WorkletRuntimeInstaller
 import expo.modules.kotlin.logger
-import expo.modules.kotlin.modules.Module
-import expo.modules.kotlin.modules.ModuleDefinitionBuilder
 import expo.modules.kotlin.sharedobjects.ClassRegistry
 import expo.modules.kotlin.sharedobjects.SharedObjectRegistry
 import expo.modules.kotlin.tracing.trace
@@ -23,15 +20,6 @@ class WorkletRuntimeContext(
   override lateinit var jsiContext: JSIContext
 
   private val appContextHolder = appContext.weak()
-
-  override val coreModule: ModuleHolder<*> = run {
-    val name = "WorkletRuntimeCoreModule"
-    val emptyModule = object : Module() {
-      override fun definition() = ModuleDefinitionBuilder(null).apply { Name(name) }.buildModule()
-    }
-    emptyModule._appContextHolder = appContextHolder
-    ModuleHolder(emptyModule, name)
-  }
 
   override val sharedObjectRegistry: SharedObjectRegistry = SharedObjectRegistry(this)
 


### PR DESCRIPTION
# Why

Moves `coreModule` from `JSIContext` to installer.

# How

Refactored how the `coreModule` is installed, to customize what we are installing on the UI runtime.

# Test Plan

- bare-expo ✅ 
- tests ✅ 