### PR TITLE
[core][Android] Add support for worklets as a function argument

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
@@ -17,6 +17,8 @@
 #include "decorators/JSDecoratorsBridgingObject.h"
 #include "installers/MainRuntimeInstaller.h"
 #include "installers/WorkletRuntimeInstaller.h"
+#include "worklets/Worklet.h"
+#include "worklets/WorkletRuntimeHolder.h"
 
 #if RN_FABRIC_ENABLED
 #include "FabricComponentsRegistry.h"
@@ -37,6 +39,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
     expo::RuntimeHolder::registerNatives();
 #endif
     expo::MainRuntimeInstaller::registerNatives();
+    expo::WorkletRuntimeHolder::registerNatives();
     expo::WorkletRuntimeInstaller::registerNatives();
     expo::JSIContext::registerNatives();
     expo::JavaScriptModuleObject::registerNatives();
@@ -49,6 +52,10 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
     expo::NativeArrayBuffer::registerNatives();
     expo::JavaCallback::registerNatives();
     expo::JNIUtils::registerNatives();
+
+#if WORKLETS_ENABLED
+    expo::Worklet::registerNatives();
+#endif
 
     // Decorators
     expo::JSDecoratorsBridgingObject::registerNatives();

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -80,7 +80,7 @@ try {                             \
   throwNewJavaException(                                       \
     UnexpectedException::create(                               \
       "[" + this->info.name + "] Cannot convert '" + stringRepresentation + \
-      "' to a Kotlin type.").get()                             \
+      "' to a Kotlin type. " + exception.what()).get()                             \
   );                              \
 }
 

--- a/packages/expo-modules-core/android/src/main/cpp/installers/WorkletRuntimeInstaller.h
+++ b/packages/expo-modules-core/android/src/main/cpp/installers/WorkletRuntimeInstaller.h
@@ -2,6 +2,10 @@
 
 #include "MainRuntimeInstaller.h"
 
+#include <fbjni/fbjni.h>
+
+namespace jni = facebook::jni;
+
 namespace expo {
 
 class WorkletRuntimeInstaller : public jni::JavaClass<WorkletRuntimeInstaller> {

--- a/packages/expo-modules-core/android/src/main/cpp/types/CppType.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/CppType.h
@@ -33,5 +33,6 @@ enum CppType {
   VALUE_OR_UNDEFINED = 1 << 21,
   JS_ARRAY_BUFFER = 1 << 22,
   NATIVE_ARRAY_BUFFER = 1 << 23,
+  WORKLET = 1 << 24,
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
@@ -13,6 +13,7 @@
 #include "../JavaScriptValue.h"
 #include "../JavaScriptFunction.h"
 #include "../javaclasses/Collections.h"
+#include "../worklets/Worklet.h"
 
 #include "react/jni/ReadableNativeMap.h"
 #include "react/jni/ReadableNativeArray.h"
@@ -739,5 +740,33 @@ jobject ValueOrUndefinedFrontendConverter::convert(
 
   return parameterConverter->convert(rt, env, value);
 }
+
+#if WORKLETS_ENABLED
+
+jobject WorkletFrontendConverter::convert(
+  jsi::Runtime &rt,
+  JNIEnv *env,
+  const jsi::Value &value
+) const {
+  JSIContext *jsiContext = getJSIContext(rt);
+
+  auto worklet = worklets::extractSerializableOrThrow<worklets::SerializableWorklet>(rt, value);
+  return Worklet::newInstance(
+    jsiContext,
+    worklet
+  ).release();
+}
+
+bool WorkletFrontendConverter::canConvert(jsi::Runtime &rt, const jsi::Value &value) const {
+  try {
+    // TODO(@lukmccall): find a better way to check this without throwing exception
+    worklets::extractSerializableOrThrow<worklets::SerializableWorklet>(rt, value);
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+#endif
 
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.h
@@ -7,6 +7,12 @@
 #include <jsi/jsi.h>
 #include <fbjni/fbjni.h>
 
+#if WORKLETS_ENABLED
+
+#include <worklets/SharedItems/Synchronizable.h>
+
+#endif
+
 namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;
 
@@ -480,4 +486,20 @@ public:
 private:
   std::shared_ptr<FrontendConverter> parameterConverter;
 };
+
+#if WORKLETS_ENABLED
+
+class WorkletFrontendConverter : public FrontendConverter {
+public:
+  jobject convert(
+    jsi::Runtime &rt,
+    JNIEnv *env,
+    const jsi::Value &value
+  ) const override;
+
+  bool canConvert(jsi::Runtime &rt, const jsi::Value &value) const override;
+};
+
+#endif
+
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverterProvider.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverterProvider.cpp
@@ -29,6 +29,11 @@ void FrontendConverterProvider::createConverters() {
   RegisterConverter(CppType::VIEW_TAG, ViewTagFrontendConverter);
   RegisterConverter(CppType::SHARED_OBJECT_ID, SharedObjectIdConverter);
   RegisterConverter(CppType::ANY, AnyFrontendConvert);
+
+#if WORKLETS_ENABLED
+  RegisterConverter(CppType::WORKLET, WorkletFrontendConverter);
+#endif
+
 #undef RegisterConverter
 
   auto registerPolyConverter = [this](const std::vector<CppType> &types) {

--- a/packages/expo-modules-core/android/src/main/cpp/worklets/Worklet.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/worklets/Worklet.cpp
@@ -1,0 +1,43 @@
+#include "Worklet.h"
+
+#if WORKLETS_ENABLED
+
+namespace expo {
+
+void Worklet::registerNatives() {
+  registerHybrid({
+                   makeNativeMethod("schedule", Worklet::schedule),
+                   makeNativeMethod("execute", Worklet::execute),
+                 });
+}
+
+jni::local_ref<Worklet::javaobject> Worklet::newInstance(
+  JSIContext *jsiContext,
+  const std::shared_ptr<worklets::SerializableWorklet> &worklet
+) {
+  auto expoWorklet = Worklet::newObjectCxxArgs(worklet);
+  jsiContext->jniDeallocator->addReference(expoWorklet);
+  return expoWorklet;
+}
+
+Worklet::Worklet(
+  const std::shared_ptr<worklets::SerializableWorklet> &worklet
+) : worklet_(worklet) {}
+
+void Worklet::schedule(
+  jni::alias_ref<WorkletRuntimeHolder::javaobject> workletRuntimeHolder
+) {
+  auto workletRuntime = workletRuntimeHolder->cthis()->workletRuntime.lock();
+  workletRuntime->schedule(worklet_);
+}
+
+void Worklet::execute(
+  jni::alias_ref<WorkletRuntimeHolder::javaobject> workletRuntimeHolder
+) {
+  auto workletRuntime = workletRuntimeHolder->cthis()->workletRuntime.lock();
+  workletRuntime->runSync(worklet_);
+}
+
+} // namespace expo
+
+#endif

--- a/packages/expo-modules-core/android/src/main/cpp/worklets/Worklet.h
+++ b/packages/expo-modules-core/android/src/main/cpp/worklets/Worklet.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#if WORKLETS_ENABLED
+
+#include "../JSIContext.h"
+#include "../JNIDeallocator.h"
+#include "WorkletRuntimeHolder.h"
+
+#include <fbjni/fbjni.h>
+#include <worklets/SharedItems/Serializable.h>
+
+namespace jni = facebook::jni;
+
+namespace expo {
+
+class Worklet : public jni::HybridClass<Worklet, Destructible> {
+public:
+  static auto constexpr
+    kJavaDescriptor = "Lexpo/modules/kotlin/jni/worklets/Worklet;";
+  static auto constexpr TAG = "Worklet";
+
+  static void registerNatives();
+
+  static jni::local_ref<Worklet::javaobject> newInstance(
+    JSIContext *jsiContext,
+    const std::shared_ptr<worklets::SerializableWorklet> &worklet
+  );
+
+  explicit Worklet(
+    const std::shared_ptr<worklets::SerializableWorklet> &worklet
+  );
+
+  void schedule(
+    jni::alias_ref<WorkletRuntimeHolder::javaobject> workletRuntimeHolder
+  );
+
+  void execute(
+    jni::alias_ref<WorkletRuntimeHolder::javaobject> workletRuntimeHolder
+  );
+private:
+  friend HybridBase;
+
+  std::shared_ptr<worklets::SerializableWorklet> worklet_;
+};
+
+} // namespace expo
+
+#endif

--- a/packages/expo-modules-core/android/src/main/cpp/worklets/WorkletRuntimeHolder.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/worklets/WorkletRuntimeHolder.cpp
@@ -1,0 +1,23 @@
+#include "WorkletRuntimeHolder.h"
+
+namespace expo {
+
+void WorkletRuntimeHolder::registerNatives() {
+  registerHybrid({
+                   makeNativeMethod("initHybrid", WorkletRuntimeHolder::initHybrid),
+                 });
+}
+
+jni::local_ref<WorkletRuntimeHolder::jhybriddata> WorkletRuntimeHolder::initHybrid(
+  jni::alias_ref<jobject> jThis,
+  jlong runtimePointer
+) {
+  return makeCxxInstance(runtimePointer);
+}
+
+WorkletRuntimeHolder::WorkletRuntimeHolder(jlong runtimePointer) {
+  auto *jsRuntime = reinterpret_cast<jsi::Runtime *>(runtimePointer);
+  workletRuntime = worklets::WorkletRuntime::getWeakRuntimeFromJSIRuntime(*jsRuntime);
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/worklets/WorkletRuntimeHolder.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/worklets/WorkletRuntimeHolder.cpp
@@ -16,8 +16,10 @@ jni::local_ref<WorkletRuntimeHolder::jhybriddata> WorkletRuntimeHolder::initHybr
 }
 
 WorkletRuntimeHolder::WorkletRuntimeHolder(jlong runtimePointer) {
+#if WORKLETS_ENABLED
   auto *jsRuntime = reinterpret_cast<jsi::Runtime *>(runtimePointer);
   workletRuntime = worklets::WorkletRuntime::getWeakRuntimeFromJSIRuntime(*jsRuntime);
+#endif
 }
 
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/worklets/WorkletRuntimeHolder.h
+++ b/packages/expo-modules-core/android/src/main/cpp/worklets/WorkletRuntimeHolder.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#if WORKLETS_ENABLED
+
+#include <worklets/WorkletRuntime/WorkletRuntime.h>
+
+#endif
+
+#include <fbjni/fbjni.h>
+
+namespace jni = facebook::jni;
+
+namespace expo {
+
+class WorkletRuntimeHolder : public jni::HybridClass<WorkletRuntimeHolder> {
+public:
+  static auto constexpr kJavaDescriptor = "Lexpo/modules/kotlin/jni/worklets/WorkletRuntimeHolder;";
+  static auto constexpr TAG = "WorkletRuntimeHolder";
+
+  static void registerNatives();
+
+  static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jobject> jThis, jlong runtimePointer);
+
+  explicit WorkletRuntimeHolder(jlong runtimePointer);
+
+#if WORKLETS_ENABLED
+  std::weak_ptr<worklets::WorkletRuntime> workletRuntime;
+#endif
+
+private:
+  friend HybridBase;
+};
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/CppType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/CppType.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.jni
 
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import expo.modules.kotlin.jni.worklets.Worklet
 import expo.modules.kotlin.typedarray.TypedArray
 import expo.modules.kotlin.types.ValueOrUndefined
 import kotlin.reflect.KClass
@@ -38,5 +39,6 @@ enum class CppType(val clazz: KClass<*>, val value: Int = nextValue()) {
   NULLABLE(Any::class),
   VALUE_OR_UNDEFINED(ValueOrUndefined::class),
   JS_ARRAY_BUFFER(JavaScriptArrayBuffer::class),
-  NATIVE_ARRAY_BUFFER(NativeArrayBuffer::class)
+  NATIVE_ARRAY_BUFFER(NativeArrayBuffer::class),
+  WORKLET(Worklet::class)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/worklets/Worklet.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/worklets/Worklet.kt
@@ -1,0 +1,39 @@
+package expo.modules.kotlin.jni.worklets
+
+import com.facebook.jni.HybridData
+import expo.modules.core.interfaces.DoNotStrip
+import expo.modules.kotlin.jni.Destructible
+import expo.modules.kotlin.runtime.WorkletRuntimeContext
+
+class Worklet @DoNotStrip private constructor(@DoNotStrip private val mHybridData: HybridData) : Destructible {
+  private val WorkletRuntimeContext.enforceHolder
+    get() = workletRuntimeHolder
+      ?: throw IllegalStateException("Worklet runtime is not installed.")
+
+  fun schedule(runtime: WorkletRuntimeContext) {
+    val runtimeHolder = runtime.enforceHolder
+    schedule(runtimeHolder)
+  }
+
+  fun execute(runtime: WorkletRuntimeContext) {
+    val runtimeHolder = runtime.enforceHolder
+    execute(runtimeHolder)
+  }
+
+  private external fun schedule(
+    workletRuntimeHolder: WorkletRuntimeHolder
+  )
+
+  private external fun execute(
+    workletRuntimeHolder: WorkletRuntimeHolder
+  )
+
+  @Throws(Throwable::class)
+  protected fun finalize() {
+    deallocate()
+  }
+
+  override fun deallocate() {
+    mHybridData.resetNative()
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/worklets/WorkletRuntimeHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/worklets/WorkletRuntimeHolder.kt
@@ -1,0 +1,11 @@
+package expo.modules.kotlin.jni.worklets
+
+import com.facebook.jni.HybridData
+
+class WorkletRuntimeHolder(
+  jsRuntimePointer: Long
+) {
+  private val mHybridData = initHybrid(jsRuntimePointer)
+
+  external fun initHybrid(jsRuntimePointer: Long): HybridData
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/runtime/WorkletRuntimeContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/runtime/WorkletRuntimeContext.kt
@@ -6,6 +6,7 @@ import expo.modules.kotlin.jni.JNIDeallocator
 import expo.modules.kotlin.jni.JSIContext
 import expo.modules.kotlin.jni.JavaScriptValue
 import expo.modules.kotlin.jni.WorkletRuntimeInstaller
+import expo.modules.kotlin.jni.worklets.WorkletRuntimeHolder
 import expo.modules.kotlin.logger
 import expo.modules.kotlin.sharedobjects.ClassRegistry
 import expo.modules.kotlin.sharedobjects.SharedObjectRegistry
@@ -18,6 +19,8 @@ class WorkletRuntimeContext(
   private val reactContextHolder: WeakReference<ReactApplicationContext>
 ) : RuntimeContext() {
   override lateinit var jsiContext: JSIContext
+
+  internal var workletRuntimeHolder: WorkletRuntimeHolder? = null
 
   private val appContextHolder = appContext.weak()
 
@@ -52,6 +55,8 @@ class WorkletRuntimeContext(
     }
 
     trace("$this.install on runtime $runtimePointer") {
+      // TODO(@lukmccall): Figure out if we can create WorkletRuntimeHolder lazy
+      workletRuntimeHolder = WorkletRuntimeHolder(runtimePointer)
       jsiContext = WorkletRuntimeInstaller(this)
         .install(runtimePointer)
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -17,6 +17,7 @@ import expo.modules.kotlin.jni.JavaScriptFunction
 import expo.modules.kotlin.jni.JavaScriptObject
 import expo.modules.kotlin.jni.JavaScriptValue
 import expo.modules.kotlin.jni.NativeArrayBuffer
+import expo.modules.kotlin.jni.worklets.Worklet
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.records.RecordTypeConverter
 import expo.modules.kotlin.sharedobjects.SharedObject
@@ -241,6 +242,9 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       ),
       NativeArrayBuffer::class to createTrivialTypeConverter(
         ExpectedType(CppType.NATIVE_ARRAY_BUFFER)
+      ),
+      Worklet::class to createTrivialTypeConverter(
+        ExpectedType(CppType.WORKLET)
       ),
 
       Int8Array::class to Int8ArrayTypeConverter(),


### PR DESCRIPTION
# Why

Adds support for worklets as a function argument

# How

- Introduced a WorkletRuntimeHolder - class needed to communicate with `worklets::WorkletRuntime`
- Added `Worklet` wrapper that allows scheduling and executing a given worklet. 
- Made `Worklet` convertible.

> [!NOTE]
> Currently, we're not supporting passing any arguments to the worklet, as it requires more setup. It will be added in the following PRs. 

# Test Plan

- Simple test module (https://github.com/expo/expo/pull/41776): 
```kt
class WorkletsTesterModule : Module() {
  override fun definition() = ModuleDefinition {
    Name("WorkletsTesterModule")

    Function("executeWorklet") { worklet: Worklet ->
      worklet.execute(appContext.uiRuntime)
    }

    Function("scheduleWorklet") { worklet: Worklet ->
      worklet.schedule(appContext.uiRuntime)
    }
  }
}
```

```ts
import { createSerializable } from 'react-native-worklets';

import WorkletsTesterModule from './WorkletsTesterModule';

export const WorkletsTester = {
  scheduleWorklet: (worklet: () => void) => {
    WorkletsTesterModule.scheduleWorklet(createSerializable(worklet));
  },

  executeWorklet: (worklet: () => void) => {
    WorkletsTesterModule.executeWorklet(createSerializable(worklet));
  },
};
```