### PR TITLE
add age-range to bundledNativeModules.json

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -38,8 +38,8 @@ jobs:
           # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
           # TODO(cedric): swap `latest` back once the issue is resolved
           bun-version: latest
-      - name: 🔨 Switch to Xcode 16.4
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
+      - name: 🔨 Switch to Xcode 26.0
+        run: sudo xcode-select --switch /Applications/Xcode_26.0.app
       - name: 🍺 Install required tools
         run: |
           brew install watchman || true

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -41,7 +41,7 @@
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/datetimepicker": "8.4.4",
     "@expo/app-integrity": "~0.1.10",
-		"expo-age-range": "~0.2.0",
+    "expo-age-range": "~0.2.0",
     "@react-native-community/netinfo": "11.4.1",
     "@react-native-community/slider": "5.0.1",
     "@react-native-masked-view/masked-view": "0.3.2",

--- a/packages/expo-age-range/CHANGELOG.md
+++ b/packages/expo-age-range/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [ios] fix compilation on sdk-54 projects ([#41768](https://github.com/expo/expo/pull/41768) by [@vonovak](https://github.com/vonovak))
+
 ### 💡 Others
 
 ## 0.2.0 — 2025-12-16

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -13,6 +13,7 @@
   "@react-native-segmented-control/segmented-control": "2.5.7",
   "@stripe/stripe-react-native": "0.50.3",
   "eslint-config-expo": "~10.0.0",
+  "expo-age-range": "~0.2.1",
   "expo-analytics-amplitude": "~11.3.0",
   "expo-app-auth": "~11.1.0",
   "expo-app-loader-provider": "~8.0.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -13,7 +13,7 @@
   "@react-native-segmented-control/segmented-control": "2.5.7",
   "@stripe/stripe-react-native": "0.50.3",
   "eslint-config-expo": "~10.0.0",
-  "expo-age-range": "~0.2.1",
+  "expo-age-range": "~0.2.0",
   "expo-analytics-amplitude": "~11.3.0",
   "expo-app-auth": "~11.1.0",
   "expo-app-loader-provider": "~8.0.0",


### PR DESCRIPTION
# Why

add expo-age-range to bundledNativeModules.json, add missing changelog entry

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
