### PR TITLE
[docs] add age-range to sdk-54 docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/age-range.mdx
+++ b/docs/pages/versions/unversioned/sdk/age-range.mdx
@@ -16,7 +16,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-age-range` provides access to user age range information. It uses Google's [Play Age Signals API](https://developer.android.com/google/play/age-signals/use-age-signals-api) on Android and Apple's [Declared Age Range framework](https://developer.apple.com/documentation/declaredagerange/) on iOS.
 
-This API allows you to request age range information from users to help you comply with age-appropriate content regulations (such as in [Texas](https://developer.apple.com/news/?id=btkirlj8)) and provide age-appropriate experiences in your app.
+This library allows you to request age range information from your app users to help you comply with age-appropriate content regulations (such as in [Texas, USA](https://developer.apple.com/news/?id=btkirlj8)) and provide age-appropriate experiences in your app.
 
 ### Limitations
 
@@ -32,7 +32,7 @@ On Android, the Play Age Signals API (beta) may throw an exception until January
 
 ### Setup iOS project
 
-To use the age range API on iOS, you need to build your project with Xcode 26.0 or later. The `com.apple.developer.declared-age-range` entitlement is required – add it to your [app config](./config/app/) file:
+To use the age range API on iOS, you need to build your project with Xcode 26.0 or later. The `com.apple.developer.declared-age-range` entitlement is required. Add it to your [app config](./config/app/) file:
 
 ```json app.json
 {

--- a/docs/pages/versions/unversioned/sdk/age-range.mdx
+++ b/docs/pages/versions/unversioned/sdk/age-range.mdx
@@ -32,7 +32,7 @@ On Android, the Play Age Signals API (beta) may throw an exception until January
 
 ### Setup iOS project
 
-To use the age range API on iOS, you need to build your project with xCode 26.0 or later. The `com.apple.developer.declared-age-range` entitlement is required – add it to your [app config](./config/app/) file:
+To use the age range API on iOS, you need to build your project with Xcode 26.0 or later. The `com.apple.developer.declared-age-range` entitlement is required – add it to your [app config](./config/app/) file:
 
 ```json app.json
 {

--- a/docs/pages/versions/v54.0.0/sdk/age-range.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/age-range.mdx
@@ -16,7 +16,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-age-range` provides access to user age range information. It uses Google's [Play Age Signals API](https://developer.android.com/google/play/age-signals/use-age-signals-api) on Android and Apple's [Declared Age Range framework](https://developer.apple.com/documentation/declaredagerange/) on iOS.
 
-This API allows you to request age range information from users to help you comply with age-appropriate content regulations (such as in [Texas](https://developer.apple.com/news/?id=btkirlj8)) and provide age-appropriate experiences in your app.
+This library allows you to request age range information from your app users to help you comply with age-appropriate content regulations (such as in [Texas, USA](https://developer.apple.com/news/?id=btkirlj8)) and provide age-appropriate experiences in your app.
 
 ### Limitations
 
@@ -32,7 +32,7 @@ On Android, the Play Age Signals API (beta) may throw an exception until January
 
 ### Setup iOS project
 
-To use the age range API on iOS, you need to build your project with Xcode 26.0 or later. The `com.apple.developer.declared-age-range` entitlement is required – add it to your [app config](./config/app/) file:
+To use the age range API on iOS, you need to build your project with Xcode 26.0 or later. The `com.apple.developer.declared-age-range` entitlement is required. Add it to your [app config](./config/app/) file:
 
 ```json app.json
 {

--- a/docs/pages/versions/v54.0.0/sdk/age-range.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/age-range.mdx
@@ -1,7 +1,7 @@
 ---
 title: AgeRange
 description: A library that provides access to age range information using Play Age Signals API on Android and Declared Age Range framework on iOS.
-sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-age-range'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-54/packages/expo-age-range'
 packageName: 'expo-age-range'
 platforms: ['android', 'ios']
 isAlpha: true

--- a/docs/pages/versions/v54.0.0/sdk/age-range.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/age-range.mdx
@@ -32,7 +32,7 @@ On Android, the Play Age Signals API (beta) may throw an exception until January
 
 ### Setup iOS project
 
-To use the age range API on iOS, you need to build your project with xCode 26.0 or later. The `com.apple.developer.declared-age-range` entitlement is required – add it to your [app config](./config/app/) file:
+To use the age range API on iOS, you need to build your project with Xcode 26.0 or later. The `com.apple.developer.declared-age-range` entitlement is required – add it to your [app config](./config/app/) file:
 
 ```json app.json
 {

--- a/docs/pages/versions/v54.0.0/sdk/app-integrity.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/app-integrity.mdx
@@ -1,7 +1,7 @@
 ---
 title: AppIntegrity
 description: A library that provides access to Google's Play Integrity API on Android and Apple's App Attest service on iOS.
-sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-app-integrity'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-54/packages/expo-app-integrity'
 packageName: '@expo/app-integrity'
 platforms: ['android', 'ios']
 isAlpha: true


### PR DESCRIPTION
# Why

age-range module should be present in the sdk-54 docs

# How

add the docs file to versioned docs

# Test Plan

tested locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
