### PR TITLE
[calendar@next][Android] Fix all-day recurrence rule

### DIFF
--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/records/EventRecord.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/records/EventRecord.kt
@@ -2,6 +2,7 @@ package expo.modules.calendar.next.records
 
 import android.provider.CalendarContract
 import expo.modules.calendar.domain.event.enums.Availability
+import expo.modules.calendar.next.utils.parseRrDate
 import expo.modules.calendar.next.utils.rrFormat
 import expo.modules.calendar.next.utils.sdf
 import expo.modules.kotlin.records.Field
@@ -99,7 +100,7 @@ data class RecurrenceRuleRecord(
       return RecurrenceRuleRecord(
         endDate = ruleMap["UNTIL"]
           ?.takeIf { it.isNotBlank() }
-          ?.let { rrFormat.parse(it) }
+          ?.let { parseRrDate(it) }
           ?.let { sdf.format(it) },
         frequency = ruleMap["FREQ"]?.lowercase(Locale.getDefault()),
         interval = ruleMap["INTERVAL"]?.toIntOrNull(),

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/utils/CalendarNextUtils.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/utils/CalendarNextUtils.kt
@@ -11,11 +11,33 @@ import expo.modules.calendar.next.exceptions.EventDateTimeInvalidException
 import java.text.SimpleDateFormat
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.util.Date
 
 val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").apply {
   timeZone = TimeZone.getTimeZone("GMT")
 }
+/**
+ * [SimpleDateFormat] used in native recurrence rule string.
+ * The format corresponds to the 'date-time' type defined by RFC-5455 section 3.3.5.
+ */
 val rrFormat = SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'")
+/**
+ * [SimpleDateFormat] used in native recurrence rule string for all-day events.
+ * The format corresponds to the 'date' type defined by RFC-5455 section 3.3.4.
+ */
+val allDayRRFormat = SimpleDateFormat("yyyyMMdd").apply {
+  timeZone = TimeZone.getTimeZone("GMT")
+}
+
+/**
+ * @param dateString RFC-5455 date or date-time string (RFC sections 3.3.4 and 3.3.5).
+ */
+fun parseRrDate(dateString: String): Date? =
+  runCatching {
+    rrFormat.parse(dateString)
+  }.recover {
+    allDayRRFormat.parse(dateString)
+  }.getOrNull()
 
 suspend fun findEvents(contentResolver: ContentResolver, startDate: Any, endDate: Any, calendars: List<String>): Cursor {
   return withContext(Dispatchers.IO) {

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/utils/CalendarNextUtils.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/utils/CalendarNextUtils.kt
@@ -16,11 +16,13 @@ import java.util.Date
 val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").apply {
   timeZone = TimeZone.getTimeZone("GMT")
 }
+
 /**
  * [SimpleDateFormat] used in native recurrence rule string.
  * The format corresponds to the 'date-time' type defined by RFC-5455 section 3.3.5.
  */
 val rrFormat = SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'")
+
 /**
  * [SimpleDateFormat] used in native recurrence rule string for all-day events.
  * The format corresponds to the 'date' type defined by RFC-5455 section 3.3.4.

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/utils/CalendarNextUtils.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/utils/CalendarNextUtils.kt
@@ -21,13 +21,15 @@ val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").apply {
  * [SimpleDateFormat] used in native recurrence rule string.
  * The format corresponds to the 'date-time' type defined by RFC-5455 section 3.3.5.
  */
-val rrFormat = SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'")
+val rrFormat = SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'").apply {
+  timeZone = TimeZone.getTimeZone("GMT")
+}
 
 /**
  * [SimpleDateFormat] used in native recurrence rule string for all-day events.
  * The format corresponds to the 'date' type defined by RFC-5455 section 3.3.4.
  */
-val allDayRRFormat = SimpleDateFormat("yyyyMMdd").apply {
+val allDayRrFormat = SimpleDateFormat("yyyyMMdd").apply {
   timeZone = TimeZone.getTimeZone("GMT")
 }
 
@@ -38,7 +40,7 @@ fun parseRrDate(dateString: String): Date? =
   runCatching {
     rrFormat.parse(dateString)
   }.recover {
-    allDayRRFormat.parse(dateString)
+    allDayRrFormat.parse(dateString)
   }.getOrNull()
 
 suspend fun findEvents(contentResolver: ContentResolver, startDate: Any, endDate: Any, calendars: List<String>): Cursor {

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/EventRecurrenceRulesTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/EventRecurrenceRulesTest.kt
@@ -1,0 +1,114 @@
+package expo.modules.calendar.next
+
+import expo.modules.calendar.next.records.RecurrenceRuleRecord
+import expo.modules.calendar.next.utils.createRecurrenceRule
+import java.util.TimeZone
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class EventRecurrenceRulesTest {
+  @Before
+  fun setUp() {
+    TimeZone.setDefault(TimeZone.getTimeZone("GMT"))
+  }
+
+  @After
+  fun tearDown() {
+    TimeZone.setDefault(null)
+  }
+
+  @Test
+  fun testCreateRecurrenceRule_withAllFields() {
+    val opts =
+      RecurrenceRuleRecord(
+        frequency = "daily",
+        interval = 1,
+        endDate = "2024-12-31T01:00:00.000Z",
+        occurrence = null
+      )
+
+    val result = opts.toRrFormat()?.let { createRecurrenceRule(it) }
+
+    assertEquals("FREQ=DAILY;INTERVAL=1;UNTIL=20241231T010000Z", result)
+  }
+
+  @Test
+  fun testCreateRecurrenceRule_withOccurrence() {
+    val opts = RecurrenceRuleRecord(frequency = "weekly", interval = 2, occurrence = 10)
+
+    val result = opts.toRrFormat()?.let { createRecurrenceRule(it) }
+
+    assertEquals("FREQ=WEEKLY;INTERVAL=2;COUNT=10", result)
+  }
+
+  @Test
+  fun testCreateRecurrenceRule_withMissingOptionalFields() {
+    val opts = RecurrenceRuleRecord(frequency = "monthly", interval = null, occurrence = null)
+
+    val result = opts.toRrFormat()?.let { createRecurrenceRule(it) }
+
+    assertEquals("FREQ=MONTHLY", result)
+  }
+
+  @Test
+  fun testParseRecurrenceRule_withAllFields() {
+    val rrule = "FREQ=DAILY;INTERVAL=1;UNTIL=20241231T010000Z"
+
+    val recurrence = RecurrenceRuleRecord.fromRrFormat(rrule)
+
+    assertEquals(recurrence?.frequency, "daily")
+    assertEquals(recurrence?.interval, 1)
+    assertEquals(recurrence?.endDate, "2024-12-31T01:00:00.000Z")
+    assertEquals(recurrence?.occurrence, null)
+  }
+
+  @Test
+  fun testParseRecurrenceRule_withOccurrence() {
+    val rrule = "FREQ=WEEKLY;INTERVAL=2;COUNT=10"
+
+    val recurrence = RecurrenceRuleRecord.fromRrFormat(rrule)
+
+    assertEquals(recurrence?.frequency, "weekly")
+    assertEquals(recurrence?.interval, 2)
+    assertEquals(recurrence?.endDate, null)
+    assertEquals(recurrence?.occurrence, 10)
+  }
+
+  @Test
+  fun testParseRecurrenceRule_withMissingOptionalFields() {
+    val rrule = "FREQ=MONTHLY"
+
+    val recurrence = RecurrenceRuleRecord.fromRrFormat(rrule)
+
+    assertEquals(recurrence?.frequency, "monthly")
+    assertEquals(recurrence?.interval, null)
+    assertEquals(recurrence?.endDate, null)
+    assertEquals(recurrence?.occurrence, null)
+  }
+
+  @Test
+  fun testParseRecurrenceRule_withAllDayDate() {
+    val rrule = "FREQ=DAILY;INTERVAL=1;UNTIL=20251024"
+
+    val recurrence = RecurrenceRuleRecord.fromRrFormat(rrule)
+
+    assertEquals(recurrence?.frequency, "daily")
+    assertEquals(recurrence?.interval, 1)
+    assertEquals(recurrence?.endDate, "2025-10-24T00:00:00.000Z")
+    assertEquals(recurrence?.occurrence, null)
+  }
+
+  @Test
+  fun testParseRecurrenceRule_withCustomOrderAndUnknownFields() {
+    val rrule = "FREQ=DAILY;UNTIL=20251024;INTERVAL=1;WKST=SU"
+
+    val recurrence = RecurrenceRuleRecord.fromRrFormat(rrule)
+
+    assertEquals(recurrence?.frequency, "daily")
+    assertEquals(recurrence?.interval, 1)
+    assertEquals(recurrence?.endDate, "2025-10-24T00:00:00.000Z")
+    assertEquals(recurrence?.occurrence, null)
+  }
+}


### PR DESCRIPTION
# Why

I noticed that calendar@next has the same issue that I fixed in #40549 (pt 2) - recurrence rule parsing is broken for all-day events.

# How

Adapted changes from #40549.

I didn't put changelog entry since the calendar@next is still unpublished

# Test Plan

- Test plan from #40549
- Copied unit tests from the current/legacy calendar and adopted to the next module APIs

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
