### PR TITLE
[core][Android] Introduce `Serializable` converter

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/types/CppType.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/CppType.h
@@ -33,6 +33,6 @@ enum CppType {
   VALUE_OR_UNDEFINED = 1 << 21,
   JS_ARRAY_BUFFER = 1 << 22,
   NATIVE_ARRAY_BUFFER = 1 << 23,
-  WORKLET = 1 << 24,
+  SERIALIZABLE = 1 << 24,
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
@@ -13,7 +13,7 @@
 #include "../JavaScriptValue.h"
 #include "../JavaScriptFunction.h"
 #include "../javaclasses/Collections.h"
-#include "../worklets/Worklet.h"
+#include "../worklets/Serializable.h"
 
 #include "react/jni/ReadableNativeMap.h"
 #include "react/jni/ReadableNativeArray.h"
@@ -743,24 +743,24 @@ jobject ValueOrUndefinedFrontendConverter::convert(
 
 #if WORKLETS_ENABLED
 
-jobject WorkletFrontendConverter::convert(
+jobject SynchronizableFrontendConverter::convert(
   jsi::Runtime &rt,
   JNIEnv *env,
   const jsi::Value &value
 ) const {
   JSIContext *jsiContext = getJSIContext(rt);
 
-  auto worklet = worklets::extractSerializableOrThrow<worklets::SerializableWorklet>(rt, value);
-  return Worklet::newInstance(
+  auto worklet = worklets::extractSerializableOrThrow(rt, value);
+  return Serializable::newInstance(
     jsiContext,
     worklet
   ).release();
 }
 
-bool WorkletFrontendConverter::canConvert(jsi::Runtime &rt, const jsi::Value &value) const {
+bool SynchronizableFrontendConverter::canConvert(jsi::Runtime &rt, const jsi::Value &value) const {
   try {
     // TODO(@lukmccall): find a better way to check this without throwing exception
-    worklets::extractSerializableOrThrow<worklets::SerializableWorklet>(rt, value);
+    worklets::extractSerializableOrThrow(rt, value);
     return true;
   } catch (...) {
     return false;

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.h
@@ -489,7 +489,7 @@ private:
 
 #if WORKLETS_ENABLED
 
-class WorkletFrontendConverter : public FrontendConverter {
+class SynchronizableFrontendConverter : public FrontendConverter {
 public:
   jobject convert(
     jsi::Runtime &rt,

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverterProvider.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverterProvider.cpp
@@ -31,7 +31,7 @@ void FrontendConverterProvider::createConverters() {
   RegisterConverter(CppType::ANY, AnyFrontendConvert);
 
 #if WORKLETS_ENABLED
-  RegisterConverter(CppType::WORKLET, WorkletFrontendConverter);
+  RegisterConverter(CppType::SERIALIZABLE, SynchronizableFrontendConverter);
 #endif
 
 #undef RegisterConverter

--- a/packages/expo-modules-core/android/src/main/cpp/worklets/Serializable.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/worklets/Serializable.cpp
@@ -1,0 +1,95 @@
+#include "Serializable.h"
+
+#if WORKLETS_ENABLED
+
+namespace expo {
+
+constexpr jint toStableId(worklets::Serializable::ValueType type) {
+  switch (type) {
+    case worklets::Serializable::ValueType::UndefinedType:
+      return 1;
+    case worklets::Serializable::ValueType::NullType:
+      return 2;
+    case worklets::Serializable::ValueType::BooleanType:
+      return 3;
+    case worklets::Serializable::ValueType::NumberType:
+      return 4;
+    case worklets::Serializable::ValueType::BigIntType:
+      return 5;
+    case worklets::Serializable::ValueType::StringType:
+      return 6;
+    case worklets::Serializable::ValueType::ObjectType:
+      return 7;
+    case worklets::Serializable::ValueType::ArrayType:
+      return 8;
+    case worklets::Serializable::ValueType::MapType:
+      return 9;
+    case worklets::Serializable::ValueType::SetType:
+      return 10;
+    case worklets::Serializable::ValueType::WorkletType:
+      return 11;
+    case worklets::Serializable::ValueType::RemoteFunctionType:
+      return 12;
+    case worklets::Serializable::ValueType::HandleType:
+      return 13;
+    case worklets::Serializable::ValueType::HostObjectType:
+      return 14;
+    case worklets::Serializable::ValueType::HostFunctionType:
+      return 15;
+    case worklets::Serializable::ValueType::ArrayBufferType:
+      return 16;
+    case worklets::Serializable::ValueType::TurboModuleLikeType:
+      return 17;
+    case worklets::Serializable::ValueType::ImportType:
+      return 18;
+    case worklets::Serializable::ValueType::SynchronizableType:
+      return 19;
+    case worklets::Serializable::ValueType::CustomType:
+      return 20;
+    default:
+      return 0; // Handle unknown cases
+  }
+}
+
+jni::local_ref<Serializable::javaobject> Serializable::newJavaInstance(
+  jni::local_ref<jni::detail::HybridData> hybridData,
+  worklets::Serializable::ValueType valueType
+) {
+  jint jValueType = toStableId(valueType);
+  return Serializable::newObjectJavaArgs(
+    std::move(hybridData),
+    jValueType
+  );
+}
+
+Serializable::Serializable(
+  const std::shared_ptr<worklets::Serializable> &serializable
+) : serializable_(serializable) {}
+
+jni::local_ref<Serializable::javaobject> Serializable::newInstance(
+  JSIContext *jsiContext,
+  const std::shared_ptr<worklets::Serializable> &serializable
+) {
+  auto cxxPart = std::make_unique<Serializable>(
+    serializable
+  );
+
+  auto hybridData = jni::detail::HybridData::create();
+  auto javaPart = Serializable::newJavaInstance(
+    hybridData,
+    serializable->valueType()
+  );
+
+
+  jni::detail::setNativePointer(hybridData, std::move(cxxPart));
+
+  return javaPart;
+}
+
+std::shared_ptr<worklets::Serializable> Serializable::getSerializable() {
+  return serializable_;
+}
+
+} // namespace expo
+
+#endif

--- a/packages/expo-modules-core/android/src/main/cpp/worklets/Serializable.h
+++ b/packages/expo-modules-core/android/src/main/cpp/worklets/Serializable.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#if WORKLETS_ENABLED
+
+#include "../JSIContext.h"
+#include "../JNIDeallocator.h"
+#include "WorkletNativeRuntime.h"
+
+#include <fbjni/fbjni.h>
+#include <worklets/SharedItems/Serializable.h>
+
+namespace jni = facebook::jni;
+
+namespace expo {
+
+class Serializable : public jni::HybridClass<Serializable, Destructible> {
+public:
+  static auto constexpr
+    kJavaDescriptor = "Lexpo/modules/kotlin/jni/worklets/Serializable;";
+  static auto constexpr TAG = "Serializable";
+
+  static jni::local_ref<Serializable::javaobject> newInstance(
+    JSIContext *jsiContext,
+    const std::shared_ptr<worklets::Serializable> &serializable
+  );
+
+  explicit Serializable(
+    const std::shared_ptr<worklets::Serializable> &serializable
+  );
+
+  std::shared_ptr<worklets::Serializable> getSerializable();
+
+private:
+  friend HybridBase;
+
+  static jni::local_ref<Serializable::javaobject> newJavaInstance(
+    jni::local_ref<jni::detail::HybridData> hybridData,
+    worklets::Serializable::ValueType valueType
+  );
+
+  std::shared_ptr<worklets::Serializable> serializable_;
+};
+
+} // namespace expo
+
+#endif

--- a/packages/expo-modules-core/android/src/main/cpp/worklets/Worklet.h
+++ b/packages/expo-modules-core/android/src/main/cpp/worklets/Worklet.h
@@ -5,6 +5,7 @@
 #include "../JSIContext.h"
 #include "../JNIDeallocator.h"
 #include "WorkletNativeRuntime.h"
+#include "Serializable.h"
 
 #include <fbjni/fbjni.h>
 #include <worklets/SharedItems/Serializable.h>
@@ -13,7 +14,7 @@ namespace jni = facebook::jni;
 
 namespace expo {
 
-class Worklet : public jni::HybridClass<Worklet, Destructible> {
+class Worklet : public jni::JavaClass<Worklet> {
 public:
   static auto constexpr
     kJavaDescriptor = "Lexpo/modules/kotlin/jni/worklets/Worklet;";
@@ -21,26 +22,17 @@ public:
 
   static void registerNatives();
 
-  static jni::local_ref<Worklet::javaobject> newInstance(
-    JSIContext *jsiContext,
-    const std::shared_ptr<worklets::SerializableWorklet> &worklet
+  static void schedule(
+    jni::alias_ref<Worklet::javaobject> self,
+    jni::alias_ref<WorkletNativeRuntime::javaobject> workletRuntimeHolder,
+    jni::alias_ref<Serializable::javaobject> synchronizable
   );
 
-  explicit Worklet(
-    const std::shared_ptr<worklets::SerializableWorklet> &worklet
+  static void execute(
+    jni::alias_ref<Worklet::javaobject> self,
+    jni::alias_ref<WorkletNativeRuntime::javaobject> workletRuntimeHolder,
+    jni::alias_ref<Serializable::javaobject> synchronizable
   );
-
-  void schedule(
-    jni::alias_ref<WorkletNativeRuntime::javaobject> workletRuntimeHolder
-  );
-
-  void execute(
-    jni::alias_ref<WorkletNativeRuntime::javaobject> workletRuntimeHolder
-  );
-private:
-  friend HybridBase;
-
-  std::shared_ptr<worklets::SerializableWorklet> worklet_;
 };
 
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/CppType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/CppType.kt
@@ -40,5 +40,5 @@ enum class CppType(val clazz: KClass<*>, val value: Int = nextValue()) {
   VALUE_OR_UNDEFINED(ValueOrUndefined::class),
   JS_ARRAY_BUFFER(JavaScriptArrayBuffer::class),
   NATIVE_ARRAY_BUFFER(NativeArrayBuffer::class),
-  WORKLET(Worklet::class)
+  SERIALIZABLE(Worklet::class)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/worklets/Serializable.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/worklets/Serializable.kt
@@ -1,0 +1,45 @@
+package expo.modules.kotlin.jni.worklets
+
+import com.facebook.jni.HybridData
+import expo.modules.core.interfaces.DoNotStrip
+import expo.modules.kotlin.jni.Destructible
+
+@DoNotStrip
+class Serializable @DoNotStrip private constructor(
+  @DoNotStrip private val mHybridData: HybridData,
+  type: Int
+) : Destructible {
+  enum class ValueType(val value: Int){
+    Undefined(1),
+    Null(2),
+    Boolean(3),
+    Number(4),
+    BigInt(5),
+    String(6),
+    Object(7),
+    Array(8),
+    Map(9),
+    Set(10),
+    Worklet(11),
+    RemoteFunction(12),
+    Handle(13),
+    HostObject(14),
+    HostFunction(15),
+    ArrayBuffer(16),
+    TurboModuleLike(17),
+    Import(18),
+    Synchronizable(19),
+    Custom(20),
+  }
+
+  val type: ValueType = ValueType.entries.first { it.value == type }
+
+  @Throws(Throwable::class)
+  protected fun finalize() {
+    deallocate()
+  }
+
+  override fun deallocate() {
+    mHybridData.resetNative()
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/worklets/Serializable.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/worklets/Serializable.kt
@@ -9,7 +9,7 @@ class Serializable @DoNotStrip private constructor(
   @DoNotStrip private val mHybridData: HybridData,
   type: Int
 ) : Destructible {
-  enum class ValueType(val value: Int){
+  enum class ValueType(val value: Int) {
     Undefined(1),
     Null(2),
     Boolean(3),
@@ -29,7 +29,7 @@ class Serializable @DoNotStrip private constructor(
     TurboModuleLike(17),
     Import(18),
     Synchronizable(19),
-    Custom(20),
+    Custom(20)
   }
 
   val type: ValueType = ValueType.entries.first { it.value == type }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/worklets/Worklet.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/worklets/Worklet.kt
@@ -1,39 +1,31 @@
 package expo.modules.kotlin.jni.worklets
 
-import com.facebook.jni.HybridData
-import expo.modules.core.interfaces.DoNotStrip
-import expo.modules.kotlin.jni.Destructible
 import expo.modules.kotlin.runtime.WorkletRuntime
 
-class Worklet @DoNotStrip private constructor(@DoNotStrip private val mHybridData: HybridData) : Destructible {
+class Worklet internal constructor(
+  private val serializable: Serializable
+){
   private val WorkletRuntime.enforceHolder
     get() = mWorkletNativeRuntime
       ?: throw IllegalStateException("Worklet runtime is not installed.")
 
   fun schedule(runtime: WorkletRuntime) {
     val runtimeHolder = runtime.enforceHolder
-    schedule(runtimeHolder)
+    schedule(runtimeHolder, serializable)
   }
 
   fun execute(runtime: WorkletRuntime) {
     val runtimeHolder = runtime.enforceHolder
-    execute(runtimeHolder)
+    execute(runtimeHolder, serializable)
   }
 
   private external fun schedule(
-    workletNativeRuntime: WorkletNativeRuntime
+    workletNativeRuntime: WorkletNativeRuntime,
+    serializable: Serializable
   )
 
   private external fun execute(
-    workletNativeRuntime: WorkletNativeRuntime
+    workletNativeRuntime: WorkletNativeRuntime,
+    serializable: Serializable
   )
-
-  @Throws(Throwable::class)
-  protected fun finalize() {
-    deallocate()
-  }
-
-  override fun deallocate() {
-    mHybridData.resetNative()
-  }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/worklets/Worklet.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/worklets/Worklet.kt
@@ -4,7 +4,7 @@ import expo.modules.kotlin.runtime.WorkletRuntime
 
 class Worklet internal constructor(
   private val serializable: Serializable
-){
+) {
   private val WorkletRuntime.enforceHolder
     get() = mWorkletNativeRuntime
       ?: throw IllegalStateException("Worklet runtime is not installed.")

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -17,6 +17,7 @@ import expo.modules.kotlin.jni.JavaScriptFunction
 import expo.modules.kotlin.jni.JavaScriptObject
 import expo.modules.kotlin.jni.JavaScriptValue
 import expo.modules.kotlin.jni.NativeArrayBuffer
+import expo.modules.kotlin.jni.worklets.Serializable
 import expo.modules.kotlin.jni.worklets.Worklet
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.records.RecordTypeConverter
@@ -41,6 +42,8 @@ import expo.modules.kotlin.types.io.PathTypeConverter
 import expo.modules.kotlin.types.net.JavaURITypeConverter
 import expo.modules.kotlin.types.net.URLTypConverter
 import expo.modules.kotlin.types.net.UriTypeConverter
+import expo.modules.kotlin.types.worklets.SerializableTypeConverter
+import expo.modules.kotlin.types.worklets.WorkletTypeConverter
 import expo.modules.kotlin.views.ViewTypeConverter
 import java.io.File
 import java.net.URI
@@ -202,6 +205,8 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       ExpectedType(CppType.BOOLEAN)
     ) { it.asBoolean() }
 
+    val serializableTypeConverter = SerializableTypeConverter()
+
     val converters = mapOf(
       Int::class to intTypeConverter,
       java.lang.Integer::class to intTypeConverter,
@@ -243,9 +248,9 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       NativeArrayBuffer::class to createTrivialTypeConverter(
         ExpectedType(CppType.NATIVE_ARRAY_BUFFER)
       ),
-      Worklet::class to createTrivialTypeConverter(
-        ExpectedType(CppType.WORKLET)
-      ),
+
+      Serializable::class to serializableTypeConverter,
+      Worklet::class to WorkletTypeConverter(serializableTypeConverter),
 
       Int8Array::class to Int8ArrayTypeConverter(),
       Int16Array::class to Int16ArrayTypeConverter(),

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/worklets/SerializableTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/worklets/SerializableTypeConverter.kt
@@ -1,0 +1,19 @@
+package expo.modules.kotlin.types.worklets
+
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.jni.CppType
+import expo.modules.kotlin.jni.ExpectedType
+import expo.modules.kotlin.jni.worklets.Serializable
+import expo.modules.kotlin.types.NonNullableTypeConverter
+
+class SerializableTypeConverter : NonNullableTypeConverter<Serializable>() {
+  override fun convertNonNullable(value: Any, context: AppContext?, forceConversion: Boolean): Serializable {
+    return value as Serializable
+  }
+
+  override fun getCppRequiredTypes(): ExpectedType {
+    return ExpectedType(CppType.SERIALIZABLE)
+  }
+
+  override fun isTrivial() = true
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/worklets/WorkletTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/worklets/WorkletTypeConverter.kt
@@ -1,0 +1,23 @@
+package expo.modules.kotlin.types.worklets
+
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.jni.worklets.Serializable
+import expo.modules.kotlin.jni.worklets.Worklet
+import expo.modules.kotlin.types.NonNullableTypeConverter
+import expo.modules.kotlin.types.TypeConverter
+
+class WorkletTypeConverter(
+  private val serializableTypeConverter: TypeConverter<Serializable>
+) : NonNullableTypeConverter<Worklet>() {
+  override fun convertNonNullable(value: Any, context: AppContext?, forceConversion: Boolean): Worklet {
+    val serializable = serializableTypeConverter.convert(value, context, forceConversion)
+      ?: throw IllegalArgumentException("Cannot convert '${value}' to Serializable.")
+    if (serializable.type != Serializable.ValueType.Worklet) {
+      throw IllegalArgumentException("Expected Serializable of type Worklet but got ${serializable.type}.")
+    }
+
+    return Worklet(serializable)
+  }
+  override fun getCppRequiredTypes() = serializableTypeConverter.getCppRequiredTypes()
+  override fun isTrivial() = false
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/worklets/WorkletTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/worklets/WorkletTypeConverter.kt
@@ -11,7 +11,7 @@ class WorkletTypeConverter(
 ) : NonNullableTypeConverter<Worklet>() {
   override fun convertNonNullable(value: Any, context: AppContext?, forceConversion: Boolean): Worklet {
     val serializable = serializableTypeConverter.convert(value, context, forceConversion)
-      ?: throw IllegalArgumentException("Cannot convert '${value}' to Serializable.")
+      ?: throw IllegalArgumentException("Cannot convert '$value' to Serializable.")
     if (serializable.type != Serializable.ValueType.Worklet) {
       throw IllegalArgumentException("Expected Serializable of type Worklet but got ${serializable.type}.")
     }


### PR DESCRIPTION
# Why

Introduces the `Serializable` converter.
Worklets introduce the concept called `Serializable` (see [documentation ](https://docs.swmansion.com/react-native-worklets/docs/memory/serializable)). Previously, I created a converter specifically for worklets, but it would be better to handle all serializables in a more unified way. This can be useful, as it allows us to change shared values inside the native function, for example. I'm not going to implement that right now. However, by adding a more generic `Serializable` converter, it can be easily extended to support other types in the future.

# How

- Added new converter for - `worklets::Serializable`
- Made a worklet converter depending on the serializable. 

# Test Plan

- bare-expo ✅ 