### PR TITLE
[core][iOS] Introduce JavaScriptActor to help with thread safety

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [iOS] Added `RNHost` to improve RN component layout inside SwiftUI views ([#40938](https://github.com/expo/expo/pull/40938) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Added `ignoreSafeAreaKeyboardInsets` to `SwiftUIHostingView`. ([#41302](https://github.com/expo/expo/pull/41302) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] JSI runtime is now accessed from public `RCTHostRuntimeDelegate` instead of unofficial `bridge.runtime`. ([#41311](https://github.com/expo/expo/pull/41311) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Introduced global `JavaScriptActor` to isolate code requiring running on the JavaScript thread. ([#41793](https://github.com/expo/expo/pull/41793) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -73,8 +73,10 @@ public final class AppContext: NSObject, @unchecked Sendable {
         // Otherwise the JSCRuntime asserts may fail on deallocation.
         releaseRuntimeObjects()
       } else if _runtime != oldValue {
-        // Try to install the core object automatically when the runtime changes.
-        try? prepareRuntime()
+        JavaScriptActor.assumeIsolated {
+          // Try to install the core object automatically when the runtime changes.
+          try? prepareRuntime()
+        }
       }
     }
   }
@@ -472,6 +474,7 @@ public final class AppContext: NSObject, @unchecked Sendable {
 
   // MARK: - Runtime
 
+  @JavaScriptActor
   internal func prepareRuntime() throws {
     let runtime = try runtime
     let coreObject = runtime.createObject()

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -68,10 +68,12 @@ public final class AppContext: NSObject, @unchecked Sendable {
   public var _runtime: ExpoRuntime? {
     didSet {
       if _runtime == nil {
-        // When the runtime is unpinned from the context (e.g. deallocated),
-        // we should make sure to release all JS objects from the memory.
-        // Otherwise the JSCRuntime asserts may fail on deallocation.
-        releaseRuntimeObjects()
+        JavaScriptActor.assumeIsolated {
+          // When the runtime is unpinned from the context (e.g. deallocated),
+          // we should make sure to release all JS objects from the memory.
+          // Otherwise the JSCRuntime asserts may fail on deallocation.
+          releaseRuntimeObjects()
+        }
       } else if _runtime != oldValue {
         JavaScriptActor.assumeIsolated {
           // Try to install the core object automatically when the runtime changes.
@@ -175,7 +177,7 @@ public final class AppContext: NSObject, @unchecked Sendable {
    - Warning: This is deprecated, use `appContext.runtime.schedule` instead.
    */
   @available(*, deprecated, renamed: "runtime.schedule")
-  public func executeOnJavaScriptThread(_ closure: @escaping () -> Void) {
+  public func executeOnJavaScriptThread(_ closure: @JavaScriptActor @escaping () -> Void) {
     _runtime?.schedule(closure)
   }
 
@@ -337,6 +339,7 @@ public final class AppContext: NSObject, @unchecked Sendable {
    Returns a JavaScript object that represents a module with given name.
    When remote debugging is enabled, this will always return `nil`.
    */
+  @JavaScriptActor
   @objc
   public func getNativeModuleObject(_ moduleName: String) -> JavaScriptObject? {
     return moduleRegistry.get(moduleHolderForName: moduleName)?.javaScriptObject
@@ -507,6 +510,7 @@ public final class AppContext: NSObject, @unchecked Sendable {
   /**
    Unsets runtime objects that we hold for each module.
    */
+  @JavaScriptActor
   private func releaseRuntimeObjects() {
     sharedObjectRegistry.clear()
     classRegistry.clear()

--- a/packages/expo-modules-core/ios/Core/Classes/ClassDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Classes/ClassDefinition.swift
@@ -43,6 +43,7 @@ public final class ClassDefinition: ObjectDefinition {
 
   // MARK: - JavaScriptObjectBuilder
 
+  @JavaScriptActor
   public override func build(appContext: AppContext) throws -> JavaScriptObject {
     let constructorBlock: ClassConstructorBlock = { [weak self, weak appContext] this, arguments in
       guard let self, let appContext else {
@@ -94,6 +95,7 @@ public final class ClassDefinition: ObjectDefinition {
     return klass
   }
 
+  @JavaScriptActor
   public override func decorate(object: JavaScriptObject, appContext: AppContext) throws {
     try decorateWithStaticFunctions(object: object, appContext: appContext)
 
@@ -107,6 +109,7 @@ public final class ClassDefinition: ObjectDefinition {
     try decorateWithProperties(object: prototype, appContext: appContext)
   }
 
+  @JavaScriptActor
   private func createClass(appContext: AppContext, name: String, consturctor: @escaping ClassConstructorBlock) throws -> JavaScriptObject {
     if isSharedRef {
       return try appContext.runtime.createSharedRefClass(name, constructor: consturctor)

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicRawType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicRawType.swift
@@ -35,7 +35,9 @@ internal struct DynamicRawType<InnerType>: AnyDynamicType {
     // TODO: Definitions and JS object builders should have its own dynamic type.
     // We use `DynamicRawType` for this only temporarily.
     if let objectBuilder = result as? JavaScriptObjectBuilder {
-      return try objectBuilder.build(appContext: appContext) as Any
+      return try JavaScriptActor.assumeIsolated {
+        return try objectBuilder.build(appContext: appContext)
+      } as Any
     }
     return result
   }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicSharedObjectType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicSharedObjectType.swift
@@ -95,7 +95,10 @@ internal struct DynamicSharedObjectType: AnyDynamicType {
 }
 
 private func getBaseSharedType(_ appContext: AppContext, nativeType: AnySharedObject.Type) throws -> JavaScriptObject {
-  return try nativeType is AnySharedRef.Type ? appContext.runtime.getSharedRefClass() : appContext.runtime.getSharedObjectClass()
+  let isSharedRef = nativeType is AnySharedRef.Type
+  return try JavaScriptActor.assumeIsolated {
+    return try isSharedRef ? appContext.runtime.getSharedRefClass() : appContext.runtime.getSharedObjectClass()
+  }
 }
 
 private func newBaseSharedObject(_ appContext: AppContext, nativeType: AnySharedObject.Type) throws -> JavaScriptObject? {

--- a/packages/expo-modules-core/ios/Core/Events/EventObservingDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Events/EventObservingDefinition.swift
@@ -40,6 +40,7 @@ public struct EventObservingDecorator: JavaScriptObjectDecorator {
    Decorates the given object with `startObserving` and `stopObserving` functions.
    These functions are automatically called by the `EventEmitter` implementation.
    */
+  @JavaScriptActor
   func decorate(object: JavaScriptObject, appContext: AppContext) throws {
     // We need to keep track the number of observed events
     // so we can call observers not attached to any event in the right moment.

--- a/packages/expo-modules-core/ios/Core/Events/LegacyEventEmitterCompat.swift
+++ b/packages/expo-modules-core/ios/Core/Events/LegacyEventEmitterCompat.swift
@@ -15,6 +15,9 @@ public final class LegacyEventEmitterCompat: EXEventEmitterService {
       return
     }
 
+    // `Any` is not sendable, so we must trick the compiler.
+    let eventArguments = NonisolatedUnsafeVar<[Any]>([body as Any])
+
     // Send the event to all modules that declare support for this particular event.
     // That's how it works in the device event emitter provided by React Native.
     let moduleHoldersWithEvent = appContext.moduleRegistry.filter { holder in
@@ -24,7 +27,7 @@ public final class LegacyEventEmitterCompat: EXEventEmitterService {
     runtime.schedule {
       for holder in moduleHoldersWithEvent {
         if let jsObject = holder.javaScriptObject {
-          JSUtils.emitEvent(name, to: jsObject, withArguments: [body], in: runtime)
+          JSUtils.emitEvent(name, to: jsObject, withArguments: eventArguments.value, in: runtime)
         }
       }
     }

--- a/packages/expo-modules-core/ios/Core/ExpoRuntime.swift
+++ b/packages/expo-modules-core/ios/Core/ExpoRuntime.swift
@@ -5,18 +5,22 @@
  For instance, the global `expo` object is available only in Expo runtimes.
  */
 public extension ExpoRuntime {
+  @JavaScriptActor
   internal func initializeCoreObject(_ coreObject: JavaScriptObject) throws {
     global().defineProperty(EXGlobalCoreObjectPropertyName, value: coreObject, options: .enumerable)
   }
 
+  @JavaScriptActor
   internal func getCoreObject() throws -> JavaScriptObject {
     return try global().getProperty(EXGlobalCoreObjectPropertyName).asObject()
   }
 
+  @JavaScriptActor
   internal func getSharedObjectClass() throws -> JavaScriptObject {
     return try getCoreObject().getProperty("SharedObject").asObject()
   }
 
+  @JavaScriptActor
   internal func getSharedRefClass() throws -> JavaScriptObject {
     return try getCoreObject().getProperty("SharedRef").asObject()
   }

--- a/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
@@ -158,6 +158,7 @@ public class AsyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnyAsyncFu
 
   // MARK: - JavaScriptObjectBuilder
 
+  @JavaScriptActor
   func build(appContext: AppContext) throws -> JavaScriptObject {
     // It seems to be safe to capture a strong reference to `self` here. This is needed for detached functions, that are not part of the module definition.
     // Module definitions are held in memory anyway, but detached definitions (returned by other functions) are not, so we need to capture them here.

--- a/packages/expo-modules-core/ios/Core/Functions/ConcurrentFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/ConcurrentFunctionDefinition.swift
@@ -106,6 +106,7 @@ public final class ConcurrentFunctionDefinition<Args, FirstArgType, ReturnType>:
 
   // MARK: - JavaScriptObjectBuilder
 
+  @JavaScriptActor
   func build(appContext: AppContext) throws -> JavaScriptObject {
     return try appContext.runtime.createAsyncFunction(name, argsCount: argumentsCount) { [weak appContext, self] this, args, resolve, reject in
       guard let appContext else {

--- a/packages/expo-modules-core/ios/Core/Functions/SyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/SyncFunctionDefinition.swift
@@ -142,6 +142,7 @@ public class SyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnySyncFunc
 
   // MARK: - JavaScriptObjectBuilder
 
+  @JavaScriptActor
   func build(appContext: AppContext) throws -> JavaScriptObject {
     // We intentionally capture a strong reference to `self`, otherwise the "detached" objects would
     // immediately lose the reference to the definition and thus the underlying native function.

--- a/packages/expo-modules-core/ios/Core/ModuleHolder.swift
+++ b/packages/expo-modules-core/ios/Core/ModuleHolder.swift
@@ -22,6 +22,7 @@ public final class ModuleHolder {
   /**
    JavaScript object that represents the module instance in the runtime.
    */
+  @JavaScriptActor
   public internal(set) lazy var javaScriptObject: JavaScriptObject? = createJavaScriptModuleObject()
 
   /**
@@ -99,6 +100,7 @@ public final class ModuleHolder {
    JavaScript can access it through `global.expo.modules[moduleName]`.
    - Note: The object will be `nil` when the runtime is unavailable (e.g. remote debugger is enabled).
    */
+  @JavaScriptActor
   private func createJavaScriptModuleObject() -> JavaScriptObject? {
     // It might be impossible to create any object at the moment (e.g. remote debugging, app context destroyed)
     guard let appContext else {

--- a/packages/expo-modules-core/ios/Core/Modules/ModuleDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Modules/ModuleDefinition.swift
@@ -69,6 +69,7 @@ public final class ModuleDefinition: ObjectDefinition {
     return self
   }
 
+  @JavaScriptActor
   public override func build(appContext: AppContext) throws -> JavaScriptObject {
     // Create an instance of `global.expo.NativeModule`
     let object = JSUtils.createNativeModuleObject(try appContext.runtime)

--- a/packages/expo-modules-core/ios/Core/Objects/JavaScriptObjectBuilder.swift
+++ b/packages/expo-modules-core/ios/Core/Objects/JavaScriptObjectBuilder.swift
@@ -7,6 +7,7 @@ internal protocol JavaScriptObjectDecorator {
   /**
    Decorates an existing `JavaScriptObject`.
    */
+  @JavaScriptActor
   func decorate(object: JavaScriptObject, appContext: AppContext) throws
 }
 
@@ -17,6 +18,7 @@ internal protocol JavaScriptObjectBuilder: JavaScriptObjectDecorator {
   /**
    Creates a decorated `JavaScriptObject` in the given app context.
    */
+  @JavaScriptActor
   func build(appContext: AppContext) throws -> JavaScriptObject
 }
 
@@ -25,12 +27,14 @@ internal protocol JavaScriptObjectBuilder: JavaScriptObjectDecorator {
  The `build(appContext:)` creates a plain object and uses `decorate(object:appContext:)` for decoration.
  */
 extension JavaScriptObjectBuilder {
+  @JavaScriptActor
   func build(appContext: AppContext) throws -> JavaScriptObject {
     let object = try appContext.runtime.createObject()
     try decorate(object: object, appContext: appContext)
     return object
   }
 
+  @JavaScriptActor
   func decorate(object: JavaScriptObject, appContext: AppContext) throws {
     // no-op by default
   }

--- a/packages/expo-modules-core/ios/Core/Objects/ObjectDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Objects/ObjectDefinition.swift
@@ -84,12 +84,14 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
 
   // MARK: - JavaScriptObjectBuilder
 
+  @JavaScriptActor
   public func build(appContext: AppContext) throws -> JavaScriptObject {
     let object = try appContext.runtime.createObject()
     try decorate(object: object, appContext: appContext)
     return object
   }
 
+  @JavaScriptActor
   public func decorate(object: JavaScriptObject, appContext: AppContext) throws {
     try decorateWithConstants(object: object, appContext: appContext)
     try decorateWithFunctions(object: object, appContext: appContext)
@@ -99,6 +101,7 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
 
   // MARK: - Internals
 
+  @JavaScriptActor
   internal func decorateWithConstants(object: JavaScriptObject, appContext: AppContext) throws {
     for (key, value) in getLegacyConstants() {
       object.setProperty(key, value: value)
@@ -110,18 +113,21 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
     }
   }
 
+  @JavaScriptActor
   internal func decorateWithFunctions(object: JavaScriptObject, appContext: AppContext) throws {
     for fn in functions.values {
       object.setProperty(fn.name, value: try fn.build(appContext: appContext))
     }
   }
 
+  @JavaScriptActor
   internal func decorateWithStaticFunctions(object: JavaScriptObject, appContext: AppContext) throws {
     for fn in staticFunctions.values {
       object.setProperty(fn.name, value: try fn.build(appContext: appContext))
     }
   }
 
+  @JavaScriptActor
   internal func decorateWithProperties(object: JavaScriptObject, appContext: AppContext) throws {
     for property in properties.values {
       let descriptor = try property.buildDescriptor(appContext: appContext)
@@ -129,6 +135,7 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
     }
   }
 
+  @JavaScriptActor
   internal func decorateWithClasses(object: JavaScriptObject, appContext: AppContext) throws {
     for klass in classes.values {
       object.setProperty(klass.name, value: try klass.build(appContext: appContext))

--- a/packages/expo-modules-core/ios/Core/Protocols/AnyViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Protocols/AnyViewDefinition.swift
@@ -42,5 +42,6 @@ public protocol AnyViewDefinition: Sendable {
   /**
    Creates a JavaScript object that may be used as a React component prototype.
    */
+  @JavaScriptActor
   func createReactComponentPrototype(appContext: AppContext) throws -> JavaScriptObject
 }

--- a/packages/expo-modules-core/ios/Core/Views/ViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ViewDefinition.swift
@@ -93,6 +93,7 @@ public class ViewDefinition<ViewType>: ObjectDefinition, AnyViewDefinition, @unc
     }
   }
 
+  @JavaScriptActor
   public func createReactComponentPrototype(appContext: AppContext) throws -> JavaScriptObject {
     let prototype = try appContext.runtime.createObject()
 

--- a/packages/expo-modules-core/ios/JS/JavaScriptActor.swift
+++ b/packages/expo-modules-core/ios/JS/JavaScriptActor.swift
@@ -1,0 +1,67 @@
+/**
+ Global actor that is used to isolate the code that should only be executed from the JavaScript thread.
+ Theoretically it does not act as a real actor; it uses a serial executor that executes jobs **synchronously**
+ without hopping to the proper thread. Meaning that running these jobs on the JavaScript thread must be ensured
+ externally before switching to the isolated context, e.g. using `schedule` function on `JavaScriptRuntime`
+ or enforcing the isolation with `JavaScriptActor.assumeIsolated`.
+ */
+@globalActor
+public actor JavaScriptActor: GlobalActor {
+  /**
+   Name of the JavaScript thread created by React Native. Copied from `RCTJSThreadManager.mm`.
+   */
+  private static let jsThreadName = "com.facebook.react.runtime.JavaScript"
+
+  public static let shared = JavaScriptActor()
+
+  private init() {}
+
+  nonisolated private let executor = Executor()
+
+  nonisolated public var unownedExecutor: UnownedSerialExecutor {
+    return executor.asUnownedSerialExecutor()
+  }
+
+  /**
+   An equivalent of `MainActor.assumeIsolated`, but for the `JavaScriptActor`. Assumes that the currently executing
+   synchronous function is actually executing on the JavaScript thread and invokes an isolated version of the operation,
+   allowing synchronous access to JavaScript runtime state without hopping through asynchronous boundaries.
+
+   See https://stackoverflow.com/a/79346971 for more information about the implementation.
+   */
+  public static func assumeIsolated<T>(_ operation: @JavaScriptActor () throws -> T) rethrows -> T {
+    typealias YesActor = @JavaScriptActor () throws -> T
+    typealias NoActor = () throws -> T
+
+    shared.preconditionThread()
+
+    // To do the unsafe cast, we have to pretend it's @escaping.
+    return try withoutActuallyEscaping(operation) { (_ fn: @escaping YesActor) throws -> T in
+      let rawFn = unsafeBitCast(fn, to: NoActor.self)
+      return try rawFn()
+    }
+  }
+
+  /**
+   Stops program execution if the current task is not executing on the JavaScript thread.
+   - Note: Its behavior is the same in both Debug and Release builds.
+  */
+  nonisolated public func preconditionThread() {
+    // We must be careful as it relies on the thread name given by React Native.
+    precondition(Thread.current.name == JavaScriptActor.jsThreadName, "JavaScriptActor operations must be run on the JavaScript thread")
+  }
+
+  /**
+   Executor for the `JavaScriptActor` that executes given jobs synchronously and immediately.
+   - Note: It does not ensure that given jobs are executed on the JavaScript thread; it must be done externally.
+   */
+  private final class Executor: SerialExecutor {
+    func enqueue(_ job: UnownedJob) {
+      job.runSynchronously(on: self.asUnownedSerialExecutor())
+    }
+
+    func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+      return UnownedSerialExecutor(ordinary: self)
+    }
+  }
+}

--- a/packages/expo-modules-core/ios/JS/JavaScriptActor.swift
+++ b/packages/expo-modules-core/ios/JS/JavaScriptActor.swift
@@ -44,11 +44,15 @@ public actor JavaScriptActor: GlobalActor {
 
   /**
    Stops program execution if the current task is not executing on the JavaScript thread.
+   The precondition is also met when running tests and in single threaded environments.
    - Note: Its behavior is the same in both Debug and Release builds.
   */
   nonisolated public func preconditionThread() {
     // We must be careful as it relies on the thread name given by React Native.
-    precondition(Thread.current.name == JavaScriptActor.jsThreadName, "JavaScriptActor operations must be run on the JavaScript thread")
+    precondition(
+      Thread.current.name == JavaScriptActor.jsThreadName || !Thread.isMultiThreaded() || ProcessInfo.processInfo.processName == "xctest",
+      "JavaScriptActor operations must be run on the JavaScript thread"
+    )
   }
 
   /**

--- a/packages/expo-modules-core/ios/JS/JavaScriptRuntime.swift
+++ b/packages/expo-modules-core/ios/JS/JavaScriptRuntime.swift
@@ -64,6 +64,14 @@ public extension JavaScriptRuntime {
   /**
    Schedules a block to be executed with granted synchronized access to the JS runtime.
    */
+  func schedule(priority: SchedulerPriority = .normal, @_implicitSelfCapture _ closure: @JavaScriptActor @escaping () -> Void) {
+    __schedule({ JavaScriptActor.assumeIsolated(closure) }, priority: priority.rawValue)
+  }
+
+  /**
+   Schedules a block to be executed with granted synchronized access to the JS runtime.
+   */
+  @available(*, deprecated, message: "Use the version with `@JavaScriptActor` instead")
   func schedule(priority: SchedulerPriority = .normal, _ closure: @escaping () -> Void) {
     __schedule(closure, priority: priority.rawValue)
   }

--- a/packages/expo-modules-core/ios/JS/JavaScriptRuntime.swift
+++ b/packages/expo-modules-core/ios/JS/JavaScriptRuntime.swift
@@ -67,14 +67,6 @@ public extension JavaScriptRuntime {
   func schedule(priority: SchedulerPriority = .normal, @_implicitSelfCapture _ closure: @JavaScriptActor @escaping () -> Void) {
     __schedule({ JavaScriptActor.assumeIsolated(closure) }, priority: priority.rawValue)
   }
-
-  /**
-   Schedules a block to be executed with granted synchronized access to the JS runtime.
-   */
-  @available(*, deprecated, message: "Use the version with `@JavaScriptActor` instead")
-  func schedule(priority: SchedulerPriority = .normal, _ closure: @escaping () -> Void) {
-    __schedule(closure, priority: priority.rawValue)
-  }
 }
 
 // Keep it in sync with the equivalent C++ enum from React Native (see SchedulerPriority.h from React-callinvoker).

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
@@ -38,6 +38,7 @@ typedef jsi::Value (^JSHostFunctionBlock)(jsi::Runtime &runtime,
                                           NSArray<EXJavaScriptValue *> *_Nonnull arguments);
 #endif // __cplusplus
 
+NS_SWIFT_SENDABLE
 NS_SWIFT_NAME(JavaScriptRuntime)
 @interface EXJavaScriptRuntime : NSObject
 

--- a/packages/expo-modules-core/ios/Tests/ClassDefinitionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ClassDefinitionSpec.swift
@@ -32,12 +32,14 @@ class ClassDefinitionSpec: ExpoSpec {
       }
 
       it("builds a class") {
-        let appContext = AppContext.create()
-        let klass = Class("") {}
-        let object = try klass.build(appContext: appContext)
+        try JavaScriptActor.assumeIsolated {
+          let appContext = AppContext.create()
+          let klass = Class("") {}
+          let object = try klass.build(appContext: appContext)
 
-        expect(object.hasProperty("prototype")) == true
-        expect(object.getProperty("prototype").kind) == .object
+          expect(object.hasProperty("prototype")) == true
+          expect(object.getProperty("prototype").kind) == .object
+        }
       }
     }
 

--- a/packages/expo-modules-core/ios/Tests/JavaScriptActorTests.swift
+++ b/packages/expo-modules-core/ios/Tests/JavaScriptActorTests.swift
@@ -1,0 +1,47 @@
+import Testing
+
+@testable import ExpoModulesCore
+
+@Suite
+struct JavaScriptActorTests {
+  @Test
+  func `awaits in nonisolated context`() async {
+    #expect(await isolatedFunction() == "func")
+    #expect(await IsolatedStruct().value == "struct")
+  }
+
+  @Test
+  func `assumeIsolated enters isolation`() {
+    JavaScriptActor.assumeIsolated {
+      #expect(isolatedFunction() == "func")
+      #expect(IsolatedStruct().value == "struct")
+    }
+  }
+
+  @Test
+  func `assumeIsolated returns value from isolated block`() {
+    let result: String = JavaScriptActor.assumeIsolated {
+      return "result"
+    }
+    #expect(result == "result")
+  }
+
+  @Test
+  func `assumeIsolated rethrows error from isolated block`() {
+    #expect(throws: NSError.self) {
+      try JavaScriptActor.assumeIsolated {
+        throw NSError(domain: "throw from isolation", code: 0)
+      }
+    }
+  }
+}
+
+@JavaScriptActor
+func isolatedFunction() -> String {
+  return "func"
+}
+
+@JavaScriptActor
+struct IsolatedStruct {
+  let value: String = "struct"
+}


### PR DESCRIPTION
# Why

I've had mixed feelings about the introduction of stricter concurrency checks in Swift 6 compiler, mainly because our and React Native code were not designed to benefit from them and it's just more annoying than useful.
Long term I'm going to change a few things to actually get some more benefits from these compiler checks and some Swift's concurrency features.

In this PR I'm happy to introduce a global JavaScript actor, that we'll be using to isolate code that accesses the JavaScript runtime, or in other words, to annotate places that need to be run on the JavaScript thread.

It doesn't fully guarantee thread-safety as the serial executor for this actor is running jobs synchronously on the same thread, which is not exactly how actors work by default. We can't reliably switch to the proper thread because we want to have only one global actor (so also only one executor) but be able to use multiple runtimes (each one uses different thread). Thus, switching to the proper JavaScript thread still needs to be provided externally, by using `appContext.runtime.schedule` or by enforcing the isolation with `JavaScript.assumeIsolated` if we're sure that we're already on the JavaScript thread. The latter is in theory not safe (uses `unsafeBitCast`), however `MainActor` does the exact same thing so I think it's fine.

Things to do in the future:
- Migrate `JavaScript`-related classes (`JavaScriptValue`, `JavaScriptObject` etc.) to Swift (may need Swift/C++ interop first) and enforce them to be used only from `JavaScriptActor`-isolated context
- Annotate some more functions that must run on the JavaScript thread with `@JavaScriptActor`
- Automatically isolate closures passed to synchronous `Function`s
- Annotate converters that return `JavaScriptValue`

# How

- Created `JavaScriptActor` global actor with a custom serial synchronous executor
- Provided custom `assumeIsolated` function, inspired by `MainActor`'s implementation
- Added a requirement on `ExpoRuntime` functions to call them from `JavaScriptActor`-isolated context (example of how we're going to use it)
- Closure passed to `runtime.schedule { ... }` now automatically runs in the isolated context

# Test Plan

Confirmed that the runtime is properly decorated with `globalThis.expo` and there are no crashes