### PR TITLE
[iOS] Replace UIApplicationMain with main for Swift 6

### DIFF
--- a/apps/expo-go/ios/Client/AppDelegate.swift
+++ b/apps/expo-go/ios/Client/AppDelegate.swift
@@ -5,7 +5,7 @@ import React
 import FirebaseCore
 import ReactAppDependencyProvider
 
-@UIApplicationMain
+@main
 class AppDelegate: ExpoAppDelegate {
   var rootViewController: EXRootViewController?
   var window: UIWindow?

--- a/packages/expo-updates/e2e/fixtures/custom_init/AppDelegate.swift
+++ b/packages/expo-updates/e2e/fixtures/custom_init/AppDelegate.swift
@@ -24,7 +24,7 @@ class CustomReactNativeFactoryDelegate: ExpoReactNativeFactoryDelegate {
   }
 }
 
-@UIApplicationMain
+@main
 class AppDelegate: ExpoAppDelegate {
   var launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   // AppDelegate keeps a nullable reference to the updates controller

--- a/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift
+++ b/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift
@@ -2,7 +2,7 @@ import Expo
 import React
 import ReactAppDependencyProvider
 
-@UIApplicationMain
+@main
 public class AppDelegate: ExpoAppDelegate {
   var window: UIWindow?
 


### PR DESCRIPTION
# Why

`@UIApplicationMain` and `@NSApplicationMain` has been deprecated since Swift 5.10 and started throwing a compiler error in Swift 6 compiler mode.

# How

Replaced `@UIApplicationMain` in the template, Expo Go and expo-updates e2e test with `@main`

# Test Plan

Expo Go and bare minimum template compile fine after enabling Swift 6 compiler mode