### PR TITLE
[updates][e2e] Fix missing dependencies

### DIFF
--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -45,6 +45,7 @@ function getExpoDependencyChunks({
     ['expo-manifests'],
     ['@expo/prebuild-config', '@expo/metro-config', 'expo-constants'],
     ['@expo/image-utils'],
+    ['@expo/dom-webview', '@expo/log-box'],
     [
       'babel-preset-expo',
       'expo-application',


### PR DESCRIPTION
# Why

Fixes missing dependencies. 
Right now, the e2e tests on Android aren't working because `@expo/dom-webview` and `@expo/log-box` are fetched from npm instead of being packaged from main like other dependencies. 


# Test Plan

- CI is green ✅  