### PR TITLE
[camera][ios] Fix incorrect default option value for scanner

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [Android] Fix certain exif keys being dropped because of invalid values. ([#41043](https://github.com/expo/expo/pull/41043) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix camera not being recreated on the old architecture. ([#41405](https://github.com/expo/expo/pull/41405) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Return correct size information when using image refs. ([#41658](https://github.com/expo/expo/pull/41658) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix incorrect isPinchToZoomEnabled default value for scanner. ([#41803](https://github.com/expo/expo/pull/41803) by [@hssdiv](https://github.com/hssdiv))
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/Current/BarcodeRecord.swift
+++ b/packages/expo-camera/ios/Current/BarcodeRecord.swift
@@ -147,9 +147,9 @@ enum VNBarcodeType: String, Enumerable {
 
 struct VisionScannerOptions: Record {
   @Field var barcodeTypes: [VNBarcodeType] = []
-  @Field var isPinchToZoomEnabled: Bool = false
-  @Field var isGuidanceEnabled: Bool = true
-  @Field var isHighlightingEnabled: Bool = false
+  @Field var isPinchToZoomEnabled: Bool?
+  @Field var isGuidanceEnabled: Bool?
+  @Field var isHighlightingEnabled: Bool?
 
   @available(iOS 16.0, *)
   func toSymbology() -> [VNBarcodeSymbology] {


### PR DESCRIPTION
# Why

[Docs say](https://docs.expo.dev/versions/latest/sdk/camera/#scanningoptions) that `isPinchToZoomEnabled` by default `is true`
<img width="560" height="255" alt="Screenshot 2025-12-22 at 14 47 21" src="https://github.com/user-attachments/assets/440f0186-ee3b-42ae-a91a-f4ce0682e620" />



and at first it [seems correct](https://github.com/expo/expo/blob/9d6f808e858f539dd534fb27b838abae1719604f/packages/expo-camera/ios/CameraViewModule.swift#L401)
<img width="544" height="191" alt="Screenshot 2025-12-22 at 14 50 21" src="https://github.com/user-attachments/assets/e7da9ec2-2909-4dd7-99cf-2c53f9ed304f" />



but it's actually `false` because it takes value [from here](https://github.com/expo/expo/blob/9d6f808e858f539dd534fb27b838abae1719604f/packages/expo-camera/ios/Current/BarcodeRecord.swift#L150)
<img width="451" height="161" alt="Screenshot 2025-12-22 at 14 50 33" src="https://github.com/user-attachments/assets/c4c4b16f-9dbe-4cbf-9fdf-8a4e6377b356" />


# How

This could be fixed by simply changing `false` to `true` (in struct) to match the dosc but I guess it's better to just have 1 place in code where default values are assigned (in CameraViewModule), so this is what I've changed

# Test Plan

I've tested it with [this patch-package](https://gist.github.com/hssdiv/9835f9d2cb78d194703a5bf5002b81b3) and it worked correctly
<img width="352" height="259" alt="Screenshot 2025-12-22 at 14 57 36" src="https://github.com/user-attachments/assets/7ef063eb-6e99-4fa0-9b6e-b935d5ccaa5d" />

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
