### PR TITLE
[ios][ui] Fixed import in example

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unpublished
 
+- [ios] - Fix modifiers import path in the example ([#41811](https://github.com/expo/expo/pull/41811) by [@pchalupa](https://github.com/pchalupa))
+
 ### 🛠 Breaking changes
 
 - [iOS] - Match `DatePicker` API with SwiftUI API. Remove `DateTimePicker` component ([#41546](https://github.com/expo/expo/pull/41546) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/build/swift-ui/types.d.ts
+++ b/packages/expo-ui/build/swift-ui/types.d.ts
@@ -74,7 +74,7 @@ export interface CommonViewModifierProps {
      *
      * @example
      * ```tsx
-     * import { background, cornerRadius, shadow, frame, padding, fixedSize } from 'expo-ui/swift-ui/modifiers';
+     * import { background, cornerRadius, shadow, frame, padding, fixedSize } from '@expo/ui/swift-ui/modifiers';
      *
      * <Text modifiers={[
      *   background('#FF0000'),

--- a/packages/expo-ui/src/swift-ui/types.ts
+++ b/packages/expo-ui/src/swift-ui/types.ts
@@ -88,7 +88,7 @@ export interface CommonViewModifierProps {
    *
    * @example
    * ```tsx
-   * import { background, cornerRadius, shadow, frame, padding, fixedSize } from 'expo-ui/swift-ui/modifiers';
+   * import { background, cornerRadius, shadow, frame, padding, fixedSize } from '@expo/ui/swift-ui/modifiers';
    *
    * <Text modifiers={[
    *   background('#FF0000'),


### PR DESCRIPTION
# Why
The import of modifiers in the example isn't correct.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
Updated the example import.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
