### PR TITLE
[expo-localization] Default allowDynamicLocaleChangesAndroid to true when supportedLocales is configured

### DIFF
--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- [Android] Default allowDynamicLocaleChangesAndroid to true when supportedLocales is configured ([#41813](https://github.com/expo/expo/pull/41813) by [@Ubax](https://github.com/Ubax))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-localization/plugin/build/withExpoLocalization.js
+++ b/packages/expo-localization/plugin/build/withExpoLocalization.js
@@ -103,12 +103,15 @@ function withExpoLocalizationAndroid(config, data) {
         return config;
     });
 }
-function withExpoLocalization(config, data = {
-    allowDynamicLocaleChangesAndroid: true,
-}) {
+function withExpoLocalization(config, data = {}) {
+    // Ensure allowDynamicLocaleChangesAndroid defaults to true
+    const normalizedData = {
+        ...data,
+        allowDynamicLocaleChangesAndroid: data.allowDynamicLocaleChangesAndroid ?? true,
+    };
     return (0, config_plugins_1.withPlugins)(config, [
-        [withExpoLocalizationIos, data],
-        [withExpoLocalizationAndroid, data],
+        [withExpoLocalizationIos, normalizedData],
+        [withExpoLocalizationAndroid, normalizedData],
     ]);
 }
 exports.default = withExpoLocalization;

--- a/packages/expo-localization/plugin/src/withExpoLocalization.ts
+++ b/packages/expo-localization/plugin/src/withExpoLocalization.ts
@@ -148,15 +148,15 @@ function withExpoLocalizationAndroid(config: ExpoConfig, data: ConfigPluginProps
   });
 }
 
-function withExpoLocalization(
-  config: ExpoConfig,
-  data: ConfigPluginProps = {
-    allowDynamicLocaleChangesAndroid: true,
-  }
-) {
+function withExpoLocalization(config: ExpoConfig, data: ConfigPluginProps = {}) {
+  // Ensure allowDynamicLocaleChangesAndroid defaults to true
+  const normalizedData = {
+    ...data,
+    allowDynamicLocaleChangesAndroid: data.allowDynamicLocaleChangesAndroid ?? true,
+  };
   return withPlugins(config, [
-    [withExpoLocalizationIos, data],
-    [withExpoLocalizationAndroid, data],
+    [withExpoLocalizationIos, normalizedData],
+    [withExpoLocalizationAndroid, normalizedData],
   ]);
 }
 


### PR DESCRIPTION
# Why

Solves: https://github.com/expo/expo/issues/41252

When a configuration was passed to `withExpoLocalization`, the default value of `allowDynamicLocaleChangesAndroid: true` was overread.  

Without `allowDynamicLocaleChangesAndroid: true`, the plugin doesn't add `locale` to `android:configChanges` in the `AndroidManifest`. This causes Android to recreate the Activity when the user changes the app's language via system settings and breaks `react-navigation` linking

# How

Normalize the plugin options by spreading the default value before the user-provided config, ensuring allowDynamicLocaleChangesAndroid defaults to true even when other options are passed.

This is technically a breaking change, but I think this is a better default

# Test Plan

Manual testing with router app

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
