### PR TITLE
[docs] Fix Platform tag spacing on mobile view

### DIFF
--- a/docs/ui/components/PageHeader/PagePlatformTags.tsx
+++ b/docs/ui/components/PageHeader/PagePlatformTags.tsx
@@ -9,7 +9,7 @@ type Props = {
 
 export function PagePlatformTags({ platforms, className }: Props) {
   return (
-    <div className={mergeClasses('inline-flex flex-wrap', className)}>
+    <div className={mergeClasses('inline-flex flex-wrap gap-y-1.5', className)}>
       {platforms
         .sort((a, b) => a.localeCompare(b))
         .map(platform => {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18533

# How

<!--
How did you build this feature or fix this bug and why?
-->

* Add the `gap-y-1.5` class to the container `div` in `PagePlatformTags` to introduce vertical spacing between wrapped rows of platform tags.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run on an iOS device and visit: http://localhost:3002/versions/latest/sdk/camera/

## Preview

<img width="912" height="1730" alt="CleanShot 2025-12-24 at 00 39 23@2x" src="https://github.com/user-attachments/assets/2a374397-26f5-456a-9187-98ee77c41534" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
