### PR TITLE
[docs] Update Terminal component

### DIFF
--- a/docs/pages/more/create-expo.mdx
+++ b/docs/pages/more/create-expo.mdx
@@ -13,6 +13,15 @@ import { Tab, Tabs } from '~/ui/components/Tabs';
 
 To create a new project, run the following command:
 
+<Terminal
+  cmd={{
+    npm: ['$ npx create-expo-app@latest'],
+    yarn: ['$ yarn create expo-app'],
+    pnpm: ['$ pnpm create expo-app'],
+    bun: ['$ bun create expo'],
+  }}
+/>
+
 <Tabs>
 
 <Tab label="npm">

--- a/docs/pages/more/create-expo.mdx
+++ b/docs/pages/more/create-expo.mdx
@@ -13,15 +13,6 @@ import { Tab, Tabs } from '~/ui/components/Tabs';
 
 To create a new project, run the following command:
 
-<Terminal
-  cmd={{
-    npm: ['$ npx create-expo-app@latest'],
-    yarn: ['$ yarn create expo-app'],
-    pnpm: ['$ pnpm create expo-app'],
-    bun: ['$ bun create expo'],
-  }}
-/>
-
 <Tabs>
 
 <Tab label="npm">

--- a/docs/ui/components/Snippet/SnippetHeader.tsx
+++ b/docs/ui/components/Snippet/SnippetHeader.tsx
@@ -8,6 +8,7 @@ import { FileStatus } from './FileStatus';
 export type SnippetHeaderProps = PropsWithChildren<{
   title: string | ReactNode;
   Icon?: ComponentType<HTMLAttributes<SVGSVGElement>>;
+  titleSlot?: ReactNode;
   alwaysDark?: boolean;
   float?: boolean;
   operationType?: 'delete' | 'add' | 'modify' | undefined;
@@ -18,6 +19,7 @@ export const SnippetHeader = ({
   title,
   children,
   Icon,
+  titleSlot,
   float,
   alwaysDark = false,
   operationType,
@@ -39,6 +41,7 @@ export const SnippetHeader = ({
       {Icon && <Icon className="icon-sm shrink-0" />}
       <span className="break-words w-max max-w-[60dvw] truncate">{title}</span>
       {showOperation && operationType ? <FileStatus type={operationType} /> : null}
+      {titleSlot}
     </LABEL>
     {!!children && <div className="flex items-center justify-end">{children}</div>}
   </div>

--- a/docs/ui/components/Snippet/Terminal.test.tsx
+++ b/docs/ui/components/Snippet/Terminal.test.tsx
@@ -64,13 +64,12 @@ describe(Terminal, () => {
     render(
       <>
         <Terminal
-          packageManagers={{
+          cmd={{
             npm: ['$ npm install expo'],
             yarn: ['$ yarn add expo'],
             pnpm: ['$ pnpm add expo'],
             bun: ['$ bun add expo'],
           }}
-          cmd={['$ npm install fallback']}
         />
         <textarea />
       </>

--- a/docs/ui/components/Snippet/Terminal.test.tsx
+++ b/docs/ui/components/Snippet/Terminal.test.tsx
@@ -79,12 +79,25 @@ describe(Terminal, () => {
     const user = userEvent.setup();
 
     expect(screen.getByRole('tab', { name: /^npm$/i })).toHaveAttribute('aria-selected', 'true');
-    expect(screen.getByText(/npm install expo/)).toBeVisible();
+    const npmLine = screen.getAllByText((_, node) => {
+      const text = node?.textContent ?? '';
+      return text.includes('npm install expo') && node.tagName.toLowerCase() === 'code';
+    })[0];
+    expect(npmLine).toBeVisible();
 
     await user.click(screen.getByRole('tab', { name: /^yarn$/i }));
     expect(screen.getByRole('tab', { name: /^yarn$/i })).toHaveAttribute('aria-selected', 'true');
-    expect(screen.queryByText(/npm install expo/)).toBeNull();
-    expect(screen.getByText(/yarn add expo/)).toBeVisible();
+    expect(
+      screen.queryByText((_, node) => {
+        const text = node?.textContent ?? '';
+        return text.includes('npm install expo') && node.tagName.toLowerCase() === 'code';
+      })
+    ).toBeNull();
+    const yarnLine = screen.getAllByText((_, node) => {
+      const text = node?.textContent ?? '';
+      return text.includes('yarn add expo') && node.tagName.toLowerCase() === 'code';
+    })[0];
+    expect(yarnLine).toBeVisible();
 
     await user.click(screen.getByText('Copy'));
     await user.click(screen.getByRole('textbox'));

--- a/docs/ui/components/Snippet/Terminal.test.tsx
+++ b/docs/ui/components/Snippet/Terminal.test.tsx
@@ -81,7 +81,7 @@ describe(Terminal, () => {
     expect(screen.getByRole('tab', { name: /^npm$/i })).toHaveAttribute('aria-selected', 'true');
     const npmLine = screen.getAllByText((_, node) => {
       const text = node?.textContent ?? '';
-      return text.includes('npm install expo') && node.tagName.toLowerCase() === 'code';
+      return !!(text.includes('npm install expo') && node?.tagName.toLowerCase() === 'code');
     })[0];
     expect(npmLine).toBeVisible();
 
@@ -90,12 +90,12 @@ describe(Terminal, () => {
     expect(
       screen.queryByText((_, node) => {
         const text = node?.textContent ?? '';
-        return text.includes('npm install expo') && node.tagName.toLowerCase() === 'code';
+        return !!(text.includes('npm install expo') && node?.tagName.toLowerCase() === 'code');
       })
     ).toBeNull();
     const yarnLine = screen.getAllByText((_, node) => {
       const text = node?.textContent ?? '';
-      return text.includes('yarn add expo') && node.tagName.toLowerCase() === 'code';
+      return !!(text.includes('yarn add expo') && node?.tagName.toLowerCase() === 'code');
     })[0];
     expect(yarnLine).toBeVisible();
 

--- a/docs/ui/components/Snippet/Terminal.test.tsx
+++ b/docs/ui/components/Snippet/Terminal.test.tsx
@@ -60,6 +60,39 @@ describe(Terminal, () => {
     expect(screen.queryByText('Copy')).toBe(null);
   });
 
+  it('renders package manager tabs and switches commands with correct copy', async () => {
+    render(
+      <>
+        <Terminal
+          packageManagers={{
+            npm: ['$ npm install expo'],
+            yarn: ['$ yarn add expo'],
+            pnpm: ['$ pnpm add expo'],
+            bun: ['$ bun add expo'],
+          }}
+          cmd={['$ npm install fallback']}
+        />
+        <textarea />
+      </>
+    );
+
+    const user = userEvent.setup();
+
+    expect(screen.getByRole('tab', { name: /^npm$/i })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByText(/npm install expo/)).toBeVisible();
+
+    await user.click(screen.getByRole('tab', { name: /^yarn$/i }));
+    expect(screen.getByRole('tab', { name: /^yarn$/i })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.queryByText(/npm install expo/)).toBeNull();
+    expect(screen.getByText(/yarn add expo/)).toBeVisible();
+
+    await user.click(screen.getByText('Copy'));
+    await user.click(screen.getByRole('textbox'));
+    await user.paste();
+
+    expect(screen.getByRole<HTMLTextAreaElement>('textbox').value).toBe('yarn add expo');
+  });
+
   it('renders browser action when provided', async () => {
     const originalWindowOpen = window.open;
     const openMock = jest.fn();

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -18,7 +18,7 @@ type PackageManagerKey = 'npm' | 'yarn' | 'pnpm' | 'bun';
 type PackageManagerCommandSet = Partial<Record<PackageManagerKey, string[]>>;
 
 type TerminalProps = {
-  cmd: string[];
+  cmd: string[] | PackageManagerCommandSet;
   cmdCopy?: string;
   hideOverflow?: boolean;
   title?: string;
@@ -27,10 +27,12 @@ type TerminalProps = {
     href: string;
     label: string;
   };
-  packageManagers?: PackageManagerCommandSet;
 };
 
-type CopyButtonProps = Pick<TerminalProps, 'cmd' | 'cmdCopy'>;
+type CopyButtonProps = {
+  cmd: string[];
+  cmdCopy?: string;
+};
 
 type BrowserActionProps = NonNullable<TerminalProps['browserAction']>;
 
@@ -54,9 +56,9 @@ const STORAGE_KEY = 'expo-docs-terminal-package-manager';
 const PACKAGE_MANAGER_ORDER: PackageManagerKey[] = ['npm', 'yarn', 'pnpm', 'bun'];
 const PACKAGE_MANAGER_LABELS: Record<PackageManagerKey, string> = {
   npm: 'npm',
-  yarn: 'Yarn',
+  yarn: 'yarn',
   pnpm: 'pnpm',
-  bun: 'Bun',
+  bun: 'bun',
 };
 
 export const Terminal = ({
@@ -66,10 +68,10 @@ export const Terminal = ({
   className,
   title = 'Terminal',
   browserAction,
-  packageManagers,
 }: TerminalProps) => {
+  const [fallbackCmd, packageManagers] = Array.isArray(cmd) ? [cmd, undefined] : [[], cmd];
   const { availableManagers, activeManager, activeCmd, shouldShowPackageTabs, setActiveManager } =
-    usePackageManagerState(packageManagers, cmd);
+    usePackageManagerState(packageManagers, fallbackCmd);
   const isMobileView = useIsMobileView();
 
   return (
@@ -105,7 +107,7 @@ export const Terminal = ({
  * This method attempts to naively generate the basic cmdCopy from the given cmd list.
  * Currently, the implementation is simple, but we can add multiline support in the future.
  */
-function getDefaultCmdCopy(cmd: TerminalProps['cmd']) {
+function getDefaultCmdCopy(cmd: string[]) {
   const validLines = cmd.filter(line => !line.startsWith('#') && line !== '');
   if (validLines.length === 1) {
     return validLines[0].startsWith('$') ? validLines[0].slice(2) : validLines[0];
@@ -197,7 +199,7 @@ const PackageTabs = ({ managers, activeManager, onSelect, className }: PackageTa
             'rounded-md px-2 py-1 text-xs font-semibold transition-colors',
             isActive
               ? 'bg-palette-gray6 text-palette-white'
-              : 'text-palette-gray9 hover:text-palette-white focus-visible:text-palette-white'
+              : 'text-palette-gray9 hocus:bg-palette-gray5'
           )}
           onClick={() => {
             onSelect(manager);

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -73,25 +73,32 @@ export const Terminal = ({
   const { availableManagers, activeManager, activeCmd, shouldShowPackageTabs, setActiveManager } =
     usePackageManagerState(packageManagers, fallbackCmd);
   const isMobileView = useIsMobileView();
+  const packageManagerSlot = shouldShowPackageTabs ? (
+    isMobileView ? (
+      <PackageSelect
+        managers={availableManagers}
+        activeManager={activeManager}
+        onSelect={setActiveManager}
+        className="ml-4"
+      />
+    ) : (
+      <PackageTabs
+        managers={availableManagers}
+        activeManager={activeManager}
+        onSelect={setActiveManager}
+        className="ml-6"
+      />
+    )
+  ) : null;
 
   return (
     <Snippet className={mergeClasses('terminal-snippet [li_&]:mt-4', className)}>
-      <SnippetHeader alwaysDark title={title} Icon={TerminalSquareIcon}>
+      <SnippetHeader
+        alwaysDark
+        title={title}
+        titleSlot={packageManagerSlot}
+        Icon={TerminalSquareIcon}>
         <div className="flex items-center gap-2">
-          {shouldShowPackageTabs &&
-            (isMobileView ? (
-              <PackageSelect
-                managers={availableManagers}
-                activeManager={activeManager}
-                onSelect={setActiveManager}
-              />
-            ) : (
-              <PackageTabs
-                managers={availableManagers}
-                activeManager={activeManager}
-                onSelect={setActiveManager}
-              />
-            ))}
           {browserAction && <BrowserAction {...browserAction} />}
           <CopyButton cmd={activeCmd} cmdCopy={cmdCopy} />
         </div>
@@ -183,10 +190,10 @@ function usePackageManagerState(
  * @returns
  */
 const PackageTabs = ({ managers, activeManager, onSelect, className }: PackageTabsProps) => (
-  <div
+  <span
     role="tablist"
     aria-label="Package managers"
-    className={mergeClasses('flex items-center gap-1 whitespace-nowrap', className)}>
+    className={mergeClasses('inline-flex items-center gap-1 whitespace-nowrap', className)}>
     {managers.map(manager => {
       const isActive = manager === activeManager;
       return (
@@ -208,7 +215,7 @@ const PackageTabs = ({ managers, activeManager, onSelect, className }: PackageTa
         </button>
       );
     })}
-  </div>
+  </span>
 );
 
 const PackageSelect = ({ managers, activeManager, onSelect, className }: PackageTabsProps) => (

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -2,14 +2,20 @@ import { mergeClasses } from '@expo/styleguide';
 import { ArrowUpRightIcon } from '@expo/styleguide-icons/outline/ArrowUpRightIcon';
 import { TerminalSquareIcon } from '@expo/styleguide-icons/outline/TerminalSquareIcon';
 import { Language, Prism } from 'prism-react-renderer';
+import { useEffect, useMemo, useState } from 'react';
 
 import { CODE } from '~/ui/components/Text';
+import { useIsMobileView } from '~/ui/components/utils/isMobileView';
 
+import { Select } from '../../Select';
 import { Snippet } from '../Snippet';
 import { SnippetAction } from '../SnippetAction';
 import { SnippetContent } from '../SnippetContent';
 import { SnippetHeader } from '../SnippetHeader';
 import { CopyAction } from '../actions/CopyAction';
+
+type PackageManagerKey = 'npm' | 'yarn' | 'pnpm' | 'bun';
+type PackageManagerCommandSet = Partial<Record<PackageManagerKey, string[]>>;
 
 type TerminalProps = {
   cmd: string[];
@@ -21,11 +27,37 @@ type TerminalProps = {
     href: string;
     label: string;
   };
+  packageManagers?: PackageManagerCommandSet;
 };
 
 type CopyButtonProps = Pick<TerminalProps, 'cmd' | 'cmdCopy'>;
 
 type BrowserActionProps = NonNullable<TerminalProps['browserAction']>;
+
+type PackageTabsProps = {
+  managers: PackageManagerKey[];
+  activeManager: PackageManagerKey | null;
+  onSelect: (manager: PackageManagerKey) => void;
+  className?: string;
+};
+
+type PackageManagerState = {
+  availableManagers: PackageManagerKey[];
+  activeManager: PackageManagerKey | null;
+  activeCmd: string[];
+  shouldShowPackageTabs: boolean;
+  setActiveManager: (manager: PackageManagerKey) => void;
+};
+
+const STORAGE_KEY = 'expo-docs-terminal-package-manager';
+
+const PACKAGE_MANAGER_ORDER: PackageManagerKey[] = ['npm', 'yarn', 'pnpm', 'bun'];
+const PACKAGE_MANAGER_LABELS: Record<PackageManagerKey, string> = {
+  npm: 'npm',
+  yarn: 'Yarn',
+  pnpm: 'pnpm',
+  bun: 'Bun',
+};
 
 export const Terminal = ({
   cmd,
@@ -34,17 +66,40 @@ export const Terminal = ({
   className,
   title = 'Terminal',
   browserAction,
-}: TerminalProps) => (
-  <Snippet className={mergeClasses('terminal-snippet [li_&]:mt-4', className)}>
-    <SnippetHeader alwaysDark title={title} Icon={TerminalSquareIcon}>
-      {browserAction && <BrowserAction {...browserAction} />}
-      <CopyButton cmd={cmd} cmdCopy={cmdCopy} />
-    </SnippetHeader>
-    <SnippetContent alwaysDark hideOverflow={hideOverflow} className="flex flex-col">
-      {cmd.map(cmdMapper)}
-    </SnippetContent>
-  </Snippet>
-);
+  packageManagers,
+}: TerminalProps) => {
+  const { availableManagers, activeManager, activeCmd, shouldShowPackageTabs, setActiveManager } =
+    usePackageManagerState(packageManagers, cmd);
+  const isMobileView = useIsMobileView();
+
+  return (
+    <Snippet className={mergeClasses('terminal-snippet [li_&]:mt-4', className)}>
+      <SnippetHeader alwaysDark title={title} Icon={TerminalSquareIcon}>
+        <div className="flex items-center gap-2">
+          {shouldShowPackageTabs &&
+            (isMobileView ? (
+              <PackageSelect
+                managers={availableManagers}
+                activeManager={activeManager}
+                onSelect={setActiveManager}
+              />
+            ) : (
+              <PackageTabs
+                managers={availableManagers}
+                activeManager={activeManager}
+                onSelect={setActiveManager}
+              />
+            ))}
+          {browserAction && <BrowserAction {...browserAction} />}
+          <CopyButton cmd={activeCmd} cmdCopy={cmdCopy} />
+        </div>
+      </SnippetHeader>
+      <SnippetContent alwaysDark hideOverflow={hideOverflow} className="flex flex-col">
+        {activeCmd.map(cmdMapper)}
+      </SnippetContent>
+    </Snippet>
+  );
+};
 
 /**
  * This method attempts to naively generate the basic cmdCopy from the given cmd list.
@@ -67,6 +122,109 @@ const CopyButton = ({ cmd, cmdCopy }: CopyButtonProps) => {
 
   return <CopyAction alwaysDark text={copyText} />;
 };
+
+/**
+ * Manages the state for the package manager tabs.
+ */
+function usePackageManagerState(
+  packageManagers: PackageManagerCommandSet | undefined,
+  fallbackCmd: string[]
+): PackageManagerState {
+  const availableManagers = useMemo(
+    () => PACKAGE_MANAGER_ORDER.filter(manager => packageManagers?.[manager]?.length),
+    [packageManagers]
+  );
+
+  const [activeManager, setActiveManager] = useState<PackageManagerKey | null>(() => {
+    if (typeof window === 'undefined') {
+      return availableManagers[0] ?? null;
+    }
+    const stored = window.localStorage.getItem(STORAGE_KEY) as PackageManagerKey | null;
+    if (stored && availableManagers.includes(stored)) {
+      return stored;
+    }
+    return availableManagers[0] ?? null;
+  });
+
+  useEffect(() => {
+    const shouldReset = !activeManager || !availableManagers.includes(activeManager);
+    setActiveManager(
+      availableManagers.length > 0 ? (shouldReset ? availableManagers[0] : activeManager) : null
+    );
+  }, [activeManager, availableManagers]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    if (activeManager) {
+      window.localStorage.setItem(STORAGE_KEY, activeManager);
+    }
+  }, [activeManager]);
+
+  const shouldShowPackageTabs = availableManagers.length > 0;
+  const activeCmd = useMemo(() => {
+    if (shouldShowPackageTabs && activeManager && packageManagers?.[activeManager]) {
+      return packageManagers[activeManager] ?? fallbackCmd;
+    }
+    return fallbackCmd;
+  }, [activeManager, fallbackCmd, packageManagers, shouldShowPackageTabs]);
+
+  return { availableManagers, activeManager, activeCmd, shouldShowPackageTabs, setActiveManager };
+}
+
+/**
+ *
+ * @param managers - The available package managers.
+ * @param activeManager - The currently active package manager.
+ * @param onSelect - The function to call when a package manager is selected.
+ * @returns
+ */
+const PackageTabs = ({ managers, activeManager, onSelect, className }: PackageTabsProps) => (
+  <div
+    role="tablist"
+    aria-label="Package managers"
+    className={mergeClasses('flex items-center gap-1 whitespace-nowrap', className)}>
+    {managers.map(manager => {
+      const isActive = manager === activeManager;
+      return (
+        <button
+          key={manager}
+          type="button"
+          role="tab"
+          aria-selected={isActive}
+          className={mergeClasses(
+            'rounded-md px-2 py-1 text-xs font-semibold transition-colors',
+            isActive
+              ? 'bg-palette-gray6 text-palette-white'
+              : 'text-palette-gray9 hover:text-palette-white focus-visible:text-palette-white'
+          )}
+          onClick={() => {
+            onSelect(manager);
+          }}>
+          {PACKAGE_MANAGER_LABELS[manager]}
+        </button>
+      );
+    })}
+  </div>
+);
+
+const PackageSelect = ({ managers, activeManager, onSelect, className }: PackageTabsProps) => (
+  <Select
+    className={mergeClasses(
+      '!h-6 !min-h-[16px] min-w-[76px] !gap-1 !px-2 !py-0 text-xs [&_svg]:!h-3 [&_svg]:!w-3',
+      className
+    )}
+    ariaLabel="Select package manager"
+    value={activeManager ?? managers[0]}
+    onValueChange={onSelect as (value: string) => void}
+    options={managers.map(manager => ({
+      id: manager,
+      label: PACKAGE_MANAGER_LABELS[manager],
+    }))}
+    size="md"
+  />
+);
 
 const BrowserAction = ({ href, label }: BrowserActionProps) => (
   <SnippetAction

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -54,13 +54,6 @@ type PackageManagerState = {
 const STORAGE_KEY = 'expo-docs-terminal-package-manager';
 
 const PACKAGE_MANAGER_ORDER: PackageManagerKey[] = ['npm', 'yarn', 'pnpm', 'bun'];
-const PACKAGE_MANAGER_LABELS: Record<PackageManagerKey, string> = {
-  npm: 'npm',
-  yarn: 'yarn',
-  pnpm: 'pnpm',
-  bun: 'bun',
-};
-
 export const Terminal = ({
   cmd,
   cmdCopy,
@@ -211,7 +204,7 @@ const PackageTabs = ({ managers, activeManager, onSelect, className }: PackageTa
           onClick={() => {
             onSelect(manager);
           }}>
-          {PACKAGE_MANAGER_LABELS[manager]}
+          {manager}
         </button>
       );
     })}
@@ -229,7 +222,7 @@ const PackageSelect = ({ managers, activeManager, onSelect, className }: Package
     onValueChange={onSelect as (value: string) => void}
     options={managers.map(manager => ({
       id: manager,
-      label: PACKAGE_MANAGER_LABELS[manager],
+      label: manager,
     }))}
     size="md"
   />

--- a/docs/ui/components/utils/isMobileView.ts
+++ b/docs/ui/components/utils/isMobileView.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+const MOBILE_MEDIA_QUERY = '(max-width: 640px)';
+
+export function useIsMobileView() {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia(MOBILE_MEDIA_QUERY);
+    const update = (event: MediaQueryListEvent | MediaQueryList) => {
+      setIsMobile(event.matches);
+    };
+
+    update(mediaQuery);
+    mediaQuery.addEventListener('change', update);
+
+    return () => {
+      mediaQuery.removeEventListener('change', update);
+    };
+  }, []);
+
+  return isMobile;
+}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18539 ENG-10173

**Proposal:**. Currently, we use external tab components (`Tabs`) to add support for multiple package managers for given command inside a doc. This PR proposes to inline the package managers for both desktop and mobile view, within the `Terminal` component, so we don't have to use and maintain external `Tabs` in `.mdx` files.

This PR also proposes to add a local storage solution so that when the reader selects a package manager, that value is used in other documents as well, where support for multiple package manager commands is available.

# How

<!--
How did you build this feature or fix this bug and why?
-->

In `Terminal.tsx`, added localStorage-backed persistence for the active package manager, refined the mobile dropdown sizing via class overrides, and fixed copy text generation for multi-line commands. Introduced a shared `useIsMobileView` hook in `isMobileView.ts` and switched `Terminal` to use it.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Example usage in `.mdx` files:

```mdx
<Terminal
  packageManagers={{
    npm: ['$ npx create-expo-app@latest'],
    yarn: ['$ yarn create expo-app'],
    pnpm: ['$ pnpm create expo-app'],
    bun: ['$ bun create expo'],
  }}
/>
```

## Preview

### Usage on desktop


https://github.com/user-attachments/assets/f4133e90-a817-4f48-8774-36336b1499a4

### Usage on mobile view


https://github.com/user-attachments/assets/0ef89323-6bc3-4ff1-80cd-29a5de22dcd7

### Local storage persistence for multiple pages



https://github.com/user-attachments/assets/d37e5672-9a22-4114-a5ae-a7b5d0fc2110





# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
