### PR TITLE
[docs] Remove invalid param from submit docs and add profile param instead.

### DIFF
--- a/docs/pages/submit/android.mdx
+++ b/docs/pages/submit/android.mdx
@@ -175,7 +175,7 @@ You can use [EAS Workflows](/eas-workflows/get-started/) to build and submit you
        needs: [build_android]
        type: submit
        params:
-         platform: android
+         profile: production
          build_id: ${{ needs.build_android.outputs.build_id }}
      # @end #
    ```


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR fixes an issue in the documentation for the **`submit_android` job in workflow** on the [Submit to Google Play Store - Expo docs](https://docs.expo.dev/submit/android/#use-eas-workflows-cicd).

In the provided [example workflow](https://docs.expo.dev/submit/android/#use-eas-workflows-cicd), the `params` section under the `submit_android` job includes an **invalid parameter**.

According to the
[`eas-workflow` schema](https://raw.githubusercontent.com/expo/vscode-expo/schemas/schema/eas-workflow.json), `platform` is **not a recognized parameter**. This PR updates the example by replacing `platform` with the correct `profile` parameter.

# How

<!--
How did you build this feature or fix this bug and why?
-->
- Updated the documentation to correct the example workflow so developers don’t waste time debugging an issue caused by an incorrect sample configuration.

# Test Plan
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

1. Run the docs locally and navigate to `/submit/android/#use-eas-workflows-cicd`.
2. Verify that the `submit_android` job now shows **valid parameters** under the `params` section.
3. Cross-check the parameters against the official
   [`eas-workflow` schema](https://raw.githubusercontent.com/expo/vscode-expo/schemas/schema/eas-workflow.json) to confirm correctness.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
