### PR TITLE
[docs] Fix typo in summary of EAS Tutorial chapter 5 summary

### DIFF
--- a/docs/pages/tutorial/eas/multiple-app-variants.mdx
+++ b/docs/pages/tutorial/eas/multiple-app-variants.mdx
@@ -204,9 +204,9 @@ You can now continue using **app.json** for static values and use **app.config.j
   summary={
     <>
       We successfully created <strong>app.config.js</strong> just for our dynamic configuration
-      while leaving static configuration in **app.json** unchanged, added environment variables in{' '}
-      <strong>eas.json</strong> to configure specific build profile, and learned how to start the
-      development server with a custom <strong>package.json</strong> script.
+      while leaving static configuration in <strong>app.json</strong> unchanged, added environment
+      variables in <strong>eas.json</strong> to configure specific build profile, and learned how to
+      start the development server with a custom <strong>package.json</strong> script.
     </>
   }
   nextChapterDescription="In the next chapter, learn about what are internal distribution builds, why we need them, and how to create them."


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
<img width="2824" height="1166" alt="CleanShot 2025-12-26 at 15 14 31@2x" src="https://github.com/user-attachments/assets/53f784a7-aed6-4c9b-9733-fa5820863c3d" />

# How

<!--
How did you build this feature or fix this bug and why?
-->

Using `strong` element for file name.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

<img width="670" height="419" alt="CleanShot 2025-12-26 at 15 15 41" src="https://github.com/user-attachments/assets/7b62c4fc-b1f9-471c-8408-dae6f91993ca" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
