### PR TITLE
[docs] Fix callout in create-expo-app reference

### DIFF
--- a/docs/pages/more/create-expo.mdx
+++ b/docs/pages/more/create-expo.mdx
@@ -156,7 +156,7 @@ By default, a project created with `create-expo-app` and pnpm uses [`node-linker
 node-linker=hoisted
 ```
 
-> **info** From **SDK 54**, Expo supports isolated installations, and you can delete the `node-linker` setting if you prefer to use isolated dependencies.
+> **info** In **SDK 54** and later, Expo supports isolated installations, and you can delete the `node-linker` setting if you prefer to use isolated dependencies.
 
 #### EAS installation
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

<img width="2482" height="900" alt="sdk 54 or later" src="https://github.com/user-attachments/assets/1fa000f8-b816-4f7a-9553-dc1a9aedf6c9" />

# How

<!--
How did you build this feature or fix this bug and why?
-->

Applies writing styleguide format in the callout.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
