### PR TITLE
[docs] Fix instructions for adopting top-level src directory

### DIFF
--- a/docs/pages/router/reference/src-directory.mdx
+++ b/docs/pages/router/reference/src-directory.mdx
@@ -1,19 +1,47 @@
 ---
 title: Top-level src directory
 description: Learn how to use a top-level src directory in your Expo Router project.
-hideTOC: true
 ---
 
 import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
 
 As your project grows, it can be helpful to move all the directories containing application code into a single **src** directory. Expo Router supports this out of the box.
+
+## Using a top-level src directory
+
+<Step label="1">
+
+Move your **app** directory to **src/app**.
 
 <FileTree
   files={['src/app/_layout.tsx', 'src/app/index.tsx', 'src/components/button.tsx', 'package.json']}
 />
 
-Simply move your **app** directory to **src/app** and restart the development server.
+</Step>
+
+<Step label="2">
+
+Update [TypeScript path aliases](/guides/typescript#path-aliases) in the **tsconfig.json** file to point to the **src** directory instead of the root directory. If you use the default `@/*` alias, set it to **./src/\***:
+
+```json tsconfig.json
+{
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}
+```
+
+This keeps `@/` imports working after moving your app directory into **src**.
+
+</Step>
+
+<Step label="3">
+
+Restart your development server.
 
 {/* prettier-ignore */}
 <Terminal cmd={[
@@ -23,7 +51,9 @@ Simply move your **app** directory to **src/app** and restart the development se
   '$ npx expo export'
 ]} />
 
-**Notes**:
+</Step>
+
+### Notes
 
 - The config files (**app.config.ts**, **app.json**, **package.json**, **metro.config.js**, **tsconfig.json**) should remain in the root directory.
 - The **src/app** directory takes higher precedence than the root **app** directory. Only the **src/app** directory will be used if you have both.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Instructions on https://docs.expo.dev/router/reference/src-directory/ are missing a curical step to update **tsconfig.json** file to support `@/src/...`.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Fix instructions for adopting the top-level src directory guide.
- Also, divide the guide into relevant sections, use `Step` for step-by-step instructions, and disable `hideTOC`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Proofread diff or run the docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
