### PR TITLE
[ui][iOS] - fix iOS list selectable + screen examples

### DIFF
--- a/apps/native-component-list/src/screens/UI/ListScreen.ios.tsx
+++ b/apps/native-component-list/src/screens/UI/ListScreen.ios.tsx
@@ -9,8 +9,8 @@ import {
   type ListStyle,
   Picker,
   Section,
-  Switch,
   Text,
+  Toggle,
 } from '@expo/ui/swift-ui';
 import {
   background,
@@ -85,7 +85,7 @@ export default function ListScreen() {
     <Host style={{ flex: 1 }}>
       <List
         editModeEnabled={editModeEnabled}
-        onSelectionChange={(items) => alert(`indexes of selected items: ${items.join(', ')}`)}
+        onSelectionChange={(items) => alert(`Tag of selected items: ${items.join(', ')}`)}
         moveEnabled={moveEnabled}
         onMoveItem={(from, to) => alert(`moved item at index ${from} to index ${to}`)}
         onDeleteItem={(item) => alert(`deleted item at index: ${item}`)}
@@ -133,33 +133,56 @@ export default function ListScreen() {
               )}
             </>
           }>
-          <Switch
+          <Toggle
+            modifiers={[tag('increasedHeader')]}
             label="Use increased section header"
-            value={increasedHeader}
-            onValueChange={setIncreasedHeader}
+            isOn={increasedHeader}
+            onIsOnChange={setIncreasedHeader}
           />
-          <Switch label="Collapsible" value={collapsible} onValueChange={setCollapsible} />
-          <Switch
+          <Toggle
+            modifiers={[tag('collapsible')]}
+            label="Collapsible"
+            isOn={collapsible}
+            onIsOnChange={setCollapsible}
+          />
+          <Toggle
+            modifiers={[tag('customHeaderFooter')]}
             label="Custom header"
-            value={customHeaderFooter.header}
-            onValueChange={(v) => setCustomHeaderFooter((prev) => ({ ...prev, header: v }))}
+            isOn={customHeaderFooter.header}
+            onIsOnChange={(v) => setCustomHeaderFooter((prev) => ({ ...prev, header: v }))}
           />
-          <Switch
+          <Toggle
             label="Custom footer"
-            value={customHeaderFooter.footer}
-            onValueChange={(v) => setCustomHeaderFooter((prev) => ({ ...prev, footer: v }))}
-            modifiers={[disabled(collapsible)]}
+            isOn={customHeaderFooter.footer}
+            onIsOnChange={(v) => setCustomHeaderFooter((prev) => ({ ...prev, footer: v }))}
+            modifiers={[disabled(collapsible), tag('customFooter')]}
           />
         </Section>
         <Section title="Controls" collapsible>
           <Button onPress={() => setEditModeEnabled(!editModeEnabled)} label="Toggle Edit" />
-          <Switch value={selectEnabled} label="Select enabled" onValueChange={setSelectEnabled} />
-          <Switch value={deleteEnabled} label="Delete enabled" onValueChange={setDeleteEnabled} />
-          <Switch value={moveEnabled} label="Move enabled" onValueChange={setMoveEnabled} />
-          <Switch
-            value={refreshEnabled}
+          <Toggle
+            modifiers={[tag('selectEnabled')]}
+            isOn={selectEnabled}
+            label="Select enabled"
+            onIsOnChange={setSelectEnabled}
+          />
+          <Toggle
+            modifiers={[tag('deleteEnabled')]}
+            isOn={deleteEnabled}
+            label="Delete enabled"
+            onIsOnChange={setDeleteEnabled}
+          />
+          <Toggle
+            modifiers={[tag('moveEnabled')]}
+            isOn={moveEnabled}
+            label="Move enabled"
+            onIsOnChange={setMoveEnabled}
+          />
+          <Toggle
+            modifiers={[tag('refreshEnabled')]}
+            isOn={refreshEnabled}
             label="Refreshable enabled"
-            onValueChange={setRefreshEnabled}
+            onIsOnChange={setRefreshEnabled}
           />
           {lastRefresh && (
             <Text size={12} color="gray">
@@ -167,6 +190,7 @@ export default function ListScreen() {
             </Text>
           )}
           <ColorPicker
+            modifiers={[tag('itemIconColor')]}
             label="Item icon color"
             selection={color}
             supportsOpacity
@@ -174,7 +198,7 @@ export default function ListScreen() {
           />
           <Picker
             label="Scroll dismisses keyboard"
-            modifiers={[pickerStyle('menu')]}
+            modifiers={[pickerStyle('menu'), tag('scrollDismissesKeyboard')]}
             selection={scrollDismissesKeyboardIndex}
             onSelectionChange={setScrollDismissesKeyboardIndex}>
             {scrollDismissesKeyboardOptions.map((option, index) => (
@@ -185,7 +209,7 @@ export default function ListScreen() {
           </Picker>
           <Picker
             label="List style"
-            modifiers={[pickerStyle('menu')]}
+            modifiers={[pickerStyle('menu'), tag('listStyle')]}
             selection={selectedIndex}
             onSelectionChange={setSelectedIndex}>
             {listStyleOptions.map((option, index) => (
@@ -197,6 +221,7 @@ export default function ListScreen() {
         </Section>
         <Section title="Data">
           <Label
+            modifiers={[tag('labelWithCustomIcon')]}
             icon={
               <Image
                 systemName="sun.max.fill"
@@ -216,7 +241,7 @@ export default function ListScreen() {
           {data.map((item, index) => (
             <Label
               key={index}
-              modifiers={[frame({ height: 24 }), foregroundStyle(color)]}
+              modifiers={[frame({ height: 24 }), foregroundStyle(color), tag(item.text)]}
               title={item.text}
               systemImage={item.systemImage}
             />

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix seletable elements in List. ([#41840](https://github.com/expo/expo/pull/41840) by [@remyr](https://github.com/remyr))
+
 ### 💡 Others
 
 - [jetpack-compose] Replaced `DynamicTheme` as `Host.colorScheme` prop. ([#41413](https://github.com/expo/expo/pull/41413) by [@kudo](https://github.com/kudo))


### PR DESCRIPTION
# Why

- Selectable list are not working in iOS.
- Using old `Switch` component in `native-component-list` list example

# How

- Use `Toggle` component instead of `Switch` component in the iOS List showcase screen.
- To have a list entry selectable, the component should have a `tag` modifier. The `tag` modifier accepts a `Set` of type `AnyHashable`. The problem is that the `List` accepts only a `Set` of `Int`. There is a miss-match of types therefore, no item on the list can be selected. I change the type in the `List` to accept a `Set` of `AnyHashable`, now components accepts the same type and selection works.
- I added a tag to all items in the list to make them selectable.

# Test Plan

I tested it with the `native-component-list` demo application.

| Before | After |
| ------ | ----- |
| <img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/b819884b-2517-437d-a1a2-b306229c9723" /> | <img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/3ec5c5da-e083-40ae-b848-f381f13e7e0d" /> |
| <video src="https://github.com/user-attachments/assets/adc616a1-c422-4c3f-99d1-265a04271956" />  | <video src="https://github.com/user-attachments/assets/0e88ae06-96ae-4169-b223-e430c0ed5b65" /> |

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
