### PR TITLE
[ios][precompiled][spm] fix a few minor swift issue

### DIFF
--- a/packages/@expo/dom-webview/ios/DomWebView.swift
+++ b/packages/@expo/dom-webview/ios/DomWebView.swift
@@ -1,5 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import React
 import ExpoModulesCore
 import WebKit
 

--- a/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
@@ -1,4 +1,5 @@
 import Foundation
+import React
 import ExpoModulesCore
 
 public protocol ScreenOrientationController: AnyObject {

--- a/packages/expo/ios/Fetch/ExpoFetchCustomExtension.swift
+++ b/packages/expo/ios/Fetch/ExpoFetchCustomExtension.swift
@@ -1,4 +1,5 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
+import ExpoModulesCore
 
 /**
  For callsites to customize network fetch functionalities like having custom `URLSessionConfiguration`.
@@ -6,7 +7,8 @@
 @objc(EXFetchCustomExtension)
 public class ExpoFetchCustomExtension: NSObject {
   @MainActor @objc
-  public static func setCustomURLSessionConfigurationProvider(_ provider: NSURLSessionConfigurationProvider?) {
+  public static func setCustomURLSessionConfigurationProvider(_ provider: URLSessionConfigurationProvider?) {
+
     urlSessionConfigurationProvider = provider
   }
 }

--- a/packages/expo/ios/Fetch/ExpoFetchModule.swift
+++ b/packages/expo/ios/Fetch/ExpoFetchModule.swift
@@ -2,8 +2,12 @@
 
 @preconcurrency import ExpoModulesCore
 
+/// Typealias matching React Native's NSURLSessionConfigurationProvider block type
+public typealias URLSessionConfigurationProvider = @convention(block) () -> URLSessionConfiguration?
+
+
 private let fetchRequestQueue = DispatchQueue(label: "expo.modules.fetch.RequestQueue")
-nonisolated(unsafe) internal var urlSessionConfigurationProvider: NSURLSessionConfigurationProvider?
+nonisolated(unsafe) internal var urlSessionConfigurationProvider: URLSessionConfigurationProvider?
 
 public final class ExpoFetchModule: Module {
   private lazy var urlSession = createURLSession()


### PR DESCRIPTION
# Why

This is a PR with a few required changed to swift code in Expo packages to make sure SPM can build Expo packages.

This PR adds a few missing imports and redeclares an imported React type when building EMC as an XCFramework.

- Added missing module imports (React, ExpoModulesCore)
- Redeclared the URLSessionConfigurationProvider type to avoid having to re-export NSURLSessionConfigurationProvider from React