### PR TITLE
[ios][precompile][spm] add support for new xcframework infra in Cocoapods

### DIFF
--- a/packages/expo-font/ios/ExpoFont.podspec
+++ b/packages/expo-font/ios/ExpoFont.podspec
@@ -17,14 +17,15 @@ Pod::Spec.new do |s|
   }
   s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
-  s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
 
-  # Swift/Objective-C compatibility
-  s.pod_target_xcconfig = {
-    'DEFINES_MODULE' => 'YES'
-  }
-
-  s.source_files = "**/*.{h,m,swift}"
+  if (!Expo::PackagesConfig.instance.try_link_with_prebuilt_xcframework(s))
+    s.static_framework = true
+    s.source_files = "**/*.{h,m,swift}"
+    # Swift/Objective-C compatibility
+    s.pod_target_xcconfig = {
+      'DEFINES_MODULE' => 'YES'
+    }
+  end
 end

--- a/packages/expo-modules-autolinking/scripts/ios/packages_config.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/packages_config.rb
@@ -5,11 +5,42 @@ module Expo
   # It is a singleton class, so it can be accessed from anywhere in the project.
   class PackagesConfig
     include Singleton
-    
+
     attr_accessor :coreFeatures
-    
+
     def initialize
       @coreFeatures = []
     end
+
+
+    # Tries to link with prebuilt framework found in the `.xcframeworks` folder.
+    # Returns false if no prebuilt framework is found for any of the packages.
+    # Arguments:
+    #  spec: Pod::Spec - The podspec of the package to link.
+    #
+    #  Examples:
+    #  try_link_with_prebuilt_xcframework(spec) - Looks for the prebuilt framework in `.xcframeworks/debug/PackageName.xcframework`
+    #
+    def try_link_with_prebuilt_xcframework(spec)
+      # TODO: Add support for switching between debug/release builds (now only uses debug build)
+      #         See React Native's implementation for reference:
+      #         https://github.com/facebook/react-native/blob/9731e8ebc5ea87526a91b9903172639e062cd920/packages/react-native/third-party-podspecs/replace_dependencies_version.js
+      # TODO: Add support for selecting wether symbol bundles should be included (Now they are included by default)
+      # TODO: Add support for configuring which packages that should be used as prebuilt frameworks, typically used when you patch
+      #         a specific package and want to build it from source (See how Android is doing this)
+      should_use_prebuilt = ENV['EXPO_USE_PRECOMPILED_MODULES'] == '1'
+      if (should_use_prebuilt)
+        xcframework_path = ".xcframeworks/debug/#{spec.name}.xcframework"
+        framework_exists = File.exist?("#{xcframework_path}")
+        Pod::UI.info "#{"[Expo-precompiled]:".blue} 📦 #{spec.name.green} #{!framework_exists ? "(❌ Build from source: framework not found #{xcframework_path})" : ""}"
+        if framework_exists
+          spec.vendored_frameworks = xcframework_path
+          return true
+        end
+
+      end
+      return false
+    end
+
   end
 end

--- a/packages/expo-modules-core/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ExpoModulesCore.podspec
@@ -85,8 +85,6 @@ Pod::Spec.new do |s|
   }
   s.swift_version  = '6.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }
-  s.static_framework = true
-  s.header_dir     = 'ExpoModulesCore'
 
   header_search_paths = []
   if ENV['USE_FRAMEWORKS']
@@ -146,8 +144,6 @@ Pod::Spec.new do |s|
     s.dependency 'React-jsc'
   end
 
-  s.dependency 'ExpoModulesJSI'
-
   s.dependency 'React-Core'
   s.dependency 'ReactCommon/turbomodule/core'
   s.dependency 'React-NativeModulesApple'
@@ -159,10 +155,15 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s)
 
-  s.source_files = 'ios/**/*.{h,m,mm,swift,cpp}', 'common/cpp/**/*.{h,cpp}'
-  s.exclude_files = ['ios/JSI', 'ios/Tests', 'common/cpp/JSI']
-  s.compiler_flags = compiler_flags
-  s.private_header_files = ['ios/**/*+Private.h', 'ios/**/Swift.h']
+  if (!Expo::PackagesConfig.instance.try_link_with_prebuilt_xcframework(s))
+    s.dependency 'ExpoModulesJSI'
+    s.static_framework = true
+    s.header_dir     = 'ExpoModulesCore'
+    s.source_files = 'ios/**/*.{h,m,mm,swift,cpp}', 'common/cpp/**/*.{h,cpp}'
+    s.exclude_files = ['ios/JSI', 'ios/Tests', 'common/cpp/JSI']
+    s.compiler_flags = compiler_flags
+    s.private_header_files = ['ios/**/*+Private.h', 'ios/**/Swift.h']
+  end
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.dependency 'ExpoModulesTestCore'

--- a/packages/expo-modules-core/ExpoModulesJSI.podspec
+++ b/packages/expo-modules-core/ExpoModulesJSI.podspec
@@ -17,35 +17,9 @@ Pod::Spec.new do |s|
     :osx => '11.0',
     :tvos => '15.1'
   }
-  s.swift_version  = '6.0'
-  s.source         = { git: 'https://github.com/expo/expo.git' }
+  s.swift_version    = '6.0'
+  s.source           = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
-  s.header_dir     = 'ExpoModulesJSI'
-
-  header_search_paths = []
-  if ENV['USE_FRAMEWORKS']
-    header_search_paths.concat([
-      # Transitive dependency of React-Core
-      '"${PODS_CONFIGURATION_BUILD_DIR}/React-jsinspectortracing/jsinspector_moderntracing.framework/Headers"',
-      '"${PODS_CONFIGURATION_BUILD_DIR}/React-jsinspectorcdp/jsinspector_moderncdp.framework/Headers"',
-      # Transitive dependencies of React-runtimescheduler
-      '"${PODS_CONFIGURATION_BUILD_DIR}/React-runtimescheduler/React_runtimescheduler.framework/Headers"',
-      '"${PODS_CONFIGURATION_BUILD_DIR}/React-performancetimeline/React_performancetimeline.framework/Headers"',
-      '"${PODS_CONFIGURATION_BUILD_DIR}/React-rendererconsistency/React_rendererconsistency.framework/Headers"',
-      '"${PODS_CONFIGURATION_BUILD_DIR}/React-timing/React_timing.framework/Headers"',
-      '"${PODS_CONFIGURATION_BUILD_DIR}/React-debug/React_debug.framework/Headers"',
-      '"${PODS_CONFIGURATION_BUILD_DIR}/RCT-Folly/folly.framework/Headers"',
-      '"${PODS_CONFIGURATION_BUILD_DIR}/fmt/fmt.framework/Headers"',
-      '"$(PODS_ROOT)/DoubleConversion"',
-    ])
-  end
-
-  # Swift/Objective-C compatibility
-  s.pod_target_xcconfig = {
-    'USE_HEADERMAP' => 'YES',
-    'DEFINES_MODULE' => 'YES',
-    'HEADER_SEARCH_PATHS' => header_search_paths.join(' '),
-  }
 
   if use_hermes
     s.dependency 'hermes-engine'
@@ -56,9 +30,47 @@ Pod::Spec.new do |s|
   s.dependency 'React-Core'
   s.dependency 'ReactCommon'
 
-  s.source_files = ['ios/JSI/**/*.{h,m,mm,swift,cpp}', 'common/cpp/JSI/**/*.{h,cpp}']
-  s.exclude_files = ['ios/JSI/Tests']
-  s.private_header_files = ['ios/JSI/**/*+Private.h', 'ios/JSI/**/Swift.h']
+  should_use_prebuilt = ENV['EXPO_USE_PRECOMPILED_MODULES'] == '1'
+  if (should_use_prebuilt)
+    s.source_files = "dummy.c"
+  else
+    s.header_dir     = 'ExpoModulesJSI'
+
+    header_search_paths = []
+    if ENV['USE_FRAMEWORKS']
+      header_search_paths.concat([
+        # Transitive dependency of React-Core
+        '"${PODS_CONFIGURATION_BUILD_DIR}/React-jsinspectortracing/jsinspector_moderntracing.framework/Headers"',
+        '"${PODS_CONFIGURATION_BUILD_DIR}/React-jsinspectorcdp/jsinspector_moderncdp.framework/Headers"',
+        # Transitive dependencies of React-runtimescheduler
+        '"${PODS_CONFIGURATION_BUILD_DIR}/React-runtimescheduler/React_runtimescheduler.framework/Headers"',
+        '"${PODS_CONFIGURATION_BUILD_DIR}/React-performancetimeline/React_performancetimeline.framework/Headers"',
+        '"${PODS_CONFIGURATION_BUILD_DIR}/React-rendererconsistency/React_rendererconsistency.framework/Headers"',
+        '"${PODS_CONFIGURATION_BUILD_DIR}/React-timing/React_timing.framework/Headers"',
+        '"${PODS_CONFIGURATION_BUILD_DIR}/React-debug/React_debug.framework/Headers"',
+        '"${PODS_CONFIGURATION_BUILD_DIR}/RCT-Folly/folly.framework/Headers"',
+        '"${PODS_CONFIGURATION_BUILD_DIR}/fmt/fmt.framework/Headers"',
+        '"$(PODS_ROOT)/DoubleConversion"',
+      ])
+    end
+
+    # Swift/Objective-C compatibility
+    s.pod_target_xcconfig = {
+      'USE_HEADERMAP' => 'YES',
+      'DEFINES_MODULE' => 'YES',
+      'HEADER_SEARCH_PATHS' => header_search_paths.join(' '),
+    }
+    # Build from sources
+    s.header_dir = 'ExpoModulesJSI'
+    s.source_files = ['ios/JSI/**/*.{h,m,mm,swift,cpp}', 'common/cpp/JSI/**/*.{h,cpp}']
+    s.exclude_files = ['ios/JSI/Tests']
+    s.private_header_files = ['ios/JSI/**/*+Private.h', 'ios/JSI/**/Swift.h']
+    # Swift/Objective-C compatibility
+    s.pod_target_xcconfig = {
+      'USE_HEADERMAP' => 'YES',
+      'DEFINES_MODULE' => 'YES',
+    }
+  end
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'ios/JSI/Tests/**/*.{m,swift}'

--- a/packages/expo-modules-core/ios/JSI/dummy.c
+++ b/packages/expo-modules-core/ios/JSI/dummy.c
@@ -1,0 +1,1 @@
+// Dummy implementation file to build ExpoModuleJSI as an empty target when using Expo precompiled binaries.


### PR DESCRIPTION
# Why

This PR adds support for simplifying how to use precompiled XCFrameworks in Expo Packages through Cocoapods.

A podspec can now test wether it should use prebuild frameworks or not using a convinience method:

```ruby
  if (!Expo::PackagesConfig.instance.try_link_with_prebuilt_xcframework(s))
    s.static_framework = true
    s.source_files = "**/*.{h,m,swift}"
    # Swift/Objective-C compatibility
    s.pod_target_xcconfig = {
      'DEFINES_MODULE' => 'YES'
    }
  end
```

The `try_link_with_prebuilt_xcframework` will setup the vendored_framework value and return true if the spec can find (and should use) a precompiled XCFramework.

In addition the PR also adds support for building ExpoModulesCore/JSI as one XCFramework due to cross-referencing issues when building these separatly for now - we should find another way to solve this.

The PR adds the necessary infra in our Ruby code and adds support for building ExpoModulesCore/JSI and ExpoFont to prove the use of nested XCFrameworks (ExpoFont imports and uses ExpoModulesCore/JSI).