### PR TITLE
[ios][precompile][spm] refactor AppContext/ReactDelegate into interfaces

### DIFF
--- a/packages/expo-modules-core/ios/Core/AppContextFactory.swift
+++ b/packages/expo-modules-core/ios/Core/AppContextFactory.swift
@@ -1,0 +1,26 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+import Foundation
+
+/// Factory class for creating AppContext instances from Objective-C without importing Swift.h.
+/// This breaks the ObjC → Swift → ObjC cyclic dependency by providing a factory pattern.
+///
+/// The ObjC code calls `createAppContext` class method directly on this class via runtime lookup.
+@objc(EXAppContextFactory)
+public final class AppContextFactory: NSObject, EXAppContextFactoryProtocol {
+
+    /**
+     Creates a new AppContext instance.
+     Called from ObjC code that needs to instantiate AppContext without importing Swift.h.
+     */
+    @objc
+    public static func createAppContext() -> EXAppContextProtocol {
+        return AppContext()
+    }
+}
+
+// MARK: - AppContext Protocol Conformance
+
+/// Declare that AppContext conforms to EXAppContextProtocol.
+/// The actual methods are implemented in AppContext.swift with @objc annotations.
+extension AppContext: EXAppContextProtocol {}

--- a/packages/expo-modules-core/ios/ExpoModulesCore.h
+++ b/packages/expo-modules-core/ios/ExpoModulesCore.h
@@ -12,6 +12,9 @@
 #import <ExpoModulesCore/ExpoModulesCore.h>
 #import <ExpoModulesCore/ExpoModulesCore.h>
 #import <ExpoModulesCore/ExpoFabricViewObjC.h>
+#import <ExpoModulesCore/EXAppContextProtocol.h>
+#import <ExpoModulesCore/EXAppContextFactoryRegistry.h>
+#import <ExpoModulesCore/EXReactDelegateProtocol.h>
 #import <ExpoModulesCore/EXCameraInterface.h>
 #import <ExpoModulesCore/EXConstantsInterface.h>
 #import <ExpoModulesCore/EXFaceDetectorManagerInterface.h>

--- a/packages/expo-modules-core/ios/JS/EXJSIInstaller.h
+++ b/packages/expo-modules-core/ios/JS/EXJSIInstaller.h
@@ -6,10 +6,11 @@
 @class RCTBridge;
 #endif
 
-// Swift classes need forward-declaration in the headers.
+// Forward declarations for types - use protocol for AppContext to avoid Swift.h import
 @class EXAppContext;
 @class EXRuntime;
 @class EXJavaScriptRuntime;
+@protocol EXAppContextProtocol;
 
 #if __has_include(<ReactCommon/RCTRuntimeExecutor.h>)
 @class RCTRuntimeExecutor;
@@ -36,7 +37,7 @@ extern NSString *_Nonnull const EXGlobalCoreObjectPropertyName;
  Installs ExpoModules host object in the runtime of the given app context.
  Returns a bool value whether the installation succeeded.
  */
-+ (BOOL)installExpoModulesHostObject:(nonnull EXAppContext *)appContext;
++ (BOOL)installExpoModulesHostObject:(nonnull id<EXAppContextProtocol>)appContext;
 
 /**
  Installs the base class for shared objects, i.e. `global.expo.SharedObject`.

--- a/packages/expo-modules-core/ios/JS/EXJSIInstaller.mm
+++ b/packages/expo-modules-core/ios/JS/EXJSIInstaller.mm
@@ -2,6 +2,7 @@
 
 #import <ExpoModulesJSI/BridgelessJSCallInvoker.h>
 
+#import <ExpoModulesCore/EXAppContextProtocol.h>
 #import <ExpoModulesCore/EXJSIInstaller.h>
 #import <ExpoModulesCore/ExpoModulesHostObject.h>
 #import <ExpoModulesCore/LazyObject.h>
@@ -9,7 +10,6 @@
 #import <ExpoModulesCore/SharedRef.h>
 #import <ExpoModulesCore/EventEmitter.h>
 #import <ExpoModulesCore/NativeModule.h>
-#import <ExpoModulesCore/Swift.h>
 #import <ExpoModulesCore/EXRuntime.h>
 #import <ExpoModulesJSI/EXJSIUtils.h>
 
@@ -24,7 +24,8 @@ namespace jsi = facebook::jsi;
 NSString *const EXGlobalCoreObjectPropertyName = @"expo";
 
 /**
- Property name used to define the modules host object in the main object of the Expo JS runtime.
+ Property name used to define the modules host object in the main object of the
+ Expo JS runtime.
  */
 static NSString *modulesHostObjectPropertyName = @"modules";
 
@@ -49,7 +50,7 @@ static NSString *modulesHostObjectPropertyName = @"modules";
 
 #pragma mark - Installing JSI bindings
 
-+ (BOOL)installExpoModulesHostObject:(nonnull EXAppContext *)appContext
++ (BOOL)installExpoModulesHostObject:(nonnull id<EXAppContextProtocol>)appContext
 {
   EXRuntime *runtime = [appContext _runtime];
 
@@ -67,7 +68,11 @@ static NSString *modulesHostObjectPropertyName = @"modules";
     return false;
   }
 
-  std::shared_ptr<expo::ExpoModulesHostObject> modulesHostObjectPtr = std::make_shared<expo::ExpoModulesHostObject>(appContext);
+  // Cast protocol to EXAppContext* for the C++ ExpoModulesHostObject
+  // constructor This is safe because EXAppContext is the ObjC name for Swift's
+  // AppContext class
+  EXAppContext *appContextObj = (EXAppContext *)appContext;
+  std::shared_ptr<expo::ExpoModulesHostObject> modulesHostObjectPtr = std::make_shared<expo::ExpoModulesHostObject>(appContextObj);
   EXJavaScriptObject *modulesHostObject = [runtime createHostObject:modulesHostObjectPtr];
 
   // Define the `global.expo.modules` object as a non-configurable, read-only and enumerable property.

--- a/packages/expo-modules-core/ios/JS/ExpoModulesHostObject.mm
+++ b/packages/expo-modules-core/ios/JS/ExpoModulesHostObject.mm
@@ -4,7 +4,7 @@
 
 #import <ExpoModulesCore/ExpoModulesHostObject.h>
 #import <ExpoModulesCore/LazyObject.h>
-#import <ExpoModulesCore/Swift.h>
+#import <ExpoModulesCore/EXAppContextProtocol.h>
 
 namespace expo {
 
@@ -12,6 +12,8 @@ ExpoModulesHostObject::ExpoModulesHostObject(EXAppContext *appContext) : appCont
 
 ExpoModulesHostObject::~ExpoModulesHostObject() {
   modulesCache.clear();
+  // Cast to protocol to access _runtime property without importing Swift.h
+  id<EXAppContextProtocol> appContext = (id<EXAppContextProtocol>)this->appContext;
   appContext._runtime = nil;
 }
 
@@ -19,6 +21,9 @@ jsi::Value ExpoModulesHostObject::get(jsi::Runtime &runtime, const jsi::PropName
   std::string moduleName = name.utf8(runtime);
   NSString *nsModuleName = [NSString stringWithUTF8String:moduleName.c_str()];
 
+  // Cast to protocol to access methods without importing Swift.h
+  id<EXAppContextProtocol> appContext = (id<EXAppContextProtocol>)this->appContext;
+  
   if (![appContext hasModule:nsModuleName]) {
     // The module object can already be cached but no longer registered — we remove it from the cache in that case.
     modulesCache.erase(moduleName);
@@ -47,6 +52,8 @@ void ExpoModulesHostObject::set(jsi::Runtime &runtime, const jsi::PropNameID &na
 }
 
 std::vector<jsi::PropNameID> ExpoModulesHostObject::getPropertyNames(jsi::Runtime &runtime) {
+  // Cast to protocol to access methods without importing Swift.h
+  id<EXAppContextProtocol> appContext = (id<EXAppContextProtocol>)this->appContext;
   NSArray<NSString *> *moduleNames = [appContext getModuleNames];
   std::vector<jsi::PropNameID> propertyNames;
 

--- a/packages/expo-modules-core/ios/Protocols/EXAppContextFactoryRegistry.h
+++ b/packages/expo-modules-core/ios/Protocols/EXAppContextFactoryRegistry.h
@@ -1,0 +1,24 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+#import "EXAppContextProtocol.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Registry for the AppContext factory.
+ ObjC code can use this to create AppContext instances by looking up
+ the Swift factory class at runtime.
+ */
+@interface EXAppContextFactoryRegistry : NSObject
+
+/**
+ Creates a new AppContext instance using the Swift factory.
+ This looks up the EXAppContextFactory class at runtime and calls its createAppContext method.
+ @return A new AppContext instance, or nil if the factory class is not found.
+ */
++ (nullable id<EXAppContextProtocol>)createAppContext;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-modules-core/ios/Protocols/EXAppContextFactoryRegistry.m
+++ b/packages/expo-modules-core/ios/Protocols/EXAppContextFactoryRegistry.m
@@ -1,0 +1,23 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+#import <ExpoModulesCore/EXAppContextFactoryRegistry.h>
+
+@implementation EXAppContextFactoryRegistry
+
++ (nullable id<EXAppContextProtocol>)createAppContext {
+  // Look up the Swift factory class at runtime
+  // The Swift class EXAppContextFactory is exposed to ObjC as
+  // "EXAppContextFactory"
+  Class factoryClass = NSClassFromString(@"EXAppContextFactory");
+
+  if (factoryClass &&
+      [factoryClass respondsToSelector:@selector(createAppContext)]) {
+    return [factoryClass createAppContext];
+  }
+
+  NSLog(@"[EXAppContextFactoryRegistry] Warning: EXAppContextFactory class not "
+        @"found. AppContext cannot be created.");
+  return nil;
+}
+
+@end

--- a/packages/expo-modules-core/ios/Protocols/EXAppContextProtocol.h
+++ b/packages/expo-modules-core/ios/Protocols/EXAppContextProtocol.h
@@ -7,7 +7,6 @@
 @class EXModulesProxyConfig;
 @class EXNativeModulesProxy;
 @class EXRuntime;
-@protocol EXEventEmitterService;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -90,13 +89,6 @@ typedef void (NS_SWIFT_SENDABLE ^EXPromiseRejectBlock)(NSString * _Nullable code
  Returns NSArray of objects (ViewModuleWrapper instances).
  */
 - (nonnull NSArray *)getViewManagers;
-
-#pragma mark - Event Emitter
-
-/**
- Returns the event emitter service for sending events to JavaScript.
- */
-@property(nonatomic, readonly, nullable) id<EXEventEmitterService> eventEmitter;
 
 #pragma mark - Native Module Registration
 

--- a/packages/expo-modules-core/ios/Protocols/EXAppContextProtocol.h
+++ b/packages/expo-modules-core/ios/Protocols/EXAppContextProtocol.h
@@ -1,0 +1,125 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+
+@class EXJavaScriptObject;
+@class EXModuleRegistry;
+@class EXModulesProxyConfig;
+@class EXNativeModulesProxy;
+@class EXRuntime;
+@protocol EXEventEmitterService;
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (NS_SWIFT_SENDABLE ^EXPromiseResolveBlock)(id _Nullable result);
+typedef void (NS_SWIFT_SENDABLE ^EXPromiseRejectBlock)(NSString * _Nullable code, NSString * _Nullable message, NSError * _Nullable error);
+
+/**
+ Protocol defining the interface for AppContext that can be used from Objective-C
+ without importing Swift.h, breaking the ObjC → Swift → ObjC cyclic dependency.
+ */
+@protocol EXAppContextProtocol <NSObject>
+
+#pragma mark - Properties
+
+/**
+ The legacy module registry with modules written in the old-fashioned way.
+ */
+@property(nonatomic, weak, nullable) EXModuleRegistry *legacyModuleRegistry;
+
+/**
+ The legacy modules proxy.
+ */
+@property(nonatomic, weak, nullable) EXNativeModulesProxy *legacyModulesProxy;
+
+/**
+ Underlying JSI runtime of the running app.
+ */
+@property(nonatomic, strong, nullable) EXRuntime *_runtime;
+
+/**
+ The application identifier used to distinguish between different RCTHost.
+ */
+@property(nonatomic, readonly, nullable) NSString *appIdentifier;
+
+#pragma mark - Module Management
+
+/**
+ Returns a bool whether the module with given name is registered in this context.
+ */
+- (BOOL)hasModule:(nonnull NSString *)moduleName;
+
+/**
+ Returns an array of names of the modules registered in the module registry.
+ */
+- (nonnull NSArray<NSString *> *)getModuleNames;
+
+/**
+ Returns a JavaScript object that represents a module with given name.
+ */
+- (nullable EXJavaScriptObject *)getNativeModuleObject:(nonnull NSString *)moduleName;
+
+/**
+ Returns an array of event names supported by all Swift modules.
+ */
+- (nonnull NSArray<NSString *> *)getSupportedEvents;
+
+/**
+ Modifies listeners count for module with given name.
+ */
+- (void)modifyEventListenersCount:(nonnull NSString *)moduleName count:(NSInteger)count;
+
+/**
+ Asynchronously calls module's function with given arguments.
+ */
+- (void)callFunction:(nonnull NSString *)functionName
+            onModule:(nonnull NSString *)moduleName
+            withArgs:(nonnull NSArray *)args
+             resolve:(nonnull EXPromiseResolveBlock)resolve
+              reject:(nonnull EXPromiseRejectBlock)reject;
+
+/**
+ Returns the expo modules config for the native modules proxy.
+ */
+@property(nonatomic, readonly, nonnull) EXModulesProxyConfig *expoModulesConfig;
+
+#pragma mark - View Management
+
+/**
+ Returns view modules wrapped by the base ViewModuleWrapper class.
+ Returns NSArray of objects (ViewModuleWrapper instances).
+ */
+- (nonnull NSArray *)getViewManagers;
+
+#pragma mark - Event Emitter
+
+/**
+ Returns the event emitter service for sending events to JavaScript.
+ */
+@property(nonatomic, readonly, nullable) id<EXEventEmitterService> eventEmitter;
+
+#pragma mark - Native Module Registration
+
+/**
+ Registers native modules provided by generated ExpoModulesProvider.
+ */
+- (void)registerNativeModules;
+
+@end
+
+#pragma mark - Factory Protocol
+
+/**
+ Factory protocol for creating AppContext instances from Objective-C
+ without importing Swift.h.
+ */
+@protocol EXAppContextFactoryProtocol <NSObject>
+
+/**
+ Creates a new AppContext instance.
+ */
++ (nonnull id<EXAppContextProtocol>)createAppContext;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-modules-core/ios/Protocols/EXReactDelegateProtocol.h
+++ b/packages/expo-modules-core/ios/Protocols/EXReactDelegateProtocol.h
@@ -1,0 +1,33 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+#import <ExpoModulesCore/Platform.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Protocol defining the interface for ExpoReactDelegate that can be used from Objective-C
+ without importing Swift.h, breaking the ObjC → Swift → ObjC cyclic dependency.
+ */
+@protocol EXReactDelegateProtocol <NSObject>
+
+/**
+ Creates a React root view with the given module name and properties.
+ */
+- (UIView *)createReactRootViewWithModuleName:(NSString *)moduleName
+                            initialProperties:(nullable NSDictionary<NSString *, id> *)initialProperties
+                                launchOptions:(nullable NSDictionary<UIApplicationLaunchOptionsKey, id> *)launchOptions;
+
+/**
+ Returns the bundle URL for the React Native bundle.
+ */
+- (nullable NSURL *)bundleURL;
+
+/**
+ Creates the root view controller.
+ */
+- (UIViewController *)createRootViewController;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-modules-core/ios/ReactDelegates/EXReactDelegateWrapper.mm
+++ b/packages/expo-modules-core/ios/ReactDelegates/EXReactDelegateWrapper.mm
@@ -1,11 +1,11 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
 #import <ExpoModulesCore/EXReactDelegateWrapper.h>
-#import <ExpoModulesCore/Swift.h>
+#import <ExpoModulesCore/EXReactDelegateProtocol.h>
 
 @interface EXReactDelegateWrapper()
 
-@property (nonatomic, weak) EXReactDelegate *expoReactDelegate;
+@property (nonatomic, weak) id<EXReactDelegateProtocol> expoReactDelegate;
 
 @end
 
@@ -14,7 +14,8 @@
 - (instancetype)initWithExpoReactDelegate:(EXReactDelegate *)expoReactDelegate
 {
   if (self = [super init]) {
-    _expoReactDelegate = expoReactDelegate;
+    // Cast to protocol - EXReactDelegate conforms to EXReactDelegateProtocol
+    _expoReactDelegate = (id<EXReactDelegateProtocol>)expoReactDelegate;
   }
   return self;
 }


### PR DESCRIPTION
# Why

In SPM we can't have mixed language targets meaning that we cannot have circular dependencies between obj-c and swift targets: objective-c -> swift -> objective-c.

This PR adds support for the AppContextProtocol, ReactDelegateProtocol and an AppContextFactory.