### PR TITLE
[ios][precompile][spm] refactor to avoid re-export of React in Expo Views

### DIFF
--- a/packages/expo-modules-core/ios/Core/Protocols/AnyExpoView.swift
+++ b/packages/expo-modules-core/ios/Core/Protocols/AnyExpoView.swift
@@ -1,6 +1,7 @@
-import React
-
-public protocol AnyExpoView: RCTView {
+// Note: We use UIView as the base constraint (not RCTView or RCTViewComponentView)
+// to avoid re-exporting React types in the xcframework's swiftinterface.
+// Both RCTViewComponentView (Fabric) and RCTView (Paper) inherit from UIView.
+public protocol AnyExpoView: UIView {
   var appContext: AppContext? { get }
 
   init(appContext: AppContext?)

--- a/packages/expo-modules-core/ios/Core/Views/ExpoView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ExpoView.swift
@@ -1,15 +1,11 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
-import React
-
 #if RCT_NEW_ARCH_ENABLED
 public typealias ExpoView = ExpoFabricView
 #else
-/**
- The view that extends `RCTView` which handles some styles (e.g. borders) and accessibility.
- Inherit from `ExpoView` to keep this behavior and let your view use the associated `AppContext`.
- */
-open class ExpoClassicView: RCTView, AnyExpoView {
+  /// The base view class for expo modules in Paper architecture.
+  /// Inherit from `ExpoView` to let your view use the associated `AppContext`.
+  open class ExpoClassicView: UIView, AnyExpoView {
   /**
    A weak pointer to the associated `AppContext`.
    */

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
@@ -2,8 +2,6 @@
 
 #import <ExpoModulesCore/Platform.h>
 
-#ifdef RCT_NEW_ARCH_ENABLED
-
 #ifdef __cplusplus
 
 #import <React/RCTViewComponentView.h> // Allows non-umbrella since it's coming from React-RCTFabric
@@ -13,22 +11,31 @@
 
 #else
 
-// Interface visible in Swift
-@interface ExpoFabricViewObjC
+// Interface visible in Swift - we expose UIView inheritance so Swift sees this as a UIView subclass.
+// The actual C++ implementation inherits from RCTViewComponentView (which is a UIView subclass).
+// Methods that Swift needs to override must be declared here (not in a category) so Swift
+// can properly override them.
+@interface ExpoFabricViewObjC : UIView
+
+/*
+ * Called for mounting (attaching) a child component view inside `self` component view.
+ * Declared in main interface (not category) so Swift subclasses can override.
+ */
+- (void)mountChildComponentView:(nonnull UIView *)childComponentView index:(NSInteger)index;
+
+/*
+ * Called for unmounting (detaching) a child component view from `self` component view.
+ * Declared in main interface (not category) so Swift subclasses can override.
+ */
+- (void)unmountChildComponentView:(nonnull UIView *)childComponentView index:(NSInteger)index;
+
 @end
 
 #endif // __cplusplus
-#else  // Paper
 
-#import <React/RCTView.h>
-
-@interface ExpoFabricViewObjC : RCTView
-@end
-
-#endif // !RCT_NEW_ARCH_ENABLED
-
-@class EXAppContext;
-@class EXViewModuleWrapper;
+// Forward declarations for ObjC compatibility - these are Swift classes with @objc(EX...) names
+// We use the protocol for AppContext to allow proper Swift type bridging
+@protocol EXAppContextProtocol;
 
 // Addition to the interface that is visible in both Swift and Objective-C
 @interface ExpoFabricViewObjC (ExpoFabricViewInterface)
@@ -49,21 +56,12 @@
 
 - (void)prepareForRecycle;
 
-/*
- * Called for mounting (attaching) a child component view inside `self` component view.
- */
-- (void)mountChildComponentView:(nonnull UIView *)childComponentView index:(NSInteger)index;
-
-/*
- * Called for unmounting (detaching) a child component view from `self` component view.
- */
-- (void)unmountChildComponentView:(nonnull UIView *)childComponentView index:(NSInteger)index;
-
 #pragma mark - Component registration
 
 /**
  Registers given view module in the global `RCTComponentViewFactory`.
+ Uses `id` types to allow proper bridging of Swift classes with @objc(EX...) names.
  */
-+ (void)registerComponent:(nonnull EXViewModuleWrapper *)viewModule appContext:(nonnull EXAppContext *)appContext;
++ (void)registerComponent:(nonnull id)viewModule appContext:(nonnull id<EXAppContextProtocol>)appContext;
 
 @end

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
@@ -5,9 +5,9 @@
 #import <objc/runtime.h>
 #import <string.h>
 
+#import <ExpoModulesCore/EXAppContextProtocol.h>
 #import <ExpoModulesCore/ExpoFabricViewObjC.h>
 #import <ExpoModulesCore/ExpoViewComponentDescriptor.h>
-#import <ExpoModulesCore/Swift.h>
 
 #import <ExpoModulesJSI/EXJSIConversions.h>
 
@@ -204,15 +204,123 @@ static std::unordered_map<std::string, ExpoViewComponentDescriptor::Flavor> _com
 
 #pragma mark - Component registration
 
-+ (void)registerComponent:(nonnull EXViewModuleWrapper *)viewModule appContext:(nonnull EXAppContext *)appContext
++ (void)registerComponent:(nonnull id)viewModule appContext:(nonnull id<EXAppContextProtocol>)appContext
 {
-  Class wrappedViewModuleClass = [EXViewModuleWrapper createViewModuleWrapperClassWithModule:viewModule appId:appContext.appIdentifier];
-  Class viewClass = [ExpoFabricView makeViewClassForAppContext:appContext
-                                                    moduleName:[viewModule moduleName]
-                                                      viewName:[viewModule viewName]
-                                                     className:NSStringFromClass(wrappedViewModuleClass)];
+  // Cache classes and selectors using dispatch_once to avoid repeated lookups
+  static Class viewModuleWrapperClass;
+  static Class expoFabricViewClass;
+  static SEL createWrapperSelector;
+  static SEL makeViewSelector;
+  static SEL moduleNameSelector;
+  static SEL viewNameSelector;
 
-  [[RCTComponentViewFactory currentComponentViewFactory] registerComponentViewClass:viewClass];
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    // EXViewModuleWrapper is defined in Swift - use runtime lookup
+    viewModuleWrapperClass = NSClassFromString(@"EXViewModuleWrapper");
+    if (!viewModuleWrapperClass) {
+      NSLog(@"[ExpoFabricViewObjC] Warning: Could not find class "
+            @"'EXViewModuleWrapper'");
+    }
+    // ExpoFabricView is defined in Swift - use runtime lookup
+    expoFabricViewClass = NSClassFromString(@"ExpoFabricView");
+    if (!expoFabricViewClass) {
+      NSLog(@"[ExpoFabricViewObjC] Warning: Could not find class "
+            @"'ExpoFabricView'");
+    }
+    // Cache all selectors
+    createWrapperSelector =
+        NSSelectorFromString(@"createViewModuleWrapperClassWithModule:appId:");
+    makeViewSelector = NSSelectorFromString(
+        @"makeViewClassForAppContext:moduleName:viewName:className:");
+    moduleNameSelector = NSSelectorFromString(@"moduleName");
+    viewNameSelector = NSSelectorFromString(@"viewName");
+  });
+
+  if (!viewModuleWrapperClass) {
+    NSLog(@"[ExpoFabricViewObjC] Error: Cannot register component - "
+          @"EXViewModuleWrapper class not found");
+    return;
+  }
+
+  if (!expoFabricViewClass) {
+    NSLog(@"[ExpoFabricViewObjC] Error: Cannot register component - "
+          @"ExpoFabricView class not found");
+    return;
+  }
+
+  Class wrappedViewModuleClass = nil;
+  NSString *appId = [appContext appIdentifier];
+
+  if (![viewModuleWrapperClass respondsToSelector:createWrapperSelector]) {
+    NSLog(@"[ExpoFabricViewObjC] Error: EXViewModuleWrapper does not respond "
+          @"to createViewModuleWrapperClassWithModule:appId:");
+    return;
+  }
+
+  NSMethodSignature *sig =
+      [viewModuleWrapperClass methodSignatureForSelector:createWrapperSelector];
+  NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:sig];
+  [invocation setTarget:viewModuleWrapperClass];
+  [invocation setSelector:createWrapperSelector];
+  [invocation setArgument:&viewModule atIndex:2];
+  [invocation setArgument:&appId atIndex:3];
+  [invocation invoke];
+  [invocation getReturnValue:&wrappedViewModuleClass];
+
+  if (!wrappedViewModuleClass) {
+    NSLog(@"[ExpoFabricViewObjC] Error: Failed to create wrapped view module "
+          @"class for module: %@",
+          viewModule);
+    return;
+  }
+
+  if (![expoFabricViewClass respondsToSelector:makeViewSelector]) {
+    NSLog(@"[ExpoFabricViewObjC] Error: ExpoFabricView does not respond to "
+          @"makeViewClassForAppContext:moduleName:viewName:className:");
+    return;
+  }
+
+  // Get moduleName and viewName from viewModule using cached selectors
+  NSString *moduleName = nil;
+  NSString *viewName = nil;
+  if ([viewModule respondsToSelector:moduleNameSelector]) {
+    moduleName = [viewModule performSelector:moduleNameSelector];
+  } else {
+    NSLog(@"[ExpoFabricViewObjC] Warning: viewModule does not respond to "
+          @"moduleName selector");
+  }
+  if ([viewModule respondsToSelector:viewNameSelector]) {
+    viewName = [viewModule performSelector:viewNameSelector];
+  } else {
+    NSLog(@"[ExpoFabricViewObjC] Warning: viewModule does not respond to "
+          @"viewName selector");
+  }
+
+  NSString *className = NSStringFromClass(wrappedViewModuleClass);
+  NSMethodSignature *makeViewSig =
+      [expoFabricViewClass methodSignatureForSelector:makeViewSelector];
+  NSInvocation *makeViewInvocation =
+      [NSInvocation invocationWithMethodSignature:makeViewSig];
+  [makeViewInvocation setTarget:expoFabricViewClass];
+  [makeViewInvocation setSelector:makeViewSelector];
+  id appContextArg = appContext;
+  [makeViewInvocation setArgument:&appContextArg atIndex:2];
+  [makeViewInvocation setArgument:&moduleName atIndex:3];
+  [makeViewInvocation setArgument:&viewName atIndex:4];
+  [makeViewInvocation setArgument:&className atIndex:5];
+  [makeViewInvocation invoke];
+
+  Class viewClass = nil;
+  [makeViewInvocation getReturnValue:&viewClass];
+
+  if (viewClass) {
+    [[RCTComponentViewFactory currentComponentViewFactory] registerComponentViewClass:viewClass];
+  } else {
+    NSLog(@"[ExpoFabricViewObjC] Error: Failed to create view class for "
+          @"module: %@, view: %@",
+          moduleName, viewName);
+  }
 }
 
 @end


### PR DESCRIPTION
# Why

When declaring Expo base views we're re-exporting React through the RCTView inheritance.

This PR Fixes this by inheriting from UIVIew when building clang modules.