### PR TITLE
[ios][precompile][spm] Redefined base classes to avoid naming clash in SwiftUIViewDefinition

### DIFF
--- a/packages/expo-audio/ios/AudioRecordingRequester.swift
+++ b/packages/expo-audio/ios/AudioRecordingRequester.swift
@@ -1,4 +1,5 @@
 import ExpoModulesCore
+import React
 
 private let selector = ["request", "Record", "Permission", ":"]
 

--- a/packages/expo-calendar/ios/Requesters/CalendarPermissionsRequester.swift
+++ b/packages/expo-calendar/ios/Requesters/CalendarPermissionsRequester.swift
@@ -1,5 +1,6 @@
 import ExpoModulesCore
 import EventKit
+import React
 
 public class CalendarPermissionsRequester: NSObject, EXPermissionsRequester {
   private let eventStore: EKEventStore

--- a/packages/expo-calendar/ios/Requesters/RemindersPermissionsRequester.swift
+++ b/packages/expo-calendar/ios/Requesters/RemindersPermissionsRequester.swift
@@ -1,5 +1,6 @@
 import ExpoModulesCore
 import EventKit
+import React
 
 public class RemindersPermissionRequester: NSObject, EXPermissionsRequester {
   private let eventStore: EKEventStore

--- a/packages/expo-camera/ios/Common/CameraPermissionsRequester.swift
+++ b/packages/expo-camera/ios/Common/CameraPermissionsRequester.swift
@@ -1,4 +1,5 @@
 import ExpoModulesCore
+import React
 import AVFoundation
 
 let cameraKey = "NSCameraUsageDescription"

--- a/packages/expo-image-picker/ios/ImagePickerPermissionRequesters.swift
+++ b/packages/expo-image-picker/ios/ImagePickerPermissionRequesters.swift
@@ -2,6 +2,7 @@
 
 import Photos
 import ExpoModulesCore
+import React
 
 public class CameraPermissionRequester: NSObject, EXPermissionsRequester {
   static public func permissionType() -> String {

--- a/packages/expo-maps/ios/MapPermissionRequester.swift
+++ b/packages/expo-maps/ios/MapPermissionRequester.swift
@@ -2,6 +2,7 @@
 
 import ExpoModulesCore
 import MapKit
+import React
 
 class MapPermissionRequester: NSObject, EXPermissionsRequester, CLLocationManagerDelegate {
   private var locationManager = CLLocationManager()

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -326,11 +326,13 @@ public final class AppContext: NSObject, @unchecked Sendable {
    */
   @objc
   public func getViewManagers() -> [Any] {
-    return moduleRegistry.flatMap { holder in
-      holder.definition.views.map { key, viewDefinition in
-        ViewModuleWrapper(holder, viewDefinition, isDefaultModuleView: key == DEFAULT_MODULE_VIEW)
+    var result: [Any] = []
+    for holder in moduleRegistry {
+      for (key, viewDefinition) in holder.definition.views {
+        result.append(ViewModuleWrapper(holder, viewDefinition, isDefaultModuleView: key == DEFAULT_MODULE_VIEW))        
       }
     }
+    return result
   }
 
   /**
@@ -354,9 +356,22 @@ public final class AppContext: NSObject, @unchecked Sendable {
    When remote debugging is enabled, this will always return `nil`.
    */
   @JavaScriptActor
-  @objc
   public func getNativeModuleObject(_ moduleName: String) -> JavaScriptObject? {
     return moduleRegistry.get(moduleHolderForName: moduleName)?.javaScriptObject
+  }
+
+  /**
+   Returns a JavaScript object that represents a module with given name.
+   This is a non-actor-isolated wrapper for ObjC interop that uses `assumeIsolated` internally.
+  
+   - Warning: This method must only be called from the JavaScript thread.
+   It will crash if called from other threads.
+   */
+  @objc
+  public func getNativeModuleObjectUnsafe(_ moduleName: String) -> JavaScriptObject? {
+    return JavaScriptActor.assumeIsolated {
+      return moduleRegistry.get(moduleHolderForName: moduleName)?.javaScriptObject
+    }
   }
 
   /**

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -57,6 +57,11 @@ public final class AppContext: NSObject, @unchecked Sendable {
   internal weak var reactBridge: RCTBridge?
 
   /**
+   RCTHost wrapper. This is set by ``ExpoReactNativeFactory`` in `didInitializeRuntime`.
+   */
+  private var hostWrapper: ExpoHostWrapper?
+
+  /**
    Underlying JSI runtime of the running app.
    */
   @objc

--- a/packages/expo-modules-core/ios/Core/AppContextFactory.swift
+++ b/packages/expo-modules-core/ios/Core/AppContextFactory.swift
@@ -2,10 +2,11 @@
 
 import Foundation
 
-/// Factory class for creating AppContext instances from Objective-C without importing Swift.h.
-/// This breaks the ObjC → Swift → ObjC cyclic dependency by providing a factory pattern.
-///
-/// The ObjC code calls `createAppContext` class method directly on this class via runtime lookup.
+/* Factory class for creating AppContext instances from Objective-C without importing Swift.h.
+ * This breaks the ObjC → Swift → ObjC cyclic dependency by providing a factory pattern.
+ *
+ * The ObjC code calls `createAppContext` class method directly on this class via runtime lookup.
+ */
 @objc(EXAppContextFactory)
 public final class AppContextFactory: NSObject, EXAppContextFactoryProtocol {
 

--- a/packages/expo-modules-core/ios/Core/AppContextFactory.swift
+++ b/packages/expo-modules-core/ios/Core/AppContextFactory.swift
@@ -2,10 +2,10 @@
 
 import Foundation
 
-/* Factory class for creating AppContext instances from Objective-C without importing Swift.h.
- * This breaks the ObjC → Swift → ObjC cyclic dependency by providing a factory pattern.
- *
- * The ObjC code calls `createAppContext` class method directly on this class via runtime lookup.
+/**
+ Factory class for creating AppContext instances from Objective-C without importing Swift.h.
+ This breaks the ObjC → Swift → ObjC cyclic dependency by providing a factory pattern.
+ The ObjC code calls `createAppContext` class method directly on this class via runtime lookup.
  */
 @objc(EXAppContextFactory)
 public final class AppContextFactory: NSObject, EXAppContextFactoryProtocol {

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
@@ -14,12 +14,12 @@ public protocol ExpoSwiftUIView<Props>: SwiftUI.View, AnyArgument, ExpoSwiftUI.A
   init(props: Props)
 }
 
-public extension ExpoSwiftUIView {
+extension ExpoSwiftUIView {
   /**
    Returns React's children as SwiftUI views.
    */
   // swiftlint:disable:next identifier_name
-  func Children() -> ForEach<[any ExpoSwiftUI.AnyChild], ObjectIdentifier, AnyView> {
+  public func Children() -> ForEach<[any ExpoSwiftUI.AnyChild], ObjectIdentifier, AnyView> {
     ForEach(props.children ?? [], id: \.id) { child in
       let view: any View = child.childView
       AnyView(view)
@@ -29,7 +29,7 @@ public extension ExpoSwiftUIView {
   /**
    Returns React's children as SwiftUI views, with any nested HostingViews stripped out.
    */
-  func UnwrappedChildren<T: View>( // swiftlint:disable:this identifier_name
+  public func UnwrappedChildren<T: View>( // swiftlint:disable:this identifier_name
     children: [(any ExpoSwiftUI.AnyChild)?]? = nil,
     @ViewBuilder transform: @escaping (_ child: AnyView, _ isHostingView: Bool)
     -> T = { child, _ in  child }
@@ -61,11 +61,11 @@ public extension ExpoSwiftUIView {
     }
   }
 
-  nonisolated static func getDynamicType() -> AnyDynamicType {
+  public nonisolated static func getDynamicType() -> AnyDynamicType {
     return DynamicSwiftUIViewType(innerType: Self.self)
   }
 
-  var appContext: AppContext? {
+  public var appContext: AppContext? {
     return props.appContext
   }
 }
@@ -73,10 +73,13 @@ public extension ExpoSwiftUIView {
 extension ExpoSwiftUI {
   public typealias View = ExpoSwiftUIView
 
-  /**
-   A definition representing the native SwiftUI view to export to React.
-   */
-  public final class ViewDefinition<Props: ViewProps, ViewType: View<Props>>: ExpoModulesCore.ViewDefinition<ViewType>, @unchecked Sendable {
+  /// Typealias for backward compatibility - ViewDefinition inside ExpoSwiftUI namespace
+  public typealias ViewDefinition = SwiftUIViewDefinition
+}
+
+/// A definition representing the native SwiftUI view to export to React.
+/// Renamed from ExpoSwiftUI.ViewDefinition to avoid collision with the base ViewDefinition class.
+  public final class SwiftUIViewDefinition<Props: ExpoSwiftUI.ViewProps, ViewType: ExpoSwiftUI.View<Props>>: ViewDefinition<ViewType>, @unchecked Sendable {
     // To obtain prop and event names from the props object we need to create a dummy instance first.
     // This is not ideal, but RN requires us to provide all names before the view is created
     // and there doesn't seem to be a better way to do this right now.
@@ -96,16 +99,16 @@ extension ExpoSwiftUI {
 #if RCT_NEW_ARCH_ENABLED
         let props = Props()
         props.appContext = appContext
-
-        if ViewType.self is WithHostingView.Type {
-          let view = HostingView(viewType: ViewType.self, props: props, appContext: appContext)
+        
+        if ViewType.self is ExpoSwiftUI.WithHostingView.Type {
+          let view = ExpoSwiftUI.HostingView(viewType: ViewType.self, props: props, appContext: appContext)
           // Set up events to call view's `dispatchEvent` method.
           // This is supported only on the new architecture, `dispatchEvent` exists only there.
           props.setUpEvents(view.dispatchEvent(_:payload:))
           return AppleView.from(view)
         }
-
-        let view = SwiftUIVirtualView(viewType: ViewType.self, props: props, viewDefinition: self, appContext: appContext)
+        
+        let view = ExpoSwiftUI.SwiftUIVirtualView(viewType: ViewType.self, props: props, viewDefinition: self, appContext: appContext)
         // Set up events to call view's `dispatchEvent` method.
         // This is supported only on the new architecture, `dispatchEvent` exists only there.
         props.setUpEvents(view.dispatchEvent(_:payload:))
@@ -134,4 +137,4 @@ extension ExpoSwiftUI {
       } as [String]
     }
   }
-}
+

--- a/packages/expo-modules-core/ios/JS/ExpoModulesHostObject.mm
+++ b/packages/expo-modules-core/ios/JS/ExpoModulesHostObject.mm
@@ -35,7 +35,7 @@ jsi::Value ExpoModulesHostObject::get(jsi::Runtime &runtime, const jsi::PropName
 
   // Create a lazy object for the specific module. It defers initialization of the final module object.
   LazyObject::Shared moduleLazyObject = std::make_shared<LazyObject>(^SharedJSIObject(jsi::Runtime &runtime) {
-    return [[appContext getNativeModuleObject:nsModuleName] getShared];
+    return [[appContext getNativeModuleObjectUnsafe:nsModuleName] getShared];
   });
 
   // Save the module's lazy host object for later use.

--- a/packages/expo-modules-core/ios/Legacy/LegacyModuleRegistry.swift
+++ b/packages/expo-modules-core/ios/Legacy/LegacyModuleRegistry.swift
@@ -1,0 +1,161 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+import Foundation
+
+/// A Swift-based registry for legacy Expo modules that use the `EX_EXPORT_MODULE`
+/// and `EX_REGISTER_SINGLETON_MODULE` Objective-C macros.
+///
+/// This registry replaces the static Objective-C data structures to enable
+/// compatibility with prebuilt SPM xcframeworks while maintaining backward
+/// compatibility with legacy module registration.
+///
+/// This made it impossible to include both files in prebuilt xcframeworks.
+///
+/// This Swift implementation:
+/// 1. Provides real registration storage via `@_cdecl` exported C functions
+/// 2. Bridges to `EXModuleRegistryProvider` for the `moduleRegistry` creation
+@objc(EXLegacyModuleRegistry)
+public final class LegacyModuleRegistry: NSObject, @unchecked Sendable {
+    /// Shared singleton instance
+    nonisolated(unsafe) public static let shared = LegacyModuleRegistry()
+
+    /// Set of registered module classes (those using `EX_EXPORT_MODULE`)
+    private var moduleClasses = Set<ObjectIdentifier>()
+    private var moduleClassList = [AnyClass]()
+
+    /// Set of registered singleton module classes (those using `EX_REGISTER_SINGLETON_MODULE`)
+    private var singletonModuleClasses = Set<ObjectIdentifier>()
+    private var singletonModuleClassList = [AnyClass]()
+
+    /// Lazy-initialized singleton module instances
+    private var singletonModules: [EXSingletonModule]?
+
+    /// Thread-safety lock
+    private let lock = NSLock()
+
+    private override init() {
+        super.init()
+        // Register the Swift FileSystemManager which was previously hardcoded
+        if let fileSystemClass = NSClassFromString("EXFileSystemLegacyUtilities") {
+            registerModule(fileSystemClass)
+        }
+    }
+
+    // MARK: - Module Registration
+
+    /**
+     Registers a module class.
+    
+     Called from `+load` methods of classes using the `EX_EXPORT_MODULE` macro.
+     */
+    @objc public func registerModule(_ moduleClass: AnyClass) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let identifier = ObjectIdentifier(moduleClass)
+        if !moduleClasses.contains(identifier) {
+            moduleClasses.insert(identifier)
+            moduleClassList.append(moduleClass)
+        }
+    }
+
+    /**
+     Registers a singleton module class.
+    
+     Called from `+load` methods of classes using the `EX_REGISTER_SINGLETON_MODULE` macro.
+    
+     Handles the subclass preference heuristic: if a subclass is registered after its
+     superclass, the superclass is removed. If a superclass is registered after a subclass,
+     it's ignored.
+     */
+    @objc public func registerSingletonModule(_ singletonModuleClass: AnyClass) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        // Remove any superclasses that are already registered
+        // (prefer subclasses for override scenarios like ExpoKit)
+        var superClass: AnyClass? = class_getSuperclass(singletonModuleClass)
+        while let currentSuper = superClass, currentSuper != NSObject.self {
+            let superId = ObjectIdentifier(currentSuper)
+            if singletonModuleClasses.contains(superId) {
+                singletonModuleClasses.remove(superId)
+                singletonModuleClassList.removeAll { ObjectIdentifier($0) == superId }
+            }
+            superClass = class_getSuperclass(currentSuper)
+        }
+
+        // If a subclass is already registered, ignore this superclass
+        for registeredClass in singletonModuleClassList {
+            if class_getSuperclass(registeredClass) != nil
+                && (singletonModuleClass as AnyObject).isKind(of: type(of: registeredClass))
+            {
+                return
+            }
+        }
+
+        let identifier = ObjectIdentifier(singletonModuleClass)
+        if !singletonModuleClasses.contains(identifier) {
+            singletonModuleClasses.insert(identifier)
+            singletonModuleClassList.append(singletonModuleClass)
+        }
+    }
+
+    // MARK: - Accessing Registered Modules
+
+    /**
+     Returns all registered module classes as an NSSet for ObjC compatibility.
+     */
+    @objc public func getModuleClasses() -> NSSet {
+        lock.lock()
+        defer { lock.unlock() }
+        return NSSet(array: moduleClassList)
+    }
+
+    /**
+     Returns all registered module classes as an array.
+     */
+    @objc public func getModuleClassesArray() -> [AnyClass] {
+        lock.lock()
+        defer { lock.unlock() }
+        return moduleClassList
+    }
+
+    /**
+     Returns all singleton module instances, creating them if necessary.
+     */
+    @objc public func getSingletonModules() -> Set<EXSingletonModule> {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let modules = singletonModules {
+            return Set(modules)
+        }
+
+        // Initialize singleton instances
+        var modules = [EXSingletonModule]()
+        for singletonClass in singletonModuleClassList {
+            if let instance = (singletonClass as? NSObject.Type)?.init() as? EXSingletonModule {
+                modules.append(instance)
+            }
+        }
+        singletonModules = modules
+        return Set(modules)
+    }
+
+    /**
+     Returns a singleton module instance for a specific class.
+     */
+    @objc public func getSingletonModule(for singletonClass: AnyClass) -> EXSingletonModule? {
+        let modules = getSingletonModules()
+        for singleton in modules where singleton.isKind(of: singletonClass) {
+            return singleton
+        }
+        return nil
+    }
+}
+
+// MARK: - Module Registration (called from EXModuleRegistryProvider.m)
+
+// Note: The C functions EXRegisterModule and EXRegisterSingletonModule are
+// defined in EXModuleRegistryProvider.m. Those functions forward to this
+// Swift class for storage. This avoids duplicate symbol issues.

--- a/packages/expo-modules-core/ios/Legacy/ModuleRegistryProvider/EXModuleRegistryProvider.m
+++ b/packages/expo-modules-core/ios/Legacy/ModuleRegistryProvider/EXModuleRegistryProvider.m
@@ -1,9 +1,10 @@
 // Copyright © 2018 650 Industries. All rights reserved.
 
-#import <ExpoModulesCore/EXDefines.h>
-#import <ExpoModulesCore/EXModuleRegistryProvider.h>
-#import <ExpoModulesCore/EXSingletonModule.h>
 #import <Foundation/Foundation.h>
+#import <ExpoModulesCore/EXSingletonModule.h>
+#import <ExpoModulesCore/EXModuleRegistryProvider.h>
+
+#import <React/RCTLog.h>
 
 // Forward declaration for LegacyModuleRegistry (Swift)
 // This allows SPM prebuilds to use the Swift-based registry
@@ -13,61 +14,24 @@ static dispatch_once_t onceToken;
 static NSMutableSet<Class> *EXModuleClasses;
 static NSMutableSet<Class> *EXSingletonModuleClasses;
 
-// Helper to get the Swift LegacyModuleRegistry if available
-static id EXGetLegacyModuleRegistry(void) {
-  static id legacyRegistry = nil;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    Class legacyRegistryClass = NSClassFromString(@"EXLegacyModuleRegistry");
-    if (legacyRegistryClass) {
-      SEL sharedSelector = NSSelectorFromString(@"shared");
-      if ([legacyRegistryClass respondsToSelector:sharedSelector]) {
-        legacyRegistry = [legacyRegistryClass performSelector:sharedSelector];
-      }
-    }
-  });
-  return legacyRegistry;
-}
-
 void (^EXinitializeGlobalModulesRegistry)(void) = ^{
   EXModuleClasses = [NSMutableSet set];
   EXSingletonModuleClasses = [NSMutableSet set];
 
   // Also add temporary Swift modules from core
-  [EXModuleClasses addObject:NSClassFromString(@"EXFileSystemLegacyUtilities")];
+  [EXModuleClasses addObject: NSClassFromString(@"EXFileSystemLegacyUtilities")];
 };
 
-EX_EXTERN_C_BEGIN
-
-__attribute__((visibility("default"))) void
-EXRegisterModule(Class moduleClass) {
-  // First try to register with Swift LegacyModuleRegistry (for SPM prebuilds)
-  id legacyRegistry = EXGetLegacyModuleRegistry();
-  if (legacyRegistry) {
-    SEL registerSelector = NSSelectorFromString(@"registerModule:");
-    if ([legacyRegistry respondsToSelector:registerSelector]) {
-      [legacyRegistry performSelector:registerSelector withObject:moduleClass];
-      return;
-    }
-  }
-  // Fall back to local ObjC storage (for CocoaPods source builds)
+extern void EXRegisterModule(Class);
+extern void EXRegisterModule(Class moduleClass)
+{
   dispatch_once(&onceToken, EXinitializeGlobalModulesRegistry);
   [EXModuleClasses addObject:moduleClass];
 }
 
-__attribute__((visibility("default"))) void
-EXRegisterSingletonModule(Class singletonModuleClass) {
-  // First try to register with Swift LegacyModuleRegistry (for SPM prebuilds)
-  id legacyRegistry = EXGetLegacyModuleRegistry();
-  if (legacyRegistry) {
-    SEL registerSelector = NSSelectorFromString(@"registerSingletonModule:");
-    if ([legacyRegistry respondsToSelector:registerSelector]) {
-      [legacyRegistry performSelector:registerSelector
-                           withObject:singletonModuleClass];
-      return;
-    }
-  }
-  // Fall back to local ObjC storage (for CocoaPods source builds)
+extern void EXRegisterSingletonModule(Class);
+extern void EXRegisterSingletonModule(Class singletonModuleClass)
+{
   dispatch_once(&onceToken, EXinitializeGlobalModulesRegistry);
 
   // A heuristic solution to "multiple singletons registering
@@ -94,8 +58,6 @@ EXRegisterSingletonModule(Class singletonModuleClass) {
   [EXSingletonModuleClasses addObject:singletonModuleClass];
 }
 
-EX_EXTERN_C_END
-
 // Singleton modules classes register in EXSingletonModuleClasses
 // with EXRegisterSingletonModule function. Then they should be
 // initialized exactly once (onceSingletonModulesToken guards that).
@@ -111,64 +73,38 @@ void (^EXinitializeGlobalSingletonModulesSet)(void) = ^{
 
 @interface EXModuleRegistryProvider ()
 
-@property(nonatomic, strong) NSSet *singletonModules;
+@property (nonatomic, strong) NSSet *singletonModules;
 
 @end
 
 @implementation EXModuleRegistryProvider
 
-- (instancetype)init {
-  return [self
-      initWithSingletonModules:[EXModuleRegistryProvider singletonModules]];
+- (instancetype)init
+{
+  return [self initWithSingletonModules:[EXModuleRegistryProvider singletonModules]];
 }
 
-- (instancetype)initWithSingletonModules:(NSSet *)modules {
+- (instancetype)initWithSingletonModules:(NSSet *)modules
+{
   if (self = [super init]) {
     _singletonModules = [NSSet setWithSet:modules];
   }
   return self;
 }
 
-+ (NSSet<Class> *)getModulesClasses {
-  // First check if LegacyModuleRegistry (Swift) has registered modules
-  // This is used for SPM prebuilds where modules register via @_cdecl functions
-  id legacyRegistry = EXGetLegacyModuleRegistry();
-  if (legacyRegistry) {
-    SEL getModulesSelector = NSSelectorFromString(@"getModuleClasses");
-    if ([legacyRegistry respondsToSelector:getModulesSelector]) {
-      NSSet *swiftModules = [legacyRegistry performSelector:getModulesSelector];
-      if (swiftModules.count > 0) {
-        return swiftModules;
-      }
-    }
-  }
-  // Fall back to static ObjC storage (used when building from source with
-  // CocoaPods)
++ (NSSet<Class> *)getModulesClasses
+{
   return EXModuleClasses;
 }
 
-+ (NSSet<EXSingletonModule *> *)singletonModules {
-  // First check if LegacyModuleRegistry (Swift) has registered singletons
-  id legacyRegistry = EXGetLegacyModuleRegistry();
-  if (legacyRegistry) {
-    SEL getSingletonsSelector = NSSelectorFromString(@"getSingletonModules");
-    if ([legacyRegistry respondsToSelector:getSingletonsSelector]) {
-      NSSet *swiftSingletons =
-          [legacyRegistry performSelector:getSingletonsSelector];
-      if (swiftSingletons.count > 0) {
-        return swiftSingletons;
-      }
-    }
-  }
-  // Fall back to static ObjC storage (used when building from source with
-  // CocoaPods)
-  dispatch_once(&onceSingletonModulesToken,
-                EXinitializeGlobalSingletonModulesSet);
++ (NSSet<EXSingletonModule *> *)singletonModules
+{
+  dispatch_once(&onceSingletonModulesToken, EXinitializeGlobalSingletonModulesSet);
   return EXSingletonModules;
 }
 
-+ (nullable EXSingletonModule *)getSingletonModuleForClass:
-    (Class)singletonClass {
++ (nullable EXSingletonModule *)getSingletonModuleForClass:(Class)singletonClass
+{
   NSSet<EXSingletonModule *> *singletonModules = [self singletonModules];
 
   for (EXSingletonModule *singleton in singletonModules) {
@@ -179,7 +115,8 @@ void (^EXinitializeGlobalSingletonModulesSet)(void) = ^{
   return nil;
 }
 
-- (EXModuleRegistry *)moduleRegistry {
+- (EXModuleRegistry *)moduleRegistry
+{
   NSMutableSet<id<EXInternalModule>> *internalModules = [NSMutableSet set];
   NSMutableSet<EXExportedModule *> *exportedModules = [NSMutableSet set];
 
@@ -191,8 +128,7 @@ void (^EXinitializeGlobalSingletonModulesSet)(void) = ^{
 
     id<EXInternalModule> instance = [self createModuleInstance:klass];
 
-    if ([[instance class] exportedInterfaces] != nil &&
-        [[[instance class] exportedInterfaces] count] > 0) {
+    if ([[instance class] exportedInterfaces] != nil && [[[instance class] exportedInterfaces] count] > 0) {
       [internalModules addObject:instance];
     }
 
@@ -201,17 +137,17 @@ void (^EXinitializeGlobalSingletonModulesSet)(void) = ^{
     }
   }
 
-  EXModuleRegistry *moduleRegistry =
-      [[EXModuleRegistry alloc] initWithInternalModules:internalModules
-                                        exportedModules:exportedModules
-                                       singletonModules:_singletonModules];
+  EXModuleRegistry *moduleRegistry = [[EXModuleRegistry alloc] initWithInternalModules:internalModules
+                                                                       exportedModules:exportedModules
+                                                                      singletonModules:_singletonModules];
   [moduleRegistry setDelegate:_moduleRegistryDelegate];
   return moduleRegistry;
 }
 
-#pragma mark - Utilities
+# pragma mark - Utilities
 
-- (id<EXInternalModule>)createModuleInstance:(Class)moduleClass {
+- (id<EXInternalModule>)createModuleInstance:(Class)moduleClass
+{
   return [[moduleClass alloc] init];
 }
 

--- a/packages/expo-modules-core/ios/Legacy/ModuleRegistryProvider/EXModuleRegistryProvider.m
+++ b/packages/expo-modules-core/ios/Legacy/ModuleRegistryProvider/EXModuleRegistryProvider.m
@@ -1,10 +1,9 @@
 // Copyright © 2018 650 Industries. All rights reserved.
 
-#import <Foundation/Foundation.h>
-#import <ExpoModulesCore/EXSingletonModule.h>
+#import <ExpoModulesCore/EXDefines.h>
 #import <ExpoModulesCore/EXModuleRegistryProvider.h>
-
-#import <React/RCTLog.h>
+#import <ExpoModulesCore/EXSingletonModule.h>
+#import <Foundation/Foundation.h>
 
 // Forward declaration for LegacyModuleRegistry (Swift)
 // This allows SPM prebuilds to use the Swift-based registry
@@ -14,24 +13,61 @@ static dispatch_once_t onceToken;
 static NSMutableSet<Class> *EXModuleClasses;
 static NSMutableSet<Class> *EXSingletonModuleClasses;
 
+// Helper to get the Swift LegacyModuleRegistry if available
+static id EXGetLegacyModuleRegistry(void) {
+  static id legacyRegistry = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    Class legacyRegistryClass = NSClassFromString(@"EXLegacyModuleRegistry");
+    if (legacyRegistryClass) {
+      SEL sharedSelector = NSSelectorFromString(@"shared");
+      if ([legacyRegistryClass respondsToSelector:sharedSelector]) {
+        legacyRegistry = [legacyRegistryClass performSelector:sharedSelector];
+      }
+    }
+  });
+  return legacyRegistry;
+}
+
 void (^EXinitializeGlobalModulesRegistry)(void) = ^{
   EXModuleClasses = [NSMutableSet set];
   EXSingletonModuleClasses = [NSMutableSet set];
 
   // Also add temporary Swift modules from core
-  [EXModuleClasses addObject: NSClassFromString(@"EXFileSystemLegacyUtilities")];
+  [EXModuleClasses addObject:NSClassFromString(@"EXFileSystemLegacyUtilities")];
 };
 
-extern void EXRegisterModule(Class);
-extern void EXRegisterModule(Class moduleClass)
-{
+EX_EXTERN_C_BEGIN
+
+__attribute__((visibility("default"))) void
+EXRegisterModule(Class moduleClass) {
+  // First try to register with Swift LegacyModuleRegistry (for SPM prebuilds)
+  id legacyRegistry = EXGetLegacyModuleRegistry();
+  if (legacyRegistry) {
+    SEL registerSelector = NSSelectorFromString(@"registerModule:");
+    if ([legacyRegistry respondsToSelector:registerSelector]) {
+      [legacyRegistry performSelector:registerSelector withObject:moduleClass];
+      return;
+    }
+  }
+  // Fall back to local ObjC storage (for CocoaPods source builds)
   dispatch_once(&onceToken, EXinitializeGlobalModulesRegistry);
   [EXModuleClasses addObject:moduleClass];
 }
 
-extern void EXRegisterSingletonModule(Class);
-extern void EXRegisterSingletonModule(Class singletonModuleClass)
-{
+__attribute__((visibility("default"))) void
+EXRegisterSingletonModule(Class singletonModuleClass) {
+  // First try to register with Swift LegacyModuleRegistry (for SPM prebuilds)
+  id legacyRegistry = EXGetLegacyModuleRegistry();
+  if (legacyRegistry) {
+    SEL registerSelector = NSSelectorFromString(@"registerSingletonModule:");
+    if ([legacyRegistry respondsToSelector:registerSelector]) {
+      [legacyRegistry performSelector:registerSelector
+                           withObject:singletonModuleClass];
+      return;
+    }
+  }
+  // Fall back to local ObjC storage (for CocoaPods source builds)
   dispatch_once(&onceToken, EXinitializeGlobalModulesRegistry);
 
   // A heuristic solution to "multiple singletons registering
@@ -58,6 +94,8 @@ extern void EXRegisterSingletonModule(Class singletonModuleClass)
   [EXSingletonModuleClasses addObject:singletonModuleClass];
 }
 
+EX_EXTERN_C_END
+
 // Singleton modules classes register in EXSingletonModuleClasses
 // with EXRegisterSingletonModule function. Then they should be
 // initialized exactly once (onceSingletonModulesToken guards that).
@@ -73,38 +111,64 @@ void (^EXinitializeGlobalSingletonModulesSet)(void) = ^{
 
 @interface EXModuleRegistryProvider ()
 
-@property (nonatomic, strong) NSSet *singletonModules;
+@property(nonatomic, strong) NSSet *singletonModules;
 
 @end
 
 @implementation EXModuleRegistryProvider
 
-- (instancetype)init
-{
-  return [self initWithSingletonModules:[EXModuleRegistryProvider singletonModules]];
+- (instancetype)init {
+  return [self
+      initWithSingletonModules:[EXModuleRegistryProvider singletonModules]];
 }
 
-- (instancetype)initWithSingletonModules:(NSSet *)modules
-{
+- (instancetype)initWithSingletonModules:(NSSet *)modules {
   if (self = [super init]) {
     _singletonModules = [NSSet setWithSet:modules];
   }
   return self;
 }
 
-+ (NSSet<Class> *)getModulesClasses
-{
++ (NSSet<Class> *)getModulesClasses {
+  // First check if LegacyModuleRegistry (Swift) has registered modules
+  // This is used for SPM prebuilds where modules register via @_cdecl functions
+  id legacyRegistry = EXGetLegacyModuleRegistry();
+  if (legacyRegistry) {
+    SEL getModulesSelector = NSSelectorFromString(@"getModuleClasses");
+    if ([legacyRegistry respondsToSelector:getModulesSelector]) {
+      NSSet *swiftModules = [legacyRegistry performSelector:getModulesSelector];
+      if (swiftModules.count > 0) {
+        return swiftModules;
+      }
+    }
+  }
+  // Fall back to static ObjC storage (used when building from source with
+  // CocoaPods)
   return EXModuleClasses;
 }
 
-+ (NSSet<EXSingletonModule *> *)singletonModules
-{
-  dispatch_once(&onceSingletonModulesToken, EXinitializeGlobalSingletonModulesSet);
++ (NSSet<EXSingletonModule *> *)singletonModules {
+  // First check if LegacyModuleRegistry (Swift) has registered singletons
+  id legacyRegistry = EXGetLegacyModuleRegistry();
+  if (legacyRegistry) {
+    SEL getSingletonsSelector = NSSelectorFromString(@"getSingletonModules");
+    if ([legacyRegistry respondsToSelector:getSingletonsSelector]) {
+      NSSet *swiftSingletons =
+          [legacyRegistry performSelector:getSingletonsSelector];
+      if (swiftSingletons.count > 0) {
+        return swiftSingletons;
+      }
+    }
+  }
+  // Fall back to static ObjC storage (used when building from source with
+  // CocoaPods)
+  dispatch_once(&onceSingletonModulesToken,
+                EXinitializeGlobalSingletonModulesSet);
   return EXSingletonModules;
 }
 
-+ (nullable EXSingletonModule *)getSingletonModuleForClass:(Class)singletonClass
-{
++ (nullable EXSingletonModule *)getSingletonModuleForClass:
+    (Class)singletonClass {
   NSSet<EXSingletonModule *> *singletonModules = [self singletonModules];
 
   for (EXSingletonModule *singleton in singletonModules) {
@@ -115,8 +179,7 @@ void (^EXinitializeGlobalSingletonModulesSet)(void) = ^{
   return nil;
 }
 
-- (EXModuleRegistry *)moduleRegistry
-{
+- (EXModuleRegistry *)moduleRegistry {
   NSMutableSet<id<EXInternalModule>> *internalModules = [NSMutableSet set];
   NSMutableSet<EXExportedModule *> *exportedModules = [NSMutableSet set];
 
@@ -128,7 +191,8 @@ void (^EXinitializeGlobalSingletonModulesSet)(void) = ^{
 
     id<EXInternalModule> instance = [self createModuleInstance:klass];
 
-    if ([[instance class] exportedInterfaces] != nil && [[[instance class] exportedInterfaces] count] > 0) {
+    if ([[instance class] exportedInterfaces] != nil &&
+        [[[instance class] exportedInterfaces] count] > 0) {
       [internalModules addObject:instance];
     }
 
@@ -137,17 +201,17 @@ void (^EXinitializeGlobalSingletonModulesSet)(void) = ^{
     }
   }
 
-  EXModuleRegistry *moduleRegistry = [[EXModuleRegistry alloc] initWithInternalModules:internalModules
-                                                                       exportedModules:exportedModules
-                                                                      singletonModules:_singletonModules];
+  EXModuleRegistry *moduleRegistry =
+      [[EXModuleRegistry alloc] initWithInternalModules:internalModules
+                                        exportedModules:exportedModules
+                                       singletonModules:_singletonModules];
   [moduleRegistry setDelegate:_moduleRegistryDelegate];
   return moduleRegistry;
 }
 
-# pragma mark - Utilities
+#pragma mark - Utilities
 
-- (id<EXInternalModule>)createModuleInstance:(Class)moduleClass
-{
+- (id<EXInternalModule>)createModuleInstance:(Class)moduleClass {
   return [[moduleClass alloc] init];
 }
 

--- a/packages/expo-modules-core/ios/Legacy/ModuleRegistryProvider/EXModuleRegistryProvider.m
+++ b/packages/expo-modules-core/ios/Legacy/ModuleRegistryProvider/EXModuleRegistryProvider.m
@@ -1,5 +1,6 @@
 // Copyright © 2018 650 Industries. All rights reserved.
 
+#import <ExpoModulesCore/EXDefines.h>
 #import <Foundation/Foundation.h>
 #import <ExpoModulesCore/EXSingletonModule.h>
 #import <ExpoModulesCore/EXModuleRegistryProvider.h>
@@ -22,15 +23,15 @@ void (^EXinitializeGlobalModulesRegistry)(void) = ^{
   [EXModuleClasses addObject: NSClassFromString(@"EXFileSystemLegacyUtilities")];
 };
 
-extern void EXRegisterModule(Class);
-extern void EXRegisterModule(Class moduleClass)
+EX_EXTERN void EXRegisterModule(Class);
+EX_EXTERN void EXRegisterModule(Class moduleClass)
 {
   dispatch_once(&onceToken, EXinitializeGlobalModulesRegistry);
   [EXModuleClasses addObject:moduleClass];
 }
 
-extern void EXRegisterSingletonModule(Class);
-extern void EXRegisterSingletonModule(Class singletonModuleClass)
+EX_EXTERN void EXRegisterSingletonModule(Class);
+EX_EXTERN void EXRegisterSingletonModule(Class singletonModuleClass)
 {
   dispatch_once(&onceToken, EXinitializeGlobalModulesRegistry);
 

--- a/packages/expo-modules-core/ios/Protocols/EXAppContextProtocol.h
+++ b/packages/expo-modules-core/ios/Protocols/EXAppContextProtocol.h
@@ -55,8 +55,11 @@ typedef void (NS_SWIFT_SENDABLE ^EXPromiseRejectBlock)(NSString * _Nullable code
 
 /**
  Returns a JavaScript object that represents a module with given name.
+
+ @warning This method must only be called from the JavaScript thread.
+ It uses assumeIsolated internally and will crash if called from other threads.
  */
-- (nullable EXJavaScriptObject *)getNativeModuleObject:(nonnull NSString *)moduleName;
+- (nullable EXJavaScriptObject *)getNativeModuleObjectUnsafe:(nonnull NSString *)moduleName;
 
 /**
  Returns an array of event names supported by all Swift modules.

--- a/packages/expo-modules-core/ios/Utilities/EXImageLoader.h
+++ b/packages/expo-modules-core/ios/Utilities/EXImageLoader.h
@@ -3,11 +3,12 @@
 #if !__building_module(ExpoModulesCore)
 #import <React/RCTBridge.h>
 #import <React/RCTImageLoader.h>
+#import <ExpoModulesCore/EXImageLoaderInterface.h>
 #else
 @class RCTBridge;
+@class RCTImageLoader;
+@protocol EXImageLoaderInterface;
 #endif
-
-#import <ExpoModulesCore/EXImageLoaderInterface.h>
 
 NS_SWIFT_NAME(ImageLoader)
 @interface EXImageLoader : NSObject <EXImageLoaderInterface>

--- a/packages/expo-modules-core/ios/Worklets/WorkletRuntimeFactory.h
+++ b/packages/expo-modules-core/ios/Worklets/WorkletRuntimeFactory.h
@@ -1,5 +1,6 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
+#import <ExpoModulesCore/EXAppContextProtocol.h>
 #import <ExpoModulesCore/EXRuntime.h>
 #import <ExpoModulesJSI/EXJavaScriptValue.h>
 #import <ExpoModulesCore/EXWorkletRuntime.h>
@@ -8,7 +9,7 @@
 
 @interface WorkletRuntimeFactory : NSObject
 
-+ (nonnull EXWorkletRuntime *)createWorkletRuntime:(nonnull EXAppContext *)appContext fromPointer:(nullable void *)pointer;
++ (nonnull EXWorkletRuntime *)createWorkletRuntime:(nonnull id<EXAppContextProtocol>)appContext fromPointer:(nullable void *)pointer;
 
 + (nullable void *)extractRuntimePointer:(nonnull EXJavaScriptValue *)jsValue runtime:(nonnull EXJavaScriptRuntime *)runtime;
 

--- a/packages/expo-modules-core/ios/Worklets/WorkletRuntimeFactory.mm
+++ b/packages/expo-modules-core/ios/Worklets/WorkletRuntimeFactory.mm
@@ -11,7 +11,7 @@
 
 @implementation WorkletRuntimeFactory
 
-+ (nonnull EXWorkletRuntime *)createWorkletRuntime:(nonnull EXAppContext *)appContext fromPointer:(nullable void *)pointer
++ (nonnull EXWorkletRuntime *)createWorkletRuntime:(nonnull id<EXAppContextProtocol>)appContext fromPointer:(nullable void *)pointer
 {
 #if WORKLETS_ENABLED
   jsi::Runtime* jsRuntime = reinterpret_cast<jsi::Runtime *>(pointer);

--- a/packages/expo-notifications/ios/ExpoNotifications/Badge/BadgeModule.swift
+++ b/packages/expo-notifications/ios/ExpoNotifications/Badge/BadgeModule.swift
@@ -2,6 +2,7 @@
 
 import ExpoModulesCore
 import UIKit
+import React
 
 public class BadgeModule: Module {
   public func definition() -> ModuleDefinition {

--- a/packages/expo-tracking-transparency/ios/TrackingTransparencyPermissionRequester.swift
+++ b/packages/expo-tracking-transparency/ios/TrackingTransparencyPermissionRequester.swift
@@ -2,6 +2,7 @@
 
 import AppTrackingTransparency
 import ExpoModulesCore
+import React
 
 public class TrackingTransparencyPermissionRequester: NSObject, EXPermissionsRequester {
   static public func permissionType() -> String {

--- a/packages/expo/ios/AppDelegates/EXAppDelegatesLoader.m
+++ b/packages/expo/ios/AppDelegates/EXAppDelegatesLoader.m
@@ -3,7 +3,12 @@
 #import <Expo/EXLegacyAppDelegateWrapper.h>
 
 #import <Expo/EXAppDelegatesLoader.h>
-#import <Expo/Swift.h>
+
+#if __has_include(<Expo/Expo-Swift.h>)
+#import <Expo/Expo-Swift.h>
+#else
+#import "Expo-Swift.h"
+#endif
 
 // Make the legacy wrapper conform to the protocol for subscribers.
 @interface EXLegacyAppDelegateWrapper () <EXAppDelegateSubscriberProtocol>

--- a/packages/expo/ios/AppDelegates/EXReactRootViewFactory.mm
+++ b/packages/expo/ios/AppDelegates/EXReactRootViewFactory.mm
@@ -2,16 +2,8 @@
 
 #import <Expo/EXReactRootViewFactory.h>
 #import <Expo/RCTAppDelegateUmbrella.h>
-#import <Expo/Swift.h>
 #import <React/RCTDevMenu.h>
-
-// When `use_frameworks!` is used, the generated Swift header is inside ExpoModulesCore module.
-// Otherwise, it's available only locally with double-quoted imports.
-#if __has_include(<ExpoModulesCore/ExpoModulesCore-Swift.h>)
-#import <ExpoModulesCore/ExpoModulesCore-Swift.h>
-#else
-#import "ExpoModulesCore-Swift.h"
-#endif
+#import <ExpoModulesCore/EXReactDelegateProtocol.h>
 
 @interface RCTRootViewFactory ()
 
@@ -38,7 +30,7 @@
           devMenuConfiguration:(RCTDevMenuConfiguration *)devMenuConfiguration
 {
   if (self.reactDelegate != nil) {
-    return [self.reactDelegate createReactRootViewWithModuleName:moduleName initialProperties:initialProperties launchOptions:launchOptions];
+    return [((id<EXReactDelegateProtocol>)self.reactDelegate) createReactRootViewWithModuleName:moduleName initialProperties:initialProperties launchOptions:launchOptions];
   }
   return [super viewWithModuleName:moduleName initialProperties:initialProperties launchOptions:launchOptions devMenuConfiguration:devMenuConfiguration];
 }
@@ -75,7 +67,7 @@
 
 - (NSURL *)bundleURL
 {
-  return [self.reactDelegate bundleURL] ?: [super bundleURL];
+  return [((id<EXReactDelegateProtocol>)self.reactDelegate) bundleURL] ?: [super bundleURL];
 }
 
 @end

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
@@ -1,6 +1,7 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
 #import <Expo/ExpoReactNativeFactory.h>
+#import <ExpoModulesCore/EXHostWrapper.h>
 
 // When using xcframeworks, the generated Swift
 // header is inside ExpoModulesCore module. Otherwise, it's available only
@@ -45,6 +46,8 @@
 
   // Inject and decorate the `global.expo` object
   _appContext._runtime = [[EXRuntime alloc] initWithRuntime:runtime];
+  [_appContext setHostWrapper:[[EXHostWrapper alloc] initWithHost:host]];
+
   
   [_appContext registerNativeModules];
 }

--- a/packages/expo/ios/Fetch/ExpoFetchModule.swift
+++ b/packages/expo/ios/Fetch/ExpoFetchModule.swift
@@ -5,7 +5,6 @@
 /// Typealias matching React Native's NSURLSessionConfigurationProvider block type
 public typealias URLSessionConfigurationProvider = @convention(block) () -> URLSessionConfiguration?
 
-
 private let fetchRequestQueue = DispatchQueue(label: "expo.modules.fetch.RequestQueue")
 nonisolated(unsafe) internal var urlSessionConfigurationProvider: URLSessionConfigurationProvider?
 


### PR DESCRIPTION
# Why

Fixed `obj-c -> swift -> obj-c` dependency cycles

- Implementing a Swift-based registry for legacy Expo modules that use the `EX_EXPORT_MODULE` and `EX_REGISTER_SINGLETON_MODULE` Objective-C macros. This registry replaces the static Objective-C data structures to enable compatibility with prebuilt SPM xcframeworks while maintaining backward compatibility with legacy module registration.
- Refactored RCTViewManager: changed the class to inherit from NSObject and implementing the necessary members directly.
- Refactored the EXReactNativeEventEmitter to expose the same members but call them throught the AppContext.
- Refactored the ViewDefinition class to avoid name clash in SwiftUIViewDefinition.