### PR TITLE
fix(cli): restore `resetCache`, `maxWorkers`, and `port` argument overrides in Metro instantiation

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### 🐛 Bug fixes
 
+- Restore `resetCache` and `maxWorkers` options in Metro config. ([#41854](https://github.com/expo/expo/pull/41854) by [@shottah](https://github.com/shottah))
 - clean up hanging processes at the end of `expo export` better. ([#41692](https://github.com/expo/expo/pull/41692) by [@EvanBacon](https://github.com/EvanBacon))
 - refactor launching Expo Go on Android ([#40020](https://github.com/expo/expo/pull/40020) by [@vonovak](https://github.com/vonovak))
 - only skip dependency validation for `EXPO_NO_DEPENDENCY_VALIDATION=1` ([#40043](https://github.com/expo/expo/pull/40043) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -19,7 +19,6 @@
 
 ### 🐛 Bug fixes
 
-- Restore `resetCache` and `maxWorkers` options in Metro config. ([#41854](https://github.com/expo/expo/pull/41854) by [@shottah](https://github.com/shottah))
 - clean up hanging processes at the end of `expo export` better. ([#41692](https://github.com/expo/expo/pull/41692) by [@EvanBacon](https://github.com/EvanBacon))
 - refactor launching Expo Go on Android ([#40020](https://github.com/expo/expo/pull/40020) by [@vonovak](https://github.com/vonovak))
 - only skip dependency validation for `EXPO_NO_DEPENDENCY_VALIDATION=1` ([#40043](https://github.com/expo/expo/pull/40043) by [@kitten](https://github.com/kitten))
@@ -29,6 +28,7 @@
 - Fix `expo install` not auto-adding config plugins for scoped packages ([#41613](https://github.com/expo/expo/pull/41613) by [@kitten](https://github.com/kitten))
 - Fix `metro-runtime/src/modules/empty-module.js` in RSC middleware ([#41687](https://github.com/expo/expo/pull/41687) by [@kitten](https://github.com/kitten))
 - Pass empty `nodeModulesPaths` when applying autolinking and fallback resolution to Metro resolver ([#41703](https://github.com/expo/expo/pull/41703) by [@kitten](https://github.com/kitten))
+- Restore `resetCache`, `maxWorkers`, and `port` override args when instantiating Metro ([#41854](https://github.com/expo/expo/pull/41854) by [@shottah](https://github.com/shottah))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -130,6 +130,8 @@ export async function loadMetroConfigAsync(
   // Force-override the reporter
   config = {
     ...config,
+    resetCache: !!options.resetCache,
+    maxWorkers: options.maxWorkers ?? config.maxWorkers,
     watchFolders: !config.watchFolders.includes(config.projectRoot)
       ? [config.projectRoot, ...config.watchFolders]
       : config.watchFolders,

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -126,12 +126,21 @@ export async function loadMetroConfigAsync(
   let config: ConfigT = resolvedConfig.isEmpty
     ? defaultConfig
     : await mergeConfig(defaultConfig, resolvedConfig.config);
+
   // Set the watchfolders to include the projectRoot, as Metro assumes this
   // Force-override the reporter
   config = {
     ...config,
+
+    // See: `overrideConfigWithArguments` https://github.com/facebook/metro/blob/5059e26/packages/metro-config/src/loadConfig.js#L274-L339
+    // Compare to `LoadOptions` type (disregard `reporter` as we don't expose this)
     resetCache: !!options.resetCache,
     maxWorkers: options.maxWorkers ?? config.maxWorkers,
+    server: {
+      ...config.server,
+      port: options.port ?? config.server.port,
+    },
+
     watchFolders: !config.watchFolders.includes(config.projectRoot)
       ? [config.projectRoot, ...config.watchFolders]
       : config.watchFolders,


### PR DESCRIPTION
## Summary

Resolves https://github.com/expo/expo/issues/41839

- Restores `resetCache` and `maxWorkers` CLI options that were inadvertently removed in commit 34dd4b38a4

## Context

The refactor in 34dd4b38a4 replaced `loadConfig` with `resolveConfig` + `mergeConfig`, which bypassed `overrideConfigWithArguments` - the function that applied CLI options to the Metro config.

This caused `--clear` and `--max-workers` flags to have no effect.

## Test plan

- Run `expo start --clear` and verify Metro cache is cleared
- Run `expo start --max-workers=4` and verify worker count is respected