### PR TITLE
[core][Android] Fix release builds

### DIFF
--- a/packages/expo-modules-core/android/proguard-rules.pro
+++ b/packages/expo-modules-core/android/proguard-rules.pro
@@ -37,3 +37,9 @@
 -keepnames class * implements expo.modules.kotlin.views.ExpoView {
   *;
 }
+
+-keep interface expo.modules.kotlin.services.Service
+
+-keep class * implements expo.modules.kotlin.services.Service {
+    <init>(...);
+}


### PR DESCRIPTION
# Why

Fixes release builds.

# How

It turns out that `serviceClass.constructors.single` is failing due to R8 optimization. I've added a proguard rule to keep the constructor of the service untouched. 

# Test Plan

- build bare-expo in release ✅ 