### PR TITLE
[docs] Fix TableOfContents (TOC) bug

### DIFF
--- a/docs/ui/components/TableOfContents/TableOfContents.test.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContents.test.tsx
@@ -1,11 +1,14 @@
 import { jest } from '@jest/globals';
+import { act, fireEvent } from '@testing-library/react';
 import GithubSlugger from 'github-slugger';
+import { createRef, type RefObject } from 'react';
 
-import { HeadingType, createHeadingManager } from '~/common/headingManager';
+import { BASE_HEADING_LEVEL, HeadingType, createHeadingManager } from '~/common/headingManager';
 import { renderWithHeadings } from '~/common/test-utilities';
 import { HeadingsContext } from '~/common/withHeadingManager';
+import { type ScrollContainerHandle } from '~/components/ScrollContainer';
 
-import { TableOfContents } from './TableOfContents';
+import { TableOfContents, TableOfContentsHandles } from './TableOfContents';
 
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
@@ -24,6 +27,54 @@ const prepareHeadingManager = () => {
   return headingManager;
 };
 
+const createHeadingManagerWithOffsets = () => {
+  const headingManager = createHeadingManager(new GithubSlugger(), { headings: [] });
+  const headingEntries = [
+    { title: 'Intro', level: BASE_HEADING_LEVEL, slug: 'intro', offset: 0 },
+    { title: 'Middle', level: BASE_HEADING_LEVEL + 1, slug: 'middle', offset: 900 },
+    { title: 'End', level: BASE_HEADING_LEVEL, slug: 'end', offset: 1800 },
+  ];
+
+  headingEntries.forEach(({ title, level, slug, offset }) => {
+    const heading = headingManager.addHeading(title, level, {}, slug);
+    heading.ref.current = document.createElement('div');
+    Object.defineProperty(heading.ref.current, 'offsetTop', {
+      value: offset,
+      configurable: true,
+    });
+  });
+
+  return headingManager;
+};
+
+const createContentRef = (
+  viewportHeight = 900,
+  scrollHeight = 2400
+): {
+  contentRef: RefObject<ScrollContainerHandle | null>;
+  scrollTo: jest.Mock;
+  scrollRef: { current: HTMLDivElement };
+} => {
+  const scrollTo = jest.fn();
+  const scrollElement = {
+    clientHeight: viewportHeight,
+    scrollHeight,
+    scrollTo,
+  } as unknown as HTMLDivElement;
+  const scrollRef = { current: scrollElement };
+
+  return {
+    contentRef: {
+      current: {
+        getScrollRef: () => scrollRef,
+        getScrollTop: () => 0,
+      },
+    } as unknown as RefObject<ScrollContainerHandle | null>,
+    scrollTo,
+    scrollRef,
+  };
+};
+
 describe('TableOfContents', () => {
   test('correctly matches snapshot', () => {
     const headingManager = prepareHeadingManager();
@@ -34,5 +85,60 @@ describe('TableOfContents', () => {
       </HeadingsContext.Provider>
     );
     expect(container).toMatchSnapshot();
+  });
+
+  test('activates headings near top, middle, and bottom positions', () => {
+    const headingManager = createHeadingManagerWithOffsets();
+    const { contentRef } = createContentRef();
+    const tocRef = createRef<TableOfContentsHandles>();
+
+    const { getByText } = renderWithHeadings(
+      <HeadingsContext.Provider value={headingManager}>
+        <TableOfContents ref={tocRef} headingManager={headingManager} contentRef={contentRef} />
+      </HeadingsContext.Provider>
+    );
+
+    act(() => tocRef.current?.handleContentScroll?.(0));
+    expect(tocRef.current).not.toBeNull();
+    const introText = getByText('Intro');
+    expect(introText).toHaveClass('!text-link');
+
+    act(() => tocRef.current?.handleContentScroll?.(950));
+    const middleText = getByText('Middle');
+    expect(middleText).toHaveClass('!text-link');
+
+    act(() => tocRef.current?.handleContentScroll?.(1500));
+    const endText = getByText('End');
+    expect(endText).toHaveClass('!text-link');
+  });
+
+  test('scrolls to align heading with activation line on click', () => {
+    const headingManager = createHeadingManager(new GithubSlugger(), { headings: [] });
+    const intro = headingManager.addHeading('Intro', BASE_HEADING_LEVEL, {}, 'intro');
+    const middle = headingManager.addHeading('Middle', BASE_HEADING_LEVEL, {}, 'middle');
+    intro.ref.current = document.createElement('div');
+    middle.ref.current = document.createElement('div');
+    Object.defineProperty(intro.ref.current, 'offsetTop', { value: 0, configurable: true });
+    Object.defineProperty(middle.ref.current, 'offsetTop', { value: 800, configurable: true });
+
+    const { contentRef, scrollTo, scrollRef } = createContentRef(800, 1600);
+    const tocRef = createRef<TableOfContentsHandles>();
+
+    const { getByText } = renderWithHeadings(
+      <HeadingsContext.Provider value={headingManager}>
+        <TableOfContents ref={tocRef} headingManager={headingManager} contentRef={contentRef} />
+      </HeadingsContext.Provider>
+    );
+
+    act(() => {
+      fireEvent.click(getByText('Middle'));
+    });
+
+    expect(scrollTo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        // 0.05 = ACTIVE_ITEM_OFFSET_FACTOR (1/20), 21 = scrollOffset
+        top: 800 - scrollRef.current.clientHeight * 0.05 + 21,
+      })
+    );
   });
 });

--- a/docs/ui/components/TableOfContents/TableOfContents.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContents.tsx
@@ -151,7 +151,9 @@ export const TableOfContents = forwardRef<
 
       for (let i = 0; i < headings.length; i++) {
         const heading = headings[i];
-        if (!heading.ref?.current) continue;
+        if (!heading.ref?.current) {
+          continue;
+        }
 
         const sectionStart = heading.ref.current.offsetTop;
         const nextHeading = headings[i + 1];

--- a/docs/ui/components/TableOfContents/TableOfContents.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContents.tsx
@@ -143,7 +143,33 @@ export const TableOfContents = forwardRef<
         : false;
 
     if (isNearBottom && headings.length > 0) {
-      nextActive = headings.at(-1) ?? nextActive;
+      const viewportTop = contentScrollPosition;
+      const viewportBottom = contentScrollPosition + viewportHeight;
+
+      let bestHeading: Heading | null = null;
+      let bestVisibleArea = 0;
+
+      for (let i = 0; i < headings.length; i++) {
+        const heading = headings[i];
+        if (!heading.ref?.current) continue;
+
+        const sectionStart = heading.ref.current.offsetTop;
+        const nextHeading = headings[i + 1];
+        const sectionEnd = nextHeading?.ref?.current?.offsetTop ?? scrollHeight;
+
+        const visibleStart = Math.max(sectionStart, viewportTop);
+        const visibleEnd = Math.min(sectionEnd, viewportBottom);
+        const visibleArea = Math.max(0, visibleEnd - visibleStart);
+
+        if (visibleArea >= bestVisibleArea) {
+          bestVisibleArea = visibleArea;
+          bestHeading = heading;
+        }
+      }
+
+      if (bestHeading && bestVisibleArea > 0) {
+        nextActive = bestHeading;
+      }
     }
 
     const activeHeading = nextActive ?? headings[0] ?? null;

--- a/docs/ui/components/TableOfContents/TableOfContents.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContents.tsx
@@ -27,6 +27,7 @@ import { TableOfContentsLink } from './TableOfContentsLink';
 const UPPER_SCROLL_LIMIT_FACTOR = 1 / 4;
 const LOWER_SCROLL_LIMIT_FACTOR = 3 / 4;
 const ACTIVE_ITEM_OFFSET_FACTOR = 1 / 20;
+const TARGET_IN_VIEW_BUFFER = 48;
 
 export type TableOfContentsProps = PropsWithChildren<{
   maxNestingDepth?: number;
@@ -73,6 +74,23 @@ export const TableOfContents = forwardRef<
 
   useImperativeHandle(ref, () => ({ handleContentScroll }), []);
 
+  function getContentScrollElement() {
+    return contentRef?.current?.getScrollRef().current;
+  }
+
+  function getViewportHeight() {
+    return getContentScrollElement()?.clientHeight ?? window.innerHeight;
+  }
+
+  function getScrollMetrics() {
+    const scrollElement = getContentScrollElement();
+    const viewportHeight = getViewportHeight();
+    const scrollHeight = scrollElement?.scrollHeight ?? 0;
+    const activationOffset = viewportHeight * ACTIVE_ITEM_OFFSET_FACTOR;
+
+    return { scrollElement, viewportHeight, scrollHeight, activationOffset };
+  }
+
   function handleContentScroll(contentScrollPosition: number) {
     const showScrollTopValue = contentScrollPosition > 120;
 
@@ -80,16 +98,18 @@ export const TableOfContents = forwardRef<
       setShowScrollTop(showScrollTopValue);
     }
 
-    const viewportMiddle = contentScrollPosition + window.innerHeight / 2;
-    const viewportActiveOffset =
-      contentScrollPosition + window.innerHeight * ACTIVE_ITEM_OFFSET_FACTOR;
+    const { scrollElement, viewportHeight, scrollHeight, activationOffset } = getScrollMetrics();
+    const activationLine = contentScrollPosition + activationOffset;
+    const bottomThreshold = Math.min(200, viewportHeight * 0.1);
 
     if (slugScrollingTo.current) {
       const targetHeading = headings.find(h => h.slug === slugScrollingTo.current);
       const targetTop = targetHeading?.ref?.current?.offsetTop;
 
       if (targetTop != null) {
-        const targetInView = targetTop >= viewportActiveOffset && targetTop <= viewportMiddle;
+        const targetInView =
+          targetTop >= activationLine - TARGET_IN_VIEW_BUFFER &&
+          targetTop <= activationLine + TARGET_IN_VIEW_BUFFER;
 
         if (!targetInView) {
           return;
@@ -101,43 +121,57 @@ export const TableOfContents = forwardRef<
       slugScrollingTo.current = null;
     }
 
-    for (const { ref, slug, level } of headings) {
-      if (!ref?.current) {
+    let nextActive: Heading | null = null;
+
+    for (const heading of headings) {
+      if (!heading.ref?.current) {
         continue;
       }
 
-      const headingTop = ref.current.offsetTop;
+      const headingTop = heading.ref.current.offsetTop;
 
-      if (headingTop > viewportMiddle) {
+      if (headingTop <= activationLine) {
+        nextActive = heading;
+      } else {
         break;
       }
+    }
 
-      const isInView = headingTop >= viewportActiveOffset && headingTop <= viewportMiddle;
+    const isNearBottom =
+      scrollElement && scrollHeight
+        ? contentScrollPosition + viewportHeight >= scrollHeight - bottomThreshold
+        : false;
 
-      if (isInView) {
-        if (slug === activeSlug) {
+    if (isNearBottom && headings.length > 0) {
+      nextActive = headings.at(-1) ?? nextActive;
+    }
+
+    const activeHeading = nextActive ?? headings[0] ?? null;
+
+    if (!activeHeading) {
+      return;
+    }
+
+    if (activeHeading.slug === activeSlug) {
+      return;
+    }
+
+    if (activeHeading.level > BASE_HEADING_LEVEL + 1 && isVersioned) {
+      const currentIndex = headings.findIndex(h => h.slug === activeHeading.slug);
+      for (let i = currentIndex; i >= 0; i--) {
+        const h = headings[i];
+        if (h.level === BASE_HEADING_LEVEL + 1) {
+          setActiveParentSlug(h.slug);
+          setActiveSlug(activeHeading.slug);
+          updateSelfScroll();
           return;
         }
-
-        if (level > BASE_HEADING_LEVEL + 1 && isVersioned) {
-          const currentIndex = headings.findIndex(h => h.slug === slug);
-          for (let i = currentIndex; i >= 0; i--) {
-            const h = headings[i];
-            if (h.level === BASE_HEADING_LEVEL + 1) {
-              setActiveParentSlug(h.slug);
-              setActiveSlug(slug);
-              updateSelfScroll();
-              return;
-            }
-          }
-        }
-
-        setActiveParentSlug(null);
-        setActiveSlug(slug);
-        updateSelfScroll();
-        return;
       }
     }
+
+    setActiveParentSlug(null);
+    setActiveSlug(activeHeading.slug);
+    updateSelfScroll();
   }
 
   function updateSelfScroll() {
@@ -224,11 +258,12 @@ export const TableOfContents = forwardRef<
 
     slugScrollingTo.current = slug;
 
+    const { activationOffset } = getScrollMetrics();
     const scrollOffset = type === 'inlineCode' ? 35 : 21;
 
     contentRef?.current?.getScrollRef().current?.scrollTo({
       behavior: reducedMotion ? 'instant' : 'smooth',
-      top: ref.current?.offsetTop - window.innerHeight * ACTIVE_ITEM_OFFSET_FACTOR - scrollOffset,
+      top: Math.max(0, (ref.current?.offsetTop ?? 0) - activationOffset + scrollOffset),
     });
 
     if (history?.replaceState) {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the TOC component has a large offset. Highlighting gets triggered while a heading is still far from the top (wide gap). TOC scroll targeting didn’t align with the activation band, causing misaligned highlights after clicking.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Rebased activation on content scroll container dimensions with a top-biased activation line and near-bottom fallback, ensuring first/last sections highlight.
- Updated tests to cover activation at top/mid/bottom and click scroll offsets.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs app locally and motice the offset gets triggered for the section in viewport from the top.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
