### PR TITLE
[expo] bump react-native version to 0.83.1 in bundledNativeModules.json to fix canary build

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -94,7 +94,7 @@
   "lottie-react-native": "~7.3.4",
   "react": "19.2.0",
   "react-dom": "19.2.0",
-  "react-native": "0.82.1",
+  "react-native": "0.83.1",
   "react-native-web": "~0.21.0",
   "react-native-gesture-handler": "~2.28.0",
   "react-native-get-random-values": "~1.11.0",


### PR DESCRIPTION
# Why

Wrong version of `react-native` is installed on canary version of expo. This in turn causes build issues.

# How

Upgrade to `0.83.1` which is the version used on main

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
