### PR TITLE
[docs] Replace "experimental" with "alpha" in callouts

### DIFF
--- a/docs/pages/brownfield/overview.mdx
+++ b/docs/pages/brownfield/overview.mdx
@@ -17,7 +17,7 @@ By these definitions, if you have an "existing native app" for Android or iOS an
 
 ## Compatibility with existing native apps
 
-> **info** Support for integrating Expo modules into existing native projects is still experimental. If you encounter issues, [create an issue on GitHub](https://github.com/expo/expo/issues). Not all features of the tools and services below will be available when used in the context of an existing native app.
+> **info** Support for integrating Expo modules into existing native projects is in alpha. If you encounter issues, [create an issue on GitHub](https://github.com/expo/expo/issues). Not all features of the tools and services below will be available when used in the context of an existing native app.
 
 Expo is primarily built with greenfield apps in mind, but we are increasingly investing in brownfield scenarios. Not all Expo tools and services are compatible with existing native projects yet. Additionally, comprehensive documentation for brownfield integrations may not yet available, and you may need to adapt other related documentation to your context.
 

--- a/docs/pages/config-plugins/patch-project.mdx
+++ b/docs/pages/config-plugins/patch-project.mdx
@@ -7,7 +7,7 @@ description: Learn about how to use patch-project to create generate, apply, and
 import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
 
-> **important** **Note**: `patch-project` is an experimental feature.
+> **important** **Note**: `patch-project` is an alpha feature.
 
 `patch-project` is an Expo config plugin and command-line interface (CLI) tool that generates and applies patches to preserve native changes after running `npx expo prebuild`. This tool is useful for native app developers who want to preserve customizations without needing to know how to write a config plugin, effectively generating an automatic solution that works with [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/).
 

--- a/docs/pages/debugging/tools.mdx
+++ b/docs/pages/debugging/tools.mdx
@@ -171,7 +171,7 @@ The **Profiler** tab allows you to record and analyze the performance of your ap
 
 ## Debugging with VS Code
 
-> **warning** VS Code debugger integration is experimental. For the most stable debugging experience, [use the React Native DevTools](#debugging-with-react-native-devtools).
+> **warning** VS Code debugger integration is in alpha. For the most stable debugging experience, [use the React Native DevTools](#debugging-with-react-native-devtools).
 
 VS Code is a popular code editor, which has a built-in debugger. This debugger uses the same system as the React Native DevTools &mdash; the inspector protocol.
 

--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -180,7 +180,7 @@ Think of these functions like React Server Functions, but instead of residing on
 
 ## Passing refs
 
-> **important** This is experimental and may change in the future.
+> **important** This is alpha and may change in the future.
 
 You can use the `useDOMImperativeHandle` hook inside a DOM component to accept ref calls from the native side. This hook is similar to React's [`useImperativeHandle`](https://react.dev/reference/react/useImperativeHandle) hook, but it does not need a ref object to be passed to it.
 
@@ -294,7 +294,7 @@ While `process.env.EXPO_OS` will always be web in a DOM component, you can detec
 
 ## Public assets
 
-> **important** **Warning:** This is experimental and may change in the future. Public assets are not supported in EAS Update. Use `require()` to load local assets instead.
+> **important** **Warning:** This is in alpha and may change in the future. Public assets are not supported in EAS Update. Use `require()` to load local assets instead.
 
 The contents of the root **public** directory are copied to the native app's binary to support the use of public assets in DOM components. Since these public assets will be served from the local filesystem, use the `process.env.EXPO_BASE_URL` prefix to reference the correct path. For example:
 

--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -180,7 +180,7 @@ Think of these functions like React Server Functions, but instead of residing on
 
 ## Passing refs
 
-> **important** This is alpha and may change in the future.
+> **important** This is in alpha and may change in the future.
 
 You can use the `useDOMImperativeHandle` hook inside a DOM component to accept ref calls from the native side. This hook is similar to React's [`useImperativeHandle`](https://react.dev/reference/react/useImperativeHandle) hook, but it does not need a ref object to be passed to it.
 

--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -299,7 +299,7 @@ For [npm](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#overrides),
 
 #### Deduplicating auto-linked native modules
 
-> **important** This is an experimental feature starting in SDK 54 and later. The process will be automated and have better support in future versions.
+> **important** This is an alpha feature starting in SDK 54 and later. The process will be automated and have better support in future versions.
 
 Often, duplicate dependencies won't cause any problems. However, native modules should never be duplicated, because only one version of a native module can be compiled for an app build at a time. Unlike JavaScript dependencies, native builds cannot contain two conflicting versions of a single native module.
 

--- a/docs/pages/guides/server-components.mdx
+++ b/docs/pages/guides/server-components.mdx
@@ -427,7 +427,7 @@ The `unstable_headers` function returns a promise that resolves to a read-only `
 
 ## Full React Server Components mode
 
-> This mode is even more experimental!
+> **important** This mode is experimental.
 
 Enabling full React Server Components support allows you to leverage even more features. In this mode, the default rendering mode for routes is server components instead of client components. It is still in development, as the Router and React Navigation need to be rewritten to support concurrency.
 

--- a/docs/pages/linking/ios-universal-links.mdx
+++ b/docs/pages/linking/ios-universal-links.mdx
@@ -28,7 +28,7 @@ To setup **two-way association** between the website and app for iOS, you need t
 
 Create an **apple-app-site-association** file for the website verification inside the **/.well-known** directory. This file specifies your Apple Developer Team ID, bundle identifier, and a list of supported paths to redirect to the native app.
 
-> **info** You can run the **experimental** CLI command `npx setup-safari` inside your project to automatically register a bundle identifier to your Apple account, assign entitlements to the ID, and create an iTunes app entry in the store. The local setup will be printed and you can skip most the following. This is the easiest way to get started with universal links on iOS.
+> **info** You can run the experimental CLI command `npx setup-safari` inside your project to automatically register a bundle identifier to your Apple account, assign entitlements to the ID, and create an iTunes app entry in the store. The local setup will be printed and you can skip most the following. This is the easiest way to get started with universal links on iOS.
 
 If you're using Expo Router to build your website (or any other modern React framework such as Remix, Next.js, and so on), create the AASA file at **public/.well-known/apple-app-site-association**. For legacy Expo webpack projects, create the file at **web/.well-known/apple-app-site-association**.
 

--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -257,7 +257,7 @@ For example, with the `--platform ios` option, it returns an object in **react-n
 
 ## Dependency resolution and conflicts
 
-> **important** This is an experimental feature starting in SDK 54 and later.
+> **important** This is an alpha feature starting in SDK 54 and later.
 
 Autolinking and Node resolution have different goals and the module resolution algorithm in Node and Metro can sometimes come into conflict. If your app contains duplicate installations of a native module that is picked up by autolinking, your JavaScript bundle may contain both versions of the native module, while autolinking and your native app will only contain one version. This might cause runtime crashes and risks incompatibilities.
 

--- a/docs/pages/router/advanced/native-intent.mdx
+++ b/docs/pages/router/advanced/native-intent.mdx
@@ -141,7 +141,7 @@ This approach is effective for directing users to external websites or Universal
 
 ## `legacy_subscribe`
 
-> `legacy_subscribe` is experimentally available in SDK 52.
+> **important** `legacy_subscribe` is in alpha and is available in SDK 52.
 
 If you're using a third-party provider that doesn't support Expo Router but does support React Navigation via the `Linking.subscribe` function for existing projects, you can use `legacy_subscribe` as an alternative API.
 

--- a/docs/pages/router/advanced/native-tabs.mdx
+++ b/docs/pages/router/advanced/native-tabs.mdx
@@ -19,7 +19,7 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
   className="mb-6"
 />
 
-> **important** Native tabs is an experimental feature available in SDK 54 and later, and its API is subject to change.
+> **important** Native tabs is in alpha and is available in SDK 54 and later. Its API is subject to change.
 
 Tabs are a common way to navigate between different sections of an app. In Expo Router, you can use different tab layouts, depending on your needs. This guide covers the native tabs. Unlike the [other tabs layout](/router/advanced/tabs/#multiple-tab-layouts), native tabs use the native system tab bar.
 

--- a/docs/pages/router/advanced/web-modals.mdx
+++ b/docs/pages/router/advanced/web-modals.mdx
@@ -7,7 +7,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { FileTree } from '~/ui/components/FileTree';
 
-> **important** Web modals is in alpha and is available in SDK 54 and later. To use this feature, you must set the `EXPO_UNSTABLE_WEB_MODAL=1` environment variable in your project.
+> **important** Web modals are in alpha and available in SDK 54 and later. To use this feature, you must set the `EXPO_UNSTABLE_WEB_MODAL=1` environment variable in your project.
 
 Modern web apps require a flexible modal experience that adapts to different content sizes and user interactions. Expo Router provides various modal presentation patterns for modern web experiences. These patterns leverage `presentation` with `modal`, `formSheet`, `transparentModal`, or `containedTransparentModal` to present either a modal based on different screen widths, and provide customizable styling props using `webModalStyle`.
 

--- a/docs/pages/router/advanced/web-modals.mdx
+++ b/docs/pages/router/advanced/web-modals.mdx
@@ -7,7 +7,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { FileTree } from '~/ui/components/FileTree';
 
-> **important** Web modals are an experimental feature available in SDK 54 and later. To use this feature, you must set the `EXPO_UNSTABLE_WEB_MODAL=1` environment variable in your project.
+> **important** Web modals is in alpha and is available in SDK 54 and later. To use this feature, you must set the `EXPO_UNSTABLE_WEB_MODAL=1` environment variable in your project.
 
 Modern web apps require a flexible modal experience that adapts to different content sizes and user interactions. Expo Router provides various modal presentation patterns for modern web experiences. These patterns leverage `presentation` with `modal`, `formSheet`, `transparentModal`, or `containedTransparentModal` to present either a modal based on different screen widths, and provide customizable styling props using `webModalStyle`.
 

--- a/docs/pages/router/web/api-routes.mdx
+++ b/docs/pages/router/web/api-routes.mdx
@@ -393,7 +393,7 @@ If you want to export API routes and skip generating a website version of your a
 
 ### Native deployment
 
-> **important** This is an experimental feature starting in SDK 52 and later. The process will be more automated and have better support in future versions.
+> **important** This is an alpha feature starting in SDK 52 and later. The process will be more automated and have better support in future versions.
 
 Server features (API routes, and React Server Components) in Expo Router are centered around native implementations of `window.location` and `fetch` which point to the remote server. In development, we automatically point to the dev server running with `npx expo start`, but for production native builds to work you'll need to deploy the server to a secure host and set the `origin` property of the Expo Router Config Plugin.
 

--- a/docs/pages/router/web/async-routes.mdx
+++ b/docs/pages/router/web/async-routes.mdx
@@ -6,7 +6,7 @@ description: Learn how to speed up development with async bundling in Expo Route
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 
-> **important** Async routes is an experimental feature.
+> **important** Async routes is in alpha.
 
 <ContentSpotlight file="expo-router/async-routes.mp4" loop={false} />
 

--- a/docs/pages/router/web/middleware.mdx
+++ b/docs/pages/router/web/middleware.mdx
@@ -7,7 +7,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-> **important** Server middleware is an experimental feature available in SDK 54 and later, and requires a [deployed server](/router/web/api-routes/#deployment) for production use.
+> **important** Server middleware is in alpha and is available in SDK 54 and later. It requires a [deployed server](/router/web/api-routes/#deployment) for production use.
 
 Server middleware in Expo Router allows you to run code before requests reach your routes, enabling powerful server-side functionality like authentication and logging for every request. Unlike [API routes](/router/web/api-routes) that handle specific endpoints, middleware runs for **every** request in your app, so it should run as quickly as possible to avoid slowing down your app's performance. Client-side navigation such as on native, or in a web app when using [`<Link />`](/versions/latest/sdk/router/#link), will not move through the server middleware.
 

--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -571,7 +571,7 @@ export async function GET(req: Request) {
 
 ## Web workers
 
-> **important** This feature is experimental and subject to breaking changes.
+> **important** This feature is alpha and subject to breaking changes.
 
 ```ts
 new Worker(new URL('./worker', window.location.href));

--- a/docs/pages/versions/unversioned/sdk/router-native-tabs.mdx
+++ b/docs/pages/versions/unversioned/sdk/router-native-tabs.mdx
@@ -13,7 +13,7 @@ import APISection from '~/components/plugins/APISection';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { ConfigPluginExample } from '~/ui/components/ConfigSection';
 
-> **important** Native tabs is an experimental feature available in SDK 54 and later, and its API is subject to change.
+> **important** Native tabs is an alpha feature available in SDK 54 and later, and its API is subject to change.
 
 `expo-router/unstable-native-tabs` is a submodule of `expo-router` and exports components to build tab layouts using platform-native system tabs.
 

--- a/docs/pages/versions/unversioned/sdk/sqlite.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite.mdx
@@ -83,7 +83,7 @@ You can configure `expo-sqlite` for advanced configurations using its built-in [
 
 ## Web setup
 
-> **important** Web support is experimental and may be unstable. [Create an issue on GitHub](https://github.com/expo/expo/issues) if you encounter any issues.
+> **important** Web support is in alpha and may be unstable. [Create an issue on GitHub](https://github.com/expo/expo/issues) if you encounter any issues.
 
 To use `expo-sqlite` on web, you need to configure Metro bundler to support **wasm** files and add HTTP headers to allow [`SharedArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) usage.
 

--- a/docs/pages/versions/v53.0.0/config/metro.mdx
+++ b/docs/pages/versions/v53.0.0/config/metro.mdx
@@ -559,7 +559,7 @@ export async function GET(req: Request) {
 
 ## Web workers
 
-> **important** This feature is experimental and subject to breaking changes.
+> **important** This feature is in alpha and subject to breaking changes.
 
 ```ts
 new Worker(new URL('./worker', window.location.href));

--- a/docs/pages/versions/v53.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/sqlite.mdx
@@ -75,7 +75,7 @@ You can configure `expo-sqlite` for advanced configurations using its built-in [
 
 ## Web setup
 
-> **important** Web support is experimental and may be unstable. [Create an issue on GitHub](https://github.com/expo/expo/issues) if you encounter any issues.
+> **important** Web support is in alpha and may be unstable. [Create an issue on GitHub](https://github.com/expo/expo/issues) if you encounter any issues.
 
 To use `expo-sqlite` on web, you need to configure Metro bundler to support **wasm** files and add HTTP headers to allow [`SharedArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) usage.
 

--- a/docs/pages/versions/v54.0.0/config/metro.mdx
+++ b/docs/pages/versions/v54.0.0/config/metro.mdx
@@ -571,7 +571,7 @@ export async function GET(req: Request) {
 
 ## Web workers
 
-> **important** This feature is experimental and subject to breaking changes.
+> **important** This feature is in alpha and subject to breaking changes.
 
 ```ts
 new Worker(new URL('./worker', window.location.href));

--- a/docs/pages/versions/v54.0.0/sdk/router-native-tabs.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/router-native-tabs.mdx
@@ -13,7 +13,7 @@ import APISection from '~/components/plugins/APISection';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { ConfigPluginExample } from '~/ui/components/ConfigSection';
 
-> **important** Native tabs is an experimental feature available in SDK 54 and later, and its API is subject to change.
+> **important** Native tabs is an alpha feature available in SDK 54 and later, and its API is subject to change.
 
 `expo-router/unstable-native-tabs` is a submodule of `expo-router` and exports components to build tab layouts using platform-native system tabs.
 

--- a/docs/pages/versions/v54.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/sqlite.mdx
@@ -83,7 +83,7 @@ You can configure `expo-sqlite` for advanced configurations using its built-in [
 
 ## Web setup
 
-> **important** Web support is experimental and may be unstable. [Create an issue on GitHub](https://github.com/expo/expo/issues) if you encounter any issues.
+> **important** Web support is in alpha and may be unstable. [Create an issue on GitHub](https://github.com/expo/expo/issues) if you encounter any issues.
 
 To use `expo-sqlite` on web, you need to configure Metro bundler to support **wasm** files and add HTTP headers to allow [`SharedArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) usage.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18291

# How

<!--
How did you build this feature or fix this bug and why?
-->

Replace "experimental" with "alpha" in callouts.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
