### PR TITLE
[iOS][Audio] Recorder - restart external audio system on end recording

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed recorder where external audio did not restart after end recording. ([#41878](https://github.com/expo/expo/pull/41878) by [@DelphineBugner](https://github.com/DelphineBugner))
 - [Android] Removed call to setShowActionsInCompactView when using custom layout in notification. ([#40557](https://github.com/expo/expo/pull/40557) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Fixed race-condition when creating the notification before the actions has been added. ([#40518](https://github.com/expo/expo/pull/40518) by [@chrfalch](https://github.com/chrfalch))
 - [iOS/Android] Aligned Android and iOS pitch correction by changing the default quality on iOS to match Android. `shouldCorrectPitch` now defaults to `true`. ([#40176](https://github.com/expo/expo/pull/40176) by [@chrfalch](https://github.com/chrfalch))

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -308,13 +308,7 @@ public class AudioModule: Module {
       AsyncFunction("stop") { recorder in
         try checkPermissions()
         recorder.stopRecording()
-
-        // Enables external audio to restart when recording is stopped.
-        do {
-            try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
-        } catch {
-            print("Failed to deactivate audio session from recorder: \(error)")
-        }
+        try setIsAudioActive(false)
       }
 
       Function("getStatus") { recorder -> [String: Any] in
@@ -513,6 +507,7 @@ public class AudioModule: Module {
   private func setIsAudioActive(_ isActive: Bool) throws {
     if !isActive {
       pauseAllPlayers()
+      pauseAllRecorders()
     }
 
     do {

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -308,6 +308,13 @@ public class AudioModule: Module {
       AsyncFunction("stop") { recorder in
         try checkPermissions()
         recorder.stopRecording()
+
+        // Enables external audio to restart when recording is stopped.
+        do {
+            try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+        } catch {
+            print("Failed to deactivate audio session from recorder: \(error)")
+        }
       }
 
       Function("getStatus") { recorder -> [String: Any] in


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

- When you start recording,  other apps pause their audio, which is expected.
- When you end recording, other apps do **not** restart their audio.

This PR intends to fix this. 

This behavior should already work for Audio Player (I did not try it, just based on reading the code), but was missing for the Audio Recorder.

# How

<!--
How did you build this feature or fix this bug and why?
-->

We need to notify external systems that recording is over. The code used is the same as the one for Audio Player.

```diff
AsyncFunction("stop") { recorder in
        try checkPermissions()
        recorder.stopRecording()

+        // Enables external audio to restart when recording is stopped.
+        do {
+          try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+     } catch {
+            print("Failed to deactivate audio session from recorder: \(error)")
+       }
      }
```

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

1. Use an Audio Recorder on a test app, on a real device (iOS)
2. Start a music on an external app on the same device
3. Start recording on your test app: music stops
4. End recording on your test app: music should restart 

It's already active on my app in production, we used a patch over the lib. 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)

