### PR TITLE
[docs] Parse JSON data for `llms-eas.txt` and Copy markdown action button for EAS CLI reference

### DIFF
--- a/docs/scripts/generate-llms/llms-eas-txt.js
+++ b/docs/scripts/generate-llms/llms-eas-txt.js
@@ -1,5 +1,7 @@
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import {
   OUTPUT_DIRECTORY_NAME,
@@ -11,21 +13,78 @@ import {
 } from './utils.js';
 import { eas } from '../../constants/navigation.js';
 
+const __filename = fileURLToPath(import.meta.url);
+const require = createRequire(__filename);
+const easCliData = require('../../ui/components/EASCLIReference/data/eas-cli-commands.json');
+
 function generateFullMarkdown({ title, description, sections }) {
   return `# ${title}\n\n${description}\n\n` + sections.map(generateSectionMarkdown).join('');
+}
+
+function formatEasCliDescription(description) {
+  if (!description) {
+    return '';
+  }
+  const normalized = description.trim();
+  if (!normalized) {
+    return '';
+  }
+  const prefixed = /^[A-Z]/.test(normalized)
+    ? normalized
+    : normalized[0].toUpperCase() + normalized.slice(1);
+  return prefixed.endsWith('.') ? prefixed : `${prefixed}.`;
+}
+
+function generateEasCliCommandsMarkdown(data) {
+  if (!data?.commands?.length) {
+    return '';
+  }
+
+  const cliVersion = data?.source?.cliVersion;
+  const header = cliVersion ? `# EAS CLI commands (v${cliVersion})` : '# EAS CLI commands';
+
+  const commands = data.commands
+    .map(command => {
+      const description = formatEasCliDescription(command.description);
+      const usage = command.usage?.trim();
+
+      let content = `## ${command.command}\n\n`;
+      if (description) {
+        content += `${description}\n\n`;
+      }
+      if (usage) {
+        content += '```\n' + usage + '\n```\n\n';
+      }
+      return content;
+    })
+    .join('');
+
+  return `${header}\n\n${commands}`.trimEnd();
 }
 
 export async function generateLlmsEasTxt() {
   try {
     const sections = eas.map(section => ({ ...processSection(section), category: 'Eas' }));
 
+    const easCliMarkdown = generateEasCliCommandsMarkdown(easCliData);
+    const baseContent = generateFullMarkdown({
+      title: TITLE_EAS,
+      description: DESCRIPTION_EAS,
+      sections,
+    });
+
+    const placeholderRegex = /<EASCLIReference\s*\/>/g;
+    let finalContent = easCliMarkdown
+      ? baseContent.replace(placeholderRegex, `\n${easCliMarkdown}\n`)
+      : baseContent.replace(placeholderRegex, '');
+
+    if (easCliMarkdown && finalContent === baseContent) {
+      finalContent = `${baseContent.replace(placeholderRegex, '')}\n\n${easCliMarkdown}`;
+    }
+
     await fs.promises.writeFile(
       path.join(process.cwd(), OUTPUT_DIRECTORY_NAME, OUTPUT_FILENAME_EAS_DOCS),
-      generateFullMarkdown({
-        title: TITLE_EAS,
-        description: DESCRIPTION_EAS,
-        sections,
-      })
+      finalContent
     );
 
     console.log(` \x1b[1m\x1b[32m✓\x1b[0m Successfully generated ${OUTPUT_FILENAME_EAS_DOCS}`);


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18506

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Updated `llms-eas-txt.js` to inline the EAS CLI reference content into `llms-eas.txt.
- Update the markdown copy pipeline (`processMarkdown.ts`) to strip `<Tabs>/<Tab>` wrappers and expand `<EASCLIReference />` during copy so the EAS CLI page’s "Copy page" includes dynamic data (JSON input).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

Run  `llms-eas-txt.js` script to generate `llms-eas.txt` file with EAS CLI reference dynamic data handling:

<img width="1854" height="2464" alt="CleanShot 2025-12-31 at 16 56 30@2x" src="https://github.com/user-attachments/assets/651b6f6d-84f2-433c-a7b4-46d078ff4ccb" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
