### PR TITLE
docs: drop OneSignal due to discontinued Expo plugin

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -216,7 +216,7 @@ exceptions:
   # Standalone Expo UI component names
   - '^(?:BottomSheet|CircularProgress|LinearProgress|DateTimePicker|ContextMenu|ColorPicker|TextField)(?:\s*\([^)]+\))?$'
   # Component, service and product names that are proper nouns
-  - '^(?:TinyBase|LiveStore|LaunchDarkly|OneSignal|CleverTap|LogRocket|Vexo|BugSnag|Meta|Vercel|TabTrigger|TabList|Tabs|Drawer|TextEncoder|TextDecoder|AudioPlayer|VideoPlayer)(?:\s*\([^)]+\))?$'
+  - '^(?:TinyBase|LiveStore|LaunchDarkly|CleverTap|LogRocket|Vexo|BugSnag|Meta|Vercel|TabTrigger|TabList|Tabs|Drawer|TextEncoder|TextDecoder|AudioPlayer|VideoPlayer)(?:\s*\([^)]+\))?$'
   # Specific edge cases
   - two-factor
   - (deprecated)

--- a/docs/pages/guides/using-push-notifications-services.mdx
+++ b/docs/pages/guides/using-push-notifications-services.mdx
@@ -43,17 +43,6 @@ For implementation details, see the following guides:
   Icon={NotificationBoxIcon}
 />
 
-## OneSignal
-
-[OneSignal](https://onesignal.com/) is a customer engagement platform that provides push notifications, in-app messaging, SMS, and email services for web and mobile apps. OneSignal supports rich media in notifications and engagement analytics. It includes an [Expo config plugin](https://github.com/OneSignal/onesignal-expo-plugin) for direct integration into your Expo project.
-
-<BoxLink
-  title="OneSignal Expo SDK Setup"
-  description="Follow this guide for a step-by-step setup on how to integrate OneSignal in your Expo project."
-  href="https://documentation.onesignal.com/docs/react-native-expo-sdk-setup"
-  Icon={BookOpen02Icon}
-/>
-
 ## Braze
 
 [Braze](https://www.braze.com/) is a customer engagement platform that delivers personalized, cross-channel messaging through push notifications, in-app messaging, email, SMS, and web. Braze supports rich notification content, push notification campaigns, and support for resending notifications after failed deliveries on Android. It provides a [React Native SDK](https://github.com/braze-inc/braze-react-native-sdk) and a [config plugin](https://github.com/braze-inc/braze-expo-plugin/tree/main). Check out the [Expo example app](https://github.com/braze-inc/braze-expo-plugin/tree/main/example) for more details.

--- a/docs/pages/workflow/continuous-native-generation.mdx
+++ b/docs/pages/workflow/continuous-native-generation.mdx
@@ -153,7 +153,7 @@ React Native library authors can adopt CNG in several ways. It depends on the co
 
 - **Libraries Dependent on Native Runtime Hooks**: Libraries that depend on specific native runtime hooks, such as intercepting the initial launch URL via the `AppDelegate`, `MainActivity`, `MainApplication`, and so on, can utilize [**Lifecycle listeners**](/modules/android-lifecycle-listeners/) in the Expo Modules API. These lifecycle listeners allow these runtime hooks to be applied via Expo Autolinking instead of by modifying these standard native project files, eliminating the need for a config plugin.
 
-Many complex libraries and services already support CNG via Expo Prebuild such as, [MapBox](https://github.com/rnmapbox/maps), [OneSignal](https://github.com/OneSignal/onesignal-expo-plugin), [Stripe](https://github.com/stripe/stripe-react-native), and [React Native Firebase](https://rnfirebase.io/#expo).
+Many complex libraries and services already support CNG via Expo Prebuild such as, [MapBox](https://github.com/rnmapbox/maps), [Sentry](https://github.com/getsentry/sentry-react-native), [Stripe](https://github.com/stripe/stripe-react-native), and [React Native Firebase](https://rnfirebase.io/#expo).
 
 Adopting CNG by library authors is not a preqrequisite for using `npx expo prebuild`. If a library author has not adopted CNG, developers can still use `npx expo prebuild` by creating local [Config Plugins](https://github.com/expo/config-plugins/) to modify the native generation pipeline. This flexibility makes CNG accessible and beneficial to all developers within the React Native community.
 
@@ -178,8 +178,6 @@ Here are a few community examples of difficult native features converted into si
 - [The entire Firebase suite](https://rnfirebase.io/): Here you can see the entire native Firebase suite going from a multi-step native configuration process across multiple IDEs, down to basic JSON configuration.
 
 - [Cross-platform home screen widgets](https://github.com/gaishimo/eas-widget-example): This Expo config plugin can generate a home screen widget for Android and iOS.
-
-- [Notification extension and code signing](https://github.com/OneSignal/onesignal-expo-plugin): This Expo config plugin generates a notification extension target on iOS and it augments the EAS credentials service to keep zero-config code signing working.
 
 - [Apple App Clips](https://github.com/bndkt/react-native-app-clip): This Expo config plugin takes the process of generating an Apple App Clip from a multi-step process, ranging across multiple targets, and reduces it to a single line `["react-native-app-clip", { "name": "My App Clip" }]`.
 

--- a/docs/pages/workflow/overview.mdx
+++ b/docs/pages/workflow/overview.mdx
@@ -123,7 +123,7 @@ Continuous Native Generation (CNG) is a process for building an Expo app where y
 
 The [native project](#android-and-ios-native-projects) directories (**android** and **ios**) are automatically added to your **.gitignore** when you create a new project, and you can delete them at any time, then re-generate them from the Expo app config with `npx expo prebuild` whenever required. You might never even run prebuild on your own development machine if you use a cloud-based development workflow.
 
-Using CNG can make upgrading to new versions of React Native much easier. It can simplify project maintenance and facilitate setting up complex features such as [App Clips](https://github.com/bndkt/react-native-app-clip), [share extensions](https://github.com/timedtext/expo-config-plugin-ios-share-extension), and [push notifications](https://github.com/OneSignal/onesignal-expo-plugin). This is all made possible with [config plugins](/config-plugins/introduction/). Learn more about [CNG](/workflow/continuous-native-generation/).
+Using CNG can make upgrading to new versions of React Native much easier. It can simplify project maintenance and facilitate setting up complex features such as [App Clips](https://github.com/bndkt/react-native-app-clip), [share extensions](https://github.com/timedtext/expo-config-plugin-ios-share-extension), and [error reporting](https://github.com/getsentry/sentry-react-native). This is all made possible with [config plugins](/config-plugins/introduction/). Learn more about [CNG](/workflow/continuous-native-generation/).
 
 <Collapsible summary="What if I want to edit the native project configuration in Android Studio or Xcode rather than generating the projects with prebuild?">
 


### PR DESCRIPTION
# Why

Unfortunately, OneSignal discontinued its Expo config plugin, which [already has caused some frustration for Expo users](https://www.reddit.com/r/expo/comments/1ptfc3z/in_a_world_shifting_towards_expo_onesignal/). We don't want Expo users to be locked out of CNG by using a service listed on our docs.

# How

- Dropped `OneSignal` term from vale
- Dropped OneSignal block from push notifications
- Dropped OneSignal from CNG documentation

# Test Plan

Docs change only.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
