### PR TITLE
[docs][video] Change deprecated FullScreen VideoView prop

### DIFF
--- a/docs/pages/versions/unversioned/sdk/video.mdx
+++ b/docs/pages/versions/unversioned/sdk/video.mdx
@@ -87,7 +87,7 @@ export default function VideoScreen() {
 
   return (
     <View style={styles.contentContainer}>
-      <VideoView style={styles.video} player={player} allowsFullscreen allowsPictureInPicture />
+      <VideoView style={styles.video} player={player} fullScreenOptions={{ allowsFullscreen: true }} allowsPictureInPicture />
       <View style={styles.controlsContainer}>
         <Button
           title={isPlaying ? 'Pause' : 'Play'}


### PR DESCRIPTION
# Why
The example code from expo-view indicated that allowsFullscreen would be deprecated soon, so I switched to the new way of handling fullscreen.
