### PR TITLE
[expo-router][iOS] reduce number of times UIBarButtonItem is recreated

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -103,6 +103,7 @@
 - add types to BaseRoute props ([#41765](https://github.com/expo/expo/pull/41765) by [@Ubax](https://github.com/Ubax))
 - throw error when array style is passed to Slot ([#41901](https://github.com/expo/expo/pull/41901) by [@Ubax](https://github.com/Ubax))
 - [ios] remove unstable_splitView and enable split view by default ([#42128](https://github.com/expo/expo/pull/42128) by [@Ubax](https://github.com/Ubax))
+- [iOS] reduce number of times UIBarButtonItem is recreated ([#41900](https://github.com/expo/expo/pull/41900) by [@Ubax](https://github.com/Ubax))
 
 ## 6.0.17 - 2025-12-05
 

--- a/packages/expo-router/ios/Toolbar/RouterToolbarItemView.swift
+++ b/packages/expo-router/ios/Toolbar/RouterToolbarItemView.swift
@@ -3,7 +3,11 @@ import UIKit
 
 class RouterToolbarItemView: RouterViewWithLogger {
   var identifier: String = ""
-  @ReactiveProp var type: ItemType?
+  // Properties requiring full rebuild
+  @ReactiveProp(needsFullRebuild: true) var type: ItemType?
+  @ReactiveProp(needsFullRebuild: true) var customView: UIView?
+
+  // Properties allowing in-place updates
   @ReactiveProp var title: String?
   @ReactiveProp var systemImageName: String?
   var customImage: SharedRef<UIImage>? {
@@ -11,14 +15,12 @@ class RouterToolbarItemView: RouterViewWithLogger {
       performUpdate()
     }
   }
-  @ReactiveProp var customView: UIView?
   @ReactiveProp var customTintColor: UIColor?
   @ReactiveProp var hidesSharedBackground: Bool = false
   @ReactiveProp var sharesBackground: Bool = true
   @ReactiveProp var barButtonItemStyle: UIBarButtonItem.Style?
   @ReactiveProp var width: Double?
-  // Using "routerHidden" to avoid conflict with UIView's "isHidden"
-  @ReactiveProp var routerHidden: Bool = false
+
   @ReactiveProp var selected: Bool = false
   @ReactiveProp var possibleTitles: Set<String>?
   @ReactiveProp var badgeConfiguration: BadgeConfiguration?
@@ -27,12 +29,29 @@ class RouterToolbarItemView: RouterViewWithLogger {
   @ReactiveProp var routerAccessibilityHint: String?
   @ReactiveProp var disabled: Bool = false
 
+  // Using "routerHidden" to avoid conflict with UIView's "isHidden"
+  // This property is not applied in this component, but read by the host
+  @ReactiveProp var routerHidden: Bool = false
+
   var host: RouterToolbarHostView?
+  private var currentBarButtonItem: UIBarButtonItem?
 
   let onSelected = EventDispatcher()
 
+  func performRebuild() {
+    // There is no need to rebuild if not mounted
+    guard self.host != nil else { return }
+    rebuildBarButtonItem()
+    self.host?.updateToolbarItems()
+  }
+
   func performUpdate() {
-    self.host?.updateToolbarItem(withId: self.identifier)
+    // There is no need to update if not mounted
+    guard self.host != nil else { return }
+    updateBarButtonItem()
+    // Even though we update in place, we need to notify the host
+    // so the toolbar array reference is updated and UIKit refreshes
+    self.host?.updateToolbarItems()
   }
 
   @objc func handleAction() {
@@ -40,7 +59,32 @@ class RouterToolbarItemView: RouterViewWithLogger {
   }
 
   var barButtonItem: UIBarButtonItem {
+    if let item = currentBarButtonItem {
+      return item
+    }
+    // If no item exists yet, create one
+    rebuildBarButtonItem()
+    return currentBarButtonItem ?? UIBarButtonItem()
+  }
+
+  private func updateBarButtonItem() {
+    guard let item = currentBarButtonItem else {
+      // If no current item exists, create one
+      rebuildBarButtonItem()
+      self.host?.updateToolbarItem(withId: self.identifier)
+      return
+    }
+
+    // Update content properties (title, image, etc.) for normal buttons
+    applyContentProperties(to: item)
+
+    // Update all common properties
+    applyCommonProperties(to: item)
+  }
+
+  private func rebuildBarButtonItem() {
     var item = UIBarButtonItem()
+
     if let customView {
       item = UIBarButtonItem(customView: customView)
     } else if type == .fluidSpacer {
@@ -48,29 +92,44 @@ class RouterToolbarItemView: RouterViewWithLogger {
     } else if type == .fixedSpacer {
       item = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
     } else if type == .searchBar {
-      if #available(iOS 16, *) {
-        // Hide the item if no search bar is provided
-        item.isHidden = true
-      }
       guard #available(iOS 26.0, *), let controller = self.host?.findViewController() else {
         // Check for iOS 26, should already be guarded by the JS side, so this warning will only fire if controller is nil
         logger?.warn(
           "[expo-router] navigationItem.searchBarPlacementBarButtonItem not available. This is most likely a bug in expo-router."
         )
-        return item
+        currentBarButtonItem = nil
+        return
       }
       guard let navController = controller.navigationController else {
-        return item
+        currentBarButtonItem = nil
+        return
       }
       guard navController.isNavigationBarHidden == false else {
         logger?.warn(
           "[expo-router] Toolbar.SearchBarPreferredSlot should only be used when stack header is shown."
         )
-        return item
+        currentBarButtonItem = nil
+        return
       }
 
       item = controller.navigationItem.searchBarPlacementBarButtonItem
     } else {
+      // Normal button - apply content properties during initial creation
+      applyContentProperties(to: item)
+    }
+
+    // Set target and action for interactive buttons
+    item.target = self
+    item.action = #selector(handleAction)
+
+    applyCommonProperties(to: item)
+
+    currentBarButtonItem = item
+  }
+
+  private func applyContentProperties(to item: UIBarButtonItem) {
+    // Only apply content properties for normal buttons
+    if type == .normal || type == nil {
       if let title {
         item.title = title
       }
@@ -89,6 +148,9 @@ class RouterToolbarItemView: RouterViewWithLogger {
         RouterFontUtils.setTitleStyle(fromConfig: titleStyle, for: item)
       }
     }
+  }
+
+  private func applyCommonProperties(to item: UIBarButtonItem) {
     if #available(iOS 26.0, *) {
       item.hidesSharedBackground = hidesSharedBackground
       item.sharesBackground = sharesBackground
@@ -96,13 +158,8 @@ class RouterToolbarItemView: RouterViewWithLogger {
     if let barButtonItemStyle {
       item.style = barButtonItemStyle
     }
-    item.target = self
-    item.action = #selector(handleAction)
     if let width = width {
       item.width = CGFloat(width)
-    }
-    if #available(iOS 16.0, *) {
-      item.isHidden = routerHidden
     }
     item.isSelected = selected
     if let routerAccessibilityLabel = routerAccessibilityLabel {
@@ -137,8 +194,6 @@ class RouterToolbarItemView: RouterViewWithLogger {
         item.badge = badge
       }
     }
-
-    return item
   }
 
   required init(appContext: AppContext? = nil) {
@@ -189,9 +244,11 @@ struct TitleStyle: Equatable {
 @propertyWrapper
 struct ReactiveProp<Value: Equatable> {
   private var value: Value
+  let needsFullRebuild: Bool
 
-  init(wrappedValue: Value) {
+  init(wrappedValue: Value, needsFullRebuild: Bool = false) {
     self.value = wrappedValue
+    self.needsFullRebuild = needsFullRebuild
   }
 
   static subscript<EnclosingSelf: RouterToolbarItemView>(
@@ -206,7 +263,11 @@ struct ReactiveProp<Value: Equatable> {
       let oldValue = instance[keyPath: storageKeyPath].value
       if oldValue != newValue {
         instance[keyPath: storageKeyPath].value = newValue
-        instance.performUpdate()
+        if instance[keyPath: storageKeyPath].needsFullRebuild {
+          instance.performRebuild()
+        } else {
+          instance.performUpdate()
+        }
       }
     }
   }
@@ -215,5 +276,12 @@ struct ReactiveProp<Value: Equatable> {
   var wrappedValue: Value {
     get { fatalError() }
     set { fatalError() }
+  }
+}
+
+extension ReactiveProp where Value: ExpressibleByNilLiteral {
+  init(needsFullRebuild: Bool = false) {
+    self.value = nil
+    self.needsFullRebuild = needsFullRebuild
   }
 }


### PR DESCRIPTION
# Why

When React Native updated multiple properties on a toolbar item in same update, each property change triggered a separate toolbar rebuild operation. This degraded performance, and remounted native components (e.g. custom text input lost focus on each update).

# How

1. Update toolbar items at most once on each render loop - use `DispatchQueue.main` to debounce the update
2. Keep the reference to the current bar item whenever possible

# Test Plan

1. Manual testing
2. e2e test

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
