### PR TITLE
Update Low Latency HLS capability identifier

### DIFF
--- a/docs/pages/build-reference/ios-capabilities.mdx
+++ b/docs/pages/build-reference/ios-capabilities.mdx
@@ -62,7 +62,7 @@ EAS Build will only enable capabilities that it has built-in support for, any un
 | <YesIcon /> | Increased Memory Limit                            | `com.apple.developer.kernel.increased-memory-limit`                                                              |
 | <YesIcon /> | Inter-App Audio                                   | `inter-app-audio`                                                                                                |
 | <YesIcon /> | Journaling Suggestions                            | `com.apple.developer.journal.allow`                                                                              |
-| <YesIcon /> | Low Latency HLS                                   | `com.apple.developer.coremedia.hls.low-latency`                                                                  |
+| <YesIcon /> | Low Latency HLS                                   | `com.apple.developer.low-latency-streaming`                                                                  |
 | <YesIcon /> | MDM Managed Associated Domains                    | `com.apple.developer.associated-domains.mdm-managed`                                                             |
 | <YesIcon /> | Managed App Installation UI                       | `com.apple.developer.managed-app-distribution.install-ui`                                                        |
 | <YesIcon /> | Maps                                              | `com.apple.developer.maps`                                                                                       |


### PR DESCRIPTION
# Why

The current capability identifier seems to have been used in beta, but it's no longer documented on apple developer website.


# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
