### PR TITLE
[android][audio] Fix recorder currentTime value

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [iOS/Android] Disable audio sampling when `useAudioSampleListener` unmounts.
 - [Android] Handle recorder stop failures and clean up after max file size events.
 - Ensure `AudioPlayer.remove()` releases native resources.
+- [Android] Fix recorder `currentTime` reporting to return elapsed seconds instead of a start timestamp.
 
 ### 💡 Others
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
@@ -491,7 +491,7 @@ class AudioModule : Module() {
       }
 
       Property("currentTime") { recorder ->
-        recorder.startTime
+        recorder.getCurrentTimeSeconds()
       }
 
       AsyncFunction("prepareToRecordAsync") { recorder: AudioRecorder, options: RecordingOptions? ->


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
