### PR TITLE
[ios][expo-go] Fix module registration

### DIFF
--- a/apps/expo-go/ios/Exponent/Versioned/Core/AppInstance/ExpoAppInstance.h
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/AppInstance/ExpoAppInstance.h
@@ -4,6 +4,7 @@
 #import <React/RCTJavaScriptLoader.h>
 
 @class RCTHost;
+@class EXAppContext;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -17,6 +18,11 @@ typedef void (^OnLoad)(NSURL *sourceURL, RCTSourceLoadBlock loadCallback);
 @property(nonatomic, strong, nonnull) RCTReactNativeFactory *reactNativeFactory;
 
 - (instancetype)initWithSourceURL:(NSURL *)sourceURL manager:(EXVersionManagerObjC *)manager onLoad:(OnLoad)onLoad;
+
+/**
+ * Creates a new app context configured for Expo Go.
+ */
+- (EXAppContext *)createExpoGoAppContext;
 
 @end
 

--- a/apps/expo-go/ios/Exponent/Versioned/Core/AppInstance/ExpoAppInstance.mm
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/AppInstance/ExpoAppInstance.mm
@@ -50,4 +50,8 @@
 - (void)host:(nonnull RCTHost *)host didReceiveJSErrorStack:(nonnull NSArray<NSDictionary<NSString *,id> *> *)stack message:(nonnull NSString *)message exceptionId:(NSUInteger)exceptionId isFatal:(BOOL)isFatal {
 }
 
+- (EXAppContext *)createExpoGoAppContext {
+  return [_manager createExpoGoAppContext];
+}
+
 @end

--- a/apps/expo-go/ios/Exponent/Versioned/Core/AppInstance/ExpoGoReactNativeFactory.mm
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/AppInstance/ExpoGoReactNativeFactory.mm
@@ -1,14 +1,13 @@
 
 #import "ExpoGoReactNativeFactory.h"
+#import "ExpoAppInstance.h"
 #import <RCTAppSetupUtils.h>
 #import <React/CoreModulesPlugins.h>
 #import <ExpoModulesCore/EXRuntime.h>
 #import <ExpoModulesCore-Swift.h>
 
 
-@implementation ExpoGoReactNativeFactory {
-  EXAppContext *_appContext;
-}
+@implementation ExpoGoReactNativeFactory
 
 - (Class)getModuleClassFromName:(const char *)name
 {
@@ -45,13 +44,14 @@
 
 - (void)host:(nonnull RCTHost *)host didInitializeRuntime:(jsi::Runtime &)runtime
 {
-  _appContext = [[EXAppContext alloc] init];
-  
+  ExpoAppInstance *appInstance = (ExpoAppInstance *)self.delegate;
+  EXAppContext *appContext = [appInstance createExpoGoAppContext];
+
   // Inject and decorate the `global.expo` object
-  _appContext._runtime = [[EXRuntime alloc] initWithRuntime:runtime];
-  [_appContext setHostWrapper:[[EXHostWrapper alloc] initWithHost:host]];
-  
-  [_appContext registerNativeModules];
+  appContext._runtime = [[EXRuntime alloc] initWithRuntime:runtime];
+  [appContext setHostWrapper:[[EXHostWrapper alloc] initWithHost:host]];
+
+  [appContext registerNativeModules];
 }
 
 @end

--- a/apps/expo-go/ios/Exponent/Versioned/Core/EXVersionManagerObjC.h
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/EXVersionManagerObjC.h
@@ -4,8 +4,8 @@
 #import <React/RCTLog.h>
 #import <React/RCTBridge.h>
 
-
 @class EXManifestsManifest;
+@class EXAppContext;
 
 @interface EXVersionManagerObjC : NSObject
 
@@ -39,5 +39,10 @@
 - (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass;
 
 - (Class)getModuleClassFromName:(const char *)name;
+
+/**
+ * Creates a new app context configured for Expo Go.
+ */
+- (nonnull EXAppContext *)createExpoGoAppContext;
 
 @end


### PR DESCRIPTION
# Why
Follow up of #41311.

# How
Because we no longer rely on the `ExpoBridgeModule` to access the bridge we need to make the same changes to expo go. The difference being we don't want the factory to own the `AppContext` in expo go but instead the `VersionManager` so we can override modules like expo-updates with an expo go specific variant. If we don't do this `ExpoGoReactNativeFactory` will call `registerNativeModules` on it's own `AppContext` in `didInitializeRuntime` and register the `UpdatesModule` from the modules provider which will then crash when accessing it's `sharedInstance`. 

I've added a method on the `ExpoAppInstance` that creates and returns an appContext that the factory can use instead of creating it's own. 

# Test Plan
Expo go
