### PR TITLE
[ios][expo-go] Finish account deletion and tracking prompt

### DIFF
--- a/apps/expo-go/ios/Client/SwiftUI/HomeRootView.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/HomeRootView.swift
@@ -3,16 +3,23 @@
 import SwiftUI
 import UIKit
 
+enum HomeTab: Hashable {
+  case home
+  case diagnostics
+  case settings
+}
+
 public struct HomeRootView: View {
   @ObservedObject var viewModel: HomeViewModel
   @State private var showingUserProfile = false
+  @State private var selectedTab: HomeTab = .home
 
   init(viewModel: HomeViewModel) {
     self.viewModel = viewModel
   }
 
   public var body: some View {
-    TabView {
+    TabView(selection: $selectedTab) {
       NavigationView {
         HomeTabView()
       }
@@ -20,6 +27,7 @@ public struct HomeRootView: View {
         Image(systemName: "house.fill")
         Text("Home")
       }
+      .tag(HomeTab.home)
       .navigationBarHidden(true)
 
       NavigationView {
@@ -29,12 +37,14 @@ public struct HomeRootView: View {
         Image(systemName: "stethoscope")
         Text("Diagnostics")
       }
+      .tag(HomeTab.diagnostics)
 
-      SettingsTabView()
+      SettingsTabView(selectedTab: $selectedTab)
         .tabItem {
           Image(systemName: "gearshape")
           Text("Settings")
         }
+        .tag(HomeTab.settings)
     }
     .environmentObject(viewModel)
     .environmentObject(ExpoGoNavigation(showingUserProfile: $showingUserProfile))

--- a/apps/expo-go/ios/Client/SwiftUI/SettingsTabView.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/SettingsTabView.swift
@@ -2,13 +2,17 @@
 
 import SwiftUI
 import AuthenticationServices
+import AppTrackingTransparency
 
 struct SettingsTabView: View {
+  @Binding var selectedTab: HomeTab
   @EnvironmentObject var viewModel: HomeViewModel
-  @State private var allowAnalytics = false
+  @State private var shouldShowTrackingSection = false
+  @State private var isTrackingRequestInFlight = false
   @State private var isDeleting = false
   @State private var deletionError: String?
-  @State private var context: AuthPresentationContextProvider?
+  @State private var authSession: ASWebAuthenticationSession?
+  private let context = AuthPresentationContextProvider()
 
   var body: some View {
     ScrollView {
@@ -76,14 +80,15 @@ struct SettingsTabView: View {
             .foregroundColor(.secondary)
         }
 
-        VStack(alignment: .leading, spacing: 16) {
+        if shouldShowTrackingSection {
+          VStack(alignment: .leading, spacing: 16) {
           Text("Tracking")
             .font(.headline)
             .foregroundColor(.primary)
 
           VStack(spacing: 0) {
             Button {
-              allowAnalytics.toggle()
+              requestTrackingPermission()
             } label: {
               HStack {
                 Text("Allow access to app-related data for tracking")
@@ -93,13 +98,13 @@ struct SettingsTabView: View {
 
                 Spacer()
 
-                if allowAnalytics {
-                  Image(systemName: "checkmark")
-                    .foregroundColor(.expoBlue)
+                if isTrackingRequestInFlight {
+                  ProgressView()
                 }
               }
               .padding()
             }
+            .disabled(isTrackingRequestInFlight)
             .buttonStyle(PlainButtonStyle())
           }
           .background(Color.expoSecondarySystemBackground)
@@ -110,6 +115,7 @@ struct SettingsTabView: View {
               .font(.caption)
               .foregroundColor(.expoBlue)
           }
+        }
         }
         VStack(alignment: .leading, spacing: 16) {
           Text("App Info")
@@ -191,6 +197,9 @@ struct SettingsTabView: View {
     .background(Color.expoSystemBackground)
     .navigationTitle("Settings")
     .navigationBarTitleDisplayMode(.inline)
+    .task {
+      await refreshTrackingStatus()
+    }
   }
 
   private func getExpoSDKVersion() -> String {
@@ -222,6 +231,7 @@ struct SettingsTabView: View {
     }
 
     let session = ASWebAuthenticationSession(url: url, callbackURLScheme: "expauth") { [self] callbackURL, error in
+      authSession = nil
       isDeleting = false
 
       if let error {
@@ -234,12 +244,33 @@ struct SettingsTabView: View {
 
       if callbackURL != nil {
         viewModel.signOut()
+        selectedTab = .home
       }
     }
 
     session.presentationContextProvider = context
     session.prefersEphemeralWebBrowserSession = false
+    authSession = session
     session.start()
+  }
+
+  private func refreshTrackingStatus() async {
+    let status = ATTrackingManager.trackingAuthorizationStatus
+    await MainActor.run {
+      shouldShowTrackingSection = (status == .notDetermined)
+    }
+  }
+
+  private func requestTrackingPermission() {
+    guard !isTrackingRequestInFlight else { return }
+    isTrackingRequestInFlight = true
+
+    ATTrackingManager.requestTrackingAuthorization { status in
+      DispatchQueue.main.async {
+        isTrackingRequestInFlight = false
+        shouldShowTrackingSection = (status == .notDetermined)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
# Why
Finish account deletion and hide tracking request if it's already accepted

# Test Plan
Expo go
