### PR TITLE
[docs] Use platform tag in Error codes table in AgeRange reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/age-range.mdx
+++ b/docs/pages/versions/unversioned/sdk/age-range.mdx
@@ -11,6 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ConfigReactNative } from '~/ui/components/ConfigSection';
 import { SnackInline } from '~/ui/components/Snippet';
+import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
 > **important** **This library is currently in alpha and will frequently experience breaking changes.**
 
@@ -126,8 +127,8 @@ import * as AgeRange from 'expo-age-range';
 
 Available in the `code` property of any error thrown by the native module. For Android-specific error codes, see "Handle API error codes" in [Use Play Age Signals API docs](https://developer.android.com/google/play/age-signals/use-age-signals-api#handle-api-errors).
 
-| Code                            | Description                                                                                                                      |
-| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `ERR_AGE_RANGE_USER_DECLINED`   | **iOS Only.** User declined to share their age range.                                                                            |
-| `ERR_AGE_RANGE_NOT_AVAILABLE`   | **iOS Only.** Age range not available. The most likely cause is that user is not signed in to their Apple account on the device. |
-| `ERR_AGE_RANGE_INVALID_REQUEST` | **iOS Only.** The provided params were invalid. The age ranges need to be minimum 2 years apart.                                 |
+| Code                            | Platform                             | Description                                                                                                        |
+| ------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `ERR_AGE_RANGE_USER_DECLINED`   | <PlatformTags platforms={['ios']} /> | User declined to share their age range.                                                                            |
+| `ERR_AGE_RANGE_NOT_AVAILABLE`   | <PlatformTags platforms={['ios']} /> | Age range not available. The most likely cause is that user is not signed in to their Apple account on the device. |
+| `ERR_AGE_RANGE_INVALID_REQUEST` | <PlatformTags platforms={['ios']} /> | The provided params were invalid. The age ranges need to be minimum 2 years apart.                                 |

--- a/docs/pages/versions/v54.0.0/sdk/age-range.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/age-range.mdx
@@ -11,6 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ConfigReactNative } from '~/ui/components/ConfigSection';
 import { SnackInline } from '~/ui/components/Snippet';
+import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
 > **important** **This library is currently in alpha and will frequently experience breaking changes.**
 
@@ -126,8 +127,8 @@ import * as AgeRange from 'expo-age-range';
 
 Available in the `code` property of any error thrown by the native module. For Android-specific error codes, see "Handle API error codes" in [Use Play Age Signals API docs](https://developer.android.com/google/play/age-signals/use-age-signals-api#handle-api-errors).
 
-| Code                            | Description                                                                                                                      |
-| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `ERR_AGE_RANGE_USER_DECLINED`   | **iOS Only.** User declined to share their age range.                                                                            |
-| `ERR_AGE_RANGE_NOT_AVAILABLE`   | **iOS Only.** Age range not available. The most likely cause is that user is not signed in to their Apple account on the device. |
-| `ERR_AGE_RANGE_INVALID_REQUEST` | **iOS Only.** The provided params were invalid. The age ranges need to be minimum 2 years apart.                                 |
+| Code                            | Platform                             | Description                                                                                                        |
+| ------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `ERR_AGE_RANGE_USER_DECLINED`   | <PlatformTags platforms={['ios']} /> | User declined to share their age range.                                                                            |
+| `ERR_AGE_RANGE_NOT_AVAILABLE`   | <PlatformTags platforms={['ios']} /> | Age range not available. The most likely cause is that user is not signed in to their Apple account on the device. |
+| `ERR_AGE_RANGE_INVALID_REQUEST` | <PlatformTags platforms={['ios']} /> | The provided params were invalid. The age ranges need to be minimum 2 years apart.                                 |


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18570

# How

<!--
How did you build this feature or fix this bug and why?
-->

Use the platform tag in the Error codes table in the AgeRange reference.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
<img width="1189" height="422" alt="CleanShot 2026-01-06 at 16 05 10" src="https://github.com/user-attachments/assets/327cc3e5-190a-4e02-8974-9345e7a5c9b4" />



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
