### PR TITLE
[docs] Improve `@deprecated` callout for SDK docs

### DIFF
--- a/docs/components/plugins/api/APISectionDeprecationNote.tsx
+++ b/docs/components/plugins/api/APISectionDeprecationNote.tsx
@@ -39,7 +39,7 @@ export const APISectionDeprecationNote = ({ comment, className, sticky = false }
           className
         )}>
         {content.length > 0 ? (
-          <ReactMarkdown components={mdComponents}>{`**Deprecated** ${content}`}</ReactMarkdown>
+          <ReactMarkdown components={mdComponents}>{`**Deprecated:** ${content}`}</ReactMarkdown>
         ) : (
           <BOLD>Deprecated</BOLD>
         )}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18579

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Added the missing colon so `@deprecated` warnings render as “Deprecated: …” in the SDK docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

<img width="2788" height="424" alt="CleanShot 2026-01-06 at 16 47 43@2x" src="https://github.com/user-attachments/assets/8a1ba09d-42e0-4307-bd3b-1c5a5d4640fc" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
