### PR TITLE
[sdk-54][templates,autolinking] Switch back to node -e for expo-modules-autolinking invocation in Podfile command

### DIFF
--- a/apps/bare-expo/ios/Podfile
+++ b/apps/bare-expo/ios/Podfile
@@ -28,7 +28,10 @@ abstract_target 'BareExpoMain' do
   use_frameworks! :linkage => ENV['USE_FRAMEWORKS'].to_sym if ENV['USE_FRAMEWORKS']
 
   config_command = [
-    'npx',
+    'node',
+    '--no-warnings',
+    '--eval',
+    'require(\'expo/bin/autolinking\')',
     'expo-modules-autolinking',
     'react-native-config',
     '--json',

--- a/apps/expo-go/ios/Podfile
+++ b/apps/expo-go/ios/Podfile
@@ -66,7 +66,10 @@ target 'Expo Go' do
   use_pods! 'vendored/unversioned/**/*.podspec.json'
 
   config_command = [
-    'npx',
+    'node',
+    '--no-warnings',
+    '--eval',
+    'require(\'expo/bin/autolinking\')',
     'expo-modules-autolinking',
     'react-native-config',
     '--json',

--- a/apps/native-tests/ios/Podfile
+++ b/apps/native-tests/ios/Podfile
@@ -22,7 +22,10 @@ target 'NativeTests' do
   pod 'ExpoModulesTestCore', :path => "../../../packages/expo-modules-test-core/ios"
 
   config_command = [
-    'npx',
+    'node',
+    '--no-warnings',
+    '--eval',
+    'require(\'expo/bin/autolinking\')',
     'expo-modules-autolinking',
     'react-native-config',
     '--json',

--- a/apps/paper-tester/ios/Podfile
+++ b/apps/paper-tester/ios/Podfile
@@ -17,7 +17,10 @@ target 'papertester' do
   use_expo_modules!
 
   config_command = [
-    'npx',
+    'node',
+    '--no-warnings',
+    '--eval',
+    'require(\'expo/bin/autolinking\')',
     'expo-modules-autolinking',
     'react-native-config',
     '--json',

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [Android] Align `expo-gradle-plugin`'s CLI command to align with iOS invocation of `expo-modules-autolinking` ([#41264](https://github.com/expo/expo/pull/41264) by [@kitten](https://github.com/kitten))
+
 ## 3.0.23 — 2025-12-04
 
 ### 💡 Others

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/main/kotlin/expo/modules/plugin/AutolinkigCommandBuilder.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/main/kotlin/expo/modules/plugin/AutolinkigCommandBuilder.kt
@@ -11,8 +11,8 @@ class AutolinkingCommandBuilder {
     "node",
     "--no-warnings",
     "--eval",
-    "require(require.resolve('expo-modules-autolinking', { paths: [require.resolve('expo/package.json')] }))(process.argv.slice(1))",
-    "--"
+    "require('expo/bin/autolinking')",
+    "expo-modules-autolinking"
   )
 
   private val platform = listOf(

--- a/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
+++ b/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
@@ -185,9 +185,8 @@ class ExpoAutolinkingManager {
       'node',
       '--no-warnings',
       '--eval',
-      // Resolve the `expo` > `expo-modules-autolinking` chain from the project root
-      'require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo\')] }))(process.argv.slice(1))',
-      '--',
+      'require(\'expo/bin/autolinking\')',
+      'expo-modules-autolinking',
       command,
       '--platform',
       'android'

--- a/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
@@ -216,7 +216,8 @@ module Expo
         'node',
         '--no-warnings',
         '--eval',
-        'require(require.resolve(\'expo-modules-autolinking\', { paths: [\'' +  __dir__ + '\'] }))(process.argv.slice(1))',
+        'require(\'expo/bin/autolinking\')',
+        'expo-modules-autolinking',
         command_name,
         '--platform',
         'apple'

--- a/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
@@ -293,7 +293,8 @@ module Expo
 
       with_node \\
         --no-warnings \\
-        --eval "require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo/package.json\')] }))(process.argv.slice(1))" \\
+        --eval "require(\'expo/bin/autolinking\')" \\
+        expo-modules-autolinking \\
         generate-modules-provider #{args.join(' ')} \\
         --target "#{modules_provider_path}" \\
         #{entitlement_param} \\

--- a/packages/expo/bin/autolinking
+++ b/packages/expo/bin/autolinking
@@ -1,3 +1,7 @@
 #!/usr/bin/env node
 
+// Executes expo-modules-autolinking CLI directly. This is accessed in three ways
+// - via the `expo-modules-autolinking` command declared via `package.json:bin` in `expo`
+// - in expo-templates-bare-minimum (prebuild) via Node resolution
+// - in expo-modules-autolinking's expo-gradle-plugin
 require('expo-modules-autolinking/bin/expo-modules-autolinking');

--- a/templates/expo-template-bare-minimum/ios/Podfile
+++ b/templates/expo-template-bare-minimum/ios/Podfile
@@ -27,7 +27,10 @@ target 'HelloWorld' do
     config_command = ['node', '-e', "process.argv=['', '', 'config'];require('@react-native-community/cli').run()"];
   else
     config_command = [
-      'npx',
+      'node',
+      '--no-warnings',
+      '--eval',
+      'require(\'expo/bin/autolinking\')',
       'expo-modules-autolinking',
       'react-native-config',
       '--json',


### PR DESCRIPTION
Backport of #41264 / https://github.com/expo/expo/commit/aae90cddf4523a508f3d7e0fbf4d4d9f508f7459

**This is applied as a PR for an additional round of reviews, just to be safe.**

Resolves #36952