### PR TITLE
[sdk-54] feat(metro): conditionally disable compression for explicit content-type and event-streams

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix response streaming from dev server (remove compression) ([#41955](https://github.com/expo/expo/pull/41955) by [@krystofwoldrich](https://github.com/krystofwoldrich))
+
 ### 💡 Others
 
 ## 54.0.21 — 2026-01-06

--- a/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/createMetroMiddleware.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/createMetroMiddleware.test.ts
@@ -7,6 +7,16 @@ jest.mock('../../../../../utils/editor');
 describe(createMetroMiddleware, () => {
   const { metro, server, projectRoot } = withMetroServer();
 
+  it('does not compress know non compressible content types like event stream', async () => {
+    metro.middleware.use('/thisiseventstream', (_req, res) => {
+      res.setHeader('Content-Type', 'text/event-stream');
+      res.end(':OK\n\n');
+    });
+    const response = await server.fetch('/thisiseventstream');
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Encoding')).toBeUndefined();
+  });
+
   it('disables cache on all requests', async () => {
     // Register an endpoint to capture the response headers
     metro.middleware.use('/thisisatest', (_req, res) => res.end('OK'));

--- a/packages/@expo/cli/src/start/server/metro/dev-server/compression.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/compression.ts
@@ -1,0 +1,39 @@
+import { NextHandleFunction } from 'connect';
+
+const createCompressionMiddleware = require('compression');
+
+const compressionMiddleware = createCompressionMiddleware();
+
+/**
+ * Compression middleware that skips compression for event stream content type
+ * and explicitly set content encoding.
+ */
+export const compression: NextHandleFunction = (req, res, next) => {
+  // if user explicitly set content encoding, we skip compression
+  // this will allow users to handle content encoding themselves
+  if (res.getHeader('Content-Encoding')) {
+    return next();
+  }
+
+  // compression package breaks streaming responses
+  // if we detect event stream content type, we skip compression
+  // this is better default than breaking the streaming response
+  const contentType = res.getHeader('Content-Type');
+  if (
+    isEventSteam(contentType) ||
+    (Array.isArray(contentType) && contentType.some(isEventSteam))
+  ) {
+    return next();
+  }
+
+  return compressionMiddleware(req, res, next);
+}
+
+function isEventSteam(type: unknown): boolean {
+  if (typeof type !== 'string') {
+    return false;
+  }
+  return type === EVENT_STREAM_CONTENT_TYPE;
+}
+
+const EVENT_STREAM_CONTENT_TYPE = 'text/event-stream';

--- a/packages/@expo/cli/src/start/server/metro/dev-server/compression.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/compression.ts
@@ -19,15 +19,12 @@ export const compression: NextHandleFunction = (req, res, next) => {
   // if we detect event stream content type, we skip compression
   // this is better default than breaking the streaming response
   const contentType = res.getHeader('Content-Type');
-  if (
-    isEventSteam(contentType) ||
-    (Array.isArray(contentType) && contentType.some(isEventSteam))
-  ) {
+  if (isEventSteam(contentType) || (Array.isArray(contentType) && contentType.some(isEventSteam))) {
     return next();
   }
 
   return compressionMiddleware(req, res, next);
-}
+};
 
 function isEventSteam(type: unknown): boolean {
   if (typeof type !== 'string') {

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
@@ -5,8 +5,7 @@ import { createEventsSocket } from './createEventSocket';
 import { createMessagesSocket } from './createMessageSocket';
 import { Log } from '../../../../log';
 import { openInEditorAsync } from '../../../../utils/editor';
-
-const compression = require('compression');
+import { compression } from './compression';
 
 export function createMetroMiddleware(metroConfig: Pick<MetroConfig, 'projectRoot'>) {
   const messages = createMessagesSocket({ logger: Log });
@@ -14,7 +13,7 @@ export function createMetroMiddleware(metroConfig: Pick<MetroConfig, 'projectRoo
 
   const middleware = connect()
     .use(noCacheMiddleware)
-    .use(compression())
+    .use(compression)
     // Support opening stack frames from clients directly in the editor
     .use('/open-stack-frame', rawBodyMiddleware)
     .use('/open-stack-frame', metroOpenStackFrameMiddleware)

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
@@ -1,11 +1,11 @@
 import type { MetroConfig } from '@expo/metro/metro';
 import connect from 'connect';
 
+import { compression } from './compression';
 import { createEventsSocket } from './createEventSocket';
 import { createMessagesSocket } from './createMessageSocket';
 import { Log } from '../../../../log';
 import { openInEditorAsync } from '../../../../utils/editor';
-import { compression } from './compression';
 
 export function createMetroMiddleware(metroConfig: Pick<MetroConfig, 'projectRoot'>) {
   const messages = createMessagesSocket({ logger: Log });


### PR DESCRIPTION
PR to main -> https://github.com/expo/expo/pull/42085


# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently steaming from API Routes is broken in development env (a.k.a expo start, from the metro dev server) when client request some type of compression. 

This is caused by compression middleware, which doesn't support steaming out of the box. And the provided flush can't unfortunately be used in API Routes.

https://github.com/expressjs/compression/tree/fb4902f1035649ed2a0baaf17ef3ffa1e62312ae?tab=readme-ov-file#server-sent-events

https://github.com/expressjs/compression/tree/fb4902f1035649ed2a0baaf17ef3ffa1e62312ae?tab=readme-ov-file#compressionoptions

# How

<!--
How did you build this feature or fix this bug and why?
-->

~This PR introduces a new compression middleware that skips compression for event stream content types and when content encoding is explicitly set. This change ensures that streaming responses are not broken by the compression package. The middleware is integrated into the Metro server setup.~

This PR scopes down the compression middleware only to the bundling and source maps requests, preserving the speed benefit on those requests and removing the compression from all other requests where it was unexpected and caused issues.

# Alternative

If response contains `Cache-Control: no-transform` the `compression` middleware will respect it and won't compress the body.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

TBA

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
