### PR TITLE
[notifications] fix syntax error in expo-module.config.json

### DIFF
--- a/packages/expo-notifications/expo-module.config.json
+++ b/packages/expo-notifications/expo-module.config.json
@@ -29,7 +29,7 @@
       "expo.modules.notifications.notifications.scheduling.NotificationScheduler",
       "expo.modules.notifications.serverregistration.ServerRegistrationModule",
       "expo.modules.notifications.tokens.PushTokenModule",
-      "expo.modules.notifications.topics.TopicSubscriptionModule"
+      "expo.modules.notifications.topics.TopicSubscriptionModule",
       "expo.modules.notifications.notifications.channels.AndroidXNotificationsChannelsProvider"
     ]
   }


### PR DESCRIPTION
# Why

This PR fixes a syntax error in the `expo-module.config.json` file for the `expo-notifications` package. The error was a missing comma in JSON

# How

Added the missing comma between

# Test Plan

Verified that the JSON is now valid

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)