### PR TITLE
[glass-effect] - tvos support and add note in docs for `opacity` change

### DIFF
--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -82,6 +82,7 @@ At this time, TV applications work with the following libraries and APIs listed 
 - [FileSystem](/versions/latest/sdk/filesystem/)
 - [FlashList](/versions/latest/sdk/flash-list/)
 - [Font](/versions/latest/sdk/font/)
+- [GlassEffect](/versions/latest/sdk/glass-effect/)
 - [Image](/versions/latest/sdk/image)
 - [ImageManipulator](/versions/latest/sdk/imagemanipulator/)
 - [KeepAwake](/versions/latest/sdk/keep-awake/)

--- a/docs/pages/versions/unversioned/sdk/glass-effect.mdx
+++ b/docs/pages/versions/unversioned/sdk/glass-effect.mdx
@@ -23,6 +23,8 @@ React components that render native iOS liquid glass effect using [`UIVisualEffe
 
 The `isInteractive` prop can only be set once on mount and cannot be changed dynamically after the component has been rendered. If you need to toggle interactive behavior, you must remount the component with a different `key`.
 
+Avoid `opacity` values less than `1` on `GlassView` or its parent views, as this causes effects to render incorrectly. See [Apple's documentation](https://developer.apple.com/documentation/uikit/uivisualeffectview#Set-the-correct-alpha-value) and [issue #41024](https://github.com/expo/expo/issues/41024).
+
 ## Usage
 
 ### `GlassView`

--- a/docs/pages/versions/v54.0.0/sdk/glass-effect.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/glass-effect.mdx
@@ -3,7 +3,7 @@ title: GlassEffect
 description: React components that render a liquid glass effect using iOS's native UIVisualEffectView.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-glass-effect'
 packageName: 'expo-glass-effect'
-platforms: ['ios']
+platforms: ['ios', 'tvos']
 isNew: true
 ---
 
@@ -22,6 +22,8 @@ React components that render native iOS liquid glass effect using [`UIVisualEffe
 ### Known issues
 
 The `isInteractive` prop can only be set once on mount and cannot be changed dynamically after the component has been rendered. If you need to toggle interactive behavior, you must remount the component with a different `key`.
+
+Avoid `opacity` values less than `1` on `GlassView` or its parent views, as this causes effects to render incorrectly. See [Apple's documentation](https://developer.apple.com/documentation/uikit/uivisualeffectview#Set-the-correct-alpha-value) and [issue #41024](https://github.com/expo/expo/issues/41024).
 
 ## Usage
 
@@ -182,10 +184,35 @@ export default function CheckLiquidGlass() {
 }
 ```
 
+### `isGlassEffectAPIAvailable`
+
+The `isGlassEffectAPIAvailable` function checks whether the Liquid Glass API is available at runtime on the device.
+
+> **Warning** This API was added because some iOS 26 beta versions do not have the Liquid Glass API available, which can lead to crashes. You should check this before using `GlassView` in your app to ensure compatibility. See [issue #40911](https://github.com/expo/expo/issues/40911) for more details.
+
+```tsx
+import { isGlassEffectAPIAvailable } from 'expo-glass-effect';
+
+export default function CheckGlassEffectAPI() {
+  return (
+    <Text>
+      {isGlassEffectAPIAvailable()
+        ? 'Glass Effect API is available'
+        : 'Glass Effect API is not available'}
+    </Text>
+  );
+}
+```
+
 ## API
 
 ```js
-import { GlassView, GlassContainer, isLiquidGlassAvailable } from 'expo-glass-effect';
+import {
+  GlassView,
+  GlassContainer,
+  isLiquidGlassAvailable,
+  isGlassEffectAPIAvailable,
+} from 'expo-glass-effect';
 ```
 
 <APISection packageName="expo-glass-effect" />

--- a/docs/pages/versions/v54.0.0/sdk/glass-effect.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/glass-effect.mdx
@@ -23,7 +23,7 @@ React components that render native iOS liquid glass effect using [`UIVisualEffe
 
 The `isInteractive` prop can only be set once on mount and cannot be changed dynamically after the component has been rendered. If you need to toggle interactive behavior, you must remount the component with a different `key`.
 
-Avoid `opacity` values less than `1` on `GlassView` or its parent views, as this causes effects to render incorrectly. See [Apple's documentation](https://developer.apple.com/documentation/uikit/uivisualeffectview#Set-the-correct-alpha-value) and [issue #41024](https://github.com/expo/expo/issues/41024).
+Avoid `opacity` values less than `1` on `GlassView` or its parent views, as this causes effects to render incorrectly. See [Apple's documentation](https://developer.apple.com/documentation/uikit/uivisualeffectview#Set-the-correct-alpha-value) and [GitHub issue #41024](https://github.com/expo/expo/issues/41024) for more information.
 
 ## Usage
 
@@ -188,7 +188,7 @@ export default function CheckLiquidGlass() {
 
 The `isGlassEffectAPIAvailable` function checks whether the Liquid Glass API is available at runtime on the device.
 
-> **Warning** This API was added because some iOS 26 beta versions do not have the Liquid Glass API available, which can lead to crashes. You should check this before using `GlassView` in your app to ensure compatibility. See [issue #40911](https://github.com/expo/expo/issues/40911) for more details.
+> **Warning** This API was added because some iOS 26 beta versions do not have the Liquid Glass API available, which can lead to crashes. You should check this before using `GlassView` in your app to ensure compatibility. See [GitHub issue #40911](https://github.com/expo/expo/issues/40911) for more information.
 
 ```tsx
 import { isGlassEffectAPIAvailable } from 'expo-glass-effect';

--- a/packages/expo-glass-effect/CHANGELOG.md
+++ b/packages/expo-glass-effect/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🎉 New features
 
 - Add `isGlassEffectAPIAvailable` API to prevent some iOS 26 beta version crashes ([#40992](https://github.com/expo/expo/pull/40992) by [@nishan](https://github.com/intergalacticspacehighway))
+- Add `tvOS` support ([#41962](https://github.com/expo/expo/pull/41962) by [@nishan](https://github.com/intergalacticspacehighway))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-glass-effect/ios/ExpoGlassEffect.podspec
+++ b/packages/expo-glass-effect/ios/ExpoGlassEffect.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.platforms      = {
     :ios => '15.1',
+    :tvos => '15.1',
   }
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true

--- a/packages/expo-glass-effect/ios/GlassContainer.swift
+++ b/packages/expo-glass-effect/ios/GlassContainer.swift
@@ -20,7 +20,7 @@ public final class GlassContainer: ExpoView {
   // https://github.com/expo/expo/issues/40911
   private func isGlassContainerEffectAvailable() -> Bool {
     #if compiler(>=6.2)
-    if #available(iOS 26.0, *) {
+    if #available(iOS 26.0, tvOS 26.0, macOS 26.0, *) {
       return NSClassFromString("UIGlassContainerEffect") != nil
     }
     #endif
@@ -33,7 +33,7 @@ public final class GlassContainer: ExpoView {
       guard isGlassContainerEffectAvailable() else {
         return
       }
-      if #available(iOS 26.0, *) {
+      if #available(iOS 26.0, tvOS 26.0, macOS 26.0, *) {
         #if compiler(>=6.2) // Xcode 26
         let effect = UIGlassContainerEffect()
         if let spacing = spacing {

--- a/packages/expo-glass-effect/ios/GlassEffectModule.swift
+++ b/packages/expo-glass-effect/ios/GlassEffectModule.swift
@@ -22,7 +22,7 @@ public final class GlassEffectModule: Module {
 
     Constant("isGlassEffectAPIAvailable") {
       #if compiler(>=6.2)
-      if #available(iOS 26.0, *) {
+      if #available(iOS 26.0, tvOS 26.0, macOS 26.0, *) {
         guard let glassEffectClass = NSClassFromString("UIGlassEffect") as? NSObject.Type else {
           return false
         }

--- a/packages/expo-glass-effect/ios/GlassStyle.swift
+++ b/packages/expo-glass-effect/ios/GlassStyle.swift
@@ -6,7 +6,7 @@ public enum GlassStyle: String, Enumerable {
   case regular
 
   #if compiler(>=6.2) // Xcode 26
-  @available(iOS 26.0, *)
+  @available(iOS 26.0, tvOS 26.0, macOS 26.0, *)
   func toUIGlassEffectStyle() -> UIGlassEffect.Style {
     switch self {
     case .clear:

--- a/packages/expo-glass-effect/ios/GlassView.swift
+++ b/packages/expo-glass-effect/ios/GlassView.swift
@@ -34,7 +34,7 @@ public final class GlassView: ExpoView {
   // https://github.com/expo/expo/issues/40911
   private func isGlassEffectAvailable() -> Bool {
     #if compiler(>=6.2)
-    if #available(iOS 26.0, *) {
+    if #available(iOS 26.0, tvOS 26.0, macOS 26.0, *) {
       guard let glassEffectClass = NSClassFromString("UIGlassEffect") as? NSObject.Type else {
         return false
       }
@@ -49,7 +49,7 @@ public final class GlassView: ExpoView {
     guard isGlassEffectAvailable() else {
       return
     }
-    if #available(iOS 26.0, *) {
+    if #available(iOS 26.0, tvOS 26.0, macOS 26.0, *) {
       #if compiler(>=6.2) // Xcode 26
       let isRTL = RCTI18nUtil.sharedInstance()?.isRTL() ?? false
 
@@ -91,7 +91,7 @@ public final class GlassView: ExpoView {
       guard isGlassEffectAvailable() else {
         return
       }
-      if #available(iOS 26.0, *) {
+      if #available(iOS 26.0, tvOS 26.0, macOS 26.0, *) {
       #if compiler(>=6.2) // Xcode 26
         let effect = UIGlassEffect(style: glassStyle?.toUIGlassEffectStyle() ?? .regular)
         glassEffectView.effect = effect
@@ -187,7 +187,7 @@ public final class GlassView: ExpoView {
     guard isGlassEffectAvailable() else {
       return
     }
-    if #available(iOS 26.0, *) {
+    if #available(iOS 26.0, tvOS 26.0, macOS 26.0, *) {
       #if compiler(>=6.2) // Xcode 26
       if let effect = glassEffect as? UIGlassEffect {
         effect.tintColor = glassTintColor


### PR DESCRIPTION
# Why

- Improve docs to highlight a known issue https://github.com/expo/expo/issues/41024. Apple introduced a breaking change when using opacity 0 with UIGlassEffect, but seems they highlighted it in their docs now. 
- Add missing tvOS checks.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Updated docs.


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested the tvOS related changes in tvOS simulator

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
