### PR TITLE
refactor(cli,create-expo): Move auto-adding of missing android/ios scripts to create-expo

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -59,6 +59,7 @@
 - Bump to `@expo/code-signing-certificates@^0.0.6` ([#41965](https://github.com/expo/expo/pull/41965) by [@kitten](https://github.com/kitten))
 - Unify nullish value handling for data loaders ([#42070](https://github.com/expo/expo/pull/42070) by [@hassankhan](https://github.com/hassankhan))
 - Add internal `EXPO_OVERRIDE_METRO_CONFIG` environment variable ([#42082](https://github.com/expo/expo/pull/42082) by [@kitten](https://github.com/kitten))
+- Remove auto-adding of missing android/ios npm scripts from prebuild ([#41964](https://github.com/expo/expo/pull/41964) by [@kitten](https://github.com/kitten))
 
 ### ⚠️ Notices
 

--- a/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
@@ -71,8 +71,10 @@ it('runs `npx expo prebuild` asserts when expo is not installed', async () => {
 
   // Create the project root aot
   await fs.mkdir(projectRoot, { recursive: true });
+
   // Create a fake package.json -- this is a terminal file that cannot be overwritten.
-  await fs.writeFile(path.join(projectRoot, 'package.json'), '{ "version": "1.0.0" }');
+  await fs.writeFile(path.join(projectRoot, 'package.json'), JSON.stringify({ version: '1.0.0' }));
+
   await fs.writeFile(path.join(projectRoot, 'app.json'), '{ "expo": { "name": "foobar" } }');
 
   await expect(
@@ -179,12 +181,6 @@ itNotWindows('runs `npx expo prebuild`', async () => {
     'react-native',
   ]);
 
-  // Updated scripts
-  expect(pkg.scripts).toStrictEqual({
-    android: 'expo run:android',
-    ios: 'expo run:ios',
-  });
-
   // If this changes then everything else probably changed as well.
   expect(findProjectFiles(projectRoot)).toMatchSnapshot();
 });
@@ -211,12 +207,6 @@ itNotWindows('runs `npx expo prebuild --template expo-template-bare-minimum@50.0
     expo: expect.any(String),
     react: expect.any(String),
     'react-native': expect.any(String),
-  });
-
-  // Updated scripts
-  expect(pkg.read().scripts).toMatchObject({
-    android: 'expo run:android',
-    ios: 'expo run:ios',
   });
 
   // If this changes then everything else probably changed as well.
@@ -287,12 +277,6 @@ itNotWindows('runs `npx expo prebuild --template <github-url>`', async () => {
     expo: expect.any(String),
     react: expect.any(String),
     'react-native': expect.any(String),
-  });
-
-  // Updated scripts
-  expect(pkg.read().scripts).toMatchObject({
-    android: 'expo run:android',
-    ios: 'expo run:ios',
   });
 
   // If this changes then everything else probably changed as well.

--- a/packages/@expo/cli/src/prebuild/updatePackageJson.ts
+++ b/packages/@expo/cli/src/prebuild/updatePackageJson.ts
@@ -255,18 +255,13 @@ export function updatePkgScripts({ pkg }: { pkg: PackageJSONConfig }) {
     pkg.scripts = {};
   }
   if (
-    !pkg.scripts.android ||
     pkg.scripts.android === 'expo start --android' ||
     pkg.scripts.android === 'react-native run-android'
   ) {
     pkg.scripts.android = 'expo run:android';
     hasChanged = true;
   }
-  if (
-    !pkg.scripts.ios ||
-    pkg.scripts.ios === 'expo start --ios' ||
-    pkg.scripts.ios === 'react-native run-ios'
-  ) {
+  if (pkg.scripts.ios === 'expo start --ios' || pkg.scripts.ios === 'react-native run-ios') {
     pkg.scripts.ios = 'expo run:ios';
     hasChanged = true;
   }

--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Auto-add missing android/ios npm scripts when they're likely missing ([#41964](https://github.com/expo/expo/pull/41964) by [@kitten](https://github.com/kitten))
+
 ## 3.5.10 - 2025-12-04
 
 ### 💡 Others

--- a/packages/create-expo/src/__tests__/sanitizeTemplate.test.ts
+++ b/packages/create-expo/src/__tests__/sanitizeTemplate.test.ts
@@ -1,0 +1,51 @@
+import { vol } from 'memfs';
+
+import { sanitizeTemplateAsync } from '../Template';
+
+jest.mock('fs');
+
+beforeEach(() => {
+  vol.reset();
+});
+
+describe(sanitizeTemplateAsync, () => {
+  it('adds default scripts for unmanaged apps', async () => {
+    vol.fromJSON({
+      '/project/package.json': JSON.stringify({
+        name: 'project',
+        version: '0.0.0',
+      }),
+      '/project/app.json': '{}',
+      '/project/ios/test': '',
+    });
+
+    await sanitizeTemplateAsync('/project');
+
+    const packageJson = JSON.parse(String(vol.readFileSync('/project/package.json')));
+
+    expect(packageJson.scripts).toMatchObject({
+      android: 'expo run:android',
+      ios: 'expo run:ios',
+    });
+  });
+
+  it('adds default scripts for managed apps', async () => {
+    vol.fromJSON({
+      '/project/package.json': JSON.stringify({
+        name: 'project',
+        version: '0.0.0',
+      }),
+      '/project/app.json': '{}',
+      '/project/.gitignore': '/ios\n/android\n',
+    });
+
+    await sanitizeTemplateAsync('/project');
+
+    const packageJson = JSON.parse(String(vol.readFileSync('/project/package.json')));
+
+    expect(packageJson.scripts).toMatchObject({
+      android: 'expo start --android',
+      ios: 'expo start --ios',
+    });
+  });
+});


### PR DESCRIPTION
# Why

Resolves #37793

We don't want `prebuild` to force-add `ios` and `android` scripts, since the user may have purposefully removed/replaced them. It's fine to keep the "switchover" logic but automatically adding the scripts should only be done in `create-expo-app`.

# How

- Remove auto-adding android/ios scripts when they're unset from prebuild script
- Add auto-adding of android/ios when they're likely missing in a template

# Test Plan

- Unit test for `create-expo-app` added
- CLI E2E test updated

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
