### PR TITLE
[expo] Update `react-native-reanimated` to `4.2.1`

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2845,7 +2845,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNReanimated (4.2.0):
+  - RNReanimated (4.2.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2867,10 +2867,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNReanimated/reanimated (= 4.2.0)
+    - RNReanimated/reanimated (= 4.2.1)
     - RNWorklets
     - Yoga
-  - RNReanimated/reanimated (4.2.0):
+  - RNReanimated/reanimated (4.2.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2892,10 +2892,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNReanimated/reanimated/apple (= 4.2.0)
+    - RNReanimated/reanimated/apple (= 4.2.1)
     - RNWorklets
     - Yoga
-  - RNReanimated/reanimated/apple (4.2.0):
+  - RNReanimated/reanimated/apple (4.2.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3912,7 +3912,7 @@ SPEC CHECKSUMS:
   RNCPicker: 38a9deb903d9a8ae18b598bac727e6c84b3cf0fa
   RNDateTimePicker: 6fdd63f5d1e0f21faf4cc8674957c52958a7efae
   RNGestureHandler: 72efe2ab9d5d1b1d25b96f3ad3d174992f3bad87
-  RNReanimated: 03e066b9967a8ccd8ff28aa88c098d8117b4d860
+  RNReanimated: 61462806110686a6f5d7c45c6f910cf73cd57dd9
   RNScreens: 08ec2d3a35cbeeb9ddd063e5aa8fb6da5bf3a978
   RNSVG: 595d31b6cd45e92424c6b623bd93e1e9b6aa8b79
   RNWorklets: 78d1eb5df6aa27c762c1466aaaffba8774d807a8

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -72,7 +72,7 @@
     "react-native-gesture-handler": "~2.28.0",
     "react-native-keyboard-controller": "^1.18.5",
     "react-native-pager-view": "6.9.1",
-    "react-native-reanimated": "4.2.0",
+    "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.19.0",
     "react-native-svg": "15.12.1",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3565,7 +3565,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNReanimated (4.2.0):
+  - RNReanimated (4.2.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -3592,11 +3592,11 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated (= 4.2.0)
+    - RNReanimated/reanimated (= 4.2.1)
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNReanimated/reanimated (4.2.0):
+  - RNReanimated/reanimated (4.2.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -3623,11 +3623,11 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated/apple (= 4.2.0)
+    - RNReanimated/reanimated/apple (= 4.2.1)
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNReanimated/reanimated/apple (4.2.0):
+  - RNReanimated/reanimated/apple (4.2.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -4758,7 +4758,7 @@ SPEC CHECKSUMS:
   RNCPicker: 51992b3407f6b70ddb8e417ec5714c3f2d48d8a4
   RNDateTimePicker: c4a42c6a77d474f05162d61a4ab4253d13008277
   RNGestureHandler: afae32614741017de0f813f74586eee29773f31a
-  RNReanimated: ef851cdf95ca947de3199fb05b863be9596a9a91
+  RNReanimated: 31da8d5f1605f5367e2392748ba9f4ba6eaf1178
   RNScreens: 69f68c95d395bc4261d27c3aae7b4a458b947b7e
   RNSVG: 6e742388ed2c7bfe7c9f5baf42b8eb850adc0442
   RNWorklets: 4e3230b74c2e466e608458b7f665a41825bca6c1

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -76,7 +76,7 @@
     "react-native-maps": "1.20.1",
     "react-native-pager-view": "6.9.1",
     "react-native-paper": "^5.12.5",
-    "react-native-reanimated": "4.2.0",
+    "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.19.0",
     "react-native-svg": "15.12.1",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -149,7 +149,7 @@
     "react-native-pager-view": "6.9.1",
     "react-native-paper": "^5.12.5",
     "react-native-worklets": "0.7.1",
-    "react-native-reanimated": "4.2.0",
+    "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.19.0",
     "react-native-svg": "15.12.1",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -102,7 +102,7 @@
   "react-native-maps": "1.20.1",
   "react-native-pager-view": "6.9.1",
   "react-native-worklets": "0.7.1",
-  "react-native-reanimated": "~4.2.0",
+  "react-native-reanimated": "~4.2.1",
   "react-native-screens": "~4.19.0",
   "react-native-safe-area-context": "~5.6.0",
   "react-native-svg": "15.12.1",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -32,7 +32,7 @@
     "react-native": "0.83.1",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-worklets": "0.7.1",
-    "react-native-reanimated": "~4.2.0",
+    "react-native-reanimated": "~4.2.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.19.0",
     "react-native-web": "~0.21.0"

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -25,7 +25,7 @@
     "react-dom": "19.2.0",
     "react-native": "0.83.1",
     "react-native-worklets": "0.7.1",
-    "react-native-reanimated": "~4.2.0",
+    "react-native-reanimated": "~4.2.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.19.0",
     "react-native-web": "~0.21.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13353,10 +13353,10 @@ react-native-paper@^5.12.5:
     color "^3.1.2"
     use-latest-callback "^0.1.5"
 
-react-native-reanimated@4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-4.2.0.tgz#5b08e53abd12f38a097c9853c8da2b1e8923fc4a"
-  integrity sha512-frhu5b8/m/VvaMWz48V8RxcsXnE3hrlErQ5chr21MzAeDCpY4X14sQjvm+jvu3aOI+7Cz2atdRpyhhIuqxVaXg==
+react-native-reanimated@4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-4.2.1.tgz#fbdee721bff0946a6e5ae67c8c38c37ca4a0a057"
+  integrity sha512-/NcHnZMyOvsD/wYXug/YqSKw90P9edN0kEPL5lP4PFf1aQ4F1V7MKe/E0tvfkXKIajy3Qocp5EiEnlcrK/+BZg==
   dependencies:
     react-native-is-edge-to-edge "1.2.1"
     semver "7.7.3"


### PR DESCRIPTION
# Why

Closes ENG-18590.
Updates `react-native-reanimated` to `4.2.1`

# Test Plan

- bare-expo ✅ 