### PR TITLE
[github] Ensure static frameworks workflow build from source

### DIFF
--- a/.github/workflows/ios-static-frameworks.yml
+++ b/.github/workflows/ios-static-frameworks.yml
@@ -42,7 +42,7 @@ jobs:
       - name: 🍏 Build iOS Project
         working-directory: ./apps/bare-expo
         run: |
-          jq '.["ios.useFrameworks"] = "static"' ios/Podfile.properties.json > temp.json && mv temp.json ios/Podfile.properties.json
+          jq '.["ios.useFrameworks"] = "static" | .["ios.buildReactNativeFromSource"] = "true"' ios/Podfile.properties.json > temp.json && mv temp.json ios/Podfile.properties.json
           pod install --project-directory=ios
           xcodebuild -workspace ios/BareExpo.xcworkspace -scheme BareExpo -configuration Release -sdk iphonesimulator -derivedDataPath "ios/build" | xcpretty
       - name: 🔔 Notify on Slack

--- a/.github/workflows/ios-static-frameworks.yml
+++ b/.github/workflows/ios-static-frameworks.yml
@@ -42,6 +42,7 @@ jobs:
       - name: 🍏 Build iOS Project
         working-directory: ./apps/bare-expo
         run: |
+          set -o pipefail
           jq '.["ios.useFrameworks"] = "static" | .["ios.buildReactNativeFromSource"] = "true"' ios/Podfile.properties.json > temp.json && mv temp.json ios/Podfile.properties.json
           pod install --project-directory=ios
           xcodebuild -workspace ios/BareExpo.xcworkspace -scheme BareExpo -configuration Release -sdk iphonesimulator -derivedDataPath "ios/build" | xcpretty


### PR DESCRIPTION
# Why

While testing canaries, I noticed that our builds were failing when using static frameworks eventhough CI was green e.g. https://github.com/expo/expo/actions/runs/20685069549/job/59384441496. Seems expo-modules core only breaks when building react-native from source, to ensure we dont miss this breaking changes again we sould update CI to also build from source.

# How

Update ios-static-frameworks.yml to make minimal-tester build react-native from source when testing static frameworks

# Test Plan

CI should be RED -> fix is here https://github.com/expo/expo/pull/41970

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
