### PR TITLE
[sdk-55] Upgrade `react-native-safe-area-context` to `5.6.2`

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2167,7 +2167,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-safe-area-context (5.6.0):
+  - react-native-safe-area-context (5.6.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2179,8 +2179,8 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-safe-area-context/common (= 5.6.0)
-    - react-native-safe-area-context/fabric (= 5.6.0)
+    - react-native-safe-area-context/common (= 5.6.2)
+    - react-native-safe-area-context/fabric (= 5.6.2)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -2191,7 +2191,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-safe-area-context/common (5.6.0):
+  - react-native-safe-area-context/common (5.6.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2213,7 +2213,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-safe-area-context/fabric (5.6.0):
+  - react-native-safe-area-context/fabric (5.6.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3867,7 +3867,7 @@ SPEC CHECKSUMS:
   react-native-keyboard-controller: 3aafec20048eb28055882697e37d5b7b39170209
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
   react-native-pager-view: e37989fc447aa4b5de6d0d2ffb0229e817329246
-  react-native-safe-area-context: d46695b29119ba0871705c55c8ac2868888dcca4
+  react-native-safe-area-context: 53f796cb6c814661bbe99fbdfd0585d07b996cdd
   react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
   react-native-skia: 009c318120ef7c6000bf14a6342ad8a89b44070b
   react-native-slider: 7814a1258f438c043f370eb82110ef036793e95a

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -73,7 +73,7 @@
     "react-native-keyboard-controller": "^1.20.3",
     "react-native-pager-view": "6.9.1",
     "react-native-reanimated": "4.2.1",
-    "react-native-safe-area-context": "5.6.0",
+    "react-native-safe-area-context": "5.6.2",
     "react-native-screens": "4.19.0",
     "react-native-svg": "15.15.1",
     "react-native-view-shot": "4.0.3",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -2636,7 +2636,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-safe-area-context (5.6.0):
+  - react-native-safe-area-context (5.6.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2654,8 +2654,8 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-safe-area-context/common (= 5.6.0)
-    - react-native-safe-area-context/fabric (= 5.6.0)
+    - react-native-safe-area-context/common (= 5.6.2)
+    - react-native-safe-area-context/fabric (= 5.6.2)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -2666,7 +2666,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-safe-area-context/common (5.6.0):
+  - react-native-safe-area-context/common (5.6.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2694,7 +2694,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-safe-area-context/fabric (5.6.0):
+  - react-native-safe-area-context/fabric (5.6.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -4660,7 +4660,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: d7a9424b7191b73c5c774d04fc2e147dd400e67f
+  hermes-engine: 452f2dd7422b2fd7973ae9ca103898d28d7744f0
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -4714,7 +4714,7 @@ SPEC CHECKSUMS:
   react-native-maps: ee1e65647460c3d41e778071be5eda10e3da6225
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
   react-native-pager-view: 899989dd025d219d3ac0d386b2bc162f81ae8330
-  react-native-safe-area-context: 2249e17382bd5a97cbccaa89e22af8756188c0fb
+  react-native-safe-area-context: 54d812805f3c4e08a4580ad086cbde1d8780c2e4
   react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
   react-native-skia: 6fe142fbe7f93579e6205d4045abdf5d6574b942
   react-native-slider: e35799fb9983a19307195d77f10caf5f6a716842

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -77,7 +77,7 @@
     "react-native-pager-view": "6.9.1",
     "react-native-paper": "^5.12.5",
     "react-native-reanimated": "4.2.1",
-    "react-native-safe-area-context": "5.6.0",
+    "react-native-safe-area-context": "5.6.2",
     "react-native-screens": "4.19.0",
     "react-native-svg": "15.15.1",
     "react-native-view-shot": "4.0.3",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -150,7 +150,7 @@
     "react-native-paper": "^5.12.5",
     "react-native-worklets": "0.7.1",
     "react-native-reanimated": "4.2.1",
-    "react-native-safe-area-context": "5.6.0",
+    "react-native-safe-area-context": "5.6.2",
     "react-native-screens": "4.19.0",
     "react-native-svg": "15.15.1",
     "react-native-view-shot": "4.0.3",

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -34,7 +34,7 @@
     "react-native-gesture-handler": "~2.30.0",
     "react": "19.2.0",
     "react-native": "0.83.1",
-    "react-native-safe-area-context": "5.6.0",
+    "react-native-safe-area-context": "5.6.2",
     "react-native-screens": "4.19.0"
   },
   "devDependencies": {

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -65,7 +65,7 @@
     "jose": "^5",
     "react": "19.2.0",
     "react-native": "0.83.1",
-    "react-native-safe-area-context": "5.6.0",
+    "react-native-safe-area-context": "5.6.2",
     "react-native-screens": "4.19.0",
     "react-native-webview": "13.16.0"
   },

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -16,7 +16,7 @@
     "expo-splash-screen": "~31.0.10",
     "react": "19.1.1",
     "react-native": "0.83.1",
-    "react-native-safe-area-context": "5.6.0",
+    "react-native-safe-area-context": "5.6.2",
     "react-native-screens": "4.11.1-nightly-20250611-8b82e081e"
   },
   "devDependencies": {

--- a/packages/expo-sqlite/dev-plugin-webui/package.json
+++ b/packages/expo-sqlite/dev-plugin-webui/package.json
@@ -27,7 +27,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",
-    "react-native-safe-area-context": "~5.6.0",
+    "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.16.0",
     "react-native-web": "~0.21.0",
     "sonner": "^2.0.7",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -104,7 +104,7 @@
   "react-native-worklets": "0.7.1",
   "react-native-reanimated": "~4.2.1",
   "react-native-screens": "~4.19.0",
-  "react-native-safe-area-context": "~5.6.0",
+  "react-native-safe-area-context": "~5.6.2",
   "react-native-svg": "15.15.1",
   "react-native-view-shot": "4.0.3",
   "react-native-webview": "13.16.0",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -33,7 +33,7 @@
     "react-native-gesture-handler": "~2.30.0",
     "react-native-worklets": "0.7.1",
     "react-native-reanimated": "~4.2.1",
-    "react-native-safe-area-context": "~5.6.0",
+    "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.19.0",
     "react-native-web": "~0.21.0"
   },

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -26,7 +26,7 @@
     "react-native": "0.83.1",
     "react-native-worklets": "0.7.1",
     "react-native-reanimated": "~4.2.1",
-    "react-native-safe-area-context": "~5.6.0",
+    "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.19.0",
     "react-native-web": "~0.21.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13361,10 +13361,10 @@ react-native-reanimated@4.2.1:
     react-native-is-edge-to-edge "1.2.1"
     semver "7.7.3"
 
-react-native-safe-area-context@5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-5.6.0.tgz#0ab284c291bb57d59330abf7dfe65156d6340e78"
-  integrity sha512-tJas3YOdsuCg3kepCTGF3LWZp9onMbb9Agju2xfs2kRX8d/5TMUPmupBpjerk/B7Tv/zeJnk+qp5neA96Y0otQ==
+react-native-safe-area-context@5.6.2:
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz#283e006f5b434fb247fcb4be0971ad7473d5c560"
+  integrity sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==
 
 react-native-screens@4.11.1-nightly-20250611-8b82e081e:
   version "4.11.1-nightly-20250611-8b82e081e"


### PR DESCRIPTION
# Why
Closes ENG-18587
Updates `react-native-safe-area-context` to `5.6.2`

# How
Update package version. 

# Test Plan
Bare-expo ✅
Expo go ✅

