### PR TITLE
[sdk-55] Update `react-native-svg` to `15.15.1`

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -75,7 +75,7 @@
     "react-native-reanimated": "4.2.0",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.19.0",
-    "react-native-svg": "15.12.1",
+    "react-native-svg": "15.15.1",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.15.0",
     "react-native-worklets": "0.7.1",

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -79,7 +79,7 @@
     "react-native-reanimated": "4.2.0",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.19.0",
-    "react-native-svg": "15.12.1",
+    "react-native-svg": "15.15.1",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.15.0",
     "react-native-worklets": "0.7.1",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -152,7 +152,7 @@
     "react-native-reanimated": "4.2.0",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.19.0",
-    "react-native-svg": "15.12.1",
+    "react-native-svg": "15.15.1",
     "react-native-view-shot": "4.0.3",
     "react-native-web": "~0.21.0",
     "react-native-webview": "13.15.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -105,7 +105,7 @@
   "react-native-reanimated": "~4.2.0",
   "react-native-screens": "~4.19.0",
   "react-native-safe-area-context": "~5.6.0",
-  "react-native-svg": "15.12.1",
+  "react-native-svg": "15.15.1",
   "react-native-view-shot": "4.0.3",
   "react-native-webview": "13.15.0",
   "react-server-dom-webpack": "~19.2.3",

--- a/patches/react-native-svg+15.15.1.patch
+++ b/patches/react-native-svg+15.15.1.patch
@@ -1,0 +1,35 @@
+diff --git a/node_modules/react-native-svg/android/src/main/java/com/horcrux/svg/VirtualView.java b/node_modules/react-native-svg/android/src/main/java/com/horcrux/svg/VirtualView.java
+index 4d71806..771e89e 100644
+--- a/node_modules/react-native-svg/android/src/main/java/com/horcrux/svg/VirtualView.java
++++ b/node_modules/react-native-svg/android/src/main/java/com/horcrux/svg/VirtualView.java
+@@ -608,17 +608,19 @@ public abstract class VirtualView extends ReactViewGroup {
+         setBottom(Math.min(bottom, root.getHeight()));
+       }
+     }
+-    EventDispatcher eventDispatcher =
+-        UIManagerHelper.getEventDispatcherForReactTag(mContext, getId());
+-    if (eventDispatcher != null) {
+-      eventDispatcher.dispatchEvent(
+-        new SvgOnLayoutEvent(
+-          UIManagerHelper.getSurfaceId(VirtualView.this),
+-          this.getId(),
+-          left,
+-          top,
+-          width,
+-          height));
++    if (!mContext.isBridgeless()) {
++      EventDispatcher eventDispatcher =
++          UIManagerHelper.getEventDispatcherForReactTag(mContext, getId());
++      if (eventDispatcher != null) {
++        eventDispatcher.dispatchEvent(
++          new SvgOnLayoutEvent(
++            UIManagerHelper.getSurfaceId(VirtualView.this),
++            this.getId(),
++            left,
++            top,
++            width,
++            height));
++      }
+     }
+   }
+ 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13388,10 +13388,10 @@ react-native-scrollable-mixin@^1.0.0:
   resolved "https://registry.yarnpkg.com/react-native-scrollable-mixin/-/react-native-scrollable-mixin-1.0.1.tgz#34a32167b64248594154fd0d6a8b03f22740548e"
   integrity sha512-haw7VtcK0Vg1p7CTE8vzhltICPhfuzLUNR1m9Rh55VYEGkD3o765Y5YTu88iA32uV/hMhJUopP5Tex/SvNidoA==
 
-react-native-svg@15.12.1:
-  version "15.12.1"
-  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-15.12.1.tgz#7ba756dd6a235f86a2c312a1e7911f9b0d18ad3a"
-  integrity sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==
+react-native-svg@15.15.1:
+  version "15.15.1"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-15.15.1.tgz#0b08716f5c389ef8550a73492c985c7b23849d65"
+  integrity sha512-ZUD1xwc3Hwo4cOmOLumjJVoc7lEf9oQFlHnLmgccLC19fNm6LVEdtB+Cnip6gEi0PG3wfvVzskViEtrySQP8Fw==
   dependencies:
     css-select "^5.1.0"
     css-tree "^1.1.3"


### PR DESCRIPTION
# Why
Closes ENG-18588
Updates `react-native-svg` to `15.15.1`

# How
Update package version and add small patch because it was crashing in expo go. 

# Test Plan
Bare-expo ✅
Expo go ✅
