### PR TITLE
[sdk-55] updated `@shopify/react-native-skia` to `2.2.14`

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2238,7 +2238,7 @@ PODS:
     - Yoga
   - react-native-segmented-control (2.5.7):
     - React-Core
-  - react-native-skia (2.2.12):
+  - react-native-skia (2.2.14):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3869,7 +3869,7 @@ SPEC CHECKSUMS:
   react-native-pager-view: e37989fc447aa4b5de6d0d2ffb0229e817329246
   react-native-safe-area-context: d46695b29119ba0871705c55c8ac2868888dcca4
   react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
-  react-native-skia: 009c318120ef7c6000bf14a6342ad8a89b44070b
+  react-native-skia: 9150fdcd08a9a8cf06447038898d5c93a5330b17
   react-native-slider: 7814a1258f438c043f370eb82110ef036793e95a
   react-native-view-shot: 26174e54ec6b4b7c5d70b86964b747919759adc1
   react-native-webview: a4f0775a31b73cf13cfc3d2d2b119aa94ec76e49

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -52,7 +52,7 @@
     "@react-native-picker/picker": "2.11.2",
     "@react-native-segmented-control/segmented-control": "2.5.7",
     "@shopify/flash-list": "2.0.2",
-    "@shopify/react-native-skia": "2.2.12",
+    "@shopify/react-native-skia": "2.2.14",
     "expo": "~54.0.8",
     "expo-build-properties": "~1.0.8",
     "expo-camera": "~17.0.8",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -2725,7 +2725,7 @@ PODS:
     - Yoga
   - react-native-segmented-control (2.5.7):
     - React-Core
-  - react-native-skia (2.2.12):
+  - react-native-skia (2.2.14):
     - boost
     - DoubleConversion
     - fast_float
@@ -4716,7 +4716,7 @@ SPEC CHECKSUMS:
   react-native-pager-view: 899989dd025d219d3ac0d386b2bc162f81ae8330
   react-native-safe-area-context: 2249e17382bd5a97cbccaa89e22af8756188c0fb
   react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
-  react-native-skia: 6fe142fbe7f93579e6205d4045abdf5d6574b942
+  react-native-skia: 4df548eb44d05ce5e35679b15a9d765e5724126e
   react-native-slider: e35799fb9983a19307195d77f10caf5f6a716842
   react-native-view-shot: aac285cd08144be29c19ab659930172836f0067f
   react-native-webview: 183e0d1f10b3c61c5ddd70f4ecd46488856a3573

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -38,7 +38,7 @@
     "@react-navigation/elements": "^2.8.1",
     "@react-navigation/native": "^7.1.21",
     "@react-navigation/stack": "^7.6.7",
-    "@shopify/react-native-skia": "2.2.12",
+    "@shopify/react-native-skia": "2.2.14",
     "@stripe/stripe-react-native": "0.50.3",
     "date-fns": "^2.28.0",
     "dedent": "^0.7.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -53,7 +53,7 @@
     "@react-navigation/native": "^7.1.21",
     "@react-navigation/stack": "^7.6.7",
     "@shopify/flash-list": "2.0.2",
-    "@shopify/react-native-skia": "2.2.12",
+    "@shopify/react-native-skia": "2.2.14",
     "date-format": "^2.0.0",
     "deep-object-diff": "^1.1.9",
     "expo": "~54.0.8",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -112,7 +112,7 @@
   "sentry-expo": "~7.0.0",
   "unimodules-app-loader": "~6.0.7",
   "unimodules-image-loader-interface": "~6.1.0",
-  "@shopify/react-native-skia": "2.2.12",
+  "@shopify/react-native-skia": "2.2.14",
   "@shopify/flash-list": "2.0.2",
   "@sentry/react-native": "~7.2.0",
   "react-native-bootsplash": "^6.3.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3882,10 +3882,10 @@
   dependencies:
     tslib "2.8.1"
 
-"@shopify/react-native-skia@2.2.12":
-  version "2.2.12"
-  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-2.2.12.tgz#1c27613035952772ce07418ace866b56df403546"
-  integrity sha512-P5wZSMPTp00hM0do+awNFtb5aPh5hSpodMGwy7NaxK90AV+SmUu7wZe6NGevzQIwgFa89Epn6xK3j4jKWdQi+A==
+"@shopify/react-native-skia@2.2.14":
+  version "2.2.14"
+  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-2.2.14.tgz#8c0dc72021e0b8c7390aa218b8b3d3345b871224"
+  integrity sha512-KnJS0YCWxZ3mAGxorpwnbL7/oSBhnlxrB/vzWUSiUR5rTAd5WMLVRcE0EdpNYEi8wM9m4DZAZ1fTxE2xHmFPew==
   dependencies:
     canvaskit-wasm "0.40.0"
     react-reconciler "0.31.0"


### PR DESCRIPTION
Updated

# Why

#Closes ENG-18593
Updated `@shopify/react-native-skia` to `2.2.14`

# How

Packages + pod install

# Test Plan

✅ Bare Expo iOS
✅ Bare Expo Android
✅ Expo Go iOS
✅ Expo Go Android

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
