### PR TITLE
[templates] disable tablet support by default

### DIFF
--- a/templates/expo-template-default/app.json
+++ b/templates/expo-template-default/app.json
@@ -8,7 +8,6 @@
     "scheme": "helloworld",
     "userInterfaceStyle": "automatic",
     "ios": {
-      "supportsTablet": false,
       "icon": "./assets/expo.icon"
     },
     "android": {

--- a/templates/expo-template-default/app.json
+++ b/templates/expo-template-default/app.json
@@ -8,7 +8,7 @@
     "scheme": "helloworld",
     "userInterfaceStyle": "automatic",
     "ios": {
-      "supportsTablet": true,
+      "supportsTablet": false,
       "icon": "./assets/expo.icon"
     },
     "android": {


### PR DESCRIPTION
# Why

Most developers don't want to support tablets and having this option turned on by default has caused some app rejections, on top of that, once you publish your application, you cannot disable tablet support.

# How

Update app.json tu disable tablet support

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
