### PR TITLE
[location] Add missing dependency on expo/image-utils

### DIFF
--- a/packages/expo-location/package.json
+++ b/packages/expo-location/package.json
@@ -38,6 +38,9 @@
   "jest": {
     "preset": "expo-module-scripts"
   },
+  "dependencies": {
+    "@expo/image-utils": "^0.8.7"
+  },
   "devDependencies": {
     "expo-module-scripts": "^5.0.7"
   },


### PR DESCRIPTION
# Why

The SDK packages checks are failing for `expo-location` (https://github.com/expo/expo/actions/runs/20800898381/job/59745363604?pr=41916#step:10:100) because of a missing dependency on `@expo/image-utils`, which is now used by its config plugin (introduced by #41132).

# How

Added the dependency

# Test Plan

`et check-packages expo-location` passes