### PR TITLE
[ci] unhide maestro artifacts when downloaded locally

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -176,6 +176,11 @@ jobs:
         env:
           MAESTRO_CLI_NO_ANALYTICS: 1
         timeout-minutes: 40
+      - name: 📦 Prepare testing artifacts
+        if: always()
+        run: |
+          # Rename .maestro to maestroArtifacts so it's not a hidden folder when downloaded locally
+          mv ~/.maestro ~/maestroArtifacts
       - name: 📸 Store testing artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -183,10 +188,9 @@ jobs:
         with:
           name: bare-expo-artifacts-ios
           path: |
-            ~/.maestro/tests/**/*
+            ~/maestroArtifacts/tests/**/*
             ~/Library/Logs/maestro/**/*
           overwrite: true
-          include-hidden-files: true # .maestro is skipped otherwise
       - name: 🔗 Artifacts download URL
         if: always()
         run: |
@@ -342,6 +346,11 @@ jobs:
             # Run the actual tests
             ./scripts/start-android-e2e-test.ts --test
           working-directory: ./apps/bare-expo
+      - name: 📦 Prepare testing artifacts
+        if: always()
+        run: |
+          # Rename .maestro to maestroArtifacts so it's not a hidden folder when downloaded locally
+          mv ~/.maestro ~/maestroArtifacts
       - name: 📸 Store testing artifacts
         if: always()
         id: upload-artifacts
@@ -349,7 +358,7 @@ jobs:
         with:
           name: bare-expo-artifacts-android
           path: |
-            ~/.maestro/tests/**/*
+            ~/maestroArtifacts/tests/**/*
           overwrite: true
       - name: 🔗 Artifacts download URL
         if: always()


### PR DESCRIPTION
# Why

This PR improves the accessibility of Maestro test artifacts by renaming the hidden `.maestro` folder to `maestroArtifacts` before uploading it as an artifact. This makes the test results easier to access when downloaded locally.

# How

- Added a new step "📦 Prepare testing artifacts" to both iOS and Android test workflows
- Modified the artifact upload paths to use the renamed folder
- Removed the `include-hidden-files: true` flag since it's no longer needed

# Test Plan

- download the artifacts, maestro artifacts are not in a hidden folder

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)