### PR TITLE
[sdk-55] Update `react-native-keyboard-controller` to `1.20.4`

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2098,7 +2098,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - react-native-keyboard-controller (1.20.3):
+  - react-native-keyboard-controller (1.20.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2110,7 +2110,7 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-keyboard-controller/common (= 1.20.3)
+    - react-native-keyboard-controller/common (= 1.20.4)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -2121,7 +2121,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-keyboard-controller/common (1.20.3):
+  - react-native-keyboard-controller/common (1.20.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3864,7 +3864,7 @@ SPEC CHECKSUMS:
   React-logger: 4462302b7135d3972e6d229d4b188caa4ffa0f2e
   React-Mapbuffer: 773eea58ff04e5fc8d525c5216957d6a82a6c84c
   React-microtasksnativemodule: 0294038bd92e2eb132975258e6ddc0a578a880ca
-  react-native-keyboard-controller: 3aafec20048eb28055882697e37d5b7b39170209
+  react-native-keyboard-controller: 162162ec94d05c4afb903a07d5414c5e719d42a1
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
   react-native-pager-view: e37989fc447aa4b5de6d0d2ffb0229e817329246
   react-native-safe-area-context: 53f796cb6c814661bbe99fbdfd0585d07b996cdd

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -70,7 +70,7 @@
     "react-native": "0.83.1",
     "react-native-edge-to-edge": "~1.6.1",
     "react-native-gesture-handler": "~2.30.0",
-    "react-native-keyboard-controller": "^1.20.3",
+    "react-native-keyboard-controller": "^1.20.4",
     "react-native-pager-view": "6.9.1",
     "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "5.6.2",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -2538,7 +2538,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - react-native-keyboard-controller (1.20.3):
+  - react-native-keyboard-controller (1.20.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2556,7 +2556,7 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-keyboard-controller/common (= 1.20.3)
+    - react-native-keyboard-controller/common (= 1.20.4)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -2567,7 +2567,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-keyboard-controller/common (1.20.3):
+  - react-native-keyboard-controller/common (1.20.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -4806,7 +4806,7 @@ SPEC CHECKSUMS:
   React-logger: 6ac901f5c7f7321d2be1a40b203bccc2e23411e3
   React-Mapbuffer: 2e0e7cc5b7064eaed9c8b8afc3a87621cb7ef5cd
   React-microtasksnativemodule: dd4d33b251b57e5027c572c6d0b45cbfbcfaa386
-  react-native-keyboard-controller: 706ad87594216864e79542852018165a5e6e0eb8
+  react-native-keyboard-controller: d07a35e49d478d26b2eb44b10aedc4e1d35354d6
   react-native-maps: 9cc71a39c6935770047b4a92a35361c3a67c539f
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
   react-native-pager-view: 4cc305d9d25eda66adf44029a84a591d8b98c072

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -71,7 +71,7 @@
     "react-native-gesture-handler": "~2.30.0",
     "react-native-infinite-scroll-view": "^0.4.5",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
-    "react-native-keyboard-controller": "^1.20.3",
+    "react-native-keyboard-controller": "^1.20.4",
     "react-native-maps": "1.26.20",
     "react-native-pager-view": "8.0.0",
     "react-native-paper": "^5.12.5",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -144,7 +144,7 @@
     "react-native": "0.83.1",
     "react-native-dropdown-picker": "^5.3.0",
     "react-native-gesture-handler": "~2.30.0",
-    "react-native-keyboard-controller": "^1.20.3",
+    "react-native-keyboard-controller": "^1.20.4",
     "react-native-maps": "1.26.20",
     "react-native-pager-view": "8.0.0",
     "react-native-paper": "^5.12.5",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -98,7 +98,7 @@
   "react-native-web": "~0.21.0",
   "react-native-gesture-handler": "~2.30.0",
   "react-native-get-random-values": "~1.11.0",
-  "react-native-keyboard-controller": "1.20.3",
+  "react-native-keyboard-controller": "1.20.4",
   "react-native-maps": "1.26.20",
   "react-native-pager-view": "8.0.0",
   "react-native-worklets": "0.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13322,10 +13322,10 @@ react-native-keyboard-aware-scroll-view@^0.9.5:
     prop-types "^15.6.2"
     react-native-iphone-x-helper "^1.0.3"
 
-react-native-keyboard-controller@^1.20.3:
-  version "1.20.3"
-  resolved "https://registry.yarnpkg.com/react-native-keyboard-controller/-/react-native-keyboard-controller-1.20.3.tgz#7bb75005cac79f7df80b221580afdc06fb7c24d1"
-  integrity sha512-OkfEkDFmFHRVdDM/uzAz5jYPjRgDHCZHI8NwcBcOTy7u2BxgcjiEHx/7IG1ct71hHBBcHfSUsMxR2n2cP4SHgA==
+react-native-keyboard-controller@^1.20.4:
+  version "1.20.4"
+  resolved "https://registry.yarnpkg.com/react-native-keyboard-controller/-/react-native-keyboard-controller-1.20.4.tgz#38d0a2cecdf766497bedc09ae2961abaad336ba5"
+  integrity sha512-IW2VatYwYhA3uRnGCOsEGARNjCYcYLUJX8KeuNz9GOMDWdLBVZWI+cy28+V4R2WvnToIIFku1NICbBSsQZi/8w==
   dependencies:
     react-native-is-edge-to-edge "^1.2.1"
 


### PR DESCRIPTION
# Why
A new version was released last night
Updates `react-native-keyboard-controller` to `1.20.4`

# How
Update package version

# Test Plan
Bare Expo ✅
Expo Go ✅
