### PR TITLE
feat(cli): Default EXPO_NO_GIT_STATUS to true and update warnings

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🎉 New features
 
+- Switch EXPO_NO_GIT_STATUS to default to true.
 - Added support for cli command extension in expo modules ([#39598](https://github.com/expo/expo/pull/39598) by [@chrfalch](https://github.com/chrfalch))
 - Add support for server data loaders in development ([#39570](https://github.com/expo/expo/pull/39570) by [@hassankhan](https://github.com/hassankhan))
 - Added support for bundling apps with a new error overlay from `@expo/log-box` package ([#39958](https://github.com/expo/expo/pull/39958) by [@krystofwoldrich](https://github.com/krystofwoldrich))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### 🎉 New features
 
-- Switch EXPO_NO_GIT_STATUS to default to true.
+- Switch EXPO_NO_GIT_STATUS to default to true. ([#42026](https://github.com/expo/expo/pull/42026) by [@EvanBacon](https://github.com/EvanBacon))
 - Added support for cli command extension in expo modules ([#39598](https://github.com/expo/expo/pull/39598) by [@chrfalch](https://github.com/chrfalch))
 - Add support for server data loaders in development ([#39570](https://github.com/expo/expo/pull/39570) by [@hassankhan](https://github.com/hassankhan))
 - Added support for bundling apps with a new error overlay from `@expo/log-box` package ([#39958](https://github.com/expo/expo/pull/39958) by [@krystofwoldrich](https://github.com/krystofwoldrich))

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -63,7 +63,7 @@ class Env {
 
   /** Skip warning users about a dirty git status */
   get EXPO_NO_GIT_STATUS() {
-    return boolish('EXPO_NO_GIT_STATUS', false);
+    return boolish('EXPO_NO_GIT_STATUS', true);
   }
   /** Disable auto web setup */
   get EXPO_NO_WEB_SETUP() {

--- a/packages/@expo/cli/src/utils/git.ts
+++ b/packages/@expo/cli/src/utils/git.ts
@@ -8,11 +8,11 @@ import * as Log from '../log';
 
 export async function maybeBailOnGitStatusAsync(): Promise<boolean> {
   if (env.EXPO_NO_GIT_STATUS) {
-    Log.warn(
-      'Git status is dirty but the command will continue because EXPO_NO_GIT_STATUS is enabled...'
-    );
     return false;
   }
+  Log.warn(
+    'Git status is dirty are you sure you want to continue (Set EXPO_NO_GIT_STATUS=0 to disable)'
+  );
   const isGitStatusClean = await validateGitStatusAsync();
 
   // Give people a chance to bail out if git working tree is dirty


### PR DESCRIPTION
# Why

- Prebuild is pretty established at this point, the extra warning seems unnecessary.
- Changed the default value of EXPO_NO_GIT_STATUS to true, so git status checks are skipped unless explicitly disabled. Updated related log messages to reflect the new default behavior.

