### PR TITLE
[ios][expo-font] Defer native font querying to prevent startup hang

### DIFF
--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Defer native font querying to prevent startup hang on iOS. ([#42033](https://github.com/expo/expo/pull/42033) by [@mozzius](https://github.com/mozzius))
 - unify `useFonts` return value in RSC ([#40481](https://github.com/expo/expo/pull/40481) by [@vonovak](https://github.com/vonovak))
 
 ### 💡 Others

--- a/packages/expo-font/ios/FontLoaderModule.swift
+++ b/packages/expo-font/ios/FontLoaderModule.swift
@@ -2,10 +2,23 @@ import ExpoModulesCore
 
 public final class FontLoaderModule: Module {
   // could be a Set, but to be able to pass to JS we keep it as an array
-  private var registeredFonts: [String]
+  private var _registeredFonts: [String] = []
+  private var hasQueriedNativeFonts = false
+
+  private var registeredFonts: [String] {
+    get {
+      if !hasQueriedNativeFonts {
+        hasQueriedNativeFonts = true
+        _registeredFonts = queryCustomNativeFonts()
+      }
+      return _registeredFonts
+    }
+    set {
+      _registeredFonts = newValue
+    }
+  }
 
   public required init(appContext: AppContext) {
-    self.registeredFonts = queryCustomNativeFonts()
     super.init(appContext: appContext)
   }
 

--- a/packages/expo-font/ios/FontLoaderModule.swift
+++ b/packages/expo-font/ios/FontLoaderModule.swift
@@ -2,21 +2,7 @@ import ExpoModulesCore
 
 public final class FontLoaderModule: Module {
   // could be a Set, but to be able to pass to JS we keep it as an array
-  private var _registeredFonts: [String] = []
-  private var hasQueriedNativeFonts = false
-
-  private var registeredFonts: [String] {
-    get {
-      if !hasQueriedNativeFonts {
-        hasQueriedNativeFonts = true
-        _registeredFonts = queryCustomNativeFonts()
-      }
-      return _registeredFonts
-    }
-    set {
-      _registeredFonts = newValue
-    }
-  }
+  private lazy var registeredFonts: [String] = queryCustomNativeFonts()
 
   public required init(appContext: AppContext) {
     super.init(appContext: appContext)


### PR DESCRIPTION
## Summary

Fixes a startup hang on iOS caused by synchronous font querying during module initialization.

Previously, `FontLoaderModule` called `queryCustomNativeFonts()` synchronously in its initializer, which would query all fonts listed in `UIAppFonts` from Info.plist. This involved calling `UIFont.fontNames(forFamilyName:)` for each font family, which could hang when called too early in the app lifecycle before the font system was fully initialized.

This PR makes the font query lazy by converting `registeredFonts` to a `lazy var` that only queries fonts on first access. Since most apps that use the config plugin don't call `getLoadedFonts()` or use dynamic font loading via `loadAsync()`, this expensive query often never runs at all, improving startup performance.

## Motivation

We can see in Xcode, `queryCustomNativeFonts()` makes up 26% of total hang time.

<img width="261" height="121" alt="Screenshot 2026-01-09 at 13 23 19" src="https://github.com/user-attachments/assets/c980703f-8581-4e19-ad3f-29c3057d585b" />


In apps with multiple fonts in `UIAppFonts` (e.g., 10+ Inter font variants), the synchronous font querying during module initialization can cause noticeable startup delays or hangs. The font query is only needed when:
1. `getLoadedFonts()` is called to check which fonts are available
2. `loadAsync()` is called and needs to merge new fonts with existing ones

Most apps that bundle fonts via the Expo config plugin never call these methods, making the eager query unnecessary.

## Test Plan

- I added logging to confirm `queryCustomNativeFonts()` is only called when needed
- `useFonts()` still works as before