### PR TITLE
[docs] Update visibility and sidebar title for LLMs page

### DIFF
--- a/docs/pages/llms.mdx
+++ b/docs/pages/llms.mdx
@@ -1,9 +1,8 @@
 ---
 title: Documentation for LLMs
-sidebar_title: LLMs
+sidebar_title: llms.txt
 description: A list of Expo and EAS documentation files available for large language models (LLMs) and apps that use them.
 hideTOC: true
-hideFromSearch: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Came up in the weekly discussion with @kadikraman.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the sidebar title to `llms.txt` and remove `hideFromSearch` so that this page is searchable in the Search UI.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="570" height="312" alt="CleanShot 2026-01-09 at 18 34 56@2x" src="https://github.com/user-attachments/assets/29581d71-f15f-47c9-a93f-fa4c0a7de652" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
