### PR TITLE
[brownfield][iOS] Fix support for react-native 0.83 

### DIFF
--- a/packages/expo-brownfield/plugin/build/cli/constants/defaults.d.ts
+++ b/packages/expo-brownfield/plugin/build/cli/constants/defaults.d.ts
@@ -1,5 +1,5 @@
 export declare const Defaults: {
     readonly artifactsPath: "./artifacts";
-    readonly hermesFrameworkPath: "Pods/hermes-engine/destroot/Library/Frameworks/universal/hermes.xcframework";
+    readonly hermesFrameworkPath: "Pods/hermes-engine/destroot/Library/Frameworks/universal/hermesvm.xcframework";
     readonly libraryName: "brownfield";
 };

--- a/packages/expo-brownfield/plugin/build/cli/constants/defaults.js
+++ b/packages/expo-brownfield/plugin/build/cli/constants/defaults.js
@@ -3,6 +3,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.Defaults = void 0;
 exports.Defaults = {
     artifactsPath: './artifacts',
-    hermesFrameworkPath: 'Pods/hermes-engine/destroot/Library/Frameworks/universal/hermes.xcframework',
+    hermesFrameworkPath: 'Pods/hermes-engine/destroot/Library/Frameworks/universal/hermesvm.xcframework',
     libraryName: 'brownfield',
 };

--- a/packages/expo-brownfield/plugin/src/cli/constants/defaults.ts
+++ b/packages/expo-brownfield/plugin/src/cli/constants/defaults.ts
@@ -1,6 +1,6 @@
 export const Defaults = {
   artifactsPath: './artifacts',
   hermesFrameworkPath:
-    'Pods/hermes-engine/destroot/Library/Frameworks/universal/hermes.xcframework',
+    'Pods/hermes-engine/destroot/Library/Frameworks/universal/hermesvm.xcframework',
   libraryName: 'brownfield',
 } as const;

--- a/packages/expo-brownfield/plugin/templates/ios/ExpoAppDelegateWrapper.swift
+++ b/packages/expo-brownfield/plugin/templates/ios/ExpoAppDelegateWrapper.swift
@@ -6,7 +6,6 @@ public class ExpoAppDelegateWrapper {
 
   init(factory: RCTReactNativeFactory) {
     expoDelegate = ExpoAppDelegate()
-    expoDelegate.bindReactNativeFactory(factory)
   }
 
   func recreateRootView(

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/ExpoSwiftUI.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/ExpoSwiftUI.swift
@@ -1,5 +1,9 @@
 // Copyright 2024-present 650 Industries. All rights reserved.
 
+// Re-export Combine so that consumers building ExpoModulesCore as a framework
+// don't need to explicitly import Combine when using ObservableObject types.
+@_exported import Combine
+
 /**
  A namespace for Expo APIs that deal with SwiftUI.
  */


### PR DESCRIPTION
# Why

Previously, expo-brownfield was targeting react-native 0.81 and it no longer builds correctly when using 0.83

# How

- Fix hermes framework path
- Remove `bindReactNativeFactory` call -> we should try to remove the whole ExpoAppDelegateWrapper.swift


# Test Plan

In minimal-tester run

- ` npx expo-brownfield build-ios`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
