### PR TITLE
docs: clarify Localizable.strings entry in localization guide

### DIFF
--- a/docs/pages/guides/localization.mdx
+++ b/docs/pages/guides/localization.mdx
@@ -204,7 +204,7 @@ The keys provided to `locales` should be the [language identifier](https://devel
 
 Now, the display name of your app is set to `こんにちは` whenever it's installed on a device with the language set to Japanese.
 
-Since SDK 55, there is the option to specify an iOS-only `Localizable.strings` object whose entries are used to create native localization files. The entries can be used in [iOS localized notifications](https://developer.apple.com/documentation/usernotifications/generating-a-remote-notification#Localize-your-alert-messages).
+In SDK 55 and later, there is an iOS-only option to specify a `Localizable.strings` object whose entries are used to create native localization files. The entries can be used in [iOS localized notifications](https://developer.apple.com/documentation/usernotifications/generating-a-remote-notification#Localize-your-alert-messages).
 
 ## Enabling RTL support
 

--- a/docs/pages/guides/localization.mdx
+++ b/docs/pages/guides/localization.mdx
@@ -204,7 +204,7 @@ The keys provided to `locales` should be the [language identifier](https://devel
 
 Now, the display name of your app is set to `こんにちは` whenever it's installed on a device with the language set to Japanese.
 
-For [iOS localized notifications](https://developer.apple.com/documentation/usernotifications/generating-a-remote-notification#Localize-your-alert-messages), keys should be defined in `Localizable.strings`.
+Since SDK 55, there is the option to specify an iOS-only `Localizable.strings` object whose entries are used to create native localization files. The entries can be used in [iOS localized notifications](https://developer.apple.com/documentation/usernotifications/generating-a-remote-notification#Localize-your-alert-messages).
 
 ## Enabling RTL support
 


### PR DESCRIPTION
# Why

Update the documentation for iOS localization in the localization guide to reflect `Localizable.strings` object introduced in SDK 55.

# How

Modified the documentation to clarify that since SDK 55, there is an option to specify an iOS-only `Localizable.strings` object that creates native localization files, which can be used for iOS localized notifications.

# Test Plan


# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)