### PR TITLE
[ios][expo-go] Add new version warning

### DIFF
--- a/apps/expo-go/ios/Client/SwiftUI/HomeTabView.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/HomeTabView.swift
@@ -22,6 +22,8 @@ struct HomeTabView: View {
             }
           }
 
+          UpgradeWarningView()
+
           DevServersSection()
 
           if !viewModel.recentlyOpenedApps.isEmpty {

--- a/apps/expo-go/ios/Client/SwiftUI/Views/UpgradeWarningView.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Views/UpgradeWarningView.swift
@@ -1,0 +1,185 @@
+//  Copyright © 2025 650 Industries. All rights reserved.
+
+import SwiftUI
+
+struct UpgradeWarningView: View {
+  @State private var shouldShow = false
+  @State private var betaSdkVersion: String?
+  @State private var hasDismissedWarning = false
+  @Environment(\.colorScheme) private var colorScheme
+
+  var body: some View {
+    Group {
+      if shouldShow && !hasDismissedWarning {
+        let background = colorScheme == .dark
+          ? Color(red: 0.22, green: 0.19, blue: 0.08)
+          : Color(red: 1.0, green: 0.97, blue: 0.84)
+        let border = colorScheme == .dark
+          ? Color(red: 0.55, green: 0.45, blue: 0.2)
+          : Color(red: 0.98, green: 0.8, blue: 0.4)
+        VStack(alignment: .leading, spacing: 8) {
+          HStack(alignment: .top) {
+            HStack(spacing: 8) {
+              Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundColor(Color(red: 0.98, green: 0.7, blue: 0.2))
+              Text("New Expo Go version coming soon!")
+                .font(.system(size: 13, weight: .semibold))
+            }
+
+            Spacer()
+
+            Button {
+              withAnimation(.easeInOut(duration: 0.2)) {
+                hasDismissedWarning = true
+              }
+            } label: {
+              Image(systemName: "xmark")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(.secondary)
+                .frame(width: 24, height: 24)
+            }
+          }
+
+          if let betaSdkVersion {
+            (Text("A new version of Expo Go will be released to the store soon, and it will ")
+              .font(.system(size: 13))
+              .foregroundColor(.primary)
+              + Text("only support SDK \(betaSdkVersion).")
+              .font(.system(size: 13, weight: .semibold))
+              .foregroundColor(.primary)
+            )
+          }
+
+          iosMessage
+        }
+        .padding()
+        .background(background)
+        .overlay(
+          RoundedRectangle(cornerRadius: BorderRadius.large)
+            .stroke(border, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: BorderRadius.large))
+      }
+    }
+    .animation(.easeInOut(duration: 0.2), value: hasDismissedWarning)
+    .task {
+      await refresh()
+    }
+  }
+
+  private var iosMessage: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      (Text("In order to ensure that you can upgrade at your own pace, we recommend ")
+        .font(.system(size: 13))
+        .foregroundColor(.primary)
+        + Text("migrating to a development build.")
+        .font(.system(size: 13, weight: .semibold))
+        .foregroundColor(.expoBlue)
+      )
+      .onTapGesture {
+        if let url = URL(string: "https://docs.expo.dev/develop/development-builds/expo-go-to-dev-build") {
+          UIApplication.shared.open(url)
+        }
+      }
+      (Text("To continue using this version of Expo Go, you can ")
+        .font(.system(size: 13))
+        .foregroundColor(.primary)
+        + Text("disable automatic app updates")
+        .font(.system(size: 13, weight: .semibold))
+        .foregroundColor(.primary)
+        + Text(" from the App Store settings before the new version is released.")
+        .font(.system(size: 13))
+        .foregroundColor(.primary)
+      )
+    }
+  }
+
+  private func refresh() async {
+    let result = await UpgradeWarningService.shouldShowUpgradeWarning()
+    await MainActor.run {
+      shouldShow = result.shouldShow
+      betaSdkVersion = result.betaSdkVersion
+    }
+  }
+}
+
+private enum UpgradeWarningService {
+  static func shouldShowUpgradeWarning() async -> (shouldShow: Bool, betaSdkVersion: String?) {
+    if !isDevice() {
+      return (false, nil)
+    }
+
+    guard let url = URL(string: "https://api.expo.dev/v2/versions") else {
+      return (false, nil)
+    }
+
+    do {
+      let (data, response) = try await URLSession.shared.data(from: url)
+      guard let httpResponse = response as? HTTPURLResponse,
+            (200..<300).contains(httpResponse.statusCode) else {
+        return (false, nil)
+      }
+
+      let decoder = JSONDecoder()
+      let versions = try decoder.decode(VersionsResponse.self, from: data)
+      let published = versions.sdkVersions.compactMap { key, value -> VersionInfo? in
+        guard let major = extractMajor(from: key) else { return nil }
+        return VersionInfo(major: major, releaseNoteUrl: value.releaseNoteUrl)
+      }.sorted(by: { $0.major < $1.major })
+
+      guard published.count >= 2 else {
+        return (false, nil)
+      }
+
+      let last = published[published.count - 1]
+      let penultimate = published[published.count - 2]
+      let currentMajor = getSDKMajorVersion(getSupportedSDKVersion())
+      let currentIsLatestPublished = currentMajor == String(penultimate.major)
+      let latestIsBeta = last.releaseNoteUrl == nil
+
+      return (currentIsLatestPublished && latestIsBeta, String(last.major))
+    } catch {
+      return (false, nil)
+    }
+  }
+
+  private static func extractMajor(from sdkVersion: String) -> Int? {
+    if #available(iOS 16, *) {
+      let pattern = /(\d+)\.0\.0/
+      guard let match = sdkVersion.firstMatch(of: pattern),
+            let major = Int(match.1) else {
+        return nil
+      }
+      return major
+    } else {
+      let pattern = #"(\d+)\.0\.0"#
+      guard let regex = try? NSRegularExpression(pattern: pattern),
+            let match = regex.firstMatch(in: sdkVersion, range: NSRange(sdkVersion.startIndex..., in: sdkVersion)),
+            let range = Range(match.range(at: 1), in: sdkVersion) else {
+        return nil
+      }
+      return Int(sdkVersion[range])
+    }
+  }
+
+  private static func isDevice() -> Bool {
+#if targetEnvironment(simulator)
+    return false
+#else
+    return true
+#endif
+  }
+}
+
+private struct VersionsResponse: Decodable {
+  let sdkVersions: [String: VersionInfoResponse]
+}
+
+private struct VersionInfoResponse: Decodable {
+  let releaseNoteUrl: String?
+}
+
+private struct VersionInfo {
+  let major: Int
+  let releaseNoteUrl: String?
+}

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -20,11 +20,6 @@ PODS:
   - EXManifests/Tests (1.0.8):
     - ExpoModulesCore
     - ExpoModulesTestCore
-  - EXNotifications (0.32.11):
-    - ExpoModulesCore
-  - EXNotifications/Tests (0.32.11):
-    - ExpoModulesCore
-    - ExpoModulesTestCore
   - Expo (54.0.8):
     - boost
     - DoubleConversion
@@ -324,6 +319,11 @@ PODS:
     - React-hermes
   - ExpoNetwork (8.0.7):
     - ExpoModulesCore
+  - ExpoNotifications (0.32.11):
+    - ExpoModulesCore
+  - ExpoNotifications/Tests (0.32.11):
+    - ExpoModulesCore
+    - ExpoModulesTestCore
   - ExpoPrint (15.0.7):
     - ExpoModulesCore
   - ExpoRouter (6.0.6):
@@ -4094,8 +4094,6 @@ DEPENDENCIES:
   - EXJSONUtils/Tests (from `../../../packages/expo-json-utils/ios`)
   - EXManifests (from `../../../packages/expo-manifests/ios`)
   - EXManifests/Tests (from `../../../packages/expo-manifests/ios`)
-  - EXNotifications (from `../../../packages/expo-notifications/ios`)
-  - EXNotifications/Tests (from `../../../packages/expo-notifications/ios`)
   - Expo (from `../../../packages/expo`)
   - expo-dev-menu (from `../../../packages/expo-dev-menu`)
   - expo-dev-menu-interface (from `../../../packages/expo-dev-menu-interface/ios`)
@@ -4146,6 +4144,8 @@ DEPENDENCIES:
   - ExpoModulesJSI/Tests (from `../../../packages/expo-modules-core`)
   - ExpoModulesTestCore (from `../../../packages/expo-modules-test-core/ios`)
   - ExpoNetwork (from `../../../packages/expo-network/ios`)
+  - ExpoNotifications (from `../../../packages/expo-notifications/ios`)
+  - ExpoNotifications/Tests (from `../../../packages/expo-notifications/ios`)
   - ExpoPrint (from `../../../packages/expo-print/ios`)
   - ExpoRouter (from `../../../packages/expo-router/ios`)
   - ExpoScreenCapture (from `../../../packages/expo-screen-capture/ios`)
@@ -4337,8 +4337,6 @@ EXTERNAL SOURCES:
     :path: "../../../packages/expo-json-utils/ios"
   EXManifests:
     :path: "../../../packages/expo-manifests/ios"
-  EXNotifications:
-    :path: "../../../packages/expo-notifications/ios"
   Expo:
     :path: "../../../packages/expo"
   expo-dev-menu:
@@ -4427,6 +4425,8 @@ EXTERNAL SOURCES:
     :path: "../../../packages/expo-modules-test-core/ios"
   ExpoNetwork:
     :path: "../../../packages/expo-network/ios"
+  ExpoNotifications:
+    :path: "../../../packages/expo-notifications/ios"
   ExpoPrint:
     :path: "../../../packages/expo-print/ios"
   ExpoRouter:
@@ -4674,7 +4674,6 @@ SPEC CHECKSUMS:
   EXConstants: 59d46d25b89f88cc38291a56dbce4d550758f72d
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
   EXManifests: 7469efed75d694ce3c43a6da9c6f3886f66d3c26
-  EXNotifications: a9eb811deeb51fb8e50ef45569be6ffab3994648
   Expo: 446942b564f6fa3f855457d1f1678a9d5c5f3741
   expo-dev-menu: ae1feaf51f47590afc4527c6a75165beb7aed0dd
   expo-dev-menu-interface: 30d9aa2fbca275a1335ca7e076273dac1d42d40a
@@ -4719,6 +4718,7 @@ SPEC CHECKSUMS:
   ExpoModulesJSI: c470ea2ed825fce73bdc4ef060c8a22e3f664092
   ExpoModulesTestCore: e65555b75a4ed7dd3bcf421ad01d7748bd372c88
   ExpoNetwork: 97073786edfe405aba5d0987a544617ed0671ad1
+  ExpoNotifications: ce045fa5f6ab4109f04468e04e6fe6ff0427a6d1
   ExpoPrint: ad836bb90da10793509651c0ea1f39e120db001e
   ExpoRouter: 84268c2b41722697cb02cd6c377d588b4f71c9b5
   ExpoScreenCapture: 0c785ab7e1fa38943f04b16060d54ae8f886544a


### PR DESCRIPTION
# Why
Adds the upcoming update notice

# How
<img width="450" height="978" alt="Simulator Screenshot - iPhone 17 - 2026-01-09 at 11 19 29" src="https://github.com/user-attachments/assets/23f97892-17cd-4b15-ae33-ef45362a911c" />

<img width="450" height="978" alt="Simulator Screenshot - iPhone 17 - 2026-01-09 at 11 19 36" src="https://github.com/user-attachments/assets/eb006b24-264e-4c2b-a5e5-fcb107f1695d" />
ssets/8b273e48-db12-498e-9cc7-7187bbf845e5" />


