### PR TITLE
[ios][expo-go] Fix gesture settings

### DIFF
--- a/apps/expo-go/ios/Client/EXRootViewController.m
+++ b/apps/expo-go/ios/Client/EXRootViewController.m
@@ -46,6 +46,31 @@ NS_ASSUME_NONNULL_BEGIN
   return self;
 }
 
+- (BOOL)canBecomeFirstResponder
+{
+  return YES;
+}
+
+- (void)viewDidAppear:(BOOL)animated
+{
+  [super viewDidAppear:animated];
+  [self becomeFirstResponder];
+}
+
+- (void)viewWillDisappear:(BOOL)animated
+{
+  [super viewWillDisappear:animated];
+  [self resignFirstResponder];
+}
+
+- (void)motionEnded:(UIEventSubtype)motion withEvent:(UIEvent * _Nullable)event
+{
+  [super motionEnded:motion withEvent:event];
+  if (motion == UIEventSubtypeMotionShake && [DevMenuManager.shared getMotionGestureEnabled]) {
+    [DevMenuManager.shared toggleMenu];
+  }
+}
+
 #pragma mark - Screen Orientation
 
 - (BOOL)shouldAutorotate

--- a/apps/expo-go/ios/Client/SwiftUI/Services/SettingsManager.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Services/SettingsManager.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import UIKit
+import EXDevMenu
 
 @MainActor
 class SettingsManager: ObservableObject {
@@ -19,11 +20,13 @@ class SettingsManager: ObservableObject {
   func updateShakeGesture(_ enabled: Bool) {
     shakeToShowDevMenu = enabled
     saveDevSetting(key: "shakeToShow", value: enabled)
+    DevMenuManager.shared.setMotionGestureEnabled(enabled)
   }
 
   func updateThreeFingerGesture(_ enabled: Bool) {
     threeFingerLongPressEnabled = enabled
     saveDevSetting(key: "threeFingerLongPress", value: enabled)
+    DevMenuManager.shared.setTouchGestureEnabled(enabled)
   }
 
   func updateTheme(_ themeIndex: Int) {
@@ -33,9 +36,8 @@ class SettingsManager: ObservableObject {
   }
 
   private func loadDevSettings() {
-    let devMenuDefaults = UserDefaults.standard.dictionary(forKey: "RCTDevMenu") ?? [:]
-    shakeToShowDevMenu = devMenuDefaults["shakeToShow"] as? Bool ?? true
-    threeFingerLongPressEnabled = devMenuDefaults["threeFingerLongPress"] as? Bool ?? true
+    shakeToShowDevMenu = DevMenuManager.shared.getMotionGestureEnabled()
+    threeFingerLongPressEnabled = DevMenuManager.shared.getTouchGestureEnabled()
   }
 
   private func saveDevSetting(key: String, value: Bool) {

--- a/apps/expo-go/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
+++ b/apps/expo-go/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
@@ -422,7 +422,7 @@ NSString *const RCTInstanceDidLoadBundle = @"RCTInstanceDidLoadBundle";
 {
   EXManifestsManifest *manifest = _appRecord.appLoader.manifest;
   if (manifest) {
-    return manifest.isUsingDeveloperTool;
+    return manifest.isUsingDeveloperTool || manifest.isDevelopmentMode;
   }
   return false;
 }
@@ -464,7 +464,7 @@ NSString *const RCTInstanceDidLoadBundle = @"RCTInstanceDidLoadBundle";
 
 - (void)toggleDevMenu
 {
-  [[EXKernel sharedInstance] switchTasks];
+  [self showDevMenu];
 }
 
 - (void)setupWebSocketControls

--- a/apps/expo-go/ios/Exponent/Versioned/Core/AppInstance/ExpoGoReactNativeFactory.mm
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/AppInstance/ExpoGoReactNativeFactory.mm
@@ -40,6 +40,9 @@
 
 - (void)hostDidStart:(nonnull RCTHost *)host {
   host.runtimeDelegate = self;
+  if ([self.delegate respondsToSelector:@selector(hostDidStart:)]) {
+    [self.delegate hostDidStart:host];
+  }
 }
 
 - (void)host:(nonnull RCTHost *)host didInitializeRuntime:(jsi::Runtime &)runtime

--- a/apps/expo-go/ios/Exponent/Versioned/Core/EXVersionManagerObjC.mm
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/EXVersionManagerObjC.mm
@@ -264,7 +264,7 @@ RCT_EXTERN void EXRegisterScopedModule(Class, ...);
 
 - (BOOL)_isDevModeEnabledForHost:(NSURL *)bundleURL
 {
-  return ([RCTGetURLQueryParam(bundleURL, @"dev") boolValue]);
+  return ([RCTGetURLQueryParam(bundleURL, @"dev") boolValue] || _manifest.isDevelopmentMode);
 }
 
 - (void)_openJsInspector:(NSURL *)bundleURL

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -109,6 +109,26 @@ open class DevMenuManager: NSObject {
   }
 
   @objc
+  public func setMotionGestureEnabled(_ enabled: Bool) {
+    DevMenuPreferences.motionGestureEnabled = enabled
+  }
+
+  @objc
+  public func setTouchGestureEnabled(_ enabled: Bool) {
+    DevMenuPreferences.touchGestureEnabled = enabled
+  }
+
+  @objc
+  public func getMotionGestureEnabled() -> Bool {
+    return DevMenuPreferences.motionGestureEnabled
+  }
+
+  @objc
+  public func getTouchGestureEnabled() -> Bool {
+    return DevMenuPreferences.touchGestureEnabled
+  }
+
+  @objc
   public func updateCurrentBridge(_ bridge: RCTBridge?) {
     currentBridge = bridge
   }
@@ -344,7 +364,8 @@ open class DevMenuManager: NSObject {
         self.window?.makeKeyAndOrderFront(nil)
 #else
         if self.window?.windowScene == nil {
-          let windowScene = UIApplication.shared.connectedScenes
+          let keyWindowScene = UIApplication.shared.windows.first(where: { $0.isKeyWindow })?.windowScene
+          let windowScene = keyWindowScene ?? UIApplication.shared.connectedScenes
             .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
           self.window?.windowScene = windowScene
         }


### PR DESCRIPTION
# Why
Gesture settings were not being updated correctly causing them to be ignored. Also, I missed calling `hostDidStart` which caused crashes on reload

# Test Plan
Expo go

