### PR TITLE
[ios][expo-go] Fix notifications import

### DIFF
--- a/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/EXScopedNotificationSerializer.swift
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/EXScopedNotificationSerializer.swift
@@ -1,7 +1,7 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
 import UserNotifications
-import EXNotifications
+import ExpoNotifications
 
 public class EXScopedNotificationSerializer {
 

--- a/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsCategoriesModule.swift
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsCategoriesModule.swift
@@ -1,7 +1,7 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
 import ExpoModulesCore
-import EXNotifications
+import ExpoNotifications
 
 public final class ExpoGoNotificationsCategoriesModule: CategoriesModule {
   private let scopeKey: String

--- a/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsEmitterModule.swift
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsEmitterModule.swift
@@ -1,7 +1,7 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
 import ExpoModulesCore
-import EXNotifications
+import ExpoNotifications
 
 public final class ExpoGoNotificationsEmitterModule: EmitterModule {
   private let scopeKey: String

--- a/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsHandlerModule.swift
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsHandlerModule.swift
@@ -1,7 +1,7 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
 import ExpoModulesCore
-import EXNotifications
+import ExpoNotifications
 
 public final class ExpoGoNotificationsHandlerModule: HandlerModule {
   private let scopeKey: String

--- a/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsPresentationModule.swift
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsPresentationModule.swift
@@ -1,7 +1,7 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
 import ExpoModulesCore
-import EXNotifications
+import ExpoNotifications
 
 public final class ExpoGoNotificationsPresentationModule: PresentationModule {
   private let scopeKey: String

--- a/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsSchedulerModule.swift
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsSchedulerModule.swift
@@ -1,7 +1,7 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
 import ExpoModulesCore
-import EXNotifications
+import ExpoNotifications
 
 public final class ExpoGoNotificationsSchedulerModule: SchedulerModule {
   private let scopeKey: String

--- a/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsServerRegistrationModule.swift
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsServerRegistrationModule.swift
@@ -1,7 +1,7 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
 import ExpoModulesCore
-import EXNotifications
+import ExpoNotifications
 
 // swiftlint:disable:next type_name
 public final class ExpoGoNotificationsServerRegistrationModule: ServerRegistrationModule {


### PR DESCRIPTION
# Why
#42009 changed the module name causing all the imports for expo notifications to break.

# How
Updated the imports

# Test Plan
Expo go

