### PR TITLE
[mininal-tester] Add expo-brownfield dependency

### DIFF
--- a/apps/minimal-tester/android/brownfield/build.gradle.kts
+++ b/apps/minimal-tester/android/brownfield/build.gradle.kts
@@ -1,0 +1,58 @@
+plugins {
+  id("com.android.library")
+  id("org.jetbrains.kotlin.android")
+  id("com.facebook.react")
+  id("expo-brownfield-setup")
+}
+
+group = "com.community.minimaltester"
+
+version = "1.0.0"
+
+react { autolinkLibrariesWithApp() }
+
+android {
+  namespace = "com.community.minimaltester.brownfield"
+  compileSdk = 36
+
+  buildFeatures { buildConfig = true }
+
+  defaultConfig {
+    minSdk = 24
+    consumerProguardFiles("consumer-rules.pro")
+    buildConfigField(
+        "boolean",
+        "IS_NEW_ARCHITECTURE_ENABLED",
+        properties["newArchEnabled"].toString(),
+    )
+    buildConfigField("boolean", "IS_HERMES_ENABLED", properties["hermesEnabled"].toString())
+    buildConfigField(
+        "boolean",
+        "IS_EDGE_TO_EDGE_ENABLED",
+        properties["edgeToEdgeEnabled"].toString(),
+    )
+    buildConfigField(
+        "String",
+        "REACT_NATIVE_RELEASE_LEVEL",
+        "\"${findProperty("reactNativeReleaseLevel") ?: "stable"}\"",
+    )
+  }
+
+  buildTypes {
+    release {
+      isMinifyEnabled = false
+      proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+    }
+  }
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+  }
+  kotlinOptions { jvmTarget = "17" }
+}
+
+dependencies {
+  api("com.facebook.react:react-android")
+  api("com.facebook.react:hermes-android")
+  compileOnly("androidx.fragment:fragment-ktx:1.6.1")
+}

--- a/apps/minimal-tester/android/brownfield/proguard-rules.pro
+++ b/apps/minimal-tester/android/brownfield/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/apps/minimal-tester/android/brownfield/src/main/AndroidManifest.xml
+++ b/apps/minimal-tester/android/brownfield/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>

--- a/apps/minimal-tester/android/brownfield/src/main/java/com/community/minimaltester/brownfield/BrownfieldActivity.kt
+++ b/apps/minimal-tester/android/brownfield/src/main/java/com/community/minimaltester/brownfield/BrownfieldActivity.kt
@@ -1,0 +1,23 @@
+package com.community.minimaltester.brownfield
+
+import android.app.Application
+import android.content.res.Configuration
+import androidx.appcompat.app.AppCompatActivity
+import expo.modules.ApplicationLifecycleDispatcher
+
+object BrownfieldLifecycleDispatcher {
+  fun onApplicationCreate(application: Application) {
+    ApplicationLifecycleDispatcher.onApplicationCreate(application)
+  }
+
+  fun onConfigurationChanged(application: Application, newConfig: Configuration) {
+    ApplicationLifecycleDispatcher.onConfigurationChanged(application, newConfig)
+  }
+}
+
+open class BrownfieldActivity : AppCompatActivity() {
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    super.onConfigurationChanged(newConfig)
+    BrownfieldLifecycleDispatcher.onConfigurationChanged(this.application, newConfig)
+  }
+}

--- a/apps/minimal-tester/android/brownfield/src/main/java/com/community/minimaltester/brownfield/ReactNativeFragment.kt
+++ b/apps/minimal-tester/android/brownfield/src/main/java/com/community/minimaltester/brownfield/ReactNativeFragment.kt
@@ -1,0 +1,63 @@
+package com.community.minimaltester.brownfield
+
+import android.app.Activity
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.commit
+
+class ReactNativeFragment : Fragment() {
+  override fun onCreateView(
+      inflater: LayoutInflater,
+      container: ViewGroup?,
+      savedInstanceState: Bundle?,
+  ): FrameLayout {
+    return ReactNativeViewFactory.createFrameLayout(
+        requireContext(),
+        requireActivity(),
+        RootComponent.Main,
+    )
+  }
+
+  companion object {
+    private const val TAG = "ReactNativeFragment"
+
+    fun createFragmentHost(activity: Activity): ViewGroup {
+      val layout =
+          object : FrameLayout(activity) {
+            init {
+              id = generateViewId()
+            }
+          }
+
+      val fragment = createAndCommit(activity, layout)
+
+      return layout
+    }
+
+    internal fun createAndCommit(
+        activity: Activity,
+        container: ViewGroup,
+    ): ReactNativeFragment {
+      val fragmentManager = (activity as FragmentActivity).supportFragmentManager
+
+      val fragment = ReactNativeFragment()
+
+      fragmentManager.commit(true) {
+        setReorderingAllowed(true)
+        add(container.id, fragment, TAG)
+      }
+
+      return fragment
+    }
+
+    internal fun findIn(activity: Activity): ReactNativeFragment? {
+      val activity = activity ?: return null
+      return (activity as FragmentActivity).supportFragmentManager.findFragmentByTag(TAG)
+          as ReactNativeFragment?
+    }
+  }
+}

--- a/apps/minimal-tester/android/brownfield/src/main/java/com/community/minimaltester/brownfield/ReactNativeHostManager.kt
+++ b/apps/minimal-tester/android/brownfield/src/main/java/com/community/minimaltester/brownfield/ReactNativeHostManager.kt
@@ -1,0 +1,79 @@
+package com.community.minimaltester.brownfield
+
+import android.app.Activity
+import android.app.Application
+import androidx.activity.ComponentActivity
+import androidx.activity.OnBackPressedCallback
+import com.facebook.react.PackageList
+import com.facebook.react.ReactHost
+import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
+import com.facebook.react.common.ReleaseLevel
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
+import com.facebook.react.modules.core.DeviceEventManagerModule
+import expo.modules.ExpoReactHostFactory
+import expo.modules.brownfield.BrownfieldNavigationState
+
+class ReactNativeHostManager {
+  companion object {
+    val shared: ReactNativeHostManager by lazy { ReactNativeHostManager() }
+    private var reactHost: ReactHost? = null
+  }
+
+  fun getReactHost(): ReactHost? {
+    return reactHost
+  }
+
+  fun initialize(application: Application) {
+    if (reactHost != null) {
+      return
+    }
+
+    DefaultNewArchitectureEntryPoint.releaseLevel =
+        try {
+          ReleaseLevel.valueOf(BuildConfig.REACT_NATIVE_RELEASE_LEVEL.uppercase())
+        } catch (e: IllegalArgumentException) {
+          ReleaseLevel.STABLE
+        }
+    loadReactNative(application)
+    BrownfieldLifecycleDispatcher.onApplicationCreate(application)
+
+    reactHost = ExpoReactHostFactory.getDefaultReactHost(
+      context = application.applicationContext,
+      packageList = PackageList(application).packages
+    )
+  }
+}
+
+fun Activity.showReactNativeFragment() {
+  ReactNativeHostManager.shared.initialize(this.application)
+  val fragment = ReactNativeFragment.createFragmentHost(this)
+  setContentView(fragment)
+  setUpNativeBackHandling()
+}
+
+fun Activity.setUpNativeBackHandling() {
+  val componentActivity = this as? ComponentActivity
+  if (componentActivity == null) {
+    return
+  }
+
+  val backCallback =
+      object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+          if (BrownfieldNavigationState.nativeBackEnabled) {
+            isEnabled = false
+            componentActivity.onBackPressedDispatcher?.onBackPressed()
+            isEnabled = true
+          } else {
+            val reactHost = ReactNativeHostManager.shared.getReactHost()
+            reactHost?.currentReactContext?.let { reactContext ->
+              val deviceEventManager =
+                  reactContext.getNativeModule(DeviceEventManagerModule::class.java)
+              deviceEventManager?.emitHardwareBackPressed()
+            }
+          }
+        }
+      }
+
+  componentActivity.onBackPressedDispatcher?.addCallback(componentActivity, backCallback)
+}

--- a/apps/minimal-tester/android/brownfield/src/main/java/com/community/minimaltester/brownfield/ReactNativeViewFactory.kt
+++ b/apps/minimal-tester/android/brownfield/src/main/java/com/community/minimaltester/brownfield/ReactNativeViewFactory.kt
@@ -1,0 +1,49 @@
+package com.community.minimaltester.brownfield
+
+import android.content.Context
+import android.os.Bundle
+import android.widget.FrameLayout
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.facebook.react.ReactDelegate
+import com.facebook.react.ReactInstanceManager
+import com.facebook.react.ReactRootView
+
+enum class RootComponent(val key: String) {
+  Main("main")
+}
+
+object ReactNativeViewFactory {
+  fun createFrameLayout(
+      context: Context,
+      activity: FragmentActivity,
+      rootComponent: RootComponent,
+      launchOptions: Bundle? = null,
+  ): FrameLayout {
+    val reactHost = ReactNativeHostManager.shared.getReactHost()
+
+    val reactDelegate = ReactDelegate(activity, reactHost!!, rootComponent.key, launchOptions)
+
+    activity.lifecycle.addObserver(
+        object : DefaultLifecycleObserver {
+          override fun onResume(owner: LifecycleOwner) {
+            reactDelegate.onHostResume()
+          }
+
+          override fun onPause(owner: LifecycleOwner) {
+            reactDelegate.onHostPause()
+          }
+
+          override fun onDestroy(owner: LifecycleOwner) {
+            reactDelegate.onHostDestroy()
+            owner.lifecycle.removeObserver(this) // Cleanup to avoid leaks
+          }
+        }
+    )
+
+    reactDelegate.loadApp()
+    return reactDelegate.reactRootView!!
+
+  }
+}

--- a/apps/minimal-tester/android/build.gradle
+++ b/apps/minimal-tester/android/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     classpath('com.android.tools.build:gradle')
     classpath('com.facebook.react:react-native-gradle-plugin')
     classpath('org.jetbrains.kotlin:kotlin-gradle-plugin')
+    classpath('expo.modules:publish')
   }
 }
 
@@ -21,4 +22,14 @@ allprojects {
 }
 
 apply plugin: "expo-root-project"
+apply plugin: "expo-brownfield-publish"
 apply plugin: "com.facebook.react.rootproject"
+
+expoBrownfieldPublishPlugin {
+  libraryName = "brownfield"
+  publications {
+    localDefault {
+        type = "localMaven"
+    }
+  }
+}

--- a/apps/minimal-tester/android/settings.gradle
+++ b/apps/minimal-tester/android/settings.gradle
@@ -37,3 +37,12 @@ expoAutolinking.useExpoVersionCatalog()
 
 include ':app'
 includeBuild(expoAutolinking.reactNativeGradlePlugin)
+include ':brownfield'
+def brownfieldPluginsPath = new File(
+  providers.exec {
+    workingDir(rootDir)
+    commandLine("node", "--print", "require.resolve('expo-brownfield/package.json')")
+  }.standardOutput.asText.get().trim(),
+  "../gradle-plugins"
+).absolutePath
+includeBuild(brownfieldPluginsPath)

--- a/apps/minimal-tester/app.json
+++ b/apps/minimal-tester/app.json
@@ -34,11 +34,15 @@
     },
     "jsEngine": "hermes",
     "plugins": [
-      ["expo-build-properties", {
-        "ios": {
-          "buildReactNativeFromSource": true
+      "expo-brownfield",
+      [
+        "expo-build-properties",
+        {
+          "ios": {
+            "buildReactNativeFromSource": true
+          }
         }
-      }]
+      ]
     ]
   }
 }

--- a/apps/minimal-tester/ios/Podfile
+++ b/apps/minimal-tester/ios/Podfile
@@ -1,3 +1,5 @@
+$BROWNFIELD_TARGET_NAME = 'minimaltesterbrownfield'
+require File.join(File.dirname(`node --print "require.resolve('expo-brownfield/package.json')"`), "plugin/src/ios/scripts/reorder_build_phases.rb")
 require File.join(File.dirname(`node --print "require.resolve('expo/package.json')"`), "scripts/autolinking")
 require File.join(File.dirname(`node --print "require.resolve('react-native/package.json')"`), "scripts/react_native_pods")
 
@@ -59,5 +61,9 @@ target 'minimaltester' do
       :mac_catalyst_enabled => false,
       :ccache_enabled => ccache_enabled?(podfile_properties),
     )
+  end
+
+  target 'minimaltesterbrownfield' do
+    inherit! :complete
   end
 end

--- a/apps/minimal-tester/ios/Podfile.lock
+++ b/apps/minimal-tester/ios/Podfile.lock
@@ -209,6 +209,7 @@ PODS:
     - React-jsinspector
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-rendererconsistency
     - React-renderercss
     - React-rendererdebug
     - React-utils
@@ -222,6 +223,8 @@ PODS:
   - ExpoAsset (12.0.8):
     - ExpoModulesCore
   - ExpoBlur (15.0.7):
+    - ExpoModulesCore
+  - ExpoBrownfieldModule (1.0.0):
     - ExpoModulesCore
   - ExpoCamera (17.0.8):
     - ExpoModulesCore
@@ -2821,6 +2824,7 @@ DEPENDENCIES:
   - ExpoAppleAuthentication (from `../../../packages/expo-apple-authentication/ios`)
   - ExpoAsset (from `../../../packages/expo-asset/ios`)
   - ExpoBlur (from `../../../packages/expo-blur/ios`)
+  - ExpoBrownfieldModule (from `../../../packages/expo-brownfield/ios`)
   - ExpoCamera (from `../../../packages/expo-camera/ios`)
   - "ExpoDomWebView (from `../../../packages/@expo/dom-webview/ios`)"
   - ExpoFileSystem (from `../../../packages/expo-file-system/ios`)
@@ -2956,6 +2960,8 @@ EXTERNAL SOURCES:
     :path: "../../../packages/expo-asset/ios"
   ExpoBlur:
     :path: "../../../packages/expo-blur/ios"
+  ExpoBrownfieldModule:
+    :path: "../../../packages/expo-brownfield/ios"
   ExpoCamera:
     :path: "../../../packages/expo-camera/ios"
   ExpoDomWebView:
@@ -3145,14 +3151,15 @@ SPEC CHECKSUMS:
   EXConstants: 59d46d25b89f88cc38291a56dbce4d550758f72d
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
   EXManifests: 7469efed75d694ce3c43a6da9c6f3886f66d3c26
-  Expo: 446942b564f6fa3f855457d1f1678a9d5c5f3741
+  Expo: 4759a8b5aa24194890a7d6dd1f339d3dfe1fa076
   expo-dev-client: b8c16c699a35787e1ac38c6d44ef7552fe3f0334
-  expo-dev-launcher: 617152822493adda0848170557a79d6bc585e6fe
-  expo-dev-menu: ae1feaf51f47590afc4527c6a75165beb7aed0dd
+  expo-dev-launcher: 7edada0ddd24272acac7619179d031817d651aca
+  expo-dev-menu: fb6b29c7b0e66ccdadf289a0adf55fb3e1449b28
   expo-dev-menu-interface: 30d9aa2fbca275a1335ca7e076273dac1d42d40a
   ExpoAppleAuthentication: 414e4316f8e25a2afbc3943cf725579c910f24b8
   ExpoAsset: 4375a46b45b12bbfcf6efac8c8a33aebdb8ba12b
   ExpoBlur: b5b7a26572b3c33a11f0b2aa2f95c17c4c393b76
+  ExpoBrownfieldModule: 9398859fd864068a86a96e79e26454bda7b8d420
   ExpoCamera: 442bbbbd75d73d17f3a972b269efe7595b9b6933
   ExpoDomWebView: f8d74b970eede6e02ca2f215742812472f046817
   ExpoFileSystem: adffad7d1f57f768ca7a5e3bf450312fb9ebd27a
@@ -3161,8 +3168,8 @@ SPEC CHECKSUMS:
   ExpoKeepAwake: 3f5e3ac53627849174f3603271df8e08f174ed4a
   ExpoLinearGradient: f9e7182e5253d53b2de4134b69d70bbfc2d50588
   ExpoLogBox: b4c81de3f21bbe2e9467a26455563c76c7709efb
-  ExpoModulesCore: d843eb08a3bc89716cd4eb517f89e17afa451ffc
-  ExpoModulesJSI: c470ea2ed825fce73bdc4ef060c8a22e3f664092
+  ExpoModulesCore: d1b69abd0ce390592ae9c0bc266b07e209d5909f
+  ExpoModulesJSI: 9570b15a60f3cbf7f7ff7784ed6d798a7b38f6d5
   ExpoSplashScreen: 896f624f2e9e98c5de938bf59a62a061f383164d
   ExpoVideo: 7e39a5933892dc640b1b83013f3f9d9d37072151
   EXStructuredHeaders: c951e77f2d936f88637421e9588c976da5827368
@@ -3188,72 +3195,72 @@ SPEC CHECKSUMS:
   React-Core: 19e0183e28d7a6613ecacebd7525fe6650efa3b6
   React-CoreModules: 73cc86f2a0ff84b93d6325073ad2e4874d21ad40
   React-cxxreact: 4bf734645c77c9b86e2f3e933e0411cf2f14d1ba
-  React-debug: 8978deb306f6f38c28b5091e52b0ac9f942b157e
-  React-defaultsnativemodule: 724eb9ec388d494f1e2057d83355ee8fe6f1d780
-  React-domnativemodule: 9068f41092f725acd09950233d2847364c731947
-  React-Fabric: 945cc8abf08d9d0966acef605bffce7b501c49d9
-  React-FabricComponents: 4c4ad6f0d16c964a68f945e029505e2eeec6654b
-  React-FabricImage: a8b628fd98db21b9f8588e06f14a9194dda11b40
-  React-featureflags: 0937601c1af1cc125851ec5bbf4654285d47a3e7
-  React-featureflagsnativemodule: ac1a3e0353e1a6e15411b17ed6c7122adb0468a4
-  React-graphics: cca521e06463608be46207a4aa160f8a7f725f8b
+  React-debug: b2c9f60a9b7a81cefd737cb61e31c2bc39fdfe17
+  React-defaultsnativemodule: d5577e030a746840c77d791f06382a5fd7c2b789
+  React-domnativemodule: cec896810e9856a07ae62682b2c4e699307f9f35
+  React-Fabric: ea457167d2bb9b8ceb31fd0882393ab08d32f0b8
+  React-FabricComponents: aa8cf0b3409a81222786fb6e2e45069f44e060ca
+  React-FabricImage: 7629c06d41d6dea01d152ce0077b15147169f48f
+  React-featureflags: 7f1e45dd4148aabba7b42b2d588fb45d432c0a6d
+  React-featureflagsnativemodule: cb1c09c4e3e4873f101bbdd9be2fa0f7906ec5ab
+  React-graphics: 163d15b019d7ff23032a1a8d2b37f5afdd561bbb
   React-hermes: ec50b9fcea2c3bfdd42f8cec845eac3f35888572
-  React-idlecallbacksnativemodule: effcae5b7b4473211adb154aaa321d5d9e2fbcc9
-  React-ImageManager: b38459e538f1840fa5c3e7612a4bcb0029a3c366
-  React-intersectionobservernativemodule: 8d33366661971200cf2e151727f6fe007b62ae7b
-  React-jserrorhandler: f94c688a0dbe2e045b91b992722b92e97d56f77f
+  React-idlecallbacksnativemodule: 1a358f7d16b9ff916a646ba184cded54f74439b8
+  React-ImageManager: 958477b5f4acc67f864111c55de84bcdbd1d6592
+  React-intersectionobservernativemodule: 189460858d6105bc44ded7fb02d19cd887f25bc6
+  React-jserrorhandler: 291eddd4e3dc80927c306e039ecbeb4dc515eb6f
   React-jsi: 3216c876cd4c571a57909e22d77c8fd9530aa067
   React-jsiexecutor: 475563c0042841a85930a455d3199f6b1483a5fe
-  React-jsinspector: bc484fb32bf1b9fed80afe8793e614eba4f7b39e
-  React-jsinspectorcdp: 5a574d1d35016968a67e78e6b8a7917473ffbb77
-  React-jsinspectornetwork: dce3a5a1351b527ee8c28ad4a8bdd211507e1a45
-  React-jsinspectortracing: 65f6b166bd67e5adc31eba027e1570bacf7a3cc7
-  React-jsitooling: d5463f5489a31640b0fa0ec4e31566ca8aa86c13
-  React-jsitracing: 3c7fc18821aba64855acb8658aa857ca6a7fddf6
+  React-jsinspector: 856aff364b569a4cd861605656de41d34c3cd92d
+  React-jsinspectorcdp: f34715c4c392e75f217bd5453aa8ff5bc394c111
+  React-jsinspectornetwork: 8a02d4d189476b1a92d6c49014fa83973b6fc24d
+  React-jsinspectortracing: 9a97753c772fbce4f2ed8d4fb684e507d7e49a5a
+  React-jsitooling: 6fda3ff1bfed7525e7be2f5ca152b6d2d378e4a8
+  React-jsitracing: a2dd6d6df9d017d5be176d5e71e09f8ce6f99594
   React-logger: 6ac901f5c7f7321d2be1a40b203bccc2e23411e3
-  React-Mapbuffer: 2e0e7cc5b7064eaed9c8b8afc3a87621cb7ef5cd
-  React-microtasksnativemodule: dd4d33b251b57e5027c572c6d0b45cbfbcfaa386
-  React-NativeModulesApple: 7f2f2fed3f6c858889eb61d09941be965d52df58
-  React-networking: 43e5e6773ac2ca2a93261a1388fed269c9fce092
+  React-Mapbuffer: 9d33f0f79b6b5705d08d89d8fb9709d1ee655c81
+  React-microtasksnativemodule: 1a5a9488d2a05c74ea276c2012df632d8221d169
+  React-NativeModulesApple: dfce21d2c4b7eab44db0af861fcb8998d0b8ad16
+  React-networking: 26355121d0bf86d974dff5a3cc11f8aeb9f28a22
   React-oscompat: 80166b66da22e7af7fad94474e9997bd52d4c8c6
   React-perflogger: 63c90e0d8c24df87ffa14dad01aeafc352847dd0
-  React-performancecdpmetrics: 5a9b81c08f75045635127d626440d9ada01e774b
-  React-performancetimeline: 31cebfff69ec9174b3fb54b0606fcb12ef91cbad
+  React-performancecdpmetrics: 5b0a0eb369b5fcb18109fba91bdd5ac2a2360753
+  React-performancetimeline: 9a45658d92ce7b30d41fa557bbe9fa7c399f301b
   React-RCTActionSheet: 3bd5f5db9f983cf38d51bb9a7a198e2ebea94821
   React-RCTAnimation: 346865a809fa5132f6c594c8b376c6cf46b44e88
   React-RCTAppDelegate: b2d1e0d3663c987f49f45094883b9e36fcbf0181
   React-RCTBlob: 74759ebb7ff9077d19f60c301782c1f8c3eb2813
-  React-RCTFabric: 7b4b14dad21ca99333ebcbc0bf5c205647a315a8
-  React-RCTFBReactNativeSpec: 39151968adb68b8c59f29a8bd4223d4d7780a793
+  React-RCTFabric: 7a352dc4db7da5334b36d0074d3e44a112d4d168
+  React-RCTFBReactNativeSpec: f74fabd086f4a302a9883086ad1398a4408aecd4
   React-RCTImage: 60763f56e8a5e45d861d7c4777e428bb820ec52a
   React-RCTLinking: 52aee78b0b3163167c7fcf58f80a42943c03a056
   React-RCTNetwork: f5e1e8ae5eff6982efff6289b06ec0a76d0a6ac2
-  React-RCTRuntime: 0e99199322afd372e74b95ae5c58f4e074cc2855
+  React-RCTRuntime: b1c69249aab7cf0ff2b9cf7bd7d1cdc23c60c89f
   React-RCTSettings: 298bb40d3412bf32e0b4f0797e48416b0b7278a1
   React-RCTText: dfb74800e27d792d1188fa975a3b9807c3362e3e
   React-RCTVibration: ffe5fd4f50a835e353a3b6869eb005dab11eea44
-  React-rendererconsistency: d280314a3e7f0097152f89e815b4de821c2be8b9
-  React-renderercss: 8a1a346f3665fd5ea7a7be7b3b9f95d4743e1180
-  React-rendererdebug: af74afdfb3d6c5382ebab35562efd8eb9e690473
-  React-RuntimeApple: 06e33d291e72fd0c73ac47046c3536d77d5aeedd
-  React-RuntimeCore: 99273d2af072062eb07f0b2d2d4a0f2de697ea14
-  React-runtimeexecutor: 2063c03c18810ee57939d138142e6493333360ef
-  React-RuntimeHermes: 2253a7f4c8d56b449230b330b0b15383ed4b3df4
-  React-runtimescheduler: ff37ac6720a943da91645c06274282ac46b71f23
-  React-timing: 831d7e081ba4c332ca5cccf389b88e363f13f2b4
-  React-utils: 25db6c17598c4fed22b5956d7551bb8bddf1f95b
-  React-webperformancenativemodule: 57e41e6193cfb815bde0b5534bef68673f1270eb
+  React-rendererconsistency: ac8a9e9ee3eb299458cc848944133ff4be46cc41
+  React-renderercss: 25ff740b0da15dab6ba505c702c86bfbe9cd764e
+  React-rendererdebug: 48afb7a15ed4f2a87760e63abdc70bb92f4165d0
+  React-RuntimeApple: bcc8fbdce32bc7100294bf9a4b741da233d38de2
+  React-RuntimeCore: 632c35fbe0980a390719470a9f6d2f1ba9dc3bd0
+  React-runtimeexecutor: 8151aae90978856b75f3c5079c428c00f795ffa6
+  React-RuntimeHermes: 1269317d3d7d899f27aa3c03a04d7ce017171837
+  React-runtimescheduler: 752209b337a93cd3a25ecea691308f6b801706cf
+  React-timing: 73729fab687aa4876d45707e9f7ddc9446effab1
+  React-utils: a60c501ec701ca062f3c5367ce766c4e5bfc363a
+  React-webperformancenativemodule: 7ec95df9690d9cc96e31f3282facecd39a3914a6
   ReactAppDependencyProvider: bfb12ead469222b022a2024f32aba47ce50de512
-  ReactCodegen: 9ca1bd49eee1eccf6e427e406d2163f49e9c48c0
-  ReactCommon: 05ad684db7d88e194272ae26baddf6300e30b8b7
+  ReactCodegen: 148faf1633ee5ba0f56a4028b6e08611019f86a8
+  ReactCommon: 136c3863bf14312a58944f674691f2c5874deafb
   SDWebImage: e9c98383c7572d713c1a0d7dd2783b10599b9838
   SDWebImageAVIFCoder: afe194a084e851f70228e4be35ef651df0fc5c57
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 5456bb010373068fc92221140921b09d126b116e
+  Yoga: 33b53536a0500d039f2cd78caf1d5d68712d3af7
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: 1902d73a5cf08a68a48f213619e17a920dc4c848
+PODFILE CHECKSUM: 5acf66a07d5fb4365e6ab08eacb79553ab6ec9f0
 
 COCOAPODS: 1.16.2

--- a/apps/minimal-tester/ios/Podfile.properties.json
+++ b/apps/minimal-tester/ios/Podfile.properties.json
@@ -3,5 +3,6 @@
   "EX_DEV_CLIENT_NETWORK_INSPECTOR": "true",
   "ios.forceStaticLinking": "[]",
   "apple.privacyManifestAggregationEnabled": "true",
-  "ios.buildReactNativeFromSource": "true"
+  "ios.buildReactNativeFromSource": "true",
+  "ios.useFrameworks": "static"
 }

--- a/apps/minimal-tester/ios/minimaltester.xcodeproj/project.pbxproj
+++ b/apps/minimal-tester/ios/minimaltester.xcodeproj/project.pbxproj
@@ -7,27 +7,55 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		09E77DB6DB339FE2A66CB6D6 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FC329DA7B6BD073E42DAC9 /* ExpoModulesProvider.swift */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
+		26C22549EA484ABEBAAEF297 /* ReactNativeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C2C3C7EFF6D49F8B48C06CB /* ReactNativeViewController.swift */; };
+		2F45FD2D313C7B9669006845 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = E19F324DB3A378AC8A8DD420 /* PrivacyInfo.xcprivacy */; };
+		378C19E0AA79F3668E4157D9 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A346BC890B45B3FF24C50214 /* ExpoModulesProvider.swift */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
-		4521FC9757B4994CC53BCACC /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = B9E3781B12FE80FEA54E0650 /* PrivacyInfo.xcprivacy */; };
-		ABF01E9172F9C00434309F7D /* libPods-minimaltester.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 345AD5C87EAB63DA63682F2A /* libPods-minimaltester.a */; };
+		4E933D18B132DBADBA6DD8E2 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7714EAB9E8B54939FE5944F4 /* ExpoModulesProvider.swift */; };
+		7BE7AF8EE45F4B6BA11C9525 /* Messaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5364FC300754B3197FE8411 /* Messaging.swift */; };
+		8BEC4B592BDF4EB8828ADCC3 /* ReactNativeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E18D2E3DFA24F04A21BD86D /* ReactNativeView.swift */; };
+		8DBED821E6565449801BCCA4 /* Pods_minimaltester.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D846368B668134B2D05C5C65 /* Pods_minimaltester.framework */; };
+		98442B62C3094DAFB2F251E1 /* BrownfieldAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490E65EC8AC24D52B546DD8F /* BrownfieldAppDelegate.swift */; };
+		A92347E5B9534046B9F311D9 /* ReactNativeHostManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F090235112184DC8BE4BC9D9 /* ReactNativeHostManager.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
+		BB415170BBD544FCAC779CA5 /* ReactNativeDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E7AE35FAC134E0FB495EA65 /* ReactNativeDelegate.swift */; };
+		EBFF5C6DF3F2045A997FACED /* Pods_minimaltester_minimaltesterbrownfield.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48F3D2872DB1642D9A9939C2 /* Pods_minimaltester_minimaltesterbrownfield.framework */; };
 		F11748422D0307B40044C1D9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11748412D0307B40044C1D9 /* AppDelegate.swift */; };
+		FF05437A600441E2BD6D4A84 /* ExpoAppDelegateWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D939CB8879994D799F5612E2 /* ExpoAppDelegateWrapper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		07151AC42D4D08B105EB9221 /* Pods-minimaltester.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-minimaltester.release.xcconfig"; path = "Target Support Files/Pods-minimaltester/Pods-minimaltester.release.xcconfig"; sourceTree = "<group>"; };
+		0B668EB906C649E990F02417 /* Messaging.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = Messaging.swift; path = Messaging.swift; sourceTree = "<group>"; };
+		0F9079AB0F574A41937CDBBE /* minimaltesterbrownfield.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = undefined; name = minimaltesterbrownfield.framework; path = minimaltesterbrownfield.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07F961A680F5B00A75B9A /* minimaltester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = minimaltester.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = minimaltester/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = minimaltester/Info.plist; sourceTree = "<group>"; };
-		345AD5C87EAB63DA63682F2A /* libPods-minimaltester.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-minimaltester.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		6DF84E1E45293BF8E01D8C20 /* Pods-minimaltester.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-minimaltester.debug.xcconfig"; path = "Target Support Files/Pods-minimaltester/Pods-minimaltester.debug.xcconfig"; sourceTree = "<group>"; };
+		1FD09DDA99384A629F5197F5 /* ReactNativeView.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ReactNativeView.swift; path = ReactNativeView.swift; sourceTree = "<group>"; };
+		34778A71D717466BBC461C6E /* ReactNativeDelegate.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ReactNativeDelegate.swift; path = ReactNativeDelegate.swift; sourceTree = "<group>"; };
+		3E18D2E3DFA24F04A21BD86D /* ReactNativeView.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ReactNativeView.swift; path = minimaltesterbrownfield/ReactNativeView.swift; sourceTree = "<group>"; };
+		43CBF060389712360DBEF7C6 /* Pods-minimaltester-minimaltesterbrownfield.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-minimaltester-minimaltesterbrownfield.release.xcconfig"; path = "Target Support Files/Pods-minimaltester-minimaltesterbrownfield/Pods-minimaltester-minimaltesterbrownfield.release.xcconfig"; sourceTree = "<group>"; };
+		48F3D2872DB1642D9A9939C2 /* Pods_minimaltester_minimaltesterbrownfield.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_minimaltester_minimaltesterbrownfield.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		490E65EC8AC24D52B546DD8F /* BrownfieldAppDelegate.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = BrownfieldAppDelegate.swift; path = minimaltesterbrownfield/BrownfieldAppDelegate.swift; sourceTree = "<group>"; };
+		5252BA4E679A4A44952EA836 /* ExpoAppDelegateWrapper.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ExpoAppDelegateWrapper.swift; path = ExpoAppDelegateWrapper.swift; sourceTree = "<group>"; };
+		7714EAB9E8B54939FE5944F4 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-minimaltester/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
+		7C2C3C7EFF6D49F8B48C06CB /* ReactNativeViewController.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ReactNativeViewController.swift; path = minimaltesterbrownfield/ReactNativeViewController.swift; sourceTree = "<group>"; };
+		99494FAB397F46C48FE50579 /* ReactNativeHostManager.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ReactNativeHostManager.swift; path = ReactNativeHostManager.swift; sourceTree = "<group>"; };
+		9E7AE35FAC134E0FB495EA65 /* ReactNativeDelegate.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ReactNativeDelegate.swift; path = minimaltesterbrownfield/ReactNativeDelegate.swift; sourceTree = "<group>"; };
+		9EF89E9A5BF3A827BAA8CAE0 /* Pods-minimaltester-minimaltesterbrownfield.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-minimaltester-minimaltesterbrownfield.debug.xcconfig"; path = "Target Support Files/Pods-minimaltester-minimaltesterbrownfield/Pods-minimaltester-minimaltesterbrownfield.debug.xcconfig"; sourceTree = "<group>"; };
+		A346BC890B45B3FF24C50214 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-minimaltester-minimaltesterbrownfield/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
+		A3C7EC2C320A437B9DE25FD3 /* ReactNativeViewController.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ReactNativeViewController.swift; path = ReactNativeViewController.swift; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = minimaltester/SplashScreen.storyboard; sourceTree = "<group>"; };
-		B9E3781B12FE80FEA54E0650 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = minimaltester/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		B573EC1525284F6D9213DC8C /* BrownfieldAppDelegate.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = BrownfieldAppDelegate.swift; path = BrownfieldAppDelegate.swift; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
-		E1FC329DA7B6BD073E42DAC9 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-minimaltester/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
+		BB531C496371298B3CB01DDE /* Pods-minimaltester.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-minimaltester.debug.xcconfig"; path = "Target Support Files/Pods-minimaltester/Pods-minimaltester.debug.xcconfig"; sourceTree = "<group>"; };
+		D5364FC300754B3197FE8411 /* Messaging.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = Messaging.swift; path = minimaltesterbrownfield/Messaging.swift; sourceTree = "<group>"; };
+		D846368B668134B2D05C5C65 /* Pods_minimaltester.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_minimaltester.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D939CB8879994D799F5612E2 /* ExpoAppDelegateWrapper.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ExpoAppDelegateWrapper.swift; path = minimaltesterbrownfield/ExpoAppDelegateWrapper.swift; sourceTree = "<group>"; };
+		E19F324DB3A378AC8A8DD420 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = minimaltester/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		E34B15B59F72A840F0DF828E /* Pods-minimaltester.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-minimaltester.release.xcconfig"; path = "Target Support Files/Pods-minimaltester/Pods-minimaltester.release.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		F090235112184DC8BE4BC9D9 /* ReactNativeHostManager.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ReactNativeHostManager.swift; path = minimaltesterbrownfield/ReactNativeHostManager.swift; sourceTree = "<group>"; };
 		F11748412D0307B40044C1D9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = minimaltester/AppDelegate.swift; sourceTree = "<group>"; };
 		F11748442D0722820044C1D9 /* minimaltester-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "minimaltester-Bridging-Header.h"; path = "minimaltester/minimaltester-Bridging-Header.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -37,19 +65,34 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				ABF01E9172F9C00434309F7D /* libPods-minimaltester.a in Frameworks */,
+				8DBED821E6565449801BCCA4 /* Pods_minimaltester.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D4FDF09B5B06A4A8949D5B37 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EBFF5C6DF3F2045A997FACED /* Pods_minimaltester_minimaltesterbrownfield.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0B4AAA84D6C73EACCC4CCB0E /* ExpoModulesProviders */ = {
+		0FCA70314D174AC895B98EB6 /* minimaltesterbrownfield */ = {
 			isa = PBXGroup;
 			children = (
-				D7D5421A4E56F7C8152FC8F2 /* minimaltester */,
+				99494FAB397F46C48FE50579 /* ReactNativeHostManager.swift */,
+				0B668EB906C649E990F02417 /* Messaging.swift */,
+				1FD09DDA99384A629F5197F5 /* ReactNativeView.swift */,
+				A3C7EC2C320A437B9DE25FD3 /* ReactNativeViewController.swift */,
+				5252BA4E679A4A44952EA836 /* ExpoAppDelegateWrapper.swift */,
+				B573EC1525284F6D9213DC8C /* BrownfieldAppDelegate.swift */,
+				34778A71D717466BBC461C6E /* ReactNativeDelegate.swift */,
 			);
-			name = ExpoModulesProviders;
+			name = minimaltesterbrownfield;
+			path = "/Users/gabriel/Workspace/expo/expo/apps/minimal-tester/ios/minimaltesterbrownfield";
 			sourceTree = "<group>";
 		};
 		13B07FAE1A68108700A75B9A /* minimaltester */ = {
@@ -61,7 +104,7 @@
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
-				B9E3781B12FE80FEA54E0650 /* PrivacyInfo.xcprivacy */,
+				E19F324DB3A378AC8A8DD420 /* PrivacyInfo.xcprivacy */,
 			);
 			name = minimaltester;
 			sourceTree = "<group>";
@@ -70,9 +113,27 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				345AD5C87EAB63DA63682F2A /* libPods-minimaltester.a */,
+				D846368B668134B2D05C5C65 /* Pods_minimaltester.framework */,
+				48F3D2872DB1642D9A9939C2 /* Pods_minimaltester_minimaltesterbrownfield.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		5703DE2069B10BAC2F91E410 /* minimaltesterbrownfield */ = {
+			isa = PBXGroup;
+			children = (
+				A346BC890B45B3FF24C50214 /* ExpoModulesProvider.swift */,
+			);
+			name = minimaltesterbrownfield;
+			sourceTree = "<group>";
+		};
+		61BDB216ACB3E9F36E774802 /* ExpoModulesProviders */ = {
+			isa = PBXGroup;
+			children = (
+				B142BD1672C5A3E31824FB55 /* minimaltester */,
+				5703DE2069B10BAC2F91E410 /* minimaltesterbrownfield */,
+			);
+			name = ExpoModulesProviders;
 			sourceTree = "<group>";
 		};
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
@@ -89,8 +150,9 @@
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
 				83CBBA001A601CBA00E9B192 /* Products */,
 				2D16E6871FA4F8E400B85C8A /* Frameworks */,
-				D4AD2F2F199AA3CBC93DA08A /* Pods */,
-				0B4AAA84D6C73EACCC4CCB0E /* ExpoModulesProviders */,
+				0FCA70314D174AC895B98EB6 /* minimaltesterbrownfield */,
+				E847163EAE0DD7D15C2E1E37 /* Pods */,
+				61BDB216ACB3E9F36E774802 /* ExpoModulesProviders */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -101,8 +163,17 @@
 			isa = PBXGroup;
 			children = (
 				13B07F961A680F5B00A75B9A /* minimaltester.app */,
+				0F9079AB0F574A41937CDBBE /* minimaltesterbrownfield.framework */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		B142BD1672C5A3E31824FB55 /* minimaltester */ = {
+			isa = PBXGroup;
+			children = (
+				7714EAB9E8B54939FE5944F4 /* ExpoModulesProvider.swift */,
+			);
+			name = minimaltester;
 			sourceTree = "<group>";
 		};
 		BB2F792B24A3F905000567C9 /* Supporting */ = {
@@ -114,22 +185,16 @@
 			path = minimaltester/Supporting;
 			sourceTree = "<group>";
 		};
-		D4AD2F2F199AA3CBC93DA08A /* Pods */ = {
+		E847163EAE0DD7D15C2E1E37 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				6DF84E1E45293BF8E01D8C20 /* Pods-minimaltester.debug.xcconfig */,
-				07151AC42D4D08B105EB9221 /* Pods-minimaltester.release.xcconfig */,
+				BB531C496371298B3CB01DDE /* Pods-minimaltester.debug.xcconfig */,
+				E34B15B59F72A840F0DF828E /* Pods-minimaltester.release.xcconfig */,
+				9EF89E9A5BF3A827BAA8CAE0 /* Pods-minimaltester-minimaltesterbrownfield.debug.xcconfig */,
+				43CBF060389712360DBEF7C6 /* Pods-minimaltester-minimaltesterbrownfield.release.xcconfig */,
 			);
 			name = Pods;
 			path = Pods;
-			sourceTree = "<group>";
-		};
-		D7D5421A4E56F7C8152FC8F2 /* minimaltester */ = {
-			isa = PBXGroup;
-			children = (
-				E1FC329DA7B6BD073E42DAC9 /* ExpoModulesProvider.swift */,
-			);
-			name = minimaltester;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -140,13 +205,13 @@
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "minimaltester" */;
 			buildPhases = (
 				08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */,
-				30D4DAE97033FD107756C1D9 /* [Expo] Configure project */,
+				B756E4E841A1C9CDAD175010 /* [Expo] Configure project */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				800E24972A6A228C8D4807E9 /* [CP] Copy Pods Resources */,
-				13D984C39A2759A5AA630C39 /* [CP] Embed Pods Frameworks */,
+				6F1FB4BFE4A6A95FF55CCB17 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -156,6 +221,27 @@
 			productName = minimaltester;
 			productReference = 13B07F961A680F5B00A75B9A /* minimaltester.app */;
 			productType = "com.apple.product-type.application";
+		};
+		6B2333D032E94C549E4C3E72 /* minimaltesterbrownfield */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BA383DF2C0DE4F0CAF8CB7C1 /* Build configuration list for PBXNativeTarget "minimaltesterbrownfield" */;
+			buildPhases = (
+				2A80DA1CCC1A799050B841AB /* [CP] Check Pods Manifest.lock */,
+				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
+				95843220E5C4EC7D7790E428 /* [Expo] Configure project */,
+				31131948B44D4E63A765AD78 /* Patch ExpoModulesProvider */,
+				02BF27A1982D44E9AD16C893 /* Sources */,
+				D4FDF09B5B06A4A8949D5B37 /* Frameworks */,
+				97A5EED552E61B71890B9AD0 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = minimaltesterbrownfield;
+			productName = minimaltesterbrownfield;
+			productReference = 0F9079AB0F574A41937CDBBE /* minimaltesterbrownfield.framework */;
+			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
 
@@ -184,6 +270,7 @@
 			projectRoot = "";
 			targets = (
 				13B07F861A680F5B00A75B9A /* minimaltester */,
+				6B2333D032E94C549E4C3E72 /* minimaltesterbrownfield */,
 			);
 		};
 /* End PBXProject section */
@@ -196,7 +283,7 @@
 				BB2F792D24A3F905000567C9 /* Expo.plist in Resources */,
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
 				3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */,
-				4521FC9757B4994CC53BCACC /* PrivacyInfo.xcprivacy in Resources */,
+				2F45FD2D313C7B9669006845 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -242,7 +329,43 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		13D984C39A2759A5AA630C39 /* [CP] Embed Pods Frameworks */ = {
+		2A80DA1CCC1A799050B841AB /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-minimaltester-minimaltesterbrownfield-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		31131948B44D4E63A765AD78 /* Patch ExpoModulesProvider */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Patch ExpoModulesProvider";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "FILE=\"${SRCROOT}/Pods/Target Support Files/Pods-minimaltester-minimaltesterbrownfield/ExpoModulesProvider.swift\"\nTEMP_FILE=\"$FILE.temp\"\n\nif [ -f \"$FILE\" ]; then\n  echo \"Patching $FILE to hide Expo from public interface\"\n  sed \\\n    -e 's/^import EX/internal import EX/' \\\n    -e 's/^import Ex/internal import Ex/' \\\n    -e 's/public class ExpoModulesProvider/internal class ExpoModulesProvider/' \"$FILE\" > \"$TEMP_FILE\"\n  mv \"$TEMP_FILE\" \"$FILE\"\nfi\n";
+		};
+		6F1FB4BFE4A6A95FF55CCB17 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -259,30 +382,6 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-minimaltester/Pods-minimaltester-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
-		};
-		30D4DAE97033FD107756C1D9 /* [Expo] Configure project */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/.xcode.env",
-				"$(SRCROOT)/.xcode.env.local",
-				"$(SRCROOT)/minimaltester/minimaltester.entitlements",
-				"$(SRCROOT)/Pods/Target Support Files/Pods-minimaltester/expo-configure-project.sh",
-			);
-			name = "[Expo] Configure project";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(SRCROOT)/Pods/Target Support Files/Pods-minimaltester/ExpoModulesProvider.swift",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# This script configures Expo modules and generates the modules provider file.\nbash -l -c \"./Pods/Target\\ Support\\ Files/Pods-minimaltester/expo-configure-project.sh\"\n";
 		};
 		800E24972A6A228C8D4807E9 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -324,15 +423,118 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-minimaltester/Pods-minimaltester-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		95843220E5C4EC7D7790E428 /* [Expo] Configure project */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+				"$(SRCROOT)/minimaltesterbrownfield/minimaltesterbrownfield.entitlements",
+				"$(SRCROOT)/Pods/Target Support Files/Pods-minimaltester-minimaltesterbrownfield/expo-configure-project.sh",
+			);
+			name = "[Expo] Configure project";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(SRCROOT)/Pods/Target Support Files/Pods-minimaltester-minimaltesterbrownfield/ExpoModulesProvider.swift",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# This script configures Expo modules and generates the modules provider file.\nbash -l -c \"./Pods/Target\\ Support\\ Files/Pods-minimaltester-minimaltesterbrownfield/expo-configure-project.sh\"\n";
+		};
+		97A5EED552E61B71890B9AD0 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-minimaltester-minimaltesterbrownfield/Pods-minimaltester-minimaltesterbrownfield-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/ExpoConstants_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoFileSystem/ExpoFileSystem_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/RCT-Folly/RCT-Folly_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ReachabilitySwift/ReachabilitySwift.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/React-Core_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/React-cxxreact/React-cxxreact_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/SDWebImage/SDWebImage.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/boost/boost_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/expo-dev-launcher/EXDevLauncher.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/glog/glog_privacy.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoConstants_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoFileSystem_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCT-Folly_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ReachabilitySwift.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-Core_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-cxxreact_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SDWebImage.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/boost_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXDevLauncher.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/glog_privacy.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-minimaltester-minimaltesterbrownfield/Pods-minimaltester-minimaltesterbrownfield-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B756E4E841A1C9CDAD175010 /* [Expo] Configure project */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+				"$(SRCROOT)/minimaltester/minimaltester.entitlements",
+				"$(SRCROOT)/Pods/Target Support Files/Pods-minimaltester/expo-configure-project.sh",
+			);
+			name = "[Expo] Configure project";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(SRCROOT)/Pods/Target Support Files/Pods-minimaltester/ExpoModulesProvider.swift",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# This script configures Expo modules and generates the modules provider file.\nbash -l -c \"./Pods/Target\\ Support\\ Files/Pods-minimaltester/expo-configure-project.sh\"\n";
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		02BF27A1982D44E9AD16C893 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A92347E5B9534046B9F311D9 /* ReactNativeHostManager.swift in Sources */,
+				7BE7AF8EE45F4B6BA11C9525 /* Messaging.swift in Sources */,
+				8BEC4B592BDF4EB8828ADCC3 /* ReactNativeView.swift in Sources */,
+				26C22549EA484ABEBAAEF297 /* ReactNativeViewController.swift in Sources */,
+				FF05437A600441E2BD6D4A84 /* ExpoAppDelegateWrapper.swift in Sources */,
+				98442B62C3094DAFB2F251E1 /* BrownfieldAppDelegate.swift in Sources */,
+				BB415170BBD544FCAC779CA5 /* ReactNativeDelegate.swift in Sources */,
+				378C19E0AA79F3668E4157D9 /* ExpoModulesProvider.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		13B07F871A680F5B00A75B9A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				F11748422D0307B40044C1D9 /* AppDelegate.swift in Sources */,
-				09E77DB6DB339FE2A66CB6D6 /* ExpoModulesProvider.swift in Sources */,
+				4E933D18B132DBADBA6DD8E2 /* ExpoModulesProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -341,7 +543,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6DF84E1E45293BF8E01D8C20 /* Pods-minimaltester.debug.xcconfig */;
+			baseConfigurationReference = BB531C496371298B3CB01DDE /* Pods-minimaltester.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -377,7 +579,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 07151AC42D4D08B105EB9221 /* Pods-minimaltester.release.xcconfig */;
+			baseConfigurationReference = E34B15B59F72A840F0DF828E /* Pods-minimaltester.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -402,6 +604,29 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		83B28BD1F43949559221AF00 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 43CBF060389712360DBEF7C6 /* Pods-minimaltester-minimaltesterbrownfield.release.xcconfig */;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_ENTITLEMENTS = minimaltesterbrownfield/minimaltesterbrownfield.entitlements;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_MODULE_VERIFIER = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = minimaltesterbrownfield/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = minimaltesterbrownfield;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
+				PRODUCT_BUNDLE_IDENTIFIER = com.community.minimaltesterbrownfield;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				USER_SCRIPT_SANDBOXING = NO;
 			};
 			name = Release;
 		};
@@ -452,6 +677,19 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-runtimeexecutor/React_runtimeexecutor.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-runtimeexecutor/React_runtimeexecutor.framework/Headers/platform/ios",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers/platform/ios",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-NativeModulesApple/React_NativeModulesApple.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
@@ -509,6 +747,19 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-runtimeexecutor/React_runtimeexecutor.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-runtimeexecutor/React_runtimeexecutor.framework/Headers/platform/ios",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers/platform/ios",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-NativeModulesApple/React_NativeModulesApple.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
@@ -524,6 +775,29 @@
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
+		};
+		876A624F2A1140C79AC74BD1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9EF89E9A5BF3A827BAA8CAE0 /* Pods-minimaltester-minimaltesterbrownfield.debug.xcconfig */;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_ENTITLEMENTS = minimaltesterbrownfield/minimaltesterbrownfield.entitlements;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_MODULE_VERIFIER = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = minimaltesterbrownfield/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = minimaltesterbrownfield;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
+				PRODUCT_BUNDLE_IDENTIFIER = com.community.minimaltesterbrownfield;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				USER_SCRIPT_SANDBOXING = NO;
+			};
+			name = Debug;
 		};
 /* End XCBuildConfiguration section */
 
@@ -542,6 +816,15 @@
 			buildConfigurations = (
 				83CBBA201A601CBA00E9B192 /* Debug */,
 				83CBBA211A601CBA00E9B192 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BA383DF2C0DE4F0CAF8CB7C1 /* Build configuration list for PBXNativeTarget "minimaltesterbrownfield" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				876A624F2A1140C79AC74BD1 /* Debug */,
+				83B28BD1F43949559221AF00 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/apps/minimal-tester/ios/minimaltesterbrownfield/BrownfieldAppDelegate.swift
+++ b/apps/minimal-tester/ios/minimaltesterbrownfield/BrownfieldAppDelegate.swift
@@ -1,0 +1,170 @@
+import UIKit
+
+@objc(BrownfieldAppDelegate)
+open class BrownfieldAppDelegate: UIResponder, UIApplicationDelegate {
+  private var expoWrapper: ExpoAppDelegateWrapper? {
+    ReactNativeHostManager.shared.expoDelegateWrapper
+  }
+
+  // SECTION: Initializing the app
+  open func application(
+    _ application: UIApplication,
+    willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    expoWrapper?.application(application, willFinishLaunchingWithOptions: launchOptions) ?? true
+  }
+
+  open func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    expoWrapper?.application(application, didFinishLaunchingWithOptions: launchOptions) ?? true
+  }
+
+  // END SECTION: Initializing the app
+
+  // SECTION: Responding to App Life-Cycle Events
+  open func applicationDidBecomeActive(_ application: UIApplication) {
+    expoWrapper?.applicationDidBecomeActive(application)
+  }
+
+  open func applicationWillResignActive(_ application: UIApplication) {
+    expoWrapper?.applicationWillResignActive(application)
+  }
+
+  open func applicationDidEnterBackground(_ application: UIApplication) {
+    expoWrapper?.applicationDidEnterBackground(application)
+  }
+
+  open func applicationWillEnterForeground(_ application: UIApplication) {
+    expoWrapper?.applicationWillEnterForeground(application)
+  }
+
+  open func applicationWillTerminate(_ application: UIApplication) {
+    expoWrapper?.applicationWillTerminate(application)
+  }
+
+  // END SECTION: Responding to App Life-Cycle Events
+
+  // SECTION: Responding to Environment Changes
+  open func applicationDidReceiveMemoryWarning(_ application: UIApplication) {
+    expoWrapper?.applicationDidReceiveMemoryWarning(application)
+  }
+
+  // END SECTION: Responding to Environment Changes
+
+  // SECTION: Downloading Data in the Background
+  open func application(
+    _ application: UIApplication,
+    handleEventsForBackgroundURLSession identifier: String,
+    completionHandler: @escaping () -> Void
+  ) {
+    expoWrapper?.application(
+      application,
+      handleEventsForBackgroundURLSession: identifier,
+      completionHandler: completionHandler
+    )
+  }
+
+  // END SECTION: Downloading Data in the Background
+
+  // SECTION: Handling Remote Notification Registration
+  open func application(
+    _ application: UIApplication,
+    didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+  ) {
+    expoWrapper?.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+  }
+
+  open func application(
+    _ application: UIApplication,
+    didFailToRegisterForRemoteNotificationsWithError error: Error
+  ) {
+    expoWrapper?.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
+  }
+
+  open func application(
+    _ application: UIApplication,
+    didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+    fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+  ) {
+    expoWrapper?.application(
+      application,
+      didReceiveRemoteNotification: userInfo,
+      fetchCompletionHandler: completionHandler
+    )
+  }
+
+  // END SECTION: Handling Remote Notification Registration
+
+  // SECTION: Continuing User Activity and Handling Quick Actions
+  open func application(
+    _ application: UIApplication,
+    willContinueUserActivityWithType userActivityType: String
+  ) -> Bool {
+    expoWrapper?.application(application, willContinueUserActivityWithType: userActivityType) ?? false
+  }
+
+  open func application(
+    _ application: UIApplication,
+    continue userActivity: NSUserActivity,
+    restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
+  ) -> Bool {
+    expoWrapper?.application(application, continue: userActivity, restorationHandler: restorationHandler) ?? false
+  }
+
+  open func application(
+    _ application: UIApplication,
+    didUpdate userActivity: NSUserActivity
+  ) {
+    expoWrapper?.application(application, didUpdate: userActivity)
+  }
+
+  open func application(
+    _ application: UIApplication,
+    didFailToContinueUserActivityWithType userActivityType: String,
+    error: Error
+  ) {
+    expoWrapper?.application(application, didFailToContinueUserActivityWithType: userActivityType, error: error)
+  }
+
+  open func application(
+    _ application: UIApplication,
+    performActionFor shortcutItem: UIApplicationShortcutItem,
+    completionHandler: @escaping (Bool) -> Void
+  ) {
+    expoWrapper?.application(application, performActionFor: shortcutItem, completionHandler: completionHandler)
+  }
+
+  // END SECTION: Continuing User Activity and Handling Quick Actions
+
+  // SECTION: Background Fetch
+  open func application(
+    _ application: UIApplication,
+    performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+  ) {
+    expoWrapper?.application(application, performFetchWithCompletionHandler: completionHandler)
+  }
+
+  // END SECTION: Background Fetch
+
+  // SECTION: Opening a URL-Specified Resource
+  open func application(
+    _ app: UIApplication,
+    open url: URL,
+    options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+  ) -> Bool {
+    expoWrapper?.application(app, open: url, options: options) ?? false
+  }
+
+  // END SECTION: Opening a URL-Specified Resource
+
+  // SECTION: Managing Interface Geometry
+  open func application(
+    _ application: UIApplication,
+    supportedInterfaceOrientationsFor window: UIWindow?
+  ) -> UIInterfaceOrientationMask {
+    expoWrapper?.application(application, supportedInterfaceOrientationsFor: window) ?? .all
+  }
+  // END SECTION: Managing Interface Geometry
+}

--- a/apps/minimal-tester/ios/minimaltesterbrownfield/BrownfieldAppDelegate.swift
+++ b/apps/minimal-tester/ios/minimaltesterbrownfield/BrownfieldAppDelegate.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-@objc(BrownfieldAppDelegate)
+@objc
 open class BrownfieldAppDelegate: UIResponder, UIApplicationDelegate {
   private var expoWrapper: ExpoAppDelegateWrapper? {
     ReactNativeHostManager.shared.expoDelegateWrapper

--- a/apps/minimal-tester/ios/minimaltesterbrownfield/ExpoAppDelegateWrapper.swift
+++ b/apps/minimal-tester/ios/minimaltesterbrownfield/ExpoAppDelegateWrapper.swift
@@ -1,0 +1,213 @@
+internal import Expo
+internal import React
+
+public class ExpoAppDelegateWrapper {
+  private let expoDelegate: ExpoAppDelegate
+
+  init(factory: RCTReactNativeFactory) {
+    expoDelegate = ExpoAppDelegate()
+  }
+
+  func recreateRootView(
+    withBundleURL: URL?,
+    moduleName: String?,
+    initialProps: [AnyHashable: Any]?,
+    launchOptions: [AnyHashable: Any]?
+  ) -> UIView {
+    expoDelegate.recreateRootView(
+      withBundleURL: withBundleURL,
+      moduleName: moduleName,
+      initialProps: initialProps,
+      launchOptions: launchOptions
+    )
+  }
+
+  // Below sections match sections from ExpoAppDelegate.swift:
+  // https://github.com/expo/expo/blob/main/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
+  // SECTION: Initializing the app
+  func application(
+    _ application: UIApplication,
+    willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+  ) -> Bool {
+    expoDelegate.application(application, willFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+  ) -> Bool {
+    expoDelegate.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  // END SECTION: Initializing the app
+
+  // SECTION: Configuring and discarding scenes
+  // TODO: Not defined in ExpoAppDelegate yet
+  // END SECTION: Configuring and discarding scenes
+
+  // SECTION: Responding to App Life-Cycle Events
+  func applicationDidBecomeActive(_ application: UIApplication) {
+    expoDelegate.applicationDidBecomeActive(application)
+  }
+
+  func applicationWillResignActive(_ application: UIApplication) {
+    expoDelegate.applicationWillResignActive(application)
+  }
+
+  func applicationDidEnterBackground(_ application: UIApplication) {
+    expoDelegate.applicationDidEnterBackground(application)
+  }
+
+  func applicationWillEnterForeground(_ application: UIApplication) {
+    expoDelegate.applicationWillEnterForeground(application)
+  }
+
+  func applicationWillTerminate(_ application: UIApplication) {
+    expoDelegate.applicationWillTerminate(application)
+  }
+
+  // END SECTION: Responding to App Life-Cycle Events
+
+  // SECTION: Responding to Environment Changes
+  func applicationDidReceiveMemoryWarning(_ application: UIApplication) {
+    expoDelegate.applicationDidReceiveMemoryWarning(application)
+  }
+
+  // END SECTION: Responding to Environment Changes
+
+  // SECTION: Managing App State Restoration
+  // TODO: Not defined in ExpoAppDelegate yet
+  // END SECTION: Managing App State Restoration
+
+  // SECTION: Downloading Data in the Background
+  func application(
+    _ application: UIApplication,
+    handleEventsForBackgroundURLSession identifier: String,
+    completionHandler: @escaping () -> Void
+  ) {
+    expoDelegate.application(
+      application,
+      handleEventsForBackgroundURLSession: identifier,
+      completionHandler: completionHandler
+    )
+  }
+
+  // END SECTION: Downloading Data in the Background
+
+  // SECTION: Handling Remote Notification Registration
+  func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+    expoDelegate.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+  }
+
+  func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+    expoDelegate.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
+  }
+
+  func application(
+    _ application: UIApplication,
+    didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+    fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+  ) {
+    expoDelegate.application(
+      application,
+      didReceiveRemoteNotification: userInfo,
+      fetchCompletionHandler: completionHandler
+    )
+  }
+
+  // END SECTION: Handling Remote Notification Registration
+
+  // SECTION: Continuing User Activity and Handling Quick Actions
+  func application(_ application: UIApplication, willContinueUserActivityWithType userActivityType: String) -> Bool {
+    expoDelegate.application(application, willContinueUserActivityWithType: userActivityType)
+  }
+
+  // func application(
+  // Expo implementation
+  //   _ application: UIApplication,
+  //   continue userActivity: NSUserActivity,
+  //   restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
+  // ) -> Bool {
+  //   return expoDelegate.application(application, continue: userActivity, restorationHandler: restorationHandler)
+  // }
+  // Expo iOS app implementation - Universal Links
+  func application(
+    _ application: UIApplication,
+    continue userActivity: NSUserActivity,
+    restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
+  ) -> Bool {
+    let result = RCTLinkingManager.application(
+      application,
+      continue: userActivity,
+      restorationHandler: restorationHandler
+    )
+    return expoDelegate
+      .application(application, continue: userActivity, restorationHandler: restorationHandler) || result
+  }
+
+  func application(_ application: UIApplication, didUpdate userActivity: NSUserActivity) {
+    expoDelegate.application(application, didUpdate: userActivity)
+  }
+
+  func application(
+    _ application: UIApplication,
+    didFailToContinueUserActivityWithType userActivityType: String,
+    error: Error
+  ) {
+    expoDelegate.application(application, didFailToContinueUserActivityWithType: userActivityType, error: error)
+  }
+
+  func application(
+    _ application: UIApplication,
+    performActionFor shortcutItem: UIApplicationShortcutItem,
+    completionHandler: @escaping (Bool) -> Void
+  ) {
+    expoDelegate.application(application, performActionFor: shortcutItem, completionHandler: completionHandler)
+  }
+
+  // END SECTION: Continuing User Activity and Handling Quick Actions
+
+  // SECTION: Background Fetch
+  func application(
+    _ application: UIApplication,
+    performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+  ) {
+    expoDelegate.application(application, performFetchWithCompletionHandler: completionHandler)
+  }
+
+  // TODO: Interacting with WatchKit and HealthKit is not yet implemented
+  //  in ExpoAppDelegate
+  // END SECTION: Background Fetch
+
+  // SECTION: Opening a URL-Specified Resource
+  // Expo implementation
+  // func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) ->
+  // Bool {
+  //   return expoDelegate.application(app, open: url, options: options)
+  // }
+  // Expo iOS app implementation - Linking API
+  func application(
+    _ app: UIApplication,
+    open url: URL,
+    options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+  ) -> Bool {
+    expoDelegate.application(app, open: url, options: options) ||
+      RCTLinkingManager.application(app, open: url, options: options) || false
+  }
+
+  // TODO: Disallowing Specified App Extension Types, handling SiriKit Intents
+  //  and CloudKit Invitations are not yet implemented in ExpoAppDelegate
+  // END SECTION: Opening a URL-Specified Resource
+
+  // SECTION: Managing Interface Geometry
+  // Sets allowed orientations for the application. It will use the values from `Info.plist`as the orientation mask
+  // unless a subscriber requested
+  // a different orientation.
+  func application(
+    _ application: UIApplication,
+    supportedInterfaceOrientationsFor window: UIWindow?
+  ) -> UIInterfaceOrientationMask {
+    expoDelegate.application(application, supportedInterfaceOrientationsFor: window)
+  }
+  // END SECTION: Managing Interface Geometry
+}

--- a/apps/minimal-tester/ios/minimaltesterbrownfield/Info.plist
+++ b/apps/minimal-tester/ios/minimaltesterbrownfield/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>com.community.minimaltesterbrownfield</string>
+	<key>CFBundleName</key>
+	<string>minimaltesterbrownfield</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>RCTNewArchEnabled</key>
+	<true/>
+</dict>
+</plist>

--- a/apps/minimal-tester/ios/minimaltesterbrownfield/Messaging.swift
+++ b/apps/minimal-tester/ios/minimaltesterbrownfield/Messaging.swift
@@ -1,0 +1,16 @@
+internal import ExpoBrownfieldModule
+
+public struct BrownfieldMessaging {
+  @discardableResult
+  public static func addListener(_ callback: @escaping ([String: Any?]) -> Void) -> String {
+    return BrownfieldMessagingInternal.shared.addListener(callback)
+  }
+
+  public static func removeListener(id: String) {
+    BrownfieldMessagingInternal.shared.removeListener(id: id)
+  }
+
+  public static func sendMessage(_ message: [String: Any?]) {
+    BrownfieldMessagingInternal.shared.sendMessage(message)
+  }
+}

--- a/apps/minimal-tester/ios/minimaltesterbrownfield/ReactNativeDelegate.swift
+++ b/apps/minimal-tester/ios/minimaltesterbrownfield/ReactNativeDelegate.swift
@@ -1,0 +1,22 @@
+internal import Expo
+internal import React
+
+class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
+  /// Extension point for config-plugins
+  override func sourceURL(for bridge: RCTBridge) -> URL? {
+    // Needed to return the correct URL for expo-dev-client
+    bridge.bundleURL ?? bundleURL()
+  }
+
+  override func bundleURL() -> URL? {
+    #if DEBUG
+      return RCTBundleURLProvider.sharedSettings().jsBundleURL(
+        forBundleRoot: ".expo/.virtual-metro-entry")
+    #else
+      /// `main.jsbundle` isn't part of the main app bundle
+      /// so we need to load it from the framework bundle
+      let frameworkBundle = Bundle(for: ReactNativeHostManager.self)
+      return frameworkBundle.url(forResource: "main", withExtension: "jsbundle")
+    #endif
+  }
+}

--- a/apps/minimal-tester/ios/minimaltesterbrownfield/ReactNativeHostManager.swift
+++ b/apps/minimal-tester/ios/minimaltesterbrownfield/ReactNativeHostManager.swift
@@ -1,0 +1,52 @@
+internal import Expo
+import Network
+internal import React
+internal import ReactAppDependencyProvider
+import UIKit
+
+public class ReactNativeHostManager {
+  public static let shared = ReactNativeHostManager()
+
+  private var reactNativeDelegate: ExpoReactNativeFactoryDelegate?
+  private var reactNativeFactory: RCTReactNativeFactory?
+  public private(set) var expoDelegateWrapper: ExpoAppDelegateWrapper?
+
+  /// Initializes the React Native host manager shared instance.
+  /// Prevents multiple initializations of the React Native host manager shared instance.
+  public func initialize() {
+    // Prevent multiple initializations
+    guard reactNativeDelegate == nil else {
+      return
+    }
+
+    let delegate = ReactNativeDelegate()
+    let factory = ExpoReactNativeFactory(delegate: delegate)
+    delegate.dependencyProvider = RCTAppDependencyProvider()
+
+    reactNativeDelegate = delegate
+    reactNativeFactory = factory
+
+    expoDelegateWrapper = ExpoAppDelegateWrapper(factory: factory)
+
+    // Ensure this won't get stripped by the Swift compiler
+    _ = ExpoModulesProvider()
+  }
+
+  /// Loads and presents the React Native view.
+  public func loadView(
+    moduleName: String,
+    initialProps: [AnyHashable: Any]?,
+    launchOptions: [AnyHashable: Any]?
+  ) throws -> UIView {
+    guard let expoDelegateWrapper else {
+      fatalError("Trying to load view without ExpoAppDelegateWrapper initialized")
+    }
+
+    return expoDelegateWrapper.recreateRootView(
+      withBundleURL: nil,
+      moduleName: moduleName,
+      initialProps: initialProps,
+      launchOptions: launchOptions
+    )
+  }
+}

--- a/apps/minimal-tester/ios/minimaltesterbrownfield/ReactNativeView.swift
+++ b/apps/minimal-tester/ios/minimaltesterbrownfield/ReactNativeView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct ReactNativeViewRepresentable: UIViewControllerRepresentable {
+  var moduleName: String
+  var initialProps: [AnyHashable: Any]?
+  var launchOptions: [AnyHashable: Any]?
+
+  func makeUIViewController(context: Context) -> UIViewController {
+    return ReactNativeViewController(
+      moduleName: moduleName,
+      initialProps: initialProps,
+      launchOptions: launchOptions,
+    )
+  }
+
+  func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+}
+
+public struct ReactNativeView: View {
+  @Environment(\.dismiss) var dismiss
+
+  var moduleName: String
+  var initialProps: [AnyHashable: Any]? = [:]
+  var launchOptions: [AnyHashable: Any]? = [:]
+
+  public init(
+    moduleName: String, 
+    initialProps: [AnyHashable: Any] = [:],
+    launchOptions: [AnyHashable: Any] = [:],  
+  ) {
+    self.moduleName = moduleName
+    self.initialProps = initialProps
+    self.launchOptions = launchOptions
+  }
+
+  public var body: some View {
+    ReactNativeViewRepresentable(
+      moduleName: moduleName, initialProps: initialProps, launchOptions: launchOptions
+    )
+    .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("popToNative"))) { _ in
+      dismiss()
+    }
+  }
+}

--- a/apps/minimal-tester/ios/minimaltesterbrownfield/ReactNativeViewController.swift
+++ b/apps/minimal-tester/ios/minimaltesterbrownfield/ReactNativeViewController.swift
@@ -1,0 +1,89 @@
+import UIKit
+
+@objc
+public class ReactNativeViewController: UIViewController {
+  private let moduleName: String
+  private let initialProps: [AnyHashable: Any]?
+  private let launchOptions: [AnyHashable: Any]?
+
+  @objc
+  public init(
+    moduleName: String,
+    initialProps: [AnyHashable: Any]? = nil,
+    launchOptions: [AnyHashable: Any]? = nil
+  ) {
+    self.moduleName = moduleName
+    self.initialProps = initialProps
+    self.launchOptions = launchOptions
+    super.init(nibName: nil, bundle: nil)
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  deinit {
+    NotificationCenter.default.removeObserver(self)
+  }
+
+  override public func viewDidLoad() {
+    super.viewDidLoad()
+
+    do {
+      self.view = try ReactNativeHostManager.shared.loadView(
+        moduleName: moduleName,
+        initialProps: initialProps,
+        launchOptions: launchOptions
+      )
+    } catch {
+      print("Error loading React Native view: \(error)")
+      print(
+        "Please make sure ReactNativeHostManager.shared.initialize() has been called prior to using the view controller"
+      )
+    }
+
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(popToNative(_:)),
+      name: NSNotification.Name("popToNative"),
+      object: nil
+    )
+
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(setNativeBackEnabled(_:)),
+      name: NSNotification.Name("setNativeBackEnabled"),
+      object: nil
+    )
+  }
+
+  @objc
+  private func popToNative(_ notification: Notification) {
+    let animated = notification.userInfo?["animated"] as? Bool ?? false
+    DispatchQueue.main.async { [weak self] in
+      self?.navigationController?.popViewController(animated: animated)
+    }
+  }
+
+  @objc
+  private func setNativeBackEnabled(_ notification: Notification) {
+    guard let enabled = notification.userInfo?["enabled"] as? Bool else {
+      return
+    }
+
+    DispatchQueue.main.async { [weak self] in
+      self?.navigationController?.interactivePopGestureRecognizer?.isEnabled = enabled
+      self?.navigationController?.view?.gestureRecognizers?.forEach { gesture in
+        if gesture === self?.navigationController?.interactivePopGestureRecognizer {
+          return
+        }
+
+        if gesture is UIScreenEdgePanGestureRecognizer
+          || gesture is UIPanGestureRecognizer {
+          gesture.isEnabled = enabled
+        }
+      }
+    }
+  }
+}

--- a/apps/minimal-tester/ios/minimaltesterbrownfield/ReactNativeViewController.swift
+++ b/apps/minimal-tester/ios/minimaltesterbrownfield/ReactNativeViewController.swift
@@ -23,10 +23,6 @@ public class ReactNativeViewController: UIViewController {
     fatalError("init(coder:) has not been implemented")
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   override public func viewDidLoad() {
     super.viewDidLoad()
 

--- a/apps/minimal-tester/ios/minimaltesterbrownfield/minimaltesterbrownfield.entitlements
+++ b/apps/minimal-tester/ios/minimaltesterbrownfield/minimaltesterbrownfield.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+"http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <!-- Empty entitlements -->
+  </dict>
+</plist>

--- a/apps/minimal-tester/package.json
+++ b/apps/minimal-tester/package.json
@@ -12,6 +12,7 @@
     "expo": "~54.0.8",
     "expo-apple-authentication": "~8.0.7",
     "expo-blur": "~15.0.7",
+    "expo-brownfield": "~0.0.1",
     "expo-build-properties": "~1.0.8",
     "expo-camera": "~17.0.8",
     "expo-dev-client": "~6.0.12",

--- a/packages/expo-brownfield/plugin/templates/ios/BrownfieldAppDelegate.swift
+++ b/packages/expo-brownfield/plugin/templates/ios/BrownfieldAppDelegate.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-@objc(BrownfieldAppDelegate)
+@objc
 open class BrownfieldAppDelegate: UIResponder, UIApplicationDelegate {
   private var expoWrapper: ExpoAppDelegateWrapper? {
     ReactNativeHostManager.shared.expoDelegateWrapper

--- a/packages/expo-brownfield/plugin/templates/ios/ReactNativeViewController.swift
+++ b/packages/expo-brownfield/plugin/templates/ios/ReactNativeViewController.swift
@@ -23,10 +23,6 @@ public class ReactNativeViewController: UIViewController {
     fatalError("init(coder:) has not been implemented")
   }
 
-  deinit {
-    NotificationCenter.default.removeObserver(self)
-  }
-
   override public func viewDidLoad() {
     super.viewDidLoad()
 


### PR DESCRIPTION
# Why

We should integrate the `expo-brownfield` package with our test apps

# How

Add expo-brownfield dependency and run prebuild

# Test Plan

Build `minimaltesterbrownfield` target

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
