### PR TITLE
feat(create-expo): Improve git repo initialization logic

### DIFF
--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Skip initializing git repo if inside another repo ([#42052](https://github.com/expo/expo/pull/42052) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/create-expo/src/utils/git.ts
+++ b/packages/create-expo/src/utils/git.ts
@@ -45,7 +45,8 @@ export async function initGitRepoAsync(root: string) {
     const { answer } = await prompts({
       type: 'confirm',
       name: 'answer',
-      message: 'You are creating a project inside of an existing Git repository. Skip initializing a new git repository?',
+      message:
+        'You are creating a project inside of an existing Git repository. Skip initializing a new git repository?',
       initial: true,
     });
 


### PR DESCRIPTION
# Why

If you run create-expo in a monorepo then it should mostly skip initializing git.

# How

Refactored git initialization to check for git installation and existing repositories. Added interactive prompt to handle nested git repo creation, with CI mode defaulting to skip initialization.

