### PR TITLE
[docs] Add Android widgets tutorial video

### DIFF
--- a/docs/pages/additional-resources/index.mdx
+++ b/docs/pages/additional-resources/index.mdx
@@ -1,5 +1,5 @@
 ---
-modificationDate: December 15, 2025
+modificationDate: January 11, 2026
 title: Additional resources
 description: A reference of resources that are useful to learn about Expo tooling and services.
 ---

--- a/docs/public/static/talks.ts
+++ b/docs/public/static/talks.ts
@@ -386,6 +386,11 @@ export const LIVE_STREAMS = [
 
 export const YOUTUBE_VIDEOS = [
   {
+    title: 'How to add Android widgets to Expo apps | Native, Resizable, Configurable widgets',
+    event: 'Expo Tutorials',
+    videoId: 'rCVWq4WkoDA',
+  },
+  {
     title: 'How to add native iOS Widgets to your Expo app',
     event: 'Expo Tutorials',
     videoId: 'UH4ejdz3fko',


### PR DESCRIPTION
## Why
  Add the Expo YouTube tutorial “How to add Android widgets to Expo apps” to the Additional resources page.

 ## How
  - Added the video to `YOUTUBE_VIDEOS` in `public/static/talks.ts`.
  - Updated `modificationDate` in `pages/additional-resources/index.mdx`.

 ## Test plan
  - Run `yarn vale pages/additional-resources/index.mdx`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
