### PR TITLE
[brownfield][android] Fix support for react-native 0.83

### DIFF
--- a/apps/minimal-tester/android/brownfield/build.gradle.kts
+++ b/apps/minimal-tester/android/brownfield/build.gradle.kts
@@ -53,6 +53,6 @@ android {
 
 dependencies {
   api("com.facebook.react:react-android")
-  api("com.facebook.react:hermes-android")
+  api("com.facebook.hermes:hermes-android")
   compileOnly("androidx.fragment:fragment-ktx:1.6.1")
 }

--- a/apps/minimal-tester/android/brownfield/src/main/java/com/community/minimaltester/brownfield/ReactNativeViewFactory.kt
+++ b/apps/minimal-tester/android/brownfield/src/main/java/com/community/minimaltester/brownfield/ReactNativeViewFactory.kt
@@ -22,7 +22,6 @@ object ReactNativeViewFactory {
       launchOptions: Bundle? = null,
   ): FrameLayout {
     val reactHost = ReactNativeHostManager.shared.getReactHost()
-
     val reactDelegate = ReactDelegate(activity, reactHost!!, rootComponent.key, launchOptions)
 
     activity.lifecycle.addObserver(

--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - [iOS] Added support for React Native 0.83 in [#42038](https://github.com/expo/expo/pull/42038) by [@gabrieldonadel](https://github.com/gabrieldonadel)
 - [iOS] Refactor podspec and fix template ([#42105](https://github.com/expo/expo/pull/42105) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [android] Added support for react-native 0.83 ([#42069](https://github.com/expo/expo/pull/42069) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 
 ### 💡 Others
 

--- a/packages/expo-brownfield/gradle-plugins/brownfield/src/main/kotlin/expo/modules/plugin/ExpoBrownfieldSetupPlugin.kt
+++ b/packages/expo-brownfield/gradle-plugins/brownfield/src/main/kotlin/expo/modules/plugin/ExpoBrownfieldSetupPlugin.kt
@@ -33,7 +33,7 @@ class ExpoBrownfieldSetupPlugin : Plugin<Project> {
     project.configurations.configureEach { config ->
       config.resolutionStrategy {
         it.force("com.facebook.react:react-android:$rnVersion")
-        it.force("com.facebook.react:hermes-android:$rnVersion")
+        it.force("com.facebook.hermes:hermes-android:0.14.0")
       }
     }
   }
@@ -54,8 +54,8 @@ class ExpoBrownfieldSetupPlugin : Plugin<Project> {
 
     libraryExtension.sourceSets.getByName("release").apply {
       jniLibs.srcDirs("libsRelease")
-      assets.srcDirs("$appBuildDir/generated/assets/createBundleReleaseJsAndAssets")
-      res.srcDirs("$appBuildDir/generated/res/createBundleReleaseJsAndAssets")
+      assets.srcDirs("$appBuildDir/generated/assets/react/release")
+      res.srcDirs("$appBuildDir/generated/res/react/release")
     }
 
     libraryExtension.sourceSets.getByName("debug").apply { jniLibs.srcDirs("libsDebug") }
@@ -149,7 +149,7 @@ class ExpoBrownfieldSetupPlugin : Plugin<Project> {
 
     val fromDir =
       appProject.layout.buildDirectory.dir(
-        "intermediates/stripped_native_libs/${buildType.toLowerCase()}/strip${buildType}DebugSymbols/out/lib"
+        "intermediates/stripped_native_libs/${buildType.lowercase()}/strip${buildType}DebugSymbols/out/lib"
       )
     val intoDir = brownfieldProject.rootProject.file("${brownfieldProject.name}/libs${buildType}")
 

--- a/packages/expo-brownfield/gradle-plugins/publish/src/main/kotlin/expo/modules/plugin/extensions.kt
+++ b/packages/expo-brownfield/gradle-plugins/publish/src/main/kotlin/expo/modules/plugin/extensions.kt
@@ -173,12 +173,14 @@ internal fun PublishingExtension.setupRepository(publication: PublicationConfig,
  * @param project The project to create the publication for.
  * @param libraryExtension The library extension to use.
  * @param rnVersion The React Native version to set (not null only for brownfield project).
+ * @param hermesVersion The Hermes version to set (not null only for brownfield project).
  */
 internal fun PublishingExtension.createPublication(
   from: String,
   project: Project,
   libraryExtension: LibraryExtension,
   rnVersion: String?,
+  hermesVersion: String?,
 ) {
   val _artifactId =
     if (rnVersion != null) {
@@ -196,8 +198,8 @@ internal fun PublishingExtension.createPublication(
 
       pom.withXml { xml ->
         removeReactNativeDependencyPom(xml)
-        if (rnVersion != null) {
-          setReactNativeVersionPom(xml, rnVersion)
+        if (rnVersion != null && hermesVersion != null) {
+          setReactNativeVersionPom(xml, rnVersion, hermesVersion)
         }
       }
     }

--- a/packages/expo-brownfield/gradle-plugins/publish/src/main/kotlin/expo/modules/plugin/prebuilts.kt
+++ b/packages/expo-brownfield/gradle-plugins/publish/src/main/kotlin/expo/modules/plugin/prebuilts.kt
@@ -21,12 +21,11 @@ internal fun setupPrebuiltsCopying(rootProject: Project) {
       )
     }
 
-    val taskName =
-      rootProject.gradle.startParameter.taskNames.firstOrNull()
-        ?: throw IllegalStateException("Cannot find task in the Gradle start parameter")
-    val repo = parsePublishInvocation(rootProject, taskName)
+    // During Gradle sync, no tasks are specified - skip prebuilts setup
+    val taskName = rootProject.gradle.startParameter.taskNames.firstOrNull() ?: return@afterEvaluate
+    val repo = parsePublishInvocation(rootProject, taskName) ?: return@afterEvaluate
 
-    if (repo != null) {
+    run {
       val publication = findPublicationWithRepository(configExtension.publications.toList(), repo)
       createPrebuiltsPublicationTask(publication, rootProject, configExtension.libraryName.get())
     }

--- a/packages/expo-brownfield/gradle-plugins/publish/src/main/kotlin/expo/modules/plugin/publishing.kt
+++ b/packages/expo-brownfield/gradle-plugins/publish/src/main/kotlin/expo/modules/plugin/publishing.kt
@@ -77,7 +77,7 @@ internal fun setupRepositories(
  * com.facebook.react:react-native is deprecated and has to be stripped similarly to what React
  * Native Gradle plugin does.
  *
- * Versions for com.facebook.react:react-android and com.facebook.react:hermes-android are set to
+ * Versions for com.facebook.react:react-android and com.facebook.hermes:hermes-android are set to
  * the same version as the React Native version of the npm project.
  *
  * @param project The project to remove react-native dependency from.
@@ -153,10 +153,14 @@ internal fun createSetReactNativeVersionModuleTask(
         val moduleJson = parseModuleJson(moduleFile)
         moduleJson?.dependencies()?.forEach { dependency ->
           if (
-            dependency["group"] == "com.facebook.react" &&
-              (dependency["module"] == "react-android" || dependency["module"] == "hermes-android")
+            (dependency["group"] == "com.facebook.react" && dependency["module"] == "react-android")
           ) {
             dependency["version"] = mapOf("requires" to rnVersion)
+          }
+          if (
+            (dependency["group"] == "com.facebook.hermes" && dependency["module"] == "hermes-android")
+          ) {
+            dependency["version"] = mapOf("requires" to "0.14.0")
           }
         }
 

--- a/packages/expo-brownfield/gradle-plugins/publish/src/main/kotlin/expo/modules/plugin/publishing.kt
+++ b/packages/expo-brownfield/gradle-plugins/publish/src/main/kotlin/expo/modules/plugin/publishing.kt
@@ -36,12 +36,18 @@ internal fun setupPublishing(project: Project) {
         } else {
           null
         }
+      val hermesVersion =
+        if (project.name == configExtension.libraryName.get()) {
+          getHermesVersion(project)
+        } else {
+          null
+        }
 
       variants.forEach { variant ->
-        publicationExtension.createPublication(variant, project, libraryExtension, rnVersion)
+        publicationExtension.createPublication(variant, project, libraryExtension, rnVersion, hermesVersion)
       }
 
-      createModuleRelatedTasks(project, rnVersion)
+      createModuleRelatedTasks(project, rnVersion, hermesVersion)
       setupRepositories(publicationExtension, project, configExtension)
     }
   }
@@ -83,12 +89,12 @@ internal fun setupRepositories(
  * @param project The project to remove react-native dependency from.
  * @param isBrownfieldProject Whether the project is the brownfield project.
  */
-internal fun createModuleRelatedTasks(project: Project, rnVersion: String?) {
-  val vairants = listOf("brownfieldDebug", "brownfieldRelease", "brownfieldAll")
-  vairants.forEach { variant ->
+internal fun createModuleRelatedTasks(project: Project, rnVersion: String?, hermesVersion: String?) {
+  val variants = listOf("brownfieldDebug", "brownfieldRelease", "brownfieldAll")
+  variants.forEach { variant ->
     createRemoveReactNativeDependencyModuleTask(project, variant)
-    if (rnVersion != null) {
-      createSetReactNativeVersionModuleTask(project, variant, rnVersion)
+    if (rnVersion != null && hermesVersion != null) {
+      createSetReactNativeVersionModuleTask(project, variant, rnVersion, hermesVersion)
     }
   }
 }
@@ -139,6 +145,7 @@ internal fun createSetReactNativeVersionModuleTask(
   project: Project,
   variant: String,
   rnVersion: String,
+  hermesVersion: String,
 ) {
   val setVersionTask =
     project.tasks.register("setRNDependencyVersionInModuleFile$variant") { task ->
@@ -153,14 +160,14 @@ internal fun createSetReactNativeVersionModuleTask(
         val moduleJson = parseModuleJson(moduleFile)
         moduleJson?.dependencies()?.forEach { dependency ->
           if (
-            (dependency["group"] == "com.facebook.react" && dependency["module"] == "react-android")
+            dependency["group"] == "com.facebook.react" && dependency["module"] == "react-android"
           ) {
             dependency["version"] = mapOf("requires" to rnVersion)
           }
           if (
-            (dependency["group"] == "com.facebook.hermes" && dependency["module"] == "hermes-android")
+            dependency["group"] == "com.facebook.hermes" && dependency["module"] == "hermes-android"
           ) {
-            dependency["version"] = mapOf("requires" to "0.14.0")
+            dependency["version"] = mapOf("requires" to hermesVersion)
           }
         }
 

--- a/packages/expo-brownfield/gradle-plugins/publish/src/main/kotlin/expo/modules/plugin/utils.kt
+++ b/packages/expo-brownfield/gradle-plugins/publish/src/main/kotlin/expo/modules/plugin/utils.kt
@@ -210,10 +210,14 @@ internal fun removeReactNativeDependencyPom(xml: XmlProvider) {
 internal fun setReactNativeVersionPom(xml: XmlProvider, rnVersion: String) {
   xml.dependencyNodes().forEach { dependency ->
     if (
-      dependency.groupId() == "com.facebook.react" &&
-        (dependency.artifactId() == "react-android" || dependency.artifactId() == "hermes-android")
+      dependency.groupId() == "com.facebook.react" && dependency.artifactId() == "react-android"
     ) {
       dependency.setVersion(rnVersion)
+    }
+    if (
+      dependency.groupId() == "com.facebook.hermes" && dependency.artifactId() == "hermes-android"
+    ) {
+      dependency.setVersion("0.14.0")
     }
   }
 }

--- a/packages/expo-brownfield/plugin/templates/android/ReactNativeHostManager.kt
+++ b/packages/expo-brownfield/plugin/templates/android/ReactNativeHostManager.kt
@@ -5,27 +5,18 @@ import android.app.Application
 import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
 import com.facebook.react.PackageList
-import com.facebook.react.ReactApplication
 import com.facebook.react.ReactHost
 import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
-import com.facebook.react.ReactNativeHost
-import com.facebook.react.ReactPackage
 import com.facebook.react.common.ReleaseLevel
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
-import com.facebook.react.defaults.DefaultReactNativeHost
 import com.facebook.react.modules.core.DeviceEventManagerModule
-import expo.modules.ReactNativeHostWrapper
+import expo.modules.ExpoReactHostFactory
 import expo.modules.brownfield.BrownfieldNavigationState
 
 class ReactNativeHostManager {
   companion object {
     val shared: ReactNativeHostManager by lazy { ReactNativeHostManager() }
-    private var reactNativeHost: ReactNativeHost? = null
     private var reactHost: ReactHost? = null
-  }
-
-  fun getReactNativeHost(): ReactNativeHost? {
-    return reactNativeHost
   }
 
   fun getReactHost(): ReactHost? {
@@ -33,7 +24,7 @@ class ReactNativeHostManager {
   }
 
   fun initialize(application: Application) {
-    if (reactNativeHost != null && reactHost != null) {
+    if (reactHost != null) {
       return
     }
 
@@ -46,35 +37,10 @@ class ReactNativeHostManager {
     loadReactNative(application)
     BrownfieldLifecycleDispatcher.onApplicationCreate(application)
 
-    val reactApp =
-        object : ReactApplication {
-          override val reactNativeHost: ReactNativeHost =
-              ReactNativeHostWrapper(
-                  application,
-                  object : DefaultReactNativeHost(application) {
-                    override fun getPackages(): List<ReactPackage> =
-                        PackageList(this).packages.apply {}
-
-                    override fun getJSMainModuleName(): String = ".expo/.virtual-metro-entry"
-
-                    override fun getBundleAssetName(): String = "index.android.bundle"
-
-                    override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG
-
-                    override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
-                  },
-              )
-
-          override val reactHost: ReactHost
-            get() =
-                ReactNativeHostWrapper.createReactHost(
-                    application.getApplicationContext(),
-                    reactNativeHost,
-                )
-        }
-
-    reactNativeHost = reactApp.reactNativeHost
-    reactHost = reactApp.reactHost
+    reactHost = ExpoReactHostFactory.getDefaultReactHost(
+      context = application.applicationContext,
+      packageList = PackageList(application).packages
+    )
   }
 }
 

--- a/packages/expo-brownfield/plugin/templates/android/ReactNativeViewFactory.kt
+++ b/packages/expo-brownfield/plugin/templates/android/ReactNativeViewFactory.kt
@@ -22,39 +22,27 @@ object ReactNativeViewFactory {
       launchOptions: Bundle? = null,
   ): FrameLayout {
     val reactHost = ReactNativeHostManager.shared.getReactHost()
-    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-      val reactDelegate = ReactDelegate(activity, reactHost!!, rootComponent.key, launchOptions)
+    val reactDelegate = ReactDelegate(activity, reactHost!!, rootComponent.key, launchOptions)
 
-      activity.lifecycle.addObserver(
-          object : DefaultLifecycleObserver {
-            override fun onResume(owner: LifecycleOwner) {
-              reactDelegate.onHostResume()
-            }
-
-            override fun onPause(owner: LifecycleOwner) {
-              reactDelegate.onHostPause()
-            }
-
-            override fun onDestroy(owner: LifecycleOwner) {
-              reactDelegate.onHostDestroy()
-              owner.lifecycle.removeObserver(this) // Cleanup to avoid leaks
-            }
+    activity.lifecycle.addObserver(
+        object : DefaultLifecycleObserver {
+          override fun onResume(owner: LifecycleOwner) {
+            reactDelegate.onHostResume()
           }
-      )
 
-      reactDelegate.loadApp()
-      return reactDelegate.reactRootView!!
-    }
+          override fun onPause(owner: LifecycleOwner) {
+            reactDelegate.onHostPause()
+          }
 
-    val instanceManager: ReactInstanceManager? =
-        ReactNativeHostManager.shared.getReactNativeHost()?.reactInstanceManager
-    val reactView = ReactRootView(context)
-    reactView.startReactApplication(
-        instanceManager,
-        rootComponent.key,
-        launchOptions,
+          override fun onDestroy(owner: LifecycleOwner) {
+            reactDelegate.onHostDestroy()
+            owner.lifecycle.removeObserver(this) // Cleanup to avoid leaks
+          }
+        }
     )
 
-    return reactView
+    reactDelegate.loadApp()
+    return reactDelegate.reactRootView!!
+
   }
 }

--- a/packages/expo-brownfield/plugin/templates/android/build.gradle.kts
+++ b/packages/expo-brownfield/plugin/templates/android/build.gradle.kts
@@ -53,6 +53,6 @@ android {
 
 dependencies {
   api("com.facebook.react:react-android")
-  api("com.facebook.react:hermes-android")
+  api("com.facebook.hermes:hermes-android")
   compileOnly("androidx.fragment:fragment-ktx:1.6.1")
 }


### PR DESCRIPTION
# Why

Expo-brownfield crashes when build react-native 0.83

# How

- Fix hermes version and group
- Fix bundle directories 
- Update Android template to ExpoReactHostFactory

# Test Plan

In mininal-tester, run `npx expo-brownfield build-android --repository MavenLocal --verbose --release` and then use that aar for brownfield-tester

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
