### PR TITLE
[image][ios] Add support for PSD images

### DIFF
--- a/apps/native-component-list/src/screens/Image/ImageFormatsScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageFormatsScreen.tsx
@@ -121,6 +121,15 @@ const data: SectionListData<ImageProps>[] = [
       },
     ],
   },
+  Platform.OS === 'ios' && {
+    title: 'PSD',
+    data: [
+      {
+        source:
+          'https://filesamples.com/samples/image/psd/sample_640%C3%97426.psd',
+      },
+    ],
+  },
 ].filter(Boolean) as SectionListData<ImageProps>[];
 
 function keyExtractor(item: any, index: number) {

--- a/apps/native-component-list/src/screens/Image/ImageFormatsScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageFormatsScreen.tsx
@@ -125,8 +125,7 @@ const data: SectionListData<ImageProps>[] = [
     title: 'PSD',
     data: [
       {
-        source:
-          'https://filesamples.com/samples/image/psd/sample_640%C3%97426.psd',
+        source: 'https://filesamples.com/samples/image/psd/sample_640%C3%97426.psd',
       },
     ],
   },

--- a/docs/pages/versions/unversioned/sdk/image.mdx
+++ b/docs/pages/versions/unversioned/sdk/image.mdx
@@ -32,17 +32,18 @@ import { Terminal } from '~/ui/components/Snippet';
 
 #### Supported image formats
 
-|   Format   |   Android   |     iOS     |                          Web                           |
-| :--------: | :---------: | :---------: | :----------------------------------------------------: |
-|    WebP    | <YesIcon /> | <YesIcon /> |                      <YesIcon />                       |
-| PNG / APNG | <YesIcon /> | <YesIcon /> |                      <YesIcon />                       |
-|    AVIF    | <YesIcon /> | <YesIcon /> |                      <YesIcon />                       |
-|    HEIC    | <YesIcon /> | <YesIcon /> | <NoIcon /> [not adopted yet](https://caniuse.com/heif) |
-|    JPEG    | <YesIcon /> | <YesIcon /> |                      <YesIcon />                       |
-|    GIF     | <YesIcon /> | <YesIcon /> |                      <YesIcon />                       |
-|    SVG     | <YesIcon /> | <YesIcon /> |                      <YesIcon />                       |
-|    ICO     | <YesIcon /> | <YesIcon /> |                      <YesIcon />                       |
-|    ICNS    | <NoIcon />  | <YesIcon /> |                       <NoIcon />                       |
+|         Format          |   Android   |     iOS     |                          Web                           |
+| :---------------------: | :---------: | :---------: | :----------------------------------------------------: |
+|          WebP           | <YesIcon /> | <YesIcon /> |                      <YesIcon />                       |
+|       PNG / APNG        | <YesIcon /> | <YesIcon /> |                      <YesIcon />                       |
+|          AVIF           | <YesIcon /> | <YesIcon /> |                      <YesIcon />                       |
+|          HEIC           | <YesIcon /> | <YesIcon /> | <NoIcon /> [not adopted yet](https://caniuse.com/heif) |
+|          JPEG           | <YesIcon /> | <YesIcon /> |                      <YesIcon />                       |
+|           GIF           | <YesIcon /> | <YesIcon /> |                      <YesIcon />                       |
+|           SVG           | <YesIcon /> | <YesIcon /> |                      <YesIcon />                       |
+|           ICO           | <YesIcon /> | <YesIcon /> |                      <YesIcon />                       |
+|          ICNS           | <NoIcon />  | <YesIcon /> |                       <NoIcon />                       |
+| PSD (composite preview) | <NoIcon />  | <YesIcon /> |                       <NoIcon />                       |
 
 ## Installation
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [iOS] Provide plugin to disable `libdav1d`. ([#40691](https://github.com/expo/expo/pull/40691) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] feat: add `configureCache` option ([#40647](https://github.com/expo/expo/pull/40647) by [@kosmydel](https://github.com/kosmydel))
 - [Web] Add `loading` prop for lazy loading images. ([#41442](https://github.com/expo/expo/pull/41442) by [@mozzius](https://github.com/mozzius))
+- [iOS] Added support for PSD images
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -12,7 +12,7 @@
 - [iOS] Provide plugin to disable `libdav1d`. ([#40691](https://github.com/expo/expo/pull/40691) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] feat: add `configureCache` option ([#40647](https://github.com/expo/expo/pull/40647) by [@kosmydel](https://github.com/kosmydel))
 - [Web] Add `loading` prop for lazy loading images. ([#41442](https://github.com/expo/expo/pull/41442) by [@mozzius](https://github.com/mozzius))
-- [iOS] Added support for PSD images
+- [iOS] Added support for PSD images. ([#42077](https://github.com/expo/expo/pull/42077) by [@barthap](https://github.com/barthap))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -261,6 +261,7 @@ public final class ImageModule: Module {
 
   static func registerCoders() {
     SDImageCodersManager.shared.addCoder(WebPCoder.shared)
+    SDImageCodersManager.shared.addCoder(PSDCoder.shared)
     SDImageCodersManager.shared.addCoder(SDImageAVIFCoder.shared)
     SDImageCodersManager.shared.addCoder(SDImageSVGCoder.shared)
     SDImageCodersManager.shared.addCoder(SDImageHEICCoder.shared)

--- a/packages/expo-image/ios/PSDCoder.swift
+++ b/packages/expo-image/ios/PSDCoder.swift
@@ -6,7 +6,9 @@ internal final class PSDCoder: NSObject, SDImageCoder {
   nonisolated(unsafe) static let shared = PSDCoder()
   
   func canDecode(from data: Data?) -> Bool {
-    guard let data = data, data.count >= 4 else { return false }
+    guard let data, data.count >= 4 else {
+      return false
+    }
     
     // verify PSD magic bytes
     let signatureData = data[0..<4]
@@ -15,7 +17,9 @@ internal final class PSDCoder: NSObject, SDImageCoder {
   }
   
   func decodedImage(with data: Data?, options: [SDImageCoderOption : Any]? = nil) -> UIImage? {
-    guard let data = data else { return nil }
+    guard let data else {
+      return nil
+    }
     
     if let scale = options?[SDImageCoderOption.decodeScaleFactor] as? CGFloat {
       return UIImage(data: data, scale: scale)
@@ -26,7 +30,7 @@ internal final class PSDCoder: NSObject, SDImageCoder {
   }
   
   func canEncode(to format: SDImageFormat) -> Bool {
-    false
+    return false
   }
   
   func encodedData(with image: UIImage?, format: SDImageFormat, options: [SDImageCoderOption : Any]? = nil) -> Data? {

--- a/packages/expo-image/ios/PSDCoder.swift
+++ b/packages/expo-image/ios/PSDCoder.swift
@@ -1,0 +1,35 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+import SDWebImage
+
+internal final class PSDCoder: NSObject, SDImageCoder {
+  nonisolated(unsafe) static let shared = PSDCoder()
+  
+  func canDecode(from data: Data?) -> Bool {
+    guard let data = data, data.count >= 4 else { return false }
+    
+    // verify PSD magic bytes
+    let signatureData = data[0..<4]
+    let signature = String(data: signatureData, encoding: .ascii)
+    return signature == "8BPS"
+  }
+  
+  func decodedImage(with data: Data?, options: [SDImageCoderOption : Any]? = nil) -> UIImage? {
+    guard let data = data else { return nil }
+    
+    if let scale = options?[SDImageCoderOption.decodeScaleFactor] as? CGFloat {
+      return UIImage(data: data, scale: scale)
+    }
+    
+    // UIImage is able to directly handle PSD data
+    return UIImage(data: data)
+  }
+  
+  func canEncode(to format: SDImageFormat) -> Bool {
+    false
+  }
+  
+  func encodedData(with image: UIImage?, format: SDImageFormat, options: [SDImageCoderOption : Any]? = nil) -> Data? {
+    return nil
+  }
+}


### PR DESCRIPTION
# Why

To keep parity with core RN `<Image />` which does support PSD previews.

On iOS, `UIImage` natively supports PSD / 8BIM images (it's part of the [Image I/O framework](https://developer.apple.com/documentation/imageio/8bim-image-properties)). Core RN image passes through data to UIImage directly, but SDWebImage does not.

# How

Added a passthrough SDWebImage coder, that verifies magic bytes* and passes the data to `UIImage`.

_*There are probably more compatible formats than PSD (I guess RAW?) so in the future we can extend this coder to support them. However, I haven't found a simple reliable way of finding all of them. Too loose checks might result in potentially overriding other dedicated SDWebImage coders (= degraded perf)._

# Test Plan

- ✅ bare-expo NCL - added sample image to the formats screen

| NCL preview | Updated docs table |
| ------------- | ------------------- |
| <img alt="NCL preview" src="https://github.com/user-attachments/assets/571d95a5-15d1-4d60-b507-0b1ecb8e5513" /> | <img alt="docs preview" src="https://github.com/user-attachments/assets/77ae6f39-0203-4592-9c46-a02910fc2749" /> |

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
