### PR TITLE
[docs] Add platform tag for Expo Go

### DIFF
--- a/docs/components/plugins/api/components/APISectionPlatformTags.tsx
+++ b/docs/components/plugins/api/components/APISectionPlatformTags.tsx
@@ -4,6 +4,7 @@ import { STYLES_SECONDARY } from '~/components/plugins/api/styles';
 import { usePageApiVersion } from '~/providers/page-api-version';
 import { usePageMetadata } from '~/providers/page-metadata';
 import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
+import { isClientPlatformTag } from '~/ui/components/Tag/helpers';
 import { StatusTag } from '~/ui/components/Tag/StatusTag';
 
 import { CommentData, CommentTagData } from '../APIDataTypes';
@@ -33,10 +34,8 @@ export const APISectionPlatformTags = ({
   const platformsData = platforms ?? getAllTagData('platform', comment);
   const experimentalData = getAllTagData('experimental', comment);
 
-  const runtimePlatforms = new Set(['expo-go', 'dev-builds']);
-  const isRuntimeTag = (platform: string) => runtimePlatforms.has(platform.toLowerCase());
   const filteredDefaultPlatforms = defaultPlatforms?.filter(
-    platform => !isRuntimeTag(platform)
+    platform => !isClientPlatformTag(platform)
   );
   const platformNames =
     userProvidedPlatforms ??

--- a/docs/components/plugins/api/components/APISectionPlatformTags.tsx
+++ b/docs/components/plugins/api/components/APISectionPlatformTags.tsx
@@ -33,12 +33,17 @@ export const APISectionPlatformTags = ({
   const platformsData = platforms ?? getAllTagData('platform', comment);
   const experimentalData = getAllTagData('experimental', comment);
 
+  const runtimePlatforms = new Set(['expo-go', 'dev-builds']);
+  const isRuntimeTag = (platform: string) => runtimePlatforms.has(platform.toLowerCase());
+  const filteredDefaultPlatforms = defaultPlatforms?.filter(
+    platform => !isRuntimeTag(platform)
+  );
   const platformNames =
     userProvidedPlatforms ??
     (platformsData.length > 0
       ? platformsData?.map(platformData => getCommentContent(platformData.content))
       : isCompatibleVersion && !disableFallback
-        ? defaultPlatforms?.map(platform => platform.replace('*', ''))
+        ? filteredDefaultPlatforms?.map(platform => platform.replace('*', ''))
         : []);
 
   if (experimentalData.length === 0 && !platformNames?.length) {

--- a/docs/components/plugins/api/components/APISectionPlatformTags.tsx
+++ b/docs/components/plugins/api/components/APISectionPlatformTags.tsx
@@ -4,8 +4,8 @@ import { STYLES_SECONDARY } from '~/components/plugins/api/styles';
 import { usePageApiVersion } from '~/providers/page-api-version';
 import { usePageMetadata } from '~/providers/page-metadata';
 import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
-import { isClientPlatformTag } from '~/ui/components/Tag/helpers';
 import { StatusTag } from '~/ui/components/Tag/StatusTag';
+import { isClientPlatformTag } from '~/ui/components/Tag/helpers';
 
 import { CommentData, CommentTagData } from '../APIDataTypes';
 import { getAllTagData, getCommentContent } from '../APISectionUtils';

--- a/docs/ui/components/PageHeader/PagePlatformTags.tsx
+++ b/docs/ui/components/PageHeader/PagePlatformTags.tsx
@@ -3,7 +3,7 @@ import { InfoCircleDuotoneIcon } from '@expo/styleguide-icons/duotone/InfoCircle
 
 import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
 import { isClientPlatformTag } from '~/ui/components/Tag/helpers';
-import { A, FOOTNOTE } from '~/ui/components/Text';
+import { FOOTNOTE } from '~/ui/components/Text';
 import * as Tooltip from '~/ui/components/Tooltip';
 
 type Props = {
@@ -24,9 +24,8 @@ export function PagePlatformTags({ platforms, className }: Props) {
         const text = platform.includes('*') ? platform.replace('*', ' (device only)') : platform;
         const platformLower = platform.toLowerCase();
         const isExpoGo = platformLower.includes('expo-go');
-        const isDevBuilds = platformLower.includes('dev-builds');
 
-        if (!isExpoGo && !isDevBuilds) {
+        if (!isExpoGo) {
           return <PlatformTag key={text} platform={text} className="rounded-full px-2.5 py-1.5" />;
         }
 
@@ -51,12 +50,6 @@ export function PagePlatformTags({ platforms, className }: Props) {
                 <FOOTNOTE>
                   This library is included in Expo Go. See "Bundled version" for the exact version
                   included in the Expo Go app.
-                </FOOTNOTE>
-              ) : (
-                <FOOTNOTE>
-                  This library is not available in the Expo Go app. Create a{' '}
-                  <A href="/develop/development-builds/introduction">development build</A> to use
-                  it.
                 </FOOTNOTE>
               )}
             </Tooltip.Content>

--- a/docs/ui/components/PageHeader/PagePlatformTags.tsx
+++ b/docs/ui/components/PageHeader/PagePlatformTags.tsx
@@ -2,6 +2,8 @@ import { mergeClasses } from '@expo/styleguide';
 
 import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
 import { isClientPlatformTag } from '~/ui/components/Tag/helpers';
+import { A, FOOTNOTE } from '~/ui/components/Text';
+import * as Tooltip from '~/ui/components/Tooltip';
 
 type Props = {
   platforms: string[];
@@ -19,7 +21,37 @@ export function PagePlatformTags({ platforms, className }: Props) {
     <div className={mergeClasses('inline-flex flex-wrap gap-y-1.5', className)}>
       {orderedPlatforms.map(platform => {
         const text = platform.includes('*') ? platform.replace('*', ' (device only)') : platform;
-        return <PlatformTag platform={text} key={text} className="rounded-full px-2.5 py-1.5" />;
+        const platformLower = platform.toLowerCase();
+        const isExpoGo = platformLower.includes('expo-go');
+        const isDevBuilds = platformLower.includes('dev-builds');
+
+        if (!isExpoGo && !isDevBuilds) {
+          return <PlatformTag key={text} platform={text} className="rounded-full px-2.5 py-1.5" />;
+        }
+
+        return (
+          <Tooltip.Root key={text} delayDuration={300}>
+            <Tooltip.Trigger asChild>
+              <span className="mr-2 inline-flex last:mr-0">
+                <PlatformTag platform={text} className="rounded-full px-2.5 py-1.5" />
+              </span>
+            </Tooltip.Trigger>
+            <Tooltip.Content side="bottom" align="start" className="max-w-[260px]">
+              {isExpoGo ? (
+                <FOOTNOTE>
+                  This package is included in Expo Go. See "Bundled version" for the exact version
+                  included in the Expo Go app.
+                </FOOTNOTE>
+              ) : (
+                <FOOTNOTE>
+                  This package is not available in the Expo Go app. Create a{' '}
+                  <A href="/develop/development-builds/introduction">development build</A> to use
+                  it.
+                </FOOTNOTE>
+              )}
+            </Tooltip.Content>
+          </Tooltip.Root>
+        );
       })}
     </div>
   );

--- a/docs/ui/components/PageHeader/PagePlatformTags.tsx
+++ b/docs/ui/components/PageHeader/PagePlatformTags.tsx
@@ -1,4 +1,5 @@
 import { mergeClasses } from '@expo/styleguide';
+
 import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
 import { isClientPlatformTag } from '~/ui/components/Tag/helpers';
 
@@ -30,7 +31,7 @@ export function PagePlatformTags({ platforms, className }: Props) {
             key={text}
             platform="expo-go"
             label="Included in Expo Go"
-            className="rounded-full px-2.5 py-1.5 bg-palette-gray3 text-palette-gray12 border-palette-gray4 dark:bg-palette-gray4 dark:border-palette-gray4"
+            className="rounded-full border-palette-gray4 bg-palette-gray3 px-2.5 py-1.5 text-palette-gray12 dark:border-palette-gray4 dark:bg-palette-gray4"
           />
         );
       })}

--- a/docs/ui/components/PageHeader/PagePlatformTags.tsx
+++ b/docs/ui/components/PageHeader/PagePlatformTags.tsx
@@ -46,7 +46,7 @@ export function PagePlatformTags({ platforms, className }: Props) {
               </span>
             </Tooltip.Trigger>
             <Tooltip.Content side="bottom" align="start" className="max-w-[260px]">
-              {isExpoGo ? (
+              {isExpoGo && (
                 <FOOTNOTE>
                   This library is included in Expo Go. See "Bundled version" for the exact version
                   included in the Expo Go app.

--- a/docs/ui/components/PageHeader/PagePlatformTags.tsx
+++ b/docs/ui/components/PageHeader/PagePlatformTags.tsx
@@ -1,10 +1,6 @@
 import { mergeClasses } from '@expo/styleguide';
-import { InfoCircleDuotoneIcon } from '@expo/styleguide-icons/duotone/InfoCircleDuotoneIcon';
-
 import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
 import { isClientPlatformTag } from '~/ui/components/Tag/helpers';
-import { FOOTNOTE } from '~/ui/components/Text';
-import * as Tooltip from '~/ui/components/Tooltip';
 
 type Props = {
   platforms: string[];
@@ -30,30 +26,12 @@ export function PagePlatformTags({ platforms, className }: Props) {
         }
 
         return (
-          <Tooltip.Root key={text} delayDuration={300}>
-            <Tooltip.Trigger asChild>
-              <span className="mr-2 inline-flex last:mr-0">
-                <PlatformTag
-                  platform={text}
-                  className="mr-0 rounded-full px-2.5 py-1.5"
-                  suffix={
-                    <InfoCircleDuotoneIcon
-                      aria-hidden="true"
-                      className="icon-2xs text-palette-gray10"
-                    />
-                  }
-                />
-              </span>
-            </Tooltip.Trigger>
-            <Tooltip.Content side="bottom" align="start" className="max-w-[260px]">
-              {isExpoGo && (
-                <FOOTNOTE>
-                  This library is included in Expo Go. See "Bundled version" for the exact version
-                  included in the Expo Go app.
-                </FOOTNOTE>
-              )}
-            </Tooltip.Content>
-          </Tooltip.Root>
+          <PlatformTag
+            key={text}
+            platform="expo-go"
+            label="Included in Expo Go"
+            className="rounded-full px-2.5 py-1.5 bg-palette-gray3 text-palette-gray12 border-palette-gray4 dark:bg-palette-gray4 dark:border-palette-gray4"
+          />
         );
       })}
     </div>

--- a/docs/ui/components/PageHeader/PagePlatformTags.tsx
+++ b/docs/ui/components/PageHeader/PagePlatformTags.tsx
@@ -1,4 +1,5 @@
 import { mergeClasses } from '@expo/styleguide';
+import { InfoCircleDuotoneIcon } from '@expo/styleguide-icons/duotone/InfoCircleDuotoneIcon';
 
 import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
 import { isClientPlatformTag } from '~/ui/components/Tag/helpers';
@@ -33,7 +34,16 @@ export function PagePlatformTags({ platforms, className }: Props) {
           <Tooltip.Root key={text} delayDuration={300}>
             <Tooltip.Trigger asChild>
               <span className="mr-2 inline-flex last:mr-0">
-                <PlatformTag platform={text} className="rounded-full px-2.5 py-1.5" />
+                <PlatformTag
+                  platform={text}
+                  className="mr-0 rounded-full px-2.5 py-1.5"
+                  suffix={
+                    <InfoCircleDuotoneIcon
+                      aria-hidden="true"
+                      className="icon-2xs text-palette-gray10"
+                    />
+                  }
+                />
               </span>
             </Tooltip.Trigger>
             <Tooltip.Content side="bottom" align="start" className="max-w-[260px]">

--- a/docs/ui/components/PageHeader/PagePlatformTags.tsx
+++ b/docs/ui/components/PageHeader/PagePlatformTags.tsx
@@ -1,6 +1,7 @@
 import { mergeClasses } from '@expo/styleguide';
 
 import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
+import { isClientPlatformTag } from '~/ui/components/Tag/helpers';
 
 type Props = {
   platforms: string[];
@@ -8,12 +9,10 @@ type Props = {
 };
 
 export function PagePlatformTags({ platforms, className }: Props) {
-  const runtimePlatforms = new Set(['expo-go', 'dev-builds']);
-  const isRuntimeTag = (platform: string) => runtimePlatforms.has(platform.toLowerCase());
   const standardPlatforms = platforms
-    .filter(platform => !isRuntimeTag(platform))
+    .filter(platform => !isClientPlatformTag(platform))
     .sort((a, b) => a.localeCompare(b));
-  const runtimePlatformsOrdered = platforms.filter(platform => isRuntimeTag(platform));
+  const runtimePlatformsOrdered = platforms.filter(platform => isClientPlatformTag(platform));
   const orderedPlatforms = [...standardPlatforms, ...runtimePlatformsOrdered];
 
   return (

--- a/docs/ui/components/PageHeader/PagePlatformTags.tsx
+++ b/docs/ui/components/PageHeader/PagePlatformTags.tsx
@@ -8,14 +8,20 @@ type Props = {
 };
 
 export function PagePlatformTags({ platforms, className }: Props) {
+  const runtimePlatforms = new Set(['expo-go', 'dev-builds']);
+  const isRuntimeTag = (platform: string) => runtimePlatforms.has(platform.toLowerCase());
+  const standardPlatforms = platforms
+    .filter(platform => !isRuntimeTag(platform))
+    .sort((a, b) => a.localeCompare(b));
+  const runtimePlatformsOrdered = platforms.filter(platform => isRuntimeTag(platform));
+  const orderedPlatforms = [...standardPlatforms, ...runtimePlatformsOrdered];
+
   return (
     <div className={mergeClasses('inline-flex flex-wrap gap-y-1.5', className)}>
-      {platforms
-        .sort((a, b) => a.localeCompare(b))
-        .map(platform => {
-          const text = platform.includes('*') ? platform.replace('*', ' (device only)') : platform;
-          return <PlatformTag platform={text} key={text} className="rounded-full px-2.5 py-1.5" />;
-        })}
+      {orderedPlatforms.map(platform => {
+        const text = platform.includes('*') ? platform.replace('*', ' (device only)') : platform;
+        return <PlatformTag platform={text} key={text} className="rounded-full px-2.5 py-1.5" />;
+      })}
     </div>
   );
 }

--- a/docs/ui/components/PageHeader/PagePlatformTags.tsx
+++ b/docs/ui/components/PageHeader/PagePlatformTags.tsx
@@ -39,12 +39,12 @@ export function PagePlatformTags({ platforms, className }: Props) {
             <Tooltip.Content side="bottom" align="start" className="max-w-[260px]">
               {isExpoGo ? (
                 <FOOTNOTE>
-                  This package is included in Expo Go. See "Bundled version" for the exact version
+                  This library is included in Expo Go. See "Bundled version" for the exact version
                   included in the Expo Go app.
                 </FOOTNOTE>
               ) : (
                 <FOOTNOTE>
-                  This package is not available in the Expo Go app. Create a{' '}
+                  This library is not available in the Expo Go app. Create a{' '}
                   <A href="/develop/development-builds/introduction">development build</A> to use
                   it.
                 </FOOTNOTE>

--- a/docs/ui/components/Tag/PlatformIcon.tsx
+++ b/docs/ui/components/Tag/PlatformIcon.tsx
@@ -1,6 +1,7 @@
 import { ExpoGoLogo, mergeClasses } from '@expo/styleguide';
 import { AndroidIcon } from '@expo/styleguide-icons/custom/AndroidIcon';
 import { AppleIcon } from '@expo/styleguide-icons/custom/AppleIcon';
+import { BuildIcon } from '@expo/styleguide-icons/custom/BuildIcon';
 import { AtSignIcon } from '@expo/styleguide-icons/outline/AtSignIcon';
 
 import { PlatformName } from '~/types/common';
@@ -31,6 +32,8 @@ export const PlatformIcon = ({ platform }: PlatformIconProps) => {
       return <AtSignIcon className="icon-2xs shrink-0 text-palette-orange12 opacity-80" />;
     case 'expo':
       return <ExpoGoLogo className="icon-2xs shrink-0 text-palette-purple12 opacity-80" />;
+    case 'dev-builds':
+      return <BuildIcon className="icon-2xs shrink-0 text-palette-gray12 opacity-80" />;
     default:
       return null;
   }

--- a/docs/ui/components/Tag/PlatformIcon.tsx
+++ b/docs/ui/components/Tag/PlatformIcon.tsx
@@ -30,7 +30,7 @@ export const PlatformIcon = ({ platform }: PlatformIconProps) => {
     case 'web':
       return <AtSignIcon className="icon-2xs shrink-0 text-palette-orange12 opacity-80" />;
     case 'expo':
-      return <ExpoGoLogo className="icon-2xs shrink-0 text-palette-purple12 opacity-80" />;
+      return <ExpoGoLogo className="icon-2xs shrink-0 text-current opacity-80" />;
     default:
       return null;
   }

--- a/docs/ui/components/Tag/PlatformIcon.tsx
+++ b/docs/ui/components/Tag/PlatformIcon.tsx
@@ -1,7 +1,6 @@
 import { ExpoGoLogo, mergeClasses } from '@expo/styleguide';
 import { AndroidIcon } from '@expo/styleguide-icons/custom/AndroidIcon';
 import { AppleIcon } from '@expo/styleguide-icons/custom/AppleIcon';
-import { BuildIcon } from '@expo/styleguide-icons/custom/BuildIcon';
 import { AtSignIcon } from '@expo/styleguide-icons/outline/AtSignIcon';
 
 import { PlatformName } from '~/types/common';
@@ -32,8 +31,6 @@ export const PlatformIcon = ({ platform }: PlatformIconProps) => {
       return <AtSignIcon className="icon-2xs shrink-0 text-palette-orange12 opacity-80" />;
     case 'expo':
       return <ExpoGoLogo className="icon-2xs shrink-0 text-palette-purple12 opacity-80" />;
-    case 'dev-builds':
-      return <BuildIcon className="icon-2xs shrink-0 text-palette-gray12 opacity-80" />;
     default:
       return null;
   }

--- a/docs/ui/components/Tag/PlatformTag.tsx
+++ b/docs/ui/components/Tag/PlatformTag.tsx
@@ -10,7 +10,7 @@ type PlatformTagProps = Omit<TagProps, 'name'> & {
   platform: PlatformName;
 };
 
-export const PlatformTag = ({ platform, className }: PlatformTagProps) => {
+export const PlatformTag = ({ platform, className, ...rest }: PlatformTagProps) => {
   const platformName = getPlatformName(platform);
 
   return (
@@ -22,7 +22,8 @@ export const PlatformTag = ({ platform, className }: PlatformTagProps) => {
         '[h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0',
         getTagClasses(platformName),
         className
-      )}>
+      )}
+      {...rest}>
       <PlatformIcon platform={platformName} />
       <span className={mergeClasses('whitespace-nowrap !text-3xs font-normal !leading-none')}>
         {formatName(platform)}

--- a/docs/ui/components/Tag/PlatformTag.tsx
+++ b/docs/ui/components/Tag/PlatformTag.tsx
@@ -1,4 +1,5 @@
 import { mergeClasses } from '@expo/styleguide';
+import type { ReactNode } from 'react';
 
 import { PlatformName } from '~/types/common';
 import { formatName, getPlatformName, getTagClasses } from '~/ui/components/Tag/helpers';
@@ -8,9 +9,10 @@ import { TagProps } from './types';
 
 type PlatformTagProps = Omit<TagProps, 'name'> & {
   platform: PlatformName;
+  suffix?: ReactNode;
 };
 
-export const PlatformTag = ({ platform, className, ...rest }: PlatformTagProps) => {
+export const PlatformTag = ({ platform, className, suffix, ...rest }: PlatformTagProps) => {
   const platformName = getPlatformName(platform);
 
   return (
@@ -28,6 +30,7 @@ export const PlatformTag = ({ platform, className, ...rest }: PlatformTagProps) 
       <span className={mergeClasses('whitespace-nowrap !text-3xs font-normal !leading-none')}>
         {formatName(platform)}
       </span>
+      {suffix}
     </div>
   );
 };

--- a/docs/ui/components/Tag/PlatformTag.tsx
+++ b/docs/ui/components/Tag/PlatformTag.tsx
@@ -9,11 +9,13 @@ import { TagProps } from './types';
 
 type PlatformTagProps = Omit<TagProps, 'name'> & {
   platform: PlatformName;
+  label?: string;
   suffix?: ReactNode;
 };
 
-export const PlatformTag = ({ platform, className, suffix, ...rest }: PlatformTagProps) => {
+export const PlatformTag = ({ platform, label, className, suffix, ...rest }: PlatformTagProps) => {
   const platformName = getPlatformName(platform);
+  const displayLabel = label ?? formatName(platform);
 
   return (
     <div
@@ -28,7 +30,7 @@ export const PlatformTag = ({ platform, className, suffix, ...rest }: PlatformTa
       {...rest}>
       <PlatformIcon platform={platformName} />
       <span className={mergeClasses('whitespace-nowrap !text-3xs font-normal !leading-none')}>
-        {formatName(platform)}
+        {displayLabel}
       </span>
       {suffix}
     </div>

--- a/docs/ui/components/Tag/helpers.ts
+++ b/docs/ui/components/Tag/helpers.ts
@@ -1,7 +1,7 @@
 import { capitalize } from '~/common/utilities';
 import { PlatformName } from '~/types/common';
 
-const CLIENT_PLATFORM_TAGS = new Set(['expo-go', 'dev-builds']);
+const CLIENT_PLATFORM_TAGS = new Set(['expo-go']);
 
 export function getPlatformName(text: string): PlatformName {
   const lowerText = text.toLowerCase().trim();
@@ -26,9 +26,6 @@ export function getPlatformName(text: string): PlatformName {
   if (lowerText === 'expo-go') {
     return 'expo';
   }
-  if (lowerText === 'dev-builds') {
-    return 'dev-builds';
-  }
   return '';
 }
 
@@ -48,8 +45,6 @@ export function getTagClasses(type: string) {
       return 'bg-palette-pink3 text-palette-pink12 border-palette-pink4';
     case 'expo':
       return 'bg-palette-purple3 text-palette-purple12 border-palette-purple4';
-    case 'dev-builds':
-      return 'bg-palette-gray3 text-palette-gray12 border-palette-gray4';
     case 'deprecated':
       return 'bg-palette-yellow2 text-palette-yellow12 border-palette-yellow4';
     case 'experimental':
@@ -66,8 +61,6 @@ export const formatName = (name: PlatformName) => {
   const cleanName = name.toLowerCase().replace('\n', '').trim();
   if (cleanName.includes('expo-go')) {
     return 'Expo Go';
-  } else if (cleanName.includes('dev-builds')) {
-    return 'Dev builds';
   } else if (cleanName.includes('ios')) {
     return cleanName.replace('ios', 'iOS');
   } else if (cleanName.includes('macos')) {

--- a/docs/ui/components/Tag/helpers.ts
+++ b/docs/ui/components/Tag/helpers.ts
@@ -2,23 +2,30 @@ import { capitalize } from '~/common/utilities';
 import { PlatformName } from '~/types/common';
 
 export function getPlatformName(text: string): PlatformName {
-  if (text.toLowerCase().includes('ios')) {
+  const lowerText = text.toLowerCase().trim();
+  if (lowerText.includes('ios')) {
     return 'ios';
   }
-  if (text.toLowerCase().includes('android')) {
+  if (lowerText.includes('android')) {
     return 'android';
   }
-  if (text.toLowerCase().includes('web')) {
+  if (lowerText.includes('web')) {
     return 'web';
   }
-  if (text.toLowerCase().includes('server')) {
+  if (lowerText.includes('server')) {
     return 'server';
   }
-  if (text.toLowerCase().includes('macos')) {
+  if (lowerText.includes('macos')) {
     return 'macos';
   }
-  if (text.toLowerCase().includes('tvos')) {
+  if (lowerText.includes('tvos')) {
     return 'tvos';
+  }
+  if (lowerText === 'expo-go') {
+    return 'expo';
+  }
+  if (lowerText === 'dev-builds') {
+    return 'dev-builds';
   }
   return '';
 }
@@ -37,6 +44,10 @@ export function getTagClasses(type: string) {
       return 'bg-palette-purple3 text-palette-purple12 border-palette-purple4';
     case 'tvos':
       return 'bg-palette-pink3 text-palette-pink12 border-palette-pink4';
+    case 'expo':
+      return 'bg-palette-purple3 text-palette-purple12 border-palette-purple4';
+    case 'dev-builds':
+      return 'bg-palette-gray3 text-palette-gray12 border-palette-gray4';
     case 'deprecated':
       return 'bg-palette-yellow2 text-palette-yellow12 border-palette-yellow4';
     case 'experimental':
@@ -47,7 +58,12 @@ export function getTagClasses(type: string) {
 }
 
 export const formatName = (name: PlatformName) => {
-  const cleanName = name.toLowerCase().replace('\n', '');
+  const cleanName = name.toLowerCase().replace('\n', '').trim();
+  if (cleanName === 'expo-go') {
+    return 'Expo Go';
+  } else if (cleanName === 'dev-builds') {
+    return 'Dev builds';
+  }
   if (cleanName.includes('ios')) {
     return cleanName.replace('ios', 'iOS');
   } else if (cleanName.includes('macos')) {

--- a/docs/ui/components/Tag/helpers.ts
+++ b/docs/ui/components/Tag/helpers.ts
@@ -1,6 +1,8 @@
 import { capitalize } from '~/common/utilities';
 import { PlatformName } from '~/types/common';
 
+const CLIENT_PLATFORM_TAGS = new Set(['expo-go', 'dev-builds']);
+
 export function getPlatformName(text: string): PlatformName {
   const lowerText = text.toLowerCase().trim();
   if (lowerText.includes('ios')) {
@@ -58,7 +60,7 @@ export function getTagClasses(type: string) {
 }
 
 export const isClientPlatformTag = (platform: string) =>
-  new Set(['expo-go', 'dev-builds']).has(platform.toLowerCase());
+  CLIENT_PLATFORM_TAGS.has(platform.toLowerCase());
 
 export const formatName = (name: PlatformName) => {
   const cleanName = name.toLowerCase().replace('\n', '').trim();

--- a/docs/ui/components/Tag/helpers.ts
+++ b/docs/ui/components/Tag/helpers.ts
@@ -57,14 +57,16 @@ export function getTagClasses(type: string) {
   }
 }
 
+export const isClientPlatformTag = (platform: string) =>
+  new Set(['expo-go', 'dev-builds']).has(platform.toLowerCase());
+
 export const formatName = (name: PlatformName) => {
   const cleanName = name.toLowerCase().replace('\n', '').trim();
-  if (cleanName === 'expo-go') {
+  if (cleanName.includes('expo-go')) {
     return 'Expo Go';
-  } else if (cleanName === 'dev-builds') {
+  } else if (cleanName.includes('dev-builds')) {
     return 'Dev builds';
-  }
-  if (cleanName.includes('ios')) {
+  } else if (cleanName.includes('ios')) {
     return cleanName.replace('ios', 'iOS');
   } else if (cleanName.includes('macos')) {
     return cleanName.replace('macos', 'macOS');


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18695

# How

<!--
How did you build this feature or fix this bug and why?
-->

* Add a utility function `isClientPlatformTag` to identify client-specific platforms and use it to filter out these tags from default platform lists in `APISectionPlatformTags.tsx`, ensuring only appropriate platforms are shown by default. 
* Update `PagePlatformTags.tsx` to display client platform tags ("Expo Go", "Dev builds") after standard platforms, and added tooltips with helpful explanations for these tags to improve user understanding.
* Modify `PlatformTag` to accept additional props and improve how it determines platform names, making the component more flexible and robust

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Run docs app locally using `yarn run dev`
- Take two pages, one that supports Expo Go and one that only supports Dev builds.
- For example, AppleAuthentication and Maps under unversioned SDK
- Update `platforms` frontmatter array to include `expo-go` and/or `dev-builds`
- Visit those pages in a browser to see the result. Hover over these tags to view the tooltip.

## Preview

<img width="2574" height="660" alt="CleanShot 2026-01-12 at 17 17 45@2x" src="https://github.com/user-attachments/assets/802bf29a-205a-4a76-b991-f3243de0a5ed" />

<img width="2426" height="722" alt="CleanShot 2026-01-12 at 17 17 49@2x" src="https://github.com/user-attachments/assets/cc742a2b-a5b2-4cc9-8b4f-8acc6820632e" />

<img width="2394" height="798" alt="CleanShot 2026-01-12 at 17 17 56@2x" src="https://github.com/user-attachments/assets/8944f763-7d3a-4a13-b2aa-8e4e2746b669" />

<img width="2438" height="782" alt="CleanShot 2026-01-12 at 17 18 00@2x" src="https://github.com/user-attachments/assets/d11aa976-2e08-441a-be57-14396b726021" />

<img width="1634" height="2166" alt="CleanShot 2026-01-12 at 17 19 08@2x" src="https://github.com/user-attachments/assets/f9a736fa-36b9-4ad8-9824-b50f9f862a21" />

These platform tags are not inherited by API properties. Example:

<img width="2680" height="2072" alt="CleanShot 2026-01-12 at 17 23 07@2x" src="https://github.com/user-attachments/assets/6b607df6-7c89-4f89-91ea-eea34e2285b7" />

<img width="2482" height="428" alt="CleanShot 2026-01-12 at 17 23 41@2x" src="https://github.com/user-attachments/assets/3c6bbac7-c788-4881-ac1d-6e976020ca77" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
