### PR TITLE
[expo][auth-session] fix failing tests

### DIFF
--- a/packages/expo/src/Expo.fx.web.tsx
+++ b/packages/expo/src/Expo.fx.web.tsx
@@ -2,6 +2,8 @@ import './winter';
 import './async-require';
 import 'expo/virtual/rsc';
 
+declare const global: typeof globalThis;
+
 // When users dangerously import a file inside of react-native, it breaks the web alias.
 // This is one of the most common, and cryptic web errors that users encounter.
 // This conditional side-effect provides a more helpful error message for debugging.

--- a/packages/expo/src/async-require/setupFastRefresh.ts
+++ b/packages/expo/src/async-require/setupFastRefresh.ts
@@ -1,5 +1,7 @@
 // This needs to run before the renderer initializes.
 
+declare const global: typeof globalThis & { [key: string]: any };
+
 const ReactRefreshRuntime = require('react-refresh/runtime');
 ReactRefreshRuntime.injectIntoGlobalHook(global);
 


### PR DESCRIPTION
# Why



auth-session tests currently fail with a TS error

```
 FAIL   Web  src/__tests__/AuthSession-test.web.ts
  ● Test suite failed to run

    ../expo/src/Expo.fx.web.tsx:12:36 - error TS2304: Cannot find name 'global'.

    12     !('__fbBatchedBridgeConfig' in global)
                                          ~~~~~~
    ../expo/src/Expo.fx.web.tsx:14:27 - error TS2304: Cannot find name 'global'.

    14     Object.defineProperty(global, '__fbBatchedBridgeConfig', {
                                 ~~~~~~

 FAIL   Node  src/__tests__/AuthSession-test.web.ts
  ● Test suite failed to run

    ../expo/src/Expo.fx.web.tsx:12:36 - error TS2304: Cannot find name 'global'.

    12     !('__fbBatchedBridgeConfig' in global)
                                          ~~~~~~
    ../expo/src/Expo.fx.web.tsx:14:27 - error TS2304: Cannot find name 'global'.

    14     Object.defineProperty(global, '__fbBatchedBridgeConfig', {
        
```

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- use updated typings

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- `et cp -a` checks okay all packages

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)