### PR TITLE
[docs] Clarify starter plan verbiage for cancellation effect in Billing docs

### DIFF
--- a/docs/pages/billing/faq.mdx
+++ b/docs/pages/billing/faq.mdx
@@ -38,7 +38,7 @@ To downgrade from the Starter to a Free plan, see [Cancel a plan](/billing/manag
 
 No. If you are subscribed to a paid plan and use up your included EAS Build credits, additional builds are billed using [usage-based pricing](/billing/usage-based-pricing/).
 
-If you cancel your subscription, the change takes effect after your current billing period ends. Once the paid subscription ends and your account is on the Free plan, you can use the Free plan's monthly quota (subject to its limits and reset schedule). See [Cancel a plan](/billing/manage/#cancel-a-plan) for more details.
+If you cancel your subscription, the Free plan will take effect after your current billing period ends. Once the paid subscription ends and your account is on the Free plan, you can use the Free plan's monthly quota (subject to its limits and reset schedule). See [Cancel a plan](/billing/manage/#cancel-a-plan) for more details.
 
 ### Can I transfer my unused free plan credits when upgrading to a paid subscription?
 

--- a/docs/pages/billing/faq.mdx
+++ b/docs/pages/billing/faq.mdx
@@ -34,6 +34,12 @@ To upgrade from the Free plan to the Starter plan, see [Upgrade to a new plan](/
 
 To downgrade from the Starter to a Free plan, see [Cancel a plan](/billing/manage/#cancel-a-plan).
 
+### I've run out of paid plan's EAS Build credits. Can I downgrade to the Free plan to use the free builds?
+
+No. If you are subscribed to a paid plan and use up your included EAS Build credits, additional builds are billed using [usage-based pricing](/billing/usage-based-pricing/).
+
+If you cancel your subscription, the change takes effect after your current billing period ends. Once the paid subscription ends and your account is on the Free plan, you can use the Free plan's monthly quota (subject to its limits and reset schedule). See [Cancel a plan](/billing/manage/#cancel-a-plan) for more details.
+
 ### Can I transfer my unused free plan credits when upgrading to a paid subscription?
 
 No, your free plan credits are not transferable to another subscription plan. All paid plans provide credits to enable priority builds for EAS Build and broader access to EAS Update through more monthly active users and extra bandwidth.

--- a/docs/pages/billing/faq.mdx
+++ b/docs/pages/billing/faq.mdx
@@ -34,7 +34,7 @@ To upgrade from the Free plan to the Starter plan, see [Upgrade to a new plan](/
 
 To downgrade from the Starter to a Free plan, see [Cancel a plan](/billing/manage/#cancel-a-plan).
 
-### I've run out of paid plan's EAS Build credits. Can I downgrade to the Free plan to use the free builds?
+### I've run out of paid plan's EAS Build credits. Can I downgrade to the Free plan to use the free build credits?
 
 No. If you are subscribed to a paid plan and use up your included EAS Build credits, additional builds are billed using [usage-based pricing](/billing/usage-based-pricing/).
 

--- a/docs/pages/billing/manage.mdx
+++ b/docs/pages/billing/manage.mdx
@@ -124,9 +124,9 @@ To cancel your plan, on [Billing](https://expo.dev/settings/billing), under **Ca
 
 <Tab label="From Starter to Free plan">
 
-Cancellation for the Starter plan takes effect immediately and resets your account's quota to the Free plan.
+Cancellation for the Starter plan takes effect after your current billing period ends.
 
-To cancel your plan, on [Billing](https://expo.dev/settings/billing), under **Cancel all subscriptions** and then click **Cancel Immediately**.
+To cancel your plan, on [Billing](https://expo.dev/settings/billing), under **Cancel all subscriptions**, follow the prompts to cancel your subscription.
 
 <ContentSpotlight
   alt="Billing page in EAS dashboard displays the Cancel Plan button to cancel a plan."


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18600

The Billing docs incorrectly stated that canceling the Starter plan takes effect immediately and resets your quota to the Free plan. This created confusion for users who run out of paid EAS Build credits and wonder if they can downgrade mid-billing-cycle to use Free plan builds.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Updated the Starter -> Free cancellation copy in `pages/billing/manage.mdx` to clarify cancellation takes effect after the current billing period ends.
-  Added a new Billing FAQ item in `pages/billing/faq.mdx` explaining that once paid plan credits are exhausted, additional builds are billed via usage-based pricing, and the Free plan quota applies only after the paid subscription ends (with internal links to the relevant docs) once the paid plan is cancelled.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
