### PR TITLE
[expo] change `global` for `globalThis` to fix failing `auth-session` tests

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Bump `react-server-dom-webpack` ([#41574](https://github.com/expo/expo/pull/41574) by [@kitten](https://github.com/kitten)) ([#41589](https://github.com/expo/expo/pull/41589) by [@kitten](https://github.com/kitten))
 - Bump to `@expo/metro@54.2.0` and `metro@0.83.3` ([#41142](https://github.com/expo/expo/pull/41142) by [@kitten](https://github.com/kitten))
 - Update `metro-source-map` import source in `expo/scripts/compose-source-maps` ([#41458](https://github.com/expo/expo/pull/41458) by [@kitten](https://github.com/kitten))
+- change `global` for `globalThis` to fix failing `auth-session` js tests ([#42083](https://github.com/expo/expo/pull/42083) by [@vonovak](https://github.com/vonovak))
 
 ### ⚠️ Notices
 

--- a/packages/expo/src/Expo.fx.web.tsx
+++ b/packages/expo/src/Expo.fx.web.tsx
@@ -9,9 +9,9 @@ import 'expo/virtual/rsc';
 if (__DEV__) {
   if (
     // Skip mocking if someone is shimming this value out.
-    !('__fbBatchedBridgeConfig' in global)
+    !('__fbBatchedBridgeConfig' in globalThis)
   ) {
-    Object.defineProperty(global, '__fbBatchedBridgeConfig', {
+    Object.defineProperty(globalThis, '__fbBatchedBridgeConfig', {
       get() {
         throw new Error(
           "Your web project is importing a module from 'react-native' instead of 'react-native-web'. Learn more: https://expo.fyi/fb-batched-bridge-config-web"

--- a/packages/expo/src/__tests__/__fbBatchedBridgeConfig-test.ts
+++ b/packages/expo/src/__tests__/__fbBatchedBridgeConfig-test.ts
@@ -6,14 +6,18 @@ jest.mock('../async-require/getDevServer');
 
 if (Platform.OS === 'web') {
   it('provides a helpful error message on web', () => {
+    const error =
+      /Your web project is importing a module from 'react-native' instead of 'react-native-web'/;
     // @ts-ignore
-    expect(() => global.__fbBatchedBridgeConfig).toThrow(
-      /Your web project is importing a module from 'react-native' instead of 'react-native-web'/
-    );
+    expect(() => global.__fbBatchedBridgeConfig).toThrow(error);
+    // @ts-ignore
+    expect(() => globalThis.__fbBatchedBridgeConfig).toThrow(error);
   });
 } else {
   it(`does not change the functionality of __fbBatchedBridgeConfig on native`, () => {
     // @ts-ignore
     expect(() => global.__fbBatchedBridgeConfig).not.toThrow();
+    // @ts-ignore
+    expect(() => globalThis.__fbBatchedBridgeConfig).not.toThrow();
   });
 }

--- a/packages/expo/src/async-require/asyncRequireModule.ts
+++ b/packages/expo/src/async-require/asyncRequireModule.ts
@@ -20,8 +20,8 @@ type DependencyMapPaths = { [moduleID: number | string]: unknown } | null;
 declare let __METRO_GLOBAL_PREFIX__: string;
 
 function maybeLoadBundle(moduleID: number, paths: DependencyMapPaths): void | Promise<void> {
-  const loadBundle: (bundlePath: unknown) => Promise<void> = (global as any)[
-    `${__METRO_GLOBAL_PREFIX__}__loadBundleAsync`
+  const loadBundle: (bundlePath: unknown) => Promise<void> = (globalThis as any)[
+    `${__METRO_GLOBAL_PREFIX__ ?? ''}__loadBundleAsync`
   ];
 
   if (loadBundle != null) {

--- a/packages/expo/src/async-require/index.ts
+++ b/packages/expo/src/async-require/index.ts
@@ -7,4 +7,4 @@
 import { buildAsyncRequire } from './buildAsyncRequire';
 
 // @ts-ignore: ignore the global which may not always be defined in jest environments.
-global[`${global.__METRO_GLOBAL_PREFIX__ ?? ''}__loadBundleAsync`] = buildAsyncRequire();
+globalThis[`${globalThis.__METRO_GLOBAL_PREFIX__ ?? ''}__loadBundleAsync`] = buildAsyncRequire();

--- a/packages/expo/src/async-require/setupFastRefresh.ts
+++ b/packages/expo/src/async-require/setupFastRefresh.ts
@@ -1,7 +1,7 @@
 // This needs to run before the renderer initializes.
 
 const ReactRefreshRuntime = require('react-refresh/runtime');
-ReactRefreshRuntime.injectIntoGlobalHook(global);
+ReactRefreshRuntime.injectIntoGlobalHook(globalThis);
 
 const Refresh = {
   performFullRefresh() {
@@ -27,4 +27,5 @@ const Refresh = {
 
 // The metro require polyfill can not have dependencies (applies for all polyfills).
 // Expose `Refresh` by assigning it to global to make it available in the polyfill.
-global[(global.__METRO_GLOBAL_PREFIX__ || '') + '__ReactRefresh'] = Refresh;
+// @ts-ignore: ignore the global which may not always be defined in jest environments.
+globalThis[(globalThis.__METRO_GLOBAL_PREFIX__ ?? '') + '__ReactRefresh'] = Refresh;


### PR DESCRIPTION
# Why



auth-session tests currently fail with a TS error

```
 FAIL   Web  src/__tests__/AuthSession-test.web.ts
  ● Test suite failed to run

    ../expo/src/Expo.fx.web.tsx:12:36 - error TS2304: Cannot find name 'global'.

    12     !('__fbBatchedBridgeConfig' in global)
                                          ~~~~~~
    ../expo/src/Expo.fx.web.tsx:14:27 - error TS2304: Cannot find name 'global'.

    14     Object.defineProperty(global, '__fbBatchedBridgeConfig', {
                                 ~~~~~~

 FAIL   Node  src/__tests__/AuthSession-test.web.ts
  ● Test suite failed to run

    ../expo/src/Expo.fx.web.tsx:12:36 - error TS2304: Cannot find name 'global'.

    12     !('__fbBatchedBridgeConfig' in global)
                                          ~~~~~~
    ../expo/src/Expo.fx.web.tsx:14:27 - error TS2304: Cannot find name 'global'.

    14     Object.defineProperty(global, '__fbBatchedBridgeConfig', {
        
```

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- use updated typings

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- `et cp -a` checks okay all packages

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)