### PR TITLE
[ncl] Fix camera record/pause screen

### DIFF
--- a/apps/native-component-list/src/screens/Camera/CameraScreenPauseRecording.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreenPauseRecording.tsx
@@ -16,6 +16,7 @@ export default function CameraScreenPauseRecording() {
   const recordAsync = async () => {
     if (recording) {
       camera.current?.stopRecording();
+      return;
     }
     setRecording(true);
     const result = await camera.current?.recordAsync();
@@ -32,25 +33,33 @@ export default function CameraScreenPauseRecording() {
   return (
     <View style={styles.screen}>
       {!uri ? (
-        <CameraView
-          ref={camera}
-          style={StyleSheet.absoluteFillObject}
-          facing="back"
-          active
-          mode="video"
-          videoQuality="2160p"
-          pictureSize="1920x1080"
-        />
+        <>
+          <CameraView
+            ref={camera}
+            style={StyleSheet.absoluteFillObject}
+            facing="back"
+            active
+            mode="video"
+            videoQuality="2160p"
+            pictureSize="1920x1080"
+          />
+          <View style={styles.controls}>
+            <Button title={`${recording ? 'Stop' : 'Start'} Recording`} onPress={recordAsync} />
+            {uri && <Button title="Clear Recording" onPress={() => setUri('')} />}
+            {recording && (
+              <Button
+                title={`${paused ? 'Resume' : 'Pause'} Recording`}
+                onPress={toggleRecording}
+              />
+            )}
+          </View>
+        </>
       ) : (
-        <VideoView player={player} style={{ width, aspectRatio: 1 }} />
+        <>
+          <VideoView player={player} style={{ width, aspectRatio: 1 }} />
+          <Button title="Go back to camera" onPress={() => setUri('')} />
+        </>
       )}
-      <View style={styles.controls}>
-        <Button title={`${recording ? 'Stop' : 'Start'} Recording`} onPress={recordAsync} />
-        {uri && <Button title="Clear Recording" onPress={() => setUri('')} />}
-        {recording && (
-          <Button title={`${paused ? 'Resume' : 'Pause'} Recording`} onPress={toggleRecording} />
-        )}
-      </View>
     </View>
   );
 }


### PR DESCRIPTION
# Why

Once the recording is finished the app shows the playback screen for a second and goes back right away on android.

# How

In the recording toggle return when recording is finished. Add a separate go back button.

# Test Plan

Tested in BareExpo on Android
