### PR TITLE
[contacts] create CNContactStore lazily

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Added contact image uri validation. ([#39658](https://github.com/expo/expo/pull/39658) by [@hryhoriiK97](https://github.com/hryhoriiK97))
+- [ios] create `CNContactStore` lazily ([#42096](https://github.com/expo/expo/pull/42096) by [@vonovak](https://github.com/vonovak))
 - [Android] Removed unused `androidx.annotation:annotation` dependency ([#39761](https://github.com/expo/expo/pull/39761) by [@lukmccall](https://github.com/lukmccall))
 
 ## 15.0.11 - 2025-12-05

--- a/packages/expo-contacts/ios/ContactsModule.swift
+++ b/packages/expo-contacts/ios/ContactsModule.swift
@@ -5,7 +5,7 @@ import ContactsUI
 let onContactsChangeEventName = "onContactsChange"
 
 public class ContactsModule: Module, OnContactPickingResultHandler {
-  private let contactStore = CNContactStore()
+  private lazy var contactStore = CNContactStore()
   private let delegate = ContactControllerDelegate()
   private var presentingViewController: UIViewController?
   private var contactPickerDelegate: ContactPickerControllerDelegate?


### PR DESCRIPTION
# Why

Refactored the `contactStore` property in `ContactsModule` to use lazy initialization, which only creates the `CNContactStore` instance when it's first accessed rather than at initialization time.
For me, I saw initialization times between 0.5 and 3ms on device, which isn't much but if multiple modules were to do this, it could add up, so decided to make the change.

motivated by https://github.com/expo/expo/commit/4e408c1bfe82a6b84c6d37deb853c86df650e40c

# How

This defers the creation of the contact store until it's actually needed.

# Test Plan

- bare expo on device

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)