### PR TITLE
[docs] Improve EAS Submit introduction

### DIFF
--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -12,7 +12,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 
-**EAS Submit** is a cloud service from EAS (Expo Application Services) for submitting Android and iOS binaries directly to the Google Play Store and Apple App Store without using Google Play Console, App Store Connect or Transporter.
+**EAS Submit** is a hosted service from EAS (Expo Application Services) for submitting Android and iOS binaries directly to the Google Play Store and Apple App Store without using Google Play Console, App Store Connect or Transporter.
 
 EAS Submit automates the final step of mobile app distribution by sending your built binaries to Google and Apple for store review. It removes the need for manual uploads and reduces errors that happen during store submission.
 

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -63,7 +63,6 @@ EAS Submit helps teams:
 - Does this mean production? No &mdash; a TestFlight build is not automatically released to the Apple App Store.
 - How production happens: You must log into App Store Connect, choose the build, and submit it for App Review before it can be released to production.
 
-
 ## When not to use EAS Submit
 
 EAS Submit is not needed when:

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -36,22 +36,16 @@ Build and submit in one step:
 
 EAS Submit helps teams:
 
+- Upload Android binaries to [Google Play Console](https://play.google.com/console/about/)
+- Upload iOS binaries to [App Store Connect](https://developer.apple.com/app-store-connect/)
 - Avoid manual uploads through Play Console, App Store Connect or Transporter
 - Submit builds from [CI or automated workflows](/eas/workflows/pre-packaged-jobs/#submit)
 - Standardize release processes via [eas.json](/eas/json/) config file
 - Reduce human errors during submission
 
-## What EAS Submit does
-
-EAS Submit enables teams to:
-
-- Upload Android binaries to [Google Play Console](https://play.google.com/console/about/)
-- Upload iOS binaries to [App Store Connect](https://developer.apple.com/app-store-connect/)
-- Apply submission profiles for different environments
-
 ## How EAS Submit works
 
-**EAS Submit** delivers your app to the app stores' distribution pipelines (a chosen track on Google Play Store or [TestFlight](https://developer.apple.com/testflight/) for iOS), following the [default submission behavior for app stores](/build/automate-submissions/#default-submission-behavior-for-app-stores). It queues up your app for distribution on the Play Store Console and App Store Connect, and then you can log into those sites to send your apps off to review, so then they can be distributed to your users.
+**EAS Submit** delivers your app to the app stores' distribution pipelines (a chosen track on Google Play Store or [TestFlight](https://developer.apple.com/testflight/) for iOS), following the [default submission behavior for app stores](/build/automate-submissions/#default-submission-behavior-for-app-stores). It queues up your app for distribution on the Google Play Console and App Store Connect, and then you can log into those sites to send your apps off to review, so then they can be distributed to your users.
 
 ### Android (Google Play Store)
 
@@ -71,7 +65,7 @@ EAS Submit enables teams to:
 
 ## When to use EAS Submit
 
-Use EAS Submit when you want to:
+EAS Submit is useful when:
 
 - Submit builds to the app stores without installing or interacting with upload tools
 - Automate release workflows in CI

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -63,14 +63,6 @@ EAS Submit helps teams:
 - Does this mean production? No &mdash; a TestFlight build is not automatically released to the Apple App Store.
 - How production happens: You must log into App Store Connect, choose the build, and submit it for App Review before it can be released to production.
 
-## When to use EAS Submit
-
-EAS Submit is useful when:
-
-- Submit builds to the app stores without installing or interacting with upload tools
-- Automate release workflows in CI
-- Promote consistent submission processes across the team
-- Manage multiple release channels from one configuration
 
 ## When not to use EAS Submit
 

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -1,7 +1,7 @@
 ---
 title: EAS Submit
 sidebar_title: Introduction
-description: EAS Submit is a hosted service for uploading and submitting an app binary to the app stores.
+description: EAS Submit is Expo's cloud service for submitting Android and iOS app binaries to the Google Play Store and Apple App Store from the command line.
 ---
 
 import { AppleAppStoreIcon } from '@expo/styleguide-icons/custom/AppleAppStoreIcon';
@@ -9,31 +9,135 @@ import { GoogleAppStoreIcon } from '@expo/styleguide-icons/custom/GoogleAppStore
 import { Settings01Icon } from '@expo/styleguide-icons/outline/Settings01Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { Collapsible } from '~/ui/components/Collapsible';
+import { Terminal } from '~/ui/components/Snippet';
 
-**EAS Submit** is a hosted service for submitting your app binaries to the Google Play Store and the Apple App Store.
+**Expo Application Services (EAS) Submit** is Expo's cloud service for submitting Android and iOS binaries directly to the Google Play Store and Apple App Store without using Google Play Console, App Store Connect or Transporter.
 
-It makes submitting your apps simple and easy by creating and handling submission credentials and running the submission process. You can trigger a submission from a CLI command, after a build is finished, or from a CI/CD service. It's the fastest way to take Android and iOS builds and submit them to the app stores.
+EAS Submit automates the final step of mobile app distribution by sending your built binaries to Google and Apple for store review. It removes the need for manual uploads and reduces errors that happen during store submission. It works with apps built with [EAS Build](/build/introduction/) or locally and supports multiple submission profiles. You can trigger a submission from a CLI command, after a build is finished, or from a CI/CD service. This gives teams a faster, more consistent release workflow across both platforms.
 
-### How does EAS Submit work?
+## Quick example
 
-**EAS Submit** delivers your app to the app stores' distribution pipelines (a chosen track on Google Play or TestFlight for iOS), following the [default submission behavior for app stores](/build/automate-submissions/#default-submission-behavior-for-app-stores). It queues up your app for distribution on the Play Store Console and App Store Connect, and then you can log into those sites to send your apps off to review, so then they can be distributed to your users.
+Submit an Android build:
 
-#### Android (Google Play Store)
+<Terminal cmd={['$ eas submit --platform android']} />
+
+Submit an iOS build:
+
+<Terminal cmd={['$ eas submit --platform ios']} />
+
+Build and submit in one step:
+
+<Terminal cmd={['$ eas build --platform ios --auto-submit']} />
+
+## Why teams use EAS Submit
+
+EAS Submit helps teams:
+
+- Avoid manual uploads through Play Console, App Store Connect or Transporter
+- Submit builds from [CI or automated workflows](/eas/workflows/pre-packaged-jobs/#submit)
+- Standardize release processes via [eas.json](/eas/json/) config file
+- Reduce human errors during submission
+
+## What EAS Submit does
+
+EAS Submit enables teams to:
+
+- Upload Android binaries to [Google Play Console](https://play.google.com/console/about/)
+- Upload iOS binaries to [App Store Connect](https://developer.apple.com/app-store-connect/)
+- Apply submission profiles for different environments
+
+## How EAS Submit works
+
+**EAS Submit** delivers your app to the app stores' distribution pipelines (a chosen track on Google Play Store or [TestFlight](https://developer.apple.com/testflight/) for iOS), following the [default submission behavior for app stores](/build/automate-submissions/#default-submission-behavior-for-app-stores). It queues up your app for distribution on the Play Store Console and App Store Connect, and then you can log into those sites to send your apps off to review, so then they can be distributed to your users.
+
+### Android (Google Play Store)
 
 - Where it goes: EAS Submit uploads the build to Google Play Console.
 - What happens then: The build is placed in the track you specify (internal, alpha, beta, or production).
+- First-time submissions: Google requires you to upload your app manually at least once before API-based submissions work.
 - Does this mean production?
   - If you use internal, alpha, or beta, the app is only available to testers in that track.
   - If you explicitly choose production, then yes &mdash; once Google approves the release, it will be available to all users.
 
-#### iOS (App Store Connect/TestFlight)
+### iOS (App Store Connect/TestFlight)
 
 - Where it goes: EAS Submit uploads the build to App Store Connect.
 - What happens then: The build becomes available in TestFlight.
 - Does this mean production?: No &mdash; a TestFlight build is not automatically released to the Apple App Store.
-- How production happens: You must log into Apple App Store Connect, choose the build, and submit it for App Review before it can be released to production.
+- How production happens: You must log into App Store Connect, choose the build, and submit it for App Review before it can be released to production.
 
-### Get started
+## When to use EAS Submit
+
+Use EAS Submit when you want to:
+
+- Submit builds to the app stores without installing or interacting with upload tools
+- Automate release workflows in CI
+- Promote consistent submission processes across the team
+- Manage multiple release channels from one configuration
+
+<Collapsible summary="Do you want to upload a binary to a store?">
+
+Yes, use EAS Submit.
+
+</Collapsible>
+
+<Collapsible summary="Did you build your binary with EAS Build or locally?">
+
+Either works. EAS Submit accepts any valid **.aab** (Android App Bundle) or **.ipa** (iOS App Archive) file.
+
+</Collapsible>
+
+<Collapsible summary="Do you want to automate submissions from CI?">
+
+Yes, use EAS Submit with [EAS Workflows](/eas/workflows/get-started/).
+
+</Collapsible>
+
+<Collapsible summary="Do you need to handle metadata or screenshots?">
+
+For Google Play Store, you must configure these manually. For App Store Connect, you can use [EAS Metadata](/eas/metadata/) to handle metadata automatically.
+
+</Collapsible>
+
+## When not to use EAS Submit
+
+EAS Submit is not needed when:
+
+- You are testing locally and not ready for a store submission
+- You do not have a store listing configured yet
+
+In these cases, preparing your store listing is required.
+
+## FAQ
+
+<Collapsible summary="Can I submit builds that were not built with EAS Build?">
+
+Yes. Any valid binary can be submitted.
+
+</Collapsible>
+
+<Collapsible summary="Can I use EAS Submit for TestFlight?">
+
+Yes. Submitting an iOS binary creates a TestFlight build.
+
+</Collapsible>
+
+<Collapsible summary="Can I use EAS Submit inside EAS Workflows?">
+
+Yes. Submit commands can be triggered in automated pipelines. For more information, see [EAS Workflows pre-packaged jobs](/eas/workflows/pre-packaged-jobs/#submit).
+
+</Collapsible>
+
+<Collapsible summary="What credentials do I need?">
+
+For Android, a Google Play Console developer account and a Google Service Account Key are required. For iOS, an Apple developer account and [`ascAppId`](/eas/json/#ascappid) (Apple App Store Connect unique application ID) are required.
+
+For more information, see [Google's Play Store's prerequisites](/submit/android/#prerequisites) and [Apple's App Store prerequisites](/submit/ios/#prerequisites).
+
+</Collapsible>
+
+## Get started
 
 <BoxLink
   title="Submit to the Google Play Store"

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -14,7 +14,9 @@ import { Terminal } from '~/ui/components/Snippet';
 
 **Expo Application Services (EAS) Submit** is Expo's cloud service for submitting Android and iOS binaries directly to the Google Play Store and Apple App Store without using Google Play Console, App Store Connect or Transporter.
 
-EAS Submit automates the final step of mobile app distribution by sending your built binaries to Google and Apple for store review. It removes the need for manual uploads and reduces errors that happen during store submission. It works with apps built with [EAS Build](/build/introduction/) or locally and supports multiple submission profiles. You can trigger a submission from a CLI command, after a build is finished, or from a CI/CD service. This gives teams a faster, more consistent release workflow across both platforms.
+EAS Submit automates the final step of mobile app distribution by sending your built binaries to Google and Apple for store review. It removes the need for manual uploads and reduces errors that happen during store submission.
+
+EAS Submit works with apps built with [EAS Build](/build/introduction/) or locally and supports multiple submission profiles. You can trigger a submission from a CLI command, after a build is finished, or from a CI/CD service. This gives teams a faster, more consistent release workflow across both platforms.
 
 ## Quick example
 
@@ -76,50 +78,6 @@ Use EAS Submit when you want to:
 - Promote consistent submission processes across the team
 - Manage multiple release channels from one configuration
 
-<Collapsible summary="Did you build your binary with EAS Build or locally?">
-
-Either works. EAS Submit accepts any valid **.aab** (Android App Bundle) or **.ipa** (iOS App Archive) file.
-
-For builds created with EAS Build, run `eas submit` and select a build from the list or let it use the latest build automatically.
-
-For local builds, use the `--path` flag to specify the binary:
-
-<Terminal
-  cmd={[
-    '$ eas submit --platform android --path ./my-app.aab',
-    '',
-    '$ eas submit --platform ios --path ./my-app.ipa',
-  ]}
-/>
-
-Local builds must be signed with the correct credentials before submission.
-
-</Collapsible>
-
-<Collapsible summary="Do you want to automate submissions from CI?">
-
-Yes. EAS Submit works in CI environments and integrates with [EAS Workflows](/eas/workflows/get-started/).
-
-To build and submit in one step, use the `--auto-submit` flag:
-
-<Terminal cmd={['$ eas build --platform ios --auto-submit']} />
-
-For CI pipelines, use `--non-interactive` to skip prompts and `--latest` to automatically select the most recent build:
-
-<Terminal cmd={['$ eas submit --platform android --latest --non-interactive']} />
-
-</Collapsible>
-
-<Collapsible summary="Do you need to handle metadata or screenshots?">
-
-EAS Submit uploads your binary but does not manage store listing metadata, screenshots, or release notes.
-
-For Google Play Store, configure your store listing directly in [Google Play Console](https://play.google.com/console/about/) before submitting.
-
-For Apple App Store, you can use [EAS Metadata](/eas/metadata/) to automate app information and localized descriptions.
-
-</Collapsible>
-
 ## When not to use EAS Submit
 
 EAS Submit is not needed when:
@@ -133,7 +91,11 @@ In these cases, preparing your store listing is required.
 
 <Collapsible summary="Can I submit builds that were not built with EAS Build?">
 
-Yes. Use the `--path` flag to submit any valid binary:
+Yes. EAS Submit accepts any valid **.aab** (Android App Bundle) or **.ipa** (iOS App Archive) file.
+
+For builds created with EAS Build, run `eas submit` and select a build from the list or let it use the latest build automatically.
+
+For local builds, use the `--path` flag to specify the binary:
 
 <Terminal
   cmd={[
@@ -155,9 +117,9 @@ Once processed, you can distribute the build to internal testers immediately or 
 
 </Collapsible>
 
-<Collapsible summary="Can I use EAS Submit inside EAS Workflows?">
+<Collapsible summary="Can I use EAS Submit inside EAS Workflows or from other CI/CD pipelines?">
 
-Yes. You can add a submit job to your workflow configuration. For example:
+Yes. EAS Submit works in CI environments and integrates with [EAS Workflows](/eas/workflows/get-started/). You can add a submit job to your workflow configuration. For example:
 
 ```yaml
 jobs:
@@ -170,6 +132,20 @@ jobs:
 ```
 
 For more information, see [EAS Workflows pre-packaged jobs](/eas/workflows/pre-packaged-jobs/#submit).
+
+For CI pipelines, you can also use the `--non-interactive` flag to skip prompts and `--latest` to automatically select the most recent build:
+
+<Terminal cmd={['$ eas submit --platform android --latest --non-interactive']} />
+
+</Collapsible>
+
+<Collapsible summary="Do I need to handle metadata or screenshots?">
+
+EAS Submit uploads your binary but does not manage store listing metadata, screenshots, or release notes.
+
+For Google Play Store, configure your store listing directly in [Google Play Console](https://play.google.com/console/about/) before submitting.
+
+For Apple App Store, you can use [EAS Metadata](/eas/metadata/) to automate app information and localized descriptions.
 
 </Collapsible>
 

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -131,7 +131,7 @@ Yes. Submit commands can be triggered in automated pipelines. For more informati
 
 <Collapsible summary="What credentials do I need?">
 
-For Android, a Google Play Console developer account and a Google Service Account Key are required. For iOS, an Apple developer account and [`ascAppId`](/eas/json/#ascappid) (Apple App Store Connect unique application ID) are required.
+For Android, a Google Play Console developer account and a Google Service Account Key are required. For iOS, an Apple Developer account and [`ascAppId`](/eas/json/#ascappid) (Apple App Store Connect unique application ID) are required.
 
 For more information, see [Google's Play Store's prerequisites](/submit/android/#prerequisites) and [Apple's App Store prerequisites](/submit/ios/#prerequisites).
 

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -1,7 +1,7 @@
 ---
 title: EAS Submit
 sidebar_title: Introduction
-description: EAS Submit is Expo's cloud service for submitting Android and iOS app binaries to the Google Play Store and Apple App Store from the command line.
+description: EAS Submit is a hosted service for submitting Android and iOS app binaries to the Google Play Store and Apple App Store from the command line.
 ---
 
 import { AppleAppStoreIcon } from '@expo/styleguide-icons/custom/AppleAppStoreIcon';

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -76,27 +76,47 @@ Use EAS Submit when you want to:
 - Promote consistent submission processes across the team
 - Manage multiple release channels from one configuration
 
-<Collapsible summary="Do you want to upload a binary to a store?">
-
-Yes, use EAS Submit.
-
-</Collapsible>
-
 <Collapsible summary="Did you build your binary with EAS Build or locally?">
 
 Either works. EAS Submit accepts any valid **.aab** (Android App Bundle) or **.ipa** (iOS App Archive) file.
+
+For builds created with EAS Build, run `eas submit` and select a build from the list or let it use the latest build automatically.
+
+For local builds, use the `--path` flag to specify the binary:
+
+<Terminal
+  cmd={[
+    '$ eas submit --platform android --path ./my-app.aab',
+    '',
+    '$ eas submit --platform ios --path ./my-app.ipa',
+  ]}
+/>
+
+Local builds must be signed with the correct credentials before submission.
 
 </Collapsible>
 
 <Collapsible summary="Do you want to automate submissions from CI?">
 
-Yes, use EAS Submit with [EAS Workflows](/eas/workflows/get-started/).
+Yes. EAS Submit works in CI environments and integrates with [EAS Workflows](/eas/workflows/get-started/).
+
+To build and submit in one step, use the `--auto-submit` flag:
+
+<Terminal cmd={['$ eas build --platform ios --auto-submit']} />
+
+For CI pipelines, use `--non-interactive` to skip prompts and `--latest` to automatically select the most recent build:
+
+<Terminal cmd={['$ eas submit --platform android --latest --non-interactive']} />
 
 </Collapsible>
 
 <Collapsible summary="Do you need to handle metadata or screenshots?">
 
-For Google Play Store, you must configure these manually. For App Store Connect, you can use [EAS Metadata](/eas/metadata/) to handle metadata automatically.
+EAS Submit uploads your binary but does not manage store listing metadata, screenshots, or release notes.
+
+For Google Play Store, configure your store listing directly in [Google Play Console](https://play.google.com/console/about/) before submitting.
+
+For Apple App Store, you can use [EAS Metadata](/eas/metadata/) to automate app information and localized descriptions.
 
 </Collapsible>
 
@@ -113,25 +133,51 @@ In these cases, preparing your store listing is required.
 
 <Collapsible summary="Can I submit builds that were not built with EAS Build?">
 
-Yes. Any valid binary can be submitted.
+Yes. Use the `--path` flag to submit any valid binary:
+
+<Terminal
+  cmd={[
+    '$ eas submit --platform android --path ./my-app.aab',
+    '',
+    '$ eas submit --platform ios --path ./my-app.ipa',
+  ]}
+/>
+
+The binary must be correctly signed. For Android, this means a release keystore. For iOS, this means a distribution certificate and provisioning profile.
 
 </Collapsible>
 
 <Collapsible summary="Can I use EAS Submit for TestFlight?">
 
-Yes. Submitting an iOS binary creates a TestFlight build.
+Yes. All iOS submissions through EAS Submit are uploaded to App Store Connect and appear in TestFlight after processing. Processing typically takes 10-15 minutes but can vary.
+
+Once processed, you can distribute the build to internal testers immediately or add external testers after a brief Beta App Review. To release to the App Store, you must manually submit the build for App Review through App Store Connect.
 
 </Collapsible>
 
 <Collapsible summary="Can I use EAS Submit inside EAS Workflows?">
 
-Yes. Submit commands can be triggered in automated pipelines. For more information, see [EAS Workflows pre-packaged jobs](/eas/workflows/pre-packaged-jobs/#submit).
+Yes. You can add a submit job to your workflow configuration. For example:
+
+```yaml
+jobs:
+  submit_ios_to_store:
+    type: submit
+    params:
+      platform: ios
+    after:
+      - build_ios
+```
+
+For more information, see [EAS Workflows pre-packaged jobs](/eas/workflows/pre-packaged-jobs/#submit).
 
 </Collapsible>
 
 <Collapsible summary="What credentials do I need?">
 
-For Android, a Google Play Console developer account and a Google Service Account Key are required. For iOS, an Apple Developer account and [`ascAppId`](/eas/json/#ascappid) (Apple App Store Connect unique application ID) are required.
+For Android, you need a [Google Service Account Key](/submit/android/#creating-a-google-service-account) with access to your app in Google Play Console. Your app must be uploaded manually at least once before API submissions work.
+
+For iOS, you need an Apple Developer account. EAS Submit requires your [`ascAppId`](/eas/json/#ascappid) (App Store Connect app ID) and will prompt for your Apple ID credentials or use an App Store Connect API Key if configured.
 
 For more information, see [Google's Play Store's prerequisites](/submit/android/#prerequisites) and [Apple's App Store prerequisites](/submit/ios/#prerequisites).
 

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -81,7 +81,7 @@ EAS Submit is not needed when:
 
 Set up your store listing first before using EAS Submit.
 
-## FAQ
+## Frequently asked questions (FAQ)
 
 <Collapsible summary="Can I submit builds that were not built with EAS Build?">
 

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -60,7 +60,7 @@ EAS Submit helps teams:
 
 - Where it goes: EAS Submit uploads the build to App Store Connect.
 - What happens then: The build becomes available in TestFlight.
-- Does this mean production?: No &mdash; a TestFlight build is not automatically released to the Apple App Store.
+- Does this mean production? No &mdash; a TestFlight build is not automatically released to the Apple App Store.
 - How production happens: You must log into App Store Connect, choose the build, and submit it for App Review before it can be released to production.
 
 ## When to use EAS Submit

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -12,7 +12,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 
-**Expo Application Services (EAS) Submit** is Expo's cloud service for submitting Android and iOS binaries directly to the Google Play Store and Apple App Store without using Google Play Console, App Store Connect or Transporter.
+**EAS Submit** is a cloud service from EAS (Expo Application Services) for submitting Android and iOS binaries directly to the Google Play Store and Apple App Store without using Google Play Console, App Store Connect or Transporter.
 
 EAS Submit automates the final step of mobile app distribution by sending your built binaries to Google and Apple for store review. It removes the need for manual uploads and reduces errors that happen during store submission.
 

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -37,7 +37,7 @@ Build and submit in one step:
 EAS Submit helps teams:
 
 - Upload Android binaries to [Google Play Console](https://play.google.com/console/about/)
-- Upload iOS binaries to [App Store Connect](https://developer.apple.com/app-store-connect/)
+- Upload iOS binaries to [Apple App Store](https://developer.apple.com/app-store-connect/)
 - Avoid manual uploads through Play Console, App Store Connect or Transporter
 - Submit builds from [CI or automated workflows](/eas/workflows/pre-packaged-jobs/#submit)
 - Standardize release processes via [eas.json](/eas/json/) config file

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -18,7 +18,7 @@ EAS Submit automates the final step of mobile app distribution by sending your b
 
 EAS Submit works with apps built with [EAS Build](/build/introduction/) or locally and supports multiple submission profiles. You can trigger a submission from a CLI command, after a build is finished, or from a CI/CD service. This gives teams a faster, more consistent release workflow across both platforms.
 
-## Quick example
+## Quick start
 
 Submit an Android build:
 

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -85,7 +85,7 @@ EAS Submit is not needed when:
 - You are testing locally and not ready for a store submission
 - You do not have a store listing configured yet
 
-In these cases, preparing your store listing is required.
+Set up your store listing first before using EAS Submit.
 
 ## FAQ
 

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -10,6 +10,7 @@ import { Settings01Icon } from '@expo/styleguide-icons/outline/Settings01Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { Terminal } from '~/ui/components/Snippet';
 
 **EAS Submit** is a hosted service from EAS (Expo Application Services) for submitting Android and iOS binaries directly to the Google Play Store and Apple App Store without using Google Play Console, App Store Connect or Transporter.
@@ -54,23 +55,15 @@ Build and submit in one step:
 
 ## When to use EAS Submit
 
-Use EAS Submit when you want to:
-
-- Upload Android binaries to [Google Play Console](https://play.google.com/console/about/)
-- Upload iOS binaries to [Apple App Store](https://developer.apple.com/app-store-connect/)
-- Avoid manual uploads through Play Console, App Store Connect or Transporter
-- Submit builds from [CI or automated workflows](/eas/workflows/pre-packaged-jobs/#submit)
-- Standardize release processes via [eas.json](/eas/json/) config file
-- Reduce human errors during submission
-
-## When not to use EAS Submit
-
-You may not need EAS Submit when:
-
-- You are testing locally and not ready for a store submission
-- You do not have a store listing configured yet
-
-Set up your store listing first before using EAS Submit.
+| Scenario                                                                                                                                                   | Recommendation |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| Upload app binaries to [Google Play Console](https://play.google.com/console/about/) and [Apple App Store](https://developer.apple.com/app-store-connect/) | <YesIcon />    |
+| Avoid manual uploads through Play Console, App Store Connect or Transporter                                                                                | <YesIcon />    |
+| Submit builds from [CI or automated workflows](/eas/workflows/pre-packaged-jobs/#submit)                                                                   | <YesIcon />    |
+| Standardize release processes via [eas.json](/eas/json/) config file                                                                                       | <YesIcon />    |
+| Reduce human errors during submission                                                                                                                      | <YesIcon />    |
+| Testing locally and not ready for a store submission                                                                                                       | <NoIcon />     |
+| Do not have a store listing configured yet for Google Play Store                                                                                           | <NoIcon />     |
 
 ## Frequently asked questions (FAQ)
 

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -58,7 +58,7 @@ Build and submit in one step:
 | Scenario                                                                                                                                                   | Recommendation |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
 | Upload app binaries to [Google Play Console](https://play.google.com/console/about/) and [Apple App Store](https://developer.apple.com/app-store-connect/) | <YesIcon />    |
-| Upload iOS app binaries on non-macOS machines    | <YesIcon />    |
+| Upload iOS app binaries on non-macOS machines                                                                                                              | <YesIcon />    |
 | Avoid manual uploads through Play Console, App Store Connect or Transporter                                                                                | <YesIcon />    |
 | Submit builds from [CI or automated workflows](/eas/workflows/pre-packaged-jobs/#submit)                                                                   | <YesIcon />    |
 | Standardize release processes via [eas.json](/eas/json/) config file                                                                                       | <YesIcon />    |

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -34,7 +34,7 @@ Build and submit in one step:
 
 ## Why teams use EAS Submit
 
-EAS Submit helps teams:
+EAS Submit helps teams to:
 
 - Upload Android binaries to [Google Play Console](https://play.google.com/console/about/)
 - Upload iOS binaries to [Apple App Store](https://developer.apple.com/app-store-connect/)

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -144,6 +144,15 @@ For more information, see [Google's Play Store's prerequisites](/submit/android/
 
 </Collapsible>
 
+<Collapsible summary="How do I know why my submission failed?">
+
+To understand why your EAS Submit submission failed, open the submission details page in the [EAS dashboard](https://expo.dev/accounts/[account]/projects/[project]/submissions):
+
+- Use the logs provided on the submission details page to understand the error.
+- Look for ["Build Annotations" bubble](https://expo.dev/changelog/2023-12-01-build-annotations) if there is one. These highlight common failure reasons and suggested fixes directly in the logs.
+
+</Collapsible>
+
 ## Get started
 
 <BoxLink

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -130,7 +130,7 @@ For Apple App Store, you can use [EAS Metadata](/eas/metadata/) to automate app 
 
 <Collapsible summary="What credentials do I need?">
 
-For Android, you need a [Google Service Account Key](/submit/android/#creating-a-google-service-account) with access to your app in Google Play Console.
+For Android, you need a [Google Service Account Key](/submit/android/#creating-a-google-service-account) with access to your app in Google Play Console. Your app must be uploaded manually at least once before API submissions work.
 
 For iOS, you need an Apple Developer account. EAS Submit requires your [`ascAppId`](/eas/json/#ascappid) (App Store Connect app ID) and will prompt for your Apple ID credentials or use an App Store Connect API Key if configured.
 

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -58,6 +58,7 @@ Build and submit in one step:
 | Scenario                                                                                                                                                   | Recommendation |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
 | Upload app binaries to [Google Play Console](https://play.google.com/console/about/) and [Apple App Store](https://developer.apple.com/app-store-connect/) | <YesIcon />    |
+| Upload iOS app binaries on non-macOS machines    | <YesIcon />    |
 | Avoid manual uploads through Play Console, App Store Connect or Transporter                                                                                | <YesIcon />    |
 | Submit builds from [CI or automated workflows](/eas/workflows/pre-packaged-jobs/#submit)                                                                   | <YesIcon />    |
 | Standardize release processes via [eas.json](/eas/json/) config file                                                                                       | <YesIcon />    |

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -32,17 +32,6 @@ Build and submit in one step:
 
 <Terminal cmd={['$ eas build --platform ios --auto-submit']} />
 
-## Why teams use EAS Submit
-
-EAS Submit helps teams to:
-
-- Upload Android binaries to [Google Play Console](https://play.google.com/console/about/)
-- Upload iOS binaries to [Apple App Store](https://developer.apple.com/app-store-connect/)
-- Avoid manual uploads through Play Console, App Store Connect or Transporter
-- Submit builds from [CI or automated workflows](/eas/workflows/pre-packaged-jobs/#submit)
-- Standardize release processes via [eas.json](/eas/json/) config file
-- Reduce human errors during submission
-
 ## How EAS Submit works
 
 **EAS Submit** delivers your app to the app stores' distribution pipelines (a chosen track on Google Play Store or [TestFlight](https://developer.apple.com/testflight/) for iOS), following the [default submission behavior for app stores](/build/automate-submissions/#default-submission-behavior-for-app-stores). It queues up your app for distribution on the Google Play Console and App Store Connect, and then you can log into those sites to send your apps off to review, so then they can be distributed to your users.
@@ -63,9 +52,20 @@ EAS Submit helps teams to:
 - Does this mean production? No &mdash; a TestFlight build is not automatically released to the Apple App Store.
 - How production happens: You must log into App Store Connect, choose the build, and submit it for App Review before it can be released to production.
 
+## When to use EAS Submit
+
+Use EAS Submit when you want to:
+
+- Upload Android binaries to [Google Play Console](https://play.google.com/console/about/)
+- Upload iOS binaries to [Apple App Store](https://developer.apple.com/app-store-connect/)
+- Avoid manual uploads through Play Console, App Store Connect or Transporter
+- Submit builds from [CI or automated workflows](/eas/workflows/pre-packaged-jobs/#submit)
+- Standardize release processes via [eas.json](/eas/json/) config file
+- Reduce human errors during submission
+
 ## When not to use EAS Submit
 
-EAS Submit is not needed when:
+You may not need EAS Submit when:
 
 - You are testing locally and not ready for a store submission
 - You do not have a store listing configured yet

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -13,9 +13,9 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { Terminal } from '~/ui/components/Snippet';
 
-**EAS Submit** is a hosted service from EAS (Expo Application Services) for submitting Android and iOS binaries directly to the Google Play Store and Apple App Store without using Google Play Console, App Store Connect or Transporter.
+**EAS Submit** is a hosted service from EAS (Expo Application Services) for submitting Android and iOS binaries directly to the Google Play Store and Apple App Store without opening the [Google Play Console](https://play.google.com/console), or downloading the [Transporter app](https://apps.apple.com/us/app/transporter/id1450874784).
 
-EAS Submit automates the final step of mobile app distribution by sending your built binaries to Google and Apple for store review. It removes the need for manual uploads and reduces errors that happen during store submission.
+EAS Submit automates the final step of mobile app distribution by sending your built binaries to Google and Apple for store review. It removes the need for manual uploads and reduces errors that happen during store submission. It also allows developers using Windows and Linux to upload iOS builds, since this is only supported on macOS machines.
 
 EAS Submit works with apps built with [EAS Build](/build/introduction/) or locally and supports multiple submission profiles. You can trigger a submission from a CLI command, after a build is finished, or from a CI/CD service. This gives teams a faster, more consistent release workflow across both platforms.
 
@@ -51,7 +51,7 @@ Build and submit in one step:
 - Where it goes: EAS Submit uploads the build to App Store Connect.
 - What happens then: The build becomes available in TestFlight.
 - Does this mean production? No &mdash; a TestFlight build is not automatically released to the Apple App Store.
-- How production happens: You must log into App Store Connect, choose the build, and submit it for App Review before it can be released to production.
+- How production happens: You must log into App Store Connect, fill in all the metadata, security questionnaire and upload app screenshots, then choose the build, and submit it for App Review before it can be released to production.
 
 ## When to use EAS Submit
 
@@ -129,7 +129,7 @@ For Apple App Store, you can use [EAS Metadata](/eas/metadata/) to automate app 
 
 <Collapsible summary="What credentials do I need?">
 
-For Android, you need a [Google Service Account Key](/submit/android/#creating-a-google-service-account) with access to your app in Google Play Console. Your app must be uploaded manually at least once before API submissions work.
+For Android, you need a [Google Service Account Key](/submit/android/#creating-a-google-service-account) with access to your app in Google Play Console.
 
 For iOS, you need an Apple Developer account. EAS Submit requires your [`ascAppId`](/eas/json/#ascappid) (App Store Connect app ID) and will prompt for your Apple ID credentials or use an App Store Connect API Key if configured.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18492

Improves the EAS Submit introduction page for better discoverability by AI engines and search engines.

# How

<!--
How did you build this feature or fix this bug and why?
-->

 Rewrote the EAS Submit introduction page with expanded content and improved structure:
 - Expanded the opening from a brief tagline ("hosted service for uploading and submitting") to a complete definition that explains what EAS Submit does, how it works, and what problems it solves
 -  Added "Quick start" section near the top with CLI commands for immediate time-to-value
 - Added "When to use EAS Submit" and "When not to sections to help users decide if EAS Submit fits their use case
 - Added "FAQ" section covering common questions about credentials, local builds, TestFlight, and EAS Workflows integration
 - Added note about Google's first-time manual upload requirement for API-based submissions
 - Added external links to Google Play Console, App Store Connect, and TestFlight documentation
 - Added internal links to related EAS services (EAS Build, EAS Workflows, EAS Metadata, eas.json)
 - Defined acronyms on first use (EAS, .aab, .ipa)

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See: /submit/introduction/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
