### PR TITLE
[expo-go] Include expo-blob

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
@@ -6,6 +6,7 @@ import expo.modules.audio.AudioModule
 import expo.modules.backgroundfetch.BackgroundFetchModule
 import expo.modules.backgroundtask.BackgroundTaskModule
 import expo.modules.battery.BatteryModule
+import expo.modules.blob.BlobModule
 import expo.modules.blur.BlurModule
 import expo.modules.brightness.BrightnessModule
 import expo.modules.calendar.CalendarModule
@@ -17,6 +18,7 @@ import expo.modules.constants.ConstantsService
 import expo.modules.contacts.ContactsModule
 import expo.modules.core.interfaces.Package
 import expo.modules.crypto.CryptoModule
+import expo.modules.crypto.aes.AesCryptoModule
 import expo.modules.device.DeviceModule
 import expo.modules.documentpicker.DocumentPickerModule
 import expo.modules.easclient.EASClientModule
@@ -131,9 +133,11 @@ object ExperiencePackagePicker : ModulesProvider {
     NotificationChannelGroupManagerModule::class.java to null,
     ExpoBackgroundNotificationTasksModule::class.java to null,
     // End of Notifications
+    AesCryptoModule::class.java to null,
     BatteryModule::class.java to null,
     BackgroundFetchModule::class.java to null,
     BackgroundTaskModule::class.java to null,
+    BlobModule::class.java to null,
     BlurModule::class.java to null,
     CalendarModule::class.java to null,
     CameraViewModule::class.java to null,

--- a/apps/expo-go/android/settings.gradle
+++ b/apps/expo-go/android/settings.gradle
@@ -40,7 +40,6 @@ expoAutolinking.exclude = [
   'expo-maps',
   'expo-network-addons',
   'expo-splash-screen',
-  'expo-blob',
   '@expo/ui',
   'expo-mesh-gradient',
   '@expo/app-integrity',

--- a/apps/expo-go/ios/Podfile
+++ b/apps/expo-go/ios/Podfile
@@ -50,7 +50,6 @@ target 'Expo Go' do
       'expo-network-addons',
       'expo-insights',
       'expo-splash-screen',
-      'expo-blob',
       '@expo/ui',
       '@expo/app-integrity',
       'expo-brownfield'


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/42093#issuecomment-3739670507

# How

- Remove expo-blob autolinking exclusion
- Add missing `AesCryptoModule` on Android

# Test Plan

- [x] Run NCL in Expo Go on Android
  - [x] Confirm Blob works
  - [x] Confirm Crypto works
- [x] Run NCL in Expo Go on iOS
  - [x] Confirm Blob works
  - [x] Confirm Crypto works

> CI failure unrelated - should be resolved when home's RN code is removed

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
