### PR TITLE
[core][iOS] Add `installOnUIRuntime` function

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -476,6 +476,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
+    - RNWorklets
     - Yoga
   - ExpoModulesCore/Tests (3.0.16):
     - ExpoModulesJSI
@@ -501,6 +502,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
+    - RNWorklets
     - Yoga
   - ExpoModulesJSI (3.0.16):
     - hermes-engine
@@ -3796,7 +3798,7 @@ SPEC CHECKSUMS:
   ExpoMaps: ac5024fd6b3db82da997bdc4074bda5c3e2e7764
   ExpoMediaLibrary: 648cee3f5dcba13410ec9cc8ac9a426e89a61a31
   ExpoMeshGradient: 763087d3b1e6e9a0974e9700ea24cb598816d93c
-  ExpoModulesCore: 22f2efcefda2486b06a0b9f0dcaab8eccdfaf0b4
+  ExpoModulesCore: 75234558d61ae2c7b81d21526a9a37a0ec957c0f
   ExpoModulesJSI: c470ea2ed825fce73bdc4ef060c8a22e3f664092
   ExpoModulesTestCore: e65555b75a4ed7dd3bcf421ad01d7748bd372c88
   ExpoNetwork: 97073786edfe405aba5d0987a544617ed0671ad1

--- a/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
@@ -17,8 +17,8 @@ import { CryptoScreens } from '../screens/Crypto/CryptoScreen';
 import ExpoApis from '../screens/ExpoApisScreen';
 import { MediaLibraryScreens } from '../screens/MediaLibrary@Next/MediaLibraryScreens';
 import { ModulesCoreScreens } from '../screens/ModulesCore/ModulesCoreScreen';
-import { type ScreenConfig } from '../types/ScreenConfig';
 import { WorkletsScreens } from '../screens/Worklets/WorkletsScreen';
+import { type ScreenConfig } from '../types/ScreenConfig';
 
 const Stack = createNativeStackNavigator();
 

--- a/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
@@ -18,6 +18,7 @@ import ExpoApis from '../screens/ExpoApisScreen';
 import { MediaLibraryScreens } from '../screens/MediaLibrary@Next/MediaLibraryScreens';
 import { ModulesCoreScreens } from '../screens/ModulesCore/ModulesCoreScreen';
 import { type ScreenConfig } from '../types/ScreenConfig';
+import { WorkletsScreens } from '../screens/Worklets/WorkletsScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -448,6 +449,13 @@ export const ScreensList: ScreenConfig[] = [
   },
   {
     getComponent() {
+      return optionalRequire(() => require('../screens/Worklets/WorkletsScreen'));
+    },
+    name: 'Worklets integration',
+    route: 'worklets',
+  },
+  {
+    getComponent() {
       return optionalRequire(() => require('../screens/WebBrowser/WebBrowserScreen'));
     },
     name: 'WebBrowser',
@@ -476,6 +484,7 @@ export const Screens: ScreenConfig[] = [
   ...CalendarsScreens,
   ...CalendarsNextScreens,
   ...CryptoScreens,
+  ...WorkletsScreens,
 ];
 
 export const screenApiItems = apiScreensToListElements(ScreensList);

--- a/apps/native-component-list/src/screens/Worklets/WorkletsInitScreen.tsx
+++ b/apps/native-component-list/src/screens/Worklets/WorkletsInitScreen.tsx
@@ -1,6 +1,6 @@
+import { installOnUIRuntime } from 'expo';
 import React, { useEffect, useState } from 'react';
 import { View, StyleSheet, Text } from 'react-native';
-import { installOnUIRuntime } from 'expo';
 import { runOnJS, runOnUI } from 'react-native-worklets';
 import 'react-native-reanimated';
 

--- a/apps/native-component-list/src/screens/Worklets/WorkletsInitScreen.tsx
+++ b/apps/native-component-list/src/screens/Worklets/WorkletsInitScreen.tsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useState } from 'react';
+import { View, StyleSheet, Text } from 'react-native';
+import { installOnUIRuntime } from 'expo';
+import { runOnJS, runOnUI } from 'react-native-worklets';
+import 'react-native-reanimated';
+
+installOnUIRuntime();
+
+export default function WorkletsInitScreen() {
+  const [isExpoObjectAvailable, setIsExpoObjectAvailable] = useState(false);
+  const [isEventEmitterAvailable, setIsEventEmitterAvailable] = useState(false);
+  const [isNativeModuleAvailable, setIsNativeModuleAvailable] = useState(false);
+
+  useEffect(() => {
+    runOnUI(() => {
+      runOnJS(setIsExpoObjectAvailable)(!!globalThis.expo);
+      runOnJS(setIsEventEmitterAvailable)(!!globalThis.expo?.EventEmitter);
+      runOnJS(setIsNativeModuleAvailable)(!!globalThis.expo?.NativeModule);
+    })();
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.section}>
+        <Text style={styles.title}>Worklets UI Runtime Status</Text>
+      </View>
+
+      <StatusRow label="Expo object" available={isExpoObjectAvailable} />
+      <StatusRow label="EventEmitter" available={isEventEmitterAvailable} />
+      <StatusRow label="NativeModule" available={isNativeModuleAvailable} />
+    </View>
+  );
+}
+
+function StatusRow({ label, available }: { label: string; available: boolean }) {
+  return (
+    <View style={styles.row}>
+      <Text style={styles.label}>{label}:</Text>
+      <View style={[styles.status, available ? styles.statusAvailable : styles.statusUnavailable]}>
+        <Text style={styles.statusText}>{available ? '✓ Available' : '✗ Unavailable'}</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    backgroundColor: '#f5f5f5',
+  },
+  section: {
+    marginBottom: 20,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: '#333',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    marginBottom: 8,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 2,
+    elevation: 2,
+  },
+  label: {
+    fontSize: 16,
+    fontWeight: '500',
+    color: '#333',
+    flex: 1,
+  },
+  status: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 6,
+  },
+  statusAvailable: {
+    backgroundColor: '#d4edda',
+  },
+  statusUnavailable: {
+    backgroundColor: '#f8d7da',
+  },
+  statusText: {
+    fontSize: 14,
+    fontWeight: '500',
+  },
+});

--- a/apps/native-component-list/src/screens/Worklets/WorkletsScreen.tsx
+++ b/apps/native-component-list/src/screens/Worklets/WorkletsScreen.tsx
@@ -1,4 +1,3 @@
-import { View, Text } from 'react-native';
 import { optionalRequire } from '../../navigation/routeBuilder';
 import ComponentListScreen, { apiScreensToListElements } from '../ComponentListScreen';
 

--- a/apps/native-component-list/src/screens/Worklets/WorkletsScreen.tsx
+++ b/apps/native-component-list/src/screens/Worklets/WorkletsScreen.tsx
@@ -1,0 +1,18 @@
+import { View, Text } from 'react-native';
+import { optionalRequire } from '../../navigation/routeBuilder';
+import ComponentListScreen, { apiScreensToListElements } from '../ComponentListScreen';
+
+export const WorkletsScreens = [
+  {
+    name: 'Worklets Initialization',
+    route: 'worklets/init',
+    getComponent() {
+      return optionalRequire(() => require('./WorkletsInitScreen'));
+    },
+  },
+];
+
+export default function WorkletsScreen() {
+  const apis = apiScreensToListElements(WorkletsScreens);
+  return <ComponentListScreen apis={apis} sort={false} />;
+}

--- a/packages/expo-modules-core/ios/Core/Exceptions/CommonExceptions.swift
+++ b/packages/expo-modules-core/ios/Core/Exceptions/CommonExceptions.swift
@@ -23,6 +23,15 @@ public struct Exceptions {
   }
 
   /**
+   The UI runtime is no longer available.
+   */
+  public final class UIRuntimeLost: Exception {
+    override public var reason: String {
+      "The UI runtime has been lost"
+    }
+  }
+
+  /**
    An exception to throw when the operation is not supported on the simulator.
    */
   public final class SimulatorNotSupported: Exception {

--- a/packages/expo-modules-core/ios/Core/Modules/CoreModule.swift
+++ b/packages/expo-modules-core/ios/Core/Modules/CoreModule.swift
@@ -3,6 +3,20 @@
 import React
 import Foundation
 
+internal final class WorkletUIRuntimeException: Exception, @unchecked Sendable {
+  override var reason: String {
+    "Cannot find UI worklet runtime"
+  }
+}
+
+internal final class WorkletUIRuntimePointerExtractionException: Exception, @unchecked Sendable {
+  override var reason: String {
+    "Cannot extract pointer to UI worklet runtime"
+  }
+}
+
+private let WORKLET_RUNTIME_KEY = "_WORKLET_RUNTIME"
+
 // The core module that describes the `global.expo` object.
 internal final class CoreModule: Module {
   internal func definition() -> ModuleDefinition {
@@ -24,6 +38,36 @@ internal final class CoreModule: Module {
 
     Constant("documentsDir") {
       FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?.path ?? ""
+    }
+
+    Function("installOnUIRuntime") {
+      guard let appContext = appContext else {
+        throw Exceptions.AppContextLost()
+      }
+
+      // Check if was already installed
+      if appContext._uiRuntime != nil {
+        return
+      }
+
+      let runtime = try appContext.runtime
+
+      if !runtime.global().hasProperty(WORKLET_RUNTIME_KEY) {
+        throw WorkletUIRuntimeException()
+      }
+
+      let pointerHolder = runtime.global().getProperty(WORKLET_RUNTIME_KEY)
+      assert(pointerHolder.isObject())
+
+      let uiRuntimePointer = WorkletRuntimeFactory.extractRuntimePointer(pointerHolder, runtime: runtime)
+      if uiRuntimePointer == 0 {
+        throw WorkletUIRuntimePointerExtractionException()
+      }
+
+      DispatchQueue.main.sync {
+        let workletRuntime = WorkletRuntimeFactory.createWorkletRuntime(appContext, fromPointer: uiRuntimePointer)
+        appContext._uiRuntime = workletRuntime
+      }
     }
 
     // Expose some common classes and maybe even the `modules` host object in the future.

--- a/packages/expo-modules-core/ios/Core/Modules/CoreModule.swift
+++ b/packages/expo-modules-core/ios/Core/Modules/CoreModule.swift
@@ -53,9 +53,17 @@ internal final class CoreModule: Module {
         throw WorkletUIRuntimePointerExtractionException()
       }
 
-      DispatchQueue.main.sync {
+      let block = {
         let workletRuntime = WorkletRuntimeFactory.createWorkletRuntime(appContext, fromPointer: uiRuntimePointer)
         appContext._uiRuntime = workletRuntime
+      }
+
+      if Thread.isMainThread {
+        block()
+      } else {
+        DispatchQueue.main.sync {
+          block()
+        }
       }
     }
 

--- a/packages/expo-modules-core/ios/JS/JavaScriptValue.swift
+++ b/packages/expo-modules-core/ios/JS/JavaScriptValue.swift
@@ -115,7 +115,7 @@ extension JavaScriptValue: AnyJavaScriptValue, AnyArgument {
     }
     throw JavaScriptValueConversionException((kind: kind, target: "TypedArray"))
   }
-  
+
   func asArrayBuffer() throws -> JavaScriptArrayBuffer {
     if let backingBuffer = getArrayBuffer() {
       return JavaScriptArrayBuffer(backingBuffer)

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
@@ -9,6 +9,8 @@
 
 #ifdef __cplusplus
 
+#import <react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h>
+
 namespace facebook::react {
 class RuntimeScheduler;
 }
@@ -50,6 +52,8 @@ NS_SWIFT_NAME(JavaScriptRuntime)
 #ifdef __cplusplus
 
 - (nonnull instancetype)initWithRuntime:(jsi::Runtime &)runtime;
+
+- (nonnull instancetype)initWithRuntime:(jsi::Runtime &)runtime callInvoker:(std::shared_ptr<react::CallInvoker>)callInvoker;
 
 /**
  Returns the underlying runtime object.

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -9,7 +9,6 @@
 #import <jsi/jsi.h>
 #import <hermes/hermes.h>
 #import <ReactCommon/SchedulerPriority.h>
-#import <react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h>
 
 @implementation EXJavaScriptRuntime {
   std::shared_ptr<jsi::Runtime> _runtime;
@@ -55,6 +54,15 @@
     _runtime = std::shared_ptr<jsi::Runtime>(std::shared_ptr<jsi::Runtime>(), &runtime);
     _runtimeScheduler = expo::runtimeSchedulerFromRuntime(runtime);
     _jsCallInvoker = std::make_shared<RuntimeSchedulerCallInvoker>(_runtimeScheduler);
+  }
+  return self;
+}
+
+- (nonnull instancetype)initWithRuntime:(jsi::Runtime &)runtime callInvoker:(std::shared_ptr<react::RuntimeSchedulerCallInvoker>)callInvoker {
+  if (self = [super init]) {
+    _runtime = std::shared_ptr<jsi::Runtime>(std::shared_ptr<jsi::Runtime>(), &runtime);
+    _runtimeScheduler = nullptr;
+    _jsCallInvoker = callInvoker;
   }
   return self;
 }

--- a/packages/expo-modules-core/ios/Worklets/WorkletJSCallInvoker.cpp
+++ b/packages/expo-modules-core/ios/Worklets/WorkletJSCallInvoker.cpp
@@ -1,0 +1,38 @@
+#if WORKLETS_ENABLED
+
+#ifdef __cplusplus
+
+#include "WorkletJSCallInvoker.h"
+
+namespace expo {
+
+  WorkletJSCallInvoker::WorkletJSCallInvoker(
+    std::weak_ptr<worklets::WorkletRuntime> &workletRuntimeHolder
+  ) : workletRuntimeHolder_(workletRuntimeHolder) {}
+
+  void WorkletJSCallInvoker::invokeAsync(react::CallFunc &&func) noexcept {
+    auto workletRuntime = workletRuntimeHolder_.lock();
+    if (!workletRuntime) {
+      return;
+    }
+
+    workletRuntime->schedule(std::move(func));
+  }
+
+  void WorkletJSCallInvoker::invokeSync(react::CallFunc &&func) {
+    auto workletRuntime = workletRuntimeHolder_.lock();
+    if (!workletRuntime) {
+      return;
+    }
+
+    workletRuntime->executeSync([func = std::move(func)](jsi::Runtime &rt) -> jsi::Value {
+      func(rt);
+      return jsi::Value::undefined();
+    });
+  }
+
+} // namespace expo
+
+#endif
+
+#endif

--- a/packages/expo-modules-core/ios/Worklets/WorkletJSCallInvoker.cpp
+++ b/packages/expo-modules-core/ios/Worklets/WorkletJSCallInvoker.cpp
@@ -6,30 +6,30 @@
 
 namespace expo {
 
-  WorkletJSCallInvoker::WorkletJSCallInvoker(
-    std::weak_ptr<worklets::WorkletRuntime> &workletRuntimeHolder
-  ) : workletRuntimeHolder_(workletRuntimeHolder) {}
+WorkletJSCallInvoker::WorkletJSCallInvoker(
+  std::weak_ptr<worklets::WorkletRuntime> &workletRuntimeHolder
+) : workletRuntimeHolder_(workletRuntimeHolder) {}
 
-  void WorkletJSCallInvoker::invokeAsync(react::CallFunc &&func) noexcept {
-    auto workletRuntime = workletRuntimeHolder_.lock();
-    if (!workletRuntime) {
-      return;
-    }
-
-    workletRuntime->schedule(std::move(func));
+void WorkletJSCallInvoker::invokeAsync(react::CallFunc &&func) noexcept {
+  auto workletRuntime = workletRuntimeHolder_.lock();
+  if (!workletRuntime) {
+    return;
   }
 
-  void WorkletJSCallInvoker::invokeSync(react::CallFunc &&func) {
-    auto workletRuntime = workletRuntimeHolder_.lock();
-    if (!workletRuntime) {
-      return;
-    }
+  workletRuntime->schedule(std::move(func));
+}
 
-    workletRuntime->executeSync([func = std::move(func)](jsi::Runtime &rt) -> jsi::Value {
-      func(rt);
-      return jsi::Value::undefined();
-    });
+void WorkletJSCallInvoker::invokeSync(react::CallFunc &&func) {
+  auto workletRuntime = workletRuntimeHolder_.lock();
+  if (!workletRuntime) {
+    return;
   }
+
+  workletRuntime->executeSync([func = std::move(func)](jsi::Runtime &rt) -> jsi::Value {
+    func(rt);
+    return jsi::Value::undefined();
+  });
+}
 
 } // namespace expo
 

--- a/packages/expo-modules-core/ios/Worklets/WorkletJSCallInvoker.h
+++ b/packages/expo-modules-core/ios/Worklets/WorkletJSCallInvoker.h
@@ -1,0 +1,33 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+#if WORKLETS_ENABLED
+
+#ifdef __cplusplus
+
+#include <ReactCommon/CallInvoker.h>
+#include <ReactCommon/RuntimeExecutor.h>
+
+#include <worklets/WorkletRuntime/WorkletRuntime.h>
+
+#include <memory>
+
+namespace react = facebook::react;
+
+namespace expo {
+
+class WorkletJSCallInvoker : public react::CallInvoker {
+public:
+  explicit WorkletJSCallInvoker(std::weak_ptr<worklets::WorkletRuntime> &workletRuntimeHolder);
+
+  void invokeAsync(react::CallFunc &&func) noexcept override;
+
+  void invokeSync(react::CallFunc &&func) override;
+private:
+  std::weak_ptr<worklets::WorkletRuntime> workletRuntimeHolder_;
+};
+
+} // namespace expo
+
+#endif
+
+#endif

--- a/packages/expo-modules-core/ios/Worklets/WorkletRuntimeFactory.h
+++ b/packages/expo-modules-core/ios/Worklets/WorkletRuntimeFactory.h
@@ -7,8 +7,8 @@
 
 @interface WorkletRuntimeFactory : NSObject
 
-+(nonnull EXRuntime *)createWorkletRuntime:(nonnull EXAppContext *)appContext fromPointer:(unsigned long)pointer;
++ (nonnull EXRuntime *)createWorkletRuntime:(nonnull EXAppContext *)appContext fromPointer:(nullable void *)pointer;
 
-+(unsigned long)extractRuntimePointer:(nonnull EXJavaScriptValue *)jsValue runtime:(nonnull EXJavaScriptRuntime *)runtime;
++ (nullable void *)extractRuntimePointer:(nonnull EXJavaScriptValue *)jsValue runtime:(nonnull EXJavaScriptRuntime *)runtime;
 
 @end

--- a/packages/expo-modules-core/ios/Worklets/WorkletRuntimeFactory.h
+++ b/packages/expo-modules-core/ios/Worklets/WorkletRuntimeFactory.h
@@ -1,0 +1,14 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+@class EXAppContext;
+@class EXRuntime;
+@class EXJavaScriptValue;
+@class EXJavaScriptRuntime;
+
+@interface WorkletRuntimeFactory : NSObject
+
++(nonnull EXRuntime *)createWorkletRuntime:(nonnull EXAppContext *)appContext fromPointer:(unsigned long)pointer;
+
++(unsigned long)extractRuntimePointer:(nonnull EXJavaScriptValue *)jsValue runtime:(nonnull EXJavaScriptRuntime *)runtime;
+
+@end

--- a/packages/expo-modules-core/ios/Worklets/WorkletRuntimeFactory.h
+++ b/packages/expo-modules-core/ios/Worklets/WorkletRuntimeFactory.h
@@ -1,9 +1,9 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
+#import <ExpoModulesCore/EXRuntime.h>
+#import <ExpoModulesJSI/EXJavaScriptValue.h>
+
 @class EXAppContext;
-@class EXRuntime;
-@class EXJavaScriptValue;
-@class EXJavaScriptRuntime;
 
 @interface WorkletRuntimeFactory : NSObject
 

--- a/packages/expo-modules-core/ios/Worklets/WorkletRuntimeFactory.mm
+++ b/packages/expo-modules-core/ios/Worklets/WorkletRuntimeFactory.mm
@@ -13,7 +13,7 @@
 
 @implementation WorkletRuntimeFactory
 
-+(nonnull EXRuntime *)createWorkletRuntime:(nonnull EXAppContext *)appContext fromPointer:(unsigned long)pointer
++ (nonnull EXRuntime *)createWorkletRuntime:(nonnull EXAppContext *)appContext fromPointer:(nullable void *)pointer
 {
 #if WORKLETS_ENABLED
   jsi::Runtime* jsRuntime = reinterpret_cast<jsi::Runtime *>(pointer);
@@ -29,23 +29,23 @@
 #endif
 }
 
-+(unsigned long)extractRuntimePointer:(nonnull EXJavaScriptValue *)jsValue runtime:(nonnull EXJavaScriptRuntime *)runtime
++ (nullable void *)extractRuntimePointer:(nonnull EXJavaScriptValue *)jsValue runtime:(nonnull EXJavaScriptRuntime *)runtime
 {
   jsi::Value rawValue = [jsValue get];
   jsi::Runtime *rawRuntime = [runtime get];
 
   jsi::Object workletRuntimeObject = rawValue.getObject(*rawRuntime);
   if (!workletRuntimeObject.isArrayBuffer(*rawRuntime)) {
-    return 0;
+    return NULL;
   }
 
   size_t pointerSize = sizeof(uintptr_t *);
   jsi::ArrayBuffer workletRuntimeArrayBuffer = workletRuntimeObject.getArrayBuffer(*rawRuntime);
   if (workletRuntimeArrayBuffer.size(*rawRuntime) != pointerSize) {
-    return 0;
+    return NULL;
   }
 
-  return *reinterpret_cast<uintptr_t *>(workletRuntimeArrayBuffer.data(*rawRuntime));
+  return *reinterpret_cast<uintptr_t **>(workletRuntimeArrayBuffer.data(*rawRuntime));
 }
 
 @end

--- a/packages/expo-modules-core/ios/Worklets/WorkletRuntimeFactory.mm
+++ b/packages/expo-modules-core/ios/Worklets/WorkletRuntimeFactory.mm
@@ -1,8 +1,6 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
 #import <ExpoModulesCore/WorkletRuntimeFactory.h>
-#import <ExpoModulesCore/EXRuntime.h>
-#import <ExpoModulesJSI/EXJavaScriptValue.h>
 
 #if WORKLETS_ENABLED
 

--- a/packages/expo-modules-core/ios/Worklets/WorkletRuntimeFactory.mm
+++ b/packages/expo-modules-core/ios/Worklets/WorkletRuntimeFactory.mm
@@ -1,0 +1,51 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+#import <ExpoModulesCore/WorkletRuntimeFactory.h>
+#import <ExpoModulesCore/EXRuntime.h>
+#import <ExpoModulesJSI/EXJavaScriptValue.h>
+
+#if WORKLETS_ENABLED
+
+#include <worklets/WorkletRuntime/WorkletRuntime.h>
+#include <ExpoModulesCore/WorkletJSCallInvoker.h>
+
+#endif
+
+@implementation WorkletRuntimeFactory
+
++(nonnull EXRuntime *)createWorkletRuntime:(nonnull EXAppContext *)appContext fromPointer:(unsigned long)pointer
+{
+#if WORKLETS_ENABLED
+  jsi::Runtime* jsRuntime = reinterpret_cast<jsi::Runtime *>(pointer);
+
+  auto workletRuntime = worklets::WorkletRuntime::getWeakRuntimeFromJSIRuntime(*jsRuntime);
+
+  return [[EXRuntime alloc] initWithRuntime:*jsRuntime
+                                callInvoker:std::make_shared<expo::WorkletJSCallInvoker>(workletRuntime)];
+#else
+  @throw [NSException exceptionWithName:@"WorkletException"
+                                 reason:@"Worklets integration is disabled"
+                               userInfo:nil];
+#endif
+}
+
++(unsigned long)extractRuntimePointer:(nonnull EXJavaScriptValue *)jsValue runtime:(nonnull EXJavaScriptRuntime *)runtime
+{
+  jsi::Value rawValue = [jsValue get];
+  jsi::Runtime *rawRuntime = [runtime get];
+
+  jsi::Object workletRuntimeObject = rawValue.getObject(*rawRuntime);
+  if (!workletRuntimeObject.isArrayBuffer(*rawRuntime)) {
+    return 0;
+  }
+
+  size_t pointerSize = sizeof(uintptr_t *);
+  jsi::ArrayBuffer workletRuntimeArrayBuffer = workletRuntimeObject.getArrayBuffer(*rawRuntime);
+  if (workletRuntimeArrayBuffer.size(*rawRuntime) != pointerSize) {
+    return 0;
+  }
+
+  return *reinterpret_cast<uintptr_t *>(workletRuntimeArrayBuffer.data(*rawRuntime));
+}
+
+@end


### PR DESCRIPTION
# Why

A follow-up to the https://github.com/expo/expo/pull/41718.
Adds `installOnUIRuntime` function, which exports some Expo-related classes to the UI runtime. 
It's not exporting native modules for now!

# How

# Test Plan

- bare-expo ✅ 