### PR TITLE
[core][Android] Enable `worklets` integration by default

### DIFF
--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -57,12 +57,8 @@ USE_HERMES = USE_HERMES && isExpoModulesCoreTests
 
 def shouldTurnWarningsIntoErrors = findProperty("EXPO_TURN_WARNINGS_INTO_ERRORS") == "true"
 
-def enableWorkletsIntegration = !isExpoModulesCoreTests && findProperty("expo.core.worklets") == "true"
+def enableWorkletsIntegration = !isExpoModulesCoreTests
 def workletsProject = enableWorkletsIntegration ? findProject(":react-native-worklets") : null
-
-if (enableWorkletsIntegration && workletsProject == null) {
-  throw new GradleException("The 'expo.core.worklets' property is set to true, but the ':react-native-worklets' project is not found.")
-}
 
 if (workletsProject != null) {
   evaluationDependsOn(":react-native-worklets")

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -41,6 +41,12 @@ def isExpoModulesCoreTests = {
   return false
 }.call()
 
+def isTests = {
+  Gradle gradle = getGradle()
+  String tskReqStr = gradle.getStartParameter().getTaskRequests().toString()
+  return tskReqStr =~ /connected\w*AndroidTest/
+}.call()
+
 def expoModuleExtension = project.extensions.getByType(ExpoModuleExtension)
 
 def reactNativeArchitectures() {
@@ -57,7 +63,7 @@ USE_HERMES = USE_HERMES && isExpoModulesCoreTests
 
 def shouldTurnWarningsIntoErrors = findProperty("EXPO_TURN_WARNINGS_INTO_ERRORS") == "true"
 
-def enableWorkletsIntegration = !isExpoModulesCoreTests
+def enableWorkletsIntegration = !isTests
 def workletsProject = enableWorkletsIntegration ? findProject(":react-native-worklets") : null
 
 if (workletsProject != null) {

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -67,7 +67,15 @@ def enableWorkletsIntegration = !isTests
 def workletsProject = enableWorkletsIntegration ? findProject(":react-native-worklets") : null
 
 if (workletsProject != null) {
-  evaluationDependsOn(":react-native-worklets")
+  evaluationDependsOn(workletsProject.path)
+
+  afterEvaluate {
+    println("Linking react-native-worklets native libs into expo-modules-core build tasks")
+    println(workletsProject.tasks.getByName("mergeDebugNativeLibs"))
+    println(workletsProject.tasks.getByName("mergeReleaseNativeLibs"))
+    tasks.getByName("buildCMakeDebug").dependsOn(workletsProject.tasks.getByName("mergeDebugNativeLibs"))
+    tasks.getByName("buildCMakeRelWithDebInfo").dependsOn(workletsProject.tasks.getByName("mergeReleaseNativeLibs"))
+  }
 }
 
 def reactNativeWorkletsRootDir = workletsProject?.projectDir?.parentFile
@@ -218,6 +226,10 @@ dependencies {
 
   compileOnly 'com.facebook.fbjni:fbjni:0.5.1'
 
+  if (workletsProject != null) {
+    implementation workletsProject
+  }
+
   testImplementation 'androidx.test:core:1.7.0'
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'io.mockk:mockk:1.13.10'
@@ -302,11 +314,4 @@ def generatePCHTask = tasks.register("generatePCH") {
 // This task will run on the IDE project sync, ensuring the PCH file is generated early enough
 tasks.register("prepareKotlinBuildScriptModel") {
   dependsOn(generatePCHTask)
-}
-
-if (workletsProject != null) {
-  afterEvaluate {
-    tasks.getByName("externalNativeBuildDebug").dependsOn(findProject(":react-native-worklets").tasks.getByName("externalNativeBuildDebug"))
-    tasks.getByName("externalNativeBuildRelease").dependsOn(findProject(":react-native-worklets").tasks.getByName("externalNativeBuildRelease"))
-  }
 }

--- a/packages/expo-modules-core/android/src/main/cpp/installers/WorkletRuntimeInstaller.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/installers/WorkletRuntimeInstaller.cpp
@@ -71,11 +71,12 @@ void WorkletRuntimeInstaller::prepareRuntime(
     cxxPart
   );
 
-  MainRuntimeInstaller::installModules(
-    runtime,
-    cxxPart,
-    mainObject
-  );
+// TODO(@lukmccall): Re-enable module installation when iOS start supporting exporting native modules
+//  MainRuntimeInstaller::installModules(
+//    runtime,
+//    cxxPart,
+//    mainObject
+//  );
 #endif
 }
 


### PR DESCRIPTION
# Why

Enables `worklets` integration by default.
I've also disabled the installation of modules on the UI runtime, as it's not supported on iOS and I'm unsure if it will be included in SDK 55.

# Test Plan

- tested using https://github.com/expo/expo/pull/42108