### PR TITLE
[font] Remove flaky test

### DIFF
--- a/apps/test-suite/tests/Font.js
+++ b/apps/test-suite/tests/Font.js
@@ -19,36 +19,38 @@ export async function test({ beforeEach, afterAll, describe, it, expect }) {
       await unloadFontAsync();
     });
 
-    it(`loads`, async () => {
-      let error = null;
-      expect(Font.isLoaded('cool-font')).toBe(false);
-      expect(Font.isLoading('cool-font')).toBe(false);
-      const loadedFontsPrior = Font.getLoadedFonts();
-      expect(loadedFontsPrior.length >= 25).toBe(true);
+    if (Platform.OS === 'web') {
+      it(`loads`, async () => {
+        let error = null;
+        expect(Font.isLoaded('cool-font')).toBe(
+          false,
+          'Font should not be loaded before loadAsync is called'
+        );
+        expect(Font.isLoading('cool-font')).toBe(
+          false,
+          'Font should not be loading before loadAsync is called'
+        );
+        const loadedFontsPrior = Font.getLoadedFonts();
+        expect(loadedFontsPrior.length >= 25).toBe(true);
 
-      try {
-        await Font.loadAsync({
-          'cool-font': {
-            uri: require('../assets/comic.ttf'),
-            display: Font.FontDisplay.SWAP,
-          },
-        });
-      } catch (e) {
-        error = e;
-      }
-      expect(error).toBeNull();
-      expect(Font.isLoaded('cool-font')).toBe(true);
+        try {
+          await Font.loadAsync({
+            'cool-font': {
+              uri: require('../assets/comic.ttf'),
+              display: Font.FontDisplay.SWAP,
+            },
+          });
+        } catch (e) {
+          error = e;
+        }
+        expect(error).toBeNull();
+        expect(Font.isLoaded('cool-font')).toBe(
+          true,
+          'Font should be loaded after loadAsync resolves'
+        );
 
-      // We are loading 1 font, but on native, it's present under 2 names `cool-font` and `CosmicSansMS`.
-      // The first one is an provided alias, the second one is a font name from the font file.
-      const numOfFontsAddedByLoad = Platform.select({
-        web: 1,
-        default: 2,
-      });
-      expect(Font.getLoadedFonts().length).toBe(loadedFontsPrior.length + numOfFontsAddedByLoad);
+        expect(Font.getLoadedFonts().length).toBe(loadedFontsPrior.length + 1);
 
-      // Test that the font-display css is correctly made and located in a <style/> element with ID `expo-generated-fonts`
-      if (Platform.OS === 'web') {
         const styleSheet = document.getElementById('expo-generated-fonts');
         expect(!!styleSheet).toBe(true);
         const [rule] = [...styleSheet.sheet.cssRules].filter((rule) => {
@@ -59,8 +61,8 @@ export async function test({ beforeEach, afterAll, describe, it, expect }) {
           );
         });
         expect(!!rule).toBe(true);
-      }
-    });
+      });
+    }
 
     if (Platform.OS !== 'web' && !isRunningInExpoGo()) {
       it(`isLoaded should support custom native fonts`, () => {


### PR DESCRIPTION
# Why

Removes flaky test from Font test suite.
On iOS and Android, we can't unload fonts, making the `load` test flaky. 