### PR TITLE
[bare-expo][Android] Fix NCL ModulesCore Benchmarks

### DIFF
--- a/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.kt
+++ b/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.kt
@@ -20,7 +20,7 @@ class MainApplication : Application(), ReactApplication {
     ExpoReactHostFactory.getDefaultReactHost(
       context = applicationContext,
       packageList =
-        PackageList(this).packages.apply {
+        expo.modules.benchmark.withBenchmarkingPackages(PackageList(this).packages).apply {
           // Packages that cannot be autolinked yet can be added manually here, for example:
           // add(MyReactNativePackage())
         }

--- a/apps/bare-expo/modules/benchmarking/android/src/main/java/expo/modules/benchmark/BenchmarkingBridgeModule.kt
+++ b/apps/bare-expo/modules/benchmarking/android/src/main/java/expo/modules/benchmark/BenchmarkingBridgeModule.kt
@@ -8,9 +8,13 @@ import expo.modules.kotlin.iterator
 class BenchmarkingBridgeModule : BaseJavaModule() {
   override fun getName(): String = "BenchmarkingBridgeModule"
 
-  @ReactMethod
-  fun nothing() {
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  fun nothing(): Double {
     // Do nothing
+
+    // For some reason, isBlockingSynchronousMethod doesn't let functions be Void/Unit
+    // so returning a dummy number
+    return 0.0
   }
 
   @ReactMethod(isBlockingSynchronousMethod = true)

--- a/apps/bare-expo/modules/benchmarking/android/src/main/java/expo/modules/benchmark/BenchmarkingBridgeModule.kt
+++ b/apps/bare-expo/modules/benchmarking/android/src/main/java/expo/modules/benchmark/BenchmarkingBridgeModule.kt
@@ -8,7 +8,7 @@ import expo.modules.kotlin.iterator
 class BenchmarkingBridgeModule : BaseJavaModule() {
   override fun getName(): String = "BenchmarkingBridgeModule"
 
-  @ReactMethod(isBlockingSynchronousMethod = true)
+  @ReactMethod
   fun nothing() {
     // Do nothing
   }

--- a/apps/bare-expo/modules/benchmarking/android/src/main/java/expo/modules/benchmark/BenchmarkingTurboModule.kt
+++ b/apps/bare-expo/modules/benchmarking/android/src/main/java/expo/modules/benchmark/BenchmarkingTurboModule.kt
@@ -9,8 +9,12 @@ class BenchmarkingTurboModule(reactContext: ReactApplicationContext) : NativeBen
     return "BenchmarkingTurboModule"
   }
 
-  override fun nothing() {
+  override fun nothing(): Double {
     // Do nothing
+
+    // For some reason, isBlockingSynchronousMethod doesn't let functions be Void/Unit
+    // so returning a dummy number
+    return 0.0
   }
 
   override fun addNumbers(a: Double, b: Double): Double {

--- a/apps/bare-expo/modules/benchmarking/android/src/main/java/expo/modules/benchmark/NativeBenchmarkingTurboModuleSpec.java
+++ b/apps/bare-expo/modules/benchmarking/android/src/main/java/expo/modules/benchmark/NativeBenchmarkingTurboModuleSpec.java
@@ -22,7 +22,7 @@ public abstract class NativeBenchmarkingTurboModuleSpec extends ReactContextBase
 
   @ReactMethod
   @DoNotStrip
-  public abstract void nothing();
+  public abstract double nothing();
 
   @ReactMethod(isBlockingSynchronousMethod = true)
   @DoNotStrip

--- a/apps/bare-expo/modules/benchmarking/ios/BenchmarkingBridgeModule.mm
+++ b/apps/bare-expo/modules/benchmarking/ios/BenchmarkingBridgeModule.mm
@@ -4,7 +4,10 @@
 
 RCT_EXPORT_MODULE(BenchmarkingBridgeModule);
 
-RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(void, nothing) {}
+RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(double, nothing)
+{
+  return 0;
+}
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(addNumbers:(double)a b:(double)b)
 {

--- a/apps/bare-expo/modules/benchmarking/ios/BenchmarkingTurboModule.mm
+++ b/apps/bare-expo/modules/benchmarking/ios/BenchmarkingTurboModule.mm
@@ -9,7 +9,10 @@ RCT_EXPORT_MODULE()
   return std::make_shared<facebook::react::NativeBenchmarkingTurboModuleSpecJSI>(params);
 }
 
-- (void)nothing {}
+- (NSNumber *)nothing
+{
+  return 0;
+}
 
 - (NSNumber *)addNumbers:(double)a b:(double)b
 {

--- a/apps/bare-expo/modules/benchmarking/src/NativeBenchmarkingTurboModule.ts
+++ b/apps/bare-expo/modules/benchmarking/src/NativeBenchmarkingTurboModule.ts
@@ -1,7 +1,7 @@
 import { TurboModule, TurboModuleRegistry } from 'react-native';
 
 export interface Spec extends TurboModule {
-  nothing(): void;
+  nothing(): number;
   addNumbers(a: number, b: number): number;
   addStrings(a: string, b: string): string;
   foldArray(array: number[]): number;

--- a/apps/native-component-list/src/screens/ModulesCore/ModulesBenchmarksScreen.tsx
+++ b/apps/native-component-list/src/screens/ModulesCore/ModulesBenchmarksScreen.tsx
@@ -39,7 +39,7 @@ function runVoidBenchmark(): BenchmarkResult {
   }
 
   let bridgeTime = 0;
-  {
+  if (BridgeModule) {
     const start = performance.now();
     for (let i = 0; i < runs; i++) {
       BridgeModule.nothing();
@@ -82,7 +82,7 @@ function runNumberBenchmark(): BenchmarkResult {
   }
 
   let bridgeTime = 0;
-  {
+  if (BridgeModule) {
     const start = performance.now();
     let num = 0;
     for (let i = 0; i < runs; i++) {
@@ -124,7 +124,7 @@ function runStringsBenchmark(): BenchmarkResult {
   }
 
   let bridgeTime = 0;
-  {
+  if (BridgeModule) {
     const start = performance.now();
     for (let i = 0; i < runs; i++) {
       BridgeModule.addStrings('hello', 'world');
@@ -165,7 +165,7 @@ function runArrayBenchmark(): BenchmarkResult {
   }
 
   let bridgeTime = 0;
-  {
+  if (BridgeModule) {
     const start = performance.now();
     for (let i = 0; i < runs; i++) {
       BridgeModule.foldArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);


### PR DESCRIPTION
# Why

NCL -> APIs -> ModulesCore -> Benchmarks was failing with `Cannot read poperty nothing of null`

# How

- Re-applied `withBenchmarksModule.js` config plugin to `MainApplication`
  - The plugin was introduced in <https://github.com/expo/expo/pull/31521#discussion_r1763557400>
  - Changes from the plugin were lost in #40222
- Added null check for `BridgeModule` in NCL
- Fixed crash due to `isBlockingSynchronousMethod` in `BridgeModule.nothing()`
  - See inline comment

# Test Plan

- Android bare-expo -> All benchmarks succeed
