### PR TITLE
[screen-capture] use main thread to call UI apis

### DIFF
--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix main thread violation warnings on app startup. ([#42204](https://github.com/expo/expo/pull/42204) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Fix main thread violation warnings on app startup. ([#42204](https://github.com/expo/expo/pull/42204) by [@lukmccall](https://github.com/lukmccall)) and ([#42118](https://github.com/expo/expo/pull/42118) by [@vonovak](https://github.com/vonovak))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

motivated by an xcode warning - Refactored the `blockView` initialization in `ScreenCaptureModule` to use a lazy property that's initialized from `preventScreenRecording` (which runs on main thread) instead of initializing it on the JS thread

# How

- Replaced the simple `blockView` property with a lazy-initialized closure
- Removed the now unnecessary `OnCreate` lifecycle method

# Test Plan

- bare expo on device

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)