### PR TITLE
[menu][Android] Fix menu is not showing on launch when `ReactContext` was initialized

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/DevMenuSharedPreferencesAdapter.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/DevMenuSharedPreferencesAdapter.kt
@@ -1,0 +1,22 @@
+package host.exp.exponent.experience
+
+import android.app.Application
+import expo.modules.devmenu.DevMenuDefaultPreferences
+import expo.modules.devmenu.DevMenuPreferences
+import host.exp.exponent.storage.ExponentSharedPreferences
+
+class DevMenuSharedPreferencesAdapter(
+  application: Application,
+  val exponentSharedPreferences: ExponentSharedPreferences,
+  val devMenuSharedPreferences: DevMenuPreferences = DevMenuDefaultPreferences(application)
+) : DevMenuPreferences by devMenuSharedPreferences {
+  override var isOnboardingFinished: Boolean
+    get() = exponentSharedPreferences
+      .getBoolean(ExponentSharedPreferences.ExponentSharedPreferencesKey.IS_ONBOARDING_FINISHED_KEY)
+    set(value) {
+      exponentSharedPreferences.setBoolean(
+        ExponentSharedPreferences.ExponentSharedPreferencesKey.IS_ONBOARDING_FINISHED_KEY,
+        value
+      )
+    }
+}

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
@@ -51,7 +51,6 @@ import host.exp.exponent.experience.splashscreen.ManagedAppSplashScreenViewProvi
 import host.exp.exponent.experience.splashscreen.legacy.singletons.SplashScreen
 import host.exp.exponent.kernel.ExperienceKey
 import host.exp.exponent.kernel.ExponentUrls
-import host.exp.exponent.kernel.Kernel.KernelStartedRunningEvent
 import host.exp.exponent.kernel.KernelConstants
 import host.exp.exponent.kernel.KernelConstants.ExperienceOptions
 import host.exp.exponent.kernel.KernelProvider
@@ -319,10 +318,6 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
     }
   }
 
-  fun onEventMainThread(event: KernelStartedRunningEvent?) {
-    AsyncCondition.notify(KERNEL_STARTED_RUNNING_KEY)
-  }
-
   override fun onDoneLoading() {
     reactSurface?.view?.let {
       setReactRootView(it)
@@ -342,7 +337,11 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
               sdkVersion = manifest?.getExpoGoSDKVersion() ?: "Unknown",
               engine = "Hermes"
             )
-          }
+          },
+          preferences = DevMenuSharedPreferencesAdapter(
+            application,
+            kernel.exponentSharedPreferences
+          )
         )
       )
     }
@@ -778,7 +777,6 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
 
   companion object {
     private val TAG = ExperienceActivity::class.java.simpleName
-    private const val KERNEL_STARTED_RUNNING_KEY = "experienceActivityKernelDidLoad"
     const val PERSISTENT_EXPONENT_NOTIFICATION_ID = 10101
     private const val READY_FOR_BUNDLE = "readyForBundle"
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Hide Action button in PiP mode to prevent crash ([#40792](https://github.com/expo/expo/pull/40792) by [@kosmydel](https://github.com/kosmydel))
 - [iOS] remove unnecessary `unregisterKeyCommand` for cmd+r ([#41449](https://github.com/expo/expo/pull/41449) by [@vonovak](https://github.com/vonovak))
 - [Android] Prevent some debug only artifacts from being included in release builds. ([#41378](https://github.com/expo/expo/pull/41378) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Fix menu is not showing on launch when `ReactContext` was initialized.
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Hide Action button in PiP mode to prevent crash ([#40792](https://github.com/expo/expo/pull/40792) by [@kosmydel](https://github.com/kosmydel))
 - [iOS] remove unnecessary `unregisterKeyCommand` for cmd+r ([#41449](https://github.com/expo/expo/pull/41449) by [@vonovak](https://github.com/vonovak))
 - [Android] Prevent some debug only artifacts from being included in release builds. ([#41378](https://github.com/expo/expo/pull/41378) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Fix menu is not showing on launch when `ReactContext` was initialized.
+- [Android] Fix menu is not showing on launch when `ReactContext` was initialized. ([#42123](https://github.com/expo/expo/pull/42123) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

Fixes menu is not showing on launch when `ReactContext` was initialized

# How

- Show menu when `ReactContex` is already initialized - which is a case in Expo Go. 
- Added an adapter for `DevMenuSharedPreferences` to use the date saved in Expo Go. 

# Test Plan

- Expo Go ✅ 
- bare-expo ✅ 