### PR TITLE
[go][Android] Fix key commands

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
@@ -297,14 +297,16 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
     return false
   }
 
-  /**
-   * Handles key commands.
-   */
-  override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
-    if (reactHost != null && !isCrashed) {
-      return devMenuFragment?.onKeyUp(keyCode, event) ?: super.onKeyUp(keyCode, event)
+  override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+    if (event.action == KeyEvent.ACTION_UP) {
+      if (reactHost != null && !isCrashed) {
+        val wasHandled = devMenuFragment?.onKeyUp(event.keyCode, event)
+        if (wasHandled == true) {
+          return true
+        }
+      }
     }
-    return super.onKeyUp(keyCode, event)
+    return super.dispatchKeyEvent(event)
   }
 
   /**

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -11,14 +11,12 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.os.Process
-import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.annotation.UiThread
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.contains
-import com.facebook.infer.annotation.Assertions
 import com.facebook.react.ReactHost
 import com.facebook.react.bridge.ReactContext.RCTDeviceEventEmitter
 import com.facebook.react.devsupport.DefaultDevLoadingViewImplementation
@@ -239,23 +237,6 @@ abstract class ReactNativeActivity :
     }
   }
   // endregion
-
-  override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
-    devSupportManager?.let { devSupportManager ->
-      if (!isCrashed && devSupportManager.devSupportEnabled) {
-        val didDoubleTapR = currentFocus?.let {
-          Assertions.assertNotNull(doubleTapReloadRecognizer)
-            .didDoubleTapR(keyCode, it)
-        }
-        if (didDoubleTapR == true) {
-          devSupportManager.reloadExpoApp()
-          return true
-        }
-      }
-    }
-
-    return super.onKeyUp(keyCode, event)
-  }
 
   override fun onBackPressed() {
     if (!isCrashed) {


### PR DESCRIPTION
# Why

Fixes an issue where key commands don't work inside Expo Go and cause a crash when invoking key event 82. 

# How

- Used `dispatchKeyEvent` instead of `onKeyUp`, preventing crashes in `react-native-screens` code 
- Removed `onKeyUp` from `ReactNativeActivity` as reload is handled by the dev menu.

# Test Plan

- Expo Go ✅ 