### PR TITLE
[test-suite] Exclude `Notifications` tests when running in Expo Go

### DIFF
--- a/apps/test-suite/TestModules.ts
+++ b/apps/test-suite/TestModules.ts
@@ -1,3 +1,4 @@
+import { isRunningInExpoGo } from 'expo';
 import { Platform } from 'expo-modules-core';
 
 import ExponentTest from './ExponentTest';
@@ -113,10 +114,14 @@ export function getTestModules() {
     optionalRequire(() => require('./tests/Speech')),
     optionalRequire(() => require('./tests/Recording')),
     optionalRequire(() => require('./tests/ScreenOrientation')),
-    optionalRequire(() => require('./tests/Notifications')),
+
     optionalRequire(() => require('./tests/NavigationBar')),
     optionalRequire(() => require('./tests/SystemUI'))
   );
+
+  if (!isRunningInExpoGo()) {
+    modules.push(optionalRequire(() => require('./tests/Notifications')));
+  }
 
   if (!isDeviceFarm()) {
     // Popup to request device's location which uses Google's location service


### PR DESCRIPTION
# Why

Exclude `Notifications` tests when running in Expo Go

# How

`expo-notifications` were removed from Expo Go, and tests suite is failing on startup.

# Test Plan

- tests suite ✅ 