### PR TITLE
[test-suite] Exclude media library screens when running in the Expo Go

### DIFF
--- a/apps/test-suite/TestModules.ts
+++ b/apps/test-suite/TestModules.ts
@@ -134,8 +134,10 @@ export function getTestModules() {
     modules.push(optionalRequire(() => require('./tests/Contacts')));
     modules.push(optionalRequire(() => require('./tests/Calendar')));
     modules.push(optionalRequire(() => require('./tests/CalendarReminders')));
-    modules.push(optionalRequire(() => require('./tests/MediaLibrary')));
-    modules.push(optionalRequire(() => require('./tests/MediaLibraryNext')));
+    if (!isRunningInExpoGo()) {
+      modules.push(optionalRequire(() => require('./tests/MediaLibrary')));
+      modules.push(optionalRequire(() => require('./tests/MediaLibraryNext')));
+    }
 
     modules.push(optionalRequire(() => require('./tests/Battery')));
     modules.push(optionalRequire(() => require('./tests/Brightness')));


### PR DESCRIPTION
# Why

Excludes media library screens when running in the Expo Go
See https://exponent-internal.slack.com/archives/C1QP38NQ5/p1768311512548259?thread_ts=1768308802.072849&cid=C1QP38NQ5
