### PR TITLE
[android][expo-audio] removed requiring shouldPlayInBackground for background recording

### DIFF
--- a/apps/native-component-list/src/screens/Audio/AudioModeSelector.android.tsx
+++ b/apps/native-component-list/src/screens/Audio/AudioModeSelector.android.tsx
@@ -99,10 +99,6 @@ export default function AudioModeSelector() {
         valueName: 'shouldRouteThroughEarpiece',
       })}
       {renderToggle({
-        title: 'Stay active in background',
-        valueName: 'shouldPlayInBackground',
-      })}
-      {renderToggle({
         title: 'Allow background recording',
         valueName: 'allowsBackgroundRecording',
       })}

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -60,6 +60,7 @@ _This version does not introduce any user-facing changes._
 ### 🐛 Bug fixes
 
 - [iOS] Fix setting audio quality for recordings. ([#39705](https://github.com/expo/expo/pull/39705) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Removed requiring shouldPlayInBackground to be true for background recording.
 
 ## 1.0.11 — 2025-09-11
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -60,7 +60,7 @@ _This version does not introduce any user-facing changes._
 ### 🐛 Bug fixes
 
 - [iOS] Fix setting audio quality for recordings. ([#39705](https://github.com/expo/expo/pull/39705) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Removed requiring shouldPlayInBackground to be true for background recording.
+- [Android] Removed requiring shouldPlayInBackground to be true for background recording. ([#42134](https://github.com/expo/expo/pull/42134) by [@chrfalch](https://github.com/chrfalch))
 
 ## 1.0.11 — 2025-09-11
 


### PR DESCRIPTION
# Why

We had some reports from our QA that audio recording in the background was not possible. After testing it seemed that `shouldPlayInBackground` had to be set together with `allowsBackgroundRecording` for this to work.

# How

This commit fixes so that only `allowsBackgroundRecording` is required for background recording on Android - `shouldPlayInBackground` is for audio playback only.

# Test Plan

✅ Bare Expo on Android (iOS is not touched) now works correctly.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
