### PR TITLE
[contacts] Fix writeContactToFileAsync() test

### DIFF
--- a/apps/test-suite/tests/Contacts.js
+++ b/apps/test-suite/tests/Contacts.js
@@ -279,10 +279,9 @@ export async function test({ describe, it, xdescribe, jasmine, expect, afterAll 
     });
 
     it('Contacts.writeContactToFileAsync() returns uri', async () => {
-      createdContacts.map(async ({ id }) => {
-        const localUri = await Contacts.writeContactToFileAsync({ id });
-        expect(typeof localUri).toBe('string');
-      });
+      const contactId = await createSimpleContact('Write', 'ToFile');
+      const localUri = await Contacts.writeContactToFileAsync({ id: contactId });
+      expect(typeof localUri).toBe('string');
     });
 
     it("Contacts.getContactByIdAsync() returns undefined when contact doesn't exist", async () => {


### PR DESCRIPTION
# Why
The promises resolve after the test ends. A race condition caused  `writeContactToFileAsync` to throw an exception - contacts were deleted before the function even started. 

# How

Rewrite the test to use async/await properly and to run in isolation from other tests. 

# Test Plan

Tested on bare-expo