### PR TITLE
[android][expo-go] Fix hot reloading

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/modules/perfmonitor/ExpoBridgelessDevSupportManager.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/modules/perfmonitor/ExpoBridgelessDevSupportManager.kt
@@ -51,6 +51,7 @@ internal class ExpoBridgelessDevSupportManager(
   }
 
   override fun onNewReactContextCreated(reactContext: ReactContext) {
+    super.onNewReactContextCreated(reactContext)
     perfController.onContextCreated(reactContext)
     if (devSettings.isFpsDebugEnabled) {
       perfController.enable(reactContext)


### PR DESCRIPTION
# Why
Fixes hot reloading in expo go.

# How
There is another issue where toggling fast refresh from the dev menu will crash the app. This is also reproducible in a bare RN app. I'll look in to fixing it

# Test Plan
Expo go 

