### PR TITLE
feat(cli): Add `EXPO_UNSTABLE_BONJOUR` flag to active local DNS-SD service advertisement to `expo start`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Add support for server data loaders in static export mode ([#40130](https://github.com/expo/expo/pull/40130) by [@hassankhan](https://github.com/hassankhan))
 - Improve SSR support ([#41477](https://github.com/expo/expo/pull/41477) by [@hassankhan](https://github.com/hassankhan))
 - Add support for server data loaders in server export mode ([#41934](https://github.com/expo/expo/pull/41934) by [@hassankhan](https://github.com/hassankhan))
+- Add `EXPO_UNSTABLE_BONJOUR` to activate Bonjour advertising ([#42138](https://github.com/expo/expo/pull/42138) by [@kitten](https://github.com/kitten))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -74,6 +74,7 @@
     "compression": "^1.7.4",
     "connect": "^3.7.0",
     "debug": "^4.3.4",
+    "dnssd-advertise": "^1.0.2",
     "env-editor": "^0.4.1",
     "expo-server": "^1.0.0",
     "freeport-async": "^2.0.0",

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -74,7 +74,7 @@
     "compression": "^1.7.4",
     "connect": "^3.7.0",
     "debug": "^4.3.4",
-    "dnssd-advertise": "^1.0.2",
+    "dnssd-advertise": "^1.0.8",
     "env-editor": "^0.4.1",
     "expo-server": "^1.0.0",
     "freeport-async": "^2.0.0",

--- a/packages/@expo/cli/src/start/server/Bonjour.ts
+++ b/packages/@expo/cli/src/start/server/Bonjour.ts
@@ -1,0 +1,56 @@
+import { ExpoConfig, getConfig } from '@expo/config';
+
+import { env } from '../../utils/env';
+
+const debug = require('debug')('expo:start:server:bonjour') as typeof console.log;
+
+export class Bonjour {
+  private stopAdvertising?: () => Promise<void>;
+
+  constructor(
+    /** Project root directory */
+    private projectRoot: string,
+    /** Port to advertise, if any */
+    private port: number | undefined,
+  ) {}
+
+  public async announceAsync({
+    exp = getConfig(this.projectRoot).exp,
+  }: {
+    exp?: Pick<ExpoConfig, 'name' | 'description' | 'slug' | 'primaryColor'>;
+  }) {
+    if (env.CI || !env.EXPO_UNSTABLE_BONJOUR) {
+      return;
+    } else if (!this.port) {
+      return;
+    }
+
+    const dnssd: typeof import('dnssd-advertise') = await import('dnssd-advertise');
+    if (this.stopAdvertising) {
+      await this.stopAdvertising();
+    }
+
+    debug('Started Bonjour service');
+    this.stopAdvertising = dnssd.advertise({
+      name: `${exp.name}`,
+      type: 'expo',
+      protocol: 'tcp',
+      hostname: exp.slug,
+      port: this.port,
+      txt: {
+        slug: exp.slug,
+      },
+    });
+  }
+
+  public async closeAsync(): Promise<boolean> {
+    if (!this.stopAdvertising) {
+      return false;
+    } else {
+      debug('Stopped Bonjour service');
+      await this.stopAdvertising?.();
+      this.stopAdvertising = undefined;
+      return true;
+    }
+  }
+}

--- a/packages/@expo/cli/src/start/server/Bonjour.ts
+++ b/packages/@expo/cli/src/start/server/Bonjour.ts
@@ -11,7 +11,7 @@ export class Bonjour {
     /** Project root directory */
     private projectRoot: string,
     /** Port to advertise, if any */
-    private port: number | undefined,
+    private port: number | undefined
   ) {}
 
   public async announceAsync({

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -235,10 +235,7 @@ export abstract class BundlerDevServer {
     }
 
     if (!options.isExporting) {
-      await Promise.all([
-        this.startDevSessionAsync(),
-        this.startBonjourAsync(),
-      ]);
+      await Promise.all([this.startDevSessionAsync(), this.startBonjourAsync()]);
       this.watchConfig();
     }
   }
@@ -283,10 +280,7 @@ export abstract class BundlerDevServer {
     // This is used to make Expo Go open the project in either Expo Go, or the web browser.
     // Must come after ngrok (`startTunnelAsync`) setup.
     if (!this.bonjour) {
-      this.bonjour = new Bonjour(
-        this.projectRoot,
-        this.getInstance()?.location.port,
-      );
+      this.bonjour = new Bonjour(this.projectRoot, this.getInstance()?.location.port);
     }
 
     await this.bonjour.announceAsync({});

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -3,6 +3,7 @@ import resolveFrom from 'resolve-from';
 
 import { AsyncNgrok } from './AsyncNgrok';
 import { AsyncWsTunnel } from './AsyncWsTunnel';
+import { Bonjour } from './Bonjour';
 import DevToolsPluginManager from './DevToolsPluginManager';
 import { DevelopmentSession } from './DevelopmentSession';
 import { CreateURLOptions, UrlCreator } from './UrlCreator';
@@ -95,6 +96,8 @@ export abstract class BundlerDevServer {
   protected tunnel: AsyncNgrok | AsyncWsTunnel | null = null;
   /** Interfaces with the Expo 'Development Session' API. */
   protected devSession: DevelopmentSession | null = null;
+  /** Announces dev server via Bonjour */
+  protected bonjour: Bonjour | null = null;
   /** Http server and related info. */
   protected instance: DevServerInstance | null = null;
   /** Native platform interfaces for opening projects.  */
@@ -232,7 +235,10 @@ export abstract class BundlerDevServer {
     }
 
     if (!options.isExporting) {
-      await this.startDevSessionAsync();
+      await Promise.all([
+        this.startDevSessionAsync(),
+        this.startBonjourAsync(),
+      ]);
       this.watchConfig();
     }
   }
@@ -273,6 +279,19 @@ export abstract class BundlerDevServer {
     });
   }
 
+  protected async startBonjourAsync() {
+    // This is used to make Expo Go open the project in either Expo Go, or the web browser.
+    // Must come after ngrok (`startTunnelAsync`) setup.
+    if (!this.bonjour) {
+      this.bonjour = new Bonjour(
+        this.projectRoot,
+        this.getInstance()?.location.port,
+      );
+    }
+
+    await this.bonjour.announceAsync({});
+  }
+
   public isTargetingNative() {
     // Temporary hack while we implement multi-bundler dev server proxy.
     return true;
@@ -306,8 +325,12 @@ export abstract class BundlerDevServer {
     // Stop file watching.
     this.notifier?.stopObserving();
 
-    // Stop the dev session timer and tell Expo API to remove dev session.
-    await this.devSession?.closeAsync();
+    await Promise.all([
+      // Stop the bonjour advertiser
+      this.bonjour?.closeAsync(),
+      // Stop the dev session timer and tell Expo API to remove dev session.
+      this.devSession?.closeAsync(),
+    ]);
 
     // Stop tunnel if running.
     await this.tunnel?.stopAsync().catch((e) => {

--- a/packages/@expo/cli/src/start/server/__mocks__/Bonjour.ts
+++ b/packages/@expo/cli/src/start/server/__mocks__/Bonjour.ts
@@ -1,0 +1,9 @@
+export class Bonjour {
+  constructor(
+    public projectRoot: string,
+    public port: number | undefined
+  ) {}
+
+  announceAsync = jest.fn(async () => ({}));
+  closeAsync = jest.fn(async () => ({}));
+}

--- a/packages/@expo/cli/src/start/server/__tests__/BundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/BundlerDevServer-test.ts
@@ -15,6 +15,7 @@ jest.mock(`../../../log`);
 jest.mock('../AsyncNgrok');
 jest.mock('../AsyncWsTunnel');
 jest.mock('../DevelopmentSession');
+jest.mock('../Bonjour');
 jest.mock('../../platforms/ios/ApplePlatformManager', () => {
   class ApplePlatformManager {
     openAsync = jest.fn(async () => ({ url: 'mock-apple-url' }));

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -291,6 +291,13 @@ class Env {
   get EXPO_UNSTABLE_LOG_BOX(): boolean {
     return boolish('EXPO_UNSTABLE_LOG_BOX', false);
   }
+
+  /**
+   * Enable Bonjour advertising of the Expo CLI on local networks
+   */
+  get EXPO_UNSTABLE_BONJOUR(): boolean {
+    return boolish('EXPO_UNSTABLE_BONJOUR', false);
+  }
 }
 
 export const env = new Env();

--- a/yarn.lock
+++ b/yarn.lock
@@ -7305,10 +7305,10 @@ dlv@^1.1.3:
   resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
 
-dnssd-advertise@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/dnssd-advertise/-/dnssd-advertise-1.0.2.tgz#e5f10b70dbc75de85f28b7f6c52cad3149d33438"
-  integrity sha512-f9p52tFRLSDLuD6vnDrHttxkoKmG6iomYH7tnk+JQMddzwZenOZkRa2WVPiL7bv2nit/nmjaXPvnqFgFB510ew==
+dnssd-advertise@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/dnssd-advertise/-/dnssd-advertise-1.0.8.tgz#48f0c7076a428bc97d7a3d422378633da56b2275"
+  integrity sha512-0+ouQ7nB/MWx4Y4xvyORFehT3izvCTOaGWZOfHY+oX1wQ1MnmZMB/HPPh5mC8JiquFilHZgLsWGN1rVBHfEywQ==
 
 doctrine@^2.1.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7305,6 +7305,11 @@ dlv@^1.1.3:
   resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
 
+dnssd-advertise@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/dnssd-advertise/-/dnssd-advertise-1.0.2.tgz#e5f10b70dbc75de85f28b7f6c52cad3149d33438"
+  integrity sha512-f9p52tFRLSDLuD6vnDrHttxkoKmG6iomYH7tnk+JQMddzwZenOZkRa2WVPiL7bv2nit/nmjaXPvnqFgFB510ew==
+
 doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"


### PR DESCRIPTION
# Why

Resolves DVT-79

We'd like to replace port scanning (and eventually probably the `DevelopmentSession`) when running `expo start`. This would allow dev clients and Expo Go to search for apps without the need to either make requests to the API (keeping track of `DevelopmentSession`s) and without scanning ports.

# How

The advertising is activated by `EXPO_UNSTABLE_BONJOUR`, so we can get it into a canary release. Once we're confident it's working and corresponding client functionality is present we can make it the default.

Supporting DNS-SD is a bit tricky and while there's several solutions we can consider, the requirements are lengthy:
- `expo start` is a long-running process, therefore the DNS-SD advertiser...
  - must behave well and not cause excessive traffic
  - must react to updating/changing network interfaces and addresses
  - must avoid conflicts as per the specification
  - must be fault-tolerant
- running on all kinds of networks, it must...
  - respond differently to different NICs to avoid address spill
  - support responding on `lo0`, when offline, and on all non-local networks otherwise
  - resolve conflicts with human-readable names preferably
- running on macOS, it must avoid conflicts with `mDNSResponder`
- running on Windows, it must support its differences in setting up a UDP6 socket
- it must be maintainable, tested, and not pose a supply chain risk

These requirements are captured in `dnssd-advertise` with corresponding tests.

# Test Plan

- `EXPO_UNSTABLE_BONJOUR=1 expo start`, e.g. in `apps/router-e2e`
- Then: `dns-sd -B _expo._tcp.`
- Then: `dns-sd -L "Router E2E" _expo._tcp`

**Manual Checks:**
- [x] Tested manually on macOS
- [x] Tested manually on Linux
- [x] Tested manually on Windows

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
