### PR TITLE
[ios][expo-go] Enable `expo-maps`

### DIFF
--- a/apps/expo-go/ios/Podfile
+++ b/apps/expo-go/ios/Podfile
@@ -46,7 +46,6 @@ target 'Expo Go' do
       'expo-dev-launcher',
       'expo-dev-client',
       'expo-dev-menu',
-      'expo-maps',
       'expo-network-addons',
       'expo-insights',
       'expo-splash-screen',

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -158,6 +158,8 @@ PODS:
     - ExpoModulesCore
   - ExpoBattery (10.0.7):
     - ExpoModulesCore
+  - ExpoBlob (0.1.6):
+    - ExpoModulesCore
   - ExpoBlur (15.0.7):
     - ExpoModulesCore
   - ExpoBrightness (14.0.7):
@@ -233,6 +235,8 @@ PODS:
   - ExpoLogBox (0.0.13-canary-20251023-4c86f95):
     - React-Core
   - ExpoMailComposer (15.0.7):
+    - ExpoModulesCore
+  - ExpoMaps (0.12.7):
     - ExpoModulesCore
   - ExpoMediaLibrary (18.2.0):
     - ExpoModulesCore
@@ -4105,6 +4109,7 @@ DEPENDENCIES:
   - ExpoBackgroundFetch (from `../../../packages/expo-background-fetch/ios`)
   - ExpoBackgroundTask (from `../../../packages/expo-background-task/ios`)
   - ExpoBattery (from `../../../packages/expo-battery/ios`)
+  - ExpoBlob (from `../../../packages/expo-blob/ios`)
   - ExpoBlur (from `../../../packages/expo-blur/ios`)
   - ExpoBrightness (from `../../../packages/expo-brightness/ios`)
   - ExpoCalendar (from `../../../packages/expo-calendar/ios`)
@@ -4135,6 +4140,7 @@ DEPENDENCIES:
   - ExpoLocation (from `../../../packages/expo-location/ios`)
   - "ExpoLogBox (from `../../../packages/@expo/log-box`)"
   - ExpoMailComposer (from `../../../packages/expo-mail-composer/ios`)
+  - ExpoMaps (from `../../../packages/expo-maps/ios`)
   - ExpoMediaLibrary (from `../../../packages/expo-media-library/ios`)
   - ExpoMediaLibrary/Tests (from `../../../packages/expo-media-library/ios`)
   - ExpoMeshGradient (from `../../../packages/expo-mesh-gradient/ios`)
@@ -4357,6 +4363,8 @@ EXTERNAL SOURCES:
     :path: "../../../packages/expo-background-task/ios"
   ExpoBattery:
     :path: "../../../packages/expo-battery/ios"
+  ExpoBlob:
+    :path: "../../../packages/expo-blob/ios"
   ExpoBlur:
     :path: "../../../packages/expo-blur/ios"
   ExpoBrightness:
@@ -4413,6 +4421,8 @@ EXTERNAL SOURCES:
     :path: "../../../packages/@expo/log-box"
   ExpoMailComposer:
     :path: "../../../packages/expo-mail-composer/ios"
+  ExpoMaps:
+    :path: "../../../packages/expo-maps/ios"
   ExpoMediaLibrary:
     :path: "../../../packages/expo-media-library/ios"
   ExpoMeshGradient:
@@ -4684,6 +4694,7 @@ SPEC CHECKSUMS:
   ExpoBackgroundFetch: e0a8fba22cb21473f667eb8220cab7feef18e63c
   ExpoBackgroundTask: c6f9ddfb624d9b5ec548d69fd7195745e08ff987
   ExpoBattery: da883ecca2a79507916edd00836ef6a50afecac2
+  ExpoBlob: e49626a466984cca4ee809628e171041c2d89bc0
   ExpoBlur: b5b7a26572b3c33a11f0b2aa2f95c17c4c393b76
   ExpoBrightness: 7c3c86da46b847aadf44401bd28fb6d67050f324
   ExpoCalendar: 46ad51c48d2cb1a95439c2215b182428919a0c3d
@@ -4712,6 +4723,7 @@ SPEC CHECKSUMS:
   ExpoLocation: 1dc9e4c06ef66ed081348a11eb637d1dfecc7d61
   ExpoLogBox: b4c81de3f21bbe2e9467a26455563c76c7709efb
   ExpoMailComposer: 8771121c8d5e6e0e194537fab79360d0f443f70d
+  ExpoMaps: ac5024fd6b3db82da997bdc4074bda5c3e2e7764
   ExpoMediaLibrary: 648cee3f5dcba13410ec9cc8ac9a426e89a61a31
   ExpoMeshGradient: 763087d3b1e6e9a0974e9700ea24cb598816d93c
   ExpoModulesCore: d843eb08a3bc89716cd4eb517f89e17afa451ffc
@@ -4757,7 +4769,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 0608099d4870cac8754bdba9b6953db543432438
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: d7a9424b7191b73c5c774d04fc2e147dd400e67f
+  hermes-engine: 452f2dd7422b2fd7973ae9ca103898d28d7744f0
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -4877,6 +4889,6 @@ SPEC CHECKSUMS:
   Yoga: 5456bb010373068fc92221140921b09d126b116e
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: dd91a5fc3556f0df4e04f71484ba3da93395243a
+PODFILE CHECKSUM: 6088eb4f8fd0e44599ef8762cdcf52e1e6d157af
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
# Why
expo-maps has been out for almost a year. We can add it to expo go. It requires no special permissions on ios.

# How
Remove from exclusions

# Test Plan
Expo go
