### PR TITLE
[file-system][legacy] Fix bad access off the MainActor

### DIFF
--- a/packages/expo-file-system/ios/Legacy/FileSystemLegacyModule.swift
+++ b/packages/expo-file-system/ios/Legacy/FileSystemLegacyModule.swift
@@ -7,9 +7,7 @@ private let EVENT_DOWNLOAD_PROGRESS = "expo-file-system.downloadProgress"
 private let EVENT_UPLOAD_PROGRESS = "expo-file-system.uploadProgress"
 
 public final class FileSystemLegacyModule: Module {
-  private lazy var sessionTaskDispatcher = EXSessionTaskDispatcher(
-    sessionHandler: ExpoAppDelegateSubscriberRepository.getSubscriberOfType(FileSystemBackgroundSessionHandler.self)
-  )
+  private var sessionTaskDispatcher: EXSessionTaskDispatcher!
   private lazy var taskHandlersManager = EXTaskHandlersManager()
   private lazy var resourceManager = PHAssetResourceManager()
 
@@ -40,6 +38,14 @@ public final class FileSystemLegacyModule: Module {
     }
 
     Events(EVENT_DOWNLOAD_PROGRESS, EVENT_UPLOAD_PROGRESS)
+    
+    OnCreate {
+      Task { @MainActor in
+        sessionTaskDispatcher = EXSessionTaskDispatcher(
+          sessionHandler: ExpoAppDelegateSubscriberRepository.getSubscriberOfType(FileSystemBackgroundSessionHandler.self)
+        )
+      }
+    }
 
     AsyncFunction("getInfoAsync") { (url: URL, options: InfoOptions, promise: Promise) in
       let optionsDict = options.toDictionary(appContext: appContext)


### PR DESCRIPTION
# Why
Fixes the legacy fileSystem module

# How
Because `ExpoAppDelegateSubscriberRepository` is now marked as `@MainActor` we cannot access its methods off the main thread. This was hidden by the `@preconcurrency` attribute. The `sessionTaskDispatcher` now needs to be initialized on the `MainActor` so I've moved its initialization to `OnCreate` and made it an implicitly unwrapped optional. It's not ideal but not unusual to do this on iOS when a value cannot be set in a initializer. 

# Test Plan
Legacy fileSystem tests no longer cause a hard crash

