### PR TITLE
[menu][Android] Temporarily disabled the fast refresh toggle

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [android] Make reactNativeHost optional in ReactHostWrapper ([#40085](https://github.com/expo/expo/pull/40085) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Remove `ReactHostWrapper` ([#40295](https://github.com/expo/expo/pull/40295) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Remove tests related files from the published package content. ([#39551](https://github.com/expo/expo/pull/39551) by [@Simek](https://github.com/Simek))
+- [Android] Temporarily disabled the fast refresh toggle in the dev menu as it's causing the app to crash due to a React Native issue.
 
 ### ⚠️ Notices
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -25,7 +25,7 @@
 - [android] Make reactNativeHost optional in ReactHostWrapper ([#40085](https://github.com/expo/expo/pull/40085) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Remove `ReactHostWrapper` ([#40295](https://github.com/expo/expo/pull/40295) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Remove tests related files from the published package content. ([#39551](https://github.com/expo/expo/pull/39551) by [@Simek](https://github.com/Simek))
-- [Android] Temporarily disabled the fast refresh toggle in the dev menu as it's causing the app to crash due to a React Native issue.
+- [Android] Temporarily disabled the fast refresh toggle in the dev menu as it's causing the app to crash due to a React Native issue. ([#42146](https://github.com/expo/expo/pull/42146) by [@lukmccall](https://github.com/lukmccall))
 
 ### ⚠️ Notices
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/ui/ToolsSection.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/ui/ToolsSection.kt
@@ -85,32 +85,33 @@ fun ToolsSection(
         }
       )
 
+      // TODO(@lukmccall): Re-enable when toggling fast refresh is not longer crashing app
+//      Divider(thickness = 0.5.dp)
+//
+//      NewMenuButton(
+//        withSurface = false,
+//        icon = {
+//          MenuIcons.Refresh(
+//            size = 20.dp,
+//            tint = NewAppTheme.colors.icon.tertiary
+//          )
+//        },
+//        content = {
+//          NewText(
+//            text = "Fast Refresh"
+//          )
+//        },
+//        rightComponent = {
+//          ToggleSwitch(
+//            isToggled = devToolsSettings.isHotLoadingEnabled
+//          )
+//        },
+//        onClick = {
+//          onAction(DevMenuAction.ToggleFastRefresh(!devToolsSettings.isHotLoadingEnabled))
+//        }
+//      )
+
       Divider(thickness = 0.5.dp)
-
-      NewMenuButton(
-        withSurface = false,
-        icon = {
-          MenuIcons.Refresh(
-            size = 20.dp,
-            tint = NewAppTheme.colors.icon.tertiary
-          )
-        },
-        content = {
-          NewText(
-            text = "Fast Refresh"
-          )
-        },
-        rightComponent = {
-          ToggleSwitch(
-            isToggled = devToolsSettings.isHotLoadingEnabled
-          )
-        },
-        onClick = {
-          onAction(DevMenuAction.ToggleFastRefresh(!devToolsSettings.isHotLoadingEnabled))
-        }
-      )
-
-      Divider(color = NewAppTheme.colors.border.default)
 
       NewMenuButton(
         withSurface = false,


### PR DESCRIPTION
# Why

Temporarily disables the fast refresh toggle in the dev menu as it's causing the app to crash due to a React Native issue.

