### PR TITLE
[NCL][iOS] Fix Speech screen importing SwiftUI in Expo Go

### DIFF
--- a/apps/native-component-list/src/screens/TextToSpeechScreen.tsx
+++ b/apps/native-component-list/src/screens/TextToSpeechScreen.tsx
@@ -1,6 +1,5 @@
-import { Picker as SwiftUIPicker, Host, Text as SwiftUIText } from '@expo/ui/swift-ui';
-import { fixedSize, pickerStyle, tag } from '@expo/ui/swift-ui/modifiers';
 import { Picker } from '@react-native-picker/picker';
+import { isRunningInExpoGo } from 'expo';
 import * as Speech from 'expo-speech';
 import * as React from 'react';
 import {
@@ -60,6 +59,57 @@ interface State {
   voiceList?: { name: string; identifier: string }[];
   voice?: string;
   volume: number;
+}
+
+let ApplicationAudioSessionPicker: React.FC<{
+  useApplicationAudioSession: boolean | undefined;
+  onSelectionChange: (useApplicationAudioSession: boolean | undefined) => void;
+}>;
+
+// SwiftUI is not included in Expo Go
+if (!isRunningInExpoGo() && Platform.OS === 'ios') {
+  const { Picker: SwiftUIPicker, Host, Text: SwiftUIText } = require('@expo/ui/swift-ui');
+  const { fixedSize, pickerStyle, tag } = require('@expo/ui/swift-ui/modifiers');
+
+  ApplicationAudioSessionPicker = function ApplicationAudioSessionPicker(props) {
+    return (
+      <View style={styles.controlRow}>
+        <Host matchContents>
+          <SwiftUIPicker
+            modifiers={[pickerStyle('segmented'), fixedSize()]}
+            selection={audioSessionOptions.findIndex(
+              (option) => option.value === props.useApplicationAudioSession
+            )}
+            onSelectionChange={(selection: any) => {
+              const index = typeof selection === 'number' ? selection : 0;
+              const useApplicationAudioSession = audioSessionOptions[index].value;
+              props.onSelectionChange(useApplicationAudioSession);
+            }}>
+            {audioSessionOptions.map((option, index) => (
+              <SwiftUIText key={index} modifiers={[tag(index)]}>
+                {option.label}
+              </SwiftUIText>
+            ))}
+          </SwiftUIPicker>
+        </Host>
+      </View>
+    )
+  }
+} else {
+  ApplicationAudioSessionPicker = function ApplicationAudioSessionPicker(props) {
+    return (
+      <Picker selectedValue={audioSessionOptions.findIndex(
+        (option) => option.value === props.useApplicationAudioSession
+      )} onValueChange={(_value, index) => {
+        const useApplicationAudioSession = audioSessionOptions[index].value;
+        props.onSelectionChange(useApplicationAudioSession);
+      }}>
+        {audioSessionOptions.map((option, index) => (
+          <Picker.Item key={index} label={option.label} value={index} />
+        ))}
+      </Picker>
+    );
+  }
 }
 
 export default class TextToSpeechScreen extends React.Component<object, State> {
@@ -165,31 +215,17 @@ export default class TextToSpeechScreen extends React.Component<object, State> {
         </View>
         {Platform.OS === 'ios' && (
           <>
-            <Text>useApplicationAudioSession</Text>
-            <View style={styles.controlRow}>
-              <Host matchContents>
-                <SwiftUIPicker
-                  modifiers={[pickerStyle('segmented'), fixedSize()]}
-                  selection={audioSessionOptions.findIndex(
-                    (option) => option.value === this.state.useApplicationAudioSession
-                  )}
-                  onSelectionChange={(selection) => {
-                    const index = typeof selection === 'number' ? selection : 0;
-                    const useApplicationAudioSession = audioSessionOptions[index].value;
-                    this.setState({
-                      useApplicationAudioSession,
-                    });
-                  }}>
-                  {audioSessionOptions.map((option, index) => (
-                    <SwiftUIText key={index} modifiers={[tag(index)]}>
-                      {option.label}
-                    </SwiftUIText>
-                  ))}
-                </SwiftUIPicker>
-              </Host>
-            </View>
+            <View style={styles.separator} />
+            <Text style={styles.controlText}>useApplicationAudioSession</Text>
+            <ApplicationAudioSessionPicker
+              useApplicationAudioSession={this.state.useApplicationAudioSession}
+              onSelectionChange={(useApplicationAudioSession) => {
+                this.setState({ useApplicationAudioSession })
+              }}
+            />
           </>
-        )}
+        )
+        }
       </ScrollView>
     );
   }

--- a/apps/native-component-list/src/screens/TextToSpeechScreen.tsx
+++ b/apps/native-component-list/src/screens/TextToSpeechScreen.tsx
@@ -93,23 +93,25 @@ if (!isRunningInExpoGo() && Platform.OS === 'ios') {
           </SwiftUIPicker>
         </Host>
       </View>
-    )
-  }
+    );
+  };
 } else {
   ApplicationAudioSessionPicker = function ApplicationAudioSessionPicker(props) {
     return (
-      <Picker selectedValue={audioSessionOptions.findIndex(
-        (option) => option.value === props.useApplicationAudioSession
-      )} onValueChange={(_value, index) => {
-        const useApplicationAudioSession = audioSessionOptions[index].value;
-        props.onSelectionChange(useApplicationAudioSession);
-      }}>
+      <Picker
+        selectedValue={audioSessionOptions.findIndex(
+          (option) => option.value === props.useApplicationAudioSession
+        )}
+        onValueChange={(_value, index) => {
+          const useApplicationAudioSession = audioSessionOptions[index].value;
+          props.onSelectionChange(useApplicationAudioSession);
+        }}>
         {audioSessionOptions.map((option, index) => (
           <Picker.Item key={index} label={option.label} value={index} />
         ))}
       </Picker>
     );
-  }
+  };
 }
 
 export default class TextToSpeechScreen extends React.Component<object, State> {
@@ -220,12 +222,11 @@ export default class TextToSpeechScreen extends React.Component<object, State> {
             <ApplicationAudioSessionPicker
               useApplicationAudioSession={this.state.useApplicationAudioSession}
               onSelectionChange={(useApplicationAudioSession) => {
-                this.setState({ useApplicationAudioSession })
+                this.setState({ useApplicationAudioSession });
               }}
             />
           </>
-        )
-        }
+        )}
       </ScrollView>
     );
   }


### PR DESCRIPTION
# Why

NCL TextToSpeech screen is throwing in Expo Go because @expo/ui SwiftUI is imported.

# How

Hack with conditional component implementation - import and use SwiftUI only on non-Expo GO iOS
Fall back to normal Picker on Expo Go

# Test Plan

- Tested picker in iOS Expo Go
- Tested picker in iOS Bare Expo
- Android Expo Go not throwing

| Bare Expo | Expo Go |
| --- | --- |
| <img width="300" alt="bare-expo" src="https://github.com/user-attachments/assets/1b5b33ef-dbbe-4d28-af7e-fa89797f2a06" /> | <img width="300" alt="expo-go" src="https://github.com/user-attachments/assets/e9cf74af-96eb-45ab-b8a8-130ae24b5ea5" /> |


