### PR TITLE
fix(brownfield): Add missing intermediary entrypoint for `expo-brownfield` CLI

### DIFF
--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -11,7 +11,7 @@
 - [iOS] Added support for React Native 0.83 in [#42038](https://github.com/expo/expo/pull/42038) by [@gabrieldonadel](https://github.com/gabrieldonadel)
 - [iOS] Refactor podspec and fix template ([#42105](https://github.com/expo/expo/pull/42105) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [android] Added support for react-native 0.83 ([#42069](https://github.com/expo/expo/pull/42069) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-
+- Add `bin/cli.js` entrypoint for CLI ([#42152](https://github.com/expo/expo/pull/42152) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/expo-brownfield/bin/cli.js
+++ b/packages/expo-brownfield/bin/cli.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../cli/build/index.js');

--- a/packages/expo-brownfield/package.json
+++ b/packages/expo-brownfield/package.json
@@ -4,7 +4,7 @@
   "description": "Toolkit and APIs for adding brownfield setup to Expo projects",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
-  "bin": "./cli/build/index.js",
+  "bin": "./bin/cli.js",
   "exports": {
     ".": {
       "source": "./src/index.ts",


### PR DESCRIPTION
# Why

This was missing a non-build entrypoint file. That means the shebang was missing from the `bin` entrypoint and that yarn was modifying the execution rights of `build`, which would be lost when `build` is cleared and wasn't present on `main` either.

# How

- Add `bin/cli.js` entrypoint (chmod `+x`)
- Switch `bin` to `bin/cli.js`

# Test Plan

- n/a

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
