### PR TITLE
[expo-audio] reverted removing the stay active.. btn from audio recording screen

### DIFF
--- a/apps/native-component-list/src/screens/Audio/AudioModeSelector.android.tsx
+++ b/apps/native-component-list/src/screens/Audio/AudioModeSelector.android.tsx
@@ -99,6 +99,10 @@ export default function AudioModeSelector() {
         valueName: 'shouldRouteThroughEarpiece',
       })}
       {renderToggle({
+        title: 'Stay active in background',
+        valueName: 'shouldPlayInBackground',
+      })}
+      {renderToggle({
         title: 'Allow background recording',
         valueName: 'allowsBackgroundRecording',
       })}


### PR DESCRIPTION
# Why

In #42134 I removed the button "Stay active in the background", this is not necessary, it can still be used in the recording screen since it contains a player as well as a recorder.

# Test Plan

✅ Bare Expo

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
