### PR TITLE
fix(cli): Restrict connections to debugger and devtools websockets

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Pass empty `nodeModulesPaths` when applying autolinking and fallback resolution to Metro resolver ([#41703](https://github.com/expo/expo/pull/41703) by [@kitten](https://github.com/kitten))
 - Restore `resetCache`, `maxWorkers`, and `port` override args when instantiating Metro ([#41854](https://github.com/expo/expo/pull/41854) by [@shottah](https://github.com/shottah))
 - Fix response streaming from dev server (remove compression) ([#41955](https://github.com/expo/expo/pull/41955) by [@krystofwoldrich](https://github.com/krystofwoldrich))
+- Restrict debugger (`/inspector/network`) and devtools (`/expo-dev-plugins/broadcast`) sockets to local connections ([#42156](https://github.com/expo/expo/pull/42156) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/DevToolsPluginWebsocketEndpoint.ts
+++ b/packages/@expo/cli/src/start/server/metro/DevToolsPluginWebsocketEndpoint.ts
@@ -14,7 +14,9 @@ export function createDevToolsPluginWebsocketEndpoint({
   wss.on('connection', (ws, request) => {
     // Explicitly limit devtools websocket to loopback requests
     if (!isLocalSocket(request.socket) || !isMatchingOrigin(request, serverBaseUrl)) {
-      ws.close();
+      // NOTE: `socket.close` nicely closes the websocket, which will still allow incoming messages
+      // `socket.terminate` instead forcefully closes down the socket
+      ws.terminate();
       return;
     }
 

--- a/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
@@ -117,7 +117,7 @@ function createNetworkWebsocket(debuggerWebsocket: WebSocketServer) {
           // If its a response body, write it to the global storage
           const { requestId, ...requestInfo } = message.params;
           NETWORK_RESPONSE_STORAGE.set(requestId, requestInfo);
-        } else {
+        } else if (message.method.startsWith('Network.')) {
           // Otherwise, directly re-broadcast the Network events to all connected debuggers
           debuggerWebsocket.clients.forEach((debuggerSocket) => {
             if (debuggerSocket.readyState === debuggerSocket.OPEN) {

--- a/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
@@ -58,7 +58,9 @@ export function createDebugMiddleware({
   // Explicitly limit debugger websocket to loopback requests
   debuggerWebsocketEndpoint.on('connection', (socket, request) => {
     if (!isLocalSocket(request.socket) || !isMatchingOrigin(request, serverBaseUrl)) {
-      socket.close();
+      // NOTE: `socket.close` nicely closes the websocket, which will still allow incoming messages
+      // `socket.terminate` instead forcefully closes down the socket
+      socket.terminate();
     }
   });
 

--- a/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
@@ -1,10 +1,9 @@
 import type { NextHandleFunction } from 'connect';
-import type { IncomingMessage } from 'node:http';
 import { WebSocketServer } from 'ws';
 
 import { createHandlersFactory } from './createHandlersFactory';
 import { env } from '../../../../utils/env';
-import { isLocalSocket } from '../../../../utils/net';
+import { isLocalSocket, isMatchingOrigin } from '../../../../utils/net';
 import { type MetroBundlerDevServer } from '../MetroBundlerDevServer';
 import { TerminalReporter } from '../TerminalReporter';
 import { NETWORK_RESPONSE_STORAGE } from './messageHandlers/NetworkResponse';
@@ -92,16 +91,6 @@ function makeLogger(reporter: TerminalReporter, level: 'info' | 'warn' | 'error'
       data,
     });
 }
-
-const isMatchingOrigin = (request: IncomingMessage, serverBaseUrl: string): boolean => {
-  // NOTE(@kitten): The browser will always send an origin header for websocket upgrade connections
-  if (!request.headers.origin) {
-    return true;
-  }
-  const actualHost = new URL(request.headers.origin).host;
-  const expectedHost = new URL(serverBaseUrl).host;
-  return actualHost === expectedHost;
-};
 
 /**
  * This adds a dedicated websocket connection that handles Network-related CDP events.

--- a/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
@@ -4,7 +4,6 @@ import { WebSocketServer } from 'ws';
 import { createHandlersFactory } from './createHandlersFactory';
 import { env } from '../../../../utils/env';
 import { isLocalSocket, isMatchingOrigin } from '../../../../utils/net';
-import { type MetroBundlerDevServer } from '../MetroBundlerDevServer';
 import { TerminalReporter } from '../TerminalReporter';
 import { NETWORK_RESPONSE_STORAGE } from './messageHandlers/NetworkResponse';
 
@@ -15,10 +14,15 @@ interface DebugMiddleware {
   debugWebsocketEndpoints: Record<string, WebSocketServer>;
 }
 
-export function createDebugMiddleware(
-  metroBundler: MetroBundlerDevServer,
-  reporter: TerminalReporter
-): DebugMiddleware {
+interface DebugMiddlewareParams {
+  serverBaseUrl: string;
+  reporter: TerminalReporter;
+}
+
+export function createDebugMiddleware({
+  serverBaseUrl,
+  reporter,
+}: DebugMiddlewareParams): DebugMiddleware {
   // Load the React Native debugging tools from project
   // TODO: check if this works with isolated modules
   const { createDevMiddleware } =
@@ -28,9 +32,7 @@ export function createDebugMiddleware(
     // TODO: Check with cedric why this can be removed
     // https://github.com/facebook/react-native/pull/53921
     // projectRoot: metroBundler.projectRoot,
-    serverBaseUrl: metroBundler
-      .getUrlCreator()
-      .constructUrl({ scheme: 'http', hostType: 'localhost' }),
+    serverBaseUrl,
     logger: createLogger(reporter),
     unstable_customInspectorMessageHandler: createHandlersFactory(),
     // TODO: Forward all events to the shared Metro log reporter. Do this when we have opinions on how all logs should be presented.

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -281,6 +281,9 @@ export async function instantiateMetroAsync(
       }
       return middleware.use(metroMiddleware);
     };
+
+    const devtoolsWebsocketEndpoints = createDevToolsPluginWebsocketEndpoint({ serverBaseUrl });
+    Object.assign(websocketEndpoints, devtoolsWebsocketEndpoints);
   }
 
   // Attach Expo Atlas if enabled
@@ -298,10 +301,7 @@ export async function instantiateMetroAsync(
     metroBundler,
     metroConfig,
     {
-      websocketEndpoints: {
-        ...websocketEndpoints,
-        ...createDevToolsPluginWebsocketEndpoint({ serverBaseUrl }),
-      },
+      websocketEndpoints,
       watch: !isExporting && isWatchEnabled(),
     },
     {

--- a/packages/@expo/cli/src/utils/__tests__/net-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/net-test.ts
@@ -1,4 +1,4 @@
-import { isLocalSocket as _isLocalSocket } from '../net';
+import { isLocalSocket as _isLocalSocket, isMatchingOrigin } from '../net';
 
 const isLocalSocket = _isLocalSocket as (x: any) => boolean;
 
@@ -30,6 +30,27 @@ describe(isLocalSocket, () => {
       isLocalSocket({ remoteFamily: 'IPv4', localAddress: '127.0.0.1', remoteAddress: '1.1.1.1' })
     ).toBe(false);
     expect(isLocalSocket({ remoteFamily: 'IPv4', localAddress: '::1', remoteAddress: '::2' })).toBe(
+      false
+    );
+  });
+});
+
+describe(isMatchingOrigin, () => {
+  it('returns true when no Origin header was sent', () => {
+    expect(isMatchingOrigin({ headers: {} }, 'http://127.0.0.1:8181')).toBe(true);
+  });
+
+  it('returns true when Origin header matches expected Host', () => {
+    expect(
+      isMatchingOrigin({ headers: { origin: 'http://127.0.0.1:8181' } }, 'http://127.0.0.1:8181')
+    ).toBe(true);
+    expect(
+      isMatchingOrigin({ headers: { origin: 'http://127.0.0.1:8180' } }, 'http://127.0.0.1:8181')
+    ).toBe(false);
+    expect(
+      isMatchingOrigin({ headers: { origin: 'https://127.0.0.1:8181' } }, 'http://127.0.0.1:8181')
+    ).toBe(true);
+    expect(isMatchingOrigin({ headers: { origin: 'http://other' } }, 'http://127.0.0.1:8181')).toBe(
       false
     );
   });

--- a/packages/@expo/cli/src/utils/__tests__/net-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/net-test.ts
@@ -1,0 +1,36 @@
+import { isLocalSocket as _isLocalSocket } from '../net';
+
+const isLocalSocket = _isLocalSocket as (x: any) => boolean;
+
+describe(isLocalSocket, () => {
+  it('detects loopback sockets', () => {
+    expect(isLocalSocket({ localAddress: '127.0.0.1', remoteAddress: '127.0.0.1' })).toBe(true);
+    expect(isLocalSocket({ remoteFamily: 'IPv4', remoteAddress: '127.0.0.1' })).toBe(true);
+    expect(isLocalSocket({ remoteFamily: 'IPv6', remoteAddress: '::ffff:127.0.0.1' })).toBe(true);
+    expect(isLocalSocket({ remoteFamily: 'IPv6', remoteAddress: '::1' })).toBe(true);
+    expect(isLocalSocket({ localAddress: '::1', remoteAddress: '::1', remoteFamily: 'IPv6' })).toBe(
+      true
+    );
+    expect(
+      isLocalSocket({ localAddress: '::ffff:127.0.0.1', remoteAddress: '::ffff:127.0.0.1' })
+    ).toBe(true);
+    expect(
+      isLocalSocket({ localAddress: '::ffff:127.0.0.1', remoteAddress: '::ffff:127.0.0.1' })
+    ).toBe(true);
+  });
+
+  it('rejects other connections', () => {
+    expect(
+      isLocalSocket({ remoteFamily: 'IPv4', localAddress: '127.0.0.1', remoteAddress: '10.0.0.2' })
+    ).toBe(false);
+    expect(
+      isLocalSocket({ remoteFamily: 'IPv4', localAddress: '127.0.0.1', remoteAddress: '100.0.0.1' })
+    ).toBe(false);
+    expect(
+      isLocalSocket({ remoteFamily: 'IPv4', localAddress: '127.0.0.1', remoteAddress: '1.1.1.1' })
+    ).toBe(false);
+    expect(isLocalSocket({ remoteFamily: 'IPv4', localAddress: '::1', remoteAddress: '::2' })).toBe(
+      false
+    );
+  });
+});

--- a/packages/@expo/cli/src/utils/net.ts
+++ b/packages/@expo/cli/src/utils/net.ts
@@ -1,3 +1,4 @@
+import type { IncomingHttpHeaders } from 'node:http';
 import type { Socket } from 'node:net';
 
 const ipv6To4Prefix = '::ffff:';
@@ -17,4 +18,21 @@ export const isLocalSocket = (socket: Socket): boolean => {
   }
 
   return remoteAddress === '::1' || remoteAddress.startsWith('127.');
+};
+
+interface AbstractIncomingMessage {
+  headers: IncomingHttpHeaders | Record<string, string | string[]>;
+}
+
+export const isMatchingOrigin = (
+  request: AbstractIncomingMessage,
+  serverBaseUrl: string
+): boolean => {
+  // NOTE(@kitten): The browser will always send an origin header for websocket upgrade connections
+  if (!request.headers.origin) {
+    return true;
+  }
+  const actualHost = new URL(`${request.headers.origin}`).host;
+  const expectedHost = new URL(serverBaseUrl).host;
+  return actualHost === expectedHost;
 };

--- a/packages/@expo/cli/src/utils/net.ts
+++ b/packages/@expo/cli/src/utils/net.ts
@@ -1,0 +1,20 @@
+import type { Socket } from 'node:net';
+
+const ipv6To4Prefix = '::ffff:';
+
+export const isLocalSocket = (socket: Socket): boolean => {
+  let { localAddress, remoteAddress, remoteFamily } = socket;
+
+  const isLoopbackRequest = localAddress && localAddress === remoteAddress;
+  if (isLoopbackRequest) {
+    return true;
+  } else if (!remoteAddress || !remoteFamily) {
+    return false;
+  }
+
+  if (remoteFamily === 'IPv6' && remoteAddress.startsWith(ipv6To4Prefix)) {
+    remoteAddress = remoteAddress.slice(ipv6To4Prefix.length);
+  }
+
+  return remoteAddress === '::1' || remoteAddress.startsWith('127.');
+};


### PR DESCRIPTION
# Why

These endpoints shouldn't be accessible from any remote, but are intended to only be used from `localhost`. This affects the CDP websocket and the devtools websocket. Any remote connection should be disabled and the connection should be dropped. Similar, the request middleware should reject any remote requests.

# How

- Add `isLocalSocket` and `isMatchingOrigin` checks
- Reject remote sockets on CDP websocket connection
- Reject remote sockets on devtools websocket connection
- Reject mismatching origin on CDP websocket connection
- Reject mismatching origin on devtools websocket connection
- Only activate devtools websocket for non-exporting modes

# Test Plan

- Unit tests added for `isLocalSocket`
- Try to access debugger endpoints from a different machine on the same network to observe request middleware not activating
- Try to connect from a different machine on the same network to observe active `close` of socket
- Try to alter `Origin` to oberve active `close` of socket
- Test that an app on the local network can still connect to CDP

**Manual Checks:**
- [x] Tested manually on macOS
- [ ] Tested manually on Linux
- [x] Tested manually on Windows

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
