### PR TITLE
[menu][Android] Add ability to remove overlay permission

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoApplication.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoApplication.kt
@@ -7,6 +7,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
 import com.facebook.react.soloader.OpenSourceMergedSoMapping
 import com.facebook.soloader.SoLoader
+import expo.modules.devmenu.api.DevMenuApi
 import host.exp.exponent.analytics.EXL
 import host.exp.exponent.branch.BranchManager
 import host.exp.exponent.di.NativeModuleDepsProvider
@@ -30,6 +31,11 @@ abstract class ExpoApplication : Application() {
 
   override fun onCreate() {
     super.onCreate()
+
+    // The performance monitor in Expo Go doesn't require overlay permission.
+    DevMenuApi.configure(
+      performanceMonitorNeedsOverlayPermission = false
+    )
 
     ExpoViewBuildConfig.DEBUG = isDebug
     ExpoViewBuildConfig.USE_EMBEDDED_KERNEL = shouldUseEmbeddedKernel()

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuSettings.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuSettings.kt
@@ -1,0 +1,8 @@
+package expo.modules.devmenu
+
+internal object DevMenuSettings {
+  /**
+   * Whether the performance monitor requires overlay permission
+   */
+  internal var performanceMonitorNeedsOverlayPermission: Boolean = true
+}

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/api/DevMenuApi.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/api/DevMenuApi.kt
@@ -12,6 +12,7 @@ import expo.modules.devmenu.AppInfoProvider
 import expo.modules.devmenu.DevMenuDefaultPreferences
 import expo.modules.devmenu.DevMenuFragment
 import expo.modules.devmenu.DevMenuPreferences
+import expo.modules.devmenu.DevMenuSettings
 import expo.modules.devmenu.GoHomeAction
 import expo.modules.devmenu.helpers.getPrivateDeclaredFieldValue
 import expo.modules.devmenu.helpers.setPrivateDeclaredFieldValue
@@ -34,6 +35,12 @@ object DevMenuApi {
     activityProvider,
     mapper = { it.viewModel }
   )
+
+  fun configure(
+    performanceMonitorNeedsOverlayPermission: Boolean = true
+  ) {
+    DevMenuSettings.performanceMonitorNeedsOverlayPermission = performanceMonitorNeedsOverlayPermission
+  }
 
   fun createFragmentHost(
     activity: Activity,

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/devtools/DevMenuDevToolsDelegate.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/devtools/DevMenuDevToolsDelegate.kt
@@ -10,6 +10,7 @@ import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.devsupport.HMRClient
 import com.facebook.react.devsupport.interfaces.DevSupportManager
+import expo.modules.devmenu.DevMenuSettings
 import expo.modules.devmenu.api.DevMenuApi
 import expo.modules.devmenu.compose.DevMenuAction
 import expo.modules.devmenu.websockets.DevMenuMetroClient
@@ -62,7 +63,9 @@ class DevMenuDevToolsDelegate(
     val devSettings = devSettings ?: return
     val context = context ?: return
 
-    requestOverlaysPermission(context)
+    if (DevMenuSettings.performanceMonitorNeedsOverlayPermission) {
+      requestOverlaysPermission(context)
+    }
     devSupportManager.setFpsDebugEnabled(!devSettings.isFpsDebugEnabled)
   }
 


### PR DESCRIPTION
# Why

Adds the ability to remove overlay permission, as it's not needed in Expo Go where we have a new performance monitor.
There's a bug currently, where you can also see the performance monitor from RN. I'll fix it in a separate PR. 

# Test Plan

- Expo Go ✅ 