### PR TITLE
[fetch] Fix streaming race condition causing out-of-order chunk delivery

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed expo-fetch race condition causing out-of-order delivery of initial chunks ([#42161](https://github.com/expo/expo/pull/42161) by [@matthieugicquel](https://github.com/matthieugicquel))
 - [iOS] Pass the React runtime scheduler to `ExpoModulesCore` through a weak handle, so dispatching onto the JS thread during a reload no longer risks calling into a scheduler the React instance already destroyed. ([#47492](https://github.com/expo/expo/pull/47492) by [@tsapeta](https://github.com/tsapeta))
 - Fix `expo/fetch` on Android sending a single `0x00` byte instead of an empty body for body-less `POST`/`PUT`/`PATCH` requests. ([#46678](https://github.com/expo/expo/pull/46678) by [@zoontek](https://github.com/zoontek))
 - Fix iOS build against React Native 0.87+ by dropping the legacy architecture (bridge) `RCTRootViewFactoryConfiguration` setup. ([#46641](https://github.com/expo/expo/pull/46641) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo/android/src/main/java/expo/modules/fetch/NativeResponse.kt
+++ b/packages/expo/android/src/main/java/expo/modules/fetch/NativeResponse.kt
@@ -9,6 +9,7 @@ import expo.modules.kotlin.sharedobjects.SharedObject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.Response
@@ -138,7 +139,7 @@ internal class NativeResponse(appContext: AppContext, private val coroutineScope
     responseInit = createResponseInit(response)
     state = ResponseState.RESPONSE_RECEIVED
 
-    coroutineScope.launch(Dispatchers.IO) {
+    coroutineScope.launch {
       val stream = response.body?.source() ?: return@launch
       pumpResponseBodyStream(stream)
       response.close()
@@ -182,9 +183,13 @@ internal class NativeResponse(appContext: AppContext, private val coroutineScope
     )
   }
 
-  private fun pumpResponseBodyStream(stream: BufferedSource) {
+  private suspend fun pumpResponseBodyStream(stream: BufferedSource) {
     try {
-      while (!stream.exhausted()) {
+      while (true) {
+        val data = withContext(Dispatchers.IO) {
+          if (stream.exhausted()) null else stream.buffer.readByteArray()
+        } ?: break
+
         if (isInvalidState(
             ResponseState.RESPONSE_RECEIVED,
             ResponseState.BODY_STREAMING_STARTED,
@@ -194,9 +199,9 @@ internal class NativeResponse(appContext: AppContext, private val coroutineScope
           break
         }
         if (state == ResponseState.RESPONSE_RECEIVED) {
-          sink.appendBufferBody(stream.buffer.readByteArray())
+          sink.appendBufferBody(data)
         } else if (state == ResponseState.BODY_STREAMING_STARTED) {
-          emit("didReceiveResponseData", stream.buffer.readByteArray())
+          emit("didReceiveResponseData", data)
         } else {
           break
         }

--- a/packages/expo/android/src/main/java/expo/modules/fetch/NativeResponse.kt
+++ b/packages/expo/android/src/main/java/expo/modules/fetch/NativeResponse.kt
@@ -8,6 +8,7 @@ import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.sharedobjects.SharedObject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.Call
@@ -141,8 +142,15 @@ internal class NativeResponse(appContext: AppContext, private val coroutineScope
 
     coroutineScope.launch {
       val stream = response.body?.source() ?: return@launch
-      pumpResponseBodyStream(stream)
-      response.close()
+      try {
+        pumpResponseBodyStream(stream)
+      } finally {
+        // Close off the modules queue so the blocking call doesn't stall it.
+        // NonCancellable guarantees the response is released even if the scope is canceled mid-stream.
+        withContext(NonCancellable + Dispatchers.IO) {
+          response.close()
+        }
+      }
 
       if (this@NativeResponse.state == ResponseState.BODY_STREAMING_STARTED) {
         emit("didComplete")


### PR DESCRIPTION
# Why

Fixes #41783 on Android.

I also observed this issue of out-of-order delivery in production in a significant amount of requests.

My understanding is that there's a race between startStreaming() (called from JS) and the network callbacks delivering chunks:

In some cases it causes a chunk loss:
```
     IO Thread                         JS Thread
        │                                  │
   sink.append(A)                          │
   sink.append(B)                          │
        │                                  │
        ├─ read state ─────────────────────┤
        │  (RESPONSE_RECEIVED)             │
        │                             state = STREAMING
        │                             data = sink.finalize() → [A,B]
        │                             emit([A,B])
        │                                  │
   sink.append(C) ←── sink is finalized, C goes nowhere
        │                                  │
        ├─ read state ─────────────────────┤
        │  (STREAMING)                     │
   emit(D)                                 │
        │                                  │
        ▼                                  ▼
JS receives: [A,B], [D]
C is lost
```

And in other ones out-of-order delivery:

```
     IO Thread                         JS Thread
        │                                  │
   sink.append(A)                          │
   sink.append(B)                          │
        │                                  │
        ├─ read state ─────────────────────┤
        │  (RESPONSE_RECEIVED)             │
        │                             state = STREAMING
   sink.append(C) ←── C wins race, added before finalize
        │                                  │
        ├─ read state ─────────────────────┤
        │  (STREAMING)                     │
   emit(D)                            data = sink.finalize() → [A,B,C]
        │                             emit([A,B,C])
        ▼                                  ▼
JS receives: [D], [A,B,C]
```

# How

Add a `synchronised` block. This seems safe, but I'm not 100% sure about the perf impact / whether that's the best way to handle this.

_Note: a previous version of this PR included an iOS fix, but as I haven't been able to reproduce the issue there, I dropped this part for now (though production logs indicate the issues exists on iOS too)._

# Test Plan

I've pushed a repro to [this commit](https://github.com/matthieugicquel/expo/commit/e83d7c11d2fb16df19ed51dd4c8763f22c6d8a43) of my fork on the minimal-tester app. It triggers the race condition ~10% of the time on the device I have before the fix, and 0% after the fix.

_Note: this repro also frequently triggers a "stream is not in a state that permits close" error that I'm not trying to fix in this PR._

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)