### PR TITLE
test(@expo/cli): improve loader E2E tests

### DIFF
--- a/apps/router-e2e/__e2e__/server-loader/app/_layout.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/_layout.tsx
@@ -1,0 +1,11 @@
+import { Slot } from 'expo-router';
+
+import { Container } from '../components/Container';
+
+export default function RootLayout() {
+  return (
+    <Container>
+      <Slot />
+    </Container>
+  );
+}

--- a/apps/router-e2e/__e2e__/server-loader/app/env.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/env.tsx
@@ -1,7 +1,9 @@
 import { useLoaderData, useLocalSearchParams, usePathname } from 'expo-router';
-import { Container } from '../components/Container';
-import { Table, TableRow } from '../components/Table';
+import { Suspense } from 'react';
+
+import { Loading } from '../components/Loading';
 import { SiteLinks, SiteLink } from '../components/SiteLink';
+import { Table, TableRow } from '../components/Table';
 
 export async function loader() {
   return Promise.resolve({
@@ -9,13 +11,21 @@ export async function loader() {
   });
 }
 
-export default function Env() {
+export default function EnvRoute() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <EnvScreen />
+    </Suspense>
+  );
+}
+
+const EnvScreen = () => {
   const pathname = usePathname();
   const localParams = useLocalSearchParams();
   const data = useLoaderData<typeof loader>();
 
   return (
-    <Container>
+    <>
       <Table>
         <TableRow label="Pathname" value={pathname} testID="pathname-result" />
         <TableRow label="Local Params" value={localParams} testID="localparams-result" />
@@ -26,6 +36,6 @@ export default function Env() {
         <SiteLink href="/">Go to Index</SiteLink>
         <SiteLink href="/second">Go to Second</SiteLink>
       </SiteLinks>
-    </Container>
-  );
+    </>
+  )
 }

--- a/apps/router-e2e/__e2e__/server-loader/app/env.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/env.tsx
@@ -7,7 +7,8 @@ import { Table, TableRow } from '../components/Table';
 
 export async function loader() {
   return Promise.resolve({
-    ...process.env,
+    TEST_SECRET_KEY: process.env.TEST_SECRET_KEY,
+    TEST_SECRET_RUNTIME_KEY: process.env.TEST_SECRET_RUNTIME_KEY,
   });
 }
 

--- a/apps/router-e2e/__e2e__/server-loader/app/error.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/error.tsx
@@ -1,6 +1,7 @@
-import { Text } from 'react-native';
 import { ErrorBoundaryProps, useLoaderData } from 'expo-router';
-import { Container } from '../components/Container';
+import { Suspense } from 'react';
+
+import { Loading } from '../components/Loading';
 import { SiteLinks, SiteLink } from '../components/SiteLink';
 import { Table, TableRow } from '../components/Table';
 
@@ -12,7 +13,7 @@ export async function loader() {
 
 export function ErrorBoundary({ error }: ErrorBoundaryProps) {
   return (
-    <Container>
+    <>
       <Table>
         <TableRow label="Error" value={error.message} testID="error-message" />
       </Table>
@@ -20,15 +21,26 @@ export function ErrorBoundary({ error }: ErrorBoundaryProps) {
       <SiteLinks>
         <SiteLink href="/">Go to Index</SiteLink>
       </SiteLinks>
-    </Container>
+    </>
   );
 }
 
 export default function ErrorRoute() {
-  const data = useLoaderData<typeof loader>();
   return (
-    <Container>
-      <Text testID="should-not-render">This should not render</Text>
-    </Container>
+    <Suspense fallback={<Loading />}>
+      <ErrorScreen />
+    </Suspense>
+  )
+}
+
+const ErrorScreen = () => {
+  const data = useLoaderData<typeof loader>();
+
+  return (
+    <>
+      <Table>
+        <TableRow label="This should not render" value={data} testID="should-not-render" />
+      </Table>
+    </>
   );
 }

--- a/apps/router-e2e/__e2e__/server-loader/app/error.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/error.tsx
@@ -1,0 +1,34 @@
+import { Text } from 'react-native';
+import { ErrorBoundaryProps, useLoaderData } from 'expo-router';
+import { Container } from '../components/Container';
+import { SiteLinks, SiteLink } from '../components/SiteLink';
+import { Table, TableRow } from '../components/Table';
+
+export async function loader() {
+  if (process.env.TEST_THROW_ERROR === 'true') {
+    throw new Error('Intentional loader error for testing');
+  }
+}
+
+export function ErrorBoundary({ error }: ErrorBoundaryProps) {
+  return (
+    <Container>
+      <Table>
+        <TableRow label="Error" value={error.message} testID="error-message" />
+      </Table>
+
+      <SiteLinks>
+        <SiteLink href="/">Go to Index</SiteLink>
+      </SiteLinks>
+    </Container>
+  );
+}
+
+export default function ErrorRoute() {
+  const data = useLoaderData<typeof loader>();
+  return (
+    <Container>
+      <Text testID="should-not-render">This should not render</Text>
+    </Container>
+  );
+}

--- a/apps/router-e2e/__e2e__/server-loader/app/index.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/index.tsx
@@ -4,6 +4,10 @@ import { Table, TableRow } from '../components/Table';
 import { SiteLinks, SiteLink } from '../components/SiteLink';
 
 export default function IndexRoute() {
+  return (<IndexScreen />)
+}
+
+const IndexScreen = () => {
   const pathname = usePathname();
   const localParams = useLocalSearchParams();
 

--- a/apps/router-e2e/__e2e__/server-loader/app/index.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/index.tsx
@@ -21,6 +21,7 @@ export default function IndexRoute() {
         <SiteLink href="/response">Go to Response</SiteLink>
         <SiteLink href="/posts/static-post-1">Go to static Post 1</SiteLink>
         <SiteLink href="/posts/static-post-2">Go to static Post 2</SiteLink>
+        <SiteLink href="/error">Go to Error</SiteLink>
       </SiteLinks>
     </>
   );

--- a/apps/router-e2e/__e2e__/server-loader/app/index.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/index.tsx
@@ -1,14 +1,14 @@
 import { useLocalSearchParams, usePathname } from 'expo-router';
-import { Container } from '../components/Container';
+
 import { Table, TableRow } from '../components/Table';
 import { SiteLinks, SiteLink } from '../components/SiteLink';
 
-export default function Index() {
+export default function IndexRoute() {
   const pathname = usePathname();
   const localParams = useLocalSearchParams();
 
   return (
-    <Container>
+    <>
       <Table>
         <TableRow label="Pathname" value={pathname} testID="pathname-result" />
         <TableRow label="Local Params" value={localParams} testID="localparams-result" />
@@ -22,7 +22,7 @@ export default function Index() {
         <SiteLink href="/posts/static-post-1">Go to static Post 1</SiteLink>
         <SiteLink href="/posts/static-post-2">Go to static Post 2</SiteLink>
       </SiteLinks>
-    </Container>
+    </>
   );
 }
 

--- a/apps/router-e2e/__e2e__/server-loader/app/meta.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/meta.tsx
@@ -1,0 +1,42 @@
+import { useLoaderData, useLocalSearchParams, usePathname } from 'expo-router';
+import Head from 'expo-router/head';
+import { Container } from '../components/Container';
+import { Table, TableRow } from '../components/Table';
+import { SiteLinks, SiteLink } from '../components/SiteLink';
+
+export async function loader() {
+  return {
+    title: 'Meta page',
+    description: 'Meta tag testing',
+    keywords: 'expo-router,loaders,meta',
+    author: 'Expo'
+  };
+}
+
+export default function MetaRoute() {
+  const pathname = usePathname();
+  const localParams = useLocalSearchParams();
+  const data = useLoaderData<typeof loader>();
+
+  return (
+    <Container>
+      <Head>
+        <title>{data.title}</title>
+        <meta name="description" content={data.description} />
+        <meta name="keywords" content={data.keywords} />
+        <meta name="author" content={data.author} />
+      </Head>
+
+      <Table>
+        <TableRow label="Pathname" value={pathname} testID="pathname-result" />
+        <TableRow label="Local Params" value={localParams} testID="localparams-result" />
+        <TableRow label="Loader Data" value={data} testID="loader-result" />
+      </Table>
+
+      <SiteLinks>
+        <SiteLink href="/">Go to Index</SiteLink>
+        <SiteLink href="/second">Go to Second</SiteLink>
+      </SiteLinks>
+    </Container>
+  );
+}

--- a/apps/router-e2e/__e2e__/server-loader/app/meta.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/meta.tsx
@@ -1,6 +1,9 @@
 import { useLoaderData, useLocalSearchParams, usePathname } from 'expo-router';
 import Head from 'expo-router/head';
+import { Suspense } from 'react';
+
 import { Container } from '../components/Container';
+import { Loading } from '../components/Loading';
 import { Table, TableRow } from '../components/Table';
 import { SiteLinks, SiteLink } from '../components/SiteLink';
 
@@ -14,12 +17,20 @@ export async function loader() {
 }
 
 export default function MetaRoute() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <MetaScreen />
+    </Suspense>
+  );
+}
+
+const MetaScreen = () => {
   const pathname = usePathname();
   const localParams = useLocalSearchParams();
   const data = useLoaderData<typeof loader>();
 
   return (
-    <Container>
+    <>
       <Head>
         <title>{data.title}</title>
         <meta name="description" content={data.description} />
@@ -37,6 +48,6 @@ export default function MetaRoute() {
         <SiteLink href="/">Go to Index</SiteLink>
         <SiteLink href="/second">Go to Second</SiteLink>
       </SiteLinks>
-    </Container>
+    </>
   );
 }

--- a/apps/router-e2e/__e2e__/server-loader/app/nullish/[value].tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/nullish/[value].tsx
@@ -33,7 +33,7 @@ const NullishScreen = () => {
   const { value } = useLocalSearchParams<{ value: string }>();
   const data = useLoaderData<typeof loader>();
 
-  const displayData = data === null ? 'NULL' : data === undefined ? 'UNDEFINED' : data;
+  const displayData = data === null ? 'NULL' : data;
   const displayType = data === null ? 'null' : typeof data;
 
   return (

--- a/apps/router-e2e/__e2e__/server-loader/app/nullish/[value].tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/nullish/[value].tsx
@@ -1,8 +1,10 @@
 import { useLoaderData, useLocalSearchParams, usePathname } from 'expo-router';
 import { ImmutableRequest } from 'expo-router/server';
-import { Container } from '../../components/Container';
-import { Table, TableRow } from '../../components/Table';
+import { Suspense } from 'react';
+
+import { Loading } from '../../components/Loading';
 import { SiteLinks, SiteLink } from '../../components/SiteLink';
+import { Table, TableRow } from '../../components/Table';
 
 export async function generateStaticParams(): Promise<Record<string, string>[]> {
   return [{ value: 'null' }, { value: 'undefined' }];
@@ -18,7 +20,15 @@ export async function loader(_: ImmutableRequest, params: { value: string }) {
   return { value: params.value };
 }
 
-export default function Nullish() {
+export default function NullishRoute() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <NullishScreen />
+    </Suspense>
+  );
+}
+
+const NullishScreen = () => {
   const pathname = usePathname();
   const { value } = useLocalSearchParams<{ value: string }>();
   const data = useLoaderData<typeof loader>();
@@ -27,7 +37,7 @@ export default function Nullish() {
   const displayType = data === null ? 'null' : typeof data;
 
   return (
-    <Container>
+    <>
       <Table>
         <TableRow label="Pathname" value={pathname} testID="pathname-result" />
         <TableRow label="Param Value" value={value} testID="param-result" />
@@ -39,6 +49,6 @@ export default function Nullish() {
         <SiteLink href="/nullish/null">Test Null</SiteLink>
         <SiteLink href="/nullish/undefined">Test Undefined</SiteLink>
       </SiteLinks>
-    </Container>
+    </>
   );
 }

--- a/apps/router-e2e/__e2e__/server-loader/app/posts/[postId].tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/posts/[postId].tsx
@@ -1,8 +1,10 @@
 import { useLoaderData, useLocalSearchParams, usePathname } from 'expo-router';
 import { ImmutableRequest } from 'expo-router/server';
-import { Container } from '../../components/Container';
-import { Table, TableRow } from '../../components/Table';
+import { Suspense } from 'react';
+
+import { Loading } from '../../components/Loading';;
 import { SiteLinks, SiteLink } from '../../components/SiteLink';
+import { Table, TableRow } from '../../components/Table';
 
 export async function generateStaticParams(params: {
   id: 'one' | 'two';
@@ -23,13 +25,21 @@ export async function loader(_: ImmutableRequest, params: Record<string, string 
   });
 }
 
-export default function PostById() {
+export default function PostByIdRoute() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <PostByIdScreen />
+    </Suspense>
+  );
+}
+
+const PostByIdScreen = () => {
   const pathname = usePathname();
   const localParams = useLocalSearchParams();
   const data = useLoaderData<typeof loader>();
 
   return (
-    <Container>
+    <>
       <Table>
         <TableRow label="Pathname" value={pathname} testID="pathname-result" />
         <TableRow label="Local Params" value={localParams} testID="localparams-result" />
@@ -40,6 +50,6 @@ export default function PostById() {
         <SiteLink href="/">Go to Index</SiteLink>
         <SiteLink href="/second">Go to Second</SiteLink>
       </SiteLinks>
-    </Container>
+    </>
   );
 }

--- a/apps/router-e2e/__e2e__/server-loader/app/request.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/request.tsx
@@ -12,6 +12,17 @@ export const loader: LoaderFunction = (request, params) => {
     return { headers: null, url: null, method: null };
   }
 
+  const url = new URL(request.url);
+
+  if (url.searchParams.get('immutable') === 'true') {
+    try {
+      request.headers.set('X-Test', 'value');
+      return { immutable: false, error: null }; // Should not reach here
+    } catch (error) {
+      return { immutable: true, error: (error as Error).message };
+    }
+  }
+
   let headers: { key: string; value: string }[] = [];
   request.headers.forEach((value, key) => {
     headers.push({ key, value });

--- a/apps/router-e2e/__e2e__/server-loader/app/request.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/request.tsx
@@ -1,6 +1,8 @@
 import { useLoaderData, useLocalSearchParams, usePathname } from 'expo-router';
 import type { LoaderFunction } from 'expo-router/server';
-import { Container } from '../components/Container';
+import { Suspense } from 'react';
+
+import { Loading } from '../components/Loading';
 import { Table, TableRow } from '../components/Table';
 import { SiteLinks, SiteLink } from '../components/SiteLink';
 
@@ -22,12 +24,20 @@ export const loader: LoaderFunction = (request, params) => {
 };
 
 export default function RequestRoute() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <RequestScreen />
+    </Suspense>
+  );
+}
+
+const RequestScreen = () => {
   const pathname = usePathname();
   const localParams = useLocalSearchParams();
   const data = useLoaderData<typeof loader>();
 
   return (
-    <Container>
+    <>
       <Table>
         <TableRow label="Pathname" value={pathname} testID="pathname-result" />
         <TableRow label="Local Params" value={localParams} testID="localparams-result" />
@@ -38,6 +48,6 @@ export default function RequestRoute() {
         <SiteLink href="/">Go to Index</SiteLink>
         <SiteLink href="/second">Go to Second</SiteLink>
       </SiteLinks>
-    </Container>
+    </>
   );
 }

--- a/apps/router-e2e/__e2e__/server-loader/app/request.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/request.tsx
@@ -16,6 +16,7 @@ export const loader: LoaderFunction = (request, params) => {
 
   if (url.searchParams.get('immutable') === 'true') {
     try {
+      // @ts-ignore The next line will fail at runtime for test purposes
       request.headers.set('X-Test', 'value');
       return { immutable: false, error: null }; // Should not reach here
     } catch (error) {

--- a/apps/router-e2e/__e2e__/server-loader/app/response.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/response.tsx
@@ -5,7 +5,7 @@ import { Container } from '../components/Container';
 import { SiteLinks, SiteLink } from '../components/SiteLink';
 import { Table, TableRow } from '../components/Table';
 
-export const loader: LoaderFunction = ({ request }) => {
+export const loader: LoaderFunction = (request) => {
   // In SSG, request is unavailable since there's no HTTP request at build time
   if (!request) {
     return { foo: null };

--- a/apps/router-e2e/__e2e__/server-loader/app/response.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/response.tsx
@@ -13,7 +13,7 @@ export const loader: LoaderFunction = (request) => {
     return { foo: null };
   }
 
-  const url = new URL(request!.url);
+  const url = new URL(request.url);
 
   if (url.searchParams.get('setresponseheaders') === 'true') {
     setResponseHeaders({

--- a/apps/router-e2e/__e2e__/server-loader/app/response.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/response.tsx
@@ -1,9 +1,11 @@
-import { type LoaderFunction, useLoaderData, useLocalSearchParams, usePathname } from 'expo-router';
+import { useLoaderData, useLocalSearchParams, usePathname } from 'expo-router';
+import { type LoaderFunction } from 'expo-router/server';
 import { setResponseHeaders } from 'expo-server';
+import { Suspense } from 'react';
 
-import { Container } from '../components/Container';
 import { SiteLinks, SiteLink } from '../components/SiteLink';
 import { Table, TableRow } from '../components/Table';
+import { Loading } from '../components/Loading';
 
 export const loader: LoaderFunction = (request) => {
   // In SSG, request is unavailable since there's no HTTP request at build time
@@ -33,12 +35,20 @@ export const loader: LoaderFunction = (request) => {
 };
 
 export default function ResponseRoute() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <ResponseScreen />
+    </Suspense>
+  );
+}
+
+const ResponseScreen = () => {
   const pathname = usePathname();
   const localParams = useLocalSearchParams();
   const data = useLoaderData<typeof loader>();
 
   return (
-    <Container>
+    <>
       <Table>
         <TableRow label="Pathname" value={pathname} testID="pathname-result" />
         <TableRow label="Local Params" value={localParams} testID="localparams-result" />
@@ -49,6 +59,6 @@ export default function ResponseRoute() {
         <SiteLink href="/">Go to Index</SiteLink>
         <SiteLink href="/second">Go to Second</SiteLink>
       </SiteLinks>
-    </Container>
+    </>
   );
 }

--- a/apps/router-e2e/__e2e__/server-loader/app/response.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/response.tsx
@@ -1,25 +1,47 @@
-import { useLoaderData, usePathname } from 'expo-router';
-import { Container } from '../components/Container';
-import { Table, TableRow } from '../components/Table';
-import { SiteLinks, SiteLink } from '../components/SiteLink';
+import { type LoaderFunction, useLoaderData, useLocalSearchParams, usePathname } from 'expo-router';
+import { setResponseHeaders } from 'expo-server';
 
-export async function loader() {
-  return Response.json({ foo: 'bar' }, {
-    headers: {
+import { Container } from '../components/Container';
+import { SiteLinks, SiteLink } from '../components/SiteLink';
+import { Table, TableRow } from '../components/Table';
+
+export const loader: LoaderFunction = ({ request }) => {
+  // In SSG, request is unavailable since there's no HTTP request at build time
+  if (!request) {
+    return { foo: null };
+  }
+
+  const url = new URL(request!.url);
+
+  if (url.searchParams.get('setresponseheaders') === 'true') {
+    setResponseHeaders({
       'Cache-Control': 'public, max-age=3600',
-      'X-Custom-Header': 'test-value',
-    },
-  });
-}
+      'X-Custom-Header': 'set-via-setResponseHeaders',
+    });
+    return { foo: 'bar' };
+  }
+
+  return Response.json(
+    { foo: 'bar' },
+    {
+      headers: {
+        'Cache-Control': 'public, max-age=3600',
+        'X-Custom-Header': 'set-via-response',
+      },
+    }
+  );
+};
 
 export default function ResponseRoute() {
   const pathname = usePathname();
+  const localParams = useLocalSearchParams();
   const data = useLoaderData<typeof loader>();
 
   return (
     <Container>
       <Table>
         <TableRow label="Pathname" value={pathname} testID="pathname-result" />
+        <TableRow label="Local Params" value={localParams} testID="localparams-result" />
         <TableRow label="Loader Data" value={data} testID="loader-result" />
       </Table>
 

--- a/apps/router-e2e/__e2e__/server-loader/app/second.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/second.tsx
@@ -1,7 +1,9 @@
 import { useLoaderData, useLocalSearchParams, usePathname } from 'expo-router';
-import { Container } from '../components/Container';
-import { Table, TableRow } from '../components/Table';
+import { Suspense } from 'react';
+
+import { Loading } from '../components/Loading';
 import { SiteLinks, SiteLink } from '../components/SiteLink';
+import { Table, TableRow } from '../components/Table';
 
 export async function loader() {
   return Promise.resolve({
@@ -9,13 +11,22 @@ export async function loader() {
   });
 }
 
-export default function Second() {
+export default function SecondRoute() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <SecondScreen />
+    </Suspense>
+  );
+
+}
+
+const SecondScreen = () => {
   const pathname = usePathname();
   const localParams = useLocalSearchParams();
   const data = useLoaderData<typeof loader>();
 
   return (
-    <Container>
+    <>
       <Table>
         <TableRow label="Pathname" value={pathname} testID="pathname-result" />
         <TableRow label="Local Params" value={localParams} testID="localparams-result" />
@@ -28,6 +39,6 @@ export default function Second() {
         <SiteLink href="/posts/static-post-1">Go to static Post 1</SiteLink>
         <SiteLink href="/posts/static-post-2">Go to static Post 2</SiteLink>
       </SiteLinks>
-    </Container>
+    </>
   );
 }

--- a/apps/router-e2e/__e2e__/server-loader/components/Container.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/components/Container.tsx
@@ -1,4 +1,4 @@
-import { View, StyleSheet } from "react-native";
+import { StyleSheet, ScrollView } from 'react-native';
 import { ReactNode } from "react";
 
 interface ContainerProps {
@@ -7,9 +7,9 @@ interface ContainerProps {
 
 export function Container({ children }: ContainerProps) {
   return (
-    <View style={styles.container}>
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
       {children}
-    </View>
+    </ScrollView>
   );
 }
 
@@ -17,6 +17,9 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: 'black',
+    padding: 20,
+  },
+  content: {
     justifyContent: 'center',
     alignItems: 'center',
     paddingHorizontal: 20,

--- a/apps/router-e2e/__e2e__/server-loader/components/Loading.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/components/Loading.tsx
@@ -1,0 +1,25 @@
+import { StyleSheet, Text, View } from 'react-native';
+
+export const Loading = () => {
+  return (
+    <View style={styles.container}>
+      <Text testID="suspense-fallback" style={styles.text}>Loading...</Text>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#202425',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#313538',
+  },
+  text: {
+    color: 'white',
+    fontSize: 16,
+    textAlign: 'center',
+  },
+});

--- a/apps/router-e2e/__e2e__/server-loader/components/Table.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/components/Table.tsx
@@ -25,7 +25,7 @@ export function TableRow({ label, value, testID }: TableRowProps) {
       <Text style={styles.tableLabel}>{label}</Text>
       <View style={{ flex: 1 }} />
       <Text testID={testID} style={styles.tableValue}>
-        {JSON.stringify(value)}
+        {JSON.stringify(value, null, 2)}
       </Text>
     </View>
   );
@@ -65,5 +65,6 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     letterSpacing: 0.5,
     flexShrink: 1,
+    maxWidth: 800,
   },
 });

--- a/apps/router-e2e/__e2e__/server-loader/workerd/config.capnp
+++ b/apps/router-e2e/__e2e__/server-loader/workerd/config.capnp
@@ -13,6 +13,7 @@ const server :Workerd.Worker = (
     (name = "_expo/server/render.js", commonJsModule = embed "_expo/server/render.js"),
     (name = "_expo/routes.json", text = embed "_expo/routes.json"),
     (name = "_expo/loaders/env.js", commonJsModule = embed "_expo/loaders/env.js"),
+    (name = "_expo/loaders/meta.js", commonJsModule = embed "_expo/loaders/meta.js"),
     (name = "_expo/loaders/second.js", commonJsModule = embed "_expo/loaders/second.js"),
     (name = "_expo/loaders/posts/[postId].js", commonJsModule = embed "_expo/loaders/posts/[postId].js"),
     (name = "_expo/loaders/nullish/[value].js", commonJsModule = embed "_expo/loaders/nullish/[value].js"),

--- a/apps/router-e2e/__e2e__/server-loader/workerd/config.capnp
+++ b/apps/router-e2e/__e2e__/server-loader/workerd/config.capnp
@@ -20,7 +20,7 @@ const server :Workerd.Worker = (
     (name = "_expo/loaders/response.js", commonJsModule = embed "_expo/loaders/response.js"),
   ],
   bindings = [
-    (name = "TEST_SECRET_KEY", text = "test-secret-key"),
+    (name = "TEST_SECRET_RUNTIME_KEY", text = "runtime-secret-value"),
   ],
   compatibilityDate = "2025-05-05",
   compatibilityFlags = [

--- a/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
@@ -10,7 +10,7 @@ import {
   RUNTIME_WORKERD,
   setupServer,
 } from '../../utils/runtime';
-import { findProjectFiles, getHtml } from '../utils';
+import { findProjectFiles, getPageAndLoaderData } from '../utils';
 
 runExportSideEffects();
 
@@ -110,7 +110,7 @@ describe.each(
       expect(data).toHaveProperty('TEST_SECRET_RUNTIME_KEY', 'runtime-secret-value');
     }
   );
-  
+
   it('loader endpoint returns `Response` with headers', async () => {
     const response = await server.fetchAsync('/_expo/loaders/response');
     expect(response.status).toBe(200);
@@ -129,69 +129,57 @@ describe.each(
     expect(data).toHaveProperty('TEST_SECRET_KEY', 'test-secret-key');
   });
 
-  it('returns `null` for `undefined` loader data', async () => {
-    const response = await server.fetchAsync('/_expo/loaders/nullish/undefined');
-    expect(response.status).toBe(200);
-    const data = await response.json();
-    expect(data).toBeNull();
-  });
+  it.each(getPageAndLoaderData('/nullish/undefined'))(
+    'returns `null` for `undefined` loader data for $url ($name)',
+    async ({ getData, url }) => {
+      const response = await server.fetchAsync(url);
+      expect(response.status).toBe(200);
+      const data = await getData(response);
+      expect(data).toBeNull();
+    }
+  );
 
-  it('returns `null` for `null` loader data', async () => {
-    const response = await server.fetchAsync('/_expo/loaders/nullish/null');
-    expect(response.status).toBe(200);
-    const data = await response.json();
-    expect(data).toBeNull();
-  });
+  it.each(getPageAndLoaderData('/nullish/null'))(
+    'returns `null` for `null` loader data for $url ($name)',
+    async ({ getData, name, url }) => {
+      const response = await server.fetchAsync(url);
+      expect(response.status).toBe(200);
+      const data = await getData(response);
 
-  it.each([
-    {
-      name: 'loader endpoint',
-      url: '/_expo/loaders/request',
-      getData: (response: Response) => {
-        return response.json();
-      },
-    },
-    {
-      name: 'page',
-      url: '/request',
-      getData: async (response: Response) => {
-        const html = getHtml(await response.text());
-        return JSON.parse(html.querySelector('[data-testid="loader-result"]')!.textContent);
-      },
-    },
-  ])('$name $url receives `Request` object', async ({ getData, url }) => {
-    const response = await server.fetchAsync(url);
-    expect(response.status).toBe(200);
-    const data = await getData(response);
+      // NOTE(@hassankhan): For HTML pages, the fixture component converts `null` to the
+      // string `NULL` for display (see `nullish/[value].tsx`). The loader endpoint
+      // returns the raw `null` value.
+      if (name === 'page') {
+        expect(data).toEqual('NULL');
+      } else {
+        expect(data).toBeNull();
+      }
+    }
+  );
 
-    expect(new URL(data.url).pathname).toBe('/request');
-    expect(data.method).toBe('GET');
-    expect(Array.isArray(data.headers)).toBe(true);
-  });
+  it.each(getPageAndLoaderData('/request'))(
+    'receives `Request` object for $url ($name)',
+    async ({ getData, url }) => {
+      const response = await server.fetchAsync(url);
+      expect(response.status).toBe(200);
+      const data = await getData(response);
 
-  it.each([
-    {
-      name: 'page',
-      url: '/request?foo=bar',
-      getData: async (response: Response) => {
-        const html = getHtml(await response.text());
-        return JSON.parse(html.querySelector('[data-testid="loader-result"]')!.textContent);
-      },
-    },
-    {
-      name: 'loader endpoint',
-      url: '/_expo/loaders/request?foo=bar',
-      getData: (response: Response) => {
-        return response.json();
-      },
-    },
-  ])('$name $url receives search params', async ({ getData, url }) => {
-    const response = await server.fetchAsync(url);
-    expect(response.status).toBe(200);
-    const data = await getData(response);
+      expect(new URL(data.url).pathname).toBe('/request');
+      expect(data.method).toBe('GET');
+      expect(Array.isArray(data.headers)).toBe(true);
+    }
+  );
 
-    expect(data.url).toContain('/request?foo=bar');
-    expect(data.method).toBe('GET');
-    expect(Array.isArray(data.headers)).toBe(true);
-  });
+  it.each(getPageAndLoaderData('/request?foo=bar'))(
+    '$name $url receives search params',
+    async ({ getData, url }) => {
+      const response = await server.fetchAsync(url);
+      expect(response.status).toBe(200);
+      const data = await getData(response);
+
+      expect(data.url).toContain('/request?foo=bar');
+      expect(data.method).toBe('GET');
+      expect(Array.isArray(data.headers)).toBe(true);
+    }
+  );
 });

--- a/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
@@ -17,6 +17,7 @@ runExportSideEffects();
 describe.each(
   prepareServers([RUNTIME_EXPO_SERVE, RUNTIME_EXPO_START, RUNTIME_WORKERD], {
     fixtureName: 'server-loader',
+    uniqueOutputKey: 'server',
     export: {
       env: {
         EXPO_USE_STATIC: 'server',

--- a/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
@@ -29,6 +29,7 @@ describe.each(
     serve: {
       env: {
         TEST_SECRET_RUNTIME_KEY: 'runtime-secret-value',
+        TEST_THROW_ERROR: 'true',
       },
     },
   })
@@ -57,6 +58,7 @@ describe.each(
 
     // Loader bundles should exist
     expect(files).toContain('_expo/loaders/env.js');
+    expect(files).toContain('_expo/loaders/error.js');
     expect(files).toContain('_expo/loaders/meta.js');
     expect(files).toContain('_expo/loaders/request.js');
     expect(files).toContain('_expo/loaders/response.js');
@@ -71,12 +73,14 @@ describe.each(
     );
 
     const envRoute = routesJson.htmlRoutes.find((r: any) => r.page === '/env');
+    const errorRoute = routesJson.htmlRoutes.find((r: any) => r.page === '/error');
     const secondRoute = routesJson.htmlRoutes.find((r: any) => r.page === '/second');
     const postRoute = routesJson.htmlRoutes.find((r: any) => r.page === '/posts/[postId]');
     const indexRoute = routesJson.htmlRoutes.find((r: any) => r.page === '/index');
 
     // Routes with loaders should have loader property
     expect(envRoute?.loader).toBe('_expo/loaders/env.js');
+    expect(errorRoute?.loader).toBe('_expo/loaders/error.js');
     expect(secondRoute?.loader).toBe('_expo/loaders/second.js');
     expect(postRoute?.loader).toBe('_expo/loaders/posts/[postId].js');
 
@@ -93,6 +97,14 @@ describe.each(
     const response = await server.fetchAsync('/_expo/loaders/nonexistent');
     expect(response.status).toBe(404);
   });
+
+  it.each(getPageAndLoaderData('/error'))(
+    'returns error when loader throws for $url ($name)',
+    async ({ url }) => {
+      const response = await server.fetchAsync(url);
+      expect(response.status).toBe(500);
+    }
+  );
 
   it.each(getPageAndLoaderData('/second'))(
     'can access data for $url ($name)',

--- a/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
@@ -92,45 +92,43 @@ describe.each(
     expect(response.status).toBe(404);
   });
 
-  it('loader endpoint returns JSON', async () => {
-    const response = await server.fetchAsync('/_expo/loaders/second');
-    expect(response.status).toBe(200);
-    expect(response.headers.get('content-type')).toContain('application/json');
-
-    const data = await response.json();
-    expect(data).toBeDefined();
-  });
-
-  it('loader endpoint returns JSON with params for dynamic route', async () => {
-    const response = await server.fetchAsync('/_expo/loaders/posts/my-test-post');
-    expect(response.status).toBe(200);
-    expect(response.headers.get('content-type')).toContain('application/json');
-
-    const data = await response.json();
-    expect(data.params).toHaveProperty('postId', 'my-test-post');
-  });
-
-  (server.isExpoStart ? it.skip : it)(
-    'loader can access server environment variables',
-    async () => {
-      const response = await server.fetchAsync('/_expo/loaders/env');
+  it.each(getPageAndLoaderData('/second'))(
+    'can access data for $url ($name)',
+    async ({ getData, name, url }) => {
+      const response = await server.fetchAsync(url);
       expect(response.status).toBe(200);
-      const data = await response.json();
+
+      if (name === 'loader') {
+        expect(response.headers.get('content-type')).toContain('application/json');
+      }
+
+      const data = await getData(response);
+      expect(data).toEqual({ data: 'second' });
+    }
+  );
+
+  it.each(getPageAndLoaderData('/posts/static-post-1'))(
+    'can access data with dynamic params for $url ($name)',
+    async ({ getData, url }) => {
+      const response = await server.fetchAsync(url);
+      expect(response.status).toBe(200);
+      const data = await getData(response);
+
+      expect(data.params).toHaveProperty('postId', 'static-post-1');
+    }
+  );
+
+  (server.isExpoStart ? it.skip : it).each(getPageAndLoaderData('/env'))(
+    'can access server environment variables for $url ($name)',
+    async ({ getData, url }) => {
+      const response = await server.fetchAsync(url);
+      expect(response.status).toBe(200);
+      const data = await getData(response);
+
       expect(data).not.toHaveProperty('TEST_SECRET_KEY', 'test-secret-key');
       expect(data).toHaveProperty('TEST_SECRET_RUNTIME_KEY', 'runtime-secret-value');
     }
   );
-
-  it('loader endpoint returns `Response` with headers', async () => {
-    const response = await server.fetchAsync('/_expo/loaders/response');
-    expect(response.status).toBe(200);
-    expect(response.headers.get('content-type')).toContain('application/json');
-    expect(response.headers.get('cache-control')).toBe('public, max-age=3600');
-    expect(response.headers.get('x-custom-header')).toBe('set-via-response');
-
-    const data = await response.json();
-    expect(data).toEqual({ foo: 'bar' });
-  });
 
   it.each(getPageAndLoaderData('/nullish/undefined'))(
     'returns `null` for `undefined` loader data for $url ($name)',
@@ -205,6 +203,17 @@ describe.each(
       expect(data.error).toContain('This operation is not allowed');
     }
   );
+
+  it('loader endpoint returns `Response`', async () => {
+    const response = await server.fetchAsync('/_expo/loaders/response');
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('application/json');
+    expect(response.headers.get('cache-control')).toBe('public, max-age=3600');
+    expect(response.headers.get('x-custom-header')).toBe('set-via-response');
+
+    const data = await response.json();
+    expect(data).toEqual({ foo: 'bar' });
+  });
 
   it('sets custom headers on response using `setResponseHeaders()`', async () => {
     const response = await server.fetchAsync('/_expo/loaders/response?setresponseheaders=true');

--- a/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
@@ -204,4 +204,15 @@ describe.each(
       expect(data.error).toContain('This operation is not allowed');
     }
   );
+
+  it('sets custom headers on `Response` using `setResponseHeaders()`', async () => {
+    const response = await server.fetchAsync('/_expo/loaders/response?setresponseheaders=true');
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('application/json');
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=3600');
+    expect(response.headers.get('X-Custom-Header')).toBe('set-via-setResponseHeaders');
+
+    const data = await response.json();
+    expect(data).toEqual({ foo: 'bar' });
+  });
 });

--- a/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
@@ -182,4 +182,16 @@ describe.each(
       expect(Array.isArray(data.headers)).toBe(true);
     }
   );
+
+  it.each(getPageAndLoaderData('/request?immutable=true'))(
+    'request is immutable for $url ($name)',
+    async ({ getData, url }) => {
+      const response = await server.fetchAsync(url);
+      expect(response.status).toBe(200);
+      const data = await getData(response);
+
+      expect(data.immutable).toBe(true);
+      expect(data.error).toContain('This operation is not allowed');
+    }
+  );
 });

--- a/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
@@ -10,7 +10,7 @@ import {
   RUNTIME_WORKERD,
   setupServer,
 } from '../../utils/runtime';
-import { findProjectFiles, getPageAndLoaderData } from '../utils';
+import { findProjectFiles, getHtml, getPageAndLoaderData } from '../utils';
 
 runExportSideEffects();
 
@@ -57,6 +57,7 @@ describe.each(
 
     // Loader bundles should exist
     expect(files).toContain('_expo/loaders/env.js');
+    expect(files).toContain('_expo/loaders/meta.js');
     expect(files).toContain('_expo/loaders/request.js');
     expect(files).toContain('_expo/loaders/response.js');
     expect(files).toContain('_expo/loaders/second.js');
@@ -225,5 +226,20 @@ describe.each(
 
     const data = await response.json();
     expect(data).toEqual({ foo: 'bar' });
+  });
+
+  it('renders meta tags from loader data in HTML', async () => {
+    const response = await server.fetchAsync('/meta');
+    expect(response.status).toBe(200);
+    const html = getHtml(await response.text());
+
+    expect(html.querySelector('title')?.textContent).toBe('Meta page');
+    expect(html.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'Meta tag testing'
+    );
+    expect(html.querySelector('meta[name="keywords"]')?.getAttribute('content')).toBe(
+      'expo-router,loaders,meta'
+    );
+    expect(html.querySelector('meta[name="author"]')?.getAttribute('content')).toBe('Expo');
   });
 });

--- a/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
@@ -82,6 +82,16 @@ describe.each(
     expect(indexRoute?.loader).toBeUndefined();
   });
 
+  it('returns 404 for loader endpoint when route has no loader', async () => {
+    const response = await server.fetchAsync('/_expo/loaders/index');
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 404 for loader endpoint when route does not exist', async () => {
+    const response = await server.fetchAsync('/_expo/loaders/nonexistent');
+    expect(response.status).toBe(404);
+  });
+
   it('loader endpoint returns JSON', async () => {
     const response = await server.fetchAsync('/_expo/loaders/second');
     expect(response.status).toBe(200);

--- a/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
@@ -27,7 +27,7 @@ describe.each(
     },
     serve: {
       env: {
-        TEST_SECRET_KEY: 'test-secret-key',
+        TEST_SECRET_RUNTIME_KEY: 'runtime-secret-value',
       },
     },
   })
@@ -100,12 +100,16 @@ describe.each(
     expect(data.params).toHaveProperty('postId', 'my-test-post');
   });
 
-  it('loader can access server environment variables during runtime', async () => {
-     const response = await server.fetchAsync('/_expo/loaders/env');
-     expect(response.status).toBe(200);
-     const data = await response.json();
-     expect(data).toHaveProperty('TEST_SECRET_KEY', 'test-secret-key');
-  });
+  (server.isExpoStart ? it.skip : it)(
+    'loader can access server environment variables',
+    async () => {
+      const response = await server.fetchAsync('/_expo/loaders/env');
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).not.toHaveProperty('TEST_SECRET_KEY', 'test-secret-key');
+      expect(data).toHaveProperty('TEST_SECRET_RUNTIME_KEY', 'runtime-secret-value');
+    }
+  );
   
   it('loader endpoint returns `Response` with headers', async () => {
     const response = await server.fetchAsync('/_expo/loaders/response');

--- a/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
@@ -42,18 +42,25 @@ describe.each(
     expect(files).toContain('_expo/routes.json');
 
     // HTML routes should NOT be pre-rendered in SSR mode
+    expect(files).not.toContain('env.html');
     expect(files).not.toContain('index.html');
+    expect(files).not.toContain('request.html');
+    expect(files).not.toContain('response.html');
     expect(files).not.toContain('second.html');
+    expect(files).not.toContain('nullish/[value].html');
+    expect(files).not.toContain('nullish/null.html');
+    expect(files).not.toContain('nullish/undefined.html');
     expect(files).not.toContain('posts/[postId].html');
     expect(files).not.toContain('posts/static-post-1.html');
     expect(files).not.toContain('posts/static-post-2.html');
 
     // Loader bundles should exist
     expect(files).toContain('_expo/loaders/env.js');
-    expect(files).toContain('_expo/loaders/second.js');
-    expect(files).toContain('_expo/loaders/posts/[postId].js');
-    expect(files).toContain('_expo/loaders/nullish/[value].js');
+    expect(files).toContain('_expo/loaders/request.js');
     expect(files).toContain('_expo/loaders/response.js');
+    expect(files).toContain('_expo/loaders/second.js');
+    expect(files).toContain('_expo/loaders/nullish/[value].js');
+    expect(files).toContain('_expo/loaders/posts/[postId].js');
   });
 
   (server.isExpoStart ? it.skip : it)('routes.json has loader paths', async () => {

--- a/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
@@ -72,20 +72,11 @@ describe.each(
       fs.readFileSync(path.join(server.outputDir, 'server/_expo/routes.json'), 'utf8')
     );
 
-    const envRoute = routesJson.htmlRoutes.find((r: any) => r.page === '/env');
-    const errorRoute = routesJson.htmlRoutes.find((r: any) => r.page === '/error');
-    const secondRoute = routesJson.htmlRoutes.find((r: any) => r.page === '/second');
-    const postRoute = routesJson.htmlRoutes.find((r: any) => r.page === '/posts/[postId]');
-    const indexRoute = routesJson.htmlRoutes.find((r: any) => r.page === '/index');
-
-    // Routes with loaders should have loader property
-    expect(envRoute?.loader).toBe('_expo/loaders/env.js');
-    expect(errorRoute?.loader).toBe('_expo/loaders/error.js');
-    expect(secondRoute?.loader).toBe('_expo/loaders/second.js');
-    expect(postRoute?.loader).toBe('_expo/loaders/posts/[postId].js');
-
-    // Route without loader should not have loader property
-    expect(indexRoute?.loader).toBeUndefined();
+    for (const route of routesJson.htmlRoutes) {
+      if (route.loader) {
+        expect(route.loader).toBe(`_expo/loaders${route.page}.js`);
+      }
+    }
   });
 
   it('returns 404 for loader endpoint when route has no loader', async () => {

--- a/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
@@ -100,6 +100,13 @@ describe.each(
     expect(data.params).toHaveProperty('postId', 'my-test-post');
   });
 
+  it('loader can access server environment variables during runtime', async () => {
+     const response = await server.fetchAsync('/_expo/loaders/env');
+     expect(response.status).toBe(200);
+     const data = await response.json();
+     expect(data).toHaveProperty('TEST_SECRET_KEY', 'test-secret-key');
+  });
+  
   it('loader endpoint returns `Response` with headers', async () => {
     const response = await server.fetchAsync('/_expo/loaders/response');
     expect(response.status).toBe(200);
@@ -148,7 +155,7 @@ describe.each(
         return JSON.parse(html.querySelector('[data-testid="loader-result"]')!.textContent);
       },
     },
-  ])('$name $url does not receive `Request` object', async ({ getData, url }) => {
+  ])('$name $url receives `Request` object', async ({ getData, url }) => {
     const response = await server.fetchAsync(url);
     expect(response.status).toBe(200);
     const data = await getData(response);

--- a/packages/@expo/cli/e2e/__tests__/export/static-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-loader.test.ts
@@ -35,7 +35,7 @@ describe.each(
     expect(files).toContain('_sitemap.html');
     expect(files).toContain('+not-found.html');
 
-    // Normal routes - static mode pre-renders HTML
+    // HTML routes should be pre-rendered in SSR mode
     expect(files).toContain('env.html');
     expect(files).toContain('index.html');
     expect(files).toContain('request.html');
@@ -48,7 +48,7 @@ describe.each(
     expect(files).toContain('posts/static-post-1.html');
     expect(files).toContain('posts/static-post-2.html');
 
-    // Loader outputs - pre-generated JSON files (no extension in static mode)
+    // Loader outputs are pre-generated JSON files
     expect(files).toContain('_expo/loaders/env');
     expect(files).toContain('_expo/loaders/request');
     expect(files).toContain('_expo/loaders/response');
@@ -78,6 +78,13 @@ describe.each(
 
     const data = await response.json();
     expect(data.params).toHaveProperty('postId', 'static-post-1');
+  });
+
+  it('loader can access server environment variables during build time', async () => {
+    const response = await server.fetchAsync('/_expo/loaders/env');
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data).toHaveProperty('TEST_SECRET_KEY', 'test-secret-key');
   });
 
   it('loader endpoint returns `Response` body', async () => {

--- a/packages/@expo/cli/e2e/__tests__/export/static-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-loader.test.ts
@@ -6,7 +6,7 @@ import {
   RUNTIME_EXPO_START,
   setupServer,
 } from '../../utils/runtime';
-import { findProjectFiles, getPageAndLoaderData } from '../utils';
+import { findProjectFiles, getHtml, getPageAndLoaderData } from '../utils';
 
 runExportSideEffects();
 
@@ -44,6 +44,7 @@ describe.each(
     // HTML routes should be pre-rendered in SSR mode
     expect(files).toContain('env.html');
     expect(files).toContain('index.html');
+    expect(files).toContain('meta.html');
     expect(files).toContain('request.html');
     expect(files).toContain('response.html');
     expect(files).toContain('second.html');
@@ -56,6 +57,7 @@ describe.each(
 
     // Loader outputs are pre-generated JSON files
     expect(files).toContain('_expo/loaders/env');
+    expect(files).toContain('_expo/loaders/meta');
     expect(files).toContain('_expo/loaders/request');
     expect(files).toContain('_expo/loaders/response');
     expect(files).toContain('_expo/loaders/second');
@@ -178,5 +180,20 @@ describe.each(
 
     const data = await response.json();
     expect(data).toEqual({ foo: null });
+  });
+
+  it('renders meta tags from loader data in HTML', async () => {
+    const response = await server.fetchAsync('/meta');
+    expect(response.status).toBe(200);
+    const html = getHtml(await response.text());
+
+    expect(html.querySelector('title')?.textContent).toBe('Meta page');
+    expect(html.querySelector('meta[name="description"]')?.getAttribute('content')).toBe(
+      'Meta tag testing'
+    );
+    expect(html.querySelector('meta[name="keywords"]')?.getAttribute('content')).toBe(
+      'expo-router,loaders,meta'
+    );
+    expect(html.querySelector('meta[name="author"]')?.getAttribute('content')).toBe('Expo');
   });
 });

--- a/packages/@expo/cli/e2e/__tests__/export/static-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-loader.test.ts
@@ -36,20 +36,29 @@ describe.each(
     expect(files).toContain('+not-found.html');
 
     // Normal routes - static mode pre-renders HTML
+    expect(files).toContain('env.html');
     expect(files).toContain('index.html');
+    expect(files).toContain('request.html');
+    expect(files).toContain('response.html');
     expect(files).toContain('second.html');
+    expect(files).toContain('nullish/[value].html');
+    expect(files).toContain('nullish/null.html');
+    expect(files).toContain('nullish/undefined.html');
     expect(files).toContain('posts/[postId].html');
     expect(files).toContain('posts/static-post-1.html');
     expect(files).toContain('posts/static-post-2.html');
 
     // Loader outputs - pre-generated JSON files (no extension in static mode)
+    expect(files).toContain('_expo/loaders/env');
+    expect(files).toContain('_expo/loaders/request');
+    expect(files).toContain('_expo/loaders/response');
     expect(files).toContain('_expo/loaders/second');
+    expect(files).toContain('_expo/loaders/nullish/[value]');
+    expect(files).toContain('_expo/loaders/nullish/null');
+    expect(files).toContain('_expo/loaders/nullish/undefined');
     expect(files).toContain('_expo/loaders/posts/[postId]');
     expect(files).toContain('_expo/loaders/posts/static-post-1');
     expect(files).toContain('_expo/loaders/posts/static-post-2');
-    expect(files).toContain('_expo/loaders/nullish/undefined');
-    expect(files).toContain('_expo/loaders/nullish/null');
-    expect(files).toContain('_expo/loaders/response');
   });
 
   it('loader endpoint returns JSON', async () => {

--- a/packages/@expo/cli/e2e/__tests__/export/static-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-loader.test.ts
@@ -20,6 +20,11 @@ describe.each(
         TEST_SECRET_KEY: 'test-secret-key',
       },
     },
+    serve: {
+      env: {
+        TEST_SECRET_RUNTIME_KEY: 'runtime-secret-value',
+      },
+    },
   })
 )('static loader - $name', (config) => {
   const server = setupServer(config);
@@ -80,12 +85,16 @@ describe.each(
     expect(data.params).toHaveProperty('postId', 'static-post-1');
   });
 
-  it('loader can access server environment variables during build time', async () => {
-    const response = await server.fetchAsync('/_expo/loaders/env');
-    expect(response.status).toBe(200);
-    const data = await response.json();
-    expect(data).toHaveProperty('TEST_SECRET_KEY', 'test-secret-key');
-  });
+  (server.isExpoStart ? it.skip : it)(
+    'loader can access server environment variables',
+    async () => {
+      const response = await server.fetchAsync('/_expo/loaders/env');
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toHaveProperty('TEST_SECRET_KEY', 'test-secret-key');
+      expect(data).not.toHaveProperty('TEST_SECRET_RUNTIME_KEY', 'runtime-secret-value');
+    }
+  );
 
   it('loader endpoint returns `Response` body', async () => {
     const response = await server.fetchAsync('/_expo/loaders/response');

--- a/packages/@expo/cli/e2e/__tests__/export/static-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-loader.test.ts
@@ -13,6 +13,7 @@ runExportSideEffects();
 describe.each(
   prepareServers([RUNTIME_EXPO_SERVE, RUNTIME_EXPO_START], {
     fixtureName: 'server-loader',
+    uniqueOutputKey: 'static',
     export: {
       env: {
         EXPO_USE_STATIC: 'static',

--- a/packages/@expo/cli/e2e/__tests__/export/static-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-loader.test.ts
@@ -116,16 +116,24 @@ describe.each(
     expect(response.headers.get('x-custom-header')).not.toBe('test-value');
 
     const data = await response.json();
-    expect(data).toEqual({ foo: 'bar' });
+    expect(data).toEqual({ foo: null });
   });
 
   it.each(getPageAndLoaderData('/nullish/undefined'))(
     'returns `null` for `undefined` loader data for $url ($name)',
-    async ({ getData, url }) => {
+    async ({ getData, name, url }) => {
       const response = await server.fetchAsync(url);
       expect(response.status).toBe(200);
       const data = await getData(response);
-      expect(data).toBeNull();
+
+      // NOTE(@hassankhan): For HTML pages, the fixture component converts `null` to the
+      // string `NULL` for display (see `nullish/[value].tsx`). The loader endpoint
+      // returns the raw `null` value.
+      if (name === 'page') {
+        expect(data).toEqual('NULL');
+      } else {
+        expect(data).toBeNull();
+      }
     }
   );
 

--- a/packages/@expo/cli/e2e/__tests__/export/static-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-loader.test.ts
@@ -66,6 +66,16 @@ describe.each(
     expect(files).toContain('_expo/loaders/posts/static-post-2');
   });
 
+  it('returns 404 for loader endpoint when route has no loader', async () => {
+    const response = await server.fetchAsync('/_expo/loaders/index');
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 404 for loader endpoint when route does not exist', async () => {
+    const response = await server.fetchAsync('/_expo/loaders/nonexistent');
+    expect(response.status).toBe(404);
+  });
+
   it('loader endpoint returns JSON', async () => {
     const response = await server.fetchAsync('/_expo/loaders/second');
     expect(response.status).toBe(200);

--- a/packages/@expo/cli/e2e/__tests__/utils.ts
+++ b/packages/@expo/cli/e2e/__tests__/utils.ts
@@ -293,3 +293,29 @@ export function findProjectFiles(projectRoot: string) {
 export function stripWhitespace(str: string): string {
   return str.replace(/\s+/g, '').trim();
 }
+
+/**
+ * Gets the data from a page and its associated loader.
+ *
+ * @remarks We retrieve the laoder first to check for a module ID collision between the main and
+ * loader bundles. See https://github.com/expo/expo/pull/42245
+ */
+export function getPageAndLoaderData(url: string) {
+  return [
+    {
+      name: 'loader endpoint',
+      url: `/_expo/loaders${url}`,
+      getData: (response: Response) => {
+        return response.json();
+      },
+    },
+    {
+      name: 'page',
+      url: `${url}`,
+      getData: async (response: Response) => {
+        const html = getHtml(await response.text());
+        return JSON.parse(html.querySelector('[data-testid="loader-result"]')!.textContent);
+      },
+    },
+  ];
+}

--- a/packages/@expo/cli/e2e/playwright/dev/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/server-loader.test.ts
@@ -135,7 +135,7 @@ test.describe('server loader in development', () => {
 
     await page.click('a[href="/posts/static-post-1"]');
 
-    const suspenseFallback = await page.locator('text=Bundling...');
+    const suspenseFallback = await page.locator('[data-testid="suspense-fallback"]');
     await expect(suspenseFallback).toBeVisible();
 
     await page.waitForSelector('[data-testid="loader-result"]');

--- a/packages/@expo/cli/e2e/playwright/dev/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/server-loader.test.ts
@@ -59,8 +59,8 @@ test.describe('server loader in development', () => {
 
     // In dev mode, loader data is fetched dynamically, so we just verify the loader result renders
     await page.waitForSelector('[data-testid="loader-result"]');
-    const loaderDataElement = await page.locator('[data-testid="loader-result"]');
-    await expect(loaderDataElement).toHaveText('{"data":"second"}');
+    const loaderDataContent = await page.locator('[data-testid="loader-result"]').textContent();
+    expect(JSON.parse(loaderDataContent!)).toEqual({ data: 'second' });
 
     expect(pageErrors.all).toEqual([]);
   });
@@ -82,8 +82,8 @@ test.describe('server loader in development', () => {
       expect.stringContaining('/_expo/loaders/posts/static-post-1')
     );
 
-    const loaderData = page.locator('[data-testid="loader-result"]');
-    await expect(loaderData).toContainText('"postId":"static-post-1"');
+    const loaderDataContent = await page.locator('[data-testid="loader-result"]').textContent();
+    expect(JSON.parse(loaderDataContent!)).toEqual({ params: { postId: 'static-post-1' } });
   });
 
   test('caches loader data for subsequent navigations', async ({ page }) => {
@@ -148,12 +148,12 @@ test.describe('server loader in development', () => {
     // Start at index route (no loader)
     await page.goto(expoStart.url.href);
 
-    // Navigate to second route (has loader) - this was previously broken
+    // Navigate to second route (has loader)
     await page.click('a[href="/second"]');
     await page.waitForSelector('[data-testid="loader-result"]');
 
-    const loaderData = page.locator('[data-testid="loader-result"]');
-    await expect(loaderData).toHaveText('{"data":"second"}');
+    const loaderDataContent = await page.locator('[data-testid="loader-result"]').textContent();
+    expect(JSON.parse(loaderDataContent!)).toEqual({ data: 'second' });
 
     expect(pageErrors.all).toEqual([]);
   });
@@ -168,13 +168,17 @@ test.describe('server loader in development', () => {
     await page.goto(url.toString());
     await page.waitForSelector('[data-testid="loader-result"]');
 
-    await expect(page.locator('[data-testid="loader-result"]')).toHaveText('{"data":"second"}');
+    const secondLoaderDataContent = await page
+      .locator('[data-testid="loader-result"]')
+      .textContent();
+    expect(JSON.parse(secondLoaderDataContent!)).toEqual({ data: 'second' });
 
-    // Navigate to posts route (has loader) - this was previously broken
+    // Navigate to posts route (has loader)
     await page.click('a[href="/posts/static-post-1"]');
-    await expect(page.locator('[data-testid="loader-result"]')).toHaveText(
-      '{"params":{"postId":"static-post-1"}}'
-    );
+    const postsLoaderDataContent = await page
+      .locator('[data-testid="loader-result"]')
+      .textContent();
+    expect(JSON.parse(postsLoaderDataContent!)).toEqual({ params: { postId: 'static-post-1' } });
 
     expect(pageErrors.all).toEqual([]);
   });

--- a/packages/@expo/cli/e2e/playwright/dev/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/server-loader.test.ts
@@ -9,177 +9,152 @@ test.beforeAll(() => clearEnv());
 test.afterAll(() => restoreEnv());
 
 const projectRoot = getRouterE2ERoot();
-const inputDir = 'server-loader';
 
-test.describe('server loader in development', () => {
-  const expoStart = createExpoStart({
-    cwd: projectRoot,
-    env: {
-      E2E_ROUTER_SRC: inputDir,
-      E2E_ROUTER_SERVER_LOADERS: 'true',
+// TODO: We'll split this test up in the future when server/single do different things.
+const outputModes = ['static', 'server'] as const;
 
-      // Ensure CI is disabled otherwise the file watcher won't run.
-      CI: '0',
-    },
-  });
+for (const outputMode of outputModes) {
+  test.describe(`${outputMode} loaders in development`, () => {
+    test.describe.configure({ mode: 'serial' });
 
-  test.beforeAll(async () => {
-    console.time('expo start');
-    await expoStart.startAsync();
-    console.timeEnd('expo start');
-  });
-  test.afterAll(async () => {
-    await expoStart.stopAsync();
-  });
+    const expoStart = createExpoStart({
+      cwd: projectRoot,
+      env: {
+        EXPO_USE_STATIC: outputMode,
+        E2E_ROUTER_SRC: 'server-loader',
+        E2E_ROUTER_SERVER_LOADERS: 'true',
+        E2E_ROUTER_SERVER_RENDERING: outputMode === 'server' ? 'true' : 'false',
 
-  test('loads and renders a route without a loader', async ({ page }) => {
-    const pageErrors = pageCollectErrors(page);
-    await page.goto(expoStart.url.href);
-
-    const loaderDataScript = await page.evaluate(() => {
-      return globalThis.__EXPO_ROUTER_LOADER_DATA__;
-    });
-    expect(loaderDataScript).not.toBeDefined();
-
-    // Index route doesn't have a loader, so no loader-result element should exist
-    const loaderResult = page.locator('[data-testid="loader-result"]');
-    await expect(loaderResult).toHaveCount(0);
-
-    expect(pageErrors.all).toEqual([]);
-  });
-
-  test('loads and renders a route with a loader', async ({ page }) => {
-    const pageErrors = pageCollectErrors(page);
-    await page.goto(expoStart.url.href + 'second');
-
-    const loaderDataScript = await page.evaluate(() => {
-      return globalThis.__EXPO_ROUTER_LOADER_DATA__;
-    });
-    expect(loaderDataScript).toBeDefined();
-
-    // In dev mode, loader data is fetched dynamically, so we just verify the loader result renders
-    await page.waitForSelector('[data-testid="loader-result"]');
-    const loaderDataContent = await page.locator('[data-testid="loader-result"]').textContent();
-    expect(JSON.parse(loaderDataContent!)).toEqual({ data: 'second' });
-
-    expect(pageErrors.all).toEqual([]);
-  });
-
-  test('loads loader data modules on client-side navigation', async ({ page }) => {
-    const loaderRequests: string[] = [];
-    page.on('request', (request) => {
-      if (request.url().includes('/_expo/loaders/')) {
-        loaderRequests.push(request.url());
-      }
+        // Ensure CI is disabled otherwise the file watcher won't run.
+        CI: '0',
+      },
     });
 
-    await page.goto(expoStart.url.href);
-    expect(loaderRequests).toHaveLength(0);
-
-    await page.click('a[href="/posts/static-post-1"]');
-    await page.waitForSelector('[data-testid="loader-result"]');
-    expect(loaderRequests).toContainEqual(
-      expect.stringContaining('/_expo/loaders/posts/static-post-1')
-    );
-
-    const loaderDataContent = await page.locator('[data-testid="loader-result"]').textContent();
-    expect(JSON.parse(loaderDataContent!)).toEqual({ params: { postId: 'static-post-1' } });
-  });
-
-  test('caches loader data for subsequent navigations', async ({ page }) => {
-    const loaderRequests: string[] = [];
-    page.on('request', (request) => {
-      if (request.url().includes('/_expo/loaders/')) {
-        loaderRequests.push(request.url());
-      }
+    test.beforeAll(async () => {
+      console.time('expo start');
+      await expoStart.startAsync();
+      console.timeEnd('expo start');
+    });
+    test.afterAll(async () => {
+      await expoStart.stopAsync();
     });
 
-    await page.goto(expoStart.url.href);
+    test('loads loader data modules on client-side navigation', async ({ page }) => {
+      const loaderRequests: string[] = [];
+      page.on('request', (request) => {
+        if (request.url().includes('/_expo/loaders/')) {
+          loaderRequests.push(request.url());
+        }
+      });
 
-    await page.click('a[href="/posts/static-post-1"]');
-    await page.waitForSelector('[data-testid="loader-result"]');
+      await page.goto(expoStart.url.href);
+      expect(loaderRequests).toHaveLength(0);
 
-    await page.click('a[href="/"]');
+      await page.click('a[href="/posts/static-post-1"]');
+      await page.waitForSelector('[data-testid="loader-result"]');
+      expect(loaderRequests).toContainEqual(
+        expect.stringContaining('/_expo/loaders/posts/static-post-1')
+      );
 
-    await page.click('a[href="/posts/static-post-2"]');
-    await page.waitForSelector('[data-testid="loader-result"]');
-
-    await page.click('a[href="/"]');
-
-    await page.click('a[href="/posts/static-post-1"]');
-    await page.waitForSelector('[data-testid="loader-result"]');
-
-    // Should not make additional requests for cached static-post-1
-    expect(loaderRequests.length).toBe(2);
-  });
-
-  test('handles loader module fetch errors gracefully', async ({ page }) => {
-    await page.goto(expoStart.url.href);
-
-    await page.route('**/_expo/loaders/**', (route) => {
-      route.abort('failed');
+      const loaderDataContent = await page.locator('[data-testid="loader-result"]').textContent();
+      expect(JSON.parse(loaderDataContent!)).toEqual({ params: { postId: 'static-post-1' } });
     });
 
-    await page.click('a[href="/posts/static-post-1"]');
+    test('caches loader data for subsequent navigations', async ({ page }) => {
+      const loaderRequests: string[] = [];
+      page.on('request', (request) => {
+        if (request.url().includes('/_expo/loaders/')) {
+          loaderRequests.push(request.url());
+        }
+      });
 
-    await expect(page.locator('[data-testid="loader-result"]')).not.toBeVisible();
-  });
+      await page.goto(expoStart.url.href);
 
-  test('shows suspense fallback while loading', async ({ page }) => {
-    await page.goto(expoStart.url.href);
+      await page.click('a[href="/posts/static-post-1"]');
+      await page.waitForSelector('[data-testid="loader-result"]');
 
-    await page.route('**/_expo/loaders/**', async (route) => {
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      await route.continue();
+      await page.click('a[href="/"]');
+
+      await page.click('a[href="/posts/static-post-2"]');
+      await page.waitForSelector('[data-testid="loader-result"]');
+
+      await page.click('a[href="/"]');
+
+      await page.click('a[href="/posts/static-post-1"]');
+      await page.waitForSelector('[data-testid="loader-result"]');
+
+      // Should not make additional requests for cached static-post-1
+      expect(loaderRequests.length).toBe(2);
     });
 
-    await page.click('a[href="/posts/static-post-1"]');
+    test('handles loader module fetch errors gracefully', async ({ page }) => {
+      await page.goto(expoStart.url.href);
 
-    const suspenseFallback = await page.locator('[data-testid="suspense-fallback"]');
-    await expect(suspenseFallback).toBeVisible();
+      await page.route('**/_expo/loaders/**', (route) => {
+        route.abort('failed');
+      });
 
-    await page.waitForSelector('[data-testid="loader-result"]');
-    await expect(suspenseFallback).not.toBeVisible();
+      await page.click('a[href="/posts/static-post-1"]');
+
+      await expect(page.locator('[data-testid="loader-result"]')).not.toBeVisible();
+    });
+
+    test('shows suspense fallback while loading', async ({ page }) => {
+      await page.goto(expoStart.url.href);
+
+      await page.route('**/_expo/loaders/**', async (route) => {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        await route.continue();
+      });
+
+      await page.click('a[href="/posts/static-post-1"]');
+
+      const suspenseFallback = await page.locator('[data-testid="suspense-fallback"]');
+      await expect(suspenseFallback).toBeVisible();
+
+      await page.waitForSelector('[data-testid="loader-result"]');
+      await expect(suspenseFallback).not.toBeVisible();
+    });
+
+    test('navigates from route without loader to route with loader', async ({ page }) => {
+      const pageErrors = pageCollectErrors(page);
+
+      // Start at index route (no loader)
+      await page.goto(expoStart.url.href);
+
+      // Navigate to second route (has loader)
+      await page.click('a[href="/second"]');
+      await page.waitForSelector('[data-testid="loader-result"]');
+
+      const loaderDataContent = await page.locator('[data-testid="loader-result"]').textContent();
+      expect(JSON.parse(loaderDataContent!)).toEqual({ data: 'second' });
+
+      expect(pageErrors.all).toEqual([]);
+    });
+
+    test('navigates from route with loader to another route with loader', async ({ page }) => {
+      const pageErrors = pageCollectErrors(page);
+
+      const url = new URL(expoStart.url.href);
+      url.pathname = '/second';
+
+      // Start on second route (with loader)
+      await page.goto(url.toString());
+      await page.waitForSelector('[data-testid="loader-result"]');
+
+      const secondLoaderDataContent = await page
+        .locator('[data-testid="loader-result"]')
+        .textContent();
+      expect(JSON.parse(secondLoaderDataContent!)).toEqual({ data: 'second' });
+
+      // Navigate to posts route (has loader)
+      await page.click('a[href="/posts/static-post-1"]');
+      const postsLoaderDataContent = await page
+        .locator('[data-testid="loader-result"]')
+        .textContent();
+      expect(JSON.parse(postsLoaderDataContent!)).toEqual({ params: { postId: 'static-post-1' } });
+
+      expect(pageErrors.all).toEqual([]);
+    });
   });
-
-  test('navigates from route without loader to route with loader', async ({ page }) => {
-    const pageErrors = pageCollectErrors(page);
-
-    // Start at index route (no loader)
-    await page.goto(expoStart.url.href);
-
-    // Navigate to second route (has loader)
-    await page.click('a[href="/second"]');
-    await page.waitForSelector('[data-testid="loader-result"]');
-
-    const loaderDataContent = await page.locator('[data-testid="loader-result"]').textContent();
-    expect(JSON.parse(loaderDataContent!)).toEqual({ data: 'second' });
-
-    expect(pageErrors.all).toEqual([]);
-  });
-
-  test('navigates from route with loader to another route with loader', async ({ page }) => {
-    const pageErrors = pageCollectErrors(page);
-
-    const url = new URL(expoStart.url.href);
-    url.pathname = '/second';
-
-    // Start on second route (with loader)
-    await page.goto(url.toString());
-    await page.waitForSelector('[data-testid="loader-result"]');
-
-    const secondLoaderDataContent = await page
-      .locator('[data-testid="loader-result"]')
-      .textContent();
-    expect(JSON.parse(secondLoaderDataContent!)).toEqual({ data: 'second' });
-
-    // Navigate to posts route (has loader)
-    await page.click('a[href="/posts/static-post-1"]');
-    const postsLoaderDataContent = await page
-      .locator('[data-testid="loader-result"]')
-      .textContent();
-    expect(JSON.parse(postsLoaderDataContent!)).toEqual({ params: { postId: 'static-post-1' } });
-
-    expect(pageErrors.all).toEqual([]);
-  });
-});
+}

--- a/packages/@expo/cli/e2e/playwright/prod/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/playwright/prod/server-loader.test.ts
@@ -101,7 +101,7 @@ test.describe('server loader (SSR) in production', () => {
     await page.goto(expoServe.url.href);
     expect(loaderRequests).toHaveLength(0);
 
-    // Navigate to a route with loader - should fetch loader data
+    // Navigate to a route with loader
     await page.click('a[href="/posts/static-post-1"]');
     await page.waitForSelector('[data-testid="loader-result"]');
     expect(loaderRequests).toContainEqual(expect.stringContaining('/_expo/loaders/posts'));
@@ -159,13 +159,11 @@ test.describe('server loader (SSR) in production', () => {
 
     await page.click('a[href="/posts/static-post-1"]');
 
-    const loaderResult = page.locator('[data-testid="loader-result"]');
+    const suspenseFallback = await page.locator('[data-testid="suspense-fallback"]');
+    await expect(suspenseFallback).toBeVisible();
 
-    // In production, `<SuspenseFallback>` returns null, but we can verify the Suspense boundary is
-    // working by checking that content is not rendered during loading
-    await expect(loaderResult).not.toBeVisible({ timeout: 100 });
-
-    await expect(loaderResult).toBeVisible({ timeout: 1000 });
+    await page.waitForSelector('[data-testid="loader-result"]');
+    await expect(suspenseFallback).not.toBeVisible();
   });
 
   test('navigates from route without loader to route with loader', async ({ page }) => {

--- a/packages/@expo/cli/e2e/playwright/prod/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/playwright/prod/server-loader.test.ts
@@ -72,8 +72,8 @@ test.describe('server loader (SSR) in production', () => {
     expect(loaderDataScript).toBeDefined();
 
     await page.waitForSelector('[data-testid="loader-result"]');
-    const loaderDataElement = await page.locator('[data-testid="loader-result"]');
-    await expect(loaderDataElement).toHaveText('{"data":"second"}');
+    const loaderDataContent = await page.locator('[data-testid="loader-result"]').textContent();
+    expect(JSON.parse(loaderDataContent!)).toEqual({ data: 'second' });
 
     expect(pageErrors.all).toEqual([]);
   });
@@ -83,8 +83,8 @@ test.describe('server loader (SSR) in production', () => {
     await page.goto(expoServe.url.href + 'posts/my-dynamic-post');
 
     await page.waitForSelector('[data-testid="loader-result"]');
-    const loaderData = page.locator('[data-testid="loader-result"]');
-    await expect(loaderData).toContainText('"postId":"my-dynamic-post"');
+    const loaderDataContent = await page.locator('[data-testid="loader-result"]').textContent();
+    expect(JSON.parse(loaderDataContent!)).toEqual({ params: { postId: 'my-dynamic-post' } });
 
     expect(pageErrors.all).toEqual([]);
   });
@@ -106,8 +106,8 @@ test.describe('server loader (SSR) in production', () => {
     await page.waitForSelector('[data-testid="loader-result"]');
     expect(loaderRequests).toContainEqual(expect.stringContaining('/_expo/loaders/posts'));
 
-    const loaderData = page.locator('[data-testid="loader-result"]');
-    await expect(loaderData).toContainText('"postId":"static-post-1"');
+    const loaderDataContent = await page.locator('[data-testid="loader-result"]').textContent();
+    expect(JSON.parse(loaderDataContent!)).toEqual({ params: { postId: 'static-post-1' } });
   });
 
   test('navigates from route without loader to route with loader', async ({ page }) => {
@@ -120,8 +120,8 @@ test.describe('server loader (SSR) in production', () => {
     await page.click('a[href="/second"]');
     await page.waitForSelector('[data-testid="loader-result"]');
 
-    const loaderData = page.locator('[data-testid="loader-result"]');
-    await expect(loaderData).toHaveText('{"data":"second"}');
+    const loaderDataContent = await page.locator('[data-testid="loader-result"]').textContent();
+    expect(JSON.parse(loaderDataContent!)).toEqual({ data: 'second' });
 
     expect(pageErrors.all).toEqual([]);
   });
@@ -194,13 +194,15 @@ test.describe('server loader (SSR) in production', () => {
     await page.goto(url.toString());
     await page.waitForSelector('[data-testid="loader-result"]');
 
-    await expect(page.locator('[data-testid="loader-result"]')).toHaveText('{"data":"second"}');
+    const secondLoaderDataContent = await page
+      .locator('[data-testid="loader-result"]')
+      .textContent();
+    expect(JSON.parse(secondLoaderDataContent!)).toEqual({ data: 'second' });
 
     // Navigate to posts route (has loader)
     await page.click('a[href="/posts/static-post-1"]');
-    await expect(page.locator('[data-testid="loader-result"]')).toContainText(
-      '"postId":"static-post-1"'
-    );
+    const postsLoaderDataContent = await page.locator('[data-testid="loader-result"]').textContent();
+    expect(JSON.parse(postsLoaderDataContent!)).toEqual({ params: { postId: 'static-post-1' } });
 
     expect(pageErrors.all).toEqual([]);
   });

--- a/packages/@expo/cli/e2e/playwright/prod/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/playwright/prod/server-loader.test.ts
@@ -61,7 +61,7 @@ test.describe('server loader (SSR) in production', () => {
     expect(pageErrors.all).toEqual([]);
   });
 
-  test('SSR injects loader data into initial HTML', async ({ page }) => {
+  test('loads and renders a route with a loader', async ({ page }) => {
     const pageErrors = pageCollectErrors(page);
     await page.goto(expoServe.url.href + 'second');
 
@@ -78,7 +78,7 @@ test.describe('server loader (SSR) in production', () => {
     expect(pageErrors.all).toEqual([]);
   });
 
-  test('SSR renders dynamic route with params', async ({ page }) => {
+  test('loads and renders a dynamic params route with a loader', async ({ page }) => {
     const pageErrors = pageCollectErrors(page);
     await page.goto(expoServe.url.href + 'posts/my-dynamic-post');
 
@@ -89,7 +89,7 @@ test.describe('server loader (SSR) in production', () => {
     expect(pageErrors.all).toEqual([]);
   });
 
-  test('client-side navigation fetches loader data', async ({ page }) => {
+  test('loads loader data modules on client-side navigation', async ({ page }) => {
     const loaderRequests: string[] = [];
     page.on('request', (request) => {
       if (request.url().includes('/_expo/loaders/')) {
@@ -108,22 +108,6 @@ test.describe('server loader (SSR) in production', () => {
 
     const loaderDataContent = await page.locator('[data-testid="loader-result"]').textContent();
     expect(JSON.parse(loaderDataContent!)).toEqual({ params: { postId: 'static-post-1' } });
-  });
-
-  test('navigates from route without loader to route with loader', async ({ page }) => {
-    const pageErrors = pageCollectErrors(page);
-
-    // Start at index route (no loader)
-    await page.goto(expoServe.url.href);
-
-    // Navigate to second route (has loader)
-    await page.click('a[href="/second"]');
-    await page.waitForSelector('[data-testid="loader-result"]');
-
-    const loaderDataContent = await page.locator('[data-testid="loader-result"]').textContent();
-    expect(JSON.parse(loaderDataContent!)).toEqual({ data: 'second' });
-
-    expect(pageErrors.all).toEqual([]);
   });
 
   test('caches loader data for subsequent navigations', async ({ page }) => {
@@ -182,6 +166,22 @@ test.describe('server loader (SSR) in production', () => {
     await expect(loaderResult).not.toBeVisible({ timeout: 100 });
 
     await expect(loaderResult).toBeVisible({ timeout: 1000 });
+  });
+
+  test('navigates from route without loader to route with loader', async ({ page }) => {
+    const pageErrors = pageCollectErrors(page);
+
+    // Start at index route (no loader)
+    await page.goto(expoServe.url.href);
+
+    // Navigate to second route (has loader)
+    await page.click('a[href="/second"]');
+    await page.waitForSelector('[data-testid="loader-result"]');
+
+    const loaderDataContent = await page.locator('[data-testid="loader-result"]').textContent();
+    expect(JSON.parse(loaderDataContent!)).toEqual({ data: 'second' });
+
+    expect(pageErrors.all).toEqual([]);
   });
 
   test('navigates from route with loader to another route with loader', async ({ page }) => {

--- a/packages/@expo/cli/e2e/playwright/prod/static-loader.test.ts
+++ b/packages/@expo/cli/e2e/playwright/prod/static-loader.test.ts
@@ -67,8 +67,8 @@ test.describe('static loader in production', () => {
     expect(loaderDataScript).toBeDefined();
 
     await page.waitForSelector('[data-testid="loader-result"]');
-    const loaderDataElement = await page.locator('[data-testid="loader-result"]');
-    await expect(loaderDataElement).toHaveText('{"data":"second"}');
+    const loaderDataContent = await page.locator('[data-testid="loader-result"]').textContent();
+    expect(JSON.parse(loaderDataContent!)).toEqual({ data: 'second' });
 
     expect(pageErrors.all).toEqual([]);
   });
@@ -90,8 +90,8 @@ test.describe('static loader in production', () => {
       expect.stringContaining('/_expo/loaders/posts/static-post-1')
     );
 
-    const loaderData = page.locator('[data-testid="loader-result"]');
-    await expect(loaderData).toContainText('"postId":"static-post-1"');
+    const loaderDataContent = await page.locator('[data-testid="loader-result"]').textContent();
+    expect(JSON.parse(loaderDataContent!)).toEqual({ params: { postId: 'static-post-1' } });
   });
 
   test('caches loader data for subsequent navigations', async ({ page }) => {
@@ -158,12 +158,12 @@ test.describe('static loader in production', () => {
     // Start at index route (no loader)
     await page.goto(expoServe.url.href);
 
-    // Navigate to second route (has loader) - this was previously broken
+    // Navigate to second route (has loader)
     await page.click('a[href="/second"]');
     await page.waitForSelector('[data-testid="loader-result"]');
 
-    const loaderData = page.locator('[data-testid="loader-result"]');
-    await expect(loaderData).toHaveText('{"data":"second"}');
+    const loaderDataContent = await page.locator('[data-testid="loader-result"]').textContent();
+    expect(JSON.parse(loaderDataContent!)).toEqual({ data: 'second' });
 
     expect(pageErrors.all).toEqual([]);
   });
@@ -178,13 +178,17 @@ test.describe('static loader in production', () => {
     await page.goto(url.toString());
     await page.waitForSelector('[data-testid="loader-result"]');
 
-    await expect(page.locator('[data-testid="loader-result"]')).toHaveText('{"data":"second"}');
+    const secondLoaderDataContent = await page
+      .locator('[data-testid="loader-result"]')
+      .textContent();
+    expect(JSON.parse(secondLoaderDataContent!)).toEqual({ data: 'second' });
 
     // Navigate to posts route (has loader)
     await page.click('a[href="/posts/static-post-1"]');
-    await expect(page.locator('[data-testid="loader-result"]')).toContainText(
-      '"postId":"static-post-1"'
-    );
+    const postsLoaderDataContent = await page
+      .locator('[data-testid="loader-result"]')
+      .textContent();
+    expect(JSON.parse(postsLoaderDataContent!)).toEqual({ params: { postId: 'static-post-1' } });
 
     expect(pageErrors.all).toEqual([]);
   });

--- a/packages/@expo/cli/e2e/playwright/prod/static-loader.test.ts
+++ b/packages/@expo/cli/e2e/playwright/prod/static-loader.test.ts
@@ -143,13 +143,11 @@ test.describe('static loader in production', () => {
 
     await page.click('a[href="/posts/static-post-1"]');
 
-    const loaderResult = page.locator('[data-testid="loader-result"]');
+    const suspenseFallback = await page.locator('[data-testid="suspense-fallback"]');
+    await expect(suspenseFallback).toBeVisible();
 
-    // In production, `<SuspenseFallback>` returns null, but we can verify the Suspense boundary is
-    // working by checking that content is not rendered during loading
-    await expect(loaderResult).not.toBeVisible({ timeout: 100 });
-
-    await expect(loaderResult).toBeVisible({ timeout: 1000 });
+    await page.waitForSelector('[data-testid="loader-result"]');
+    await expect(suspenseFallback).not.toBeVisible();
   });
 
   test('navigates from route without loader to route with loader', async ({ page }) => {

--- a/packages/@expo/cli/e2e/playwright/prod/static-loader.test.ts
+++ b/packages/@expo/cli/e2e/playwright/prod/static-loader.test.ts
@@ -9,11 +9,9 @@ test.beforeAll(() => clearEnv());
 test.afterAll(() => restoreEnv());
 
 const projectRoot = getRouterE2ERoot();
-const outputDir = 'dist-static-loader';
+const outputDir = 'dist-static-loader-playwright';
 
-test.describe('static loader in production', () => {
-  test.describe.configure({ mode: 'serial' });
-
+test.describe('static loaders in production', () => {
   const expoServe = createExpoServe({
     cwd: projectRoot,
     env: {
@@ -33,44 +31,12 @@ test.describe('static loader in production', () => {
     });
     console.timeEnd('expo export');
 
-    console.time('npx serve');
+    console.time('expo serve');
     await expoServe.startAsync([outputDir]);
-    console.timeEnd('npx serve');
+    console.timeEnd('expo serve');
   });
   test.afterAll(async () => {
     await expoServe.stopAsync();
-  });
-
-  test('loads and renders a route without a loader', async ({ page }) => {
-    const pageErrors = pageCollectErrors(page);
-    await page.goto(expoServe.url.href);
-
-    const loaderDataScript = await page.evaluate(() => {
-      return globalThis.__EXPO_ROUTER_LOADER_DATA__;
-    });
-    expect(loaderDataScript).not.toBeDefined();
-
-    // Index route doesn't have a loader, so no loader-result element should exist
-    const loaderResult = page.locator('[data-testid="loader-result"]');
-    await expect(loaderResult).toHaveCount(0);
-
-    expect(pageErrors.all).toEqual([]);
-  });
-
-  test('loads and renders a route with a loader', async ({ page }) => {
-    const pageErrors = pageCollectErrors(page);
-    await page.goto(expoServe.url.href + 'second');
-
-    const loaderDataScript = await page.evaluate(() => {
-      return globalThis.__EXPO_ROUTER_LOADER_DATA__;
-    });
-    expect(loaderDataScript).toBeDefined();
-
-    await page.waitForSelector('[data-testid="loader-result"]');
-    const loaderDataContent = await page.locator('[data-testid="loader-result"]').textContent();
-    expect(JSON.parse(loaderDataContent!)).toEqual({ data: 'second' });
-
-    expect(pageErrors.all).toEqual([]);
   });
 
   test('loads loader data modules on client-side navigation', async ({ page }) => {


### PR DESCRIPTION
# Why

There were a few missing cases from previous loader PRs that needed addressing. Additionally, there were some opportunities to tidy things up in the Jest E2E tests.

# How

- Added Suspense handling to loader E2E fixture
- Added missing test cases to Jest E2E tests
- Created a new `getPageAndLoaderData()` helper to ensure the HTML output and loader JSON are aligned
- Added test cases for:
  - environment variable support
  - immutable requests
  - proper 404 behavior
  - `setResponseHeaders()` support
  - `<Head>` support
  - error handling
- Modified dev server Playwright tests to run in both static and server rendering mode
- Removed unnecessary test cases from Playwright

# Test Plan

- CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
