### PR TITLE
[ios][dev-launcher] Use auto layout instead of autoresizingMask

### DIFF
--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewController.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewController.swift
@@ -5,17 +5,8 @@ import ExpoModulesCore
   private var hostingController: UIHostingController<DevLauncherRootView>?
   var viewModel = DevLauncherViewModel()
 
-  @objc public override init(nibName: String?, bundle: Bundle?) {
-    super.init(nibName: nibName, bundle: bundle)
-    addHostingController()
-  }
-
-  @objc public convenience init() {
-    self.init(nibName: nil, bundle: nil)
-  }
-
-  required init?(coder: NSCoder) {
-    super.init(coder: coder)
+  public override func viewDidLoad() {
+    super.viewDidLoad()
     addHostingController()
   }
 
@@ -31,9 +22,15 @@ import ExpoModulesCore
   }
 
   @objc public func resetHostingController() {
+    if let hostingController {
+      hostingController.willMove(toParent: nil)
+      hostingController.view.removeFromSuperview()
+      hostingController.removeFromParent()
+    }
     hostingController = nil
-    view = UIView()
-    addHostingController()
+    if isViewLoaded {
+      addHostingController()
+    }
   }
 
   private func addHostingController() {
@@ -46,30 +43,20 @@ import ExpoModulesCore
     }
 
     addChild(hostingController)
+    hostingController.view.translatesAutoresizingMaskIntoConstraints = false
     view.addSubview(hostingController.view)
 
+    NSLayoutConstraint.activate([
+      hostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      hostingController.view.topAnchor.constraint(equalTo: view.topAnchor),
+      hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+    ])
+
 #if !os(macOS)
-    hostingController.view.frame = view.bounds
-    hostingController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-    hostingController.didMove(toParent: self)
     navigationController?.setNavigationBarHidden(true, animated: false)
-#else
-    hostingController.view.frame = view.frame
-    hostingController.view.autoresizingMask = [.width, .height]
 #endif
+    hostingController.didMove(toParent: self)
 
   }
-
-#if os(iOS) || os(tvOS)
-  public override func viewDidLayoutSubviews() {
-    super.viewDidLayoutSubviews()
-    hostingController?.view.frame = view.bounds
-  }
-
-#else
-  public override func viewDidLayout() {
-    super.viewDidLayout()
-    hostingController?.view.frame = view.bounds
-  }
-#endif
 }

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewController.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewController.swift
@@ -55,8 +55,7 @@ import ExpoModulesCore
 
 #if !os(macOS)
     navigationController?.setNavigationBarHidden(true, animated: false)
-#endif
     hostingController.didMove(toParent: self)
-
+#endif
   }
 }

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewController.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewController.swift
@@ -22,11 +22,13 @@ import ExpoModulesCore
   }
 
   @objc public func resetHostingController() {
+#if !os(macOS)
     if let hostingController {
       hostingController.willMove(toParent: nil)
       hostingController.view.removeFromSuperview()
       hostingController.removeFromParent()
     }
+#endif
     hostingController = nil
     if isViewLoaded {
       addHostingController()


### PR DESCRIPTION
# Why
Fixes some issues with the dev launchers view controller layout code.

# How
- Calling `addHostingController` from an init block is not correct because there is no guarantee the view is available at this point. `viewDidLoad` is sufficient because the view will always be available.
- Use auto layout instead of autoresizingMask. This means we can also remove `viewDidLayoutSubviews`

# Test Plan
Bare Expo

