### PR TITLE
[menu][Android] Fix bottom sheet expanding to full height when closing onboarding

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -17,7 +17,7 @@
 - [iOS] remove unnecessary `unregisterKeyCommand` for cmd+r ([#41449](https://github.com/expo/expo/pull/41449) by [@vonovak](https://github.com/vonovak))
 - [Android] Prevent some debug only artifacts from being included in release builds. ([#41378](https://github.com/expo/expo/pull/41378) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Fix menu is not showing on launch when `ReactContext` was initialized. ([#42123](https://github.com/expo/expo/pull/42123) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Fix bottom sheet expanding to full height when closing onboarding.
+- [Android] Fix bottom sheet expanding to full height when closing onboarding. ([#42173](https://github.com/expo/expo/pull/42173) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [iOS] remove unnecessary `unregisterKeyCommand` for cmd+r ([#41449](https://github.com/expo/expo/pull/41449) by [@vonovak](https://github.com/vonovak))
 - [Android] Prevent some debug only artifacts from being included in release builds. ([#41378](https://github.com/expo/expo/pull/41378) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Fix menu is not showing on launch when `ReactContext` was initialized. ([#42123](https://github.com/expo/expo/pull/42123) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Fix bottom sheet expanding to full height when closing onboarding.
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/android/build.gradle
+++ b/packages/expo-dev-menu/android/build.gradle
@@ -135,7 +135,7 @@ dependencies {
   debugOnly "androidx.compose.ui:ui:$composeVersion"
   debugOnly "androidx.compose.ui:ui-tooling:$composeVersion"
 
-  debugOnly("com.composables:core:1.46.1")
+  debugOnly("com.composables:core:1.49.6")
 
   debugOnlyApi 'io.github.lukmccall:radix-ui-colors:1.0.1'
 


### PR DESCRIPTION
# Why

Fixes the bottom sheet expanding to full height when closing onboarding. 
It was patched upstream probably in 1.47.0 - https://github.com/composablehorizons/compose-unstyled/releases/tag/1.47.0.
The fix isn't perfect, as the transition onboarding and full menu experience lack an animation, but it's much better than what we had previously. 

# How

Bumped `composables` to the newest version.

# Test Plan

- Expo Go ✅ 
- bare-expo ✅ 