### PR TITLE
[docs] Improve EAS Hosting introduction

### DIFF
--- a/docs/pages/eas/hosting/get-started.mdx
+++ b/docs/pages/eas/hosting/get-started.mdx
@@ -17,18 +17,6 @@ This guide will walk you through the process of creating your first web deployme
 
 <VideoBoxLink videoId="NaKsfWciJLo" title="Watch: Deploy your Expo Router web project" />
 
-## Why EAS Hosting
-
-Historically, traditional website hosting services were recommended for deploying Expo Router and React apps. However, this approach doesn't address the unique challenges of dealing with native apps. Here are some key limitations:
-
-- Version synchronization: During the app store publishing process, you may need to deploy new versions of your servers.
-
-- Request routing complexity: Different versions of your native app may require routing to specific server versions. This can create additional complexity when handling requests.
-
-- Platform-specific analysis: When running native apps, you need enhanced observability for platform-specific metrics.
-
-The introduction of EAS Hosting aims to address these limitations.
-
 ## Prerequisites
 
 <Collapsible summary="An Expo user account">

--- a/docs/pages/eas/hosting/introduction.mdx
+++ b/docs/pages/eas/hosting/introduction.mdx
@@ -109,6 +109,33 @@ API routes can return `Cache-Control` directives that EAS Hosting uses to cache 
 
 </Collapsible>
 
+<Collapsible summary="Can I use EAS Hosting with EAS Workflows?">
+
+EAS Hosting integrates with [EAS Workflows](/eas/workflows/get-started/) using the `deploy` job type. You can add a deploy job to your workflow configuration. For example:
+
+```yaml
+jobs:
+  deploy_web:
+    type: deploy
+    environment: production
+    params:
+      prod: true
+```
+
+You can also deploy to a specific alias or make production conditional based on the branch:
+
+```yaml
+jobs:
+  deploy:
+    type: deploy
+    params:
+      prod: ${{ github.ref_name == 'main' }}
+```
+
+For more information, see the [Web deployments with EAS Workflows](/eas/hosting/workflows/).
+
+</Collapsible>
+
 ## Get started
 
 <BoxLink

--- a/docs/pages/eas/hosting/introduction.mdx
+++ b/docs/pages/eas/hosting/introduction.mdx
@@ -93,7 +93,7 @@ EAS Hosting deployments are immutable. Each deployment gets a unique preview URL
 
 </Collapsible>
 
-<Collapsible summary="What monitoring capabilities are available?">
+<Collapsible summary="What monitoring capabilities are available in EAS Hosting?">
 
 EAS Hosting provides built-in monitoring in the [EAS dashboard](/eas/hosting/api-routes/):
 
@@ -103,7 +103,7 @@ EAS Hosting provides built-in monitoring in the [EAS dashboard](/eas/hosting/api
 
 </Collapsible>
 
-<Collapsible summary="How can I configure caching?">
+<Collapsible summary="How can I configure caching in EAS Hosting?">
 
 API routes can return `Cache-Control` directives that EAS Hosting uses to cache responses on its global CDN (Content Delivery Network). Static assets are cached with a default browser cache time of 3600 seconds. See the [Caching](/eas/hosting/reference/caching/) reference for details.
 

--- a/docs/pages/eas/hosting/introduction.mdx
+++ b/docs/pages/eas/hosting/introduction.mdx
@@ -9,6 +9,7 @@ import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
+import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
 import { Terminal } from '~/ui/components/Snippet';
 
 **EAS Hosting** is a service from EAS (Expo Application Services) for quickly deploying your web projects built using [Expo Router](/router/introduction/) and React Native web. It seamlessly integrates with the Expo CLI, allowing you to automate the deployment of API routes, server functions, and server-side assets.
@@ -25,7 +26,7 @@ To publish your web app, run the following command:
 
 <Terminal cmd={['$ eas deploy']} />
 
-Once your deployment is complete, the EAS CLI will output a preview URL to access your deployed app.
+Once your deployment is complete, the EAS CLI will output a preview URL to access your deployed web app.
 
 ## Why EAS Hosting
 
@@ -41,21 +42,16 @@ EAS Hosting addresses these limitations by providing a unified deployment experi
 
 ## When to use EAS Hosting
 
-Use EAS Hosting when you want to:
-
-- Deploy a web build without setting up a separate hosting provider
-- Use API routes or server functions in your Expo Router app
-- Maintain consistent deployment workflows across Android, iOS, and web
-- Automate deployments using [EAS Workflows](/eas/hosting/workflows/)
-- Get built-in monitoring for server-side code crashes, logs, and requests
-
-## When not to use EAS Hosting
-
-You may not need EAS Hosting when:
-
-- Your project is mobile-only with no web component
-- You need full Node.js runtime compatibility (EAS Hosting uses [Cloudflare Workers runtime](/eas/hosting/reference/worker-runtime/) with partial Node.js support)
-- You already have established web infrastructure that meets your needs
+| Scenario                                                                                                                                                | Recommendation |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| Deploy a web build without setting up a separate hosting provider                                                                                       | <YesIcon />    |
+| Use API routes or server functions in your Expo Router app                                                                                              | <YesIcon />    |
+| Maintain consistent deployment workflows across Android, iOS, and web                                                                                   | <YesIcon />    |
+| Automate deployments using [EAS Workflows](/eas/hosting/workflows/)                                                                                     | <YesIcon />    |
+| Built-in monitoring for server-side code crashes, logs, and requests                                                                                    | <YesIcon />    |
+| Mobile-only project with no web component                                                                                                               | <NoIcon />     |
+| Full Node.js runtime compatibility (EAS Hosting uses [Cloudflare Workers runtime](/eas/hosting/reference/worker-runtime/) with partial Node.js support) | <NoIcon />     |
+| Already have established web infrastructure that meets your needs                                                                                       | <NoIcon />     |
 
 ## Frequently asked questions (FAQ)
 

--- a/docs/pages/eas/hosting/introduction.mdx
+++ b/docs/pages/eas/hosting/introduction.mdx
@@ -1,20 +1,115 @@
 ---
 title: Introduction to EAS Hosting
 sidebar_title: Introduction
-hideTOC: true
-description: EAS Hosting is a service for quickly deploying the web projects built using the Expo Router library and React Native web.
+description: EAS Hosting is a service for quickly deploying web projects built using the Expo Router library and React Native web.
 searchRank: 10
 ---
 
 import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { Collapsible } from '~/ui/components/Collapsible';
+import { Terminal } from '~/ui/components/Snippet';
 
-**EAS Hosting** is a service for quickly deploying your web projects built using [Expo Router](/router/introduction/) and React Native web. It seamlessly integrates with the Expo CLI, allowing you to automate the deployment of API routes, server functions, and server-side assets.
+**EAS Hosting** is a service from EAS (Expo Application Services) for quickly deploying your web projects built using [Expo Router](/router/introduction/) and React Native web. It seamlessly integrates with the Expo CLI, allowing you to automate the deployment of API routes, server functions, and server-side assets.
 
-Hosting offers the fastest path from `npx create-expo-app` to a fully deployed web app with API routes and server functions.
+EAS Hosting offers the fastest path from `npx create-expo-app` to a fully deployed web app with API routes and server functions.
 
-### Get started
+## Quick start
+
+To deploy your web app, you need to create a static build of your web project. Run the following command to export your web project into a **dist** directory:
+
+<Terminal cmd={['$ npx expo export --platform web']} />
+
+To publish your web app, run the following command:
+
+<Terminal cmd={['$ eas deploy']} />
+
+Once your deployment is complete, the EAS CLI will output a preview URL to access your deployed app.
+
+## Why EAS Hosting
+
+Historically, traditional website hosting services were recommended for deploying Expo Router and React apps. However, this approach doesn't address the unique challenges of dealing with native apps. Here are some key limitations:
+
+- **Version synchronization**: During the app store publishing process, you may need to deploy new versions of your servers.
+
+- **Request routing complexity**: Different versions of your native app may require routing to specific server versions. This can create additional complexity when handling requests.
+
+- **Platform-specific analysis**: When running native apps, you need enhanced observability for platform-specific metrics.
+
+EAS Hosting addresses these limitations by providing a unified deployment experience across all platforms.
+
+## When to use EAS Hosting
+
+Use EAS Hosting when you want to:
+
+- Deploy a web build without setting up a separate hosting provider
+- Use API routes or server functions in your Expo Router app
+- Maintain consistent deployment workflows across Android, iOS, and web
+- Automate deployments using [EAS Workflows](/eas/hosting/workflows/)
+- Get built-in monitoring for server-side code crashes, logs, and requests
+
+## When not to use EAS Hosting
+
+You may not need EAS Hosting when:
+
+- Your project is mobile-only with no web component
+- You need full Node.js runtime compatibility (EAS Hosting uses [Cloudflare Workers runtime](/eas/hosting/reference/worker-runtime/) with partial Node.js support)
+- You already have established web infrastructure that meets your needs
+
+## Frequently asked questions (FAQ)
+
+<Collapsible summary="What web output modes can I use with EAS Hosting?">
+
+EAS Hosting supports all three output modes configured in your app config's `expo.web.output`:
+
+- `single`: Exports your Expo app to a single-page app with only one **index.html** output
+- `static`: Exports your Expo app to a [statically generated web app](/router/web/static-rendering/)
+- `server`: Supports [server functions](/guides/server-components/#react-server-functions) and [API routes](/router/web/api-routes/) as well as static pages
+
+</Collapsible>
+
+<Collapsible summary="Can I use API routes with EAS Hosting?">
+
+EAS Hosting fully supports [API routes](/router/web/api-routes/) (files ending with **+api.ts**) when using the `server` output mode. You can monitor crashes, logs, and requests from your API routes in the [EAS dashboard](/eas/hosting/api-routes/).
+
+</Collapsible>
+
+<Collapsible summary="What runtime does EAS Hosting use?">
+
+EAS Hosting is built on [Cloudflare Workers](https://developers.cloudflare.com/workers/), which runs on the V8 JavaScript engine. It uses V8 isolates instead of full Node.js processes. Node.js compatibility modules are available but with some limitations. See the [worker runtime reference](/eas/hosting/reference/worker-runtime/) for the full list of supported modules.
+
+</Collapsible>
+
+<Collapsible summary="Can I set up a custom domain for my production deployment?">
+
+[Custom domains](/eas/hosting/custom-domain/) are available on paid plans. Each project can have one custom domain assigned to the production deployment. Both apex domains and subdomains are supported.
+
+</Collapsible>
+
+<Collapsible summary="How can I create deployment aliases?">
+
+EAS Hosting deployments are immutable. Each deployment gets a unique preview URL. You can create [aliases](/eas/hosting/deployments-and-aliases/) to assign custom names to deployments (such as `staging` or `production`). Since deployments are immutable, you can instantly roll back by reassigning an alias to a previous deployment ID using `eas deploy:alias --prod --id=<deploymentId>`.
+
+</Collapsible>
+
+<Collapsible summary="What monitoring capabilities are available?">
+
+EAS Hosting provides built-in monitoring in the [EAS dashboard](/eas/hosting/api-routes/):
+
+- **Crashes**: View uncaught errors from API routes, grouped by similarity
+- **Logs**: All `console.log`, `console.info`, and `console.error` output from API routes
+- **Requests**: Request metadata including status, browser, region, and duration
+
+</Collapsible>
+
+<Collapsible summary="How can I configure caching?">
+
+API routes can return `Cache-Control` directives that EAS Hosting uses to cache responses on its global CDN (Content Delivery Network). Static assets are cached with a default browser cache time of 3600 seconds. See the [Caching](/eas/hosting/reference/caching/) reference for details.
+
+</Collapsible>
+
+## Get started
 
 <BoxLink
   title="Create your first deployment"
@@ -46,7 +141,7 @@ Hosting offers the fastest path from `npx create-expo-app` to a fully deployed w
 
 <BoxLink
   title="API Routes"
-  description="Inspect requests from API routes on the EAS Hosting Dashboard."
+  description="Inspect requests from API routes on the EAS Hosting dashboard."
   href="/eas/hosting/api-routes"
   Icon={Cloud01Icon}
 />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18493

# How

<!--
How did you build this feature or fix this bug and why?
-->

Rewrote the EAS Hosting introduction page with expanded content and improved structure:

- Added "Quick start" section near the top with CLI commands for immediate time-to-value
- Moved Why EAS Hosting section from get started to introduction
- Added "When to use EAS Hosting" and "When not to use" sections to help users decide if it fits their use case
- Added "FAQ" section covering common questions
- Defined acronyms on first use (EAS)

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See: /eas/hosting/introduction/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
