### PR TITLE
[splash-screen][iOS] Fix crash when storyboard is not present

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix crash when storyboard is not present ([#42178](https://github.com/expo/expo/pull/42178) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 - [iOS] Remove new architecture checks. ([#41767](https://github.com/expo/expo/pull/41767) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-splash-screen/ios/SplashScreenManager.swift
+++ b/packages/expo-splash-screen/ios/SplashScreenManager.swift
@@ -58,6 +58,11 @@ public class SplashScreenManager: NSObject, RCTReloadListener {
 
   private func showSplashScreen() {
     let splashScreenFilename = Bundle.main.object(forInfoDictionaryKey: "UILaunchStoryboardName") as? String ?? "SplashScreen"
+    // Prevents crashes in brownfield apps where the splash screen storyboard may not be present.
+    guard Bundle.main.path(forResource: splashScreenFilename, ofType: "storyboardc") != nil else {
+      return
+    }
+
     if let vc = UIStoryboard(name: splashScreenFilename, bundle: nil).instantiateInitialViewController() {
       loadingView = vc.view
       loadingView?.autoresizingMask = [.flexibleWidth, .flexibleHeight]


### PR DESCRIPTION
# Why

When building an app that has `expo-splash-screen` in its dependencies as an `.xcframework`

# How

Prevents crashes in brownfield apps where the splash screen storyboard may not be present in the main bundle

# Test Plan

Run minimal-tester and brownfield-tester

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
