### PR TITLE
[ios][expo-go] Fix dev settings

### DIFF
--- a/apps/expo-go/ios/Exponent/Kernel/Core/EXKernel.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Core/EXKernel.m
@@ -300,6 +300,14 @@ NSString * const kEXReloadActiveAppRequest = @"EXReloadActiveAppRequest";
   [self switchTasks];
 }
 
+- (void)devMenuTogglePerformanceMonitor {
+  [[self visibleApp].appManager togglePerformanceMonitor];
+}
+
+- (void)devMenuToggleElementInspector {
+  [[self visibleApp].appManager toggleElementInspector];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/apps/expo-go/ios/Exponent/Kernel/Views/EXAppViewController.mm
+++ b/apps/expo-go/ios/Exponent/Kernel/Views/EXAppViewController.mm
@@ -57,7 +57,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSDate *dtmLastFatalErrorShown;
 @property (nonatomic, strong) NSMutableArray<UIViewController *> *backgroundedControllers;
 
-@property (nonatomic, assign) BOOL isHomeApp;
 @property (nonatomic, assign) UIInterfaceOrientation previousInterfaceOrientation;
 
 /*
@@ -110,9 +109,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)viewDidLoad
 {
   [super viewDidLoad];
-  _isHomeApp = NO;
 
-  
   self.appLoadingCancelView = [EXAppLoadingCancelView new];
   self.appLoadingCancelView.delegate = self;
   [self.view addSubview:self.appLoadingCancelView];
@@ -237,15 +234,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)appStateDidBecomeActive
 {
-  if (_isHomeApp) {
-      [EXTextDirectionController setRTLPreferences:false :false];
-  } else if(_appRecord.appLoader.manifest != nil) {
-      BOOL supportsRTL = [self _readSupportsRTLFromManifest:_appRecord.appLoader.manifest];
-      BOOL forceRTL = [self _readForcesRTLFromManifest:_appRecord.appLoader.manifest];
-      [EXTextDirectionController setRTLPreferences:supportsRTL :forceRTL];
+  if (_appRecord.appLoader.manifest != nil) {
+    BOOL supportsRTL = [self _readSupportsRTLFromManifest:_appRecord.appLoader.manifest];
+    BOOL forceRTL = [self _readForcesRTLFromManifest:_appRecord.appLoader.manifest];
+    [EXTextDirectionController setRTLPreferences:supportsRTL :forceRTL];
   }
   dispatch_async(dispatch_get_main_queue(), ^{
-    // Reset the root view background color and window color if we switch between Expo home and project
     [self _setBackgroundColor];
   });
 }
@@ -303,13 +297,9 @@ NS_ASSUME_NONNULL_BEGIN
  * - actual one served when app is fetched.
  * For each of them we should show SplashScreen,
  * therefore for any consecutive SplashScreen.show call we just reconfigure what's already visible.
- * In HomeApp or standalone apps this function is no-op as SplashScreen is managed differently.
  */
 - (void)_showOrReconfigureManagedAppSplashScreen:(EXManifestsManifest *)manifest
 {
-  if (_isHomeApp) {
-    return;
-  }
   if (!_managedAppSplashScreenViewProvider) {
     _managedAppSplashScreenViewProvider = [[EXManagedAppSplashScreenViewProvider alloc] initWith:manifest];
 
@@ -321,10 +311,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)_showCachedExperienceAlert
 {
-  if (self.isHomeApp) {
-    return;
-  }
-
   dispatch_async(dispatch_get_main_queue(), ^{
     UIAlertController *alert = [UIAlertController
                                 alertControllerWithTitle:@"Using a cached project"
@@ -443,11 +429,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)appLoader:(EXAbstractLoader *)appLoader didFinishLoadingManifest:(EXManifestsManifest *)manifest bundle:(NSData *)data
 {
   [self _showOrReconfigureManagedAppSplashScreen:manifest];
-  if (!_isHomeApp) {
-    BOOL supportsRTL = [self _readSupportsRTLFromManifest:_appRecord.appLoader.manifest];
-    BOOL forceRTL = [self _readForcesRTLFromManifest:_appRecord.appLoader.manifest];
-    [EXTextDirectionController setRTLPreferences:supportsRTL :forceRTL];
-  }
+  BOOL supportsRTL = [self _readSupportsRTLFromManifest:_appRecord.appLoader.manifest];
+  BOOL forceRTL = [self _readForcesRTLFromManifest:_appRecord.appLoader.manifest];
+  [EXTextDirectionController setRTLPreferences:supportsRTL :forceRTL];
   [self _rebuildHost];
   if (self->_appRecord.appManager.status == kEXReactAppManagerStatusBridgeLoading) {
     [self->_appRecord.appManager appLoaderFinished];
@@ -543,7 +527,7 @@ NS_ASSUME_NONNULL_BEGIN
     return [super supportedInterfaceOrientations];
   }
 
-  if ([ScreenOrientationRegistry.shared requiredOrientationMask] > 0 && !self.isHomeApp) {
+  if ([ScreenOrientationRegistry.shared requiredOrientationMask] > 0) {
     return [ScreenOrientationRegistry.shared requiredOrientationMask];
   }
 

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -158,6 +158,8 @@ PODS:
     - ExpoModulesCore
   - ExpoBattery (10.0.7):
     - ExpoModulesCore
+  - ExpoBlob (0.1.6):
+    - ExpoModulesCore
   - ExpoBlur (15.0.7):
     - ExpoModulesCore
   - ExpoBrightness (14.0.7):
@@ -388,6 +390,8 @@ PODS:
   - ExpoVideoThumbnails (10.0.7):
     - ExpoModulesCore
   - ExpoWebBrowser (15.0.7):
+    - ExpoModulesCore
+  - ExpoWidgets (0.0.0):
     - ExpoModulesCore
   - EXStructuredHeaders (5.0.0)
   - EXStructuredHeaders/Tests (5.0.0)
@@ -4105,6 +4109,7 @@ DEPENDENCIES:
   - ExpoBackgroundFetch (from `../../../packages/expo-background-fetch/ios`)
   - ExpoBackgroundTask (from `../../../packages/expo-background-task/ios`)
   - ExpoBattery (from `../../../packages/expo-battery/ios`)
+  - ExpoBlob (from `../../../packages/expo-blob/ios`)
   - ExpoBlur (from `../../../packages/expo-blur/ios`)
   - ExpoBrightness (from `../../../packages/expo-brightness/ios`)
   - ExpoCalendar (from `../../../packages/expo-calendar/ios`)
@@ -4164,6 +4169,7 @@ DEPENDENCIES:
   - ExpoVideo (from `../../../packages/expo-video/ios`)
   - ExpoVideoThumbnails (from `../../../packages/expo-video-thumbnails/ios`)
   - ExpoWebBrowser (from `../../../packages/expo-web-browser/ios`)
+  - ExpoWidgets (from `../../../packages/expo-widgets/ios`)
   - EXStructuredHeaders (from `../../../packages/expo-structured-headers/ios`)
   - EXStructuredHeaders/Tests (from `../../../packages/expo-structured-headers/ios`)
   - EXUpdates (from `../../../packages/expo-updates/ios`)
@@ -4357,6 +4363,8 @@ EXTERNAL SOURCES:
     :path: "../../../packages/expo-background-task/ios"
   ExpoBattery:
     :path: "../../../packages/expo-battery/ios"
+  ExpoBlob:
+    :path: "../../../packages/expo-blob/ios"
   ExpoBlur:
     :path: "../../../packages/expo-blur/ios"
   ExpoBrightness:
@@ -4463,6 +4471,8 @@ EXTERNAL SOURCES:
     :path: "../../../packages/expo-video-thumbnails/ios"
   ExpoWebBrowser:
     :path: "../../../packages/expo-web-browser/ios"
+  ExpoWidgets:
+    :path: "../../../packages/expo-widgets/ios"
   EXStructuredHeaders:
     :path: "../../../packages/expo-structured-headers/ios"
   EXUpdates:
@@ -4684,6 +4694,7 @@ SPEC CHECKSUMS:
   ExpoBackgroundFetch: e0a8fba22cb21473f667eb8220cab7feef18e63c
   ExpoBackgroundTask: c6f9ddfb624d9b5ec548d69fd7195745e08ff987
   ExpoBattery: da883ecca2a79507916edd00836ef6a50afecac2
+  ExpoBlob: e49626a466984cca4ee809628e171041c2d89bc0
   ExpoBlur: b5b7a26572b3c33a11f0b2aa2f95c17c4c393b76
   ExpoBrightness: 7c3c86da46b847aadf44401bd28fb6d67050f324
   ExpoCalendar: 46ad51c48d2cb1a95439c2215b182428919a0c3d
@@ -4737,6 +4748,7 @@ SPEC CHECKSUMS:
   ExpoVideo: 7e39a5933892dc640b1b83013f3f9d9d37072151
   ExpoVideoThumbnails: c951ae8c6ed9974dd3ae5f79b2dd1d9b6e8ab266
   ExpoWebBrowser: 4f0dc52a559027cc0fba6920adc19a7604e2733d
+  ExpoWidgets: ce5a271b6480612f0b87123e9ab0e9510cf6fc5e
   EXStructuredHeaders: c951e77f2d936f88637421e9588c976da5827368
   EXUpdates: a318472f1671f936208c26ef71955415a1b2e279
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
@@ -4877,6 +4889,6 @@ SPEC CHECKSUMS:
   Yoga: 5456bb010373068fc92221140921b09d126b116e
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: dd91a5fc3556f0df4e04f71484ba3da93395243a
+PODFILE CHECKSUM: cf4f6931a91820299135101b61fe9642686cc8e2
 
 COCOAPODS: 1.16.2

--- a/packages/expo-dev-menu-interface/ios/DevMenuHostDelegate.swift
+++ b/packages/expo-dev-menu-interface/ios/DevMenuHostDelegate.swift
@@ -8,4 +8,14 @@ public protocol DevMenuHostDelegate: NSObjectProtocol {
    Optional function to navigate the host application to its home screen.
    */
   @objc optional func devMenuNavigateHome()
+
+  /**
+   Optional function to toggle the performance monitor.
+   */
+  @objc optional func devMenuTogglePerformanceMonitor()
+
+  /**
+   Optional function to toggle the element inspector.
+   */
+  @objc optional func devMenuToggleElementInspector()
 }

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -421,11 +421,23 @@ open class DevMenuManager: NSObject {
   }
 
   func togglePerformanceMonitor() {
+    if let delegate = hostDelegate,
+       delegate.responds(to: #selector(DevMenuHostDelegate.devMenuTogglePerformanceMonitor)) {
+      delegate.devMenuTogglePerformanceMonitor?()
+      return
+    }
+
     let devToolsDelegate = getDevToolsDelegate()
     devToolsDelegate?.togglePerformanceMonitor()
   }
 
   func toggleInspector() {
+    if let delegate = hostDelegate,
+       delegate.responds(to: #selector(DevMenuHostDelegate.devMenuToggleElementInspector)) {
+      delegate.devMenuToggleElementInspector?()
+      return
+    }
+
     let devToolsDelegate = getDevToolsDelegate()
     devToolsDelegate?.toggleElementInsector()
   }


### PR DESCRIPTION
# Why
Currently, updating the dev settings leads to inconsistent results. This is because we are still using the bridge to get the module registry when we use the DevMenuManager and don't delegate to a `DevMenuHostDelegate`. Expo go needs to use the module registry on the host or the devSettings get out of sync. We have access to the host in `EXReactAppManager` so we need to implement extra delegates and update the dev settings from there. I've also removed `isHomeApp` in `EXAppViewController` as this is no longer needed. 

In the long term we need to make this work without a bridge but it's difficult when we cannot use RCTHost from swift

# Test Plan
Expo go
