### PR TITLE
[crypto][Android] Fix typed array double offset writes

### DIFF
--- a/packages/expo-crypto/CHANGELOG.md
+++ b/packages/expo-crypto/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix memory corruption when offset typed array was provided to `digest()` or `getRandomValues()`.
+
 ### 💡 Others
 
 - bump base64-js from 1.2.3 to 1.5.1 ([#41211](https://github.com/expo/expo/pull/41211) by [@hassankhan](https://github.com/hassankhan))

--- a/packages/expo-crypto/CHANGELOG.md
+++ b/packages/expo-crypto/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix memory corruption when offset typed array was provided to `digest()` or `getRandomValues()`.
+- [Android] Fix memory corruption when offset typed array was provided to `digest()` or `getRandomValues()`. ([#42186](https://github.com/expo/expo/pull/42186) by [@barthap](https://github.com/barthap))
 
 ### 💡 Others
 

--- a/packages/expo-crypto/android/src/main/java/expo/modules/crypto/CryptoModule.kt
+++ b/packages/expo-crypto/android/src/main/java/expo/modules/crypto/CryptoModule.kt
@@ -45,12 +45,12 @@ class CryptoModule : Module() {
     val messageDigest = MessageDigest.getInstance(algorithm.value).apply { update(data.toDirectBuffer()) }
 
     val digest: ByteArray = messageDigest.digest()
-    output.write(digest, output.byteOffset, output.byteLength)
+    output.write(digest, 0, output.byteLength)
   }
 
   private fun getRandomValues(typedArray: TypedArray) {
     val array = ByteArray(typedArray.byteLength)
     secureRandom.nextBytes(array)
-    typedArray.write(array, typedArray.byteOffset, typedArray.byteLength)
+    typedArray.write(array, 0, typedArray.byteLength)
   }
 }

--- a/packages/expo-crypto/android/src/main/java/expo/modules/crypto/CryptoModule.kt
+++ b/packages/expo-crypto/android/src/main/java/expo/modules/crypto/CryptoModule.kt
@@ -7,6 +7,7 @@ import expo.modules.kotlin.typedarray.TypedArray
 import java.security.MessageDigest
 import java.security.SecureRandom
 import java.util.UUID
+import kotlin.math.min
 
 class CryptoModule : Module() {
   private val secureRandom by lazy { SecureRandom() }
@@ -45,7 +46,8 @@ class CryptoModule : Module() {
     val messageDigest = MessageDigest.getInstance(algorithm.value).apply { update(data.toDirectBuffer()) }
 
     val digest: ByteArray = messageDigest.digest()
-    output.write(digest, 0, output.byteLength)
+    val outputLength = min(digest.size, output.byteLength)
+    output.write(digest, 0, outputLength)
   }
 
   private fun getRandomValues(typedArray: TypedArray) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/TypedArray.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/TypedArray.kt
@@ -35,7 +35,21 @@ interface TypedArray {
    */
   fun toDirectBuffer(): ByteBuffer
 
+  /**
+   * Reads bytes from this typed array into [buffer].
+   *
+   * @param buffer output buffer
+   * @param position start position, relative to the beginning of the array
+   * @param size number of bytes to read
+   */
   fun read(buffer: ByteArray, position: Int, size: Int)
+  /**
+   * Writes content of [buffer] into the typed array.
+   *
+   * @param buffer source buffer
+   * @param position start position, relative to the beginning of the array
+   * @param size number of bytes to write
+   */
   fun write(buffer: ByteArray, position: Int, size: Int)
 
   fun readByte(position: Int): Byte

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/TypedArray.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/TypedArray.kt
@@ -43,6 +43,7 @@ interface TypedArray {
    * @param size number of bytes to read
    */
   fun read(buffer: ByteArray, position: Int, size: Int)
+
   /**
    * Writes content of [buffer] into the typed array.
    *

--- a/packages/expo-modules-core/ios/Core/TypedArrays/TypedArray.swift
+++ b/packages/expo-modules-core/ios/Core/TypedArrays/TypedArray.swift
@@ -60,7 +60,8 @@ public class TypedArray: AnyTypedArray {
   public lazy var length: Int = jsTypedArray.getProperty("length").getInt()
 
   /**
-   The unsafe mutable raw pointer to the start of the array buffer.
+   The unsafe mutable raw pointer to the start of the typed array.
+   It is the beignning of the underlying ArrayBuffer, with this array's `byteOffset` applied.
    */
   public lazy var rawPointer: UnsafeMutableRawPointer = jsTypedArray.getUnsafeMutableRawPointer()
 


### PR DESCRIPTION
# Why

Resolves <https://linear.app/expo/issue/ENG-18754/bug-report-heap-corruption>

Expo's TypedArray implementation always returns data pointer with byteOffset applied ([source](https://github.com/expo/expo/blob/1cf92d61390bd06649d2debb8ab1258bda2e6f4d/packages/expo-modules-core/common/cpp/JSI/TypedArray.cpp#L55)). So functions like [`read()`/`write()`](https://github.com/expo/expo/blob/1cf92d61390bd06649d2debb8ab1258bda2e6f4d/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/TypedArray.kt#L38-L39) on Android or [`rawPointer`](https://github.com/expo/expo/blob/1cf92d61390bd06649d2debb8ab1258bda2e6f4d/packages/expo-modules-core/ios/Core/TypedArrays/TypedArray.swift#L65) on iOS already return relative offset.
Thus, we shouldn't apply `byteOffset` again on callsites.

# How

- Removed `byteOffset` offsets when writing typed arrays in `digest()` and `getRandomValues()` (set to 0)
- Added comments in typed array methods to make it more clear about the offsets.

# Test Plan

Manual tests with custom offsets, including repro from Linear

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
