### PR TITLE
[tools][docs] Use latest version of Reviewdog for lint-prose job

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -52,13 +52,15 @@ jobs:
           NODE_ENV: production
         run: yarn lint --max-warnings 0
       - name: 💬 Lint Docs website content
-        uses: errata-ai/vale-action@reviewdog
+        uses: errata-ai/vale-action@v2.1.1
         with:
           version: 3.12.0
           reporter: github-pr-check
           files: 'docs/pages'
           vale_flags: '--config=./docs/.vale.ini'
           fail_on_error: true
+          # Override bundled reviewdog (0.17.0) to avoid 300-file diff limit
+          reviewdog_url: https://github.com/reviewdog/reviewdog/releases/download/v0.21.0/reviewdog_0.21.0_Linux_x86_64.tar.gz
       - name: 🏗️ Build Docs website
         run: yarn export-preview
         timeout-minutes: 20

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,13 +62,15 @@ jobs:
           NODE_ENV: production
         run: yarn lint --max-warnings 0
       - name: 💬 Lint Docs website content
-        uses: errata-ai/vale-action@reviewdog
+        uses: errata-ai/vale-action@v2.1.1
         with:
           version: 3.12.0
           reporter: github-pr-check
           files: 'docs/pages'
           vale_flags: '--config=./docs/.vale.ini'
           fail_on_error: true
+          # Override bundled reviewdog (0.17.0) to avoid 300-file diff limit
+          reviewdog_url: https://github.com/reviewdog/reviewdog/releases/download/v0.21.0/reviewdog_0.21.0_Linux_x86_64.tar.gz
       - name: 🏗️ Build Docs website for deploy
         working-directory: docs
         run: yarn export


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, running into an issue with Reviewdog which is used by Vale/lint-prose job. The error code is about large number of files limit, for which Review dog fails (for anything above 300 files).

<img width="3524" height="392" alt="CleanShot 2026-01-15 at 15 41 09@2x" src="https://github.com/user-attachments/assets/fdae2dd2-623f-4f40-8dea-7fbeef288c0a" />

Action and PR affected: https://github.com/expo/expo/actions/runs/21026667504/job/60453144780?pr=42160 & https://github.com/expo/expo/pull/42160

# How

<!--
How did you build this feature or fix this bug and why?
-->

Vale's GitHub Action uses Reviewdog's v17. However, chceking the Reviewdog's issues, found that this issue was resolved later here: https://github.com/reviewdog/reviewdog/issues/1696 & https://github.com/reviewdog/reviewdog/pull/1697. This PR adds `reviewdog_url` to the job to override the default version used by Vale GH.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Check the docs Lint docs website content logs in this PR:

<img width="4076" height="1878" alt="CleanShot 2026-01-15 at 16 08 04@2x" src="https://github.com/user-attachments/assets/b503f41f-f098-4ded-83e5-538b5dd7dfaf" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
