### PR TITLE
[cli] refactor output types from audio/image -> resource

### DIFF
--- a/packages/@expo/cli/src/start/interface/cliExtensionMenuItemHandler.ts
+++ b/packages/@expo/cli/src/start/interface/cliExtensionMenuItemHandler.ts
@@ -109,17 +109,14 @@ function handleOutput(output: DevToolsPluginOutput, spinner: Ora) {
     switch (line.type) {
       case 'text':
         appendSpinnerText(
-          line.url
-            ? link(line.url, { text: normalizeText(line.text, line.level), dim: false })
+          line.uri
+            ? link(line.uri, { text: normalizeText(line.text, line.level), dim: false })
             : normalizeText(line.text, line.level),
           spinner
         );
         break;
-      case 'audio':
-        appendSpinnerText(link(line.url, { text: line.text ?? 'Audio', dim: false }), spinner);
-        break;
-      case 'image':
-        appendSpinnerText(link(line.url, { text: line.text ?? 'Image', dim: false }), spinner);
+      case 'uri':
+        appendSpinnerText(link(line.uri, { text: line.text ?? 'uri', dim: false }), spinner);
         break;
     }
   });

--- a/packages/@expo/cli/src/start/server/DevToolsPlugin.schema.ts
+++ b/packages/@expo/cli/src/start/server/DevToolsPlugin.schema.ts
@@ -45,17 +45,12 @@ const DevToolsPluginOutputLinesSchema = z.union([
   z.object({
     type: z.literal('text'),
     text: z.string(),
-    url: z.string().optional(),
+    uri: z.string().optional(),
     level: z.enum(['info', 'warning', 'error']),
   }),
   z.object({
-    type: z.literal('audio'),
-    url: z.string().url(),
-    text: z.string().optional(),
-  }),
-  z.object({
-    type: z.literal('image'),
-    url: z.string().url(),
+    type: z.literal('uri'),
+    uri: z.string().url(),
     text: z.string().optional(),
   }),
 ]);

--- a/packages/@expo/cli/src/start/server/DevToolsPlugin.schema.ts
+++ b/packages/@expo/cli/src/start/server/DevToolsPlugin.schema.ts
@@ -47,17 +47,12 @@ const DevToolsPluginOutputLinesSchema = z.union([
   z.object({
     type: z.literal('text'),
     text: z.string(),
-    url: z.string().optional(),
+    uri: z.string().optional(),
     level: z.enum(['info', 'warning', 'error']),
   }),
   z.object({
-    type: z.literal('audio'),
-    url: z.string().url(),
-    text: z.string().optional(),
-  }),
-  z.object({
-    type: z.literal('image'),
-    url: z.string().url(),
+    type: z.literal('uri'),
+    uri: z.string().url(),
     text: z.string().optional(),
   }),
 ]);

--- a/packages/@expo/cli/src/start/server/MCPDevToolsPluginCLIExtensions.ts
+++ b/packages/@expo/cli/src/start/server/MCPDevToolsPluginCLIExtensions.ts
@@ -58,13 +58,13 @@ export async function addMcpCapabilities(mcpServer: McpServer, devServerManager:
                 .map((line) => {
                   const { type } = line;
                   if (type === 'text') {
-                    return { type, text: line.text, level: line.level, url: line.url };
-                  } else if (line.type === 'image' || line.type === 'audio') {
+                    return { type, text: line.text, level: line.level, uri: line.uri };
+                  } else if (line.type === 'uri') {
                     // We could present this as a resource_link, but it seems not to be well supported in MCP clients,
                     // so we'll return a text with the link instead.
                     return {
                       type: 'text',
-                      text: `${type} resource: ${line.url}${line.text ? ' (' + line.text + ')' : ''}`,
+                      text: `Resource: ${line.uri}${line.text ? ' (' + line.text + ')' : ''}`,
                     } as const;
                   }
                   return null;

--- a/packages/@expo/cli/src/start/server/MCPDevToolsPluginCLIExtensions.ts
+++ b/packages/@expo/cli/src/start/server/MCPDevToolsPluginCLIExtensions.ts
@@ -70,13 +70,13 @@ export async function addMcpCapabilities(mcpServer: McpServer, devServerManager:
                 .map((line) => {
                   const { type } = line;
                   if (type === 'text') {
-                    return { type, text: line.text, level: line.level, url: line.url };
-                  } else if (line.type === 'image' || line.type === 'audio') {
+                    return { type, text: line.text, level: line.level, uri: line.uri };
+                  } else if (line.type === 'uri') {
                     // We could present this as a resource_link, but it seems not to be well supported in MCP clients,
                     // so we'll return a text with the link instead.
                     return {
                       type: 'text',
-                      text: `${type} resource: ${line.url}${line.text ? ' (' + line.text + ')' : ''}`,
+                      text: `Resource: ${line.uri}${line.text ? ' (' + line.text + ')' : ''}`,
                     } as const;
                   }
                   return null;

--- a/packages/@expo/cli/src/start/server/__tests__/DevToolsPluginCliExtensionResults-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/DevToolsPluginCliExtensionResults-test.ts
@@ -34,7 +34,7 @@ describe('DevToolsPluginCliExtensionResults', () => {
       const valueToTest = new DevToolsPluginCliExtensionResults();
       const elements = [
         { type: 'text', text: 'Just some text output', level: 'info' },
-        { type: 'image', url: 'https://example.com/image.png' },
+        { type: 'uri', uri: 'https://example.com/image.png' },
       ];
       valueToTest.append(JSON.stringify(elements));
       expect(valueToTest.getOutput()).toEqual(elements);
@@ -44,7 +44,7 @@ describe('DevToolsPluginCliExtensionResults', () => {
       const valueToTest = new DevToolsPluginCliExtensionResults();
       const elements = [
         { type: 'text', text: 'This is an info text', level: 'info' },
-        { type: 'image', url: 'https://example.com/image.png' },
+        { type: 'uri', uri: 'https://example.com/image.png' },
       ];
       valueToTest.append(JSON.stringify(elements), 'error');
       expect(valueToTest.getOutput()).toEqual(elements);

--- a/packages/@expo/cli/src/start/server/__tests__/MCPDevToolsPluginCLIExtensions-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/MCPDevToolsPluginCLIExtensions-test.ts
@@ -79,9 +79,9 @@ describe(addMcpCapabilities, () => {
     const mcpServer = { registerTool } as unknown as McpServer;
 
     const pluginOutput = [
-      { type: 'text', text: 'Run complete', level: 'info', url: 'https://example.com' },
-      { type: 'image', url: 'https://example.com/image.png', text: 'Screenshot' },
-      { type: 'audio', url: 'https://example.com/sound.mp3' },
+      { type: 'text', text: 'Run complete', level: 'info', uri: 'https://example.com' },
+      { type: 'uri', uri: 'https://example.com/image.png', text: 'Screenshot' },
+      { type: 'uri', uri: 'https://example.com/sound.mp3' },
     ] as const;
     executeMock.mockResolvedValue(pluginOutput);
 
@@ -109,15 +109,15 @@ describe(addMcpCapabilities, () => {
           type: 'text',
           text: 'Run complete',
           level: 'info',
-          url: 'https://example.com',
+          uri: 'https://example.com',
         },
         {
           type: 'text',
-          text: 'image resource: https://example.com/image.png (Screenshot)',
+          text: 'Resource: https://example.com/image.png (Screenshot)',
         },
         {
           type: 'text',
-          text: 'audio resource: https://example.com/sound.mp3',
+          text: 'Resource: https://example.com/sound.mp3',
         },
       ],
     });

--- a/packages/@expo/cli/src/start/server/__tests__/MCPDevToolsPluginCLIExtensions-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/MCPDevToolsPluginCLIExtensions-test.ts
@@ -79,9 +79,9 @@ describe(addMcpCapabilities, () => {
     const mcpServer = { registerTool } as unknown as McpServer;
 
     const pluginOutput = [
-      { type: 'text', text: 'Run complete', level: 'info', url: 'https://example.com' },
-      { type: 'image', url: 'https://example.com/image.png', text: 'Screenshot' },
-      { type: 'audio', url: 'https://example.com/sound.mp3' },
+      { type: 'text', text: 'Run complete', level: 'info', uri: 'https://example.com' },
+      { type: 'uri', uri: 'https://example.com/image.png', text: 'Screenshot' },
+      { type: 'uri', uri: 'https://example.com/sound.mp3' },
     ] as const;
     executeMock.mockResolvedValue(pluginOutput);
 
@@ -120,15 +120,15 @@ describe(addMcpCapabilities, () => {
           type: 'text',
           text: 'Run complete',
           level: 'info',
-          url: 'https://example.com',
+          uri: 'https://example.com',
         },
         {
           type: 'text',
-          text: 'image resource: https://example.com/image.png (Screenshot)',
+          text: 'Resource: https://example.com/image.png (Screenshot)',
         },
         {
           type: 'text',
-          text: 'audio resource: https://example.com/sound.mp3',
+          text: 'Resource: https://example.com/sound.mp3',
         },
       ],
     });


### PR DESCRIPTION
# Why

The types that describes the output for cli extensions have two specific output types for audio and image. This is a bit limiting, since we might need other types of output as well. 

# How

The types are now refactored to include a single type called uri which is a resource with a uri. This can be used for images, audio, video or other types of files.

# Test Plan

CLI/Bare Expo 

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
