### PR TITLE
[e2e] Attempt to improve comparison tests

### DIFF
--- a/apps/bare-expo/e2e/_nested-flows/viewshot-comparison.yaml
+++ b/apps/bare-expo/e2e/_nested-flows/viewshot-comparison.yaml
@@ -14,6 +14,11 @@
 
 appId: dev.expo.Payments
 ---
+- extendedWaitUntil:
+    visible:
+      id: ${testID}
+    timeout: 10000
+
 - runScript:
     file: ./compare-images-http.js
     env:


### PR DESCRIPTION
# Why
These tests are failing pretty regularly for me so I'm trying to make them more reliable. 

# How
We take the screenshot too early before the view is fully on screen giving us images like this
<img width="400" height="51" alt="header-Appearance diff_15" src="https://github.com/user-attachments/assets/d2997f7a-f99c-4397-b5c1-be2fedc7f437" />
Waiting for the view to be on screen with `extendedWaitUntil`  seems to fix this

# Test Plan
Test passed locally 

