### PR TITLE
[cli][mcp][devtools] refactored cli extension for improved output handling and error formatting

### DIFF
--- a/packages/@expo/cli/src/start/server/DevToolsPluginCliExtensionExecutor.ts
+++ b/packages/@expo/cli/src/start/server/DevToolsPluginCliExtensionExecutor.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'child_process';
 import path from 'path';
+import { createInterface } from 'readline';
 
 import type {
   DevToolsPluginExecutorArguments,
@@ -28,6 +29,7 @@ export class DevToolsPluginCliExtensionExecutor {
   constructor(
     private plugin: DevToolsPluginInfo,
     private projectRoot: string,
+    private enableColorTTY = true,
     private spawnFunc: typeof spawn = spawn, // Used for injection when testing,
     private timeoutMs = DEFAULT_TIMEOUT_MS // Timeout for command execution
   ) {
@@ -86,16 +88,27 @@ export class DevToolsPluginCliExtensionExecutor {
         [tool, command, `${JSON.stringify(args)}`, `${metroServerOrigin}`],
         {
           cwd: this.projectRoot,
-          env: { ...process.env },
+          /**
+           * This tells chalk (and other color libraries) to output ANSI color codes even when not running in a TTY.
+           */
+          env: { ...process.env, ...(this.enableColorTTY ? { FORCE_COLOR: '1' } : {}) },
         }
       );
 
       let finished = false;
       const pluginResults = new DevToolsPluginCliExtensionResults(onOutput);
 
-      // Collect output/error data
-      child.stdout.on('data', (data) => pluginResults.append(data.toString()));
-      child.stderr.on('data', (data) => pluginResults.append(data.toString(), 'error'));
+      // Use readline to handle line-buffered output
+      const stdoutRL = createInterface({ input: child.stdout, crlfDelay: Infinity });
+      const stderrRL = createInterface({ input: child.stderr, crlfDelay: Infinity });
+
+      stdoutRL.on('line', (line) => pluginResults.append(line));
+      stderrRL.on('line', (line) => pluginResults.append(line, 'error'));
+
+      const closeHandler = () => {
+        stdoutRL.close();
+        stderrRL.close();
+      };
 
       // Setup timeout
       const timeout = setTimeout(() => {
@@ -111,6 +124,7 @@ export class DevToolsPluginCliExtensionExecutor {
         if (finished) return;
         clearTimeout(timeout);
         finished = true;
+        closeHandler();
         pluginResults.exit(code);
         resolve(pluginResults.getOutput());
       });
@@ -119,6 +133,7 @@ export class DevToolsPluginCliExtensionExecutor {
         if (finished) return;
         clearTimeout(timeout);
         finished = true;
+        closeHandler();
         pluginResults.append(err.toString(), 'error');
         resolve(pluginResults.getOutput());
       });

--- a/packages/@expo/cli/src/start/server/DevToolsPluginCliExtensionExecutor.ts
+++ b/packages/@expo/cli/src/start/server/DevToolsPluginCliExtensionExecutor.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
 import path from 'path';
+import { createInterface } from 'readline';
 
 import { isPathInside } from '../../utils/dir';
 import type {
@@ -31,6 +32,7 @@ export class DevToolsPluginCliExtensionExecutor {
   constructor(
     private plugin: DevToolsPluginInfo,
     private projectRoot: string,
+    private enableColorTTY = true,
     private spawnFunc: typeof spawn = spawn, // Used for injection when testing,
     private timeoutMs = DEFAULT_TIMEOUT_MS // Timeout for command execution
   ) {
@@ -111,7 +113,11 @@ export class DevToolsPluginCliExtensionExecutor {
           [this.resolvedEntryPoint, command, `${JSON.stringify(args)}`, `${metroServerOrigin}`],
           {
             cwd: this.projectRoot,
-            env: { ...process.env },
+            /**
+             * FORCE_COLOR tells chalk (and other color libraries) to emit ANSI color codes
+             * even when the child process is not attached to a TTY.
+             */
+            env: { ...process.env, ...(this.enableColorTTY ? { FORCE_COLOR: '1' } : {}) },
           }
         );
       } catch (err: any) {
@@ -121,22 +127,31 @@ export class DevToolsPluginCliExtensionExecutor {
         return;
       }
 
+      // Use readline to handle line-buffered output.
+      const stdoutRL = createInterface({ input: child.stdout, crlfDelay: Infinity });
+      const stderrRL = createInterface({ input: child.stderr, crlfDelay: Infinity });
+      const closeReadline = () => {
+        stdoutRL.close();
+        stderrRL.close();
+      };
+
       const finishOnTruncation = () => {
         if (pluginResults.isTruncated() && !finished) {
           finished = true;
           if (timeout) clearTimeout(timeout);
+          closeReadline();
           child.kill('SIGKILL');
           resolve(pluginResults.getOutput());
         }
       };
 
       // Collect output/error data
-      child.stdout.on('data', (data) => {
-        pluginResults.append(data.toString());
+      stdoutRL.on('line', (line) => {
+        pluginResults.append(line);
         finishOnTruncation();
       });
-      child.stderr.on('data', (data) => {
-        pluginResults.append(data.toString(), 'error');
+      stderrRL.on('line', (line) => {
+        pluginResults.append(line, 'error');
         finishOnTruncation();
       });
 
@@ -144,6 +159,7 @@ export class DevToolsPluginCliExtensionExecutor {
       timeout = setTimeout(() => {
         if (!finished) {
           finished = true;
+          closeReadline();
           child.kill('SIGKILL');
           pluginResults.append('Command timed out', 'error');
           resolve(pluginResults.getOutput());
@@ -154,6 +170,7 @@ export class DevToolsPluginCliExtensionExecutor {
         if (finished) return;
         if (timeout) clearTimeout(timeout);
         finished = true;
+        closeReadline();
         pluginResults.exit(code);
         resolve(pluginResults.getOutput());
       });
@@ -162,6 +179,7 @@ export class DevToolsPluginCliExtensionExecutor {
         if (finished) return;
         if (timeout) clearTimeout(timeout);
         finished = true;
+        closeReadline();
         pluginResults.append(err.toString(), 'error');
         resolve(pluginResults.getOutput());
       });

--- a/packages/@expo/cli/src/start/server/DevToolsPluginCliExtensionResults.ts
+++ b/packages/@expo/cli/src/start/server/DevToolsPluginCliExtensionResults.ts
@@ -1,3 +1,5 @@
+import type { ZodError, ZodIssue } from 'zod';
+
 import type { DevToolsPluginOutput } from './DevToolsPlugin.schema';
 import { DevToolsPluginOutputSchema } from './DevToolsPlugin.schema';
 
@@ -42,7 +44,7 @@ export class DevToolsPluginCliExtensionResults {
         return [
           {
             type: 'text',
-            text: `Invalid JSON: ${result.error.issues.map((issue) => issue.message).join(', ')}`,
+            text: `Invalid JSON: ${DevToolsPluginCliExtensionResults.formatZodError(result.error)}`,
             level: 'error',
           },
         ];
@@ -59,5 +61,76 @@ export class DevToolsPluginCliExtensionResults {
       }
       return results;
     }
+  }
+
+  /**
+   * Formats a Zod path array into a human-readable string.
+   * Example: [0, "level"] → "[0].level"
+   */
+  private static formatPath(path: (string | number)[]): string {
+    if (path.length === 0) return 'value';
+    return path
+      .map((segment, i) =>
+        typeof segment === 'number' ? `[${segment}]` : i === 0 ? segment : `.${segment}`
+      )
+      .join('');
+  }
+
+  /**
+   * Formats a single Zod issue into a human-readable message.
+   */
+  private static formatIssue(issue: ZodIssue): string {
+    const path = this.formatPath(issue.path);
+
+    switch (issue.code) {
+      case 'invalid_type':
+        if (issue.received === 'undefined') {
+          return `"${path}" is required`;
+        }
+        return `"${path}" expected ${issue.expected}, got ${issue.received}`;
+
+      case 'invalid_enum_value':
+        return `"${path}" must be one of: ${(issue as any).options.join(', ')} (got "${(issue as any).received}")`;
+
+      case 'invalid_literal':
+        return `"${path}" must be "${(issue as any).expected}" (got "${(issue as any).received}")`;
+
+      case 'invalid_union': {
+        // Pick the branch with fewest errors
+        const unionErrors = (issue as any).unionErrors as ZodError[];
+        const bestBranch = unionErrors.reduce((best, current) =>
+          current.issues.length < best.issues.length ? current : best
+        );
+        return bestBranch.issues.map(this.formatIssue.bind(this)).join('; ');
+      }
+
+      case 'too_small':
+        if ((issue as any).type === 'string' && (issue as any).minimum === 1) {
+          return `"${path}" must not be empty`;
+        }
+        return `"${path}" is too small`;
+
+      case 'unrecognized_keys':
+        return `Unknown field(s): ${(issue as any).keys.join(', ')}`;
+
+      default:
+        return issue.message;
+    }
+  }
+
+  /**
+   * Formats a ZodError into a human-readable error message.
+   * Shows at most 3 errors with a count of remaining errors.
+   */
+  public static formatZodError(error: ZodError): string {
+    const MAX_ERRORS = 3;
+    const messages = error.issues.map(this.formatIssue.bind(this));
+    const shown = messages.slice(0, MAX_ERRORS);
+    const remaining = messages.length - MAX_ERRORS;
+
+    if (remaining > 0) {
+      return `${shown.join('; ')} ...and ${remaining} more error${remaining > 1 ? 's' : ''}`;
+    }
+    return shown.join('; ');
   }
 }

--- a/packages/@expo/cli/src/start/server/DevToolsPluginCliExtensionResults.ts
+++ b/packages/@expo/cli/src/start/server/DevToolsPluginCliExtensionResults.ts
@@ -1,4 +1,5 @@
 import { constants as bufferConstants } from 'node:buffer';
+import { ZodError, ZodIssue } from 'zod';
 
 import type { DevToolsPluginOutput } from './DevToolsPlugin.schema';
 import { DevToolsPluginOutputSchema } from './DevToolsPlugin.schema';
@@ -66,7 +67,7 @@ export class DevToolsPluginCliExtensionResults {
         return [
           {
             type: 'text',
-            text: `Invalid JSON: ${result.error.issues.map((issue) => issue.message).join(', ')}`,
+            text: `Invalid JSON: ${DevToolsPluginCliExtensionResults.formatZodError(result.error)}`,
             level: 'error',
           },
         ];
@@ -83,5 +84,76 @@ export class DevToolsPluginCliExtensionResults {
       }
       return results;
     }
+  }
+
+  /**
+   * Formats a Zod path array into a human-readable string.
+   * Example: [0, "level"] → "[0].level"
+   */
+  private static formatPath(path: (string | number)[]): string {
+    if (path.length === 0) return 'value';
+    return path
+      .map((segment, i) =>
+        typeof segment === 'number' ? `[${segment}]` : i === 0 ? segment : `.${segment}`
+      )
+      .join('');
+  }
+
+  /**
+   * Formats a single Zod issue into a human-readable message.
+   */
+  private static formatIssue(issue: ZodIssue): string {
+    const path = this.formatPath(issue.path);
+
+    switch (issue.code) {
+      case 'invalid_type':
+        if (issue.received === 'undefined') {
+          return `"${path}" is required`;
+        }
+        return `"${path}" expected ${issue.expected}, got ${issue.received}`;
+
+      case 'invalid_enum_value':
+        return `"${path}" must be one of: ${(issue as any).options.join(', ')} (got "${(issue as any).received}")`;
+
+      case 'invalid_literal':
+        return `"${path}" must be "${(issue as any).expected}" (got "${(issue as any).received}")`;
+
+      case 'invalid_union': {
+        // Pick the branch with fewest errors
+        const unionErrors = (issue as any).unionErrors as ZodError[];
+        const bestBranch = unionErrors.reduce((best, current) =>
+          current.issues.length < best.issues.length ? current : best
+        );
+        return bestBranch.issues.map(this.formatIssue.bind(this)).join('; ');
+      }
+
+      case 'too_small':
+        if ((issue as any).type === 'string' && (issue as any).minimum === 1) {
+          return `"${path}" must not be empty`;
+        }
+        return `"${path}" is too small`;
+
+      case 'unrecognized_keys':
+        return `Unknown field(s): ${(issue as any).keys.join(', ')}`;
+
+      default:
+        return issue.message;
+    }
+  }
+
+  /**
+   * Formats a ZodError into a human-readable error message.
+   * Shows at most 3 errors with a count of remaining errors.
+   */
+  public static formatZodError(error: ZodError): string {
+    const MAX_ERRORS = 3;
+    const messages = error.issues.map(this.formatIssue.bind(this));
+    const shown = messages.slice(0, MAX_ERRORS);
+    const remaining = messages.length - MAX_ERRORS;
+
+    if (remaining > 0) {
+      return `${shown.join('; ')} ...and ${remaining} more error${remaining > 1 ? 's' : ''}`;
+    }
+    return shown.join('; ');
   }
 }

--- a/packages/@expo/cli/src/start/server/MCPDevToolsPluginCLIExtensions.ts
+++ b/packages/@expo/cli/src/start/server/MCPDevToolsPluginCLIExtensions.ts
@@ -1,6 +1,7 @@
 import type { DevServerManager } from './DevServerManager';
 import { DevToolsPluginOutputSchema } from './DevToolsPlugin.schema';
 import { DevToolsPluginCliExtensionExecutor } from './DevToolsPluginCliExtensionExecutor';
+import { DevToolsPluginCliExtensionResults } from './DevToolsPluginCliExtensionResults';
 import type { McpServer } from './MCP';
 import { createMCPDevToolsExtensionSchema } from './createMCPDevToolsExtensionSchema';
 import { Log } from '../../log';
@@ -42,15 +43,14 @@ export async function addMcpCapabilities(mcpServer: McpServer, devServerManager:
 
             const results = await new DevToolsPluginCliExtensionExecutor(
               plugin,
-              devServerManager.projectRoot
+              devServerManager.projectRoot,
+              false // disable tty color for MCP clients
             ).execute({ command, args, metroServerOrigin });
 
             const parsedResults = DevToolsPluginOutputSchema.safeParse(results);
             if (parsedResults.success === false) {
               throw new Error(
-                `Invalid output from CLI command: ${parsedResults.error.issues
-                  .map((issue) => issue.message)
-                  .join(', ')}`
+                `Invalid output from CLI command: ${DevToolsPluginCliExtensionResults.formatZodError(parsedResults.error)}`
               );
             }
             return {

--- a/packages/@expo/cli/src/start/server/MCPDevToolsPluginCLIExtensions.ts
+++ b/packages/@expo/cli/src/start/server/MCPDevToolsPluginCLIExtensions.ts
@@ -3,6 +3,7 @@ import type { DevServerManager } from './DevServerManager';
 import type { DevToolsPluginInfo } from './DevToolsPlugin.schema';
 import { DevToolsPluginOutputSchema } from './DevToolsPlugin.schema';
 import { DevToolsPluginCliExtensionExecutor } from './DevToolsPluginCliExtensionExecutor';
+import { DevToolsPluginCliExtensionResults } from './DevToolsPluginCliExtensionResults';
 import type { McpServer } from './MCP';
 import { createMCPDevToolsExtensionSchema } from './createMCPDevToolsExtensionSchema';
 import { debugEvent } from './devtoolsEvents';
@@ -54,15 +55,14 @@ export async function addMcpCapabilities(mcpServer: McpServer, devServerManager:
 
             const results = await new DevToolsPluginCliExtensionExecutor(
               mcpPlugin,
-              devServerManager.projectRoot
+              devServerManager.projectRoot,
+              false // disable tty color for MCP clients
             ).execute({ command, args, metroServerOrigin });
 
             const parsedResults = DevToolsPluginOutputSchema.safeParse(results);
             if (parsedResults.success === false) {
               throw new Error(
-                `Invalid output from CLI command: ${parsedResults.error.issues
-                  .map((issue) => issue.message)
-                  .join(', ')}`
+                `Invalid output from CLI command: ${DevToolsPluginCliExtensionResults.formatZodError(parsedResults.error)}`
               );
             }
             return {

--- a/packages/@expo/cli/src/start/server/__tests__/DevToolsPluginCliExtensionExecutor-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/DevToolsPluginCliExtensionExecutor-test.ts
@@ -1,3 +1,5 @@
+import { PassThrough } from 'stream';
+
 import type { DevToolsPluginInfo } from '../DevToolsPlugin.schema';
 import { DevToolsPluginCliExtensionExecutor } from '../DevToolsPluginCliExtensionExecutor';
 
@@ -190,6 +192,10 @@ const executePluginCommandAsync = async (params: {
   let log = '';
   let err = '';
   const kill = jest.fn();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  stdout.on('data', (data) => (log += data.toString()));
+  stderr.on('data', (data) => (err += data.toString()));
   const mock = {
     spawn:
       spawnFunc ??
@@ -201,8 +207,8 @@ const executePluginCommandAsync = async (params: {
           });
         },
         kill,
-        stdout: { on: (t) => (log += t) },
-        stderr: { on: (t) => (err += t) },
+        stdout,
+        stderr,
       }),
   };
   jest.doMock('child_process', () => mock);
@@ -210,6 +216,7 @@ const executePluginCommandAsync = async (params: {
   const executor = new DevToolsPluginCliExtensionExecutor(
     pluginDescriptor,
     PROJECT_ROOT,
+    false,
     mock.spawn,
     timeoutMs
   );

--- a/packages/@expo/cli/src/start/server/__tests__/DevToolsPluginCliExtensionExecutor-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/DevToolsPluginCliExtensionExecutor-test.ts
@@ -1,3 +1,5 @@
+import { PassThrough } from 'stream';
+
 import type { DevToolsPluginInfo } from '../DevToolsPlugin.schema';
 import { DevToolsPluginCliExtensionExecutor } from '../DevToolsPluginCliExtensionExecutor';
 
@@ -223,6 +225,10 @@ const executePluginCommandAsync = async (params: {
   let log = '';
   let err = '';
   const kill = jest.fn();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  stdout.on('data', (data) => (log += data.toString()));
+  stderr.on('data', (data) => (err += data.toString()));
   const mock = {
     spawn:
       spawnFunc ??
@@ -234,8 +240,8 @@ const executePluginCommandAsync = async (params: {
           });
         },
         kill,
-        stdout: { on: (t: string) => (log += t) },
-        stderr: { on: (t: string) => (err += t) },
+        stdout,
+        stderr,
       }),
   };
   jest.doMock('child_process', () => mock);
@@ -243,6 +249,7 @@ const executePluginCommandAsync = async (params: {
   const executor = new DevToolsPluginCliExtensionExecutor(
     pluginDescriptor,
     PROJECT_ROOT,
+    false,
     mock.spawn,
     timeoutMs
   );

--- a/packages/@expo/cli/src/start/server/__tests__/DevToolsPluginCliExtensionResults-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/DevToolsPluginCliExtensionResults-test.ts
@@ -26,7 +26,11 @@ describe('DevToolsPluginCliExtensionResults', () => {
       const valueToTest = new DevToolsPluginCliExtensionResults();
       valueToTest.append(JSON.stringify([{ anotherValue: 234, text: 'Unexpected number' }]));
       expect(valueToTest.getOutput()).toEqual([
-        { type: 'text', text: 'Invalid JSON: Invalid input', level: 'error' },
+        {
+          type: 'text',
+          text: 'Invalid JSON: "[0].type" must be "text" (got "undefined"); "[0].level" is required',
+          level: 'error',
+        },
       ]);
     });
 

--- a/packages/@expo/cli/src/start/server/__tests__/MCPDevToolsPluginCLIExtensions-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/MCPDevToolsPluginCLIExtensions-test.ts
@@ -83,6 +83,7 @@ describe(addMcpCapabilities, () => {
       { type: 'uri', uri: 'https://example.com/image.png', text: 'Screenshot' },
       { type: 'uri', uri: 'https://example.com/sound.mp3' },
     ] as const;
+
     executeMock.mockResolvedValue(pluginOutput);
 
     await addMcpCapabilities(mcpServer, devServerManager);
@@ -96,7 +97,7 @@ describe(addMcpCapabilities, () => {
     });
 
     expect(MockedExecutor).toHaveBeenCalledTimes(1);
-    expect(MockedExecutor).toHaveBeenLastCalledWith(plugin, PROJECT_ROOT);
+    expect(MockedExecutor).toHaveBeenLastCalledWith(plugin, PROJECT_ROOT, false); // no color for MCP
     expect(executeMock).toHaveBeenCalledWith({
       command: 'run-analysis',
       args: { path: '/tmp/data' },

--- a/packages/@expo/cli/src/start/server/__tests__/MCPDevToolsPluginCLIExtensions-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/MCPDevToolsPluginCLIExtensions-test.ts
@@ -106,7 +106,8 @@ describe(addMcpCapabilities, () => {
           commands: [command],
         },
       },
-      PROJECT_ROOT
+      PROJECT_ROOT,
+      false // no color for MCP
     );
     expect(executeMock).toHaveBeenCalledWith({
       command: 'run-analysis',


### PR DESCRIPTION
# Why

When the cli is spawning extensions, we need to be strict about parsing the return values and formatting of errors.

# How

This commit fixes this by using createInterface to get line-by-line based output handling (meaning we can reliably parse the JSON output from the extension - if any).

In addition a utility for formatting errors from parsing output has been added - making sure to display the source and details of errors occuring in the JSON-output from the cli extensions.  
  
Added support for handling colors in console (disabled in mcp context)