### PR TITLE
[contacts] Fix adding a contact when default account is set to cloud

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix adding contact when default account is set to cloud ([#42203](https://github.com/expo/expo/pull/42203) by [@Wenszel](https://github.com/Wenszel))
+
 ### 💡 Others
 
 - Added contact image uri validation. ([#39658](https://github.com/expo/expo/pull/39658) by [@hryhoriiK97](https://github.com/hryhoriiK97))

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.kt
@@ -198,8 +198,6 @@ class Contact(var contactId: String, var appContext: AppContext) {
   fun toInsertOperationList(): ArrayList<ContentProviderOperation> {
     val ops = ArrayList<ContentProviderOperation>()
     var op = ContentProviderOperation.newInsert(RawContacts.CONTENT_URI)
-      .withValue(RawContacts.ACCOUNT_TYPE, null)
-      .withValue(RawContacts.ACCOUNT_NAME, null)
       .withValue(RawContacts.STARRED, isFavorite)
     ops.add(op.build())
     op = ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)


### PR DESCRIPTION
# Why
Fixes an issue with adding a contact when a default account is set to cloud: 
`Cannot add contacts to local or SIM accounts when default account is set to cloud`

The problem seems to occur only on pure Android - I reproduced it on Google Pixel, while for example on Xiaomi it doesn't happen.
The cause is adding a contact with the account type/name hardcoded to null, whereas those fields should be overwritten with the system default type.

# How
Removes unnecessary hardcoded ACCOUNT_TYPE and ACCOUNT_NAME when creating a contact. When they are not present, the system can create a contact in its default location.

# Test Plan
Tested on BareExpo on Google Pixel 9 and Xiaomi Poco X3 Pro