### PR TITLE
[screen-capture][iOS] Fix main thread violation warnings on app startup

### DIFF
--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix main thread violation warnings on app startup.
+- [iOS] Fix main thread violation warnings on app startup. ([#42204](https://github.com/expo/expo/pull/42204) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix main thread violation warnings on app startup.
+
 ### 💡 Others
 
 - Remove warning about iOS screenshot limitations. ([#40115](https://github.com/expo/expo/pull/40115) by [@hryhoriiK97](https://github.com/hryhoriiK97))

--- a/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
+++ b/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
@@ -5,7 +5,7 @@ let onScreenshotEventName = "onScreenshot"
 public final class ScreenCaptureModule: Module {
   private var isBeingObserved = false
   private var isListening = false
-  private var blockView = UIView()
+  private var blockView: UIView? = nil
   private var protectionTextField: UITextField?
   private var originalParent: CALayer?
   private var blurEffectView: AnimatedBlurEffectView?
@@ -20,12 +20,6 @@ public final class ScreenCaptureModule: Module {
     Name("ExpoScreenCapture")
 
     Events(onScreenshotEventName)
-
-    OnCreate {
-      let boundLength = max(UIScreen.main.bounds.size.width, UIScreen.main.bounds.size.height)
-      blockView.frame = CGRect(x: 0, y: 0, width: boundLength, height: boundLength)
-      blockView.backgroundColor = .black
-    }
 
     OnDestroy {
       allowScreenshots()
@@ -98,8 +92,9 @@ public final class ScreenCaptureModule: Module {
   func preventScreenRecording() {
     guard let keyWindow = keyWindow,
       let visibleView = keyWindow.subviews.first else { return }
-    let isCaptured = UIScreen.main.isCaptured
+    let blockView = getOrCreateBlockView()
 
+    let isCaptured = UIScreen.main.isCaptured
     if isCaptured {
       visibleView.addSubview(blockView)
     } else {
@@ -112,6 +107,19 @@ public final class ScreenCaptureModule: Module {
     sendEvent(onScreenshotEventName, [
       "body": nil
     ])
+  }
+
+  private func getOrCreateBlockView() -> UIView {
+    guard let blockView = blockView else {
+      let view = UIView()
+      let boundLength = max(UIScreen.main.bounds.size.width, UIScreen.main.bounds.size.height)
+      view.frame = CGRect(x: 0, y: 0, width: boundLength, height: boundLength)
+      view.backgroundColor = .black
+
+      self.blockView = view
+      return view
+    }
+    return blockView
   }
 
   private func preventScreenshots() {

--- a/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
+++ b/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
@@ -5,7 +5,7 @@ let onScreenshotEventName = "onScreenshot"
 public final class ScreenCaptureModule: Module {
   private var isBeingObserved = false
   private var isListening = false
-  private var blockView: UIView? = nil
+  private var blockView: UIView?
   private var protectionTextField: UITextField?
   private var originalParent: CALayer?
   private var blurEffectView: AnimatedBlurEffectView?
@@ -110,7 +110,7 @@ public final class ScreenCaptureModule: Module {
   }
 
   private func getOrCreateBlockView() -> UIView {
-    guard let blockView = blockView else {
+    guard let blockView else {
       let view = UIView()
       let boundLength = max(UIScreen.main.bounds.size.width, UIScreen.main.bounds.size.height)
       view.frame = CGRect(x: 0, y: 0, width: boundLength, height: boundLength)


### PR DESCRIPTION
# Why

Fixes main thread violation warnings on app startup.
They're not causing any problems right now, but they can lead to crashes in the future. 

# Test Plan

- NCL ✅ 