### PR TITLE
[expo-cli] Add Metro `cacheStores` configuration via envs

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Improve SSR support ([#41477](https://github.com/expo/expo/pull/41477) by [@hassankhan](https://github.com/hassankhan))
 - Add support for server data loaders in server export mode ([#41934](https://github.com/expo/expo/pull/41934) by [@hassankhan](https://github.com/hassankhan))
 - Add `EXPO_UNSTABLE_BONJOUR` to activate Bonjour advertising ([#42138](https://github.com/expo/expo/pull/42138) by [@kitten](https://github.com/kitten))
+- Add `EXPO_METRO_CACHE_STORES_DIR` to configure Metro cache directory ([#42210](https://github.com/expo/expo/pull/42210) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/start/server/metro/__tests__/instantiateMetro.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/instantiateMetro.test.ts
@@ -1,7 +1,19 @@
+import type { ConfigT } from '@expo/metro/metro-config';
+import * as fs from 'node:fs';
+
 import { Log } from '../../../../log';
-import { isWatchEnabled } from '../instantiateMetro';
+import { isWatchEnabled, overrideExpoMetroCacheStores } from '../instantiateMetro';
 
 jest.mock('../../../../log');
+jest.mock('@expo/metro-config/file-store', () => ({
+  FileStore: jest.fn().mockImplementation((options) => ({
+    ...options,
+    _isFileStore: true,
+  })),
+}));
+
+const mockMkdir = jest.fn();
+jest.spyOn(fs.promises, 'mkdir').mockImplementation(mockMkdir);
 
 describe(isWatchEnabled, () => {
   const originalValue = process.env.CI;
@@ -27,5 +39,78 @@ describe(isWatchEnabled, () => {
     process.env.CI = 'true';
     expect(isWatchEnabled()).toBe(false);
     expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('Metro is running in CI mode'));
+  });
+});
+
+describe(overrideExpoMetroCacheStores, () => {
+  const originalValue = process.env.EXPO_METRO_CACHE_STORES_DIR;
+
+  beforeEach(() => {
+    delete process.env.EXPO_METRO_CACHE_STORES_DIR;
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env.EXPO_METRO_CACHE_STORES_DIR = originalValue;
+  });
+
+  it('does not modify cacheStores when env is not set', async () => {
+    const originalCacheStores = [{ root: '/original/cache' }];
+    const config = {
+      cacheStores: originalCacheStores,
+    } as unknown as ConfigT;
+
+    await overrideExpoMetroCacheStores(config, { projectRoot: '/test/project' });
+
+    expect(config.cacheStores).toBe(originalCacheStores);
+    expect(config.cacheStores).toHaveLength(1);
+  });
+
+  it('overrides cacheStores with exactly one FileStore when env is set - absolute path', async () => {
+    process.env.EXPO_METRO_CACHE_STORES_DIR = '/tmp/custom-cache';
+    const originalCacheStores = [{ root: '/original/cache' }, { root: '/another/cache' }];
+    const config = {
+      cacheStores: originalCacheStores,
+    } as unknown as ConfigT;
+
+    await overrideExpoMetroCacheStores(config, { projectRoot: '/test/project' });
+
+    expect(config.cacheStores).not.toBe(originalCacheStores);
+    expect(config.cacheStores).toHaveLength(1);
+    expect(config.cacheStores[0]).toMatchObject({
+      root: '/tmp/custom-cache',
+      _isFileStore: true,
+    });
+  });
+
+  it('overrides cacheStores with exactly one FileStore when env is set - relative path', async () => {
+    process.env.EXPO_METRO_CACHE_STORES_DIR = 'custom-cache';
+    const originalCacheStores = [{ root: '/original/cache' }, { root: '/another/cache' }];
+    const config = {
+      cacheStores: originalCacheStores,
+    } as unknown as ConfigT;
+
+    await overrideExpoMetroCacheStores(config, { projectRoot: '/test/project' });
+
+    expect(config.cacheStores).not.toBe(originalCacheStores);
+    expect(config.cacheStores).toHaveLength(1);
+    expect(config.cacheStores[0]).toMatchObject({
+      root: '/test/project/custom-cache',
+      _isFileStore: true,
+    });
+  });
+
+  it('re-throws mkdir error when directory creation fails', async () => {
+    process.env.EXPO_METRO_CACHE_STORES_DIR = '/tmp/custom-cache';
+    const mkdirError = new Error('Permission denied');
+    mockMkdir.mockRejectedValueOnce(mkdirError);
+
+    const config = {
+      cacheStores: [],
+    } as unknown as ConfigT;
+
+    await expect(
+      overrideExpoMetroCacheStores(config, { projectRoot: '/test/project' })
+    ).rejects.toThrow(mkdirError);
   });
 });

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -154,6 +154,31 @@ export async function loadMetroConfigAsync(
     },
   };
 
+  // Handle EXPO_METRO_CACHE_STORES_DIR environment variable override
+  if (env.EXPO_METRO_CACHE_STORES_DIR) {
+    const { FileStore } = require('@expo/metro-config/file-store');
+
+    // Check if user has custom cacheStores in their metro.config.js
+    const userHasCustomCacheStores =
+      !resolvedConfig.isEmpty && resolvedConfig.config.cacheStores !== undefined;
+
+    if (userHasCustomCacheStores) {
+      Log.warn(
+        `Using EXPO_METRO_CACHE_STORES_DIR="${env.EXPO_METRO_CACHE_STORES_DIR}" which overrides cacheStores from metro.config.js`
+      );
+    }
+
+    // Override cacheStores with the env-specified directory
+    config = {
+      ...config,
+      cacheStores: [
+        new FileStore({
+          root: env.EXPO_METRO_CACHE_STORES_DIR,
+        }),
+      ],
+    };
+  }
+
   globalThis.__requireCycleIgnorePatterns = config.resolver?.requireCycleIgnorePatterns;
 
   if (isExporting) {

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -159,23 +159,23 @@ export async function loadMetroConfigAsync(
   if (env.EXPO_METRO_CACHE_STORES_DIR) {
     const { FileStore } = require('@expo/metro-config/file-store');
 
-    // Resolve relative paths to absolute paths based on current working directory
+    // Resolve relative paths to absolute paths based on project root
     const cacheStoresDir = path.isAbsolute(env.EXPO_METRO_CACHE_STORES_DIR)
       ? env.EXPO_METRO_CACHE_STORES_DIR
-      : path.resolve(process.cwd(), env.EXPO_METRO_CACHE_STORES_DIR);
+      : path.resolve(projectRoot, env.EXPO_METRO_CACHE_STORES_DIR);
 
     // Create the directory if it doesn't exist
     try {
       await fs.promises.mkdir(cacheStoresDir, { recursive: true });
     } catch (error: any) {
       if (error.code !== 'EEXIST') {
+        Log.error(`Provided EXPO_METRO_CACHE_STORES_DIR="${cacheStoresDir} is not a directory. Use new or existing directory path.`)
         throw error;
       }
     }
 
     // Check if user has custom cacheStores in their metro.config.js
-    const userHasCustomCacheStores =
-      !resolvedConfig.isEmpty && resolvedConfig.config.cacheStores !== undefined;
+    const userHasCustomCacheStores = config.cacheStores
 
     if (userHasCustomCacheStores) {
       Log.warn(

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -164,6 +164,14 @@ class Env {
     return boolish('EXPO_METRO_UNSTABLE_ERRORS', true);
   }
 
+  /**
+   * Override the Metro cache stores directory. When set, this takes precedence over
+   * any `cacheStores` configuration in metro.config.js.
+   */
+  get EXPO_METRO_CACHE_STORES_DIR(): string {
+    return string('EXPO_METRO_CACHE_STORES_DIR', '');
+  }
+
   /** Enable the experimental sticky resolver for Metro (Uses Expo Autolinking results and applies them to Metro's resolution)
    * @deprecated Replaced by `exp.experiments.autolinkingModuleResolution`
    */


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This is useful for sandbox environments where the cache can be reused across builds without requiring project configuration changes.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Adds `EXPO_METRO_CACHE_STORES_DIR` environment variable to configure Metro's cache directory without modifying `metro.config.js`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Added unit test.

When `EXPO_METRO_CACHE_STORES_DIR` is configured observer the folder being filled with Metro cache.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
