### PR TITLE
[ci] fix nightlies pod install error

### DIFF
--- a/.github/workflows/test-react-native-nightly.yml
+++ b/.github/workflows/test-react-native-nightly.yml
@@ -67,10 +67,10 @@ jobs:
           echo "DEVICE_ID=$DEVICE_ID" >> $GITHUB_ENV
       - name: 🍏 Build iOS Project
         run: |
-          pod install --project-directory=ios
-          xcodebuild -workspace ios/testnightlies.xcworkspace -scheme testnightlies -configuration $CONFIGURATION -sdk iphonesimulator -destination "id=$DEVICE_ID" -derivedDataPath "ios/build" | xcpretty
+          pod install
+          xcodebuild -workspace testnightlies.xcworkspace -scheme testnightlies -configuration $CONFIGURATION -sdk iphonesimulator -destination "id=$DEVICE_ID" -derivedDataPath "build" | xcpretty
         shell: bash
-        working-directory: ${{ runner.temp }}/test-nightlies
+        working-directory: ${{ runner.temp }}/test-nightlies/ios
         env:
           NODE_ENV: production
           CONFIGURATION: ${{ matrix.build-type == 'release' && 'Release' || 'Debug' }}


### PR DESCRIPTION
# Why

fixes nightly error: https://github.com/expo/expo/actions/runs/21030475887/job/60465036144
```
[!] Invalid `Podfile` file: Couldn't find the React Native package.json file at /Users/runner/work/_temp/node_modules/.bun/react-native@0.85.0-nightly-20260115-caa1fb6a0+904203dc08a63dd6/node_modules/react-native/package.json.
```

# How

try to pod install from ios directory

# Test Plan

nightlies ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
