### PR TITLE
refactor(build-properties): Switch from `ajv` to `@expo/schema-utils`

### DIFF
--- a/packages/expo-build-properties/CHANGELOG.md
+++ b/packages/expo-build-properties/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Switch from `ajv` to `@expo/schema-utils` ([#42218](https://github.com/expo/expo/pull/42218) by [@kitten](https://github.com/kitten))
+
 ## 55.0.0 — 2026-01-21
 
 ### 🛠 Breaking changes

--- a/packages/expo-build-properties/build/pluginConfig.d.ts
+++ b/packages/expo-build-properties/build/pluginConfig.d.ts
@@ -530,4 +530,4 @@ export interface PluginConfigTypeAndroidQueriesData {
 /**
  * @ignore
  */
-export declare function validateConfig(config: any): PluginConfigType;
+export declare function validateConfig(config: unknown): PluginConfigType;

--- a/packages/expo-build-properties/package.json
+++ b/packages/expo-build-properties/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/build-properties",
   "dependencies": {
-    "ajv": "^8.11.0",
+    "@expo/schema-utils": "^55.0.0",
     "semver": "^7.6.0"
   },
   "devDependencies": {

--- a/packages/expo-build-properties/src/pluginConfig.ts
+++ b/packages/expo-build-properties/src/pluginConfig.ts
@@ -840,18 +840,29 @@ function maybeThrowInvalidVersions(config: PluginConfigType) {
   }
 }
 
+/** Handle deprecated enableProguardInReleaseBuilds */
+const fixupDeprecatedEnableProguardInReleaseBuilds = (config: unknown) => {
+  if (
+    config &&
+    typeof config === 'object' &&
+    'android' in config &&
+    config.android &&
+    typeof config.android === 'object'
+  ) {
+    const androidConfig = config.android as PluginConfigTypeAndroid & Record<string, unknown>;
+    if (androidConfig.enableProguardInReleaseBuilds != null) {
+      if (androidConfig.enableMinifyInReleaseBuilds === undefined) {
+        androidConfig.enableMinifyInReleaseBuilds = !!androidConfig.enableProguardInReleaseBuilds;
+      }
+    }
+  }
+};
+
 /**
  * @ignore
  */
-export function validateConfig(config: any): PluginConfigType {
-  // handle deprecated enableProguardInReleaseBuilds
-  if (
-    config.android?.enableProguardInReleaseBuilds !== undefined &&
-    config.android?.enableMinifyInReleaseBuilds === undefined
-  ) {
-    config.android.enableMinifyInReleaseBuilds = config.android.enableProguardInReleaseBuilds;
-  }
-
+export function validateConfig(config: unknown): PluginConfigType {
+  fixupDeprecatedEnableProguardInReleaseBuilds(config);
   validate(schema, config);
   maybeThrowInvalidVersions(config);
 

--- a/packages/expo-build-properties/src/pluginConfig.ts
+++ b/packages/expo-build-properties/src/pluginConfig.ts
@@ -1,4 +1,4 @@
-import Ajv, { JSONSchemaType } from 'ajv';
+import { validate, type JSONSchema } from '@expo/schema-utils';
 import semver from 'semver';
 
 /**
@@ -595,7 +595,8 @@ export interface PluginConfigTypeAndroidQueriesData {
   mimeType?: string;
 }
 
-const schema: JSONSchemaType<PluginConfigType> = {
+const schema: JSONSchema<PluginConfigType> = {
+  title: 'expo-build-properties',
   type: 'object',
   properties: {
     buildReactNativeFromSource: { type: 'boolean', nullable: true },
@@ -843,7 +844,6 @@ function maybeThrowInvalidVersions(config: PluginConfigType) {
  * @ignore
  */
 export function validateConfig(config: any): PluginConfigType {
-  const validate = new Ajv({ allowUnionTypes: true }).compile(schema);
   // handle deprecated enableProguardInReleaseBuilds
   if (
     config.android?.enableProguardInReleaseBuilds !== undefined &&
@@ -851,10 +851,8 @@ export function validateConfig(config: any): PluginConfigType {
   ) {
     config.android.enableMinifyInReleaseBuilds = config.android.enableProguardInReleaseBuilds;
   }
-  if (!validate(config)) {
-    throw new Error('Invalid expo-build-properties config: ' + JSON.stringify(validate.errors));
-  }
 
+  validate(schema, config);
   maybeThrowInvalidVersions(config);
 
   if (

--- a/yarn.lock
+++ b/yarn.lock
@@ -5288,7 +5288,7 @@ ajv@^6.12.4, ajv@^6.12.6:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.1.0, ajv@^8.11.0, ajv@^8.17.1:
+ajv@^8.0.0, ajv@^8.1.0, ajv@^8.17.1:
   version "8.17.1"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
   integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==


### PR DESCRIPTION
Stacked on #42215

# Why

`expo-build-properties` (among a few other) config plugins are still using the raw `ajv` library, which we've since replaced with `@expo/schema-utils`. This is leaner and has so far not caused any issues when replacing our prior implementations.

`ajv` is expensive to load and this config plugin validation is in the load path for `expo start`. Replacing it will improve startup performance. It also increases our control over the dependency chain of commonly used code, which is why it's replaced the old schema utilities in `expo-router`. The old `ajv` deps chain could cause installation corruption with npm.

I've also noticed that the `enableProguardInReleaseBuilds` fixup is unsafe and doesn't technically work on all possible inputs. Since it runs before validation it should be resilient to errors.

# How

- Replace ajv with `@expo/schema-utils`
- Add missing `title` to schema and swap out types
- Replace `validate` call
- Refactor fixup for `enableProguardInReleaseBuilds`

# Test Plan

- Existing tests should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
