### PR TITLE
[core][ui][iOS] Add new initializer to ExpoSwiftUI.ViewProps

### DIFF
--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewProps.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewProps.swift
@@ -19,6 +19,11 @@ extension ExpoSwiftUI {
   open class ViewProps: ObservableObject, Record {
     public required init() {}
 
+    public required init(rawProps: [String: Any], context: AppContext) throws {
+      appContext = context
+      try updateRawProps(rawProps, appContext: context)
+    }
+
     /**
      An array of views passed by React as children.
      */

--- a/packages/expo-ui/ios/UIBaseViewProps.swift
+++ b/packages/expo-ui/ios/UIBaseViewProps.swift
@@ -7,7 +7,7 @@ import SwiftUI
  Base view props for all SwiftUI view props in expo-ui.
  Contains common modifiers that are shared across most views.
  */
-public class UIBaseViewProps: ExpoSwiftUI.ViewProps {
+open class UIBaseViewProps: ExpoSwiftUI.ViewProps {
   @Field var testID: String?
   @Field var modifiers: ModifierArray?
 
@@ -18,5 +18,9 @@ public class UIBaseViewProps: ExpoSwiftUI.ViewProps {
 
   public required init() {
     super.init()
+  }
+
+  public required init(rawProps: [String: Any], context: AppContext) throws {
+    try super.init(rawProps: rawProps, context: context)
   }
 }


### PR DESCRIPTION
# Why

In Expo Widgets, we need to recreate props from dictionary. 
To not make `appContext` setter and `updateRawProps` public, we need this new init. 

# How

Create new `init(rawProps: [String: Any], context: AppContext)`  on `ExpoSwiftUI.ViewProps`

# Test Plan

Bare Expo builds and Widgets works. 