### PR TITLE
refactor(dev-launcher/plugin): Switch from `ajv` to `@expo/schema-utils`

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -33,6 +33,7 @@
 - [Android] Remove `ReactHostWrapper` ([#40295](https://github.com/expo/expo/pull/40295) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Remove custom `ReactNativeFactory`. ([#41084](https://github.com/expo/expo/pull/41084) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Remove unused reactNativeFactory. ([#41286](https://github.com/expo/expo/pull/41286) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Switch from `ajv` to `@expo/schema-utils` ([#42221](https://github.com/expo/expo/pull/42221) by [@kitten](https://github.com/kitten))
 
 ## 6.0.20 - 2025-12-05
 

--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev",
   "dependencies": {
-    "ajv": "^8.11.0",
+    "@expo/schema-utils": "^0.1.7",
     "expo-dev-menu": "7.0.11",
     "expo-manifests": "~1.0.8"
   },

--- a/packages/expo-dev-launcher/plugin/build/pluginConfig.js
+++ b/packages/expo-dev-launcher/plugin/build/pluginConfig.js
@@ -1,11 +1,9 @@
 "use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.validateConfig = validateConfig;
-const ajv_1 = __importDefault(require("ajv"));
+const schema_utils_1 = require("@expo/schema-utils");
 const schema = {
+    title: 'expo-dev-launcher',
     type: 'object',
     properties: {
         launchMode: {
@@ -56,10 +54,7 @@ const schema = {
  * @ignore
  */
 function validateConfig(config) {
-    const validate = new ajv_1.default({ allowUnionTypes: true }).compile(schema);
-    if (!validate(config)) {
-        throw new Error('Invalid expo-dev-launcher config: ' + JSON.stringify(validate.errors));
-    }
+    (0, schema_utils_1.validate)(schema, config);
     if (config.launchModeExperimental ||
         config.ios?.launchModeExperimental ||
         config.android?.launchModeExperimental) {

--- a/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
+++ b/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
@@ -1,4 +1,4 @@
-import Ajv, { JSONSchemaType } from 'ajv';
+import { validate, type JSONSchema } from '@expo/schema-utils';
 
 /**
  * Type representing base dev launcher configuration.
@@ -42,7 +42,8 @@ export type PluginConfigOptions = {
   launchModeExperimental?: 'most-recent' | 'launcher';
 };
 
-const schema: JSONSchemaType<PluginConfigType> = {
+const schema: JSONSchema<PluginConfigType> = {
+  title: 'expo-dev-launcher',
   type: 'object',
   properties: {
     launchMode: {
@@ -94,10 +95,7 @@ const schema: JSONSchemaType<PluginConfigType> = {
  * @ignore
  */
 export function validateConfig<T>(config: T): PluginConfigType {
-  const validate = new Ajv({ allowUnionTypes: true }).compile(schema);
-  if (!validate(config)) {
-    throw new Error('Invalid expo-dev-launcher config: ' + JSON.stringify(validate.errors));
-  }
+  validate(schema, config);
 
   if (
     config.launchModeExperimental ||


### PR DESCRIPTION
Stacked on #42215
Related to #42218

# Why

`expo-dev-launcher`'s config plugin is still using the raw `ajv` library, which we've since replaced with `@expo/schema-utils`. This is leaner and has so far not caused any issues when replacing our prior implementations.

# How

- Replace ajv with `@expo/schema-utils`
- Add missing `title` to schema and swap out types
- Replace `validate` call

# Test Plan

- Existing tests should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
