### PR TITLE
[expo-router][ios] fix build error 'Logger' is ambiguous

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -65,6 +65,7 @@
 - fix PlatformColor not available when using Color on web ([#41801](https://github.com/expo/expo/pull/41801) by [@Ubax](https://github.com/Ubax))
 - Fix unknown key in link preview ([#41756](https://github.com/expo/expo/pull/41756) by [@Ubax](https://github.com/Ubax))
 - add replace action handling to headless tabs ([#41815](https://github.com/expo/expo/pull/41815) by [@Ubax](https://github.com/Ubax))
+- [ios] fix build error 'Logger' is ambiguous ([#42229](https://github.com/expo/expo/pull/42229) by [@Ubax](https://github.com/Ubax))
 
 ### 💡 Others
 

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeActionView.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeActionView.swift
@@ -57,7 +57,8 @@ class LinkPreviewNativeActionView: RouterViewWithLogger, LinkPreviewMenuUpdatabl
   private var image: UIImage? {
     if let customImage = customImage {
       return customImage.ref
-    } else if let icon = icon {
+    }
+    if let icon = icon {
       return UIImage(systemName: icon)
     }
     return nil

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeNavigation.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeNavigation.swift
@@ -11,9 +11,9 @@ internal class LinkPreviewNativeNavigation {
   private weak var preloadedScreenView: RNSScreenView?
   private weak var preloadedStackView: RNSScreenStackView?
   private var tabChangeCommands: [TabChangeCommand] = []
-  private let logger: Logger?
+  private let logger: ExpoModulesCore.Logger?
 
-  init(logger: Logger?) {
+  init(logger: ExpoModulesCore.Logger?) {
     self.logger = logger
   }
 

--- a/packages/expo-router/ios/LinkPreview/LinkZoomTransition.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkZoomTransition.swift
@@ -18,9 +18,9 @@ class LinkZoomTransitionsSourceRepository {
   private var sources: [String: LinkSourceInfo] = [:]
   private let lock = NSLock()
 
-  private weak var logger: Logger?
+  private weak var logger: ExpoModulesCore.Logger?
 
-  init(logger: Logger?) {
+  init(logger: ExpoModulesCore.Logger?) {
     self.logger = logger
   }
 


### PR DESCRIPTION
# Why

@tomekzaw reported an issue, that in his setup he gets an error: `'Logger' is ambiguous for type lookup`.

The other type that was found is `os.Logger`. I couldn't reproduce the issue locally, but the approach used in this PR solves it, by specifying which `Logger` to use.

# How

Change `Logger` to `ExpoModulesCore.Logger`

# Test Plan

1. Build the router-e2e app

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
