### PR TITLE
[template] Add a placeholder in template's Podfile for env variables

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -104,6 +104,7 @@
 - throw error when array style is passed to Slot ([#41901](https://github.com/expo/expo/pull/41901) by [@Ubax](https://github.com/Ubax))
 - [ios] remove unstable_splitView and enable split view by default ([#42128](https://github.com/expo/expo/pull/42128) by [@Ubax](https://github.com/Ubax))
 - [iOS] reduce number of times UIBarButtonItem is recreated ([#41900](https://github.com/expo/expo/pull/41900) by [@Ubax](https://github.com/Ubax))
+- [ios] add comment to ENV['RNS_GAMMA_ENABLED'] set by config plugin ([#42231](https://github.com/expo/expo/pull/42231) by [@Ubax](https://github.com/Ubax))
 
 ## 6.0.17 - 2025-12-05
 

--- a/packages/expo-router/plugin/build/index.js
+++ b/packages/expo-router/plugin/build/index.js
@@ -24,7 +24,7 @@ const withExpoHeadIos = (config) => {
 const withGammaScreens = (config) => {
     return (0, config_plugins_1.withPodfile)(config, (config) => {
         if (!config.modResults.contents.includes('RNS_GAMMA_ENABLED')) {
-            config.modResults.contents = `ENV['RNS_GAMMA_ENABLED']='1'\n${config.modResults.contents}`;
+            config.modResults.contents = `# Set by expo-router. This enables Fabric-only features from react-native-screens\nENV['RNS_GAMMA_ENABLED'] ||= '1'\n${config.modResults.contents}`;
         }
         return config;
     });

--- a/packages/expo-router/plugin/build/index.js
+++ b/packages/expo-router/plugin/build/index.js
@@ -24,7 +24,12 @@ const withExpoHeadIos = (config) => {
 const withGammaScreens = (config) => {
     return (0, config_plugins_1.withPodfile)(config, (config) => {
         if (!config.modResults.contents.includes('RNS_GAMMA_ENABLED')) {
-            config.modResults.contents = `# Set by expo-router. This enables Fabric-only features from react-native-screens\nENV['RNS_GAMMA_ENABLED'] ||= '1'\n${config.modResults.contents}`;
+            const rnsGammaEnv = "# Set by expo-router. This enables Fabric-only features from react-native-screens\nENV['RNS_GAMMA_ENABLED'] ||= '1'";
+            if (config.modResults.contents.includes('# Environment variables set by config plugins')) {
+                config.modResults.contents = config.modResults.contents.replace('# Environment variables set by config plugins', `# Environment variables set by config plugins\n${rnsGammaEnv}`);
+            }
+            else
+                config.modResults.contents = `${rnsGammaEnv}\n${config.modResults.contents}`;
         }
         return config;
     });

--- a/packages/expo-router/plugin/src/index.ts
+++ b/packages/expo-router/plugin/src/index.ts
@@ -26,7 +26,7 @@ const withExpoHeadIos: ConfigPlugin = (config) => {
 const withGammaScreens: ConfigPlugin = (config) => {
   return withPodfile(config, (config) => {
     if (!config.modResults.contents.includes('RNS_GAMMA_ENABLED')) {
-      config.modResults.contents = `ENV['RNS_GAMMA_ENABLED']='1'\n${config.modResults.contents}`;
+      config.modResults.contents = `# Set by expo-router. This enables Fabric-only features from react-native-screens\nENV['RNS_GAMMA_ENABLED'] ||= '1'\n${config.modResults.contents}`;
     }
     return config;
   });

--- a/packages/expo-router/plugin/src/index.ts
+++ b/packages/expo-router/plugin/src/index.ts
@@ -26,8 +26,16 @@ const withExpoHeadIos: ConfigPlugin = (config) => {
 const withGammaScreens: ConfigPlugin = (config) => {
   return withPodfile(config, (config) => {
     if (!config.modResults.contents.includes('RNS_GAMMA_ENABLED')) {
-      config.modResults.contents = `# Set by expo-router. This enables Fabric-only features from react-native-screens\nENV['RNS_GAMMA_ENABLED'] ||= '1'\n${config.modResults.contents}`;
+      const rnsGammaEnv =
+        "# Set by expo-router. This enables Fabric-only features from react-native-screens\nENV['RNS_GAMMA_ENABLED'] ||= '1'";
+      if (config.modResults.contents.includes('# Environment variables set by config plugins')) {
+        config.modResults.contents = config.modResults.contents.replace(
+          '# Environment variables set by config plugins',
+          `# Environment variables set by config plugins\n${rnsGammaEnv}`
+        );
+      } else config.modResults.contents = `${rnsGammaEnv}\n${config.modResults.contents}`;
     }
+
     return config;
   });
 };

--- a/templates/expo-template-bare-minimum/ios/Podfile
+++ b/templates/expo-template-bare-minimum/ios/Podfile
@@ -17,6 +17,7 @@ ENV['RCT_USE_RN_DEP'] ||= '1' if podfile_properties['ios.buildReactNativeFromSou
 ENV['RCT_USE_PREBUILT_RNCORE'] ||= '1' if podfile_properties['ios.buildReactNativeFromSource'] != 'true'
 ENV['RCT_HERMES_V1_ENABLED'] ||= '1' if podfile_properties['expo.useHermesV1'] == 'true'
 platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'
+# Environment variables set by config plugins
 
 prepare_react_native_project!
 


### PR DESCRIPTION
# Why

When a config plugin needs to set an environment variable in the Podfile, there is currently no reliable way to place it near existing environment variables. As a result, when the `expo-router` plugin sets an environment variable, it must be added at the beginning of the file, far from the other ENV declarations.

This PR is only a proposal. If you think there is a better approach, or that this could cause issues, I don’t have a strong opinion about merging it.

**Before**

```Podfile
# Set by expo-router. This enables SplitView and other fabric-only components from react-native-screens
ENV['RNS_GAMMA_ENABLED'] ||= '1'
require File.join(File.dirname(`node --print "require.resolve('expo/package.json')"`), "scripts/autolinking")
require File.join(File.dirname(`node --print "require.resolve('react-native/package.json')"`), "scripts/react_native_pods")

...

ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] ||= podfile_properties['EX_DEV_CLIENT_NETWORK_INSPECTOR']
ENV['RCT_USE_RN_DEP'] ||= '1' if podfile_properties['ios.buildReactNativeFromSource'] != 'true'
ENV['RCT_USE_PREBUILT_RNCORE'] ||= '1' if podfile_properties['ios.buildReactNativeFromSource'] != 'true'
ENV['RCT_HERMES_V1_ENABLED'] ||= '1' if podfile_properties['expo.useHermesV1'] == 'true'
platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'
...
```

**After**

```Podfile
require File.join(File.dirname(`node --print "require.resolve('expo/package.json')"`), "scripts/autolinking")
require File.join(File.dirname(`node --print "require.resolve('react-native/package.json')"`), "scripts/react_native_pods")

...

ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] ||= podfile_properties['EX_DEV_CLIENT_NETWORK_INSPECTOR']
ENV['RCT_USE_RN_DEP'] ||= '1' if podfile_properties['ios.buildReactNativeFromSource'] != 'true'
ENV['RCT_USE_PREBUILT_RNCORE'] ||= '1' if podfile_properties['ios.buildReactNativeFromSource'] != 'true'
ENV['RCT_HERMES_V1_ENABLED'] ||= '1' if podfile_properties['expo.useHermesV1'] == 'true'
platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'
# Environment variables set by config plugins
# Set by expo-router. This enables SplitView and other fabric-only components from react-native-screens
ENV['RNS_GAMMA_ENABLED'] ||= '1'
...
```

# How

1. Add a comment to Podfile `# Environment variables set by config plugins`
2. Use the comment in the router config plugin

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
