### PR TITLE
[docs] Add the `--environment` flag to the update example

### DIFF
--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -261,9 +261,13 @@ Publishing an update allows:
 - Fixing bugs and quickly updating non-native parts of a project instead of creating a new build
 - [Sharing a preview version of an app](/review/overview/) using internal distribution
 
-To publish an update with changes from your project, use the `eas update` command, and specify a name for the channel and a `message` to describe the update:
+To publish an update with changes from your project, use the `eas update` command, and specify a name for the channel, a `message` to describe the update and if using [EAS environment variables](/eas/environment-variables/), the environment pull variables from (leave unspecified to use the **.env** files present in your project directory):
 
-<Terminal cmd={['$ eas update --channel [channel-name] --message "[message]"']} />
+<Terminal
+  cmd={[
+    '$ eas update --channel [channel-name] --message "[message]" --environment [environment-name]',
+  ]}
+/>
 
 <Collapsible summary="How does publishing an update work?">
 


### PR DESCRIPTION
# Why

Forgetting to include env vars for `eas update` is a common point of failure to for users.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Applying a suggestion from [this Reddit comment](https://www.reddit.com/r/expo/comments/1qcp70o/expo_web_eas_deploy_prod_does_not_update_env/nztu7t0/?context=1) of updating the getting started guide to include the environment flag in the example.

This will raise awareness of how env vars are included, and if someone doesn't want to use it, they can always omit it.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

See http://localhost:3002/eas-update/getting-started/

### Before
<img width="1146" height="428" alt="Screenshot 2026-01-16 at 11 18 27" src="https://github.com/user-attachments/assets/fe1714e1-6de5-4941-9f3b-163bb43034a5" />

### After

<img width="1142" height="448" alt="Screenshot 2026-01-16 at 11 18 19" src="https://github.com/user-attachments/assets/0120e9a3-d92c-478d-a5f9-9e961c8f81cc" />


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
