### PR TITLE
[sharing][1/n] Share-into: add config plugin for receiving data from other apps

### DIFF
--- a/packages/expo-sharing/CHANGELOG.md
+++ b/packages/expo-sharing/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add config plugin for receiving data from other apps. ([#42242](https://github.com/expo/expo/pull/42242) by [@behenate](https://github.com/behenate))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-sharing/app.plugin.js
+++ b/packages/expo-sharing/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./plugin/build/index');

--- a/packages/expo-sharing/ios/shared/Constants.swift
+++ b/packages/expo-sharing/ios/shared/Constants.swift
@@ -1,0 +1,1 @@
+internal let SHARE_INTO_DEFAULTS_KEY = "expo-sharing"

--- a/packages/expo-sharing/ios/shared/Constants.swift
+++ b/packages/expo-sharing/ios/shared/Constants.swift
@@ -1,1 +1,1 @@
-internal let SHARE_INTO_DEFAULTS_KEY = "expo-sharing"
+let SHARE_INTO_DEFAULTS_KEY = "expo-sharing"

--- a/packages/expo-sharing/ios/shared/ShareProtocol.swift
+++ b/packages/expo-sharing/ios/shared/ShareProtocol.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct SharePayload: Codable {
+  let type: ShareType
+  let value: String
+  let mimeType: String
+  let metadata: ShareMetadata?
+}
+
+struct ShareMetadata: Codable {
+  let originalName: String?
+  let size: Int?
+}
+
+enum ShareType: String, Codable {
+  case text
+  case url
+  case audio
+  case image
+  case video
+  case file
+}

--- a/packages/expo-sharing/package.json
+++ b/packages/expo-sharing/package.json
@@ -33,11 +33,18 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/sharing/",
-  "dependencies": {},
+  "dependencies": {
+    "resolve-from": "^5.0.0",
+    "@expo/plist": "^0.4.7",
+    "expo-linking": "^8.0.0",
+    "@expo/config-plugins": "^54.0.1",
+    "@expo/config-types": "^54.0.8"
+  },
   "devDependencies": {
     "expo-module-scripts": "^5.0.7"
   },
   "peerDependencies": {
-    "expo": "*"
+    "expo": "*",
+    "react-native": "*"
   }
 }

--- a/packages/expo-sharing/package.json
+++ b/packages/expo-sharing/package.json
@@ -7,6 +7,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "expo-module build",
+    "build:plugin": "expo-module build plugin",
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "expo-module test",
@@ -34,9 +35,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/sharing/",
   "dependencies": {
-    "resolve-from": "^5.0.0",
     "@expo/plist": "^0.4.7",
-    "expo-linking": "^8.0.0",
     "@expo/config-plugins": "^54.0.1",
     "@expo/config-types": "^54.0.8"
   },

--- a/packages/expo-sharing/plugin/build/android/parseIntentFilters.d.ts
+++ b/packages/expo-sharing/plugin/build/android/parseIntentFilters.d.ts
@@ -1,0 +1,3 @@
+import { SingleIntentFilter, MultiIntentFilter } from '../sharingPlugin.types';
+export declare function parseIntentFilters(filters: string[], type: 'single'): SingleIntentFilter;
+export declare function parseIntentFilters(filters: string[], type: 'multiple'): MultiIntentFilter;

--- a/packages/expo-sharing/plugin/build/android/parseIntentFilters.js
+++ b/packages/expo-sharing/plugin/build/android/parseIntentFilters.js
@@ -1,0 +1,19 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.parseIntentFilters = parseIntentFilters;
+function parseIntentFilters(filters, type) {
+    const mimeTypeRegex = /^([\w.+-]+|\*)\/([\w.+-]+|\*)$/;
+    filters.forEach((filter) => {
+        if (!filter.match(mimeTypeRegex)) {
+            throw new Error(`Invalid intent filter type: ${filter} is not a valid mime type`);
+        }
+    });
+    return {
+        action: type === 'single' ? 'android.intent.action.SEND' : 'android.intent.action.SEND_MULTIPLE',
+        category: 'android.intent.category.DEFAULT',
+        filters,
+        data: filters.map((filter) => ({
+            mimeType: filter,
+        })),
+    };
+}

--- a/packages/expo-sharing/plugin/build/android/withAndroidIntentFilters.d.ts
+++ b/packages/expo-sharing/plugin/build/android/withAndroidIntentFilters.d.ts
@@ -1,0 +1,9 @@
+import { ConfigPlugin, AndroidManifest, AndroidConfig, ExportedConfigWithProps } from '@expo/config-plugins';
+import { SingleIntentFilter, MultiIntentFilter, IntentFilter } from '../sharingPlugin.types';
+type WithAndroidIntentFiltersOptions = {
+    intentFilters: IntentFilter[];
+};
+export declare const withAndroidIntentFilters: ConfigPlugin<WithAndroidIntentFiltersOptions>;
+export declare function setAndroidIntentFilters(config: ExportedConfigWithProps<AndroidManifest>, intentFilters: IntentFilter[]): ExportedConfigWithProps<AndroidManifest>;
+export default function renderIntentFilters(intentFilters: (SingleIntentFilter | MultiIntentFilter)[]): AndroidConfig.Manifest.ManifestIntentFilter[];
+export {};

--- a/packages/expo-sharing/plugin/build/android/withAndroidIntentFilters.js
+++ b/packages/expo-sharing/plugin/build/android/withAndroidIntentFilters.js
@@ -1,0 +1,59 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withAndroidIntentFilters = void 0;
+exports.setAndroidIntentFilters = setAndroidIntentFilters;
+exports.default = renderIntentFilters;
+const config_plugins_1 = require("@expo/config-plugins");
+const SHARING_GENERATED_TAG = 'expo-sharing-intent-filters';
+const withAndroidIntentFilters = (config, { intentFilters }) => {
+    return (0, config_plugins_1.withAndroidManifest)(config, (config) => {
+        setAndroidIntentFilters(config, intentFilters);
+        return config;
+    });
+};
+exports.withAndroidIntentFilters = withAndroidIntentFilters;
+function setAndroidIntentFilters(config, intentFilters) {
+    const mainActivity = config_plugins_1.AndroidConfig.Manifest.getMainActivityOrThrow(config.modResults);
+    // Remove all generated tags from previous runs...
+    if (mainActivity['intent-filter']?.length) {
+        mainActivity['intent-filter'] = mainActivity['intent-filter'].filter(
+        // @ts-ignore
+        (value) => value.$?.[SHARING_GENERATED_TAG] !== 'true');
+    }
+    if (!intentFilters.length) {
+        return config;
+    }
+    mainActivity['intent-filter'] = mainActivity['intent-filter']?.concat(renderIntentFilters(intentFilters));
+    return config;
+}
+function renderIntentFilters(intentFilters) {
+    return intentFilters.map((intentFilter) => ({
+        $: {
+            'android:autoVerify': 'false',
+            // Add a custom "generated" tag that we can query later to remove.
+            [SHARING_GENERATED_TAG]: 'true',
+        },
+        action: [
+            // <action android:name="android.intent.action.SEND"/> or SEND_MULTIPLE
+            {
+                $: {
+                    'android:name': intentFilter.action,
+                },
+            },
+        ],
+        data: renderIntentFilterData(intentFilter.data),
+        category: [
+            {
+                $: {
+                    'android:name': intentFilter.category,
+                },
+            },
+        ],
+    }));
+}
+/** Like `<data android:scheme="exp"/>` */
+function renderIntentFilterData(data) {
+    return (Array.isArray(data) ? data : [data]).filter(Boolean).map((datum) => ({
+        $: Object.entries(datum ?? {}).reduce((prev, [key, value]) => ({ ...prev, [`android:${key}`]: value }), {}),
+    }));
+}

--- a/packages/expo-sharing/plugin/build/android/withShareIntoSchemeString.d.ts
+++ b/packages/expo-sharing/plugin/build/android/withShareIntoSchemeString.d.ts
@@ -1,0 +1,3 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+declare const withShareIntoSchemeString: ConfigPlugin<string>;
+export { withShareIntoSchemeString };

--- a/packages/expo-sharing/plugin/build/android/withShareIntoSchemeString.js
+++ b/packages/expo-sharing/plugin/build/android/withShareIntoSchemeString.js
@@ -1,0 +1,17 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withShareIntoSchemeString = void 0;
+const config_plugins_1 = require("@expo/config-plugins");
+const withShareIntoSchemeString = (config, scheme) => {
+    return (0, config_plugins_1.withStringsXml)(config, (config) => {
+        config.modResults = config_plugins_1.AndroidConfig.Strings.setStringItem([
+            config_plugins_1.AndroidConfig.Resources.buildResourceItem({
+                name: 'share_into_scheme',
+                value: scheme,
+                translatable: false,
+            }),
+        ], config.modResults);
+        return config;
+    });
+};
+exports.withShareIntoSchemeString = withShareIntoSchemeString;

--- a/packages/expo-sharing/plugin/build/index.d.ts
+++ b/packages/expo-sharing/plugin/build/index.d.ts
@@ -1,0 +1,4 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+import { ShareExtensionConfigPluginProps } from './sharingPlugin.types';
+declare const _default: ConfigPlugin<ShareExtensionConfigPluginProps>;
+export default _default;

--- a/packages/expo-sharing/plugin/build/index.js
+++ b/packages/expo-sharing/plugin/build/index.js
@@ -1,0 +1,96 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const config_plugins_1 = require("@expo/config-plugins");
+const parseIntentFilters_1 = require("./android/parseIntentFilters");
+const withAndroidIntentFilters_1 = require("./android/withAndroidIntentFilters");
+const withShareIntoSchemeString_1 = require("./android/withShareIntoSchemeString");
+const withAppGroupId_1 = require("./ios/withAppGroupId");
+const withShareExtensionFiles_1 = require("./ios/withShareExtensionFiles");
+const withShareExtensionXcodeProject_1 = require("./ios/withShareExtensionXcodeProject");
+const withConfig_1 = require("./withConfig");
+const EXPO_SHARE_EXTENSION_TARGET_NAME = 'expo-sharing-extension';
+const pkg = require('expo-sharing/package.json');
+const withShareExtension = (config, props) => {
+    let plugins = [];
+    const iosEnabled = props?.ios?.enabled ?? true;
+    const androidEnabled = props?.android?.enabled ?? true;
+    if (iosEnabled) {
+        const deploymentTarget = '15.1';
+        const bundleIdentifier = config.ios?.bundleIdentifier;
+        if (!bundleIdentifier) {
+            throw new Error("The application config doesn't define a bundle identifier. Make sure that `ios.bundleIdentifier` field has a value.");
+        }
+        const extensionBundleIdentifier = props?.ios?.extensionBundleIdentifier ??
+            `${config.ios?.bundleIdentifier}.${EXPO_SHARE_EXTENSION_TARGET_NAME}`;
+        const fallbackAppGroupId = `group.${bundleIdentifier}`;
+        const appGroupId = props?.ios?.appGroupId ?? fallbackAppGroupId;
+        const urlScheme = (config.scheme ?? bundleIdentifier); // TODO: Fix this type;
+        const activationRule = props?.ios?.activationRule ?? {
+            supportsText: true,
+            supportsWebUrlWithMaxCount: 1,
+        };
+        if (!urlScheme) {
+            throw new Error(`Expo sharing: The app doesn't define a scheme or a bundle identifier. Define at least one of those properties in app json`);
+        }
+        if (!props?.ios?.appGroupId) {
+            console.warn(`Expo sharing: Using the default ${fallbackAppGroupId} app group id. If you are using EAS Build` +
+                ` no further steps are required, otherwise make sure that this app group is registered` +
+                ` with your Apple development team, or set \`ios.appGroupId\` field to an already registered app group.`);
+        }
+        const shareExtensionFiles = {};
+        plugins = [
+            ...plugins,
+            [
+                withConfig_1.withConfig,
+                {
+                    bundleIdentifier: extensionBundleIdentifier,
+                    targetName: EXPO_SHARE_EXTENSION_TARGET_NAME,
+                    groupIdentifier: appGroupId,
+                },
+            ],
+            [withAppGroupId_1.withAppGroupId, appGroupId],
+            [
+                withShareExtensionFiles_1.withShareExtensionFiles,
+                {
+                    targetName: EXPO_SHARE_EXTENSION_TARGET_NAME,
+                    appGroupId,
+                    urlScheme,
+                    activationRule,
+                    onFilesWritten: (writtenFiles) => {
+                        Object.assign(shareExtensionFiles, writtenFiles);
+                    },
+                },
+            ],
+            [
+                withShareExtensionXcodeProject_1.withShareExtensionXcodeProject,
+                {
+                    targetName: EXPO_SHARE_EXTENSION_TARGET_NAME,
+                    bundleIdentifier: extensionBundleIdentifier,
+                    deploymentTarget,
+                    activationRule,
+                    shareExtensionFiles,
+                },
+            ],
+        ];
+    }
+    if (androidEnabled) {
+        const urlScheme = config.scheme ?? config.android?.package;
+        if (!urlScheme) {
+            throw new Error("The application config doesn't define a scheme or an Android package. Define the scheme in the app config.");
+        }
+        const singleIntentFilter = (0, parseIntentFilters_1.parseIntentFilters)(props?.android?.singleShareMimeTypes ?? [], 'single');
+        const multiIntentFilter = (0, parseIntentFilters_1.parseIntentFilters)(props?.android?.multipleShareMimeTypes ?? [], 'multiple');
+        plugins = [
+            ...plugins,
+            [
+                withAndroidIntentFilters_1.withAndroidIntentFilters,
+                {
+                    intentFilters: [singleIntentFilter, multiIntentFilter],
+                },
+            ],
+            [withShareIntoSchemeString_1.withShareIntoSchemeString, urlScheme],
+        ];
+    }
+    return (0, config_plugins_1.withPlugins)(config, plugins);
+};
+exports.default = (0, config_plugins_1.createRunOncePlugin)(withShareExtension, pkg.name, pkg.version);

--- a/packages/expo-sharing/plugin/build/index.js
+++ b/packages/expo-sharing/plugin/build/index.js
@@ -1,10 +1,14 @@
 "use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 const config_plugins_1 = require("@expo/config-plugins");
 const parseIntentFilters_1 = require("./android/parseIntentFilters");
 const withAndroidIntentFilters_1 = require("./android/withAndroidIntentFilters");
 const withShareIntoSchemeString_1 = require("./android/withShareIntoSchemeString");
 const withAppGroupId_1 = require("./ios/withAppGroupId");
+const withIosWarning_1 = __importDefault(require("./ios/withIosWarning"));
 const withShareExtensionFiles_1 = require("./ios/withShareExtensionFiles");
 const withShareExtensionXcodeProject_1 = require("./ios/withShareExtensionXcodeProject");
 const withConfig_1 = require("./withConfig");
@@ -24,7 +28,7 @@ const withShareExtension = (config, props) => {
             `${config.ios?.bundleIdentifier}.${EXPO_SHARE_EXTENSION_TARGET_NAME}`;
         const fallbackAppGroupId = `group.${bundleIdentifier}`;
         const appGroupId = props?.ios?.appGroupId ?? fallbackAppGroupId;
-        const urlScheme = (config.scheme ?? bundleIdentifier); // TODO: Fix this type;
+        const urlScheme = config.scheme ?? bundleIdentifier;
         const activationRule = props?.ios?.activationRule ?? {
             supportsText: true,
             supportsWebUrlWithMaxCount: 1,
@@ -33,9 +37,15 @@ const withShareExtension = (config, props) => {
             throw new Error(`Expo sharing: The app doesn't define a scheme or a bundle identifier. Define at least one of those properties in app json`);
         }
         if (!props?.ios?.appGroupId) {
-            console.warn(`Expo sharing: Using the default ${fallbackAppGroupId} app group id. If you are using EAS Build` +
-                ` no further steps are required, otherwise make sure that this app group is registered` +
-                ` with your Apple development team, or set \`ios.appGroupId\` field to an already registered app group.`);
+            plugins.push([
+                withIosWarning_1.default,
+                {
+                    property: 'appGroupId',
+                    warning: `Expo sharing: Using the default ${fallbackAppGroupId} app group id. If you are using EAS Build` +
+                        ` no further steps are required, otherwise make sure that this app group is registered` +
+                        ` with your Apple development team, or set \`ios.appGroupId\` field to an already registered app group.`,
+                },
+            ]);
         }
         const shareExtensionFiles = {};
         plugins = [

--- a/packages/expo-sharing/plugin/build/ios/conflictingExtensionExists.d.ts
+++ b/packages/expo-sharing/plugin/build/ios/conflictingExtensionExists.d.ts
@@ -1,0 +1,4 @@
+import { XcodeProject } from '@expo/config-plugins';
+type conflictingExtensionResult = 'doesnt-exist' | 'exists' | 'exists-conflicting';
+export declare function conflictingExtensionExists(xcodeProject: XcodeProject, targetName: string, bundleIdentifier: string): conflictingExtensionResult;
+export {};

--- a/packages/expo-sharing/plugin/build/ios/conflictingExtensionExists.js
+++ b/packages/expo-sharing/plugin/build/ios/conflictingExtensionExists.js
@@ -1,0 +1,20 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.conflictingExtensionExists = conflictingExtensionExists;
+function conflictingExtensionExists(xcodeProject, targetName, bundleIdentifier) {
+    const nativeTargets = xcodeProject.pbxNativeTargetSection();
+    const existingTarget = Object.values(nativeTargets).find((target) => target.name && unquote(target.name) === targetName);
+    if (existingTarget) {
+        const buildConfigurations = xcodeProject.pbxXCBuildConfigurationSection();
+        const configurationList = xcodeProject.pbxXCConfigurationList()[existingTarget.buildConfigurationList];
+        const buildConfiguration = buildConfigurations[configurationList.buildConfigurations[0].value];
+        const existingBundleIdentifier = unquote(buildConfiguration.buildSettings.PRODUCT_BUNDLE_IDENTIFIER);
+        return existingBundleIdentifier === bundleIdentifier ? 'exists' : 'exists-conflicting';
+    }
+    return 'doesnt-exist';
+}
+function unquote(str) {
+    if (str)
+        return str.replace(/^"(.*)"$/, '$1');
+    return str;
+}

--- a/packages/expo-sharing/plugin/build/ios/createEntitlements.d.ts
+++ b/packages/expo-sharing/plugin/build/ios/createEntitlements.d.ts
@@ -1,0 +1,3 @@
+export type ShareIntoEntitlements = Record<string, string[]>;
+export declare function createEntitlements(appGroupId: string): ShareIntoEntitlements;
+export declare function createEntitlementsFile(targetDirectory: string, extensionTargetName: string, appGroupId: string): void;

--- a/packages/expo-sharing/plugin/build/ios/createEntitlements.js
+++ b/packages/expo-sharing/plugin/build/ios/createEntitlements.js
@@ -1,0 +1,22 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.createEntitlements = createEntitlements;
+exports.createEntitlementsFile = createEntitlementsFile;
+const plist_1 = __importDefault(require("@expo/plist"));
+const fs_1 = __importDefault(require("fs"));
+const path_1 = __importDefault(require("path"));
+const SECURITY_GROUPS_KEY = 'com.apple.security.application-groups';
+function createEntitlements(appGroupId) {
+    const buildObject = {};
+    buildObject[SECURITY_GROUPS_KEY] = [appGroupId];
+    return buildObject;
+}
+function createEntitlementsFile(targetDirectory, extensionTargetName, appGroupId) {
+    const entitlementsPath = path_1.default.join(targetDirectory, `/${extensionTargetName}.entitlements`);
+    const entitlementsObject = createEntitlements(appGroupId);
+    const builtPlist = plist_1.default.build(entitlementsObject);
+    return fs_1.default.writeFileSync(entitlementsPath, builtPlist);
+}

--- a/packages/expo-sharing/plugin/build/ios/createInfoPlistFile.d.ts
+++ b/packages/expo-sharing/plugin/build/ios/createInfoPlistFile.d.ts
@@ -1,0 +1,2 @@
+import { ActivationRule } from '../sharingPlugin.types';
+export default function createInfoPlistFile(targetDirectory: string, appGroupId: string, urlScheme: string, activationRule: ActivationRule): void;

--- a/packages/expo-sharing/plugin/build/ios/createInfoPlistFile.js
+++ b/packages/expo-sharing/plugin/build/ios/createInfoPlistFile.js
@@ -1,0 +1,68 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = createInfoPlistFile;
+const plist_1 = __importDefault(require("@expo/plist"));
+const fs_1 = __importDefault(require("fs"));
+const path_1 = __importDefault(require("path"));
+function createInfoPlistFile(targetDirectory, appGroupId, urlScheme, activationRule) {
+    const infoPlistPath = path_1.default.join(targetDirectory, 'Info.plist');
+    let activationRuleValue;
+    if (typeof activationRule === 'string') {
+        activationRuleValue = activationRule;
+    }
+    else {
+        const rules = {};
+        if (activationRule.supportsText) {
+            rules.NSExtensionActivationSupportsText = true;
+        }
+        if (activationRule.supportsWebUrlWithMaxCount) {
+            rules.NSExtensionActivationSupportsWebURLWithMaxCount =
+                activationRule.supportsWebUrlWithMaxCount;
+        }
+        if (activationRule.supportsImageWithMaxCount) {
+            rules.NSExtensionActivationSupportsImageWithMaxCount =
+                activationRule.supportsImageWithMaxCount;
+        }
+        if (activationRule.supportsMovieWithMaxCount) {
+            rules.NSExtensionActivationSupportsMovieWithMaxCount =
+                activationRule.supportsMovieWithMaxCount;
+        }
+        if (activationRule.supportsFileWithMaxCount) {
+            rules.NSExtensionActivationSupportsFileWithMaxCount = activationRule.supportsFileWithMaxCount;
+        }
+        if (activationRule.supportsWebPageWithMaxCount) {
+            rules.NSExtensionActivationSupportsWebPageWithMaxCount =
+                activationRule.supportsWebPageWithMaxCount;
+        }
+        if (activationRule.supportsAttachmentsWithMaxCount) {
+            rules.NSExtensionActivationSupportsAttachmentsWithMaxCount =
+                activationRule.supportsAttachmentsWithMaxCount;
+        }
+        activationRuleValue = rules;
+    }
+    const buildObject = {
+        AppGroupId: appGroupId,
+        MainTargetUrlScheme: urlScheme,
+        CFBundleDevelopmentRegion: '$(DEVELOPMENT_LANGUAGE)',
+        CFBundleDisplayName: '$(PRODUCT_NAME)',
+        CFBundleExecutable: '$(EXECUTABLE_NAME)',
+        CFBundleIdentifier: '$(PRODUCT_BUNDLE_IDENTIFIER)',
+        CFBundleInfoDictionaryVersion: '6.0',
+        CFBundleName: '$(PRODUCT_NAME)',
+        CFBundlePackageType: 'XPC!',
+        CFBundleShortVersionString: '$(MARKETING_VERSION)',
+        CFBundleVersion: '$(CURRENT_PROJECT_VERSION)',
+        NSExtension: {
+            NSExtensionAttributes: {
+                NSExtensionActivationRule: activationRuleValue,
+            },
+            NSExtensionPointIdentifier: 'com.apple.share-services',
+            NSExtensionPrincipalClass: '$(PRODUCT_MODULE_NAME).ShareIntoViewController',
+        },
+    };
+    const builtPlist = plist_1.default.build(buildObject);
+    return fs_1.default.writeFileSync(infoPlistPath, builtPlist);
+}

--- a/packages/expo-sharing/plugin/build/ios/setupShareExtensionFiles.d.ts
+++ b/packages/expo-sharing/plugin/build/ios/setupShareExtensionFiles.d.ts
@@ -1,0 +1,20 @@
+import { ActivationRule } from '../sharingPlugin.types';
+export type ProjectFiles = {
+    swiftFiles: string[];
+    entitlementFiles: string[];
+    plistFiles: string[];
+    assetDirectories: string[];
+    intentFiles: string[];
+    otherFiles: string[];
+};
+export type ShareExtensionFiles = ProjectFiles & {
+    sharedFiles: ProjectFiles | null;
+};
+/**
+ * Copies the template files into the native project directory and prepares the extension entitlements file.
+ * @returns Object storing categorized copied files.
+ * Note @behenate: This doesn't support nested folders as of now, we don't need this, so I didn't bother adding it.
+ */
+export declare function setupShareExtensionFiles(targetPath: string, extensionTargetName: string, appGroupId: string, urlScheme: string, activationRule: ActivationRule): ShareExtensionFiles;
+export declare function parseDirectoryFiles(directoryPath: string): ProjectFiles;
+export declare function copyFileSync(source: string, target: string): void;

--- a/packages/expo-sharing/plugin/build/ios/setupShareExtensionFiles.js
+++ b/packages/expo-sharing/plugin/build/ios/setupShareExtensionFiles.js
@@ -1,0 +1,125 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.setupShareExtensionFiles = setupShareExtensionFiles;
+exports.parseDirectoryFiles = parseDirectoryFiles;
+exports.copyFileSync = copyFileSync;
+const fs_1 = __importDefault(require("fs"));
+const path = __importStar(require("path"));
+const utils_1 = require("../utils");
+const createEntitlements_1 = require("./createEntitlements");
+const createInfoPlistFile_1 = __importDefault(require("./createInfoPlistFile"));
+/**
+ * Copies the template files into the native project directory and prepares the extension entitlements file.
+ * @returns Object storing categorized copied files.
+ * Note @behenate: This doesn't support nested folders as of now, we don't need this, so I didn't bother adding it.
+ */
+function setupShareExtensionFiles(targetPath, extensionTargetName, appGroupId, urlScheme, activationRule) {
+    const templateFilesPath = (0, utils_1.getTemplateFilesPath)('ios');
+    const sharedDirectoryPath = (0, utils_1.getSharedFilesPath)();
+    if (!fs_1.default.existsSync(targetPath)) {
+        fs_1.default.mkdirSync(targetPath, { recursive: true });
+    }
+    const targetSharedPath = path.join(targetPath, 'shared');
+    if (!fs_1.default.existsSync(targetSharedPath)) {
+        fs_1.default.mkdirSync(targetSharedPath, { recursive: true });
+    }
+    (0, createEntitlements_1.createEntitlementsFile)(targetPath, extensionTargetName, appGroupId);
+    (0, createInfoPlistFile_1.default)(targetPath, appGroupId, urlScheme, activationRule);
+    const extensionTargetFiles = parseDirectoryFiles(templateFilesPath);
+    const sharedFiles = parseDirectoryFiles(sharedDirectoryPath);
+    const shareExtensionFiles = {
+        ...extensionTargetFiles,
+        sharedFiles,
+    };
+    Object.values(extensionTargetFiles)
+        .flat()
+        .forEach((file) => {
+        const source = path.join(templateFilesPath, file);
+        copyFileSync(source, targetPath);
+    });
+    return shareExtensionFiles;
+}
+function parseDirectoryFiles(directoryPath) {
+    const projectFiles = {
+        swiftFiles: [],
+        entitlementFiles: [],
+        plistFiles: [],
+        assetDirectories: [],
+        intentFiles: [],
+        otherFiles: [],
+    };
+    if (fs_1.default.lstatSync(directoryPath).isDirectory()) {
+        const files = fs_1.default.readdirSync(directoryPath);
+        files.forEach((file) => {
+            // Skip directories
+            if (fs_1.default.lstatSync(path.join(directoryPath, file)).isDirectory()) {
+                return;
+            }
+            const fileExtension = file.split('.').pop();
+            switch (fileExtension) {
+                case 'swift':
+                    projectFiles.swiftFiles.push(file);
+                    break;
+                case 'entitlements':
+                    projectFiles.entitlementFiles.push(file);
+                    break;
+                case 'plist':
+                    projectFiles.plistFiles.push(file);
+                    break;
+                case 'xcassets':
+                    projectFiles.assetDirectories.push(file);
+                    break;
+                case 'intentdefinition':
+                    projectFiles.intentFiles.push(file);
+                    break;
+                default:
+                    projectFiles.otherFiles.push(file);
+                    break;
+            }
+        });
+    }
+    return projectFiles;
+}
+function copyFileSync(source, target) {
+    let targetFile = target;
+    if (fs_1.default.existsSync(target) && fs_1.default.lstatSync(target).isDirectory()) {
+        targetFile = path.join(target, path.basename(source));
+    }
+    fs_1.default.writeFileSync(targetFile, fs_1.default.readFileSync(source));
+}

--- a/packages/expo-sharing/plugin/build/ios/withAppGroupId.d.ts
+++ b/packages/expo-sharing/plugin/build/ios/withAppGroupId.d.ts
@@ -1,0 +1,2 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+export declare const withAppGroupId: ConfigPlugin<string>;

--- a/packages/expo-sharing/plugin/build/ios/withAppGroupId.js
+++ b/packages/expo-sharing/plugin/build/ios/withAppGroupId.js
@@ -1,0 +1,24 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withAppGroupId = void 0;
+const config_plugins_1 = require("@expo/config-plugins");
+const withAppGroupId = (config, appGroupId) => {
+    // Add do entitlements
+    config = (0, config_plugins_1.withEntitlementsPlist)(config, async (config) => {
+        const appGroups = config.modResults['com.apple.security.application-groups'];
+        if (!appGroups) {
+            config.modResults['com.apple.security.application-groups'] = [appGroupId];
+            return config;
+        }
+        if (!appGroups.includes(appGroupId)) {
+            config.modResults['com.apple.security.application-groups'] = [...appGroups, appGroupId];
+        }
+        return config;
+    });
+    // Add to Info.plist
+    return (0, config_plugins_1.withInfoPlist)(config, (config) => {
+        config.modResults['ExpoShareIntoAppGroupId'] = appGroupId;
+        return config;
+    });
+};
+exports.withAppGroupId = withAppGroupId;

--- a/packages/expo-sharing/plugin/build/ios/withIosWarning.d.ts
+++ b/packages/expo-sharing/plugin/build/ios/withIosWarning.d.ts
@@ -1,0 +1,7 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+type WithIosWarningProps = {
+    property: string;
+    warning: string;
+};
+declare const withIosWarning: ConfigPlugin<WithIosWarningProps>;
+export default withIosWarning;

--- a/packages/expo-sharing/plugin/build/ios/withIosWarning.js
+++ b/packages/expo-sharing/plugin/build/ios/withIosWarning.js
@@ -1,0 +1,9 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const config_plugins_1 = require("@expo/config-plugins");
+// Hack to display the warning only once
+const withIosWarning = (config, { property, warning }) => (0, config_plugins_1.withInfoPlist)(config, (config) => {
+    config_plugins_1.WarningAggregator.addWarningIOS(property, warning);
+    return config;
+});
+exports.default = withIosWarning;

--- a/packages/expo-sharing/plugin/build/ios/withShareExtensionFiles.d.ts
+++ b/packages/expo-sharing/plugin/build/ios/withShareExtensionFiles.d.ts
@@ -1,0 +1,12 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+import { ActivationRule } from '../sharingPlugin.types';
+import { ShareExtensionFiles } from './setupShareExtensionFiles';
+type WithShareExtensionSourceFilesProps = {
+    targetName: string;
+    appGroupId: string;
+    urlScheme: string;
+    activationRule: ActivationRule;
+    onFilesWritten: (files: ShareExtensionFiles) => void;
+};
+export declare const withShareExtensionFiles: ConfigPlugin<WithShareExtensionSourceFilesProps>;
+export {};

--- a/packages/expo-sharing/plugin/build/ios/withShareExtensionFiles.js
+++ b/packages/expo-sharing/plugin/build/ios/withShareExtensionFiles.js
@@ -1,0 +1,20 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withShareExtensionFiles = void 0;
+const config_plugins_1 = require("@expo/config-plugins");
+const path_1 = __importDefault(require("path"));
+const setupShareExtensionFiles_1 = require("./setupShareExtensionFiles");
+const withShareExtensionFiles = (config, { targetName, appGroupId, urlScheme, activationRule, onFilesWritten }) => (0, config_plugins_1.withDangerousMod)(config, [
+    'ios',
+    async (config) => {
+        const { platformProjectRoot } = config.modRequest;
+        const targetPath = path_1.default.join(platformProjectRoot, targetName);
+        const files = (0, setupShareExtensionFiles_1.setupShareExtensionFiles)(targetPath, targetName, appGroupId, urlScheme, activationRule);
+        onFilesWritten(files);
+        return config;
+    },
+]);
+exports.withShareExtensionFiles = withShareExtensionFiles;

--- a/packages/expo-sharing/plugin/build/ios/withShareExtensionXcodeProject.d.ts
+++ b/packages/expo-sharing/plugin/build/ios/withShareExtensionXcodeProject.d.ts
@@ -1,0 +1,10 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+import { ShareExtensionFiles } from './setupShareExtensionFiles';
+type WithShareExtensionXcodeProjectProps = {
+    targetName: string;
+    bundleIdentifier: string;
+    deploymentTarget: string;
+    shareExtensionFiles: ShareExtensionFiles;
+};
+export declare const withShareExtensionXcodeProject: ConfigPlugin<WithShareExtensionXcodeProjectProps>;
+export {};

--- a/packages/expo-sharing/plugin/build/ios/withShareExtensionXcodeProject.js
+++ b/packages/expo-sharing/plugin/build/ios/withShareExtensionXcodeProject.js
@@ -1,0 +1,73 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withShareExtensionXcodeProject = void 0;
+const config_plugins_1 = require("@expo/config-plugins");
+const console = __importStar(require("node:console"));
+const conflictingExtensionExists_1 = require("./conflictingExtensionExists");
+const addBuildPhases_1 = require("./xcode/addBuildPhases");
+const addPbxGroup_1 = require("./xcode/addPbxGroup");
+const addProductFile_1 = require("./xcode/addProductFile");
+const addToPbxNativeTargetSection_1 = require("./xcode/addToPbxNativeTargetSection");
+const addToPbxProjectSection_1 = require("./xcode/addToPbxProjectSection");
+const addXCConfigurationList_1 = require("./xcode/addXCConfigurationList");
+const withShareExtensionXcodeProject = (config, { targetName, bundleIdentifier, deploymentTarget, shareExtensionFiles }) => {
+    return (0, config_plugins_1.withXcodeProject)(config, (config) => {
+        const groupName = 'Embed Foundation Extensions';
+        const xcodeProject = config.modResults;
+        const { platformProjectRoot } = config.modRequest;
+        const targetUuid = xcodeProject.generateUuid();
+        // Technically we should be able to remove the existing target, but I don't have time to add it before the release.
+        // Most users will chose not to modify the identifier anyways.
+        // TODO: Add smart existing target removal
+        const conflict_status = (0, conflictingExtensionExists_1.conflictingExtensionExists)(xcodeProject, targetName, bundleIdentifier);
+        if (conflict_status === 'exists-conflicting') {
+            throw new Error(`Expo-sharing: An extension with the name ${targetName} already exists in the project, but is registered with a different bundle identifier.` +
+                ` The existing extension will not be modified. In order to apply a new bundle identifier run the prebuild command with \`--clean\` flag`);
+        }
+        if (conflict_status === 'exists') {
+            console.warn(`Expo-sharing: Target with bundleId: ${bundleIdentifier} already exists in the project and will not be added`);
+            return config;
+        }
+        const xcConfigurationList = (0, addXCConfigurationList_1.addXCConfigurationList)(xcodeProject, targetName, bundleIdentifier, deploymentTarget, config.ios?.buildNumber ?? '1', config.version ?? '1.0');
+        const productFile = (0, addProductFile_1.addProductFile)(xcodeProject, targetName, groupName);
+        const pbxNativeTargetObject = (0, addToPbxNativeTargetSection_1.addToPbxNativeTargetSection)(xcodeProject, targetName, targetUuid, productFile, xcConfigurationList);
+        (0, addToPbxProjectSection_1.addToPbxProjectSection)(xcodeProject, pbxNativeTargetObject);
+        (0, addBuildPhases_1.addBuildPhases)(xcodeProject, targetUuid, targetName, groupName, productFile, shareExtensionFiles, platformProjectRoot);
+        (0, addPbxGroup_1.addPbxGroup)(xcodeProject, targetName, shareExtensionFiles, platformProjectRoot);
+        return config;
+    });
+};
+exports.withShareExtensionXcodeProject = withShareExtensionXcodeProject;

--- a/packages/expo-sharing/plugin/build/ios/xcode/addBuildPhases.d.ts
+++ b/packages/expo-sharing/plugin/build/ios/xcode/addBuildPhases.d.ts
@@ -1,0 +1,8 @@
+import { XcodeProject } from '@expo/config-plugins';
+import { ShareExtensionFiles } from '../setupShareExtensionFiles';
+export declare function addBuildPhases(xcodeProject: XcodeProject, targetUuid: string, targetName: string, groupName: string, productFile: {
+    uuid: string;
+    target: string;
+    basename: string;
+    group: string;
+}, shareExtensionFiles: ShareExtensionFiles, platformProjectRoot: string): void;

--- a/packages/expo-sharing/plugin/build/ios/xcode/addBuildPhases.js
+++ b/packages/expo-sharing/plugin/build/ios/xcode/addBuildPhases.js
@@ -1,0 +1,32 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.addBuildPhases = addBuildPhases;
+const path_1 = __importDefault(require("path"));
+const utils_1 = require("../../utils");
+function addBuildPhases(xcodeProject, targetUuid, targetName, groupName, productFile, shareExtensionFiles, platformProjectRoot) {
+    const buildPath = `""`;
+    const sharedFilesPath = (0, utils_1.getSharedFilesPath)();
+    const folderType = 'app_extension';
+    const { swiftFiles, intentFiles, assetDirectories, sharedFiles } = shareExtensionFiles;
+    // Gets the location of the shared files relative to the extension directory
+    const sharedSwiftFiles = sharedFiles?.swiftFiles
+        .map((file) => path_1.default.join(sharedFilesPath, file))
+        .map((file) => {
+        const shareExtensionDirectory = path_1.default.join(platformProjectRoot, targetName, 'shared');
+        return path_1.default.relative(shareExtensionDirectory, file);
+    }) || [];
+    xcodeProject.addBuildPhase([...swiftFiles, ...intentFiles, ...sharedSwiftFiles], 'PBXSourcesBuildPhase', groupName, targetUuid, folderType, buildPath);
+    xcodeProject.addBuildPhase([], 'PBXCopyFilesBuildPhase', groupName, xcodeProject.getFirstTarget().uuid, folderType, buildPath);
+    xcodeProject
+        .buildPhaseObject('PBXCopyFilesBuildPhase', groupName, productFile.target)
+        .files.push({
+        value: productFile.uuid,
+        comment: `${productFile.basename} in ${productFile.group}`,
+    });
+    xcodeProject.addToPbxBuildFileSection(productFile);
+    xcodeProject.addBuildPhase([], 'PBXFrameworksBuildPhase', groupName, targetUuid, folderType, buildPath);
+    xcodeProject.addBuildPhase([...assetDirectories], 'PBXResourcesBuildPhase', groupName, targetUuid, folderType, buildPath);
+}

--- a/packages/expo-sharing/plugin/build/ios/xcode/addPbxGroup.d.ts
+++ b/packages/expo-sharing/plugin/build/ios/xcode/addPbxGroup.d.ts
@@ -1,0 +1,3 @@
+import { XcodeProject } from '@expo/config-plugins';
+import { ShareExtensionFiles } from '../setupShareExtensionFiles';
+export declare function addPbxGroup(xcodeProject: XcodeProject, targetName: string, shareExtensionFiles: ShareExtensionFiles, platformProjectRoot: string): void;

--- a/packages/expo-sharing/plugin/build/ios/xcode/addPbxGroup.js
+++ b/packages/expo-sharing/plugin/build/ios/xcode/addPbxGroup.js
@@ -1,0 +1,35 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.addPbxGroup = addPbxGroup;
+const path_1 = __importDefault(require("path"));
+const utils_1 = require("../../utils");
+function addPbxGroup(xcodeProject, targetName, shareExtensionFiles, platformProjectRoot) {
+    const sharedFilesPath = (0, utils_1.getSharedFilesPath)();
+    const targetFiles = Object.values({
+        ...shareExtensionFiles,
+        sharedFiles: [],
+    }).flat();
+    // Add generated files
+    targetFiles.push(`${targetName}.entitlements`);
+    targetFiles.push(`Info.plist`);
+    const sharedFiles = Object.values(shareExtensionFiles.sharedFiles ?? [])
+        .flat()
+        .map((file) => path_1.default.join(sharedFilesPath, file))
+        .map((file) => path_1.default.relative(path_1.default.join(platformProjectRoot, targetName, 'shared'), file));
+    const { uuid: mainGroupUuid } = xcodeProject.addPbxGroup(targetFiles, targetName, targetName);
+    const { uuid: sharedGroupUuid } = xcodeProject.addPbxGroup(sharedFiles, 'shared', 'shared');
+    if (mainGroupUuid && sharedGroupUuid) {
+        xcodeProject.addToPbxGroup(sharedGroupUuid, mainGroupUuid);
+    }
+    const groups = xcodeProject.hash.project.objects['PBXGroup'];
+    if (mainGroupUuid) {
+        Object.keys(groups).forEach((key) => {
+            if (!groups[key].name && !groups[key].path) {
+                xcodeProject.addToPbxGroup(mainGroupUuid, key);
+            }
+        });
+    }
+}

--- a/packages/expo-sharing/plugin/build/ios/xcode/addProductFile.d.ts
+++ b/packages/expo-sharing/plugin/build/ios/xcode/addProductFile.d.ts
@@ -1,0 +1,2 @@
+import { XcodeProject } from '@expo/config-plugins';
+export declare function addProductFile(xcodeProject: XcodeProject, targetName: string, groupName: string): any;

--- a/packages/expo-sharing/plugin/build/ios/xcode/addProductFile.js
+++ b/packages/expo-sharing/plugin/build/ios/xcode/addProductFile.js
@@ -1,0 +1,17 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.addProductFile = addProductFile;
+function addProductFile(xcodeProject, targetName, groupName) {
+    const options = {
+        basename: `${targetName}.appex`,
+        group: groupName,
+        explicitFileType: 'wrapper.app-extension',
+        settings: {
+            ATTRIBUTES: ['RemoveHeadersOnCopy'],
+        },
+        includeInIndex: 0,
+        path: `${targetName}.appex`,
+        sourceTree: 'BUILT_PRODUCTS_DIR',
+    };
+    return xcodeProject.addProductFile(targetName, options);
+}

--- a/packages/expo-sharing/plugin/build/ios/xcode/addToPbxNativeTargetSection.d.ts
+++ b/packages/expo-sharing/plugin/build/ios/xcode/addToPbxNativeTargetSection.d.ts
@@ -1,0 +1,19 @@
+import { XcodeProject } from '@expo/config-plugins';
+export declare function addToPbxNativeTargetSection(xcodeProject: XcodeProject, targetName: string, targetUuid: string, productFile: {
+    fileRef: string;
+}, xcConfigurationList: {
+    uuid: string;
+}): {
+    uuid: string;
+    pbxNativeTarget: {
+        isa: string;
+        name: string;
+        productName: string;
+        productReference: string;
+        productType: string;
+        buildConfigurationList: string;
+        buildPhases: never[];
+        buildRules: never[];
+        dependencies: never[];
+    };
+};

--- a/packages/expo-sharing/plugin/build/ios/xcode/addToPbxNativeTargetSection.js
+++ b/packages/expo-sharing/plugin/build/ios/xcode/addToPbxNativeTargetSection.js
@@ -1,0 +1,21 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.addToPbxNativeTargetSection = addToPbxNativeTargetSection;
+function addToPbxNativeTargetSection(xcodeProject, targetName, targetUuid, productFile, xcConfigurationList) {
+    const target = {
+        uuid: targetUuid,
+        pbxNativeTarget: {
+            isa: 'PBXNativeTarget',
+            name: targetName,
+            productName: targetName,
+            productReference: productFile.fileRef,
+            productType: `"com.apple.product-type.app-extension"`,
+            buildConfigurationList: xcConfigurationList.uuid,
+            buildPhases: [],
+            buildRules: [],
+            dependencies: [],
+        },
+    };
+    xcodeProject.addToPbxNativeTargetSection(target);
+    return target;
+}

--- a/packages/expo-sharing/plugin/build/ios/xcode/addToPbxProjectSection.d.ts
+++ b/packages/expo-sharing/plugin/build/ios/xcode/addToPbxProjectSection.d.ts
@@ -1,0 +1,4 @@
+import { XcodeProject } from '@expo/config-plugins';
+export declare function addToPbxProjectSection(xcodeProject: XcodeProject, target: {
+    uuid: string;
+}): void;

--- a/packages/expo-sharing/plugin/build/ios/xcode/addToPbxProjectSection.js
+++ b/packages/expo-sharing/plugin/build/ios/xcode/addToPbxProjectSection.js
@@ -1,0 +1,16 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.addToPbxProjectSection = addToPbxProjectSection;
+function addToPbxProjectSection(xcodeProject, target) {
+    xcodeProject.addToPbxProjectSection(target);
+    const projectUuid = xcodeProject.getFirstProject().uuid;
+    const projectSection = xcodeProject.pbxProjectSection()[projectUuid];
+    if (!projectSection.attributes.TargetAttributes) {
+        projectSection.attributes.TargetAttributes = {};
+    }
+    projectSection.attributes.TargetAttributes[target.uuid] = {
+        LastSwiftMigration: 1250, // Adds the Swift 5.0 target migration attribute to avoid "Convert to Current Swift Syntax" warning
+        ProvisioningStyle: 'Automatic', // Uses "Automatically manage signing" by default
+        CreatedOnToolsVersion: '15.1',
+    };
+}

--- a/packages/expo-sharing/plugin/build/ios/xcode/addXCConfigurationList.d.ts
+++ b/packages/expo-sharing/plugin/build/ios/xcode/addXCConfigurationList.d.ts
@@ -1,0 +1,2 @@
+import { XcodeProject } from '@expo/config-plugins';
+export declare function addXCConfigurationList(xcodeProject: XcodeProject, targetName: string, bundleIdentifier: string, deploymentTarget: string, currentProjectVersion: string, marketingVersion: string): any;

--- a/packages/expo-sharing/plugin/build/ios/xcode/addXCConfigurationList.js
+++ b/packages/expo-sharing/plugin/build/ios/xcode/addXCConfigurationList.js
@@ -1,0 +1,67 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.addXCConfigurationList = addXCConfigurationList;
+function addXCConfigurationList(xcodeProject, targetName, bundleIdentifier, deploymentTarget, currentProjectVersion, marketingVersion) {
+    // Based on the default output of Xcode when adding a sharing extension target
+    const commonSettings = {
+        ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS: 'YES',
+        CLANG_ANALYZER_NONNULL: 'YES',
+        CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION: 'YES_AGGRESSIVE',
+        CODE_SIGN_STYLE: 'Automatic',
+        CODE_SIGN_ENTITLEMENTS: `"${targetName}/${targetName}.entitlements"`,
+        CURRENT_PROJECT_VERSION: `"${currentProjectVersion}"`,
+        ENABLE_USER_SCRIPT_SANDBOXING: 'YES',
+        GENERATE_INFOPLIST_FILE: 'NO',
+        INFOPLIST_FILE: `"${targetName}/Info.plist"`,
+        INFOPLIST_KEY_CFBundleDisplayName: `"${targetName}"`,
+        INFOPLIST_KEY_NSHumanReadableCopyright: '""',
+        IPHONEOS_DEPLOYMENT_TARGET: `"${deploymentTarget}"`,
+        LD_RUNPATH_SEARCH_PATHS: [
+            '"$(inherited)"',
+            '"@executable_path/Frameworks"',
+            '"@executable_path/../../Frameworks"',
+        ],
+        LOCALIZATION_PREFERS_STRING_CATALOGS: 'YES',
+        MARKETING_VERSION: `${marketingVersion}`,
+        MTL_FAST_MATH: 'YES',
+        PRODUCT_BUNDLE_IDENTIFIER: `"${bundleIdentifier}"`,
+        PRODUCT_NAME: '"$(TARGET_NAME)"',
+        SKIP_INSTALL: 'YES',
+        STRING_CATALOG_GENERATE_SYMBOLS: 'YES',
+        SWIFT_APPROACHABLE_CONCURRENCY: 'YES',
+        SWIFT_EMIT_LOC_STRINGS: 'YES',
+        SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY: 'YES',
+        SWIFT_VERSION: '5.0',
+        TARGETED_DEVICE_FAMILY: '"1,2"',
+    };
+    const debugSpecifics = {
+        DEBUG_INFORMATION_FORMAT: 'dwarf',
+        MTL_ENABLE_DEBUG_INFO: 'INCLUDE_SOURCE',
+        SWIFT_ACTIVE_COMPILATION_CONDITIONS: '"DEBUG $(inherited)"',
+        SWIFT_OPTIMIZATION_LEVEL: '"-Onone"',
+    };
+    const releaseSpecifics = {
+        COPY_PHASE_STRIP: 'NO',
+        DEBUG_INFORMATION_FORMAT: '"dwarf-with-dsym"',
+        SWIFT_COMPILATION_MODE: 'wholemodule',
+    };
+    const xCConfigurationList = [
+        {
+            name: 'Debug',
+            isa: 'XCBuildConfiguration',
+            buildSettings: {
+                ...commonSettings,
+                ...debugSpecifics,
+            },
+        },
+        {
+            name: 'Release',
+            isa: 'XCBuildConfiguration',
+            buildSettings: {
+                ...commonSettings,
+                ...releaseSpecifics,
+            },
+        },
+    ];
+    return xcodeProject.addXCConfigurationList(xCConfigurationList, 'Release', `Build configuration list for PBXNativeTarget "${targetName}"`);
+}

--- a/packages/expo-sharing/plugin/build/sharingPlugin.types.d.ts
+++ b/packages/expo-sharing/plugin/build/sharingPlugin.types.d.ts
@@ -1,0 +1,40 @@
+export type SingleShareAction = 'android.intent.action.SEND';
+export type MultiShareAction = 'android.intent.action.SEND_MULTIPLE';
+export type ShareAction = SingleShareAction | MultiShareAction;
+export type IntentFilter = {
+    action: ShareAction;
+    category: 'android.intent.category.DEFAULT';
+    filters: string[];
+    data: {
+        mimeType: string;
+    }[];
+};
+export type SingleIntentFilter = IntentFilter & {
+    action: SingleShareAction;
+};
+export type MultiIntentFilter = IntentFilter & {
+    action: MultiShareAction;
+};
+export type ActivationRuleOptions = {
+    supportsText?: boolean;
+    supportsWebUrlWithMaxCount?: number;
+    supportsImageWithMaxCount?: number;
+    supportsMovieWithMaxCount?: number;
+    supportsFileWithMaxCount?: number;
+    supportsWebPageWithMaxCount?: number;
+    supportsAttachmentsWithMaxCount?: number;
+};
+export type ActivationRule = ActivationRuleOptions | string;
+export type ShareExtensionConfigPluginProps = {
+    ios?: {
+        enabled?: boolean;
+        extensionBundleIdentifier?: string;
+        appGroupId?: string;
+        activationRule?: ActivationRule;
+    };
+    android?: {
+        enabled?: boolean;
+        singleShareMimeTypes?: string[];
+        multipleShareMimeTypes?: string[];
+    };
+};

--- a/packages/expo-sharing/plugin/build/sharingPlugin.types.js
+++ b/packages/expo-sharing/plugin/build/sharingPlugin.types.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/packages/expo-sharing/plugin/build/utils.d.ts
+++ b/packages/expo-sharing/plugin/build/utils.d.ts
@@ -1,0 +1,2 @@
+export declare function getTemplateFilesPath(platform: 'android' | 'ios'): string;
+export declare function getSharedFilesPath(): string;

--- a/packages/expo-sharing/plugin/build/utils.js
+++ b/packages/expo-sharing/plugin/build/utils.js
@@ -1,0 +1,16 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getTemplateFilesPath = getTemplateFilesPath;
+exports.getSharedFilesPath = getSharedFilesPath;
+const path_1 = __importDefault(require("path"));
+function getTemplateFilesPath(platform) {
+    const packagePath = path_1.default.dirname(require.resolve('expo-sharing/package.json'));
+    return path_1.default.join(packagePath, '/plugin/template-files/ios');
+}
+function getSharedFilesPath() {
+    const packagePath = path_1.default.dirname(require.resolve('expo-sharing/package.json'));
+    return path_1.default.join(packagePath, '/ios/shared');
+}

--- a/packages/expo-sharing/plugin/build/withConfig.d.ts
+++ b/packages/expo-sharing/plugin/build/withConfig.d.ts
@@ -1,0 +1,6 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+export declare const withConfig: ConfigPlugin<{
+    bundleIdentifier: string;
+    targetName: string;
+    groupIdentifier: string;
+}>;

--- a/packages/expo-sharing/plugin/build/withConfig.js
+++ b/packages/expo-sharing/plugin/build/withConfig.js
@@ -1,0 +1,76 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withConfig = void 0;
+const createEntitlements_1 = require("./ios/createEntitlements");
+function addShareIntoEntitlements(existingEntitlements, shareIntoEntitlements) {
+    if (!shareIntoEntitlements) {
+        return existingEntitlements;
+    }
+    for (const key of Object.keys(shareIntoEntitlements)) {
+        const itemsToAdd = shareIntoEntitlements[key];
+        const existingValue = existingEntitlements[key] ?? [];
+        if (!Array.isArray(existingValue)) {
+            // Users should never see this error, if you encounter it during development you most likely need to write parsing for the provided type below.
+            throw new Error('Expo-sharing plugin cannot handle this entitlement. Update the plugin.');
+        }
+        const typedExistingValue = existingValue;
+        for (const item of itemsToAdd) {
+            if (!typedExistingValue.includes(item)) {
+                typedExistingValue.push(item);
+            }
+        }
+        existingEntitlements[key] = typedExistingValue;
+    }
+    return existingEntitlements;
+}
+const withConfig = (config, { bundleIdentifier, targetName, groupIdentifier }) => {
+    let configIndex = null;
+    config.extra?.eas?.build?.experimental?.ios?.appExtensions?.forEach((ext, index) => {
+        if (ext.targetName === targetName) {
+            configIndex = index;
+        }
+    });
+    if (configIndex === null) {
+        config.extra = {
+            ...config.extra,
+            eas: {
+                ...config.extra?.eas,
+                build: {
+                    ...config.extra?.eas?.build,
+                    experimental: {
+                        ...config.extra?.eas?.build?.experimental,
+                        ios: {
+                            ...config.extra?.eas?.build?.experimental?.ios,
+                            appExtensions: [
+                                ...(config.extra?.eas?.build?.experimental?.ios?.appExtensions ?? []),
+                                {
+                                    targetName,
+                                    bundleIdentifier,
+                                    entitlements: [],
+                                },
+                            ],
+                        },
+                    },
+                },
+            },
+        };
+        configIndex = 0;
+    }
+    if (config.extra) {
+        const widgetsExtensionConfig = config.extra.eas.build.experimental.ios.appExtensions[configIndex];
+        const shareIntoEntitlements = (0, createEntitlements_1.createEntitlements)(groupIdentifier);
+        addShareIntoEntitlements(widgetsExtensionConfig.entitlements, shareIntoEntitlements);
+        if (!config.ios) {
+            throw new Error('Expo-sharing: the ios config is missing. The project is not configured correctly.');
+        }
+        if (!config.ios?.entitlements) {
+            config.ios = {
+                ...config.ios,
+                entitlements: {},
+            };
+        }
+        addShareIntoEntitlements(config.ios?.entitlements, shareIntoEntitlements);
+    }
+    return config;
+};
+exports.withConfig = withConfig;

--- a/packages/expo-sharing/plugin/jest.config.js
+++ b/packages/expo-sharing/plugin/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('expo-module-scripts/jest-preset-plugin');

--- a/packages/expo-sharing/plugin/src/android/parseIntentFilters.ts
+++ b/packages/expo-sharing/plugin/src/android/parseIntentFilters.ts
@@ -1,0 +1,28 @@
+import { SingleIntentFilter, MultiIntentFilter } from '../sharingPlugin.types';
+
+export function parseIntentFilters(filters: string[], type: 'single'): SingleIntentFilter;
+
+export function parseIntentFilters(filters: string[], type: 'multiple'): MultiIntentFilter;
+
+export function parseIntentFilters(
+  filters: string[],
+  type: 'single' | 'multiple'
+): SingleIntentFilter | MultiIntentFilter {
+  const mimeTypeRegex = /^([\w.+-]+|\*)\/([\w.+-]+|\*)$/;
+
+  filters.forEach((filter) => {
+    if (!filter.match(mimeTypeRegex)) {
+      throw new Error(`Invalid intent filter type: ${filter} is not a valid mime type`);
+    }
+  });
+
+  return {
+    action:
+      type === 'single' ? 'android.intent.action.SEND' : 'android.intent.action.SEND_MULTIPLE',
+    category: 'android.intent.category.DEFAULT',
+    filters,
+    data: filters.map((filter) => ({
+      mimeType: filter,
+    })),
+  };
+}

--- a/packages/expo-sharing/plugin/src/android/withAndroidIntentFilters.ts
+++ b/packages/expo-sharing/plugin/src/android/withAndroidIntentFilters.ts
@@ -1,0 +1,87 @@
+import {
+  ConfigPlugin,
+  withAndroidManifest,
+  AndroidManifest,
+  AndroidConfig,
+  ExportedConfigWithProps,
+} from '@expo/config-plugins';
+import { AndroidIntentFiltersData } from '@expo/config-types';
+
+import { SingleIntentFilter, MultiIntentFilter, IntentFilter } from '../sharingPlugin.types';
+
+const SHARING_GENERATED_TAG = 'expo-sharing-intent-filters';
+type WithAndroidIntentFiltersOptions = {
+  intentFilters: IntentFilter[];
+};
+
+export const withAndroidIntentFilters: ConfigPlugin<WithAndroidIntentFiltersOptions> = (
+  config,
+  { intentFilters }
+) => {
+  return withAndroidManifest(config, (config) => {
+    setAndroidIntentFilters(config, intentFilters);
+    return config;
+  });
+};
+
+export function setAndroidIntentFilters(
+  config: ExportedConfigWithProps<AndroidManifest>,
+  intentFilters: IntentFilter[]
+): ExportedConfigWithProps<AndroidManifest> {
+  const mainActivity = AndroidConfig.Manifest.getMainActivityOrThrow(config.modResults);
+  // Remove all generated tags from previous runs...
+  if (mainActivity['intent-filter']?.length) {
+    mainActivity['intent-filter'] = mainActivity['intent-filter'].filter(
+      // @ts-ignore
+      (value) => value.$?.[SHARING_GENERATED_TAG] !== 'true'
+    );
+  }
+
+  if (!intentFilters.length) {
+    return config;
+  }
+
+  mainActivity['intent-filter'] = mainActivity['intent-filter']?.concat(
+    renderIntentFilters(intentFilters)
+  );
+
+  return config;
+}
+
+export default function renderIntentFilters(
+  intentFilters: (SingleIntentFilter | MultiIntentFilter)[]
+): AndroidConfig.Manifest.ManifestIntentFilter[] {
+  return intentFilters.map((intentFilter) => ({
+    $: {
+      'android:autoVerify': 'false',
+      // Add a custom "generated" tag that we can query later to remove.
+      [SHARING_GENERATED_TAG]: 'true',
+    },
+    action: [
+      // <action android:name="android.intent.action.SEND"/> or SEND_MULTIPLE
+      {
+        $: {
+          'android:name': intentFilter.action,
+        },
+      },
+    ],
+    data: renderIntentFilterData(intentFilter.data),
+    category: [
+      {
+        $: {
+          'android:name': intentFilter.category,
+        },
+      },
+    ],
+  }));
+}
+
+/** Like `<data android:scheme="exp"/>` */
+function renderIntentFilterData(data?: AndroidIntentFiltersData | AndroidIntentFiltersData[]) {
+  return (Array.isArray(data) ? data : [data]).filter(Boolean).map((datum) => ({
+    $: Object.entries(datum ?? {}).reduce(
+      (prev, [key, value]) => ({ ...prev, [`android:${key}`]: value }),
+      {}
+    ),
+  }));
+}

--- a/packages/expo-sharing/plugin/src/android/withShareIntoSchemeString.ts
+++ b/packages/expo-sharing/plugin/src/android/withShareIntoSchemeString.ts
@@ -1,0 +1,20 @@
+import { withStringsXml, AndroidConfig, ConfigPlugin } from '@expo/config-plugins';
+
+const withShareIntoSchemeString: ConfigPlugin<string> = (config, scheme) => {
+  return withStringsXml(config, (config) => {
+    config.modResults = AndroidConfig.Strings.setStringItem(
+      [
+        AndroidConfig.Resources.buildResourceItem({
+          name: 'share_into_scheme',
+          value: scheme,
+          translatable: false,
+        }),
+      ],
+      config.modResults
+    );
+
+    return config;
+  });
+};
+
+export { withShareIntoSchemeString };

--- a/packages/expo-sharing/plugin/src/index.ts
+++ b/packages/expo-sharing/plugin/src/index.ts
@@ -1,0 +1,126 @@
+import { ConfigPlugin, createRunOncePlugin, StaticPlugin, withPlugins } from '@expo/config-plugins';
+
+import { parseIntentFilters } from './android/parseIntentFilters';
+import { withAndroidIntentFilters } from './android/withAndroidIntentFilters';
+import { withShareIntoSchemeString } from './android/withShareIntoSchemeString';
+import { ShareExtensionFiles } from './ios/setupShareExtensionFiles';
+import { withAppGroupId } from './ios/withAppGroupId';
+import { withShareExtensionFiles } from './ios/withShareExtensionFiles';
+import { withShareExtensionXcodeProject } from './ios/withShareExtensionXcodeProject';
+import { ShareExtensionConfigPluginProps } from './sharingPlugin.types';
+import { withConfig } from './withConfig';
+
+const EXPO_SHARE_EXTENSION_TARGET_NAME = 'expo-sharing-extension';
+const pkg = require('expo-sharing/package.json');
+
+type ShareExtensionConfigPlugin = ConfigPlugin<ShareExtensionConfigPluginProps>;
+
+const withShareExtension: ShareExtensionConfigPlugin = (config, props?) => {
+  let plugins: (StaticPlugin | ConfigPlugin | string)[] = [];
+  const iosEnabled = props?.ios?.enabled ?? true;
+  const androidEnabled = props?.android?.enabled ?? true;
+
+  if (iosEnabled) {
+    const deploymentTarget = '15.1';
+    const bundleIdentifier = config.ios?.bundleIdentifier;
+    if (!bundleIdentifier) {
+      throw new Error(
+        "The application config doesn't define a bundle identifier. Make sure that `ios.bundleIdentifier` field has a value."
+      );
+    }
+    const extensionBundleIdentifier =
+      props?.ios?.extensionBundleIdentifier ??
+      `${config.ios?.bundleIdentifier}.${EXPO_SHARE_EXTENSION_TARGET_NAME}`;
+    const fallbackAppGroupId = `group.${bundleIdentifier}`;
+    const appGroupId = props?.ios?.appGroupId ?? fallbackAppGroupId;
+    const urlScheme = (config.scheme ?? bundleIdentifier) as string; // TODO: Fix this type;
+    const activationRule = props?.ios?.activationRule ?? {
+      supportsText: true,
+      supportsWebUrlWithMaxCount: 1,
+    };
+
+    if (!urlScheme) {
+      throw new Error(
+        `Expo sharing: The app doesn't define a scheme or a bundle identifier. Define at least one of those properties in app json`
+      );
+    }
+    if (!props?.ios?.appGroupId) {
+      console.warn(
+        `Expo sharing: Using the default ${fallbackAppGroupId} app group id. If you are using EAS Build` +
+          ` no further steps are required, otherwise make sure that this app group is registered` +
+          ` with your Apple development team, or set \`ios.appGroupId\` field to an already registered app group.`
+      );
+    }
+
+    const shareExtensionFiles: ShareExtensionFiles = {} as ShareExtensionFiles;
+
+    plugins = [
+      ...plugins,
+      [
+        withConfig,
+        {
+          bundleIdentifier: extensionBundleIdentifier,
+          targetName: EXPO_SHARE_EXTENSION_TARGET_NAME,
+          groupIdentifier: appGroupId,
+        },
+      ],
+      [withAppGroupId, appGroupId],
+      [
+        withShareExtensionFiles,
+        {
+          targetName: EXPO_SHARE_EXTENSION_TARGET_NAME,
+          appGroupId,
+          urlScheme,
+          activationRule,
+          onFilesWritten: (writtenFiles: ShareExtensionFiles) => {
+            Object.assign(shareExtensionFiles, writtenFiles);
+          },
+        },
+      ],
+      [
+        withShareExtensionXcodeProject,
+        {
+          targetName: EXPO_SHARE_EXTENSION_TARGET_NAME,
+          bundleIdentifier: extensionBundleIdentifier,
+          deploymentTarget,
+          activationRule,
+          shareExtensionFiles,
+        },
+      ],
+    ];
+  }
+
+  if (androidEnabled) {
+    const urlScheme = config.scheme ?? config.android?.package;
+
+    if (!urlScheme) {
+      throw new Error(
+        "The application config doesn't define a scheme or an Android package. Define the scheme in the app config."
+      );
+    }
+
+    const singleIntentFilter = parseIntentFilters(
+      props?.android?.singleShareMimeTypes ?? [],
+      'single'
+    );
+    const multiIntentFilter = parseIntentFilters(
+      props?.android?.multipleShareMimeTypes ?? [],
+      'multiple'
+    );
+
+    plugins = [
+      ...plugins,
+      [
+        withAndroidIntentFilters,
+        {
+          intentFilters: [singleIntentFilter, multiIntentFilter],
+        },
+      ],
+      [withShareIntoSchemeString, urlScheme],
+    ];
+  }
+
+  return withPlugins(config, plugins);
+};
+
+export default createRunOncePlugin(withShareExtension, pkg.name, pkg.version);

--- a/packages/expo-sharing/plugin/src/index.ts
+++ b/packages/expo-sharing/plugin/src/index.ts
@@ -5,6 +5,7 @@ import { withAndroidIntentFilters } from './android/withAndroidIntentFilters';
 import { withShareIntoSchemeString } from './android/withShareIntoSchemeString';
 import { ShareExtensionFiles } from './ios/setupShareExtensionFiles';
 import { withAppGroupId } from './ios/withAppGroupId';
+import withIosWarning from './ios/withIosWarning';
 import { withShareExtensionFiles } from './ios/withShareExtensionFiles';
 import { withShareExtensionXcodeProject } from './ios/withShareExtensionXcodeProject';
 import { ShareExtensionConfigPluginProps } from './sharingPlugin.types';
@@ -33,7 +34,7 @@ const withShareExtension: ShareExtensionConfigPlugin = (config, props?) => {
       `${config.ios?.bundleIdentifier}.${EXPO_SHARE_EXTENSION_TARGET_NAME}`;
     const fallbackAppGroupId = `group.${bundleIdentifier}`;
     const appGroupId = props?.ios?.appGroupId ?? fallbackAppGroupId;
-    const urlScheme = (config.scheme ?? bundleIdentifier) as string; // TODO: Fix this type;
+    const urlScheme = config.scheme ?? bundleIdentifier;
     const activationRule = props?.ios?.activationRule ?? {
       supportsText: true,
       supportsWebUrlWithMaxCount: 1,
@@ -45,11 +46,16 @@ const withShareExtension: ShareExtensionConfigPlugin = (config, props?) => {
       );
     }
     if (!props?.ios?.appGroupId) {
-      console.warn(
-        `Expo sharing: Using the default ${fallbackAppGroupId} app group id. If you are using EAS Build` +
-          ` no further steps are required, otherwise make sure that this app group is registered` +
-          ` with your Apple development team, or set \`ios.appGroupId\` field to an already registered app group.`
-      );
+      plugins.push([
+        withIosWarning,
+        {
+          property: 'appGroupId',
+          warning:
+            `Expo sharing: Using the default ${fallbackAppGroupId} app group id. If you are using EAS Build` +
+            ` no further steps are required, otherwise make sure that this app group is registered` +
+            ` with your Apple development team, or set \`ios.appGroupId\` field to an already registered app group.`,
+        },
+      ]);
     }
 
     const shareExtensionFiles: ShareExtensionFiles = {} as ShareExtensionFiles;

--- a/packages/expo-sharing/plugin/src/ios/conflictingExtensionExists.ts
+++ b/packages/expo-sharing/plugin/src/ios/conflictingExtensionExists.ts
@@ -1,0 +1,32 @@
+import { XcodeProject } from '@expo/config-plugins';
+
+type conflictingExtensionResult = 'doesnt-exist' | 'exists' | 'exists-conflicting';
+
+export function conflictingExtensionExists(
+  xcodeProject: XcodeProject,
+  targetName: string,
+  bundleIdentifier: string
+): conflictingExtensionResult {
+  const nativeTargets = xcodeProject.pbxNativeTargetSection();
+  const existingTarget: any = Object.values(nativeTargets).find(
+    (target: any) => target.name && unquote(target.name) === targetName
+  );
+
+  if (existingTarget) {
+    const buildConfigurations = xcodeProject.pbxXCBuildConfigurationSection();
+    const configurationList =
+      xcodeProject.pbxXCConfigurationList()[existingTarget.buildConfigurationList];
+    const buildConfiguration = buildConfigurations[configurationList.buildConfigurations[0].value];
+    const existingBundleIdentifier = unquote(
+      buildConfiguration.buildSettings.PRODUCT_BUNDLE_IDENTIFIER
+    );
+
+    return existingBundleIdentifier === bundleIdentifier ? 'exists' : 'exists-conflicting';
+  }
+  return 'doesnt-exist';
+}
+
+function unquote(str: string) {
+  if (str) return str.replace(/^"(.*)"$/, '$1');
+  return str;
+}

--- a/packages/expo-sharing/plugin/src/ios/createEntitlements.ts
+++ b/packages/expo-sharing/plugin/src/ios/createEntitlements.ts
@@ -1,0 +1,24 @@
+import plist from '@expo/plist';
+import fs from 'fs';
+import path from 'path';
+
+const SECURITY_GROUPS_KEY = 'com.apple.security.application-groups';
+export type ShareIntoEntitlements = Record<string, string[]>;
+
+export function createEntitlements(appGroupId: string): ShareIntoEntitlements {
+  const buildObject: ShareIntoEntitlements = {};
+  buildObject[SECURITY_GROUPS_KEY] = [appGroupId];
+  return buildObject;
+}
+
+export function createEntitlementsFile(
+  targetDirectory: string,
+  extensionTargetName: string,
+  appGroupId: string
+) {
+  const entitlementsPath = path.join(targetDirectory, `/${extensionTargetName}.entitlements`);
+  const entitlementsObject = createEntitlements(appGroupId);
+  const builtPlist = plist.build(entitlementsObject);
+
+  return fs.writeFileSync(entitlementsPath, builtPlist);
+}

--- a/packages/expo-sharing/plugin/src/ios/createInfoPlistFile.ts
+++ b/packages/expo-sharing/plugin/src/ios/createInfoPlistFile.ts
@@ -1,0 +1,75 @@
+import plist from '@expo/plist';
+import fs from 'fs';
+import path from 'path';
+
+import { ActivationRule } from '../sharingPlugin.types';
+
+export default function createInfoPlistFile(
+  targetDirectory: string,
+  appGroupId: string,
+  urlScheme: string,
+  activationRule: ActivationRule
+) {
+  const infoPlistPath = path.join(targetDirectory, 'Info.plist');
+
+  let activationRuleValue: string | Record<string, unknown>;
+
+  if (typeof activationRule === 'string') {
+    activationRuleValue = activationRule;
+  } else {
+    const rules: Record<string, unknown> = {};
+
+    if (activationRule.supportsText) {
+      rules.NSExtensionActivationSupportsText = true;
+    }
+    if (activationRule.supportsWebUrlWithMaxCount) {
+      rules.NSExtensionActivationSupportsWebURLWithMaxCount =
+        activationRule.supportsWebUrlWithMaxCount;
+    }
+    if (activationRule.supportsImageWithMaxCount) {
+      rules.NSExtensionActivationSupportsImageWithMaxCount =
+        activationRule.supportsImageWithMaxCount;
+    }
+    if (activationRule.supportsMovieWithMaxCount) {
+      rules.NSExtensionActivationSupportsMovieWithMaxCount =
+        activationRule.supportsMovieWithMaxCount;
+    }
+    if (activationRule.supportsFileWithMaxCount) {
+      rules.NSExtensionActivationSupportsFileWithMaxCount = activationRule.supportsFileWithMaxCount;
+    }
+    if (activationRule.supportsWebPageWithMaxCount) {
+      rules.NSExtensionActivationSupportsWebPageWithMaxCount =
+        activationRule.supportsWebPageWithMaxCount;
+    }
+    if (activationRule.supportsAttachmentsWithMaxCount) {
+      rules.NSExtensionActivationSupportsAttachmentsWithMaxCount =
+        activationRule.supportsAttachmentsWithMaxCount;
+    }
+    activationRuleValue = rules;
+  }
+
+  const buildObject = {
+    AppGroupId: appGroupId,
+    MainTargetUrlScheme: urlScheme,
+    CFBundleDevelopmentRegion: '$(DEVELOPMENT_LANGUAGE)',
+    CFBundleDisplayName: '$(PRODUCT_NAME)',
+    CFBundleExecutable: '$(EXECUTABLE_NAME)',
+    CFBundleIdentifier: '$(PRODUCT_BUNDLE_IDENTIFIER)',
+    CFBundleInfoDictionaryVersion: '6.0',
+    CFBundleName: '$(PRODUCT_NAME)',
+    CFBundlePackageType: 'XPC!',
+    CFBundleShortVersionString: '$(MARKETING_VERSION)',
+    CFBundleVersion: '$(CURRENT_PROJECT_VERSION)',
+    NSExtension: {
+      NSExtensionAttributes: {
+        NSExtensionActivationRule: activationRuleValue,
+      },
+      NSExtensionPointIdentifier: 'com.apple.share-services',
+      NSExtensionPrincipalClass: '$(PRODUCT_MODULE_NAME).ShareIntoViewController',
+    },
+  };
+
+  const builtPlist = plist.build(buildObject);
+
+  return fs.writeFileSync(infoPlistPath, builtPlist);
+}

--- a/packages/expo-sharing/plugin/src/ios/setupShareExtensionFiles.ts
+++ b/packages/expo-sharing/plugin/src/ios/setupShareExtensionFiles.ts
@@ -1,0 +1,121 @@
+import fs from 'fs';
+import * as path from 'path';
+
+import { getSharedFilesPath, getTemplateFilesPath } from '../utils';
+import { createEntitlementsFile } from './createEntitlements';
+import createInfoPlistFile from './createInfoPlistFile';
+import { ActivationRule } from '../sharingPlugin.types';
+
+export type ProjectFiles = {
+  swiftFiles: string[];
+  entitlementFiles: string[];
+  plistFiles: string[];
+  assetDirectories: string[];
+  intentFiles: string[];
+  otherFiles: string[];
+};
+
+export type ShareExtensionFiles = ProjectFiles & {
+  sharedFiles: ProjectFiles | null;
+};
+
+/**
+ * Copies the template files into the native project directory and prepares the extension entitlements file.
+ * @returns Object storing categorized copied files.
+ * Note @behenate: This doesn't support nested folders as of now, we don't need this, so I didn't bother adding it.
+ */
+export function setupShareExtensionFiles(
+  targetPath: string,
+  extensionTargetName: string,
+  appGroupId: string,
+  urlScheme: string,
+  activationRule: ActivationRule
+): ShareExtensionFiles {
+  const templateFilesPath = getTemplateFilesPath('ios');
+  const sharedDirectoryPath = getSharedFilesPath();
+
+  if (!fs.existsSync(targetPath)) {
+    fs.mkdirSync(targetPath, { recursive: true });
+  }
+
+  const targetSharedPath = path.join(targetPath, 'shared');
+  if (!fs.existsSync(targetSharedPath)) {
+    fs.mkdirSync(targetSharedPath, { recursive: true });
+  }
+
+  createEntitlementsFile(targetPath, extensionTargetName, appGroupId);
+  createInfoPlistFile(targetPath, appGroupId, urlScheme, activationRule);
+
+  const extensionTargetFiles = parseDirectoryFiles(templateFilesPath);
+  const sharedFiles = parseDirectoryFiles(sharedDirectoryPath);
+
+  const shareExtensionFiles: ShareExtensionFiles = {
+    ...extensionTargetFiles,
+    sharedFiles,
+  };
+
+  Object.values(extensionTargetFiles)
+    .flat()
+    .forEach((file) => {
+      const source = path.join(templateFilesPath, file);
+      copyFileSync(source, targetPath);
+    });
+
+  return shareExtensionFiles;
+}
+
+export function parseDirectoryFiles(directoryPath: string): ProjectFiles {
+  const projectFiles: ProjectFiles = {
+    swiftFiles: [],
+    entitlementFiles: [],
+    plistFiles: [],
+    assetDirectories: [],
+    intentFiles: [],
+    otherFiles: [],
+  };
+
+  if (fs.lstatSync(directoryPath).isDirectory()) {
+    const files = fs.readdirSync(directoryPath);
+
+    files.forEach((file) => {
+      // Skip directories
+      if (fs.lstatSync(path.join(directoryPath, file)).isDirectory()) {
+        return;
+      }
+
+      const fileExtension = file.split('.').pop();
+      switch (fileExtension) {
+        case 'swift':
+          projectFiles.swiftFiles.push(file);
+          break;
+        case 'entitlements':
+          projectFiles.entitlementFiles.push(file);
+          break;
+        case 'plist':
+          projectFiles.plistFiles.push(file);
+          break;
+        case 'xcassets':
+          projectFiles.assetDirectories.push(file);
+          break;
+        case 'intentdefinition':
+          projectFiles.intentFiles.push(file);
+          break;
+        default:
+          projectFiles.otherFiles.push(file);
+          break;
+      }
+    });
+  }
+
+  return projectFiles;
+}
+
+export function copyFileSync(source: string, target: string) {
+  let targetFile = target;
+
+  if (fs.existsSync(target) && fs.lstatSync(target).isDirectory()) {
+    targetFile = path.join(target, path.basename(source));
+  }
+
+  fs.writeFileSync(targetFile, fs.readFileSync(source));
+}

--- a/packages/expo-sharing/plugin/src/ios/withAppGroupId.ts
+++ b/packages/expo-sharing/plugin/src/ios/withAppGroupId.ts
@@ -1,0 +1,27 @@
+import { ConfigPlugin, withEntitlementsPlist, withInfoPlist } from '@expo/config-plugins';
+
+export const withAppGroupId: ConfigPlugin<string> = (config, appGroupId) => {
+  // Add do entitlements
+  config = withEntitlementsPlist(config, async (config) => {
+    const appGroups = config.modResults['com.apple.security.application-groups'] as
+      | string[]
+      | undefined;
+
+    if (!appGroups) {
+      config.modResults['com.apple.security.application-groups'] = [appGroupId];
+      return config;
+    }
+
+    if (!appGroups.includes(appGroupId)) {
+      config.modResults['com.apple.security.application-groups'] = [...appGroups, appGroupId];
+    }
+
+    return config;
+  });
+
+  // Add to Info.plist
+  return withInfoPlist(config, (config) => {
+    config.modResults['ExpoShareIntoAppGroupId'] = appGroupId;
+    return config;
+  });
+};

--- a/packages/expo-sharing/plugin/src/ios/withIosWarning.ts
+++ b/packages/expo-sharing/plugin/src/ios/withIosWarning.ts
@@ -1,0 +1,16 @@
+import { ConfigPlugin, WarningAggregator, withInfoPlist } from '@expo/config-plugins';
+import { ExpoConfig } from '@expo/config-types';
+
+type WithIosWarningProps = { property: string; warning: string };
+
+// Hack to display the warning only once
+const withIosWarning: ConfigPlugin<WithIosWarningProps> = (
+  config: ExpoConfig,
+  { property, warning }: WithIosWarningProps
+) =>
+  withInfoPlist(config, (config) => {
+    WarningAggregator.addWarningIOS(property, warning);
+    return config;
+  });
+
+export default withIosWarning;

--- a/packages/expo-sharing/plugin/src/ios/withShareExtensionFiles.ts
+++ b/packages/expo-sharing/plugin/src/ios/withShareExtensionFiles.ts
@@ -1,0 +1,36 @@
+import { ConfigPlugin, withDangerousMod } from '@expo/config-plugins';
+import path from 'path';
+
+import { ActivationRule } from '../sharingPlugin.types';
+import { setupShareExtensionFiles, ShareExtensionFiles } from './setupShareExtensionFiles';
+
+type WithShareExtensionSourceFilesProps = {
+  targetName: string;
+  appGroupId: string;
+  urlScheme: string;
+  activationRule: ActivationRule;
+  onFilesWritten: (files: ShareExtensionFiles) => void;
+};
+export const withShareExtensionFiles: ConfigPlugin<WithShareExtensionSourceFilesProps> = (
+  config,
+  { targetName, appGroupId, urlScheme, activationRule, onFilesWritten }
+) =>
+  withDangerousMod(config, [
+    'ios',
+    async (config) => {
+      const { platformProjectRoot } = config.modRequest;
+      const targetPath = path.join(platformProjectRoot, targetName);
+
+      const files = setupShareExtensionFiles(
+        targetPath,
+        targetName,
+        appGroupId,
+        urlScheme,
+        activationRule
+      );
+
+      onFilesWritten(files);
+
+      return config;
+    },
+  ]);

--- a/packages/expo-sharing/plugin/src/ios/withShareExtensionXcodeProject.ts
+++ b/packages/expo-sharing/plugin/src/ios/withShareExtensionXcodeProject.ts
@@ -1,0 +1,80 @@
+import { ConfigPlugin, withXcodeProject } from '@expo/config-plugins';
+import * as console from 'node:console';
+
+import { conflictingExtensionExists } from './conflictingExtensionExists';
+import { ShareExtensionFiles } from './setupShareExtensionFiles';
+import { addBuildPhases } from './xcode/addBuildPhases';
+import { addPbxGroup } from './xcode/addPbxGroup';
+import { addProductFile } from './xcode/addProductFile';
+import { addToPbxNativeTargetSection } from './xcode/addToPbxNativeTargetSection';
+import { addToPbxProjectSection } from './xcode/addToPbxProjectSection';
+import { addXCConfigurationList } from './xcode/addXCConfigurationList';
+
+type WithShareExtensionXcodeProjectProps = {
+  targetName: string;
+  bundleIdentifier: string;
+  deploymentTarget: string;
+  shareExtensionFiles: ShareExtensionFiles;
+};
+export const withShareExtensionXcodeProject: ConfigPlugin<WithShareExtensionXcodeProjectProps> = (
+  config,
+  { targetName, bundleIdentifier, deploymentTarget, shareExtensionFiles }
+) => {
+  return withXcodeProject(config, (config) => {
+    const groupName = 'Embed Foundation Extensions';
+    const xcodeProject = config.modResults;
+    const { platformProjectRoot } = config.modRequest;
+    const targetUuid = xcodeProject.generateUuid();
+
+    // Technically we should be able to remove the existing target, but I don't have time to add it before the release.
+    // Most users will chose not to modify the identifier anyways.
+    // TODO: Add smart existing target removal
+    const conflict_status = conflictingExtensionExists(xcodeProject, targetName, bundleIdentifier);
+    if (conflict_status === 'exists-conflicting') {
+      throw new Error(
+        `Expo-sharing: An extension with the name ${targetName} already exists in the project, but is registered with a different bundle identifier.` +
+          ` The existing extension will not be modified. In order to apply a new bundle identifier run the prebuild command with \`--clean\` flag`
+      );
+    }
+    if (conflict_status === 'exists') {
+      console.warn(
+        `Expo-sharing: Target with bundleId: ${bundleIdentifier} already exists in the project and will not be added`
+      );
+      return config;
+    }
+
+    const xcConfigurationList = addXCConfigurationList(
+      xcodeProject,
+      targetName,
+      bundleIdentifier,
+      deploymentTarget,
+      config.ios?.buildNumber ?? '1',
+      config.version ?? '1.0'
+    );
+
+    const productFile = addProductFile(xcodeProject, targetName, groupName);
+
+    const pbxNativeTargetObject = addToPbxNativeTargetSection(
+      xcodeProject,
+      targetName,
+      targetUuid,
+      productFile,
+      xcConfigurationList
+    );
+
+    addToPbxProjectSection(xcodeProject, pbxNativeTargetObject);
+
+    addBuildPhases(
+      xcodeProject,
+      targetUuid,
+      targetName,
+      groupName,
+      productFile,
+      shareExtensionFiles,
+      platformProjectRoot
+    );
+
+    addPbxGroup(xcodeProject, targetName, shareExtensionFiles, platformProjectRoot);
+    return config;
+  });
+};

--- a/packages/expo-sharing/plugin/src/ios/xcode/addBuildPhases.ts
+++ b/packages/expo-sharing/plugin/src/ios/xcode/addBuildPhases.ts
@@ -1,0 +1,80 @@
+import { XcodeProject } from '@expo/config-plugins';
+import path from 'path';
+
+import { getSharedFilesPath } from '../../utils';
+import { ShareExtensionFiles } from '../setupShareExtensionFiles';
+
+export function addBuildPhases(
+  xcodeProject: XcodeProject,
+  targetUuid: string,
+  targetName: string,
+  groupName: string,
+  productFile: {
+    uuid: string;
+    target: string;
+    basename: string;
+    group: string;
+  },
+  shareExtensionFiles: ShareExtensionFiles,
+  platformProjectRoot: string
+) {
+  const buildPath = `""`;
+  const sharedFilesPath = getSharedFilesPath();
+  const folderType = 'app_extension';
+
+  const { swiftFiles, intentFiles, assetDirectories, sharedFiles } = shareExtensionFiles;
+
+  // Gets the location of the shared files relative to the extension directory
+  const sharedSwiftFiles =
+    sharedFiles?.swiftFiles
+      .map((file) => path.join(sharedFilesPath, file))
+      .map((file) => {
+        const shareExtensionDirectory = path.join(platformProjectRoot, targetName, 'shared');
+        return path.relative(shareExtensionDirectory, file);
+      }) || [];
+
+  xcodeProject.addBuildPhase(
+    [...swiftFiles, ...intentFiles, ...sharedSwiftFiles],
+    'PBXSourcesBuildPhase',
+    groupName,
+    targetUuid,
+    folderType,
+    buildPath
+  );
+
+  xcodeProject.addBuildPhase(
+    [],
+    'PBXCopyFilesBuildPhase',
+    groupName,
+    xcodeProject.getFirstTarget().uuid,
+    folderType,
+    buildPath
+  );
+
+  xcodeProject
+    .buildPhaseObject('PBXCopyFilesBuildPhase', groupName, productFile.target)
+    .files.push({
+      value: productFile.uuid,
+      comment: `${productFile.basename} in ${productFile.group}`,
+    });
+
+  xcodeProject.addToPbxBuildFileSection(productFile);
+
+  xcodeProject.addBuildPhase(
+    [],
+    'PBXFrameworksBuildPhase',
+    groupName,
+    targetUuid,
+    folderType,
+    buildPath
+  );
+
+  xcodeProject.addBuildPhase(
+    [...assetDirectories],
+    'PBXResourcesBuildPhase',
+    groupName,
+    targetUuid,
+    folderType,
+    buildPath
+  );
+}

--- a/packages/expo-sharing/plugin/src/ios/xcode/addPbxGroup.ts
+++ b/packages/expo-sharing/plugin/src/ios/xcode/addPbxGroup.ts
@@ -1,0 +1,44 @@
+import { XcodeProject } from '@expo/config-plugins';
+import path from 'path';
+
+import { getSharedFilesPath } from '../../utils';
+import { ShareExtensionFiles } from '../setupShareExtensionFiles';
+
+export function addPbxGroup(
+  xcodeProject: XcodeProject,
+  targetName: string,
+  shareExtensionFiles: ShareExtensionFiles,
+  platformProjectRoot: string
+) {
+  const sharedFilesPath = getSharedFilesPath();
+
+  const targetFiles = Object.values({
+    ...shareExtensionFiles,
+    sharedFiles: [],
+  }).flat();
+
+  // Add generated files
+  targetFiles.push(`${targetName}.entitlements`);
+  targetFiles.push(`Info.plist`);
+
+  const sharedFiles = Object.values(shareExtensionFiles.sharedFiles ?? [])
+    .flat()
+    .map((file) => path.join(sharedFilesPath, file))
+    .map((file) => path.relative(path.join(platformProjectRoot, targetName, 'shared'), file));
+
+  const { uuid: mainGroupUuid } = xcodeProject.addPbxGroup(targetFiles, targetName, targetName);
+  const { uuid: sharedGroupUuid } = xcodeProject.addPbxGroup(sharedFiles, 'shared', 'shared');
+
+  if (mainGroupUuid && sharedGroupUuid) {
+    xcodeProject.addToPbxGroup(sharedGroupUuid, mainGroupUuid);
+  }
+
+  const groups = xcodeProject.hash.project.objects['PBXGroup'];
+  if (mainGroupUuid) {
+    Object.keys(groups).forEach((key) => {
+      if (!groups[key].name && !groups[key].path) {
+        xcodeProject.addToPbxGroup(mainGroupUuid, key);
+      }
+    });
+  }
+}

--- a/packages/expo-sharing/plugin/src/ios/xcode/addProductFile.ts
+++ b/packages/expo-sharing/plugin/src/ios/xcode/addProductFile.ts
@@ -1,0 +1,17 @@
+import { XcodeProject } from '@expo/config-plugins';
+
+export function addProductFile(xcodeProject: XcodeProject, targetName: string, groupName: string) {
+  const options = {
+    basename: `${targetName}.appex`,
+    group: groupName,
+    explicitFileType: 'wrapper.app-extension',
+    settings: {
+      ATTRIBUTES: ['RemoveHeadersOnCopy'],
+    },
+    includeInIndex: 0,
+    path: `${targetName}.appex`,
+    sourceTree: 'BUILT_PRODUCTS_DIR',
+  };
+
+  return xcodeProject.addProductFile(targetName, options);
+}

--- a/packages/expo-sharing/plugin/src/ios/xcode/addToPbxNativeTargetSection.ts
+++ b/packages/expo-sharing/plugin/src/ios/xcode/addToPbxNativeTargetSection.ts
@@ -1,0 +1,28 @@
+import { XcodeProject } from '@expo/config-plugins';
+
+export function addToPbxNativeTargetSection(
+  xcodeProject: XcodeProject,
+  targetName: string,
+  targetUuid: string,
+  productFile: { fileRef: string },
+  xcConfigurationList: { uuid: string }
+) {
+  const target = {
+    uuid: targetUuid,
+    pbxNativeTarget: {
+      isa: 'PBXNativeTarget',
+      name: targetName,
+      productName: targetName,
+      productReference: productFile.fileRef,
+      productType: `"com.apple.product-type.app-extension"`,
+      buildConfigurationList: xcConfigurationList.uuid,
+      buildPhases: [],
+      buildRules: [],
+      dependencies: [],
+    },
+  };
+
+  xcodeProject.addToPbxNativeTargetSection(target);
+
+  return target;
+}

--- a/packages/expo-sharing/plugin/src/ios/xcode/addToPbxProjectSection.ts
+++ b/packages/expo-sharing/plugin/src/ios/xcode/addToPbxProjectSection.ts
@@ -1,0 +1,17 @@
+import { XcodeProject } from '@expo/config-plugins';
+
+export function addToPbxProjectSection(xcodeProject: XcodeProject, target: { uuid: string }) {
+  xcodeProject.addToPbxProjectSection(target);
+
+  const projectUuid = xcodeProject.getFirstProject().uuid;
+  const projectSection = xcodeProject.pbxProjectSection()[projectUuid];
+  if (!projectSection.attributes.TargetAttributes) {
+    projectSection.attributes.TargetAttributes = {};
+  }
+
+  projectSection.attributes.TargetAttributes[target.uuid] = {
+    LastSwiftMigration: 1250, // Adds the Swift 5.0 target migration attribute to avoid "Convert to Current Swift Syntax" warning
+    ProvisioningStyle: 'Automatic', // Uses "Automatically manage signing" by default
+    CreatedOnToolsVersion: '15.1',
+  };
+}

--- a/packages/expo-sharing/plugin/src/ios/xcode/addXCConfigurationList.ts
+++ b/packages/expo-sharing/plugin/src/ios/xcode/addXCConfigurationList.ts
@@ -1,0 +1,81 @@
+import { XcodeProject } from '@expo/config-plugins';
+
+export function addXCConfigurationList(
+  xcodeProject: XcodeProject,
+  targetName: string,
+  bundleIdentifier: string,
+  deploymentTarget: string,
+  currentProjectVersion: string,
+  marketingVersion: string
+) {
+  // Based on the default output of Xcode when adding a sharing extension target
+  const commonSettings = {
+    ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS: 'YES',
+    CLANG_ANALYZER_NONNULL: 'YES',
+    CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION: 'YES_AGGRESSIVE',
+    CODE_SIGN_STYLE: 'Automatic',
+    CODE_SIGN_ENTITLEMENTS: `"${targetName}/${targetName}.entitlements"`,
+    CURRENT_PROJECT_VERSION: `"${currentProjectVersion}"`,
+    ENABLE_USER_SCRIPT_SANDBOXING: 'YES',
+    GENERATE_INFOPLIST_FILE: 'NO',
+    INFOPLIST_FILE: `"${targetName}/Info.plist"`,
+    INFOPLIST_KEY_CFBundleDisplayName: `"${targetName}"`,
+    INFOPLIST_KEY_NSHumanReadableCopyright: '""',
+    IPHONEOS_DEPLOYMENT_TARGET: `"${deploymentTarget}"`,
+    LD_RUNPATH_SEARCH_PATHS: [
+      '"$(inherited)"',
+      '"@executable_path/Frameworks"',
+      '"@executable_path/../../Frameworks"',
+    ],
+    LOCALIZATION_PREFERS_STRING_CATALOGS: 'YES',
+    MARKETING_VERSION: `${marketingVersion}`,
+    MTL_FAST_MATH: 'YES',
+    PRODUCT_BUNDLE_IDENTIFIER: `"${bundleIdentifier}"`,
+    PRODUCT_NAME: '"$(TARGET_NAME)"',
+    SKIP_INSTALL: 'YES',
+    STRING_CATALOG_GENERATE_SYMBOLS: 'YES',
+    SWIFT_APPROACHABLE_CONCURRENCY: 'YES',
+    SWIFT_EMIT_LOC_STRINGS: 'YES',
+    SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY: 'YES',
+    SWIFT_VERSION: '5.0',
+    TARGETED_DEVICE_FAMILY: '"1,2"',
+  };
+
+  const debugSpecifics = {
+    DEBUG_INFORMATION_FORMAT: 'dwarf',
+    MTL_ENABLE_DEBUG_INFO: 'INCLUDE_SOURCE',
+    SWIFT_ACTIVE_COMPILATION_CONDITIONS: '"DEBUG $(inherited)"',
+    SWIFT_OPTIMIZATION_LEVEL: '"-Onone"',
+  };
+
+  const releaseSpecifics = {
+    COPY_PHASE_STRIP: 'NO',
+    DEBUG_INFORMATION_FORMAT: '"dwarf-with-dsym"',
+    SWIFT_COMPILATION_MODE: 'wholemodule',
+  };
+
+  const xCConfigurationList = [
+    {
+      name: 'Debug',
+      isa: 'XCBuildConfiguration',
+      buildSettings: {
+        ...commonSettings,
+        ...debugSpecifics,
+      },
+    },
+    {
+      name: 'Release',
+      isa: 'XCBuildConfiguration',
+      buildSettings: {
+        ...commonSettings,
+        ...releaseSpecifics,
+      },
+    },
+  ];
+
+  return xcodeProject.addXCConfigurationList(
+    xCConfigurationList,
+    'Release',
+    `Build configuration list for PBXNativeTarget "${targetName}"`
+  );
+}

--- a/packages/expo-sharing/plugin/src/sharingPlugin.types.ts
+++ b/packages/expo-sharing/plugin/src/sharingPlugin.types.ts
@@ -1,0 +1,43 @@
+export type SingleShareAction = 'android.intent.action.SEND';
+export type MultiShareAction = 'android.intent.action.SEND_MULTIPLE';
+export type ShareAction = SingleShareAction | MultiShareAction;
+export type IntentFilter = {
+  action: ShareAction;
+  category: 'android.intent.category.DEFAULT';
+  filters: string[];
+  data: {
+    mimeType: string;
+  }[];
+};
+export type SingleIntentFilter = IntentFilter & {
+  action: SingleShareAction;
+};
+
+export type MultiIntentFilter = IntentFilter & {
+  action: MultiShareAction;
+};
+
+export type ActivationRuleOptions = {
+  supportsText?: boolean;
+  supportsWebUrlWithMaxCount?: number;
+  supportsImageWithMaxCount?: number;
+  supportsMovieWithMaxCount?: number;
+  supportsFileWithMaxCount?: number;
+  supportsWebPageWithMaxCount?: number;
+  supportsAttachmentsWithMaxCount?: number;
+};
+export type ActivationRule = ActivationRuleOptions | string;
+
+export type ShareExtensionConfigPluginProps = {
+  ios?: {
+    enabled?: boolean;
+    extensionBundleIdentifier?: string;
+    appGroupId?: string;
+    activationRule?: ActivationRule;
+  };
+  android?: {
+    enabled?: boolean;
+    singleShareMimeTypes?: string[];
+    multipleShareMimeTypes?: string[];
+  };
+};

--- a/packages/expo-sharing/plugin/src/utils.ts
+++ b/packages/expo-sharing/plugin/src/utils.ts
@@ -1,0 +1,11 @@
+import path from 'path';
+
+export function getTemplateFilesPath(platform: 'android' | 'ios') {
+  const packagePath = path.dirname(require.resolve('expo-sharing/package.json'));
+  return path.join(packagePath, '/plugin/template-files/ios');
+}
+
+export function getSharedFilesPath() {
+  const packagePath = path.dirname(require.resolve('expo-sharing/package.json'));
+  return path.join(packagePath, '/ios/shared');
+}

--- a/packages/expo-sharing/plugin/src/withConfig.ts
+++ b/packages/expo-sharing/plugin/src/withConfig.ts
@@ -1,0 +1,99 @@
+import { ConfigPlugin, InfoPlist } from '@expo/config-plugins';
+
+import { createEntitlements, ShareIntoEntitlements } from './ios/createEntitlements';
+
+function addShareIntoEntitlements(
+  existingEntitlements: InfoPlist,
+  shareIntoEntitlements?: ShareIntoEntitlements
+) {
+  if (!shareIntoEntitlements) {
+    return existingEntitlements;
+  }
+
+  for (const key of Object.keys(shareIntoEntitlements)) {
+    const itemsToAdd = shareIntoEntitlements[key];
+    const existingValue = existingEntitlements[key] ?? [];
+
+    if (!Array.isArray(existingValue)) {
+      // Users should never see this error, if you encounter it during development you most likely need to write parsing for the provided type below.
+      throw new Error('Expo-sharing plugin cannot handle this entitlement. Update the plugin.');
+    }
+
+    const typedExistingValue = existingValue as string[];
+
+    for (const item of itemsToAdd) {
+      if (!typedExistingValue.includes(item)) {
+        typedExistingValue.push(item);
+      }
+    }
+
+    existingEntitlements[key] = typedExistingValue;
+  }
+
+  return existingEntitlements;
+}
+
+export const withConfig: ConfigPlugin<{
+  bundleIdentifier: string;
+  targetName: string;
+  groupIdentifier: string;
+}> = (config, { bundleIdentifier, targetName, groupIdentifier }) => {
+  let configIndex: null | number = null;
+  config.extra?.eas?.build?.experimental?.ios?.appExtensions?.forEach((ext: any, index: number) => {
+    if (ext.targetName === targetName) {
+      configIndex = index;
+    }
+  });
+
+  if (configIndex === null) {
+    config.extra = {
+      ...config.extra,
+      eas: {
+        ...config.extra?.eas,
+        build: {
+          ...config.extra?.eas?.build,
+          experimental: {
+            ...config.extra?.eas?.build?.experimental,
+            ios: {
+              ...config.extra?.eas?.build?.experimental?.ios,
+              appExtensions: [
+                ...(config.extra?.eas?.build?.experimental?.ios?.appExtensions ?? []),
+                {
+                  targetName,
+                  bundleIdentifier,
+                  entitlements: [],
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+    configIndex = 0;
+  }
+
+  if (config.extra) {
+    const widgetsExtensionConfig =
+      config.extra.eas.build.experimental.ios.appExtensions[configIndex];
+
+    const shareIntoEntitlements = createEntitlements(groupIdentifier);
+
+    addShareIntoEntitlements(widgetsExtensionConfig.entitlements, shareIntoEntitlements);
+
+    if (!config.ios) {
+      throw new Error(
+        'Expo-sharing: the ios config is missing. The project is not configured correctly.'
+      );
+    }
+    if (!config.ios?.entitlements) {
+      config.ios = {
+        ...config.ios,
+        entitlements: {},
+      };
+    }
+
+    addShareIntoEntitlements(config.ios?.entitlements as InfoPlist, shareIntoEntitlements);
+  }
+
+  return config;
+};

--- a/packages/expo-sharing/plugin/template-files/ios/ShareIntoViewController.swift
+++ b/packages/expo-sharing/plugin/template-files/ios/ShareIntoViewController.swift
@@ -1,0 +1,288 @@
+import UIKit
+import Social
+import MobileCoreServices
+import UniformTypeIdentifiers
+import AVFoundation
+
+class ShareIntoViewController: SLComposeServiceViewController {
+  private var hostAppScheme: String? {
+    return Bundle.main.object(forInfoDictionaryKey: "MainTargetUrlScheme") as? String
+  }
+
+  private var appGroupId: String? {
+    return Bundle.main.object(forInfoDictionaryKey: "AppGroupId") as? String
+  }
+
+  // MARK: - Lifecycle
+
+  override func didSelectPost() {
+    // This is called if the standard Apple UI "Post" button is pressed.
+    // Since we are redirecting immediately in viewWillAppear, should never be reached,
+    // but good to have.
+    handleShare()
+  }
+
+  override func viewWillAppear(_ animated: Bool) {
+    // Immediately start processing when view appears
+    handleShare()
+    super.viewWillAppear(animated)
+  }
+
+  // MARK: - Core Logic
+
+  private func handleShare() {
+    guard let items = extensionContext?.inputItems as? [NSExtensionItem] else {
+      self.extensionContext?.completeRequest(returningItems: nil)
+      return
+    }
+
+    Task {
+      let payload = await Task.detached(priority: .userInitiated) {
+        return await self.processInputItems(items)
+      }.value
+
+      if !payload.isEmpty {
+        saveToUserDefaults(payload)
+        openParentApp()
+      } else {
+        self.extensionContext?.completeRequest(returningItems: nil, completionHandler: nil)
+      }
+    }
+  }
+
+  nonisolated private func processInputItems(_ items: [NSExtensionItem]) async -> [SharePayload] {
+    var results: [SharePayload] = []
+
+    for item in items {
+      guard let attachments = item.attachments else { continue }
+
+      for provider in attachments {
+        if let payload = await parseProvider(provider) {
+          results.append(payload)
+        }
+      }
+    }
+
+    return results
+  }
+
+  private func saveToUserDefaults(_ payload: [SharePayload]) {
+    guard let userDefaults = UserDefaults(suiteName: appGroupId) else {
+      print("Error: Expo-sharing could not initialize UserDefaults with group: \(appGroupId ?? "unresolved group id")")
+      return
+    }
+
+    if let encoded = try? JSONEncoder().encode(payload) {
+      userDefaults.set(encoded, forKey: SHARE_INTO_DEFAULTS_KEY)
+      userDefaults.synchronize()
+    }
+  }
+
+  // MARK: - Provider Parsing
+
+  private func parseProvider(_ provider: NSItemProvider) async -> SharePayload? {
+    guard let appGroupId else {
+      print("Error: Expo-sharing has failed to resolve the appGroupId, the shared data cannot be processed")
+      return nil
+    }
+
+    if provider.hasItemConformingToTypeIdentifier(UTType.url.identifier) &&
+    !provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
+      return await handleWebURL(provider)
+    }
+
+    if provider.hasItemConformingToTypeIdentifier(UTType.audio.identifier) {
+      return await handleFile(provider, type: .audio, utType: .audio, appGroupId: appGroupId)
+    }
+
+    if provider.hasItemConformingToTypeIdentifier(UTType.movie.identifier) {
+      return await handleFile(provider, type: .video, utType: .movie, appGroupId: appGroupId)
+    }
+
+    if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier) {
+      return await handleFile(provider, type: .image, utType: .image, appGroupId: appGroupId)
+    }
+
+    if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) ||
+    provider.hasItemConformingToTypeIdentifier(UTType.pdf.identifier) {
+      return await handleFile(provider, type: .file, utType: .data, appGroupId: appGroupId)
+    }
+
+    if provider.hasItemConformingToTypeIdentifier(UTType.text.identifier) {
+      return await handleText(provider)
+    }
+
+    return nil
+  }
+
+  // MARK: - Handlers
+
+  private func handleText(_ provider: NSItemProvider) async -> SharePayload? {
+    return await withCheckedContinuation { continuation in
+      provider.loadItem(forTypeIdentifier: UTType.text.identifier, options: nil) { item, _ in
+        guard let text = item as? String else {
+          continuation.resume(returning: nil)
+          return
+        }
+
+        let payload = SharePayload(
+          type: .text,
+          value: text,
+          mimeType: "text/plain",
+          metadata: nil
+        )
+        continuation.resume(returning: payload)
+      }
+    }
+  }
+
+  private func handleWebURL(_ provider: NSItemProvider) async -> SharePayload? {
+    return await withCheckedContinuation { continuation in
+      provider.loadItem(forTypeIdentifier: UTType.url.identifier, options: nil) { item, _ in
+        guard let url = item as? URL else {
+          continuation.resume(returning: nil)
+          return
+        }
+
+        let payload = SharePayload(
+          type: .url,
+          value: url.absoluteString,
+          mimeType: "text/html",
+          metadata: nil
+        )
+        continuation.resume(returning: payload)
+      }
+    }
+  }
+
+  private func handleFile(_ provider: NSItemProvider, type: ShareType, utType: UTType, appGroupId: String) async -> SharePayload? {
+    return await withCheckedContinuation { continuation in
+      let identifier = provider.registeredTypeIdentifiers.first { providerIdentifier in
+        UTType(providerIdentifier)?.conforms(to: utType) ?? false
+      } ?? utType.identifier
+
+      provider.loadItem(forTypeIdentifier: identifier, options: nil) { item, _ in
+        if let url = item as? URL {
+          let result = self.copyAndProcessFile(url: url, type: type, appGroupId: appGroupId)
+          continuation.resume(returning: result)
+          return
+        }
+
+        if let data = item as? Data {
+          let ext = UTType(identifier)?.preferredFilenameExtension ?? "dat"
+          let fileName = UUID().uuidString + "." + ext
+          let result = self.saveDataToAppGroup(
+            data: data,
+            fileName: fileName,
+            type: type,
+            mimeType: UTType(identifier)?.preferredMIMEType,
+            appGroupId: appGroupId
+          )
+          continuation.resume(returning: result)
+          return
+        }
+
+        if type == .image, let image = item as? UIImage, let data = image.pngData() {
+          let fileName = UUID().uuidString + ".png"
+          let result = self.saveDataToAppGroup(data: data, fileName: fileName, type: .image, mimeType: "image/png", appGroupId: appGroupId)
+          continuation.resume(returning: result)
+          return
+        }
+
+        continuation.resume(returning: nil)
+      }
+    }
+  }
+
+  // MARK: - File Management
+
+  private func copyAndProcessFile(url: URL, type: ShareType, appGroupId: String) -> SharePayload? {
+    guard let containerURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupId) else {
+      return nil
+    }
+
+    let fileName = url.lastPathComponent.isEmpty ? UUID().uuidString : url.lastPathComponent
+    let destinationURL = containerURL.appendingPathComponent(fileName)
+
+    do {
+      if FileManager.default.fileExists(atPath: destinationURL.path) {
+        try FileManager.default.removeItem(at: destinationURL)
+      }
+      try FileManager.default.copyItem(at: url, to: destinationURL)
+    } catch {
+      print("Error copying file: \(error)")
+      return nil
+    }
+
+    let size = (try? FileManager.default.attributesOfItem(atPath: destinationURL.path)[.size] as? Int)
+    let fileExt = destinationURL.pathExtension
+    let mimeType = UTType(filenameExtension: fileExt)?.preferredMIMEType ?? "application/octet-stream"
+
+    let metadata = ShareMetadata(
+      originalName: fileName,
+      size: size
+    )
+
+    return SharePayload(
+      type: type,
+      value: destinationURL.absoluteString,
+      mimeType: mimeType,
+      metadata: metadata
+    )
+  }
+
+  private func saveDataToAppGroup(data: Data, fileName: String, type: ShareType, mimeType: String?, appGroupId: String) -> SharePayload? {
+    guard let containerURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupId) else {
+      return nil
+    }
+    let destinationURL = containerURL.appendingPathComponent(fileName)
+
+    do {
+      try data.write(to: destinationURL)
+    } catch {
+      return nil
+    }
+
+    return SharePayload(
+      type: type,
+      value: destinationURL.absoluteString,
+      mimeType: mimeType ?? "application/octet-stream",
+      metadata: ShareMetadata(originalName: fileName, size: data.count)
+    )
+  }
+
+  // MARK: - Open main app
+
+  @MainActor
+  func openParentApp() {
+    guard let hostAppScheme else {
+      print("Error: Expo-sharing has failed to fetch the host app scheme. Cancelling the share request.")
+      self.close()
+      return
+    }
+
+    guard let url = URL(string: "\(hostAppScheme)://expo-sharing") else {
+      return
+    }
+
+    openURL(url)
+    self.close()
+  }
+
+  // This is a hack that allows us to open the main app target from a share-extension target. Technically this is really
+  // discouraged by apple, but I've found that multiple apps exist that use this method and pass the App Store review
+  // (TikTok for example). We should be good, as long as we mention this as a possible future instability in the docs.
+  private func openURL(_ url: URL) {
+    var responder: UIResponder? = self
+    while responder != nil {
+      if let application = responder as? UIApplication {
+        application.open(url, options: [:], completionHandler: nil)
+      }
+      responder = responder?.next
+    }
+  }
+
+  private func close() {
+    self.extensionContext?.completeRequest(returningItems: nil, completionHandler: nil)
+  }
+}

--- a/packages/expo-sharing/plugin/tsconfig.json
+++ b/packages/expo-sharing/plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "expo-module-scripts/tsconfig.plugin",
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src"
+  },
+  "include": ["./src"],
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+}


### PR DESCRIPTION
# Why

Adds a config plugin, which adds appropiate sharing target on iOS and intent filters on Android.

# How

The plugin adds a `share-extension` target, which makes the app appear in the system sharing bottom sheet. One a share is received the main app is opened with a deeplink. Subsequent PRs include code for handling the data. 

On Android we just need to add some intent filters.

You can check out  `ShareExtensionConfigPluginProps` for possible configuration options of the plugin.

On iOS opening the main target from a sharing extension is unsupported and generally discouraged, but possible with a hack (see `template-files/ShareIntoViewController`).  This is not guaranteed to work in future iOS versions and is the main roadblock in marking these changes as non-experimental. Based on other similar libraries and information on the web I can pretty confidently say, that this hack will not cause apps to be rejected from the App Store though.

There is some stuff, like data structures, that we'd like to share between the extension target and the main-target. Such files are stored in the `ios/shared` directory and are automatically linked with the target during the prebuild.

Here is how a sample plugin configuration would look like in an app

```
      [
        "expo-sharing",
        {
          "ios": {
            "enabled": true,
            "activationRule": {
              "supportsText": 1,
              "supportsWebUrlWithMaxCount": 1,
              "supportsImageWithMaxCount": 2,
              "supportsMovieWithMaxCount": 3,
              "supportsFileWithMaxCount": 4,
              "supportsWebPageWithMaxCount": 5,
              "supportsAttachmentsWithMaxCount": 6
            }
          },
          "android": {
            "enabled": true,
            "singleShareMimeTypes": [
              "image/*",
              "application/*",
              "text/*",
              "video/*"
            ],
            "multipleShareMimeTypes": [
              "image/*",
              "application/*",
              "text/*",
              "video/*"
            ]
          }
        }
      ]
 ```
 
 iOS activation rule can also be a string 

# Test Plan

Tested on iOS and Android

Functionality demo:

https://github.com/user-attachments/assets/d2caa3b8-d861-4113-83a7-ca49281d59b7


