### PR TITLE
[expo/cli] json output mode

### DIFF
--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -4,6 +4,10 @@ import chalk from 'chalk';
 import Debug from 'debug';
 import { boolish } from 'getenv';
 
+// JSONL interceptor - must be installed before any output occurs
+import { installJsonlInterceptor } from '../src/utils/jsonl';
+installJsonlInterceptor();
+
 // Setup before requiring `debug`.
 if (boolish('EXPO_DEBUG', false)) {
   Debug.enable('expo:*');

--- a/packages/@expo/cli/src/start/interface/interactiveActions.ts
+++ b/packages/@expo/cli/src/start/interface/interactiveActions.ts
@@ -67,11 +67,12 @@ export class DevServerManagerActions {
           );
         }
       } catch (error) {
-        console.log('err', error);
         // @ts-ignore: If there is no development build scheme, then skip the QR code.
         if (error.code !== 'NO_DEV_CLIENT_SCHEME') {
+          console.error('Failed to print QR code:', error);
           throw error;
         } else {
+          console.error('No development build scheme found:', error);
           const serverUrl = devServer.getDevServerUrl();
           Log.log(printItem(chalk`Metro waiting on {underline ${serverUrl}}`));
           Log.log(printItem(`Linking is disabled because the client scheme cannot be resolved.`));

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -298,6 +298,23 @@ class Env {
   get EXPO_UNSTABLE_BONJOUR(): boolean {
     return boolish('EXPO_UNSTABLE_BONJOUR', false);
   }
+
+  /**
+   * Enable JSONL output mode for machine-readable output
+   * If set to a string, it will be used as a path for the JSONL output.
+   * If set to a boolish value, it will be used as a flag
+   * to enable/disable JSONL output in stdout.
+   */
+  get EXPO_UNSTABLE_JSONL_OUTPUT(): boolean | string {
+    const value = string('EXPO_UNSTABLE_JSONL_OUTPUT', '');
+    const valueNormalized = value.toLowerCase();
+    if (['0', 'false', ''].includes(valueNormalized)) {
+      return false;
+    } else if (['1', 'true'].includes(valueNormalized)) {
+      return true;
+    }
+    return value;
+  }
 }
 
 export const env = new Env();

--- a/packages/@expo/cli/src/utils/interactive.ts
+++ b/packages/@expo/cli/src/utils/interactive.ts
@@ -2,5 +2,5 @@ import { env } from './env';
 
 /** @returns `true` if the process is interactive. */
 export function isInteractive(): boolean {
-  return !env.CI && process.stdout.isTTY;
+  return !env.CI && !env.EXPO_UNSTABLE_JSONL_OUTPUT && process.stdout.isTTY;
 }

--- a/packages/@expo/cli/src/utils/jsonl.ts
+++ b/packages/@expo/cli/src/utils/jsonl.ts
@@ -1,0 +1,320 @@
+import fs from 'fs';
+import path from 'path';
+
+import { stripAnsi } from './ansi';
+import { env } from './env';
+
+// Save original write functions BEFORE any patching
+const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+
+/** Get the output file path if EXPO_UNSTABLE_JSONL_OUTPUT is a path string */
+function getOutputFilePath(): string | null {
+  const value = env.EXPO_UNSTABLE_JSONL_OUTPUT;
+  if (typeof value === 'string') {
+    try {
+      fs.mkdirSync(path.dirname(value), { recursive: true });
+    } catch (error) {
+      // Silently ignore, the process will error on write if the directory does not exist
+    }
+    return path.resolve(value);
+  }
+  return null;
+}
+
+/** Base event */
+export interface JsonlEvent {
+  type: string;
+  timestamp: number; // Unix timestamp in milliseconds
+}
+
+/** Console output from JS runtime */
+export interface JsonlConsoleEvent extends JsonlEvent {
+  type:
+    | 'console.log'
+    | 'console.error'
+    | 'console.warn'
+    | 'console.debug'
+    | 'console.info'
+    | 'console.trace'
+    | 'console.group'
+    | 'console.groupCollapsed'
+    | 'console.groupEnd';
+  source: 'server' | 'client';
+  platform?: 'ios' | 'android' | 'web'; // Extracted from bundle URL in stack traces
+  value: string;
+}
+
+/** Generic stdout/stderr output from CLI */
+export interface JsonlStdEvent extends JsonlEvent {
+  type: 'stdout' | 'stderr';
+  value: string;
+}
+
+/** Bundling started */
+export interface JsonlBundlingStartedEvent extends JsonlEvent {
+  type: 'bundling.started';
+  id: string;
+  platform: 'ios' | 'android' | 'web' | string;
+  path: string;
+  environment?: 'client' | 'node' | 'react-server'; // For SSR, API routes, RSC
+}
+
+/** Bundling progress */
+export interface JsonlBundlingProgressEvent extends JsonlEvent {
+  type: 'bundling.progress';
+  id: string;
+  progress: number; // 0-1
+  files: {
+    total: number;
+    current: number;
+  };
+}
+
+/** Bundling completed successfully */
+export interface JsonlBundlingDoneEvent extends JsonlEvent {
+  type: 'bundling.done';
+  id: string;
+  duration: number | undefined; // milliseconds
+  modules: {
+    total: number;
+  };
+}
+
+/** Bundling error (combined failure + error details) */
+export interface JsonlBundlingErrorEvent extends JsonlEvent {
+  type: 'bundling.error';
+  id?: string;
+  value: string; // Error message
+  duration?: number; // milliseconds (if available)
+}
+
+export type JsonlEventType =
+  | JsonlConsoleEvent
+  | JsonlStdEvent
+  | JsonlBundlingStartedEvent
+  | JsonlBundlingProgressEvent
+  | JsonlBundlingDoneEvent
+  | JsonlBundlingErrorEvent;
+
+/** Payload type for emit method (without timestamp) */
+type JsonlEventPayload =
+  | Omit<JsonlConsoleEvent, 'timestamp'>
+  | Omit<JsonlStdEvent, 'timestamp'>
+  | Omit<JsonlBundlingStartedEvent, 'timestamp'>
+  | Omit<JsonlBundlingProgressEvent, 'timestamp'>
+  | Omit<JsonlBundlingDoneEvent, 'timestamp'>
+  | Omit<JsonlBundlingErrorEvent, 'timestamp'>;
+
+export class JsonlReporter {
+  private outputFilePath: string | null;
+
+  constructor() {
+    this.outputFilePath = getOutputFilePath();
+  }
+
+  get isEnabled(): boolean {
+    return !!env.EXPO_UNSTABLE_JSONL_OUTPUT;
+  }
+
+  /** Get the output file path (null if writing to stdout) */
+  getOutputFilePath(): string | null {
+    return this.outputFilePath;
+  }
+
+  /** Emit a JSONL event to stdout or file */
+  public emit(event: JsonlEventPayload): boolean {
+    const eventWithTimestamp = { ...event, timestamp: Date.now() };
+    const line = JSON.stringify(eventWithTimestamp) + '\n';
+
+    if (this.outputFilePath) {
+      // Append to file
+      // TODO: Consider using async queue to write to file
+      fs.appendFileSync(this.outputFilePath, line);
+    } else {
+      // Write to stdout using the original (unpatched) write function
+      originalStdoutWrite(line);
+    }
+    return true;
+  }
+
+  /** Emit stdout output */
+  public emitStdout(value: string): boolean {
+    return this.emit({ type: 'stdout', value: stripAnsi(value) ?? '' });
+  }
+
+  /** Emit stderr output */
+  public emitStderr(value: string): boolean {
+    return this.emit({ type: 'stderr', value: stripAnsi(value) ?? '' });
+  }
+
+  /** Emit console log from client or server */
+  public emitConsole(options: {
+    level:
+      | 'log'
+      | 'error'
+      | 'warn'
+      | 'debug'
+      | 'info'
+      | 'trace'
+      | 'group'
+      | 'groupCollapsed'
+      | 'groupEnd';
+    source: 'server' | 'client';
+    platform?: 'ios' | 'android' | 'web';
+    value: string | any[];
+  }): boolean {
+    return this.emit({
+      type: `console.${options.level}`,
+      source: options.source,
+      platform: options.platform,
+      value: Array.isArray(options.value)
+        ? // Due to serialization on the client side, these will mostly be arrays of strings
+          // but to be safe, we stringify the array. Eventually we would like to send the as-is.
+          // To get more detailed logs.
+          options.value.map((item: unknown) => String(item)).join(' ')
+        : String(options.value),
+    });
+  }
+
+  /** Emit console log from server */
+  public emitServerLog(options: {
+    level: 'info' | 'warn' | 'error' | undefined;
+    value: string | any[];
+  }): boolean {
+    return this.emitConsole({
+      level: options.level ?? 'log',
+      source: 'server',
+      value: options.value,
+    });
+  }
+
+  /** Emit bundling started event */
+  public emitBundlingStarted(options: {
+    id: string;
+    platform: string;
+    path: string;
+    environment?: 'client' | 'node' | 'react-server';
+  }): boolean {
+    return this.emit({
+      type: 'bundling.started',
+      id: options.id,
+      platform: options.platform,
+      path: options.path,
+      environment: options.environment,
+    });
+  }
+
+  /** Emit bundling progress event */
+  public emitBundlingProgress(options: {
+    id: string;
+    progress: number;
+    total: number;
+    current: number;
+  }): boolean {
+    return this.emit({
+      type: 'bundling.progress',
+      id: options.id,
+      progress: options.progress,
+      files: {
+        total: options.total,
+        current: options.current,
+      },
+    });
+  }
+
+  /** Emit bundling done event */
+  public emitBundlingDone(options: {
+    id: string;
+    duration: number | undefined;
+    totalModules: number;
+  }): boolean {
+    return this.emit({
+      type: 'bundling.done',
+      id: options.id,
+      duration: options.duration,
+      modules: {
+        total: options.totalModules,
+      },
+    });
+  }
+
+  /** Emit bundling error event */
+  public emitBundlingError(options: {
+    id: string | undefined;
+    value: string;
+    duration?: number;
+    filename?: string;
+    lineNumber?: number;
+    column?: number;
+  }): boolean {
+    return this.emit({
+      type: 'bundling.error',
+      id: options.id,
+      value: stripAnsi(options.value) ?? '',
+      duration: options.duration,
+    });
+  }
+}
+
+let reporterInstance: JsonlReporter | null = null;
+
+/** Get the singleton JSONL reporter instance */
+export function getJsonlReporter(): JsonlReporter {
+  if (!reporterInstance) {
+    if (env.EXPO_UNSTABLE_JSONL_OUTPUT) {
+      reporterInstance = new JsonlReporter();
+    } else {
+      // Use noop reporter
+      reporterInstance = {
+        get isEnabled(): boolean {
+          return false;
+        },
+        getOutputFilePath: () => null,
+        emit: () => false,
+        emitStdout: () => false,
+        emitStderr: () => false,
+        emitConsole: () => false,
+        emitServerLog: () => false,
+        emitBundlingStarted: () => false,
+        emitBundlingProgress: () => false,
+        emitBundlingDone: () => false,
+        emitBundlingError: () => false,
+      } as unknown as JsonlReporter;
+    }
+  }
+  return reporterInstance;
+}
+
+/** Install JSONL interceptor to patch process.stdout.write and process.stderr.write */
+export function installJsonlInterceptor(): void {
+  if (!env.EXPO_UNSTABLE_JSONL_OUTPUT) return;
+
+  const reporter = getJsonlReporter();
+  const outputFilePath = reporter.getOutputFilePath();
+
+  // If writing to a file, print a message to stdout to inform users
+  if (outputFilePath) {
+    originalStdoutWrite(`JSONL output is being written to: ${outputFilePath}\n`);
+  }
+
+  // Patch stdout
+  process.stdout.write = (chunk: any, encoding?: any, callback?: any) => {
+    const str = typeof chunk === 'string' ? chunk : chunk.toString();
+    reporter.emitStdout(str);
+
+    // Call callback if provided (for stream compatibility)
+    if (typeof encoding === 'function') encoding();
+    else if (typeof callback === 'function') callback();
+    return true;
+  };
+
+  // Patch stderr
+  process.stderr.write = (chunk: any, encoding?: any, callback?: any) => {
+    const str = typeof chunk === 'string' ? chunk : chunk.toString();
+    reporter.emitStderr(str);
+
+    if (typeof encoding === 'function') encoding();
+    else if (typeof callback === 'function') callback();
+    return true;
+  };
+}

--- a/packages/@expo/cli/src/utils/jsonl.ts
+++ b/packages/@expo/cli/src/utils/jsonl.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 import { stripAnsi } from './ansi';
 import { env } from './env';
@@ -13,6 +13,7 @@ function getOutputFilePath(): string | null {
   if (typeof value === 'string') {
     try {
       fs.mkdirSync(path.dirname(value), { recursive: true });
+      fs.writeFileSync(value, '');
     } catch (error) {
       // Silently ignore, the process will error on write if the directory does not exist
     }

--- a/packages/@expo/cli/src/utils/progress.ts
+++ b/packages/@expo/cli/src/utils/progress.ts
@@ -1,5 +1,7 @@
 import ProgressBar from 'progress';
 
+import { env } from './env';
+
 let currentProgress: ProgressBar | null = null;
 
 export function setProgressBar(bar: ProgressBar | null): void {
@@ -11,6 +13,11 @@ export function getProgressBar(): ProgressBar | null {
 }
 
 export function createProgressBar(barFormat: string, options: ProgressBar.ProgressBarOptions) {
+  // Disable progress bars in JSONL mode
+  if (env.EXPO_UNSTABLE_JSONL_OUTPUT) {
+    return null;
+  }
+
   if (process.stderr.clearLine == null) {
     return null;
   }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Adds machine-readable JSONL (JSON Lines) output support via `EXPO_UNSTABLE_JSONL_OUTPUT` environment variable for programmatic consumption of CLI output.

Example of the output, prettified.

```jsonl
{
  "type": "stdout",
  "value": "env: load .env",
  "timestamp": 1768600122154
}
{
  "type": "stdout",
  "value": "env: export EXPO_PUBLIC_TEST_VALUE EXPO_NOT_PUBLIC_TEST_VALUE EXPO_SKIP_MANIFEST_VALIDATION_TOKEN EXPO_NO_TELEMETRY TEST_SECRET_VALUE EXPO_UNSTABLE_LOG_BOX EXPO_DEBUG_LOG_BOX APPLE_BUNDLE_ID",
  "timestamp": 1768600122154
}
{
  "type": "stdout",
  "value": "Starting project at /Users/krystofwoldrich/expo/macau/apps/router-e2e",
  "timestamp": 1768600122190
}
{
  "type": "stderr",
  "value": "Experimental Expo LogBox is enabled.",
  "timestamp": 1768600122466
}
{
  "type": "stderr",
  "value": "Experimental Expo Autolinking module resolver is enabled.",
  "timestamp": 1768600122466
}
{
  "type": "stdout",
  "value": "Starting Metro Bundler",
  "timestamp": 1768600122857
}
{
  "type": "stdout",
  "value": "Waiting on http://localhost:8082",
  "timestamp": 1768600123126
}
{
  "type": "stdout",
  "value": "Logs for your project will appear below.",
  "timestamp": 1768600123126
}
{
  "type": "bundling.started",
  "id": "2",
  "platform": "ios",
  "path": "/Users/krystofwoldrich/expo/macau/packages/expo-router/entry.js",
  "timestamp": 1768600138229
}
{
  "type": "bundling.progress",
  "id": "2",
  "progress": 0,
  "files": {
    "total": 1,
    "current": 0
  },
  "timestamp": 1768600138229
}
{
  "type": "bundling.progress",
  "id": "2",
  "progress": 0,
  "files": {
    "total": 1,
    "current": 0
  },
  "timestamp": 1768600138232
}
{
  "type": "bundling.progress",
  "id": "2",
  "progress": 0.21051903114186848,
  "files": {
    "total": 510,
    "current": 234
  },
  "timestamp": 1768600138333
}
{
  "type": "bundling.progress",
  "id": "2",
  "progress": 0.5018636090106311,
  "files": {
    "total": 926,
    "current": 656
  },
  "timestamp": 1768600138433
}
{
  "type": "bundling.progress",
  "id": "2",
  "progress": 0.8985460069444444,
  "files": {
    "total": 1152,
    "current": 1092
  },
  "timestamp": 1768600138533
}
{
  "type": "bundling.done",
  "id": "2",
  "duration": 363.868208,
  "modules": {
    "total": 1152
  },
  "timestamp": 1768600138593
}
{
  "type": "console.warn",
  "source": "client",
  "value": "Deep imports from the 'react-native' package are deprecated ('react-native/Libraries/NativeComponent/NativeComponentRegistry'). Source: /Users/krystofwoldrich/expo/macau/packages/expo-modules-core/src/NativeViewManagerAdapter.native.tsx 9:0",
  "timestamp": 1768600140019
}
{
  "type": "console.warn",
  "source": "client",
  "value": "Deep imports from the 'react-native' package are deprecated ('react-native/Libraries/Image/AssetSourceResolver'). Source: /Users/krystofwoldrich/expo/macau/packages/expo-asset/build/AssetSourceResolver.native.js 1:0",
  "timestamp": 1768600140020
}
{
  "type": "console.warn",
  "source": "client",
  "value": "Deep imports from the 'react-native' package are deprecated ('react-native/Libraries/Image/resolveAssetSource'). Source: /Users/krystofwoldrich/expo/macau/packages/expo-asset/build/resolveAssetSource.native.js 1:0",
  "timestamp": 1768600140020
}
{
  "type": "console.warn",
  "source": "client",
  "value": "Deep imports from the 'react-native' package are deprecated ('react-native/Libraries/Core/Devtools/getDevServer'). Source: /Users/krystofwoldrich/expo/macau/packages/expo/src/async-require/getDevServer.native.ts 2:0",
  "timestamp": 1768600140020
}
{
  "type": "console.warn",
  "source": "client",
  "value": "Deep imports from the 'react-native' package are deprecated ('react-native/Libraries/Core/Devtools/getDevServer'). Source: /Users/krystofwoldrich/expo/macau/packages/@expo/metro-runtime/src/getDevServer.native.ts 1:0",
  "timestamp": 1768600140020
}

```

# How

<!--
How did you build this feature or fix this bug and why?
-->

- **New `jsonl.ts` module** - JSONL reporter responsible for creating the output events
- **Metro Terminal Reporter integration** - Emits structured bundling events and console logs from client (ios, android, web)/server (api routes)
- **Process-level interception** - Patches stdout/stderr to capture any generic cli output and to avoid breaking the jsonl output
- **Disables visual elements** - Spinners, progress bars, and interactive prompts disabled in JSONL mode

### Event Types

- `console.*` - Client and server console output
- `bundling.started/progress/done/error` - Bundle lifecycle events
- `stdout/stderr` - Generic CLI output

### Usage

currently 

```bash
EXPO_UNSTABLE_JSONL_OUTPUT=1 npx expo start
```

or path to file

```bash
EXPO_UNSTABLE_JSONL_OUTPUT=path/to/file npx expo start
```

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
