### PR TITLE
Change iOS build command to use ios-simulator profile

### DIFF
--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -143,7 +143,7 @@ Edit `development` profile in **eas.json** and set the [`simulator`](/eas/json/#
 }
 ```
 
-<Terminal cmd={['$ eas build --platform ios --profile development']} />
+<Terminal cmd={['$ eas build --platform ios --profile ios-simulator']} />
 
 iOS Simulator builds can only be installed on simulators and not on real devices.
 


### PR DESCRIPTION
Updated the command for building iOS development profiles to use 'ios-simulator' instead of 'development'.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
