### PR TITLE
[docs] add codex support to mcp guide

### DIFF
--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -109,6 +109,26 @@ Click the following link to install the MCP server for Cursor:
 
 </Collapsible>
 
+<Collapsible summary="Codex setup">
+
+Codex stores MCP config in `~/.codex/config.toml` (shared by CLI and IDE).
+
+```
+[mcp_servers.expo]
+url = "https://mcp.expo.dev/mcp"
+```
+
+Then authenticate with OAuth:
+
+<Terminal cmd={['$ codex mcp login expo']} />
+
+**Notes:**
+
+- **Server type**: Streamable HTTP
+- **Authentication**: OAuth
+
+</Collapsible>
+
 </Step>
 
 <Step label="2">

--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -113,7 +113,6 @@ Click the following link to install the MCP server for Cursor:
 
 <Terminal cmd={['$ codex mcp add expo-mcp --url https://mcp.expo.dev/mcp']} />
 
-
 </Collapsible>
 
 </Step>

--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -111,21 +111,8 @@ Click the following link to install the MCP server for Cursor:
 
 <Collapsible summary="Codex setup">
 
-Codex stores MCP config in `~/.codex/config.toml` (shared by CLI and IDE).
+<Terminal cmd={['$ codex mcp add expo-mcp --url https://mcp.expo.dev/mcp']} />
 
-```
-[mcp_servers.expo]
-url = "https://mcp.expo.dev/mcp"
-```
-
-Then authenticate with OAuth:
-
-<Terminal cmd={['$ codex mcp login expo']} />
-
-**Notes:**
-
-- **Server type**: Streamable HTTP
-- **Authentication**: OAuth
 
 </Collapsible>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Codex is my main driver. I assume many other developers would also like to use Expo MCP with Codex. 

# How

<!--
How did you build this feature or fix this bug and why?
-->

I configured it myself on my own machine, and just confirmed that it works. 
<img width="860" height="632" alt="image" src="https://github.com/user-attachments/assets/814cff19-bb04-48f3-be86-065fd9a3ccdb" />


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
I added the config to my config.toml in my.codex file. Then I asked Codex to mcp Expo, and it successfully makes the API call. 
# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
