### PR TITLE
test(@expo/cli): update server export tests to use `unstable_useServerRendering: true`

### DIFF
--- a/apps/router-e2e/__e2e__/server-headers/workerd/config.capnp
+++ b/apps/router-e2e/__e2e__/server-headers/workerd/config.capnp
@@ -11,9 +11,7 @@ const serverConfig :Workerd.Config = (
 const server :Workerd.Worker = (
   modules = [
     (name = "worker", esModule = embed "workerd.js"),
-    (name = "_sitemap.html", text = embed "_sitemap.html"),
-    (name = "index.html", text = embed "index.html"),
-    (name = "+not-found.html", text = embed "+not-found.html"),
+    (name = "_expo/server/render.js", commonJsModule = embed "_expo/server/render.js"),
     (name = "_expo/functions/api+api.js", commonJsModule = embed "_expo/functions/api+api.js"),
     (name = "_expo/routes.json", text = embed "_expo/routes.json"),
   ],

--- a/apps/router-e2e/__e2e__/server-middleware-async/workerd/config.capnp
+++ b/apps/router-e2e/__e2e__/server-middleware-async/workerd/config.capnp
@@ -11,11 +11,7 @@ const serverConfig :Workerd.Config = (
 const server :Workerd.Worker = (
   modules = [
     (name = "worker", esModule = embed "workerd.js"),
-    (name = "_sitemap.html", text = embed "_sitemap.html"),
-    (name = "index.html", text = embed "index.html"),
-    (name = "second.html", text = embed "second.html"),
-    (name = "redirect.html", text = embed "redirect.html"),
-    (name = "+not-found.html", text = embed "+not-found.html"),
+    (name = "_expo/server/render.js", commonJsModule = embed "_expo/server/render.js"),
     (name = "_expo/functions/api+api.js", commonJsModule = embed "_expo/functions/api+api.js"),
     (name = "_expo/functions/+middleware.js", commonJsModule = embed "_expo/functions/+middleware.js"),
     (name = "_expo/routes.json", text = embed "_expo/routes.json"),

--- a/apps/router-e2e/__e2e__/server/workerd/config.capnp
+++ b/apps/router-e2e/__e2e__/server/workerd/config.capnp
@@ -11,12 +11,7 @@ const serverConfig :Workerd.Config = (
 const server :Workerd.Worker = (
   modules = [
     (name = "worker", esModule = embed "workerd.js"),
-    (name = "_sitemap.html", text = embed "_sitemap.html"),
-    (name = "index.html", text = embed "index.html"),
-    (name = "matching-route/alpha.html", text = embed "matching-route/alpha.html"),
-    (name = "+not-found.html", text = embed "+not-found.html"),
-    (name = "(alpha)/index.html", text = embed "(alpha)/index.html"),
-    (name = "(alpha)/beta.html", text = embed "(alpha)/beta.html"),
+    (name = "_expo/server/render.js", commonJsModule = embed "_expo/server/render.js"),
     (name = "_expo/functions/matching-route/alpha+api.js", commonJsModule = embed "_expo/functions/matching-route/alpha+api.js"),
     (name = "_expo/functions/(a,b)/multi-group-api+api.js", commonJsModule = embed "_expo/functions/(a,b)/multi-group-api+api.js"),
     (name = "_expo/functions/api/error+api.js", commonJsModule = embed "_expo/functions/api/error+api.js"),
@@ -31,11 +26,6 @@ const server :Workerd.Worker = (
     (name = "_expo/functions/api/headers+api.js", commonJsModule = embed "_expo/functions/api/headers+api.js"),
     (name = "_expo/functions/methods+api.js", commonJsModule = embed "_expo/functions/methods+api.js"),
     (name = "_expo/routes.json", text = embed "_expo/routes.json"),
-    (name = "blog/[post].html", text = embed "blog/[post].html"),
-    (name = "blog-ssg/abc.html", text = embed "blog-ssg/abc.html"),
-    (name = "blog-ssg/[post].html", text = embed "blog-ssg/[post].html"),
-    (name = "(b)/multi-group.html", text = embed "(b)/multi-group.html"),
-    (name = "(a)/multi-group.html", text = embed "(a)/multi-group.html"),
   ],
   compatibilityDate = "2025-05-05",
   compatibilityFlags = [

--- a/packages/@expo/cli/e2e/__tests__/export/__snapshots__/server.test.ts.snap
+++ b/packages/@expo/cli/e2e/__tests__/export/__snapshots__/server.test.ts.snap
@@ -92,6 +92,12 @@ exports[`server-output express requests exported files has expected routes manif
       },
     },
   ],
+  "assets": {
+    "css": [],
+    "js": [
+      "/_expo/static/js/web/entry-[HASH].js",
+    ],
+  },
   "htmlRoutes": [
     {
       "file": "./index.tsx",
@@ -131,12 +137,6 @@ exports[`server-output express requests exported files has expected routes manif
       "routeKeys": {},
     },
     {
-      "file": "./blog-ssg/abc.tsx",
-      "namedRegex": "^/blog\\-ssg/abc(?:/)?$",
-      "page": "/blog-ssg/abc",
-      "routeKeys": {},
-    },
-    {
       "file": "./matching-route/alpha.tsx",
       "namedRegex": "^/matching\\-route/alpha(?:/)?$",
       "page": "/matching-route/alpha",
@@ -170,6 +170,10 @@ exports[`server-output express requests exported files has expected routes manif
     },
   ],
   "redirects": [],
+  "rendering": {
+    "file": "_expo/server/render.js",
+    "mode": "ssr",
+  },
   "rewrites": [],
 }
 `;
@@ -266,6 +270,12 @@ exports[`server-output workerd requests exported files has expected routes manif
       },
     },
   ],
+  "assets": {
+    "css": [],
+    "js": [
+      "/_expo/static/js/web/entry-[HASH].js",
+    ],
+  },
   "htmlRoutes": [
     {
       "file": "./index.tsx",
@@ -305,12 +315,6 @@ exports[`server-output workerd requests exported files has expected routes manif
       "routeKeys": {},
     },
     {
-      "file": "./blog-ssg/abc.tsx",
-      "namedRegex": "^/blog\\-ssg/abc(?:/)?$",
-      "page": "/blog-ssg/abc",
-      "routeKeys": {},
-    },
-    {
       "file": "./matching-route/alpha.tsx",
       "namedRegex": "^/matching\\-route/alpha(?:/)?$",
       "page": "/matching-route/alpha",
@@ -344,6 +348,10 @@ exports[`server-output workerd requests exported files has expected routes manif
     },
   ],
   "redirects": [],
+  "rendering": {
+    "file": "_expo/server/render.js",
+    "mode": "ssr",
+  },
   "rewrites": [],
 }
 `;

--- a/packages/@expo/cli/e2e/__tests__/export/server-middleware.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-middleware.test.ts
@@ -25,6 +25,7 @@ describe('exports middleware', () => {
           ]),
           E2E_ROUTER_REWRITES: JSON.stringify([{ source: '/rewrite', destination: '/second' }]),
           E2E_ROUTER_SERVER_MIDDLEWARE: 'true',
+          E2E_ROUTER_SERVER_RENDERING: 'true',
         },
         cliFlags: ['--source-maps'],
       },
@@ -118,19 +119,18 @@ describe('exports middleware', () => {
     });
 
     it('has expected files', async () => {
-      const files = findProjectFiles(server.outputDir);
+      const files = findProjectFiles(path.join(server.outputDir, 'server'));
 
-      // The wrapper should not be included as a route.
-      expect(files).not.toContain('+html.html');
-      expect(files).not.toContain('_layout.html');
+      // In SSR mode, no HTML files are pre-rendered - they're rendered at request time
+      const serverHtmlFiles = files.filter((f) => f.endsWith('.html'));
+      expect(serverHtmlFiles.length).toEqual(0);
 
-      // In server mode, HTML files are in the server directory
-      expect(files).toContain('server/_sitemap.html');
-      expect(files).toContain('server/+not-found.html');
-      expect(files).toContain('server/index.html');
+      // SSR-specific files should exist
+      expect(files).toContain('_expo/server/render.js');
+      expect(files).toContain('_expo/routes.json');
 
       // Middleware should be bundled and referenced in routes.json
-      expect(files).toContain('server/_expo/functions/+middleware.js');
+      expect(files).toContain('_expo/functions/+middleware.js');
       const routesJson = JSON.parse(
         fs.readFileSync(path.join(server.outputDir, 'server/_expo/routes.json'), 'utf8')
       );

--- a/packages/@expo/cli/e2e/__tests__/export/server-rewrites-screens.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-rewrites-screens.test.ts
@@ -19,6 +19,7 @@ describe('server rewrites', () => {
         NODE_ENV: 'production',
         EXPO_USE_STATIC: 'server',
         E2E_ROUTER_SRC: 'static-rendering',
+        E2E_ROUTER_SERVER_RENDERING: 'true',
         E2E_ROUTER_REWRITES: JSON.stringify([
           { source: '/rewrite', destination: '/styled' },
         ] as RewriteConfig[]),
@@ -69,25 +70,12 @@ describe('server rewrites', () => {
   it('has expected files', async () => {
     const files = findProjectFiles(path.join(projectRoot, outputName, 'server'));
 
-    // The wrapper should not be included as a route.
-    expect(files).not.toContain('+html.html');
-    expect(files).not.toContain('_layout.html');
+    // In SSR mode, no HTML files are pre-rendered - they're rendered at request time
+    const serverHtmlFiles = files.filter((f) => f.endsWith('.html'));
+    expect(serverHtmlFiles.length).toEqual(0);
 
-    // Injected by framework
-    expect(files).toContain('_sitemap.html');
-    expect(files).toContain('+not-found.html');
-
-    // Normal routes
-    expect(files).toContain('about.html');
-    expect(files).toContain('index.html');
-    expect(files).toContain('styled.html');
-
-    // Rewrite routes should not be written to disk
-    expect(files).not.toContain('rewrite.html');
-
-    // generateStaticParams values
-    expect(files).toContain('[post].html');
-    expect(files).toContain('welcome-to-the-universe.html');
-    expect(files).toContain('other.html');
+    // SSR-specific files SHOULD exist
+    expect(files).toContain('_expo/server/render.js');
+    expect(files).toContain('_expo/routes.json');
   });
 });

--- a/packages/@expo/cli/e2e/__tests__/export/server-root-group.test.tsx
+++ b/packages/@expo/cli/e2e/__tests__/export/server-root-group.test.tsx
@@ -26,6 +26,7 @@ describe('server-root-group', () => {
           EXPO_USE_STATIC: 'server',
           E2E_ROUTER_SRC: 'server-root-group',
           E2E_ROUTER_ASYNC: 'development',
+          E2E_ROUTER_SERVER_RENDERING: 'true',
         },
       }
     );
@@ -65,18 +66,14 @@ describe('server-root-group', () => {
   });
 
   it('has expected files', async () => {
-    // Request HTML
-    const files = findProjectFiles(outputDir);
+    const files = findProjectFiles(path.join(outputDir, 'server'));
 
-    // The wrapper should not be included as a route.
-    expect(files).not.toContain('server/+html.html');
-    expect(files).not.toContain('server/_layout.html');
+    // In SSR mode, no HTML files are pre-rendered - they're rendered at request time
+    const serverHtmlFiles = files.filter((f) => f.endsWith('.html'));
+    expect(serverHtmlFiles.length).toEqual(0);
 
     // Has routes.json
-    expect(files).toContain('server/_expo/routes.json');
-
-    // HTML
-    expect(files).toContain('server/(root)/index.html');
-    expect(files).not.toContain('server/index.html');
+    expect(files).toContain('_expo/server/render.js');
+    expect(files).toContain('_expo/routes.json');
   });
 });

--- a/packages/@expo/cli/e2e/__tests__/export/server.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server.test.ts
@@ -22,6 +22,7 @@ describe('server-output', () => {
       export: {
         env: {
           E2E_ROUTER_ASYNC: 'development',
+          E2E_ROUTER_SERVER_RENDERING: 'true',
         },
       },
       serve: {
@@ -41,18 +42,13 @@ describe('server-output', () => {
       });
     });
 
-    it(`can serve build-time static dynamic route`, async () => {
-      const res = await server.fetchAsync('/blog-ssg/abc');
+    it.each([
+      { path: '/blog-ssg/abc', value: 'abc' },
+      { path: '/blog-ssg/123', value: '123' },
+    ])(`can serve dynamic route at $path`, async ({ path, value }) => {
+      const res = await server.fetchAsync(path);
       expect(res.status).toEqual(200);
-      expect(await res.text()).toMatch(/Post: <!-- -->abc/);
-
-      if (!server.isExpoStart) {
-        // Behaves like a dynamic route in development, but is pre-rendered in production.
-        // This route is not pre-rendered and should show the default value for the dynamic parameter.
-        const res2 = await server.fetchAsync('/blog-ssg/123');
-        expect(res2.status).toEqual(200);
-        expect(await res2.text()).toMatch(/Post: <!-- -->\[post\]/);
-      }
+      expect(await res.text()).toMatch(new RegExp(`Post: <!-- -->${value}`));
     });
 
     it(`can serve up custom not-found`, async () => {
@@ -88,14 +84,6 @@ describe('server-output', () => {
         /<div data-testid="alpha-beta-text">/
       );
     });
-
-    // Behaves like a dynamic route in development, but is pre-rendered in production.
-    (server.isExpoStart ? it.skip : it)(
-      `can serve up built time generated dynamic html routes`,
-      async () => {
-        expect(await server.fetchAsync('/blog/123').then((res) => res.text())).toMatch(/\[post\]/);
-      }
-    );
 
     it(`can hit the 404 route`, async () => {
       expect(await server.fetchAsync('/clearly-missing').then((res) => res.text())).toMatch(
@@ -356,14 +344,6 @@ describe('server-output', () => {
 
     // Tests that require exported files (not available for dev server)
     (server.isExpoStart ? describe.skip : describe)('exported files', () => {
-      it(`has expected static html from array group`, async () => {
-        const files = findProjectFiles(server.outputDir);
-        expect(files).not.toContain('server/multi-group.html');
-        expect(files).not.toContain('server/(a,b)/multi-group.html');
-        expect(files).toContain('server/(a)/multi-group.html');
-        expect(files).toContain('server/(b)/multi-group.html');
-      });
-
       it(`has expected API route from array group`, async () => {
         const files = findProjectFiles(server.outputDir);
         expect(files).toContain('server/_expo/functions/(a,b)/multi-group-api+api.js');
@@ -383,47 +363,44 @@ describe('server-output', () => {
       });
 
       it('has expected files', async () => {
-        const files = findProjectFiles(server.outputDir);
-
-        // The wrapper should not be included as a route.
-        expect(files).not.toContain('server/+html.html');
-        expect(files).not.toContain('server/_layout.html');
-
-        // Has routes.json
-        expect(files).toContain('server/_expo/routes.json');
+        const files = findProjectFiles(path.join(server.outputDir, 'server'));
 
         // Has functions
-        expect(files).toContain('server/_expo/functions/methods+api.js');
-        expect(files).toContain('server/_expo/functions/methods+api.js.map');
-        expect(files).toContain('server/_expo/functions/api/[dynamic]+api.js');
-        expect(files).toContain('server/_expo/functions/api/[dynamic]+api.js.map');
-        expect(files).toContain('server/_expo/functions/api/externals+api.js');
-        expect(files).toContain('server/_expo/functions/api/externals+api.js.map');
+        expect(files).toContain('_expo/functions/methods+api.js');
+        expect(files).toContain('_expo/functions/methods+api.js.map');
+        expect(files).toContain('_expo/functions/api/[dynamic]+api.js');
+        expect(files).toContain('_expo/functions/api/[dynamic]+api.js.map');
+        expect(files).toContain('_expo/functions/api/externals+api.js');
+        expect(files).toContain('_expo/functions/api/externals+api.js.map');
 
         // TODO: We shouldn't export this
-        expect(files).toContain('server/_expo/functions/api/empty+api.js');
-        expect(files).toContain('server/_expo/functions/api/empty+api.js.map');
+        expect(files).toContain('_expo/functions/api/empty+api.js');
+        expect(files).toContain('_expo/functions/api/empty+api.js.map');
 
-        // Has single variation of group file
-        expect(files).toContain('server/(alpha)/index.html');
-        expect(files).toContain('server/(alpha)/beta.html');
-        expect(files).not.toContain('server/beta.html');
+        // In SSR mode, no HTML files are pre-rendered - they're rendered at request time
+        const serverHtmlFiles = files.filter((f) => f.endsWith('.html'));
+        expect(serverHtmlFiles.length).toEqual(0);
 
-        // Injected by framework
-        expect(files).toContain('server/_sitemap.html');
-        expect(files).toContain('server/+not-found.html');
-
-        // Normal routes
-        expect(files).toContain('server/index.html');
-        expect(files).toContain('server/blog/[post].html');
+        // SSR-specific files
+        expect(files).toContain('_expo/server/render.js');
+        expect(files).toContain('_expo/routes.json');
       });
 
       // Ensure the `/server/_expo/routes.json` contains the right file paths and named regexes.
       // This test is created to avoid and detect regressions on Windows
       it('has expected routes manifest entries', async () => {
-        expect(
-          await JsonFile.readAsync(path.join(server.outputDir, 'server/_expo/routes.json'))
-        ).toMatchSnapshot();
+        const manifest = (await JsonFile.readAsync(
+          path.join(server.outputDir, 'server/_expo/routes.json')
+        )) as unknown as { assets?: { js?: string[] } };
+
+        // HACK: Bundle hashes differ locally vs on CI
+        if (manifest.assets?.js) {
+          manifest.assets.js = manifest.assets.js.map((asset) =>
+            asset.replace(/entry-(.*)\.js$/, 'entry-[HASH].js')
+          );
+        }
+
+        expect(manifest).toMatchSnapshot();
       });
     });
   });


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
