### PR TITLE
[expo-sqlite][web] Enhance error serialization and deserialization 

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -13,6 +13,8 @@
 ### 🐛 Bug fixes
 
 - Fixed `serializeAsync` / `serializeSync` errors from memory database on web. ([#40899](https://github.com/expo/expo/pull/40899) by [@kudo](https://github.com/kudo))
+- [web] Fixed error serialization displaying "[Object object]" instead of actual error messages. ([#42265](https://github.com/expo/expo/pull/42265) by [@chrisamador](https://github.com/chrisamador))
+- [web] Fixed buffer length encoding causing truncated or corrupted error messages. ([#42265](https://github.com/expo/expo/pull/42265) by [@chrisamador](https://github.com/chrisamador))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/src/__tests__/SyncSerializer-test.web.ts
+++ b/packages/expo-sqlite/src/__tests__/SyncSerializer-test.web.ts
@@ -1,0 +1,255 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import { serialize, deserialize } from '../../web/SyncSerializer';
+
+describe('SyncSerializer', () => {
+  describe('Error serialization', () => {
+    it('should serialize and deserialize Error objects with message', () => {
+      const error = new Error('Test error message');
+      const serialized = serialize({ error });
+      const deserialized = deserialize<{ error: Error }>(serialized);
+
+      expect(deserialized.error).toBeInstanceOf(Error);
+      expect(deserialized.error.message).toBe('Test error message');
+    });
+
+    it('should preserve Error enumerable properties like code', () => {
+      const error = new Error('UNIQUE constraint failed');
+      (error as any).code = 19;
+
+      const serialized = serialize({ error });
+      const deserialized = deserialize<{ error: Error & { code: number } }>(serialized);
+
+      expect(deserialized.error).toBeInstanceOf(Error);
+      expect(deserialized.error.message).toBe('UNIQUE constraint failed');
+      expect(deserialized.error.code).toBe(19);
+    });
+
+    it('should preserve Error stack trace', () => {
+      const error = new Error('Test error');
+      const originalStack = error.stack;
+
+      const serialized = serialize({ error });
+      const deserialized = deserialize<{ error: Error }>(serialized);
+
+      expect(deserialized.error.stack).toBe(originalStack);
+    });
+
+    it('should handle nested Error objects', () => {
+      const innerError = new Error('Inner error');
+      (innerError as any).code = 42;
+
+      const data = {
+        success: false,
+        error: innerError,
+        metadata: { timestamp: Date.now() },
+      };
+
+      const serialized = serialize(data);
+      const deserialized = deserialize<typeof data>(serialized);
+
+      expect(deserialized.error).toBeInstanceOf(Error);
+      expect(deserialized.error.message).toBe('Inner error');
+      expect((deserialized.error as any).code).toBe(42);
+    });
+
+    it('should handle multiple enumerable properties on Error', () => {
+      const error = new Error('Complex error');
+      (error as any).code = 19;
+      (error as any).errno = -4058;
+      (error as any).path = '/some/file.db';
+
+      const serialized = serialize({ error });
+      const deserialized = deserialize<{ error: Error }>(serialized);
+
+      expect(deserialized.error.message).toBe('Complex error');
+      expect((deserialized.error as any).code).toBe(19);
+      expect((deserialized.error as any).errno).toBe(-4058);
+      expect((deserialized.error as any).path).toBe('/some/file.db');
+    });
+  });
+
+  describe('Uint8Array serialization', () => {
+    it('should serialize and deserialize Uint8Array', () => {
+      const data = new Uint8Array([1, 2, 3, 4, 5]);
+      const serialized = serialize({ data });
+      const deserialized = deserialize<{ data: Uint8Array }>(serialized);
+
+      expect(deserialized.data).toBeInstanceOf(Uint8Array);
+      expect(Array.from(deserialized.data)).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('should handle objects with both Error and Uint8Array', () => {
+      const error = new Error('Binary error');
+      (error as any).code = 99;
+      const binary = new Uint8Array([0xff, 0xfe, 0xfd]);
+
+      const data = { error, binary };
+      const serialized = serialize(data);
+      const deserialized = deserialize<typeof data>(serialized);
+
+      expect(deserialized.error).toBeInstanceOf(Error);
+      expect(deserialized.error.message).toBe('Binary error');
+      expect((deserialized.error as any).code).toBe(99);
+      expect(deserialized.binary).toBeInstanceOf(Uint8Array);
+      expect(Array.from(deserialized.binary)).toEqual([0xff, 0xfe, 0xfd]);
+    });
+  });
+
+  describe('General serialization', () => {
+    it('should handle regular objects', () => {
+      const data = { foo: 'bar', num: 42, nested: { key: 'value' } };
+      const serialized = serialize(data);
+      const deserialized = deserialize<typeof data>(serialized);
+
+      expect(deserialized).toEqual(data);
+    });
+
+    it('should handle arrays', () => {
+      const data = [1, 'two', { three: 3 }, [4, 5]];
+      const serialized = serialize(data);
+      const deserialized = deserialize<typeof data>(serialized);
+
+      expect(deserialized).toEqual(data);
+    });
+
+    it('should handle null and undefined', () => {
+      const data = { a: null, b: undefined };
+      const serialized = serialize(data);
+      const deserialized = deserialize<typeof data>(serialized);
+
+      expect(deserialized.a).toBeNull();
+      // Note: undefined values are dropped by JSON.stringify
+      expect(deserialized.b).toBeUndefined();
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle very long error messages', () => {
+      const longMessage = 'Error: ' + 'x'.repeat(10000);
+      const error = new Error(longMessage);
+      (error as any).code = 999;
+
+      const serialized = serialize({ error });
+      const deserialized = deserialize<{ error: Error }>(serialized);
+
+      expect(deserialized.error.message).toBe(longMessage);
+      expect((deserialized.error as any).code).toBe(999);
+    });
+
+    it('should handle errors with unicode and special characters', () => {
+      const error = new Error('错误: Ошибка: エラー: 🚨💥');
+      (error as any).code = 42;
+      (error as any).emoji = '😀';
+
+      const serialized = serialize({ error });
+      const deserialized = deserialize<{ error: Error }>(serialized);
+
+      expect(deserialized.error.message).toBe('错误: Ошибка: エラー: 🚨💥');
+      expect((deserialized.error as any).emoji).toBe('😀');
+    });
+
+    it('should handle errors with null/undefined properties', () => {
+      const error = new Error('Test error');
+      (error as any).nullProp = null;
+      (error as any).undefinedProp = undefined;
+      (error as any).code = 0;
+
+      const serialized = serialize({ error });
+      const deserialized = deserialize<{ error: Error }>(serialized);
+
+      expect(deserialized.error.message).toBe('Test error');
+      expect((deserialized.error as any).nullProp).toBeNull();
+      // undefined gets dropped by JSON
+      expect((deserialized.error as any).code).toBe(0);
+    });
+
+    it('should handle empty error message', () => {
+      const error = new Error('');
+      (error as any).code = 100;
+
+      const serialized = serialize({ error });
+      const deserialized = deserialize<{ error: Error }>(serialized);
+
+      expect(deserialized.error.message).toBe('');
+      expect((deserialized.error as any).code).toBe(100);
+    });
+
+    it('should handle error with numeric properties', () => {
+      const error = new Error('Numeric error');
+      (error as any).code = 19;
+      (error as any).errno = -4058;
+      (error as any).line = 42;
+      (error as any).column = 10;
+
+      const serialized = serialize({ error });
+      const deserialized = deserialize<{ error: Error }>(serialized);
+
+      expect((deserialized.error as any).code).toBe(19);
+      expect((deserialized.error as any).errno).toBe(-4058);
+      expect((deserialized.error as any).line).toBe(42);
+      expect((deserialized.error as any).column).toBe(10);
+    });
+
+    it('should handle errors with array properties', () => {
+      const error = new Error('Array error');
+      (error as any).args = ['arg1', 'arg2', 123];
+
+      const serialized = serialize({ error });
+      const deserialized = deserialize<{ error: Error }>(serialized);
+
+      expect((deserialized.error as any).args).toEqual(['arg1', 'arg2', 123]);
+    });
+
+    it('should handle errors with object properties', () => {
+      const error = new Error('Object error');
+      (error as any).metadata = { userId: 123, action: 'insert' };
+
+      const serialized = serialize({ error });
+      const deserialized = deserialize<{ error: Error }>(serialized);
+
+      expect((deserialized.error as any).metadata).toEqual({ userId: 123, action: 'insert' });
+    });
+
+    it('should handle large Uint8Array data', () => {
+      const largeArray = new Uint8Array(50000);
+      for (let i = 0; i < largeArray.length; i++) {
+        largeArray[i] = i % 256;
+      }
+
+      const serialized = serialize({ data: largeArray });
+      const deserialized = deserialize<{ data: Uint8Array }>(serialized);
+
+      expect(deserialized.data.length).toBe(50000);
+      expect(Array.from(deserialized.data.slice(0, 10))).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    });
+
+    it('should handle complex nested structures', () => {
+      const error1 = new Error('First error');
+      (error1 as any).code = 1;
+
+      const error2 = new Error('Second error');
+      (error2 as any).code = 2;
+
+      const data = {
+        errors: [error1, error2],
+        binary: new Uint8Array([1, 2, 3]),
+        nested: {
+          error: error1,
+          data: new Uint8Array([4, 5, 6]),
+        },
+      };
+
+      const serialized = serialize(data);
+      const deserialized = deserialize<typeof data>(serialized);
+
+      expect(deserialized.errors[0]).toBeInstanceOf(Error);
+      expect(deserialized.errors[0].message).toBe('First error');
+      expect((deserialized.errors[0] as any).code).toBe(1);
+      expect(deserialized.errors[1].message).toBe('Second error');
+      expect(deserialized.binary).toBeInstanceOf(Uint8Array);
+      expect(deserialized.nested.error).toBeInstanceOf(Error);
+      expect(deserialized.nested.data).toBeInstanceOf(Uint8Array);
+    });
+  });
+});

--- a/packages/expo-sqlite/src/__tests__/WorkerChannel-test.web.ts
+++ b/packages/expo-sqlite/src/__tests__/WorkerChannel-test.web.ts
@@ -1,0 +1,285 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import { sendWorkerResult, invokeWorkerSync } from '../../web/WorkerChannel';
+import { ResultTypeMap } from '../../web/web.types';
+
+// Polyfill TextEncoder/TextDecoder for test environment
+if (typeof TextEncoder === 'undefined') {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const util = require('util');
+  (globalThis as any).TextEncoder = util.TextEncoder;
+  (globalThis as any).TextDecoder = util.TextDecoder;
+}
+
+describe('WorkerChannel', () => {
+  describe('sendWorkerResult', () => {
+    it('should serialize error message and code for sync operations', () => {
+      const lockBuffer = new SharedArrayBuffer(4);
+      const resultBuffer = new SharedArrayBuffer(1024 * 1024);
+      const lock = new Int32Array(lockBuffer);
+      const resultArray = new Uint8Array(resultBuffer);
+
+      // Create an error with a code property (like SQLite errors)
+      const error = new Error('UNIQUE constraint failed');
+      (error as any).code = 19;
+
+      sendWorkerResult({
+        id: 1,
+        result: null,
+        error,
+        syncTrait: {
+          lockBuffer,
+          resultBuffer,
+        },
+      });
+
+      // Verify the lock was set to RESOLVED (2)
+      expect(Atomics.load(lock, 0)).toBe(2);
+
+      // Decode and verify the serialized error
+      const length = new Uint32Array(resultArray.buffer, 0, 1)[0];
+      const resultBytes = new Uint8Array(resultArray.buffer, 4, length);
+      const resultJson = new TextDecoder().decode(resultBytes);
+      const parsed = JSON.parse(resultJson);
+
+      // Verify error object is serialized with special marker
+      expect(parsed.error).toHaveProperty('__error__', true);
+      expect(parsed.error.message).toBe('UNIQUE constraint failed');
+      expect(parsed.error.code).toBe(19);
+    });
+
+    it('should serialize result for sync operations', () => {
+      const lockBuffer = new SharedArrayBuffer(4);
+      const resultBuffer = new SharedArrayBuffer(1024 * 1024);
+      const lock = new Int32Array(lockBuffer);
+      const resultArray = new Uint8Array(resultBuffer);
+
+      const result: ResultTypeMap['run'] = { lastInsertRowId: 42, changes: 1, firstRowValues: [] };
+
+      sendWorkerResult({
+        id: 1,
+        result,
+        error: null,
+        syncTrait: {
+          lockBuffer,
+          resultBuffer,
+        },
+      });
+
+      // Verify the lock was set to RESOLVED (2)
+      expect(Atomics.load(lock, 0)).toBe(2);
+
+      // Decode and verify the serialized result
+      const length = new Uint32Array(resultArray.buffer, 0, 1)[0];
+      const resultBytes = new Uint8Array(resultArray.buffer, 4, length);
+      const resultJson = new TextDecoder().decode(resultBytes);
+      const parsed = JSON.parse(resultJson);
+
+      expect(parsed.result).toEqual(result);
+      expect(parsed.error).toBeUndefined();
+    });
+  });
+
+  describe('invokeWorkerSync error handling', () => {
+    let mockWorker: any;
+
+    beforeEach(() => {
+      mockWorker = {
+        postMessage: jest.fn(),
+      };
+    });
+
+    it('should throw error with message from worker', () => {
+      // Mock Atomics.load to simulate immediate resolution
+      let callCount = 0;
+      // @ts-expect-error mocking Atomics.load with number return type
+      jest.spyOn(Atomics, 'load').mockImplementation(() => {
+        callCount++;
+        // Return PENDING first, then RESOLVED
+        return callCount === 1 ? 1 : 2;
+      });
+
+      // Mock the worker postMessage to simulate an error response
+      mockWorker.postMessage = jest.fn((message: any) => {
+        const { resultBuffer } = message;
+        const lengthView = new Uint32Array(resultBuffer, 0, 1);
+        const resultArray = new Uint8Array(resultBuffer);
+
+        // Simulate worker sending back an error (matching serialized format)
+        const errorResponse = JSON.stringify({
+          error: {
+            __error__: true,
+            message: 'UNIQUE constraint failed',
+            code: 19,
+          },
+        });
+        const errorBytes = new TextEncoder().encode(errorResponse);
+        lengthView[0] = errorBytes.length;
+        resultArray.set(errorBytes, 4);
+      });
+
+      try {
+        invokeWorkerSync(mockWorker, 'exec' as any, { nativeDatabaseId: 1, source: 'SELECT 1' });
+        fail('Should have thrown an error');
+      } catch (error: any) {
+        expect(error.message).toBe('UNIQUE constraint failed');
+        expect(error.code).toBe(19);
+      }
+
+      jest.spyOn(Atomics, 'load').mockRestore();
+    });
+  });
+
+  describe('Buffer length encoding edge cases', () => {
+    it('should handle message at buffer boundary (1MB)', () => {
+      const lockBuffer = new SharedArrayBuffer(4);
+      const resultBuffer = new SharedArrayBuffer(1024 * 1024);
+
+      // Create a large error that's close to buffer limit
+      const largeMessage = 'Error: ' + 'x'.repeat(1024 * 1024 - 200);
+      const error = new Error(largeMessage);
+
+      sendWorkerResult({
+        id: 1,
+        result: null,
+        error,
+        syncTrait: {
+          lockBuffer,
+          resultBuffer,
+        },
+      });
+
+      // Verify length was written correctly (4 bytes as Uint32)
+      const lengthView = new Uint32Array(resultBuffer, 0, 1);
+      const storedLength = lengthView[0];
+
+      // Decode and verify
+      const resultBytes = new Uint8Array(resultBuffer, 4, storedLength);
+      const resultJson = new TextDecoder().decode(resultBytes);
+      const parsed = JSON.parse(resultJson);
+
+      expect(parsed.error).toHaveProperty('__error__', true);
+      expect(parsed.error.message.length).toBeGreaterThan(1024 * 1000);
+    });
+
+    it('should correctly encode length for small messages', () => {
+      const lockBuffer = new SharedArrayBuffer(4);
+      const resultBuffer = new SharedArrayBuffer(1024);
+
+      const error = new Error('Small');
+      (error as any).code = 1;
+
+      sendWorkerResult({
+        id: 1,
+        result: null,
+        error,
+        syncTrait: {
+          lockBuffer,
+          resultBuffer,
+        },
+      });
+
+      // Read the length (first 4 bytes as Uint32)
+      const lengthView = new Uint32Array(resultBuffer, 0, 1);
+      const storedLength = lengthView[0];
+
+      // Verify length is reasonable (should be less than 200 bytes for this small error)
+      expect(storedLength).toBeLessThan(200);
+      expect(storedLength).toBeGreaterThan(0);
+
+      // Verify we can decode it
+      const resultBytes = new Uint8Array(resultBuffer, 4, storedLength);
+      const resultJson = new TextDecoder().decode(resultBytes);
+      const parsed = JSON.parse(resultJson);
+
+      expect(parsed.error.message).toBe('Small');
+      expect(parsed.error.code).toBe(1);
+    });
+
+    it('should handle unicode characters in length calculation', () => {
+      const lockBuffer = new SharedArrayBuffer(4);
+      const resultBuffer = new SharedArrayBuffer(1024);
+
+      // Unicode characters take multiple bytes
+      const error = new Error('🚨💥错误エラー');
+      (error as any).code = 999;
+
+      sendWorkerResult({
+        id: 1,
+        result: null,
+        error,
+        syncTrait: {
+          lockBuffer,
+          resultBuffer,
+        },
+      });
+
+      const lengthView = new Uint32Array(resultBuffer, 0, 1);
+      const storedLength = lengthView[0];
+
+      const resultBytes = new Uint8Array(resultBuffer, 4, storedLength);
+      const resultJson = new TextDecoder().decode(resultBytes);
+      const parsed = JSON.parse(resultJson);
+
+      expect(parsed.error.message).toBe('🚨💥错误エラー');
+    });
+
+    it('should handle empty result object', () => {
+      const lockBuffer = new SharedArrayBuffer(4);
+      const resultBuffer = new SharedArrayBuffer(1024);
+
+      sendWorkerResult({
+        id: 1,
+        result: {} as any,
+        error: null,
+        syncTrait: {
+          lockBuffer,
+          resultBuffer,
+        },
+      });
+
+      const lengthView = new Uint32Array(resultBuffer, 0, 1);
+      const storedLength = lengthView[0];
+
+      const resultBytes = new Uint8Array(resultBuffer, 4, storedLength);
+      const resultJson = new TextDecoder().decode(resultBytes);
+      const parsed = JSON.parse(resultJson);
+
+      expect(parsed.result).toEqual({});
+    });
+
+    it('should handle result with nested data', () => {
+      const lockBuffer = new SharedArrayBuffer(4);
+      const resultBuffer = new SharedArrayBuffer(1024);
+
+      const result = {
+        rows: [
+          { id: 1, name: 'Alice', data: { age: 30 } },
+          { id: 2, name: 'Bob', data: { age: 25 } },
+        ],
+        changes: 2,
+      } as any;
+
+      sendWorkerResult({
+        id: 1,
+        result,
+        error: null,
+        syncTrait: {
+          lockBuffer,
+          resultBuffer,
+        },
+      });
+
+      const lengthView = new Uint32Array(resultBuffer, 0, 1);
+      const storedLength = lengthView[0];
+
+      const resultBytes = new Uint8Array(resultBuffer, 4, storedLength);
+      const resultJson = new TextDecoder().decode(resultBytes);
+      const parsed = JSON.parse(resultJson);
+
+      expect(parsed.result.rows).toHaveLength(2);
+      expect(parsed.result.rows[0].name).toBe('Alice');
+      expect(parsed.result.changes).toBe(2);
+    });
+  });
+});

--- a/packages/expo-sqlite/web/SyncSerializer.ts
+++ b/packages/expo-sqlite/web/SyncSerializer.ts
@@ -1,10 +1,50 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 const UINT8ARRAY_TYPE = '__uint8array__';
+const ERROR_TYPE = '__error__';
+
+/**
+ * Converts an Error object to a plain object with message, stack, and enumerable properties.
+ */
+export function serializeError(error: Error): Record<string, any> {
+  const props: Record<string, any> = {};
+  Object.keys(error).forEach((key) => {
+    props[key] = (error as any)[key];
+  });
+  return {
+    message: error.message,
+    stack: error.stack,
+    ...props,
+  };
+}
+
+/**
+ * Reconstructs an Error object from a serialized error object.
+ */
+export function deserializeError(data: any): Error {
+  const error = new Error(data.message !== undefined ? data.message : String(data));
+  if (data.stack) {
+    error.stack = data.stack;
+  }
+  // Restore enumerable properties (like 'code')
+  Object.keys(data).forEach((key) => {
+    if (key !== 'message' && key !== 'stack') {
+      (error as any)[key] = data[key];
+    }
+  });
+  return error;
+}
 
 interface Uint8ArrayMarker {
   [UINT8ARRAY_TYPE]: true;
   data: number[];
+}
+
+interface ErrorMarker {
+  [ERROR_TYPE]: true;
+  message: string;
+  stack?: string;
+  [key: string]: any; // Allow additional enumerable properties like 'code'
 }
 
 function isUint8ArrayMarker(value: any): value is Uint8ArrayMarker {
@@ -16,8 +56,12 @@ function isUint8ArrayMarker(value: any): value is Uint8ArrayMarker {
   );
 }
 
+function isErrorMarker(value: any): value is ErrorMarker {
+  return value !== null && typeof value === 'object' && ERROR_TYPE in value;
+}
+
 /**
- * Serializes a value to a string that supports Uint8Arrays.
+ * Serializes a value to a string that supports Uint8Arrays and Error objects.
  */
 export function serialize(value: any): string {
   return JSON.stringify(value, (_, v) => {
@@ -27,17 +71,28 @@ export function serialize(value: any): string {
         data: Array.from(v),
       };
     }
+    if (v instanceof Error) {
+      return {
+        [ERROR_TYPE]: true,
+        ...serializeError(v),
+      };
+    }
     return v;
   });
 }
 
 /**
- * Deserializes a string to value that supports Uint8Arrays.
+ * Deserializes a string to value that supports Uint8Arrays and Error objects.
  */
 export function deserialize<T>(json: string): T {
   return JSON.parse(json, (_, value) => {
     if (isUint8ArrayMarker(value)) {
       return new Uint8Array(value.data);
+    }
+    if (isErrorMarker(value)) {
+      // Remove the marker before deserializing
+      const { [ERROR_TYPE]: _, ...errorData } = value;
+      return deserializeError(errorData);
     }
     return value;
   });


### PR DESCRIPTION
# Why

When using `expo-sqlite` on web with synchronous operations, errors were being displayed as `[Object object]` instead of showing the actual error message. This made debugging nearly impossible when database constraints failed or other SQLite errors occurred.

For example, a NOT NULL constraint violation would show:
```
Error: [Object object]
```

Instead of the helpful message:
```
Error: NOT NULL constraint failed: table.created_at
```

Additionally, some error messages were being truncated or corrupted, causing `JSON.parse` errors that would crash the application.

# How

## Root Causes

### 1. Error Serialization Issue
Error objects were being serialized directly with `JSON.stringify({ error })`. Since `error.message` and `error.stack` are non-enumerable properties on the Error prototype, they were lost during serialization. Only custom enumerable properties like `code` were preserved:

```typescript
const error = new Error("NOT NULL constraint failed");
error.code = 19;
JSON.stringify(error); // -> {"code": 19}  ❌ Message lost!
```

### 2. Buffer Length Encoding Issue
The length header was being written incorrectly:
```typescript
// ❌ Wrong: Only writes 1 byte of the 4-byte Uint32 value
resultArray.set(new Uint32Array([length]), 0);
```

This caused the length to be truncated. When reading back 4 bytes, we'd get corrupted data that included the start of the actual message.

## Solution

### Error Serialization Fix
Created `serializeError()` and `deserializeError()` helper functions in `SyncSerializer.ts` that explicitly preserve `message`, `stack`, and all enumerable properties:

```typescript
export function serializeError(error: Error): Record<string, any> {
  const props: Record<string, any> = {};
  Object.keys(error).forEach((key) => {
    props[key] = (error as any)[key];
  });
  return {
    message: error.message,      // ✅ Explicitly preserve message
    stack: error.stack,            // ✅ Explicitly preserve stack
    ...props,                      // ✅ Preserve enumerable props (code, etc.)
  };
}
```

These helpers are used for:
- **Sync operations**: Integrated into `serialize()`/`deserialize()` with a special `__error__` marker that automatically handles Error objects during JSON serialization
- **Async operations**: Used directly in `postMessage` handlers via `serializeError()`/`deserializeError()`

### Buffer Length Encoding Fix
Changed to use a proper Uint32Array view of the buffer:

```typescript
// ✅ Correct: Write length as 4 bytes using Uint32Array view
const lengthView = new Uint32Array(resultBuffer, 0, 1);
lengthView[0] = length;
// Write the actual data starting at byte 4
resultArray.set(resultBytes, 4);
```

## Files Changed
- `web/SyncSerializer.ts`: Added `serializeError()` and `deserializeError()` helpers, enhanced `serialize()`/`deserialize()` to handle Error objects
- `web/WorkerChannel.ts`: Fixed buffer length encoding and updated error handling for both sync and async paths
- `src/__tests__/SyncSerializer-test.web.ts`: Comprehensive tests for error serialization edge cases
- `src/__tests__/WorkerChannel-test.web.ts`: Tests for buffer encoding and error handling

# Test Plan

## Automated Tests

Run the test suites:
```bash
cd packages/expo-sqlite
yarn test SyncSerializer
yarn test WorkerChannel
```

The tests cover:
- ✅ Error messages with code properties (SQLite error code 19, etc.)
- ✅ Unicode and special characters in error messages
- ✅ Very long messages (near 1MB buffer limit)
- ✅ Empty error messages
- ✅ Complex nested structures with multiple errors
- ✅ Uint8Array serialization alongside errors
- ✅ Buffer length encoding correctness for all message sizes

## Manual Testing

To reproduce the original issue and verify the fix:

1. Create a database constraint violation:
```typescript
import * as SQLite from 'expo-sqlite';

const db = SQLite.openDatabaseSync('test.db');
db.execSync('CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY NOT NULL, name TEXT)');

try {
  // This will fail with NOT NULL constraint
  db.execSync('INSERT INTO test (name) VALUES (null)');
} catch (error) {
  console.log(error.message); 
  // Before: "[Object object]"
  // After: "Error code 19: NOT NULL constraint failed: test.name"
  console.log(error.code); 
  // Should be: 19
}
```

2. Copy the modified files to `node_modules/expo-sqlite/web/` in your test project
3. Run the code above and verify the error message is readable

## Expected Results

- Error messages display the full error text instead of `[Object object]`
- Error codes and other custom properties are preserved
- No truncation or corruption of long error messages
- Unicode characters in errors display correctly

