### PR TITLE
docs(expo-router): document server rendering (SSR)

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -274,6 +274,7 @@ export const general = [
       makePage('router/web/api-routes.mdx'),
       makePage('router/web/middleware.mdx'),
       makePage('router/web/static-rendering.mdx'),
+      makePage('router/web/server-rendering.mdx'),
       makePage('router/web/async-routes.mdx'),
     ]),
     makeGroup('Reference', [

--- a/docs/pages/router/web/server-rendering.mdx
+++ b/docs/pages/router/web/server-rendering.mdx
@@ -169,7 +169,7 @@ export default function Root({ children }: PropsWithChildren) {
 }
 ```
 
-The **+html.tsx** file is only used by the server-renderer and never by client code. This means:
+The **+html.tsx** file is only used by the server renderer and never by client code. This means:
 
 - It will be run by `expo-server` during server rendering
 - It is not rehydrated on the client, and hence shouldn't use React hooks
@@ -239,18 +239,26 @@ EAS Hosting supports server rendering out of the box. Export your app and deploy
 
 ## Common questions
 
-### Can I use data loaders with server rendering?
+<Collapsible summary="Can I use data loaders with server rendering?">
 
 Yes. Server rendering works with [data loaders](/router/web/data-loaders) to fetch data on the server before rendering.
 
-### Can I mix server and static rendering?
+</Collapsible>
+
+<Collapsible summary="Can I mix server and static rendering?">
 
 Currently, Expo Router does not support mixing server and static rendering in the same project. Choose a single output mode based on your requirements.
 
-### How do I cache server-rendered responses?
+</Collapsible>
+
+<Collapsible summary="How do I cache server-rendered responses?">
 
 Caching is handled at the server or CDN level. Configure your deployment platform to cache responses based on URL patterns or cache headers.
 
-### Does server rendering work with API routes?
+</Collapsible>
+
+<Collapsible summary="Does server rendering work with API routes?">
 
 Yes. [API routes](/router/web/api-routes/) work independently of the rendering mode. They are always executed on the server.
+
+</Collapsible>

--- a/docs/pages/router/web/server-rendering.mdx
+++ b/docs/pages/router/web/server-rendering.mdx
@@ -1,7 +1,6 @@
 ---
 title: Server Rendering
 description: Learn how to render Expo Router routes dynamically at request time using server-side rendering (SSR).
-isNew: true
 isAlpha: true
 ---
 

--- a/docs/pages/router/web/server-rendering.mdx
+++ b/docs/pages/router/web/server-rendering.mdx
@@ -1,0 +1,252 @@
+---
+title: Server Rendering
+description: Learn how to render Expo Router routes dynamically at request time using server-side rendering (SSR).
+isNew: true
+isAlpha: true
+---
+
+import { Collapsible } from '~/ui/components/Collapsible';
+import { FileTree } from '~/ui/components/FileTree';
+import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
+
+> **important** Server rendering is in alpha and is available in SDK 55 and later. It requires a [deployed server](/router/web/api-routes/#deployment) for production use.
+
+Server-side rendering (SSR) generates HTML dynamically on each request, as opposed to [static rendering](/router/web/static-rendering) which pre-renders HTML at build time.
+This guide will walk you through the process of enabling server rendering for your Expo Router app.
+
+## Setup
+
+<Step label="1">
+
+Enable Metro bundler and server output in your project's [app config](/versions/latest/config/app/):
+
+```json app.json
+{
+  "expo": {
+    /* @hide ... */
+    /* @end */
+    "web": {
+      /* @info Server rendering requires Metro bundler */
+      "bundler": "metro",
+      /* @end */
+      "output": "server"
+    }
+  }
+}
+```
+
+</Step>
+
+<Step label="2">
+
+Enable server rendering in the `expo-router` plugin configuration:
+
+```json app.json
+{
+  "expo": {
+    /* @hide ... */
+    /* @end */
+    "plugins": [
+      [
+        "expo-router",
+        {
+          /* @info Enable server-side rendering */
+          "unstable_useServerRendering": true
+          /* @end */
+        }
+      ]
+    ]
+  }
+}
+```
+
+</Step>
+
+<Step label="3">
+
+If you have a **metro.config.js** file in your project, ensure it extends `expo/metro-config`:
+
+```js metro.config.js
+const { getDefaultConfig } = require('expo/metro-config');
+
+/** @type {import('expo/metro-config').MetroConfig} */
+const config = getDefaultConfig(__dirname, {
+  // Additional features...
+});
+
+module.exports = config;
+```
+
+</Step>
+
+<Step label="4">
+
+Start the development server:
+
+<Terminal cmd={['$ npx expo start']} />
+
+</Step>
+
+## Production
+
+To export your app for production, run the universal export command:
+
+<Terminal cmd={['$ npx expo export --platform web']} />
+
+This creates a **dist** directory with your server-rendered application. Unlike static rendering, no HTML files are pre-generated. Instead, the output includes:
+
+<FileTree
+  files={[
+    'dist/client/_expo/static/js/web/entry-[hash].js',
+    'dist/client/_expo/static/css/[name]-[hash].css',
+    'dist/server/_expo/routes.json',
+    'dist/server/_expo/server/render.js',
+  ]}
+/>
+
+- **client/**: Contains JavaScript and CSS bundles for client-side hydration
+- **server/**: Contains the routes manifest and server rendering module
+
+You can test the production build locally by running the following command and opening the linked URL in your browser:
+
+<Terminal cmd={['$ npx expo serve']} />
+
+This starts a local server that renders pages on each request, simulating a production environment.
+
+## Dynamic routes
+
+With server rendering, dynamic routes work automatically without needing [`generateStaticParams()`](/router/web/static-rendering/#generatestaticparams). The route is rendered at request time with the actual parameters from the URL.
+
+```tsx app/blog/[id].tsx
+import { Text } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+
+export default function Page() {
+  const { id } = useLocalSearchParams();
+
+  /* @info The id parameter is available immediately from the URL */
+  return <Text>Post {id}</Text>;
+  /* @end */
+}
+```
+
+When a user visits `/blog/my-post`, the page is rendered on the server with `id` set to `"my-post"`.
+
+> **info** If your route file exports `generateStaticParams()`, those routes are excluded and are now handled dynamically. Remove `generateStaticParams()` exports when using server rendering.
+
+## Root HTML
+
+You can customize the root HTML document by creating an **app/+html.tsx** file. This component wraps all routes and runs only on the server.
+
+```tsx app/+html.tsx
+import { ScrollViewStyleReset } from 'expo-router/html';
+import { type PropsWithChildren } from 'react';
+
+// This file is web-only and used to configure the root HTML for every
+// web page during server rendering.
+// The contents of this function only run in Node.js environments and
+// do not have access to the DOM or browser APIs.
+export default function Root({ children }: PropsWithChildren) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+
+        {/*
+          Disable body scrolling on web. This makes ScrollView components work closer to how they do on native.
+          However, body scrolling is often nice to have for mobile web. If you want to enable it, remove this line.
+        */}
+        <ScrollViewStyleReset />
+
+        {/* Add any additional <head> elements that you want globally available on web... */}
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}
+```
+
+The **+html.tsx** file:
+
+- Runs only in Node.js during server rendering
+- Cannot import global CSS (use the [Root Layout](/router/basics/layout/#root-layout) for styles)
+- Cannot access browser APIs like `window` or `document`
+- Receives pre-rendered content via the `children` prop
+
+## Meta tags
+
+Add meta tags to your pages using the `<Head />` component from `expo-router`:
+
+```tsx app/about.tsx
+import Head from 'expo-router/head';
+import { Text } from 'react-native';
+
+export default function Page() {
+  return (
+    <>
+      <Head>
+        <title>About Us</title>
+        <meta name="description" content="Learn more about our company." />
+      </Head>
+      <Text>About page content</Text>
+    </>
+  );
+}
+```
+
+In server rendering mode, `<Head>` elements are rendered server-side and included in the initial HTML response, improving search engine optimization (SEO).
+
+## Deployment
+
+Server rendering requires a runtime server to render pages on each request. You **cannot** deploy to static hosting services like GitHub Pages.
+
+### Supported platforms
+
+| Platform                                  | Adapter                       |
+| ----------------------------------------- | ----------------------------- |
+| [EAS Hosting](/eas/hosting/introduction/) | Built-in                      |
+| Node.js/Express                           | `expo-server/adapter/express` |
+| Cloudflare Workers                        | `expo-server/adapter/workerd` |
+| Vercel Edge Functions                     | `expo-server/adapter/vercel`  |
+| Netlify Edge Functions                    | `expo-server/adapter/netlify` |
+| Bun                                       | `expo-server/adapter/bun`     |
+
+<Collapsible summary="Example: Deploying to EAS Hosting">
+
+EAS Hosting supports server rendering out of the box. Export your app and deploy with:
+
+<Terminal cmd={['$ npx expo export --platform web', '$ npx eas-cli hosting:deploy dist']} />
+
+</Collapsible>
+
+## Comparison with static rendering
+
+| Feature            | Static Rendering                                                                        | Server Rendering              |
+| ------------------ | --------------------------------------------------------------------------------------- | ----------------------------- |
+| HTML generation    | Build time                                                                              | Request time                  |
+| Configuration      | `web.output: 'static'`                                                                  | `web.output: 'server'`        |
+| Dynamic routes     | Requires [`generateStaticParams()`](/router/web/static-rendering/#generatestaticparams) | Works automatically           |
+| Server required    | No                                                                                      | Yes                           |
+| Time to First Byte | Fastest (cached)                                                                        | Slower (rendered per request) |
+| Hosting            | Any static host                                                                         | Server runtime required       |
+
+## Common questions
+
+### Can I use data loaders with server rendering?
+
+Yes. Server rendering works with [data loaders](/router/web/data-loaders) to fetch data on the server before rendering.
+
+### Can I mix server and static rendering?
+
+Currently, Expo Router does not support mixing server and static rendering in the same project. Choose a single output mode based on your requirements.
+
+### How do I cache server-rendered responses?
+
+Caching is handled at the server or CDN level. Configure your deployment platform to cache responses based on URL patterns or cache headers.
+
+### Does server rendering work with API routes?
+
+Yes. API routes (files in **app/+api.ts**) work independently of the rendering mode. They are always executed on the server.

--- a/docs/pages/router/web/server-rendering.mdx
+++ b/docs/pages/router/web/server-rendering.mdx
@@ -104,6 +104,7 @@ This creates a **dist** directory with your server-rendered application. Unlike 
 />
 
 In output above includes the following directories inside **dist** directory:
+
 - **client** directory: Contains JavaScript and CSS bundles for client-side hydration
 - **server** directory: Contains the routes manifest and server rendering module
 
@@ -219,7 +220,9 @@ Server-side rendering requires a runtime server to render pages on each request.
 
 EAS Hosting supports server rendering out of the box. Export your app and deploy with:
 
-<Terminal cmd={['$ npx expo export --platform web', '', '$ npx eas-cli@latest hosting:deploy dist']} />
+<Terminal
+  cmd={['$ npx expo export --platform web', '', '$ npx eas-cli@latest hosting:deploy dist']}
+/>
 
 </Collapsible>
 

--- a/docs/pages/router/web/server-rendering.mdx
+++ b/docs/pages/router/web/server-rendering.mdx
@@ -12,8 +12,7 @@ import { Step } from '~/ui/components/Step';
 
 > **important** Server rendering is in alpha and is available in SDK 55 and later. It requires a [deployed server](/router/web/api-routes/#deployment) for production use.
 
-Server-side rendering (SSR) generates HTML dynamically on each request, as opposed to [static rendering](/router/web/static-rendering) which pre-renders HTML at build time.
-This guide will walk you through the process of enabling server rendering for your Expo Router app.
+Server-side rendering (SSR) generates HTML dynamically on each request, as opposed to [static rendering](/router/web/static-rendering), which pre-renders HTML at build time. This guide walks you through enabling server rendering for your Expo Router app.
 
 ## Setup
 
@@ -94,7 +93,7 @@ To export your app for production, run the universal export command:
 
 <Terminal cmd={['$ npx expo export --platform web']} />
 
-This creates a **dist** directory with your server-rendered application. Unlike static rendering, no HTML files are pre-generated. Instead, the output includes:
+This creates a **dist** directory with your server-rendered application. Unlike static rendering, no HTML files are pre-generated. Instead, the output includes a similar directory structure as shown below:
 
 <FileTree
   files={[
@@ -105,14 +104,15 @@ This creates a **dist** directory with your server-rendered application. Unlike 
   ]}
 />
 
-- **client/**: Contains JavaScript and CSS bundles for client-side hydration
-- **server/**: Contains the routes manifest and server rendering module
+In output above includes the following directories inside **dist** directory:
+- **client** directory: Contains JavaScript and CSS bundles for client-side hydration
+- **server** directory: Contains the routes manifest and server rendering module
 
 You can test the production build locally by running the following command and opening the linked URL in your browser:
 
 <Terminal cmd={['$ npx expo serve']} />
 
-This starts a local server that renders pages on each request, simulating a production environment.
+The above command starts a local server that renders pages on each request, simulating a production environment.
 
 ## Dynamic routes
 
@@ -131,7 +131,7 @@ export default function Page() {
 }
 ```
 
-When a user visits `/blog/my-post`, the page is rendered on the server with `id` set to `"my-post"`.
+In the above example, when the app user visits `/blog/my-post`, the page is rendered on the server with `id` set to `"my-post"`.
 
 > **info** If your route file exports `generateStaticParams()`, those routes are excluded and are now handled dynamically. Remove `generateStaticParams()` exports when using server rendering.
 
@@ -156,7 +156,7 @@ export default function Root({ children }: PropsWithChildren) {
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 
         {/*
-          Disable body scrolling on web. This makes ScrollView components work closer to how they do on native.
+          Disable body scrolling on web. This makes ScrollView components work closer to how they do on native platforms.
           However, body scrolling is often nice to have for mobile web. If you want to enable it, remove this line.
         */}
         <ScrollViewStyleReset />
@@ -214,11 +214,11 @@ Server rendering requires a runtime server to render pages on each request. You 
 | Netlify Edge Functions                    | `expo-server/adapter/netlify` |
 | Bun                                       | `expo-server/adapter/bun`     |
 
-<Collapsible summary="Example: Deploying to EAS Hosting">
+<Collapsible summary="Example: Deployment with EAS Hosting">
 
 EAS Hosting supports server rendering out of the box. Export your app and deploy with:
 
-<Terminal cmd={['$ npx expo export --platform web', '$ npx eas-cli hosting:deploy dist']} />
+<Terminal cmd={['$ npx expo export --platform web', '', '$ npx eas-cli@latest hosting:deploy dist']} />
 
 </Collapsible>
 

--- a/docs/pages/router/web/server-rendering.mdx
+++ b/docs/pages/router/web/server-rendering.mdx
@@ -116,7 +116,7 @@ The above command starts a local server that renders pages on each request, simu
 
 ## Dynamic routes
 
-With server rendering, dynamic routes are rendered on the fly, and the [`generateStaticParams()`](/router/web/static-rendering/#generatestaticparams) export is redundant and should not be added. The route is rendered at request time with the actual parameters from the URL.
+With server rendering, dynamic routes are rendered on the fly, and the [`generateStaticParams`](/router/web/static-rendering/#generatestaticparams) export is not needed and should be removed. If your route file exports `generateStaticParams`, those routes will be handled dynamically instead. The route is rendered at request time with the actual parameters from the URL.
 
 ```tsx app/blog/[id].tsx
 import { Text } from 'react-native';
@@ -132,8 +132,6 @@ export default function Page() {
 ```
 
 In the above example, when the app user visits `/blog/my-post`, the page is rendered on the server with `id` set to `"my-post"`.
-
-> **info** If your route file exports `generateStaticParams()`, those routes are excluded and are now handled dynamically. Remove `generateStaticParams()` exports when using server rendering.
 
 ## Root HTML
 
@@ -228,14 +226,14 @@ EAS Hosting supports server rendering out of the box. Export your app and deploy
 
 ## Comparison with static rendering
 
-| Feature            | Static Rendering                                                                        | Server Rendering              |
-| ------------------ | --------------------------------------------------------------------------------------- | ----------------------------- |
-| HTML generation    | Build time                                                                              | Request time                  |
-| Configuration      | `web.output: 'static'`                                                                  | `web.output: 'server'`        |
-| Dynamic routes     | Requires [`generateStaticParams()`](/router/web/static-rendering/#generatestaticparams) | Works automatically           |
-| Server required    | No                                                                                      | Yes                           |
-| Time to First Byte | Fastest (cached)                                                                        | Slower (rendered per request) |
-| Hosting            | Any static host                                                                         | Server runtime required       |
+| Feature            |     | Static Rendering                                                                      | Server Rendering              |
+| ------------------ | :-- | ------------------------------------------------------------------------------------- | ----------------------------- |
+| HTML generation    |     | Build time                                                                            | Request time                  |
+| Configuration      |     | `web.output: 'static'`                                                                | `web.output: 'server'`        |
+| Dynamic routes     |     | Requires [`generateStaticParams`](/router/web/static-rendering/#generatestaticparams) | Works automatically           |
+| Server required    |     | No                                                                                    | Yes                           |
+| Time to First Byte |     | Fastest (cached)                                                                      | Slower (rendered per request) |
+| Hosting            |     | Any static host                                                                       | Server runtime required       |
 
 ## Common questions
 

--- a/docs/pages/router/web/server-rendering.mdx
+++ b/docs/pages/router/web/server-rendering.mdx
@@ -115,7 +115,7 @@ The above command starts a local server that renders pages on each request, simu
 
 ## Dynamic routes
 
-With server rendering, dynamic routes work automatically without needing [`generateStaticParams()`](/router/web/static-rendering/#generatestaticparams). The route is rendered at request time with the actual parameters from the URL.
+With server rendering, dynamic routes are rendered on the fly, and the [`generateStaticParams()`](/router/web/static-rendering/#generatestaticparams) export is redundant and should not be added. The route is rendered at request time with the actual parameters from the URL.
 
 ```tsx app/blog/[id].tsx
 import { Text } from 'react-native';
@@ -168,12 +168,14 @@ export default function Root({ children }: PropsWithChildren) {
 }
 ```
 
-The **+html.tsx** file:
+The **+html.tsx** file is only used by the server-renderer and never by client code. This means:
 
-- Runs only in Node.js during server rendering
-- Cannot import global CSS (use the [Root Layout](/router/basics/layout/#root-layout) for styles)
-- Cannot access browser APIs like `window` or `document`
-- Receives pre-rendered content via the `children` prop
+- It will be run by `expo-server` during server rendering
+- It is not rehydrated on the client, and hence shouldn't use React hooks
+- You may not import global CSS in `+html.tsx` (use the [Root Layout](/router/basics/layout/#root-layout) for styles)
+- You may not call browser APIs like `window` or `document` in your `+html.tsx`
+
+All `+html.tsx` components are expected to render the `children` prop they receive in their JSX content.
 
 ## Meta tags
 
@@ -196,11 +198,11 @@ export default function Page() {
 }
 ```
 
-In server rendering mode, `<Head>` elements are rendered server-side and included in the initial HTML response, improving search engine optimization (SEO).
+During server-side rendering, `<Head>` elements are extracted and included in the initial HTML response, modifying the `<head>` element sent to the client, and improving search engine optimization (SEO).
 
 ## Deployment
 
-Server rendering requires a runtime server to render pages on each request. You **cannot** deploy to static hosting services like GitHub Pages.
+Server-side rendering requires a runtime server to render pages on each request. Server-side rendered Expo apps **cannot** be deployed to static hosting services like GitHub Pages.
 
 ### Supported platforms
 
@@ -248,4 +250,4 @@ Caching is handled at the server or CDN level. Configure your deployment platfor
 
 ### Does server rendering work with API routes?
 
-Yes. API routes (files in **app/+api.ts**) work independently of the rendering mode. They are always executed on the server.
+Yes. [API routes](/router/web/api-routes/) work independently of the rendering mode. They are always executed on the server.

--- a/docs/pages/router/web/static-rendering.mdx
+++ b/docs/pages/router/web/static-rendering.mdx
@@ -331,7 +331,7 @@ In the future, there will be a server API, and a new `web.output` mode which wil
 
 ## Server-side Rendering
 
-Rendering at request-time (SSR) is not supported in `web.output: 'static'`. This will likely be added in a future version of Expo Router.
+Rendering at request-time is not supported with `web.output: 'static'`. To render pages dynamically on each request, use [server rendering](/router/web/server-rendering) with `web.output: 'server'` instead.
 
 ### Where can I deploy statically rendered websites?
 


### PR DESCRIPTION
# Why

Server rendering support was added in https://github.com/expo/expo/pull/41477 and requires documentation on how to set it up, specifically the new `unstable_useServerRendering` flag that was added to the `expo-router` config plugin.

# How

Added a new documentation page with a similar flow to the [existing Static Rendering page](https://docs.expo.dev/router/web/static-rendering/). Also updated the Static Rendering page with a link to the new Server Rendering page.

There's also a link to a Data Loaders page that doesn't yet exist, this will be addressed in a followup PR.

# Test Plan

- CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
