### PR TITLE
docs(expo-router): add missing "Alpha" tag for server middleware

### DIFF
--- a/docs/pages/router/web/middleware.mdx
+++ b/docs/pages/router/web/middleware.mdx
@@ -1,6 +1,7 @@
 ---
 title: Server middleware
 description: Learn how to create middleware that runs for every request to the server in Expo Router.
+isAlpha: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';


### PR DESCRIPTION
# Why

Server middleware is in alpha, and should therefore display the "Alpha" tag in the sidebar.

# How

Added the missing `isAlpha: true` property to the document's front-matter.

# Test Plan

- CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
