### PR TITLE
docs(expo-router): document how to set specifying user-defined headers for all routes

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -273,6 +273,7 @@ export const general = [
     makeGroup('Web', [
       makePage('router/web/api-routes.mdx'),
       makePage('router/web/middleware.mdx'),
+      makePage('router/web/server-headers.mdx'),
       makePage('router/web/static-rendering.mdx'),
       makePage('router/web/async-routes.mdx'),
     ]),

--- a/docs/pages/guides/publishing-websites.mdx
+++ b/docs/pages/guides/publishing-websites.mdx
@@ -45,7 +45,7 @@ Expo Router supports three output targets for web apps.
 | `server`           | <YesIcon /> | <YesIcon /> | Creates **client** and **server** directories. Client files are output as separate HTML files. API routes as separate JavaScript files for hosting with a custom Node.js server. |
 | `static`           | <YesIcon /> | <NoIcon />  | Outputs separate HTML files for every route in the **app** directory.                                                                                                            |
 
-> For `static` and `server` output modes, you can configure [global HTTP headers](/router/web/server-headers) that are applied to all route responses via the `expo-router` plugin.
+> **info** **Note**: For `static` and `server` output modes, you can configure [global HTTP headers](/router/web/server-headers) that are applied to all route responses via the `expo-router` plugin.
 
 ## Create a build
 

--- a/docs/pages/guides/publishing-websites.mdx
+++ b/docs/pages/guides/publishing-websites.mdx
@@ -45,6 +45,8 @@ Expo Router supports three output targets for web apps.
 | `server`           | <YesIcon /> | <YesIcon /> | Creates **client** and **server** directories. Client files are output as separate HTML files. API routes as separate JavaScript files for hosting with a custom Node.js server. |
 | `static`           | <YesIcon /> | <NoIcon />  | Outputs separate HTML files for every route in the **app** directory.                                                                                                            |
 
+> For `static` and `server` output modes, you can configure [global HTTP headers](/router/web/server-headers) that are applied to all route responses via the `expo-router` plugin.
+
 ## Create a build
 
 Creating a build of the project is the first step to publishing a web app. Whether you want to serve it locally or deploy to a hosting service, you'll need to export all JavaScript and assets of a project. This is known as a static bundle. It can be exported by running the following command:

--- a/docs/pages/router/web/server-headers.mdx
+++ b/docs/pages/router/web/server-headers.mdx
@@ -1,7 +1,6 @@
 ---
 title: Server headers
 description: Learn how to set custom HTTP headers for all server route responses in Expo Router.
-isNew: true
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
@@ -17,7 +16,7 @@ Server headers in Expo Router allow you to set custom HTTP headers on all route 
 
 <Step label="1">
 
-Configure headers in the **expo-router** plugin in your [app config](/versions/latest/config/app/):
+Configure headers in the `expo-router` plugin in your [app config](/versions/latest/config/app/):
 
 ```json app.json
 {

--- a/docs/pages/router/web/server-headers.mdx
+++ b/docs/pages/router/web/server-headers.mdx
@@ -55,10 +55,6 @@ Headers are automatically applied to all HTML and API route responses.
 
 Headers are configured as an object where keys are header names and values are either strings or arrays of strings.
 
-### Single-value headers
-
-Use a string value for headers that have a single value:
-
 ```json app.json
 {
   "expo": {
@@ -68,27 +64,7 @@ Use a string value for headers that have a single value:
         {
           "headers": {
             "X-Frame-Options": "DENY",
-            "X-Content-Type-Options": "nosniff"
-          }
-        }
-      ]
-    ]
-  }
-}
-```
-
-### Multi-value headers
-
-Use an array of strings for headers that can have multiple values, such as `Set-Cookie`:
-
-```json app.json
-{
-  "expo": {
-    "plugins": [
-      [
-        "expo-router",
-        {
-          "headers": {
+            "X-Content-Type-Options": "nosniff",
             "Set-Cookie": ["session=abc123; HttpOnly", "preference=dark; Path=/"]
           }
         }
@@ -97,8 +73,6 @@ Use an array of strings for headers that can have multiple values, such as `Set-
   }
 }
 ```
-
-When using arrays, each value is appended to the response headers using the `append()` method, which is required for headers like `Set-Cookie` that can appear multiple times.
 
 ## Examples
 

--- a/docs/pages/router/web/server-headers.mdx
+++ b/docs/pages/router/web/server-headers.mdx
@@ -8,7 +8,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-> **important** Server headers are available in SDK 55 and later.
+> **important** Server headers are available in SDK 54 and later.
 
 Server headers in Expo Router allow you to set custom HTTP headers on all route responses from your server. This feature works with both `static` and `server` output modes, making it useful for security headers, caching policies, cookies, and custom metadata.
 
@@ -205,7 +205,7 @@ Add custom headers with metadata about your app:
 
 Server headers work with both output modes configured in your app config:
 
-- **`static`**: Headers are applied when serving pre-rendered HTML files
+- **`static`**: Headers are applied when serving pre-rendered HTML files with `expo-server`
 - **`server`**: Headers are applied to dynamically rendered responses
 
 ### Header precedence
@@ -216,7 +216,7 @@ For example, if you configure `Cache-Control: public, max-age=3600` globally, bu
 
 ## Known limitations
 
-- **Redirects**: Headers do not apply to redirect responses. This is a limitation of the [Fetch API's](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) [`Response.redirect()`](https://developer.mozilla.org/en-US/docs/Web/API/Response/redirect_static) method, which does not support passing extra headers.
+- **Redirects**: Headers do not apply to redirect responses
 - **Static assets**: Headers are only applied to HTML and API route responses, not to static assets like images, fonts, or JavaScript bundles.
 
 ## Related

--- a/docs/pages/router/web/server-headers.mdx
+++ b/docs/pages/router/web/server-headers.mdx
@@ -1,0 +1,235 @@
+---
+title: Server headers
+description: Learn how to set custom HTTP headers for all server route responses in Expo Router.
+isNew: true
+---
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { Collapsible } from '~/ui/components/Collapsible';
+import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
+
+> **important** Server headers are available in SDK 55 and later.
+
+Server headers in Expo Router allow you to set custom HTTP headers on all route responses from your server. This feature works with both `static` and `server` output modes, making it useful for security headers, caching policies, cookies, and custom metadata.
+
+## Setup
+
+<Step label="1">
+
+Configure headers in the **expo-router** plugin in your [app config](/versions/latest/config/app/):
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-router",
+        {
+          "headers": {
+            "X-Frame-Options": "DENY"
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+</Step>
+
+<Step label="2">
+
+Start the development server or export for production:
+
+<Terminal
+  cmd={['$ npx expo start', '', '# Or export for production', '$ npx expo export -p web']}
+/>
+
+Headers are automatically applied to all HTML and API route responses.
+
+</Step>
+
+## Configuration
+
+Headers are configured as an object where keys are header names and values are either strings or arrays of strings.
+
+### Single-value headers
+
+Use a string value for headers that have a single value:
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-router",
+        {
+          "headers": {
+            "X-Frame-Options": "DENY",
+            "X-Content-Type-Options": "nosniff"
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+### Multi-value headers
+
+Use an array of strings for headers that can have multiple values, such as `Set-Cookie`:
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-router",
+        {
+          "headers": {
+            "Set-Cookie": ["session=abc123; HttpOnly", "preference=dark; Path=/"]
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+When using arrays, each value is appended to the response headers using the `append()` method, which is required for headers like `Set-Cookie` that can appear multiple times.
+
+## Examples
+
+<Collapsible summary="Security headers">
+
+Add common security headers to protect your application:
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-router",
+        {
+          "headers": {
+            "X-Frame-Options": "DENY",
+            "X-Content-Type-Options": "nosniff",
+            "Referrer-Policy": "strict-origin-when-cross-origin",
+            "X-XSS-Protection": "1; mode=block"
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+</Collapsible>
+
+<Collapsible summary="Cache-Control headers">
+
+Set caching policies for your responses:
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-router",
+        {
+          "headers": {
+            "Cache-Control": "public, max-age=3600, s-maxage=86400"
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+</Collapsible>
+
+<Collapsible summary="Setting cookies">
+
+Set cookies on all responses using the array syntax:
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-router",
+        {
+          "headers": {
+            "Set-Cookie": [
+              "session=abc123; HttpOnly; Secure; SameSite=Strict",
+              "preferences=dark; Path=/; Max-Age=31536000"
+            ]
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+</Collapsible>
+
+<Collapsible summary="Custom headers">
+
+Add custom headers with metadata about your app:
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-router",
+        {
+          "headers": {
+            "X-App-Version": "1.0.0",
+            "X-Environment": "production"
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+</Collapsible>
+
+## How it works
+
+### Output modes
+
+Server headers work with both output modes configured in your app config:
+
+- **`static`**: Headers are applied when serving pre-rendered HTML files
+- **`server`**: Headers are applied to dynamically rendered responses
+
+### Header precedence
+
+Headers defined in the `expo-router` plugin are applied globally but do not override headers set by API routes. If an API route returns a response with a header that is also defined in the plugin configuration, the route-specific header takes precedence.
+
+For example, if you configure `Cache-Control: public, max-age=3600` globally, but an API route that returns real-time data sets `Cache-Control: no-store`, the API route's header takes precedence.
+
+## Known limitations
+
+- **Redirects**: Headers do not apply to redirect responses. This is a limitation of the [Fetch API's](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) [`Response.redirect()`](https://developer.mozilla.org/en-US/docs/Web/API/Response/redirect_static) method, which does not support passing extra headers.
+- **Static assets**: Headers are only applied to HTML and API route responses, not to static assets like images, fonts, or JavaScript bundles.
+
+## Related
+
+<BoxLink
+  title="API Routes"
+  description="Learn how to create server endpoints with Expo Router."
+  href="/router/web/api-routes"
+/>
+
+<BoxLink
+  title="Server middleware"
+  description="Learn how to create middleware that runs for every request to the server."
+  href="/router/web/middleware"
+/>

--- a/docs/pages/router/web/server-headers.mdx
+++ b/docs/pages/router/web/server-headers.mdx
@@ -3,14 +3,16 @@ title: Server headers
 description: Learn how to set custom HTTP headers for all server route responses in Expo Router.
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-> **important** Server headers are available in SDK 54 and later.
+> **important** Server headers are available in SDK 54 and later, and requires [`expo-server`](/versions/latest/sdk/server/) to serve your exported application.
 
-Server headers in Expo Router allow you to set custom HTTP headers on all route responses from your server. This feature works with both `static` and `server` output modes, making it useful for security headers, caching policies, cookies, and custom metadata.
+Server headers in Expo Router allow you to set custom HTTP headers for security, caching, cookies, and custom metadata on route responses. Headers **only** apply to HTML and API route responses, and are not applicable to static assets such as images, fonts, or JavaScript bundles.
 
 ## Setup
 
@@ -126,6 +128,30 @@ Add common security headers to protect your application:
 
 </Collapsible>
 
+<Collapsible summary="Cross-Origin headers for SharedArrayBuffer">
+
+Some web APIs like [`SharedArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) require specific Cross-Origin headers. This is required for features like [`expo-sqlite` on web](/versions/latest/sdk/sqlite/#web-setup).
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-router",
+        {
+          "headers": {
+            "Cross-Origin-Embedder-Policy": "credentialless",
+            "Cross-Origin-Opener-Policy": "same-origin"
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+</Collapsible>
+
 <Collapsible summary="Cache-Control headers">
 
 Set caching policies for your responses:
@@ -139,32 +165,6 @@ Set caching policies for your responses:
         {
           "headers": {
             "Cache-Control": "public, max-age=3600, s-maxage=86400"
-          }
-        }
-      ]
-    ]
-  }
-}
-```
-
-</Collapsible>
-
-<Collapsible summary="Setting cookies">
-
-Set cookies on all responses using the array syntax:
-
-```json app.json
-{
-  "expo": {
-    "plugins": [
-      [
-        "expo-router",
-        {
-          "headers": {
-            "Set-Cookie": [
-              "session=abc123; HttpOnly; Secure; SameSite=Strict",
-              "preferences=dark; Path=/; Max-Age=31536000"
-            ]
           }
         }
       ]
@@ -205,7 +205,7 @@ Add custom headers with metadata about your app:
 
 Server headers work with both output modes configured in your app config:
 
-- **`static`**: Headers are applied when serving pre-rendered HTML files with `expo-server`
+- **`static`**: Headers are applied when serving pre-rendered HTML files with [`expo-server`](/versions/latest/sdk/server/)
 - **`server`**: Headers are applied to dynamically rendered responses
 
 ### Header precedence
@@ -217,7 +217,7 @@ For example, if you configure `Cache-Control: public, max-age=3600` globally, bu
 ## Known limitations
 
 - **Redirects**: Headers do not apply to redirect responses
-- **Static assets**: Headers are only applied to HTML and API route responses, not to static assets like images, fonts, or JavaScript bundles.
+- **Static assets**: Headers are only applied to HTML and API route responses, not to static assets like images, fonts, or JavaScript bundles
 
 ## Related
 
@@ -225,10 +225,12 @@ For example, if you configure `Cache-Control: public, max-age=3600` globally, bu
   title="API Routes"
   description="Learn how to create server endpoints with Expo Router."
   href="/router/web/api-routes"
+  Icon={BookOpen02Icon}
 />
 
 <BoxLink
   title="Server middleware"
   description="Learn how to create middleware that runs for every request to the server."
   href="/router/web/middleware"
+  Icon={BookOpen02Icon}
 />


### PR DESCRIPTION
# Why

We currently don't document how to set user-defined headers for Expo apps, support for which was added in https://github.com/expo/expo/pull/40173.

# How

Created a new page in the documentation with examples of how to add user-defined headers, along with its limitations.

# Test Plan

- CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
