### PR TITLE
[go][Android] Add `ContactsNextModule`

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
@@ -16,6 +16,7 @@ import expo.modules.clipboard.ClipboardModule
 import expo.modules.constants.ConstantsModule
 import expo.modules.constants.ConstantsService
 import expo.modules.contacts.ContactsModule
+import expo.modules.contacts.next.ContactsNextModule
 import expo.modules.core.interfaces.Package
 import expo.modules.crypto.CryptoModule
 import expo.modules.crypto.aes.AesCryptoModule
@@ -146,6 +147,7 @@ object ExperiencePackagePicker : ModulesProvider {
     CryptoModule::class.java to null,
     ConstantsModule::class.java to null,
     ContactsModule::class.java to null,
+    ContactsNextModule::class.java to null,
     DeviceModule::class.java to null,
     DocumentPickerModule::class.java to null,
     EASClientModule::class.java to null,


### PR DESCRIPTION
# Why

Adds `ContactsNextModule` to Expo Go on Android. It should be automatically added on iOS via auto-linking.

# Test Plan

- NCL in Expo Go ✅ 