### PR TITLE
[docs] Improve Ask AI prompt for SDK docs

### DIFF
--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -266,14 +266,14 @@ export function AskPageAIChat({
       }
       const origin = typeof window !== 'undefined' ? window.location.href : '';
       return [
-        'You are ExpoDocsExpert, an assistant that should base answers on the supplied Expo SDK documentation context from this page.',
-        `The user is reading the Expo docs page titled "${contextLabel}" at ${origin || 'the latest Expo SDK docs'}.`,
-        'Use only information from this page as your source; do not rely on other pages, memory, or general knowledge.',
-        'If the page supports part of the question, answer that part and state clearly which parts are not covered by this page. Do not add unsupported details.',
-        `If this page provides zero relevant information (or the question is unrelated), respond exactly with: "${fallbackResponse}" followed by " To find this, choose “Search all Expo docs.”" Do not add anything else.`,
-        'Prefer concise explanations, reference relevant APIs or headings, and format instructions as short steps or bullet lists when helpful.',
-        'Whenever you share code or configuration examples, return complete, ready-to-run snippets with all required imports and setup so the user can copy and paste them into their app without additional context.',
-        'Mention the Expo SDK version when relevant (this context represents the "latest" docs).',
+        'You are ExpoDocsExpert answering only from this page’s Expo SDK docs.',
+        `Current page title: "${contextLabel}" at ${origin || 'latest Expo SDK docs'}.`,
+        'Use only this page; do not pull from other pages, memory, or prior answers.',
+        'If only part of the question is covered here, answer that part and say what is missing. Do not add details not on this page.',
+        `If nothing on this page is relevant (or the question is unrelated), respond exactly with: "${fallbackResponse}" followed by " To find this, choose 'Search Expo docs.'" Do not add anything else.`,
+        'Keep answers concise; reference headings/APIs; use short steps or bullets when helpful.',
+        'Code/config examples must be complete and ready to run with all imports/setup.',
+        'Mention the Expo SDK version when helpful (this page is "latest").',
         '',
         `User question: ${text}`,
       ].join('\n');

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -268,10 +268,9 @@ export function AskPageAIChat({
       return [
         'You are ExpoDocsExpert, an assistant that should base answers on the supplied Expo SDK documentation context from this page.',
         `The user is reading the Expo docs page titled "${contextLabel}" at ${origin || 'the latest Expo SDK docs'}.`,
-        'Use only information from this page as your source; do not invent facts outside it.',
-        'If the context answers part of the question, answer those parts and state clearly where more information is needed.',
-        'When the question needs details beyond this page, invite the user to "Search all Expo docs" rather than refusing.',
-        `If the question is unrelated to the provided context and you cannot answer with this page alone, respond exactly with: "${fallbackResponse}" Do not explain or apologize.`,
+        'Use only information from this page as your source; do not rely on other pages, memory, or general knowledge.',
+        'If the page supports part of the question, answer that part and state clearly which parts are not covered by this page. Do not add unsupported details.',
+        `If this page provides zero relevant information (or the question is unrelated), respond exactly with: "${fallbackResponse}" followed by " To find this, choose “Search all Expo docs.”" Do not add anything else.`,
         'Prefer concise explanations, reference relevant APIs or headings, and format instructions as short steps or bullet lists when helpful.',
         'Whenever you share code or configuration examples, return complete, ready-to-run snippets with all required imports and setup so the user can copy and paste them into their app without additional context.',
         'Mention the Expo SDK version when relevant (this context represents the "latest" docs).',
@@ -431,6 +430,7 @@ export function AskPageAIChat({
           markersByIndex={markersByIndex}
           isBusy={isBusy}
           markdownComponents={markdownComponents}
+          basePath={basePath}
           onSearchAcrossDocs={handleSearchAcrossDocs}
           extractUserQuestion={extractUserQuestion}
           onNavigate={handleNavigation}

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -266,12 +266,12 @@ export function AskPageAIChat({
       }
       const origin = typeof window !== 'undefined' ? window.location.href : '';
       return [
-        'You are ExpoDocsExpert, an assistant that must answer strictly using the supplied Expo SDK documentation context.',
+        'You are ExpoDocsExpert, an assistant that should base answers on the supplied Expo SDK documentation context from this page.',
         `The user is reading the Expo docs page titled "${contextLabel}" at ${origin || 'the latest Expo SDK docs'}.`,
-        'You only have access to the content from this page. You do not have access to other pages, past answers, or external knowledge.',
-        'Before responding, confirm that every sentence in your answer is directly supported by the provided context.',
-        `If you cannot confirm this support, respond exactly with: "${fallbackResponse}" Do not explain or apologize.`,
-        `If the question is unrelated to the provided context, respond exactly with: "${fallbackResponse}"`,
+        'Use only information from this page as your source; do not invent facts outside it.',
+        'If the context answers part of the question, answer those parts and state clearly where more information is needed.',
+        'When the question needs details beyond this page, invite the user to "Search all Expo docs" rather than refusing.',
+        `If the question is unrelated to the provided context and you cannot answer with this page alone, respond exactly with: "${fallbackResponse}" Do not explain or apologize.`,
         'Prefer concise explanations, reference relevant APIs or headings, and format instructions as short steps or bullet lists when helpful.',
         'Whenever you share code or configuration examples, return complete, ready-to-run snippets with all required imports and setup so the user can copy and paste them into their app without additional context.',
         'Mention the Expo SDK version when relevant (this context represents the "latest" docs).',

--- a/docs/ui/components/AskPageAI/AskPageAIChatMessages.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChatMessages.tsx
@@ -84,11 +84,12 @@ export function AskPageAIChatMessages({
         const trimmedAnswer = normalizedAnswer?.trim();
         const trimmedLower = trimmedAnswer?.toLowerCase() ?? '';
         const fallbackLower = fallbackResponse.toLowerCase();
+        const hasSources = Array.isArray(qa.sources) && qa.sources.length > 0;
         const isOffPageAnswer =
           contextScope === 'page' &&
-          Boolean(qa.sources?.length) &&
-          qa.sources.some(source => !source.source_url.includes(basePath));
-        const sourcesForDisplay = isOffPageAnswer ? [] : qa.sources;
+          hasSources &&
+          (qa.sources?.some(source => !source.source_url.includes(basePath)) ?? false);
+        const sourcesForDisplay = isOffPageAnswer ? [] : qa.sources ?? [];
         const isFallbackAnswer =
           trimmedAnswer === fallbackResponse ||
           trimmedLower.startsWith(fallbackLower) ||

--- a/docs/ui/components/AskPageAI/AskPageAIChatMessages.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChatMessages.tsx
@@ -88,8 +88,8 @@ export function AskPageAIChatMessages({
         const isOffPageAnswer =
           contextScope === 'page' &&
           hasSources &&
-          (qa.sources?.some(source => !source.source_url.includes(basePath)) ?? false);
-        const sourcesForDisplay = isOffPageAnswer ? [] : qa.sources ?? [];
+          qa.sources!.some(source => !source.source_url.includes(basePath));
+        const sourcesForDisplay = isOffPageAnswer ? [] : (qa.sources ?? []);
         const isFallbackAnswer =
           trimmedAnswer === fallbackResponse ||
           trimmedLower.startsWith(fallbackLower) ||

--- a/docs/ui/components/AskPageAI/AskPageAIChatMessages.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChatMessages.tsx
@@ -91,8 +91,6 @@ export function AskPageAIChatMessages({
           qa.sources!.some(source => !source.source_url.includes(basePath));
         const sourcesForDisplay = isOffPageAnswer ? [] : (qa.sources ?? []);
         const isFallbackAnswer =
-          trimmedAnswer === fallbackResponse ||
-          trimmedLower.startsWith(fallbackLower) ||
           trimmedLower.includes(fallbackLower) ||
           trimmedLower.includes('search all expo docs') ||
           isOffPageAnswer;


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Fix ENG-18752

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Shortened the widget's prompt for the currently viewed page.
- Loosened page-scope prompt to allow partial answers while still blocking unsupported content and nudging users to global search when the page has no relevant info.
- Improved fallback detection to catch polite/modified fallback phrasing and off-page answers, showing the “Search Expo docs” button reliably.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally, visit an SDK page under `/latest` and ask it relevant and out-of-scope questions.

<img width="1937" height="1177" alt="CleanShot 2026-01-19 at 15 44 27" src="https://github.com/user-attachments/assets/181f0f70-de51-42bb-919d-6662d3da9b5a" />

<img width="1937" height="1177" alt="CleanShot 2026-01-19 at 15 46 08" src="https://github.com/user-attachments/assets/db8dfe66-6688-4ca0-a328-d6323e03d0ba" />

<img width="1937" height="1177" alt="CleanShot 2026-01-19 at 15 48 57" src="https://github.com/user-attachments/assets/c951802d-2ec8-4d41-b62a-3fdff82f6292" />

<img width="1937" height="1177" alt="CleanShot 2026-01-19 at 15 49 27" src="https://github.com/user-attachments/assets/e8df62a5-dc3b-4937-ab03-e2d5186ad96f" />

In Kapa dashboard:

<img width="666" height="247" alt="CleanShot 2026-01-19 at 15 53 54" src="https://github.com/user-attachments/assets/f358cf5b-d85d-43b7-ac74-8406f528265b" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
