### PR TITLE
[docs] Improve MCP Server guide

### DIFF
--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -129,7 +129,7 @@ After installing the MCP server, you'll need to authenticate using one of two me
 
 Generate a **Personal access token** from your Expo account and use it during the OAuth flow.
 
-- To generate an access token, go to your EAS dashboard and open [Access tokens](https://expo.dev/accounts/[account]/settings/access-tokens) settings page.
+- To generate an access token, open [Access tokens](https://expo.dev/accounts/[account]/settings/access-tokens) settings page in EAS dashboard.
 - Under **Personal access tokens**, click **Create token**. Copy the token and use it during the OAuth flow.
 
 

--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -56,7 +56,7 @@ The complete table of [MCP capabilities](#available-mcp-capabilities) documents 
 Before using Expo MCP Server, ensure you have:
 
 - An Expo account with an EAS paid plan
-- An Expo project with Expo SDK 54 and the latest `expo` package version
+- An Expo project created either with `npx create-expo-app@latest` or has the latest `expo` package version installed
 - AI-assisted tools with remote MCP server support (Claude Code, Cursor, VS Code, and so on)
 
 ## Installation and setup
@@ -112,6 +112,8 @@ Click the following link to install the MCP server for Cursor:
 <Collapsible summary="Codex setup">
 
 <Terminal cmd={['$ codex mcp add expo-mcp --url https://mcp.expo.dev/mcp']} />
+
+The above command adds the MCP server to your Codex configuration file and prompts you to authenticate with your Expo account.
 
 </Collapsible>
 

--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -132,7 +132,6 @@ Generate a **Personal access token** from your Expo account and use it during th
 - To generate an access token, open [Access tokens](https://expo.dev/accounts/[account]/settings/access-tokens) settings page in EAS dashboard.
 - Under **Personal access tokens**, click **Create token**. Copy the token and use it during the OAuth flow.
 
-
 #### Credentials
 
 Use your Expo account username and password. In this case, the server will generate an access token automatically.

--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -129,7 +129,9 @@ After installing the MCP server, you'll need to authenticate using one of two me
 
 Generate a **Personal access token** from your Expo account and use it during the OAuth flow.
 
-To generate an access token, open your EAS dashboard, navigate to **Credentials** > **Access tokens** > **Personal access tokens**, and then click **Create token**.
+- To generate an access token, go to your EAS dashboard and open [Access tokens](https://expo.dev/accounts/[account]/settings/access-tokens) settings page.
+- Under **Personal access tokens**, click **Create token**. Copy the token and use it during the OAuth flow.
+
 
 #### Credentials
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18803

The prerequisite mentions SDK 54. I think with the new SDK upcoming, the second statement under Prerequisite section should mention using `latest` tag to create an Expo project or the `expo` sdk version in a project.

# How

<!--
How did you build this feature or fix this bug and why?
-->

* Clarified that an Expo project can be created with `npx create-expo-app@latest` or by installing the latest `expo` package version, instead of requiring Expo SDK 54 specifically.
* Added a note explaining that the `codex mcp add` command updates your Codex configuration and prompts for Expo account authentication.
* Improved instructions for generating a personal access token by providing a direct link to the Access Tokens settings page and breaking down the steps for clarity.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally, and visit: http://localhost:3002/eas/ai/mcp/

## Preview

<img width="870" height="234" alt="CleanShot 2026-01-19 at 16 56 51" src="https://github.com/user-attachments/assets/fba3f2cb-26c9-4f7d-8875-e8ce4c634ed0" />

<img width="879" height="248" alt="CleanShot 2026-01-19 at 16 57 28" src="https://github.com/user-attachments/assets/9b76aca0-6d95-4245-bb2a-9aa0dae92593" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
