### PR TITLE
[docs] Improve build locally overview and its discoverability

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -177,7 +177,7 @@ export const general = [
       { expanded: false }
     ),
     makeGroup(
-      'Compile locally',
+      'Build locally',
       [
         makePage('guides/local-app-overview.mdx'),
         makePage('guides/local-app-development.mdx'),

--- a/docs/pages/guides/local-app-development.mdx
+++ b/docs/pages/guides/local-app-development.mdx
@@ -1,7 +1,7 @@
 ---
-title: Local app development
+title: Create a debug build locally
 sidebar_title: Development
-description: Learn how to compile and build your Expo app locally.
+description: Learn how to create a debug build for your Expo app locally.
 ---
 
 import { BuildIcon } from '@expo/styleguide-icons/custom/BuildIcon';

--- a/docs/pages/guides/local-app-overview.mdx
+++ b/docs/pages/guides/local-app-overview.mdx
@@ -1,27 +1,29 @@
 ---
-title: 'Compile locally: Overview'
+title: 'Build locally: Overview'
 sidebar_title: Overview
-description: An overview on local app compilation process for your Expo apps.
+description: An overview of how to build your app locally using your own machine for Expo projects.
+searchRank: 90
+searchPosition: 1
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 
-You can leverage your local development environment to compile your app locally by utilizing Android Studio and Xcode. This compilation process can be done for both debug and release builds. This page provides an overview of the local app compilation process and references to other guides that might be necessary in this workflow.
+You can leverage your local development environment to build your app locally by utilizing Android Studio and Xcode. This build process can be done for both debug and release builds. This page provides an overview on different ways to build your app locally using your own machine and references to other guides that might be necessary in this workflow.
 
-## When to compile your app locally
+## When to build your app locally
 
-There are different scenarios when you want to compile your app on your developer machine. It includes:
+There are different scenarios when you want to build your app on your developer machine:
 
-- You want to iterate quickly on native code changes or test platform-specific changes in your debug build
-- You want to manually generate native code to test your debug build
-- Any scenario where you are required to create builds inside an environment where access to a network is restricted
-- You want to locally manage your own credentials (such as upload key, and so on)
-- You want to test or integrate your own custom build cache provider
-- You want to opt out of prebuilt Expo Modules for Android and compile them from source locally once
+- You want to iterate quickly on native code changes or test platform-specific changes in your debug build.
+- You want to manually generate native code to test your debug build.
+- Any scenario where you are required to create builds inside an environment where access to a network is restricted.
+- You want to locally manage your own credentials (such as upload key, and so on).
+- You want to test or integrate your own custom build cache provider.
+- You want to opt out of prebuilt Expo Modules for Android and compile them from source locally once.
 
-> **Note**: Compiling your app locally complements EAS Build. You can keep using the build service for cloud automation and fall back to local builds for development.
+> **Note**: Building your app locally complements EAS Build. You can keep using the build service for cloud automation and fall back to local builds for development.
 
 ## Prerequisites
 
@@ -30,24 +32,24 @@ You need to install and set up Android Studio and Xcode to compile and run Andro
 - [Android Studio](/get-started/set-up-your-environment/?platform=android&device=physical&mode=development-build&buildEnv=local#set-up-an-android-device-with-a-development-build)
 - [Xcode](/get-started/set-up-your-environment/?platform=ios&device=physical&mode=development-build&buildEnv=local#set-up-an-ios-device-with-a-development-build)
 
-## Compiling your debug build
+## Creating your debug build locally
 
 To quickly build and iterate on a debug build, you can use Expo CLI's `npx expo run:[android|ios]` commands. These commands compile your project, using your locally installed Android SDK or Xcode, into a debug build of your app.
 
 <BoxLink
-  title="Local app development"
-  description="Learn how to compile and build your Expo app locally."
+  title="Create a debug build locally"
+  description="Learn how to create a debug build for your Expo app locally."
   href="/guides/local-app-development/"
   Icon={BookOpen02Icon}
 />
 
-## Compiling your release build
+## Creating your release build locally
 
 To create a release build (also known as production build) of your app, you generate signing credentials by utilizing tools provided by Android Studio and Xcode. Then, you can generate a release build and follow the process of manually submitting your app to Google Play Store or Apple App Store.
 
 <BoxLink
-  title="Create a production build locally"
-  description="Generate signed Android App Bundles, archive iOS builds in Xcode, and submit them manually."
+  title="Create a release build locally"
+  description="Generate signed Android App Bundles, archive iOS builds in Xcode, and submit them manually to app stores."
   href="/guides/local-app-production/"
   Icon={BookOpen02Icon}
 />

--- a/docs/pages/guides/local-app-overview.mdx
+++ b/docs/pages/guides/local-app-overview.mdx
@@ -16,12 +16,12 @@ You can leverage your local development environment to build your app locally by
 
 There are different scenarios when you want to build your app on your developer machine:
 
-- You want to iterate quickly on native code changes or test platform-specific changes in your debug build.
-- You want to manually generate native code to test your debug build.
+- You want to iterate quickly on native code changes or test platform-specific changes in your debug build
+- You want to manually generate native code to test your debug build
 - Any scenario where you are required to create builds inside an environment where access to a network is restricted.
-- You want to locally manage your own credentials (such as upload key, and so on).
-- You want to test or integrate your own custom build cache provider.
-- You want to opt out of prebuilt Expo Modules for Android and compile them from source locally once.
+- You want to locally manage your own credentials (such as upload key, and so on)
+- You want to test or integrate your own custom build cache provider
+- You want to opt out of prebuilt Expo Modules for Android and compile them from source locally once
 
 > **Note**: Building your app locally complements EAS Build. You can keep using the build service for cloud automation and fall back to local builds for development.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18794

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Retitle the local app overview to "Build locally" and add searchRank/searchPosition to boost the “build locally” query in
  Algolia.
- Replace "compile" phrasing with "build" across headings, intro, and box links; clarify debug/release wording.
- Retitle the debug guide to "Create a debug build locally" to align with the overview and search intent.
- Rename the Compile locally sidebar group title to "Build locally"

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
