### PR TITLE
[docs] Add/remove `isNew` field from Reference docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/blob.mdx
+++ b/docs/pages/versions/unversioned/sdk/blob.mdx
@@ -4,7 +4,6 @@ description: A web standards-compliant Blob implementation for React Native.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-blob'
 packageName: 'expo-blob'
 platforms: ['android', 'ios', 'web', 'expo-go']
-isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/filesystem.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem.mdx
@@ -5,7 +5,6 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-file-system
 packageName: 'expo-file-system'
 iconUrl: '/static/images/packages/expo-file-system.png'
 platforms: ['android', 'ios', 'tvos', 'expo-go']
-isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/glass-effect.mdx
+++ b/docs/pages/versions/unversioned/sdk/glass-effect.mdx
@@ -4,7 +4,6 @@ description: React components that render a liquid glass effect using iOS's nati
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-glass-effect'
 packageName: 'expo-glass-effect'
 platforms: ['ios', 'tvos', 'expo-go']
-isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/router-native-tabs.mdx
+++ b/docs/pages/versions/unversioned/sdk/router-native-tabs.mdx
@@ -4,7 +4,6 @@ description: An Expo Router submodule that provides native tabs layout.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
 packageName: 'expo-router'
 platforms: ['android', 'ios', 'tvos', 'web', 'expo-go']
-isNew: true
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';

--- a/docs/pages/versions/unversioned/sdk/router-split-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/router-split-view.mdx
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
 packageName: 'expo-router'
 platforms: ['ios']
 isAlpha: true
+isNew: true
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';

--- a/docs/pages/versions/unversioned/sdk/server.mdx
+++ b/docs/pages/versions/unversioned/sdk/server.mdx
@@ -4,7 +4,6 @@ description: Server-side API and runtime for Expo Router projects.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-server'
 packageName: 'expo-server'
 platforms: ['server']
-isNew: true
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Add/remove `isNew` field from Reference docs from unversioned before cut off. This way, libraries introduced in the previous/current SDK are aligned with the next SDK release.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
