### PR TITLE
[docs] Add code blocks under API sections in Expo UI

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/bottomsheet.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/bottomsheet.mdx
@@ -46,4 +46,8 @@ A bottom sheet component that slides up from the bottom of the screen to present
 
 ## API
 
+```tsx
+import { BottomSheet } from '@expo/ui/jetpack-compose';
+```
+
 <APISection packageName="expo-ui/jetpack-compose/bottomsheet" apiName="BottomSheet" />

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/button.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/button.mdx
@@ -57,4 +57,8 @@ A button component for displaying native buttons.
 
 ## API
 
+```tsx
+import { Button } from '@expo/ui/jetpack-compose';
+```
+
 <APISection packageName="expo-ui/jetpack-compose/button" apiName="Button" />

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/chip.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/chip.mdx
@@ -72,4 +72,8 @@ A chip component for displaying compact elements that represent inputs, attribut
 
 ## API
 
+```tsx
+import { Chip } from '@expo/ui/jetpack-compose';
+```
+
 <APISection packageName="expo-ui/jetpack-compose/chip" apiName="Chip" />

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/circularprogress.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/circularprogress.mdx
@@ -41,4 +41,8 @@ A circular progress indicator component for displaying progress in a circular fo
 
 ## API
 
+```tsx
+import { CircularProgress } from '@expo/ui/jetpack-compose';
+```
+
 <APISection packageName="expo-ui/jetpack-compose/circularprogress" apiName="CircularProgress" />

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/contextmenu.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/contextmenu.mdx
@@ -69,4 +69,8 @@ A context menu component that displays a menu when triggered, commonly used for 
 
 ## API
 
+```tsx
+import { ContextMenu } from '@expo/ui/jetpack-compose';
+```
+
 <APISection packageName="expo-ui/jetpack-compose/contextmenu" apiName="ContextMenu" />

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/datetimepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/datetimepicker.mdx
@@ -77,4 +77,8 @@ A date and time picker component that allows users to select dates, times, or bo
 
 ## API
 
+```tsx
+import { DateTimePicker } from '@expo/ui/jetpack-compose';
+```
+
 <APISection packageName="expo-ui/jetpack-compose/datetimepicker" apiName="DateTimePicker" />

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/index.mdx
@@ -6,6 +6,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
 platforms: ['android']
 isAlpha: true
+hideTOC: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/linearprogress.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/linearprogress.mdx
@@ -41,4 +41,8 @@ A linear progress indicator component for displaying progress in a horizontal ba
 
 ## API
 
+```tsx
+import { LinearProgress } from '@expo/ui/jetpack-compose';
+```
+
 <APISection packageName="expo-ui/jetpack-compose/linearprogress" apiName="LinearProgress" />

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/picker.mdx
@@ -77,4 +77,8 @@ A picker component that allows users to select from a list of options with diffe
 
 ## API
 
+```tsx
+import { Picker } from '@expo/ui/jetpack-compose';
+```
+
 <APISection packageName="expo-ui/jetpack-compose/picker" apiName="Picker" />

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/slider.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/slider.mdx
@@ -47,4 +47,8 @@ A slider component that allows users to select a value from a continuous range b
 
 ## API
 
+```tsx
+import { Slider } from '@expo/ui/jetpack-compose';
+```
+
 <APISection packageName="expo-ui/jetpack-compose/slider" apiName="Slider" />

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/switch.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/switch.mdx
@@ -83,4 +83,8 @@ A switch component that provides toggle functionality with different visual styl
 
 ## API
 
+```tsx
+import { Switch } from '@expo/ui/jetpack-compose';
+```
+
 <APISection packageName="expo-ui/jetpack-compose/switch" apiName="Switch" />

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/textinput.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/textinput.mdx
@@ -41,4 +41,8 @@ A text input component that allows users to enter and edit text using native And
 
 ## API
 
+```tsx
+import { TextInput } from '@expo/ui/jetpack-compose';
+```
+
 <APISection packageName="expo-ui/jetpack-compose/textinput" apiName="TextInput" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/bottomsheet.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/bottomsheet.mdx
@@ -265,4 +265,8 @@ export default function BottomSheetWithFlexRNContentExample() {
 
 ## API
 
+```tsx
+import { BottomSheet } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/bottomsheet" apiName="BottomSheet" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/button.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/button.mdx
@@ -196,4 +196,8 @@ export default function CustomContentExample() {
 
 ## API
 
+```tsx
+import { Button } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/button" apiName="Button" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/colorpicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/colorpicker.mdx
@@ -60,4 +60,8 @@ export default function ColorPickerOpacityExample() {
 
 ## API
 
+```tsx
+import { ColorPicker } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/colorpicker" apiName="ColorPicker" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/contextmenu.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/contextmenu.mdx
@@ -199,4 +199,8 @@ export default function NestedContextMenuExample() {
 
 ## API
 
+```tsx
+import { ContextMenu } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/contextmenu" apiName="ContextMenu" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/datepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/datepicker.mdx
@@ -169,4 +169,8 @@ export default function GraphicalDatePickerExample() {
 
 ## API
 
+```tsx
+import { DatePicker } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/datepicker" apiName="DatePicker" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/disclosuregroup.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/disclosuregroup.mdx
@@ -56,4 +56,8 @@ export default function InitiallyExpandedExample() {
 
 ## API
 
+```tsx
+import { DisclosureGroup } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/disclosuregroup" apiName="DisclosureGroup" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/divider.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/divider.mdx
@@ -85,4 +85,8 @@ export default function DividerInContextMenuExample() {
 
 ## API
 
+```tsx
+import { Divider } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/divider" apiName="Divider" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/form.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/form.mdx
@@ -152,4 +152,8 @@ export default function RefreshableFormExample() {
 
 ## API
 
+```tsx
+import { Form } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/form" apiName="Form" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/gauge.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/gauge.mdx
@@ -125,4 +125,8 @@ export default function TintedGaugeExample() {
 
 ## API
 
+```tsx
+import { Gauge } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/gauge" apiName="Gauge" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/group.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/group.mdx
@@ -40,4 +40,8 @@ export default function BasicGroupExample() {
 
 ## API
 
+```tsx
+import { Group } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/group" apiName="Group" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/host.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/host.mdx
@@ -58,4 +58,8 @@ function Example() {
 
 ## API
 
+```tsx
+import { Host } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/host" apiName="Host" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/hstack.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/hstack.mdx
@@ -58,4 +58,8 @@ export default function HStackAlignmentExample() {
 
 ## API
 
+```tsx
+import { HStack } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/hstack" apiName="HStack" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/image.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/image.mdx
@@ -71,4 +71,8 @@ export default function ImageVariableExample() {
 
 ## API
 
+```tsx
+import { Image } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/image" apiName="Image" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/label.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/label.mdx
@@ -66,4 +66,8 @@ export default function LabelIconOnlyExample() {
 
 ## API
 
+```tsx
+import { Label } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/label" apiName="Label" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/list.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/list.mdx
@@ -273,4 +273,8 @@ export default function HeaderProminenceExample() {
 
 ## API
 
+```tsx
+import { List } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/list" apiName="List" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/menu.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/menu.mdx
@@ -169,4 +169,8 @@ export default function IconOnlyMenuExample() {
 
 ## API
 
+```tsx
+import { Menu } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/menu" apiName="Menu" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/modifiers.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/modifiers.mdx
@@ -79,4 +79,8 @@ function ModifiersExample() {
 
 ## API
 
+```tsx
+import { background, cornerRadius, padding, shadow, foregroundColor, onTapGesture } from '@expo/ui/swift-ui/modifiers';
+```
+
 <APISection packageName="expo-ui/swift-ui/modifiers" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/modifiers.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/modifiers.mdx
@@ -80,7 +80,14 @@ function ModifiersExample() {
 ## API
 
 ```tsx
-import { background, cornerRadius, padding, shadow, foregroundColor, onTapGesture } from '@expo/ui/swift-ui/modifiers';
+import {
+  background,
+  cornerRadius,
+  padding,
+  shadow,
+  foregroundColor,
+  onTapGesture,
+} from '@expo/ui/swift-ui/modifiers';
 ```
 
 <APISection packageName="expo-ui/swift-ui/modifiers" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/namespace.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/namespace.mdx
@@ -189,4 +189,8 @@ function MatchedGeometryExample() {
 
 ## API
 
+```tsx
+import { Namespace } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/namespace" apiName="Namespace" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/picker.mdx
@@ -115,4 +115,8 @@ export default function WheelPickerExample() {
 
 ## API
 
+```tsx
+import { Picker } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/picker" apiName="Picker" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/popover.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/popover.mdx
@@ -157,4 +157,8 @@ export default function RNContentPopoverExample() {
 
 ## API
 
+```tsx
+import { Popover } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/popover" apiName="Popover" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/progressview.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/progressview.mdx
@@ -129,4 +129,8 @@ export default function TimerExample() {
 
 ## API
 
+```tsx
+import { ProgressView } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/progressview" apiName="ProgressView" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/rnhostview.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/rnhostview.mdx
@@ -133,4 +133,8 @@ function Example() {
 
 ## API
 
+```tsx
+import { RNHostView } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/rnhostview" apiName="RNHostView" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/section.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/section.mdx
@@ -162,4 +162,8 @@ export default function FormSectionsExample() {
 
 ## API
 
+```tsx
+import { Section } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/section" apiName="Section" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/slider.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/slider.mdx
@@ -99,4 +99,8 @@ export default function LabeledSliderExample() {
 
 ## API
 
+```tsx
+import { Slider } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/slider" apiName="Slider" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/spacer.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/spacer.mdx
@@ -59,4 +59,8 @@ export default function SpacerVStackExample() {
 
 ## API
 
+```tsx
+import { Spacer } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/spacer" apiName="Spacer" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/text.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/text.mdx
@@ -180,4 +180,8 @@ export default function LineLimitExample() {
 
 ## API
 
+```tsx
+import { Text } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/text" apiName="Text" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/textfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/textfield.mdx
@@ -43,4 +43,8 @@ A text field component that allows users to enter and edit text.
 
 ## API
 
+```tsx
+import { TextField } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/textfield" apiName="TextField" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/toggle.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/toggle.mdx
@@ -165,4 +165,8 @@ export default function HiddenLabelExample() {
 
 ## API
 
+```tsx
+import { Toggle } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/toggle" apiName="Toggle" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/vstack.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/vstack.mdx
@@ -58,4 +58,8 @@ export default function VStackAlignmentExample() {
 
 ## API
 
+```tsx
+import { VStack } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/vstack" apiName="VStack" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/zstack.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/zstack.mdx
@@ -77,4 +77,8 @@ export default function ZStackBadgeExample() {
 
 ## API
 
+```tsx
+import { ZStack } from '@expo/ui/swift-ui';
+```
+
 <APISection packageName="expo-ui/swift-ui/zstack" apiName="ZStack" />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Add missing API namespace code blocks under API sections in Expo UI docs under unversioned.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

<img width="934" height="365" alt="CleanShot 2026-01-19 at 21 44 45" src="https://github.com/user-attachments/assets/102dfc7b-3da3-4a55-b7d7-6f8e090d6704" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
