### PR TITLE
[ios][go] Fix reload behavior from dev menu

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- Fixed reload when used in Expo Go. ([#42295](https://github.com/expo/expo/pull/42295) by [@aleqsio](https://github.com/aleqsio))
 - [iOS] Fix React Native dev menu not showing up in 0.83.x ([#40819](https://github.com/expo/expo/pull/40819) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Hide Action button in PiP mode to prevent crash ([#40792](https://github.com/expo/expo/pull/40792) by [@kosmydel](https://github.com/kosmydel))
 - [iOS] remove unnecessary `unregisterKeyCommand` for cmd+r ([#41449](https://github.com/expo/expo/pull/41449) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
+++ b/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
@@ -1,6 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 import React
+import ExpoModulesCore
 
 class DevMenuDevOptionsDelegate {
   internal private(set) weak var bridge: RCTBridge?
@@ -25,7 +26,8 @@ class DevMenuDevOptionsDelegate {
     DevMenuManager.shared.hideMenu()
 
     DispatchQueue.main.async {
-      RCTTriggerReloadCommandListeners("Dev menu - reload")
+      let emc = self.bridge?.moduleRegistry.module(forName: "ExpoModulesCore") as? ExpoBridgeModule
+      emc?.appContext?.reloadAppAsync()
     }
   }
 

--- a/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
+++ b/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
@@ -25,10 +25,8 @@ class DevMenuDevOptionsDelegate {
     // No native splash screen registered for given view controller. Call 'SplashScreen.show' for given view controller first.
     DevMenuManager.shared.hideMenu()
 
-    DispatchQueue.main.async {
-      let emc = self.bridge?.moduleRegistry.module(forName: "ExpoModulesCore") as? ExpoBridgeModule
-      emc?.appContext?.reloadAppAsync()
-    }
+    let emc = self.bridge?.moduleRegistry.module(forName: "ExpoModulesCore") as? ExpoBridgeModule
+    emc?.appContext?.reloadAppAsync()
   }
 
   internal func toggleElementInsector() {

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -35,7 +35,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fixed DSL view props using stale state when updating. ([#41622](https://github.com/expo/expo/pull/41622) by [@kimchi-developer](https://github.com/kimchi-developer))
-  - [core] Fixed `useReleasingSharedObject` to defer releasing until after render.
+- [core] Fixed `useReleasingSharedObject` to defer releasing until after render.
 - [android] Fix source sets for events for functional view definitions. ([#41685](https://github.com/expo/expo/pull/41685) by [@aleqsio](https://github.com/aleqsio))
 - [iOS] Fix throwing `InvalidArgsNumberException` when declaring `AsyncFunction` with optional arguments and `Promise`. ([#41054](https://github.com/expo/expo/pull/41054) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] fix queue assertion crash ([#41296](https://github.com/expo/expo/pull/41296) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- Add `reloadAppAsync` method to AppContext. ([#42295](https://github.com/expo/expo/pull/42295) by [@aleqsio](https://github.com/aleqsio))
 - Add `map` to `ValueOrUndefined`. ([#40593](https://github.com/expo/expo/pull/40593) by [@Wenszel](https://github.com/Wenszel))
 - Add types for `process.env.EXPO_DOM_HOST_OS`. ([#40382](https://github.com/expo/expo/pull/40382) by [@EvanBacon](https://github.com/EvanBacon))
 - [Android] Add `ComposableScope` for compose Content functions. ([#39155](https://github.com/expo/expo/pull/39155) by [@aleqsio](https://github.com/aleqsio))
@@ -34,7 +35,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fixed DSL view props using stale state when updating. ([#41622](https://github.com/expo/expo/pull/41622) by [@kimchi-developer](https://github.com/kimchi-developer))
-- [core] Fixed `useReleasingSharedObject` to defer releasing until after render.
+  - [core] Fixed `useReleasingSharedObject` to defer releasing until after render.
 - [android] Fix source sets for events for functional view definitions. ([#41685](https://github.com/expo/expo/pull/41685) by [@aleqsio](https://github.com/aleqsio))
 - [iOS] Fix throwing `InvalidArgsNumberException` when declaring `AsyncFunction` with optional arguments and `Promise`. ([#41054](https://github.com/expo/expo/pull/41054) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] fix queue assertion crash ([#41296](https://github.com/expo/expo/pull/41296) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -607,6 +607,16 @@ public final class AppContext: NSObject, @unchecked Sendable {
     // [3] Fallback to an empty `ModulesProvider` if `ExpoModulesProvider` was not generated
     return ModulesProvider()
   }
+
+  public func reloadAppAsync(_ reason: String = "Reload from appContext") {
+    if(moduleRegistry.has(moduleWithName: "ExpoGo")) {
+      NotificationCenter.default.post(name: NSNotification.Name(rawValue: "EXReloadActiveAppRequest"), object: nil)
+    } else {
+      DispatchQueue.main.async {
+        RCTTriggerReloadCommandListeners(reason)
+      }
+    }
+  }
 }
 
 // MARK: - Public exceptions

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -595,7 +595,7 @@ public final class AppContext: NSObject, @unchecked Sendable {
     if let providerClass = NSClassFromString(providerName) as? ModulesProvider.Type {
       return providerClass.init()
     }
-    
+
     // [2] Fallback to search for `ExpoModulesProvider` in frameworks (brownfield use case)
     for bundle in Bundle.allFrameworks {
       guard let bundleName = bundle.infoDictionary?["CFBundleName"] as? String else { continue }
@@ -609,7 +609,7 @@ public final class AppContext: NSObject, @unchecked Sendable {
   }
 
   public func reloadAppAsync(_ reason: String = "Reload from appContext") {
-    if(moduleRegistry.has(moduleWithName: "ExpoGo")) {
+    if moduleRegistry.has(moduleWithName: "ExpoGo") {
       NotificationCenter.default.post(name: NSNotification.Name(rawValue: "EXReloadActiveAppRequest"), object: nil)
     } else {
       DispatchQueue.main.async {

--- a/packages/expo-modules-core/ios/Core/Modules/CoreModule.swift
+++ b/packages/expo-modules-core/ios/Core/Modules/CoreModule.swift
@@ -108,9 +108,7 @@ internal final class CoreModule: Module {
     }
 
     AsyncFunction("reloadAppAsync") { (reason: String) in
-      DispatchQueue.main.async {
-        RCTTriggerReloadCommandListeners(reason)
-      }
+      appContext?.reloadAppAsync(reason)
     }
   }
 


### PR DESCRIPTION
# Why

Fixes "reloading NCL causes a “NativeJSLogger.addListener is not a function error” ~50% of time"

# How

Made dev-menu call the correct method in expo-go

# Test Plan

Tested in expo-go

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
