### PR TITLE
[docs] Improve formatting for compound component API documentation

### DIFF
--- a/docs/components/plugins/api/APISectionCompoundNames.test.ts
+++ b/docs/components/plugins/api/APISectionCompoundNames.test.ts
@@ -1,0 +1,66 @@
+import { GeneratedData, PropData, TypeDefinitionData, TypeDocKind } from './APIDataTypes';
+import { buildCompoundNameByComponent } from './APISectionCompoundNames';
+
+const makeComponentType = (propsName: string): TypeDefinitionData => ({
+  type: 'reference',
+  name: 'React.FC',
+  typeArguments: [{ type: 'reference', name: propsName }],
+});
+
+const makeProp = (name: string, type?: TypeDefinitionData, defaultValue?: string): PropData =>
+  ({
+    name,
+    kind: TypeDocKind.Property,
+    type,
+    defaultValue,
+  }) as PropData;
+
+const makeComponent = (name: string, propsName: string, children: PropData[] = []): GeneratedData =>
+  ({
+    name,
+    kind: TypeDocKind.Class,
+    type: makeComponentType(propsName),
+    children,
+  }) as GeneratedData;
+
+describe('buildCompoundNameByComponent', () => {
+  test('maps direct component properties to compound names', () => {
+    const menuItem = makeComponent('MenuItem', 'MenuItemProps');
+    const menu = makeComponent('Menu', 'MenuProps', [
+      makeProp('Item', makeComponentType('MenuItemProps')),
+    ]);
+
+    const result = Object.fromEntries(buildCompoundNameByComponent([menu, menuItem]));
+
+    expect(result).toEqual({
+      MenuItem: 'Menu.Item',
+    });
+  });
+
+  test('chains compound names when parent is itself a compound component', () => {
+    const menuItemIcon = makeComponent('MenuItemIcon', 'MenuItemIconProps');
+    const menuItem = makeComponent('MenuItem', 'MenuItemProps', [
+      makeProp('Icon', makeComponentType('MenuItemIconProps')),
+    ]);
+    const menu = makeComponent('Menu', 'MenuProps', [
+      makeProp('Item', makeComponentType('MenuItemProps')),
+    ]);
+
+    const result = Object.fromEntries(buildCompoundNameByComponent([menu, menuItem, menuItemIcon]));
+
+    expect(result).toEqual({
+      MenuItem: 'Menu.Item',
+      MenuItemIcon: 'Menu.Item.Icon',
+    });
+  });
+
+  test('uses string default values as component targets', () => {
+    const tabs = makeComponent('Tabs', 'TabsProps', [makeProp('Tab', undefined, 'Tab')]);
+
+    const result = Object.fromEntries(buildCompoundNameByComponent([tabs]));
+
+    expect(result).toEqual({
+      Tab: 'Tabs.Tab',
+    });
+  });
+});

--- a/docs/components/plugins/api/APISectionCompoundNames.ts
+++ b/docs/components/plugins/api/APISectionCompoundNames.ts
@@ -1,0 +1,145 @@
+import { GeneratedData, PropData, TypeDefinitionData, TypeDocKind } from './APIDataTypes';
+import { getComponentName } from './APISectionUtils';
+
+const componentTypeNames = new Set([
+  'React.FC',
+  'FC',
+  'ForwardRefExoticComponent',
+  'React.ForwardRefExoticComponent',
+  'ComponentType',
+  'React.ComponentType',
+  'NamedExoticComponent',
+  'React.NamedExoticComponent',
+]);
+
+const getComponentPropertyChildren = (entry: GeneratedData): PropData[] => {
+  const candidates: PropData[] = [];
+  const pushChildren = (children?: PropData[]) => {
+    if (children?.length) {
+      candidates.push(...children);
+    }
+  };
+
+  if ('children' in entry) {
+    pushChildren(entry.children as PropData[] | undefined);
+  }
+  pushChildren(entry.type?.declaration?.children);
+  entry.type?.types?.forEach(type => {
+    pushChildren(type.declaration?.children);
+  });
+
+  if (candidates.length === 0) {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  return candidates.filter(child => {
+    if (!child || child.kind !== TypeDocKind.Property) {
+      return false;
+    }
+    const id = `${child.name ?? ''}-${child.kind ?? ''}`;
+    if (seen.has(id)) {
+      return false;
+    }
+    seen.add(id);
+    return true;
+  });
+};
+
+const getPropsTypeNameFromComponentType = (type?: TypeDefinitionData): string | undefined => {
+  if (!type) {
+    return undefined;
+  }
+  if (type.type === 'reference') {
+    const typeName = type.name ?? type.target?.qualifiedName;
+    if (!typeName || !componentTypeNames.has(typeName)) {
+      return undefined;
+    }
+    const propsType = type.typeArguments?.[0];
+    return propsType?.type === 'reference' ? propsType.name : undefined;
+  }
+  if (type.type === 'intersection' || type.type === 'union') {
+    for (const nested of type.types ?? []) {
+      const found = getPropsTypeNameFromComponentType(nested);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return undefined;
+};
+
+export const buildCompoundNameByComponent = (components: GeneratedData[]) => {
+  const componentNameByPropsType = new Map<string, string>();
+  const propertiesByEntry = new Map<GeneratedData, PropData[]>();
+  const baseNameByEntry = new Map<GeneratedData, string>();
+
+  components.forEach(entry => {
+    const baseName = getComponentName(entry.name, entry.children);
+    const propsTypeName = getPropsTypeNameFromComponentType(entry.type);
+    if (propsTypeName && baseName) {
+      componentNameByPropsType.set(propsTypeName, baseName);
+    }
+    if (baseName) {
+      baseNameByEntry.set(entry, baseName);
+    }
+    propertiesByEntry.set(entry, getComponentPropertyChildren(entry));
+  });
+
+  const resolveComponentFromProperty = (prop: PropData) => {
+    if (typeof prop.defaultValue === 'string') {
+      return prop.defaultValue;
+    }
+    const propsTypeName = getPropsTypeNameFromComponentType(prop.type);
+    if (!propsTypeName) {
+      return undefined;
+    }
+    return componentNameByPropsType.get(propsTypeName);
+  };
+
+  const directMap = new Map<string, string>();
+
+  components.forEach(entry => {
+    const parentName = baseNameByEntry.get(entry);
+    if (!parentName) {
+      return;
+    }
+    const properties = propertiesByEntry.get(entry) ?? [];
+    properties.forEach(property => {
+      if (!property.name) {
+        return;
+      }
+      const target = resolveComponentFromProperty(property);
+      if (!target) {
+        return;
+      }
+      directMap.set(target, `${parentName}.${property.name}`);
+    });
+  });
+
+  const compoundMap = new Map<string, string>(directMap);
+
+  components.forEach(entry => {
+    const parentName = baseNameByEntry.get(entry);
+    if (!parentName) {
+      return;
+    }
+    const parentAlias = directMap.get(parentName);
+    if (!parentAlias) {
+      return;
+    }
+    const properties = propertiesByEntry.get(entry) ?? [];
+    properties.forEach(property => {
+      if (!property.name) {
+        return;
+      }
+      const target = resolveComponentFromProperty(property);
+      if (!target) {
+        return;
+      }
+      compoundMap.set(target, `${parentAlias}.${property.name}`);
+    });
+  });
+
+  return compoundMap;
+};

--- a/docs/ui/components/TableOfContents/TableOfContentsLink.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContentsLink.tsx
@@ -85,7 +85,8 @@ export const TableOfContentsLink = forwardRef<HTMLAnchorElement, SidebarLinkProp
  * Replaces `Module.someFunction<T>(arguments: argType)` with `someFunction()`
  */
 function trimCodedTitle(str: string) {
-  if (!str.includes('...')) {
+  const hasParens = str.includes('(');
+  if (!str.includes('...') && hasParens) {
     const dotIdx = str.indexOf('.');
     if (dotIdx > 0) {
       str = str.slice(Math.max(0, dotIdx + 1));


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18835

Display compound component names (e.g., `NativeTabs.BottomAccessory`, `NativeTabs.Trigger.Badge`) in API docs components sections.

# How

<!--
How did you build this feature or fix this bug and why?
-->



- Add `APISectionCompoundNames.ts` to derive compound component names from TypeDoc JSON (defaultValue + props-type fallback).
- Update `APISectionComponents.tsx` to use compound display names while preserving props matching.
- Update TOC shortening to retain prefixes for compound components.




# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview of NativeTabs and Router references.

### Preview

<img width="846" height="459" alt="CleanShot 2026-01-20 at 01 09 53" src="https://github.com/user-attachments/assets/aac34945-f638-418a-bad4-5490423a76e6" />


<img width="263" height="553" alt="CleanShot 2026-01-20 at 01 06 28" src="https://github.com/user-attachments/assets/89542399-f5d2-4587-baf0-a125a795e4bf" />


<img width="276" height="679" alt="CleanShot 2026-01-20 at 01 06 08" src="https://github.com/user-attachments/assets/84532563-ae47-4ccd-a8ef-e232ca799a35" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->


- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
