### PR TITLE
[expo/cli] fix: Include `protocol` and `port` in derived manifest URLs to improve compatibility with proxies and custom tunnels

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix response streaming from dev server (remove compression) ([#41955](https://github.com/expo/expo/pull/41955) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Restrict debugger (`/inspector/network`) and devtools (`/expo-dev-plugins/broadcast`) sockets to local connections ([#42156](https://github.com/expo/expo/pull/42156) by [@kitten](https://github.com/kitten))
+- Include `protocol` and `port` when dynamically deriving manifest URLs from request headers (`host`, `x-forwarded-proto`) to support serving through proxies and custom tunnels. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/UrlCreator.ts
+++ b/packages/@expo/cli/src/start/server/UrlCreator.ts
@@ -13,6 +13,8 @@ export interface CreateURLOptions {
   hostType?: 'localhost' | 'lan' | 'tunnel';
   /** Requested hostname. */
   hostname?: string | null;
+  /** Requested port. */
+  port?: string | null;
 }
 
 interface UrlComponents {
@@ -117,7 +119,7 @@ export class UrlCreator {
 
     return {
       hostname: getDefaultHostname(options),
-      port: this.bundlerInfo.port.toString(),
+      port: options.port ?? this.bundlerInfo.port.toString(),
       protocol: options.scheme ?? 'http',
     };
   }

--- a/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
@@ -21,7 +21,7 @@ import {
   FormDataField,
   EncodedFormData,
 } from '../../../utils/multipartMixed';
-import { stripPort } from '../../../utils/url';
+import { parseUrl } from '../../../utils/url';
 
 const debug = require('debug')('expo:start:server:middleware:ExpoGoManifestHandlerMiddleware');
 
@@ -81,11 +81,14 @@ export class ExpoGoManifestHandlerMiddleware extends ManifestMiddleware<ExpoGoMa
 
     const expectSignature = req.headers['expo-expect-signature'];
 
+    const requestedUrl = parseUrl(req.headers['host']);
+
     return {
       responseContentType,
       platform,
       expectSignature: expectSignature ? String(expectSignature) : null,
-      hostname: stripPort(req.headers['host']),
+      hostname: requestedUrl?.hostname,
+      port: requestedUrl?.port,
       protocol: req.headers['x-forwarded-proto'] as 'http' | 'https' | undefined,
     };
   }

--- a/packages/@expo/cli/src/utils/url.ts
+++ b/packages/@expo/cli/src/utils/url.ts
@@ -50,12 +50,7 @@ export function validateUrl(
   }
 }
 
-/** Remove the port from a given `host` URL string. */
-export function stripPort(host?: string): string | null {
-  return coerceUrl(host)?.hostname ?? null;
-}
-
-function coerceUrl(urlString?: string): URL | null {
+export function parseUrl(urlString?: string): URL | null {
   if (!urlString) {
     return null;
   }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
