### PR TITLE
[docs] Add `@experimental` annotation support for API methods

### DIFF
--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -152,6 +152,7 @@ export const renderMethod = (
             parameters,
             typeParameter
           )}
+          comment={method?.comment ?? comment}
           platforms={platforms.length > 0 ? platforms : parentPlatforms}
           baseNestingLevel={baseNestingLevel}
           // only show first overload in sidebar to avoid duplicates


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18860

`@experimental` annotation only shows up in the header because `APIBoxHeader` calls `getTagNamesList` to build its tags. In the methods renderer, we weren't passing any comment into `APIBoxHeader`, so it never sees the `@experimental` tag.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Tested it locally with Expo Sharing package by adding `@experimental` annotation to a method.

<img width="1928" height="750" alt="CleanShot 2026-01-20 at 02 45 07@2x" src="https://github.com/user-attachments/assets/34528186-1376-428a-8b57-0f20e36c6438" />

Result:

<img width="2500" height="1068" alt="CleanShot 2026-01-20 at 02 44 57@2x" src="https://github.com/user-attachments/assets/6824fcd8-41b5-4521-b640-520a49531a02" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
