### PR TITLE
[expo-build-properties] Add top-level shared config fields

### DIFF
--- a/packages/expo-build-properties/CHANGELOG.md
+++ b/packages/expo-build-properties/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🎉 New features
 
 - Add support for enabling Hermes V1 ([#41715](https://github.com/expo/expo/pull/41715) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add top-level `buildReactNativeFromSource`, `reactNativeReleaseLevel`, and `useHermesV1` config fields that apply to both platforms, with platform-specific values taking precedence. ([#42302](https://github.com/expo/expo/pull/42302) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-build-properties/build/android.d.ts
+++ b/packages/expo-build-properties/build/android.d.ts
@@ -1,5 +1,5 @@
 import { ConfigPlugin } from 'expo/config-plugins';
-import type { PluginConfigType } from './pluginConfig';
+import { PluginConfigType } from './pluginConfig';
 export declare const withAndroidBuildProperties: ConfigPlugin<PluginConfigType>;
 /**
  * Appends `props.android.extraProguardRules` content into `android/app/proguard-rules.pro`

--- a/packages/expo-build-properties/build/android.js
+++ b/packages/expo-build-properties/build/android.js
@@ -11,6 +11,7 @@ const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const androidQueryUtils_1 = require("./androidQueryUtils");
 const fileContentsUtils_1 = require("./fileContentsUtils");
+const pluginConfig_1 = require("./pluginConfig");
 const { createBuildGradlePropsConfigPlugin } = config_plugins_1.AndroidConfig.BuildProperties;
 exports.withAndroidBuildProperties = createBuildGradlePropsConfigPlugin([
     {
@@ -67,7 +68,7 @@ exports.withAndroidBuildProperties = createBuildGradlePropsConfigPlugin([
     },
     {
         propName: 'reactNativeReleaseLevel',
-        propValueGetter: (config) => config.android?.reactNativeReleaseLevel,
+        propValueGetter: (config) => (0, pluginConfig_1.resolveConfigValue)(config, 'android', 'reactNativeReleaseLevel'),
     },
     {
         propName: 'expo.useLegacyPackaging',
@@ -103,12 +104,7 @@ exports.withAndroidBuildProperties = createBuildGradlePropsConfigPlugin([
     },
     {
         propName: 'hermesV1Enabled',
-        propValueGetter: (config) => {
-            if (config.android?.useHermesV1 && config.android?.buildReactNativeFromSource !== true) {
-                config_plugins_1.WarningAggregator.addWarningAndroid('withAndroidBuildProperties', 'Hermes V1 requires building React Native from source. Set `buildReactNativeFromSource` to `true` to enable it.');
-            }
-            return config.android?.useHermesV1?.toString();
-        },
+        propValueGetter: (config) => (0, pluginConfig_1.resolveConfigValue)(config, 'android', 'useHermesV1')?.toString(),
     },
 ], 'withAndroidBuildProperties');
 /**
@@ -262,9 +258,12 @@ const withAndroidDayNightTheme = (config, props) => {
 exports.withAndroidDayNightTheme = withAndroidDayNightTheme;
 const withAndroidSettingsGradle = (config, props) => {
     return (0, config_plugins_1.withSettingsGradle)(config, (config) => {
+        // Resolution order: android.buildReactNativeFromSource > top-level > deprecated android.buildFromSource
+        const buildFromSource = (0, pluginConfig_1.resolveConfigValue)(props, 'android', 'buildReactNativeFromSource') ??
+            props.android?.buildFromSource; // Deprecated fallback (last resort)
         config.modResults.contents = updateAndroidSettingsGradle({
             contents: config.modResults.contents,
-            buildFromSource: props.android?.buildReactNativeFromSource ?? props.android?.buildFromSource,
+            buildFromSource,
         });
         return config;
     });

--- a/packages/expo-build-properties/build/ios.d.ts
+++ b/packages/expo-build-properties/build/ios.d.ts
@@ -1,5 +1,5 @@
 import { ConfigPlugin } from 'expo/config-plugins';
-import type { PluginConfigType } from './pluginConfig';
+import { PluginConfigType } from './pluginConfig';
 export declare const withIosBuildProperties: ConfigPlugin<PluginConfigType>;
 export declare const withIosDeploymentTarget: ConfigPlugin<PluginConfigType>;
 export declare const withIosInfoPlist: ConfigPlugin<PluginConfigType>;

--- a/packages/expo-build-properties/build/ios.js
+++ b/packages/expo-build-properties/build/ios.js
@@ -2,6 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.withIosInfoPlist = exports.withIosDeploymentTarget = exports.withIosBuildProperties = void 0;
 const config_plugins_1 = require("expo/config-plugins");
+const pluginConfig_1 = require("./pluginConfig");
 const { createBuildPodfilePropsConfigPlugin } = config_plugins_1.IOSConfig.BuildProperties;
 exports.withIosBuildProperties = createBuildPodfilePropsConfigPlugin([
     {
@@ -33,16 +34,11 @@ exports.withIosBuildProperties = createBuildPodfilePropsConfigPlugin([
     },
     {
         propName: 'ios.buildReactNativeFromSource',
-        propValueGetter: (config) => config.ios?.buildReactNativeFromSource?.toString(),
+        propValueGetter: (config) => (0, pluginConfig_1.resolveConfigValue)(config, 'ios', 'buildReactNativeFromSource')?.toString(),
     },
     {
         propName: 'expo.useHermesV1',
-        propValueGetter: (config) => {
-            if (config.ios?.useHermesV1 && config.ios?.buildReactNativeFromSource !== true) {
-                config_plugins_1.WarningAggregator.addWarningIOS('withIosBuildProperties', 'Hermes V1 requires building React Native from source. Set `buildReactNativeFromSource` to `true` to enable it.');
-            }
-            return config.ios?.useHermesV1?.toString();
-        },
+        propValueGetter: (config) => (0, pluginConfig_1.resolveConfigValue)(config, 'ios', 'useHermesV1')?.toString(),
     },
 ], 'withIosBuildProperties');
 const withIosDeploymentTarget = (config, props) => {
@@ -58,7 +54,7 @@ const withIosDeploymentTarget = (config, props) => {
 };
 exports.withIosDeploymentTarget = withIosDeploymentTarget;
 const withIosInfoPlist = (config, props) => {
-    const reactNativeReleaseLevel = props.ios?.reactNativeReleaseLevel;
+    const reactNativeReleaseLevel = (0, pluginConfig_1.resolveConfigValue)(props, 'ios', 'reactNativeReleaseLevel');
     if (reactNativeReleaseLevel) {
         config = withIosReactNativeReleaseLevel(config, { reactNativeReleaseLevel });
     }

--- a/packages/expo-build-properties/build/pluginConfig.d.ts
+++ b/packages/expo-build-properties/build/pluginConfig.d.ts
@@ -1,7 +1,46 @@
 /**
+ * Shared build configuration fields that can be set at the top level
+ * or overridden per-platform. Platform-specific values take precedence.
+ */
+export interface SharedBuildConfigFields {
+    /**
+     * Enable building React Native from source. Turning this on will significantly increase the build times.
+     *
+     * On iOS, this controls support for precompiled React Native iOS dependencies (`ReactNativeDependencies.xcframework`).
+     * Setting this value to `true` will enable building React Native from source and disable the use of precompiled xcframeworks.
+     * This feature is available from React Native 0.80 and later when using the new architecture.
+     * From React Native 0.81, this setting will also control the use of a precompiled React Native Core (`React.xcframework`).
+     *
+     * @default false
+     * @see [Precompiled React Native for iOS: Faster builds are coming in 0.81](https://expo.dev/blog/precompiled-react-native-for-ios) for more information.
+     */
+    buildReactNativeFromSource?: boolean;
+    /**
+     * The React Native release level to use for the project.
+     * This can be used to enable different sets of internal React Native feature flags.
+     *
+     * @default 'stable'
+     */
+    reactNativeReleaseLevel?: 'stable' | 'canary' | 'experimental';
+    /**
+     * Enable the experimental Hermes V1 engine.
+     *
+     * In React Native 0.83, using Hermes V1 requires building React Native from source.
+     * You must set `buildReactNativeFromSource` to `true` when enabling this option.
+     *
+     * @default false
+     */
+    useHermesV1?: boolean;
+}
+/**
+ * Resolves a shared config value with platform-specific override.
+ * Platform-specific values take precedence over top-level values.
+ */
+export declare function resolveConfigValue<K extends keyof SharedBuildConfigFields>(config: PluginConfigType, platform: 'android' | 'ios', key: K): SharedBuildConfigFields[K];
+/**
  * Interface representing base build properties configuration.
  */
-export interface PluginConfigType {
+export interface PluginConfigType extends SharedBuildConfigFields {
     /**
      * Interface representing available configuration for Android native build properties.
      * @platform android
@@ -17,7 +56,7 @@ export interface PluginConfigType {
  * Interface representing available configuration for Android native build properties.
  * @platform android
  */
-export interface PluginConfigTypeAndroid {
+export interface PluginConfigTypeAndroid extends SharedBuildConfigFields {
     /**
      * Override the default `minSdkVersion` version number in **build.gradle**.
      * */
@@ -143,7 +182,6 @@ export interface PluginConfigTypeAndroid {
      * @default false
      */
     enableBundleCompression?: boolean;
-    buildReactNativeFromSource?: boolean;
     /**
      * Enable building React Native from source. Turning this on will significantly increase the build times.
      * @deprecated Use `buildReactNativeFromSource` instead.
@@ -170,22 +208,6 @@ export interface PluginConfigTypeAndroid {
      * @see [Using a Maven Mirror](https://reactnative.dev/docs/build-speed#using-a-maven-mirror-android-only)
      */
     exclusiveMavenMirror?: string;
-    /**
-     * The React Native release level to use for the project.
-     * This can be used to enable different sets of internal React Native feature flags.
-     *
-     * @default 'stable'
-     */
-    reactNativeReleaseLevel?: 'stable' | 'canary' | 'experimental';
-    /**
-     * Enable the experimental Hermes V1 engine.
-     *
-     * In React Native 0.83, using Hermes V1 requires building React Native from source.
-     * You must set `buildReactNativeFromSource` to `true` when enabling this option.
-     *
-     * @default false
-     */
-    useHermesV1?: boolean;
 }
 /**
  * @platform android
@@ -261,7 +283,7 @@ export type AndroidMavenRepositoryCredentials = AndroidMavenRepositoryPasswordCr
  * Interface representing available configuration for iOS native build properties.
  * @platform ios
  */
-export interface PluginConfigTypeIos {
+export interface PluginConfigTypeIos extends SharedBuildConfigFields {
     /**
      * Override the default iOS "Deployment Target" version in the following projects:
      *  - in CocoaPods projects,
@@ -330,33 +352,6 @@ export interface PluginConfigTypeIos {
      * and [Apple's documentation on Privacy manifest files](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files).
      */
     privacyManifestAggregationEnabled?: boolean;
-    /**
-     * Enables support for precompiled React Native iOS dependencies (`ReactNativeDependencies.xcframework`).
-     * Setting this value to `true` will enable building React Native from source and disable the use of precompiled xcframeworks.
-     * This feature is available from React Native 0.80 and later when using the new architecture.
-     * From React Native 0.81, this setting will also control the use of a precompiled React Native Core (`React.xcframework`).
-     *
-     * @default false
-     * @see React Expo blog for details: [Precompiled React Native for iOS: Faster builds are coming in 0.81](https://expo.dev/blog/precompiled-react-native-for-ios) for more information.
-     * @experimental
-     */
-    buildReactNativeFromSource?: boolean;
-    /**
-     * The React Native release level to use for the project.
-     * This can be used to enable different sets of internal React Native feature flags.
-     *
-     * @default 'stable'
-     */
-    reactNativeReleaseLevel?: 'stable' | 'canary' | 'experimental';
-    /**
-     * Enable the experimental Hermes V1 engine.
-     *
-     * In React Native 0.83, using Hermes V1 requires building React Native from source.
-     * You must set `buildReactNativeFromSource` to `true` when enabling this option.
-     *
-     * @default false
-     */
-    useHermesV1?: boolean;
 }
 /**
  * Interface representing extra CocoaPods dependency.

--- a/packages/expo-build-properties/build/pluginConfig.js
+++ b/packages/expo-build-properties/build/pluginConfig.js
@@ -3,6 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.resolveConfigValue = resolveConfigValue;
 exports.validateConfig = validateConfig;
 const ajv_1 = __importDefault(require("ajv"));
 const semver_1 = __importDefault(require("semver"));
@@ -21,9 +22,23 @@ const EXPO_SDK_MINIMAL_SUPPORTED_VERSIONS = {
         deploymentTarget: '15.1',
     },
 };
+/**
+ * Resolves a shared config value with platform-specific override.
+ * Platform-specific values take precedence over top-level values.
+ */
+function resolveConfigValue(config, platform, key) {
+    return config[platform]?.[key] ?? config[key];
+}
 const schema = {
     type: 'object',
     properties: {
+        buildReactNativeFromSource: { type: 'boolean', nullable: true },
+        reactNativeReleaseLevel: {
+            type: 'string',
+            enum: ['stable', 'canary', 'experimental'],
+            nullable: true,
+        },
+        useHermesV1: { type: 'boolean', nullable: true },
         android: {
             type: 'object',
             properties: {
@@ -258,6 +273,19 @@ function validateConfig(config) {
     if (config.android?.enableShrinkResourcesInReleaseBuilds === true &&
         config.android?.enableMinifyInReleaseBuilds !== true) {
         throw new Error('`android.enableShrinkResourcesInReleaseBuilds` requires `android.enableMinifyInReleaseBuilds` to be enabled.');
+    }
+    // Validate useHermesV1 requires buildReactNativeFromSource for Android
+    const androidUseHermesV1 = resolveConfigValue(config, 'android', 'useHermesV1');
+    const androidBuildFromSource = resolveConfigValue(config, 'android', 'buildReactNativeFromSource') ??
+        config.android?.buildFromSource; // Deprecated fallback
+    if (androidUseHermesV1 === true && androidBuildFromSource !== true) {
+        throw new Error('`useHermesV1` requires `buildReactNativeFromSource` to be `true` for Android.');
+    }
+    // Validate useHermesV1 requires buildReactNativeFromSource for iOS
+    const iosUseHermesV1 = resolveConfigValue(config, 'ios', 'useHermesV1');
+    const iosBuildFromSource = resolveConfigValue(config, 'ios', 'buildReactNativeFromSource');
+    if (iosUseHermesV1 === true && iosBuildFromSource !== true) {
+        throw new Error('`useHermesV1` requires `buildReactNativeFromSource` to be `true` for iOS.');
     }
     return config;
 }

--- a/packages/expo-build-properties/src/__tests__/withBuildProperties-test.ts
+++ b/packages/expo-build-properties/src/__tests__/withBuildProperties-test.ts
@@ -319,3 +319,134 @@ describe(withBuildProperties, () => {
     });
   });
 });
+
+describe('shared config fields', () => {
+  it('should apply top-level buildReactNativeFromSource to iOS', async () => {
+    const pluginProps: PluginConfigType = {
+      buildReactNativeFromSource: true,
+    };
+
+    const { modResults: iosModResults } = await compileMockModWithResultsAsync(
+      {},
+      {
+        plugin: withBuildProperties,
+        pluginProps,
+        mod: withPodfileProperties,
+        modResults: {},
+      }
+    );
+    expect(iosModResults).toMatchObject({
+      'ios.buildReactNativeFromSource': 'true',
+    });
+  });
+
+  it('should apply top-level reactNativeReleaseLevel to Android', async () => {
+    const pluginProps: PluginConfigType = {
+      reactNativeReleaseLevel: 'experimental',
+    };
+
+    const { modResults: androidModResults } = await compileMockModWithResultsAsync<
+      AndroidConfig.Properties.PropertiesItem[],
+      PluginConfigType
+    >(
+      {},
+      {
+        plugin: withBuildProperties,
+        pluginProps,
+        mod: withGradleProperties,
+        modResults: [],
+      }
+    );
+    expect(androidModResults).toContainEqual({
+      type: 'property',
+      key: 'reactNativeReleaseLevel',
+      value: 'experimental',
+    });
+  });
+
+  it('should allow platform-specific override of top-level buildReactNativeFromSource', async () => {
+    const pluginProps: PluginConfigType = {
+      buildReactNativeFromSource: true,
+      ios: { buildReactNativeFromSource: false },
+    };
+
+    const { modResults: iosModResults } = await compileMockModWithResultsAsync(
+      {},
+      {
+        plugin: withBuildProperties,
+        pluginProps,
+        mod: withPodfileProperties,
+        modResults: {},
+      }
+    );
+    expect(iosModResults).toMatchObject({
+      'ios.buildReactNativeFromSource': 'false',
+    });
+  });
+
+  it('should apply top-level useHermesV1 to Android when buildReactNativeFromSource is true', async () => {
+    const pluginProps: PluginConfigType = {
+      useHermesV1: true,
+      buildReactNativeFromSource: true,
+    };
+
+    const { modResults: androidModResults } = await compileMockModWithResultsAsync<
+      AndroidConfig.Properties.PropertiesItem[],
+      PluginConfigType
+    >(
+      {},
+      {
+        plugin: withBuildProperties,
+        pluginProps,
+        mod: withGradleProperties,
+        modResults: [],
+      }
+    );
+    expect(androidModResults).toContainEqual({
+      type: 'property',
+      key: 'hermesV1Enabled',
+      value: 'true',
+    });
+  });
+
+  it('should apply top-level useHermesV1 to iOS when buildReactNativeFromSource is true', async () => {
+    const pluginProps: PluginConfigType = {
+      useHermesV1: true,
+      buildReactNativeFromSource: true,
+    };
+
+    const { modResults: iosModResults } = await compileMockModWithResultsAsync(
+      {},
+      {
+        plugin: withBuildProperties,
+        pluginProps,
+        mod: withPodfileProperties,
+        modResults: {},
+      }
+    );
+    expect(iosModResults).toMatchObject({
+      'expo.useHermesV1': 'true',
+    });
+  });
+
+  it('should allow platform-specific override of top-level useHermesV1', async () => {
+    const pluginProps: PluginConfigType = {
+      useHermesV1: true,
+      buildReactNativeFromSource: true,
+      ios: { useHermesV1: false },
+    };
+
+    const { modResults: iosModResults } = await compileMockModWithResultsAsync(
+      {},
+      {
+        plugin: withBuildProperties,
+        pluginProps,
+        mod: withPodfileProperties,
+        modResults: {},
+      }
+    );
+    expect(iosModResults).toMatchObject({
+      'expo.useHermesV1': 'false',
+    });
+  });
+});

--- a/packages/expo-build-properties/src/android.ts
+++ b/packages/expo-build-properties/src/android.ts
@@ -108,8 +108,7 @@ export const withAndroidBuildProperties = createBuildGradlePropsConfigPlugin<Plu
     },
     {
       propName: 'hermesV1Enabled',
-      propValueGetter: (config) =>
-        resolveConfigValue(config, 'android', 'useHermesV1')?.toString(),
+      propValueGetter: (config) => resolveConfigValue(config, 'android', 'useHermesV1')?.toString(),
     },
   ],
   'withAndroidBuildProperties'

--- a/packages/expo-build-properties/src/android.ts
+++ b/packages/expo-build-properties/src/android.ts
@@ -2,7 +2,6 @@ import {
   AndroidConfig,
   ConfigPlugin,
   History,
-  WarningAggregator,
   withAndroidManifest,
   withAndroidStyles,
   withDangerousMod,
@@ -13,7 +12,7 @@ import path from 'path';
 
 import { renderQueryIntents, renderQueryPackages, renderQueryProviders } from './androidQueryUtils';
 import { appendContents, purgeContents } from './fileContentsUtils';
-import type { PluginConfigType } from './pluginConfig';
+import { PluginConfigType, resolveConfigValue } from './pluginConfig';
 
 const { createBuildGradlePropsConfigPlugin } = AndroidConfig.BuildProperties;
 
@@ -73,7 +72,7 @@ export const withAndroidBuildProperties = createBuildGradlePropsConfigPlugin<Plu
     },
     {
       propName: 'reactNativeReleaseLevel',
-      propValueGetter: (config) => config.android?.reactNativeReleaseLevel,
+      propValueGetter: (config) => resolveConfigValue(config, 'android', 'reactNativeReleaseLevel'),
     },
     {
       propName: 'expo.useLegacyPackaging',
@@ -109,16 +108,8 @@ export const withAndroidBuildProperties = createBuildGradlePropsConfigPlugin<Plu
     },
     {
       propName: 'hermesV1Enabled',
-      propValueGetter: (config) => {
-        if (config.android?.useHermesV1 && config.android?.buildReactNativeFromSource !== true) {
-          WarningAggregator.addWarningAndroid(
-            'withAndroidBuildProperties',
-            'Hermes V1 requires building React Native from source. Set `buildReactNativeFromSource` to `true` to enable it.'
-          );
-        }
-
-        return config.android?.useHermesV1?.toString();
-      },
+      propValueGetter: (config) =>
+        resolveConfigValue(config, 'android', 'useHermesV1')?.toString(),
     },
   ],
   'withAndroidBuildProperties'
@@ -316,9 +307,13 @@ export const withAndroidDayNightTheme: ConfigPlugin<PluginConfigType> = (config,
 
 export const withAndroidSettingsGradle: ConfigPlugin<PluginConfigType> = (config, props) => {
   return withSettingsGradle(config, (config) => {
+    // Resolution order: android.buildReactNativeFromSource > top-level > deprecated android.buildFromSource
+    const buildFromSource =
+      resolveConfigValue(props, 'android', 'buildReactNativeFromSource') ??
+      props.android?.buildFromSource; // Deprecated fallback (last resort)
     config.modResults.contents = updateAndroidSettingsGradle({
       contents: config.modResults.contents,
-      buildFromSource: props.android?.buildReactNativeFromSource ?? props.android?.buildFromSource,
+      buildFromSource,
     });
     return config;
   });

--- a/packages/expo-build-properties/src/ios.ts
+++ b/packages/expo-build-properties/src/ios.ts
@@ -1,13 +1,12 @@
 import {
   ConfigPlugin,
   IOSConfig,
-  WarningAggregator,
   XcodeProject,
   withInfoPlist,
   withXcodeProject,
 } from 'expo/config-plugins';
 
-import type { PluginConfigType } from './pluginConfig';
+import { PluginConfigType, resolveConfigValue } from './pluginConfig';
 
 const { createBuildPodfilePropsConfigPlugin } = IOSConfig.BuildProperties;
 
@@ -43,19 +42,13 @@ export const withIosBuildProperties = createBuildPodfilePropsConfigPlugin<Plugin
     },
     {
       propName: 'ios.buildReactNativeFromSource',
-      propValueGetter: (config) => config.ios?.buildReactNativeFromSource?.toString(),
+      propValueGetter: (config) =>
+        resolveConfigValue(config, 'ios', 'buildReactNativeFromSource')?.toString(),
     },
     {
       propName: 'expo.useHermesV1',
-      propValueGetter: (config) => {
-        if (config.ios?.useHermesV1 && config.ios?.buildReactNativeFromSource !== true) {
-          WarningAggregator.addWarningIOS(
-            'withIosBuildProperties',
-            'Hermes V1 requires building React Native from source. Set `buildReactNativeFromSource` to `true` to enable it.'
-          );
-        }
-        return config.ios?.useHermesV1?.toString();
-      },
+      propValueGetter: (config) =>
+        resolveConfigValue(config, 'ios', 'useHermesV1')?.toString(),
     },
   ],
   'withIosBuildProperties'
@@ -77,7 +70,7 @@ export const withIosDeploymentTarget: ConfigPlugin<PluginConfigType> = (config, 
 };
 
 export const withIosInfoPlist: ConfigPlugin<PluginConfigType> = (config, props) => {
-  const reactNativeReleaseLevel = props.ios?.reactNativeReleaseLevel;
+  const reactNativeReleaseLevel = resolveConfigValue(props, 'ios', 'reactNativeReleaseLevel');
   if (reactNativeReleaseLevel) {
     config = withIosReactNativeReleaseLevel(config, { reactNativeReleaseLevel });
   }

--- a/packages/expo-build-properties/src/ios.ts
+++ b/packages/expo-build-properties/src/ios.ts
@@ -47,8 +47,7 @@ export const withIosBuildProperties = createBuildPodfilePropsConfigPlugin<Plugin
     },
     {
       propName: 'expo.useHermesV1',
-      propValueGetter: (config) =>
-        resolveConfigValue(config, 'ios', 'useHermesV1')?.toString(),
+      propValueGetter: (config) => resolveConfigValue(config, 'ios', 'useHermesV1')?.toString(),
     },
   ],
   'withIosBuildProperties'

--- a/packages/expo-build-properties/src/pluginConfig.ts
+++ b/packages/expo-build-properties/src/pluginConfig.ts
@@ -881,9 +881,7 @@ export function validateConfig(config: any): PluginConfigType {
   const iosUseHermesV1 = resolveConfigValue(config, 'ios', 'useHermesV1');
   const iosBuildFromSource = resolveConfigValue(config, 'ios', 'buildReactNativeFromSource');
   if (iosUseHermesV1 === true && iosBuildFromSource !== true) {
-    throw new Error(
-      '`useHermesV1` requires `buildReactNativeFromSource` to be `true` for iOS.'
-    );
+    throw new Error('`useHermesV1` requires `buildReactNativeFromSource` to be `true` for iOS.');
   }
 
   return config;


### PR DESCRIPTION
## Summary

Adds `buildReactNativeFromSource`, `useHermesV1`, and `reactNativeReleaseLevel` as top-level config fields for consistency with how we define platform-specific properties. This allows users to conveniently set a value in a single place for multiple platforms, with platform-specific overrides when needed.

**Example:**
```json
{
  "buildReactNativeFromSource": true,
  "useHermesV1": true,
  "reactNativeReleaseLevel": "experimental",
  "android": { "minSdkVersion": 24 },
  "ios": { "useHermesV1": false }
}
```

## Changes

- Added `SharedBuildConfigFields` interface and `resolveConfigValue()` helper
- Updated `PluginConfigType`, `PluginConfigTypeAndroid`, `PluginConfigTypeIos` to extend shared interface
- Updated Android/iOS plugins to use resolved config values
- Added comprehensive tests

## Test plan

- [x] All 70 existing tests pass
- [x] TypeScript type checking passes
- [x] New tests cover resolution logic and validation warnings