### PR TITLE
docs(expo-camera): document barcodeScannerEnabled config plugin property

### DIFF
--- a/docs/pages/versions/unversioned/sdk/camera.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera.mdx
@@ -41,7 +41,8 @@ You can configure `expo-camera` using its built-in [config plugin](/config-plugi
         {
           "cameraPermission": "Allow $(PRODUCT_NAME) to access your camera",
           "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone",
-          "recordAudioAndroid": true
+          "recordAudioAndroid": true,
+          "barcodeScannerEnabled": true
         }
       ]
     ]
@@ -70,6 +71,12 @@ You can configure `expo-camera` using its built-in [config plugin](/config-plugi
       platform: 'android',
       description:
         'A boolean that determines whether to enable the `RECORD_AUDIO` permission on Android.',
+      default: 'true',
+    },
+    {
+      name: 'barcodeScannerEnabled',
+      description:
+        'A boolean that determines whether to enable barcode scanning support. Disabling this reduces app size when barcode scanning is not needed.',
       default: 'true',
     },
   ]}


### PR DESCRIPTION
## Summary

Documents the `barcodeScannerEnabled` config plugin property for expo-camera in the unversioned docs.

This property allows users to disable barcode scanning support to reduce app size when the feature is not needed.