### PR TITLE
docs(expo-brownfield): add config plugin documentation

### DIFF
--- a/docs/pages/brownfield/get-started.mdx
+++ b/docs/pages/brownfield/get-started.mdx
@@ -5,6 +5,10 @@ description: A guide for adding Expo and React Native to existing native apps an
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import {
+  ConfigPluginExample,
+  ConfigPluginProperties,
+} from '~/ui/components/ConfigSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal, DiffBlock } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
@@ -501,3 +505,89 @@ You have completed all the basic steps to integrate React Native with your appli
 <Terminal cmd={['$ yarn start']} />
 
 Metro builds your TypeScript application code into a bundle, serves it through its HTTP server, and shares the bundle from `localhost` on your developer environment to a simulator or device, allowing for [hot reloading](https://reactnative.dev/blog/2016/03/24/introducing-hot-reloading). Now you can build and run your app as normal. Once you reach your React-powered Activity inside the app, it should load the JavaScript code from the development server.
+
+## Configuration in app config
+
+The `expo-brownfield` package provides a [config plugin](/config-plugins/introduction/) that can be used to configure the brownfield integration when using [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/). This plugin allows you to customize how your Expo project is packaged and integrated into your existing native app.
+
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-brownfield",
+        {
+          "ios": {
+            "targetName": "MyBrownfieldTarget",
+            "bundleIdentifier": "com.example.brownfield"
+          },
+          "android": {
+            "group": "com.example",
+            "libraryName": "brownfield",
+            "package": "com.example.brownfield",
+            "version": "1.0.0"
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'ios.targetName',
+      platform: 'ios',
+      description:
+        'Name of the Xcode target for the brownfield integration. This is used to create a separate target in your Xcode project for the React Native code.',
+      default: '"<scheme>brownfield" or "<slug>brownfield"',
+    },
+    {
+      name: 'ios.bundleIdentifier',
+      platform: 'ios',
+      description:
+        'Bundle identifier for the brownfield target. This should be unique and different from your main app bundle identifier.',
+      default: '"<ios.bundleIdentifier base>.<targetName>" or "com.example.<targetName>"',
+    },
+    {
+      name: 'android.group',
+      platform: 'android',
+      description:
+        'Maven group ID for the generated Android library. This is used when publishing the library to a Maven repository.',
+      default: '"<package without last segment>"',
+    },
+    {
+      name: 'android.libraryName',
+      platform: 'android',
+      description:
+        'Name of the generated Android library module.',
+      default: '"brownfield"',
+    },
+    {
+      name: 'android.package',
+      platform: 'android',
+      description:
+        'Java/Kotlin package name for the generated Android library code.',
+      default: '"<android.package>.brownfield" or "com.example.brownfield"',
+    },
+    {
+      name: 'android.version',
+      platform: 'android',
+      description:
+        'Version string for the generated Android library. This is used when publishing to a Maven repository.',
+      default: '"1.0.0"',
+    },
+    {
+      name: 'android.publishing',
+      platform: 'android',
+      description:
+        'Publishing configuration for the generated Android library. Supports `localMaven`, `localDirectory`, `remotePublic`, and `remotePrivate` publication types. Each type has different configuration options for specifying where and how the library is published.',
+      default: '[{ type: "localMaven" }]',
+    },
+  ]}
+/>

--- a/docs/pages/brownfield/get-started.mdx
+++ b/docs/pages/brownfield/get-started.mdx
@@ -5,10 +5,7 @@ description: A guide for adding Expo and React Native to existing native apps an
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
-import {
-  ConfigPluginExample,
-  ConfigPluginProperties,
-} from '~/ui/components/ConfigSection';
+import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/ConfigSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal, DiffBlock } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
@@ -564,15 +561,13 @@ The `expo-brownfield` package provides a [config plugin](/config-plugins/introdu
     {
       name: 'android.libraryName',
       platform: 'android',
-      description:
-        'Name of the generated Android library module.',
+      description: 'Name of the generated Android library module.',
       default: '"brownfield"',
     },
     {
       name: 'android.package',
       platform: 'android',
-      description:
-        'Java/Kotlin package name for the generated Android library code.',
+      description: 'Java/Kotlin package name for the generated Android library code.',
       default: '"<android.package>.brownfield" or "com.example.brownfield"',
     },
     {


### PR DESCRIPTION
## Summary
Adds documentation for the expo-brownfield config plugin properties including:
- `ios.targetName` and `ios.bundleIdentifier`
- `android.group`, `android.libraryName`, `android.package`, `android.version`, `android.publishing`

## Test plan
- [x] Documentation verified against source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)