### PR TITLE
docs(expo-router): document config plugin properties

### DIFF
--- a/docs/pages/versions/unversioned/sdk/router.mdx
+++ b/docs/pages/versions/unversioned/sdk/router.mdx
@@ -11,7 +11,7 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import APISection from '~/components/plugins/APISection';
 import { BoxLink } from '~/ui/components/BoxLink';
-import { ConfigPluginExample } from '~/ui/components/ConfigSection';
+import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/ConfigSection';
 
 `expo-router` is a routing library for React Native and web apps. It enables navigation management using a file-based routing system and provides native navigation components and is built on top of [React Navigation](https://reactnavigation.org/).
 
@@ -48,6 +48,84 @@ If you are using the [default](/more/create-expo/#--template) template to create
 ```
 
 </ConfigPluginExample>
+
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'root',
+      description: 'Changes the routes directory from `app` to another value. Avoid using this property unless you have a specific need.',
+      default: '"app"',
+    },
+    {
+      name: 'origin',
+      description: 'Production origin URL where assets in the public folder are hosted. The fetch function is polyfilled to support relative requests from this origin in production. The development origin is inferred using the Expo CLI development server.',
+      default: 'undefined',
+    },
+    {
+      name: 'headOrigin',
+      description: 'A more specific origin URL used in the `expo-router/head` module for iOS handoff. Defaults to `origin`.',
+      default: 'undefined',
+    },
+    {
+      name: 'asyncRoutes',
+      description: 'Enable async routes (lazy loading). Can be a boolean, a string (`"development"` or `"production"`), or an object with platform-specific values (`{ android, ios, web, default }`). `production` is currently web-only and will be disabled on native.',
+      default: 'undefined',
+    },
+    {
+      name: 'platformRoutes',
+      description: 'Enable or disable platform-specific routes (for example, **index.ios.tsx** and **index.android.tsx**).',
+      default: 'true',
+    },
+    {
+      name: 'sitemap',
+      description: 'Enable or disable the automatically generated sitemap at **/_sitemap**.',
+      default: 'true',
+    },
+    {
+      name: 'partialRouteTypes',
+      description: 'Enable partial typed routes generation. This allows TypeScript to provide type checking for routes without requiring all routes to be statically known.',
+      default: 'true',
+    },
+    {
+      name: 'redirects',
+      description: 'An array of static redirect rules. Each rule should have `source`, `destination`, and optionally `permanent` (defaults to `false`) and `methods` (HTTP methods to redirect).',
+      default: 'undefined',
+    },
+    {
+      name: 'rewrites',
+      description: 'An array of static rewrite rules. Each rule should have `source`, `destination`, and optionally `methods` (HTTP methods to rewrite).',
+      default: 'undefined',
+    },
+    {
+      name: 'headers',
+      description: 'A list of headers that are set on every route response from the server. The value can be a string or an array of strings.',
+      default: 'undefined',
+    },
+    {
+      name: 'disableSynchronousScreensUpdates',
+      description: 'Disable synchronous layout updates for native screens. This can help with performance in some cases.',
+      default: 'false',
+    },
+    {
+      name: 'unstable_useServerMiddleware',
+      description: 'Enable server middleware support with a `+middleware.ts` file. Requires `web.output: "server"` to be set in app config.',
+      default: 'false',
+      experimental: true,
+    },
+    {
+      name: 'unstable_useServerDataLoaders',
+      description: 'Enable data loader support. This is only supported for `web.output: "static"` outputs at the moment.',
+      default: 'false',
+      experimental: true,
+    },
+    {
+      name: 'unstable_useServerRendering',
+      description: 'Enable server-side rendering. When enabled with `web.output: "server"`, HTML is rendered at request time instead of being pre-rendered at build time.',
+      default: 'false',
+      experimental: true,
+    },
+  ]}
+/>
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/router.mdx
+++ b/docs/pages/versions/unversioned/sdk/router.mdx
@@ -53,27 +53,32 @@ If you are using the [default](/more/create-expo/#--template) template to create
   properties={[
     {
       name: 'root',
-      description: 'Changes the routes directory from `app` to another value. Avoid using this property unless you have a specific need.',
+      description:
+        'Changes the routes directory from `app` to another value. Avoid using this property unless you have a specific need.',
       default: '"app"',
     },
     {
       name: 'origin',
-      description: 'Production origin URL where assets in the public folder are hosted. The fetch function is polyfilled to support relative requests from this origin in production. The development origin is inferred using the Expo CLI development server.',
+      description:
+        'Production origin URL where assets in the public folder are hosted. The fetch function is polyfilled to support relative requests from this origin in production. The development origin is inferred using the Expo CLI development server.',
       default: 'undefined',
     },
     {
       name: 'headOrigin',
-      description: 'A more specific origin URL used in the `expo-router/head` module for iOS handoff. Defaults to `origin`.',
+      description:
+        'A more specific origin URL used in the `expo-router/head` module for iOS handoff. Defaults to `origin`.',
       default: 'undefined',
     },
     {
       name: 'asyncRoutes',
-      description: 'Enable async routes (lazy loading). Can be a boolean, a string (`"development"` or `"production"`), or an object with platform-specific values (`{ android, ios, web, default }`). `production` is currently web-only and will be disabled on native.',
+      description:
+        'Enable async routes (lazy loading). Can be a boolean, a string (`"development"` or `"production"`), or an object with platform-specific values (`{ android, ios, web, default }`). `production` is currently web-only and will be disabled on native.',
       default: 'undefined',
     },
     {
       name: 'platformRoutes',
-      description: 'Enable or disable platform-specific routes (for example, **index.ios.tsx** and **index.android.tsx**).',
+      description:
+        'Enable or disable platform-specific routes (for example, **index.ios.tsx** and **index.android.tsx**).',
       default: 'true',
     },
     {
@@ -83,44 +88,52 @@ If you are using the [default](/more/create-expo/#--template) template to create
     },
     {
       name: 'partialRouteTypes',
-      description: 'Enable partial typed routes generation. This allows TypeScript to provide type checking for routes without requiring all routes to be statically known.',
+      description:
+        'Enable partial typed routes generation. This allows TypeScript to provide type checking for routes without requiring all routes to be statically known.',
       default: 'true',
     },
     {
       name: 'redirects',
-      description: 'An array of static redirect rules. Each rule should have `source`, `destination`, and optionally `permanent` (defaults to `false`) and `methods` (HTTP methods to redirect).',
+      description:
+        'An array of static redirect rules. Each rule should have `source`, `destination`, and optionally `permanent` (defaults to `false`) and `methods` (HTTP methods to redirect).',
       default: 'undefined',
     },
     {
       name: 'rewrites',
-      description: 'An array of static rewrite rules. Each rule should have `source`, `destination`, and optionally `methods` (HTTP methods to rewrite).',
+      description:
+        'An array of static rewrite rules. Each rule should have `source`, `destination`, and optionally `methods` (HTTP methods to rewrite).',
       default: 'undefined',
     },
     {
       name: 'headers',
-      description: 'A list of headers that are set on every route response from the server. The value can be a string or an array of strings.',
+      description:
+        'A list of headers that are set on every route response from the server. The value can be a string or an array of strings.',
       default: 'undefined',
     },
     {
       name: 'disableSynchronousScreensUpdates',
-      description: 'Disable synchronous layout updates for native screens. This can help with performance in some cases.',
+      description:
+        'Disable synchronous layout updates for native screens. This can help with performance in some cases.',
       default: 'false',
     },
     {
       name: 'unstable_useServerMiddleware',
-      description: 'Enable server middleware support with a `+middleware.ts` file. Requires `web.output: "server"` to be set in app config.',
+      description:
+        'Enable server middleware support with a `+middleware.ts` file. Requires `web.output: "server"` to be set in app config.',
       default: 'false',
       experimental: true,
     },
     {
       name: 'unstable_useServerDataLoaders',
-      description: 'Enable data loader support. This is only supported for `web.output: "static"` outputs at the moment.',
+      description:
+        'Enable data loader support. This is only supported for `web.output: "static"` outputs at the moment.',
       default: 'false',
       experimental: true,
     },
     {
       name: 'unstable_useServerRendering',
-      description: 'Enable server-side rendering. When enabled with `web.output: "server"`, HTML is rendered at request time instead of being pre-rendered at build time.',
+      description:
+        'Enable server-side rendering. When enabled with `web.output: "server"`, HTML is rendered at request time instead of being pre-rendered at build time.',
       default: 'false',
       experimental: true,
     },

--- a/docs/pages/versions/unversioned/sdk/router.mdx
+++ b/docs/pages/versions/unversioned/sdk/router.mdx
@@ -78,7 +78,7 @@ If you are using the [default](/more/create-expo/#--template) template to create
     {
       name: 'platformRoutes',
       description:
-        'Enable or disable platform-specific routes (for example, **index.ios.tsx** and **index.android.tsx**).',
+        'Enable or disable platform-specific routes (for example, **index.android.tsx** and **index.ios.tsx**).',
       default: 'true',
     },
     {


### PR DESCRIPTION
## Summary
Documents the expo-router config plugin properties including:
- `root`, `origin`, `headOrigin`
- `asyncRoutes`, `platformRoutes`, `sitemap`, `partialRouteTypes`
- `redirects`, `rewrites`, `headers`
- `disableSynchronousScreensUpdates`
- Experimental: `unstable_useServerMiddleware`, `unstable_useServerDataLoaders`, `unstable_useServerRendering`

## Test plan
- [x] Documentation verified against source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)