### PR TITLE
docs(expo-updates): document enableBsdiffPatchSupport and useNativeDebug

### DIFF
--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -64,6 +64,8 @@ There are build-time configuration options that control the behavior of the libr
 | [`updates.codeSigningMetadata`](../config/app/#codesigningmetadata)                 | (none)   | <NoIcon />  | `EXUpdatesCodeSigningMetadata`         | `expo.modules.updates.CODE_SIGNING_METADATA`                     | `codeSigningMetadata`         |
 | [`updates.assetPatternsToBeBundled`](../config/app/#assetpatternstobebundled)       | (none)   | <NoIcon />  | N/A                                    | N/A                                                              | N/A                           |
 | [`updates.disableAntiBrickingMeasures`](../config/app/#disableantibrickingmeasures) | `false`  | <NoIcon />  | `EXUpdatesDisableAntiBrickingMeasures` | `expo.modules.updates.  DISABLE_ANTI_BRICKING_MEASURES`          | `disableAntiBrickingMeasures` |
+| [`updates.useNativeDebug`](../config/app/#usenativedebug)                           | `false`  | <NoIcon />  | N/A                                    | N/A                                                              | N/A                           |
+| [`updates.enableBsdiffPatchSupport`](../config/app/#enablebsdiffpatchsupport)       | `true`   | <NoIcon />  | `EXUpdatesEnableBsdiffPatchSupport`    | `expo.modules.updates.ENABLE_BSDIFF_PATCH_SUPPORT`               | `enableBsdiffPatchSupport`    |
 
 The two core required configuration options are:
 


### PR DESCRIPTION
## Summary
Documents two missing config plugin properties:
- `enableBsdiffPatchSupport` - Enable BSDiff patch support for asset updates (default: true)
- `useNativeDebug` - Enable native debugging with updates enabled (default: false)

## Test plan
- [x] Documentation verified against source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)