### PR TITLE
docs(expo-dev-client): add platform-specific launchMode documentation

### DIFF
--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -66,6 +66,40 @@ You can configure development client launcher using its built-in [config plugin]
       ].join('\n'),
       default: 'true',
     },
+    {
+      name: 'android',
+      description: [
+        'Android-specific configuration options.',
+      ].join('\n'),
+      properties: [
+        {
+          name: 'launchMode',
+          description: [
+            'Determines whether to launch the most recently opened project or navigate to the launcher screen on Android. Overrides the top-level `launchMode` setting for Android only.',
+            '* `most-recent` - Attempt to launch directly into a previously opened project and if unable to connect, fall back to the launcher screen.',
+            '* `launcher` - Opens the launcher screen.',
+          ].join('\n'),
+          default: '"most-recent"',
+        },
+      ],
+    },
+    {
+      name: 'ios',
+      description: [
+        'iOS-specific configuration options.',
+      ].join('\n'),
+      properties: [
+        {
+          name: 'launchMode',
+          description: [
+            'Determines whether to launch the most recently opened project or navigate to the launcher screen on iOS. Overrides the top-level `launchMode` setting for iOS only.',
+            '* `most-recent` - Attempt to launch directly into a previously opened project and if unable to connect, fall back to the launcher screen.',
+            '* `launcher` - Opens the launcher screen.',
+          ].join('\n'),
+          default: '"most-recent"',
+        },
+      ],
+    },
   ]}
 />
 

--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -68,9 +68,7 @@ You can configure development client launcher using its built-in [config plugin]
     },
     {
       name: 'android',
-      description: [
-        'Android-specific configuration options.',
-      ].join('\n'),
+      description: ['Android-specific configuration options.'].join('\n'),
       properties: [
         {
           name: 'launchMode',
@@ -85,9 +83,7 @@ You can configure development client launcher using its built-in [config plugin]
     },
     {
       name: 'ios',
-      description: [
-        'iOS-specific configuration options.',
-      ].join('\n'),
+      description: ['iOS-specific configuration options.'].join('\n'),
       properties: [
         {
           name: 'launchMode',

--- a/docs/pages/versions/unversioned/sdk/dev-client.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-client.mdx
@@ -67,34 +67,24 @@ You can configure development client launcher using its built-in [config plugin]
       default: 'true',
     },
     {
-      name: 'android',
-      description: ['Android-specific configuration options.'].join('\n'),
-      properties: [
-        {
-          name: 'launchMode',
-          description: [
-            'Determines whether to launch the most recently opened project or navigate to the launcher screen on Android. Overrides the top-level `launchMode` setting for Android only.',
-            '* `most-recent` - Attempt to launch directly into a previously opened project and if unable to connect, fall back to the launcher screen.',
-            '* `launcher` - Opens the launcher screen.',
-          ].join('\n'),
-          default: '"most-recent"',
-        },
-      ],
+      name: 'android.launchMode',
+      description: [
+        'Determines whether to launch the most recently opened project or navigate to the launcher screen on Android. Overrides the top-level `launchMode` setting for Android only.',
+        '* `most-recent` - Attempt to launch directly into a previously opened project and if unable to connect, fall back to the launcher screen.',
+        '* `launcher` - Opens the launcher screen.',
+      ].join('\n'),
+      default: '"most-recent"',
+      platform: 'android',
     },
     {
-      name: 'ios',
-      description: ['iOS-specific configuration options.'].join('\n'),
-      properties: [
-        {
-          name: 'launchMode',
-          description: [
-            'Determines whether to launch the most recently opened project or navigate to the launcher screen on iOS. Overrides the top-level `launchMode` setting for iOS only.',
-            '* `most-recent` - Attempt to launch directly into a previously opened project and if unable to connect, fall back to the launcher screen.',
-            '* `launcher` - Opens the launcher screen.',
-          ].join('\n'),
-          default: '"most-recent"',
-        },
-      ],
+      name: 'ios.launchMode',
+      description: [
+        'Determines whether to launch the most recently opened project or navigate to the launcher screen on iOS. Overrides the top-level `launchMode` setting for iOS only.',
+        '* `most-recent` - Attempt to launch directly into a previously opened project and if unable to connect, fall back to the launcher screen.',
+        '* `launcher` - Opens the launcher screen.',
+      ].join('\n'),
+      default: '"most-recent"',
+      platform: 'ios',
     },
   ]}
 />


### PR DESCRIPTION
## Summary
Documents the platform-specific `android.launchMode` and `ios.launchMode` configuration options that allow overriding the top-level `launchMode` setting per platform.

## Test plan
- [x] Documentation verified against source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)