### PR TITLE
docs(expo-localization): document config plugin properties

### DIFF
--- a/docs/pages/versions/unversioned/sdk/localization.mdx
+++ b/docs/pages/versions/unversioned/sdk/localization.mdx
@@ -9,10 +9,7 @@ platforms: ['android', 'ios', 'tvos', 'web', 'expo-go']
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import {
-  ConfigPluginExample,
-  ConfigPluginProperties,
-} from '~/ui/components/ConfigSection';
+import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/ConfigSection';
 
 `expo-localization` allows you to Localize your app, customizing the experience for specific regions, languages, or cultures. It also provides access to the locale data on the native device. Using a localization library such as [`lingui-js`](https://lingui.dev/introduction), [`react-i18next`](https://react.i18next.com/), [`react-intl`](https://formatjs.io/docs/getting-started/installation/) or [`i18n-js`](https://github.com/fnando/i18n-js) with `expo-localization` will enable you to create a very accessible experience for users.
 

--- a/docs/pages/versions/unversioned/sdk/localization.mdx
+++ b/docs/pages/versions/unversioned/sdk/localization.mdx
@@ -9,7 +9,10 @@ platforms: ['android', 'ios', 'tvos', 'web', 'expo-go']
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import { ConfigPluginExample } from '~/ui/components/ConfigSection';
+import {
+  ConfigPluginExample,
+  ConfigPluginProperties,
+} from '~/ui/components/ConfigSection';
 
 `expo-localization` allows you to Localize your app, customizing the experience for specific regions, languages, or cultures. It also provides access to the locale data on the native device. Using a localization library such as [`lingui-js`](https://lingui.dev/introduction), [`react-i18next`](https://react.i18next.com/), [`react-intl`](https://formatjs.io/docs/getting-started/installation/) or [`i18n-js`](https://github.com/fnando/i18n-js) with `expo-localization` will enable you to create a very accessible experience for users.
 
@@ -26,12 +29,50 @@ You can configure `expo-localization` using its built-in [config plugin](/config
 ```json app.json
 {
   "expo": {
-    "plugins": ["expo-localization"]
+    "plugins": [
+      [
+        "expo-localization",
+        {
+          "supportsRTL": true,
+          "allowDynamicLocaleChangesAndroid": true
+        }
+      ]
+    ]
   }
 }
 ```
 
 </ConfigPluginExample>
+
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'supportsRTL',
+      description:
+        'A boolean to enable or disable right-to-left (RTL) layout support for your app.',
+      default: 'undefined',
+    },
+    {
+      name: 'forcesRTL',
+      description:
+        'A boolean to force RTL layout direction regardless of the device locale settings. Requires `supportsRTL` to be enabled to have an effect.',
+      default: 'undefined',
+    },
+    {
+      name: 'allowDynamicLocaleChangesAndroid',
+      platform: 'android',
+      description:
+        'A boolean that enables the app to respond to locale and layout direction changes without restarting. When enabled, adds `locale` and `layoutDirection` to the `android:configChanges` attribute in **AndroidManifest.xml**.',
+      default: 'true',
+    },
+    {
+      name: 'supportedLocales',
+      description:
+        'An array of locale strings (for example, `["en", "es", "pl"]`) or an object with `ios` and `android` keys containing separate arrays for each platform. On iOS, this sets `CFBundleLocalizations` in **Info.plist**. On Android, this creates a `locales_config.xml` file and configures the `resourceConfigurations` in **build.gradle**.',
+      default: 'undefined',
+    },
+  ]}
+/>
 
 ## Usage
 


### PR DESCRIPTION
## Summary
Documents the expo-localization config plugin properties:
- supportsRTL
- forcesRTL
- allowDynamicLocaleChangesAndroid
- supportedLocales

## Test plan
- [x] Documentation verified against source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)