### PR TITLE
[docs] Add a resolution for baseline-browser-mapping

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -152,6 +152,9 @@
       "autoprefixer": {}
     }
   },
+  "resolutions": {
+    "baseline-browser-mapping": "2.9.15"
+  },
   "volta": {
     "node": "22.13.1"
   }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -4782,12 +4782,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"baseline-browser-mapping@npm:^2.8.25":
-  version: 2.8.29
-  resolution: "baseline-browser-mapping@npm:2.8.29"
+"baseline-browser-mapping@npm:2.9.15":
+  version: 2.9.15
+  resolution: "baseline-browser-mapping@npm:2.9.15"
   bin:
     baseline-browser-mapping: dist/cli.js
-  checksum: 10c0/bb5f082d91b59c885504fd4ff999bd890c39e8b818afe00f15f0dfcdb7f7b80a655ad57429563091c0d3722649ba4a2f023ca3ede02e022b12ba6b0322a3314e
+  checksum: 10c0/e5c8cb8600fcbed8132f122b737b00b5b3fcf25a119ea5e42476e6d6b2263274ddc5df16d4cffebbcd46974b691008558973b06100508903ea8a382a5edd34ab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Running `yarn run lint` in docs app emits the baseline-browser-mapping stale data warning bot on CI and locally.

<img width="3456" height="192" alt="CleanShot 2026-01-20 at 14 18 37@2x" src="https://github.com/user-attachments/assets/baa5ed90-f589-44b4-b601-0fb1266e4a14" />


# How

<!--
How did you build this feature or fix this bug and why?
-->

Add a `resolutions` override for baseline-browser-mapping in `package.json` and run `yarn install` to update `yarn.lock` in docs app.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn run lint` and it should exit without any warning or error.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
