### PR TITLE
[ios][brownfield] fix ExpoAppDelegate.swift symlink issues

### DIFF
--- a/packages/expo-brownfield/plugin/templates/ios/ExpoAppDelegate.swift
+++ b/packages/expo-brownfield/plugin/templates/ios/ExpoAppDelegate.swift
@@ -1,1 +1,1 @@
-/Users/gabriel/Workspace/expo/expo/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
+../../../../expo/ios/AppDelegates/ExpoAppDelegate.swift


### PR DESCRIPTION
# Why

Actions that revolve around the symlink (e.g. `npm pack` or just directly running `yarn prepack`) end in an error wven though the file exists:

```bash
> expo-brownfield@0.0.1 prepack
> cp -L plugin/templates/ios/ExpoAppDelegate.swift plugin/templates/ios/ExpoAppDelegate.swift.tmp \
  && mv plugin/templates/ios/ExpoAppDelegate.swift.tmp plugin/templates/ios/ExpoAppDelegate.swift

cp: plugin/templates/ios/ExpoAppDelegate.swift: No such file or directory
```

That's because symlink seems to be an absolute path instead of a relative one:

```bash
> ls -al plugin/templates/ios

total 64
drwxr-xr-x  11 patrykmleczek  staff   352 Jan 20 10:56 .
drwxr-xr-x   5 patrykmleczek  staff   160 Jan 20 10:30 ..
lrwxr-xr-x   1 patrykmleczek  staff    87 Jan 20 10:56 ExpoAppDelegate.swift -> /Users/gabriel/Workspace/expo/expo/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
-rw-r--r--   1 patrykmleczek  staff   516 Jan  9 08:13 Info.plist
```

# How

Changed symlink to be a relative path to the original `ExpoAppDelegate.swift`

# Test Plan

Tested using `npx expo prebuild` and `npx expo-brownfield build-ios` in `apps/minimal-tester`

# Checklist

- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
