### PR TITLE
[ios][expo-go] Fix double initialization

### DIFF
--- a/apps/expo-go/ios/Client/SwiftUI/HomeTabView.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/HomeTabView.swift
@@ -70,12 +70,8 @@ struct HomeTabView: View {
       }
     }
     .onAppear {
-      viewModel.onViewWillAppear()
       reviewManager.recordHomeAppear()
       reviewManager.updateCounts(apps: viewModel.projects.count, snacks: viewModel.snacks.count)
-    }
-    .onDisappear {
-      viewModel.onViewDidDisappear()
     }
     .onChange(of: viewModel.projects.count) { _ in
       reviewManager.updateCounts(apps: viewModel.projects.count, snacks: viewModel.snacks.count)


### PR DESCRIPTION
# Why
`onViewWillAppear` and `onViewDidDisappear` are called from the `EXRootViewController`, they should not be called as part of the swift UI lifecycle as they start and end port scanning so this is wasteful doing it twice

# How
Remove the calls from the swift UI view

# Test Plan
Expo go
