### PR TITLE
[go] Exclude expo-widgets from Expo Go

### DIFF
--- a/apps/expo-go/android/settings.gradle
+++ b/apps/expo-go/android/settings.gradle
@@ -43,7 +43,8 @@ expoAutolinking.exclude = [
   '@expo/ui',
   'expo-mesh-gradient',
   '@expo/app-integrity',
-  '@expo/home'
+  '@expo/home',
+  'expo-widgets'
 ]
 
 expoAutolinking.useExpoModules()

--- a/apps/expo-go/ios/Podfile
+++ b/apps/expo-go/ios/Podfile
@@ -52,7 +52,8 @@ target 'Expo Go' do
       'expo-splash-screen',
       '@expo/ui',
       '@expo/app-integrity',
-      'expo-brownfield'
+      'expo-brownfield',
+      'expo-widgets'
     ],
     includeTests: true,
     flags: {


### PR DESCRIPTION
# Why

`expo-widgets` should not be available in Expo Go

# How

Exclude package from autolinking

# Test Plan

`pod install` in `expo-go`