### PR TITLE
[expo-router][ios] fix toolbar updates

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -71,6 +71,7 @@
 - [ios] fix shadow color in native tabs ([#42125](https://github.com/expo/expo/pull/42125) by [@Ubax](https://github.com/Ubax))
 - Preserve search params for loader data fetches ([#42227](https://github.com/expo/expo/pull/42227) by [@hassankhan](https://github.com/hassankhan))
 - fix withAnchor for deeply nested routes ([#40528](https://github.com/expo/expo/pull/40528) by [@Ubax](https://github.com/Ubax))
+- [ios] fix toolbar updates ([#42338](https://github.com/expo/expo/pull/42338) by [@Ubax](https://github.com/Ubax))
 
 ### 💡 Others
 

--- a/packages/expo-router/ios/Toolbar/RouterToolbarHostView.swift
+++ b/packages/expo-router/ios/Toolbar/RouterToolbarHostView.swift
@@ -38,15 +38,6 @@ class RouterToolbarHostView: RouterViewWithLogger, LinkPreviewMenuUpdatable {
     }
   }
 
-  func updateToolbarItem(withId id: String) {
-    if let controller = self.findViewController() {
-      let index = toolbarItemsArray.firstIndex(of: id)
-      if let index = index, let item = toolbarItemsMap[id] {
-        controller.toolbarItems?[index] = item.barButtonItem
-      }
-    }
-  }
-
   func updateToolbarItems() {
     // If update already scheduled, skip - the pending async block will handle it
     if hasPendingToolbarUpdate {

--- a/packages/expo-router/ios/Toolbar/RouterToolbarItemView.swift
+++ b/packages/expo-router/ios/Toolbar/RouterToolbarItemView.swift
@@ -71,7 +71,6 @@ class RouterToolbarItemView: RouterViewWithLogger {
     guard let item = currentBarButtonItem else {
       // If no current item exists, create one
       rebuildBarButtonItem()
-      self.host?.updateToolbarItem(withId: self.identifier)
       return
     }
 


### PR DESCRIPTION
# Why

There were two issues:
- sometimes when updating the toolbar there was index out of range exception
- the update animation looked clunky

# How

By removing the `updateToolbarItem` function we can solve two issues at the same time. Moreover the function was not necessary anyway, since the update is always happening at the end of the loop. So a side effect of this fix is a small additional performance boost 

# Test Plan

Manual testing

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
