### PR TITLE
[ios][expo-go] Make row types equatable

### DIFF
--- a/apps/expo-go/ios/Client/SwiftUI/GraphQL/Models.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/GraphQL/Models.swift
@@ -112,13 +112,13 @@ struct OwnerAccount: Codable {
   let name: String
 }
 
-struct Branch: Codable {
+struct Branch: Codable, Equatable {
   let id: String
   let name: String
   let updates: [AppUpdate]
 }
 
-struct AppUpdate: Identifiable, Codable {
+struct AppUpdate: Identifiable, Codable, Equatable {
   let id: String
   let group: String?
   let message: String?
@@ -129,7 +129,7 @@ struct AppUpdate: Identifiable, Codable {
   let manifestPermalink: String
 }
 
-struct Snack: Identifiable, Codable {
+struct Snack: Identifiable, Codable, Equatable {
   let id: String
   let name: String
   let description: String?

--- a/apps/expo-go/ios/Client/SwiftUI/HomeViewModel.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/HomeViewModel.swift
@@ -275,7 +275,7 @@ struct RecentlyOpenedApp: Identifiable, Codable {
   var iconUrl: String?
 }
 
-struct DevelopmentServer: Identifiable {
+struct DevelopmentServer: Identifiable, Equatable {
   var id: String { url }
   let url: String
   let description: String
@@ -284,7 +284,7 @@ struct DevelopmentServer: Identifiable {
   var iconUrl: String?
 }
 
-struct ExpoProject: Identifiable, Codable {
+struct ExpoProject: Identifiable, Codable, Equatable {
   let id: String
   let name: String
   let fullName: String

--- a/apps/expo-go/ios/Client/SwiftUI/Services/DataService.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Services/DataService.swift
@@ -47,9 +47,18 @@ class DataService: ObservableObject {
         return
       }
 
-      self.projects = response.data.account.byName.apps.map { $0.toExpoProject() }
-      self.snacks = response.data.account.byName.snacks
-      self.dataError = nil
+      let newProjects = response.data.account.byName.apps.map { $0.toExpoProject() }
+      let newSnacks = response.data.account.byName.snacks
+
+      if newProjects != self.projects {
+        self.projects = newProjects
+      }
+      if newSnacks != self.snacks {
+        self.snacks = newSnacks
+      }
+      if self.dataError != nil {
+        self.dataError = nil
+      }
     } catch is CancellationError {
       return
     } catch let error as APIError {

--- a/apps/expo-go/ios/Client/SwiftUI/Services/DevelopmentServerService.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Services/DevelopmentServerService.swift
@@ -270,7 +270,10 @@ class DevelopmentServerService: ObservableObject {
         merged[key] = server
       }
     }
-    developmentServers = merged.values.sorted { $0.url < $1.url }
+    let newServers = merged.values.sorted { $0.url < $1.url }
+    if newServers != developmentServers {
+      developmentServers = newServers
+    }
   }
 
   private func dedupeKey(for server: DevelopmentServer) -> String {


### PR DESCRIPTION
# Why
Currently, not all of the types used in list rows conform to `Equatable`, because of this, when we poll for projects and snacks, these list are updated even if the data has not changed

# How
Added `Equatable` conformance to these types

# Test Plan
Expo go
