### PR TITLE
[ui][iOS] Skip rendering `label` as `Menu` item

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -40,6 +40,7 @@
 - [jetpack-compose] Fixed `Picker` crash when selecting an option. ([#41622](https://github.com/expo/expo/pull/41622) by [@kimchi-developer](https://github.com/kimchi-developer))
 - [jetpack-compose] Fixed `Carousel` not displaying items. ([#41622](https://github.com/expo/expo/pull/41622) by [@kimchi-developer](https://github.com/kimchi-developer))
 - [jetpack-compose] Fixed modifiers not being applied correctly. ([#41622](https://github.com/expo/expo/pull/41622) by [@kimchi-developer](https://github.com/kimchi-developer))
+- [iOS] Skip rendering `label` as `Menu` item.
 
 ### 💡 Others
 

--- a/packages/expo-ui/ios/Menu/MenuView.swift
+++ b/packages/expo-ui/ios/Menu/MenuView.swift
@@ -6,6 +6,16 @@ import ExpoModulesCore
 internal struct MenuView: ExpoSwiftUI.View {
   @ObservedObject var props: MenuProps
 
+  // If label is a component, it is passed as a child, so we need to exclude it in order to display the menu content
+  @ViewBuilder
+  func ChildrenWithoutLabel() -> some View {
+    let labelView = props.children?.first(where: { $0.childView is MenuLabel })
+    ForEach(props.children?.filter { $0.id != labelView?.id } ?? [], id: \.id) { child in
+      let view: any View = child.childView
+      AnyView(view)
+    }
+  }
+
   var body: some View {
     if #available(iOS 14.0, tvOS 17.0, *) {
       let labelContent = props.children?
@@ -17,7 +27,7 @@ internal struct MenuView: ExpoSwiftUI.View {
         if let systemImage = props.systemImage, let label = props.label {
           Menu(LocalizedStringKey(label), systemImage: systemImage) { Children() } primaryAction: { props.onPrimaryAction() }
         } else if let labelContent {
-          Menu { Children() } label: { labelContent } primaryAction: { props.onPrimaryAction() }
+          Menu { ChildrenWithoutLabel() } label: { labelContent } primaryAction: { props.onPrimaryAction() }
         } else if let label = props.label {
           Menu(LocalizedStringKey(label)) { Children() } primaryAction: { props.onPrimaryAction() }
         }
@@ -26,7 +36,7 @@ internal struct MenuView: ExpoSwiftUI.View {
         if let systemImage = props.systemImage, let label = props.label {
           Menu(label, systemImage: systemImage) { Children() }
         } else if let labelContent {
-          Menu { Children() } label: { labelContent }
+          Menu { ChildrenWithoutLabel() } label: { labelContent }
         } else if let label = props.label {
           Menu(label) { Children() }
         }


### PR DESCRIPTION
# Why

When `label` is a component it's displayed as a menu item as well. 

# How

If label is a component, it is passed as a child, so we need to exclude it from menu content. 

# Test Plan

NCL
```tsx
<Menu
  label={<Button systemImage="line.3.horizontal" label="More" />}
  systemImage="ellipsis.circle">
  <Button systemImage="gear" onPress={() => console.log('Settings')} label="Settings" />
  <Button systemImage="person" onPress={() => console.log('Profile')} label="Profile" />
  <Divider />
  <Button role="destructive" systemImage="trash" onPress={() => console.log('Delete')} label="Delete" />
</Menu>
```

Before:

https://github.com/user-attachments/assets/2d4ab5de-c7a4-4e22-b5c8-9508314b0ade

After: 

https://github.com/user-attachments/assets/e85ecaa4-538c-4d00-85bb-796d51a1d9fe

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
