### PR TITLE
[go] Fix image manipulator and module permissions for http uris

### DIFF
--- a/packages/expo-contacts/ios/ContactsModule.swift
+++ b/packages/expo-contacts/ios/ContactsModule.swift
@@ -578,7 +578,7 @@ public class ContactsModule: Module, OnContactPickingResultHandler {
     let path = url.path
     let standardizedPath = NSString(string: path).standardizingPath
 
-    guard FileSystemUtilities.permissions(appContext, for: url).contains(.read) && FileManager.default.isReadableFile(atPath: url.path) else {
+    guard FileSystemUtilities.isReadableFile(appContext, url) else {
       return nil
     }
 

--- a/packages/expo-contacts/ios/next/objects/contact/services/ImageService.swift
+++ b/packages/expo-contacts/ios/next/objects/contact/services/ImageService.swift
@@ -21,7 +21,7 @@ class ImageService {
     guard let url = URL(string: url), url.isFileURL else {
       throw RemoteImageUriException(url)
     }
-    guard FileSystemUtilities.permissions(appContext, for: url.standardized).contains(.read) && FileManager.default.isReadableFile(atPath: url.path) else {
+    guard FileSystemUtilities.isReadableFile(appContext, url.standardized) else {
       throw FailedToOpenImageException()
     }
     guard let image = UIImage(contentsOfFile: url.path) else {

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix image manipulator in Expo Go. ([#42347](https://github.com/expo/expo/pull/42347) by [@aleqsio](https://github.com/aleqsio))
 - fix TS build issue ([#41448](https://github.com/expo/expo/pull/41448) by [@vonovak](https://github.com/vonovak))
 
 ### 💡 Others

--- a/packages/expo-image-manipulator/ios/ImageManipulatorUtils.swift
+++ b/packages/expo-image-manipulator/ios/ImageManipulatorUtils.swift
@@ -21,7 +21,7 @@ internal func loadImage(atUrl url: URL, appContext: AppContext) async throws -> 
   guard let imageLoader = appContext.imageLoader else {
     throw ImageLoaderNotFoundException()
   }
-  guard FileSystemUtilities.permissions(appContext, for: url).contains(.read) && FileManager.default.isReadableFile(atPath: url.path) else {
+  guard FileSystemUtilities.isReadableFile(appContext, url) else {
     throw FileSystemReadPermissionException(url.absoluteString)
   }
 

--- a/packages/expo-media-library/ios/MediaLibraryUtilities.swift
+++ b/packages/expo-media-library/ios/MediaLibraryUtilities.swift
@@ -240,7 +240,7 @@ func createAsset(uri: URL, appContext: AppContext?, completion: @escaping (PHAss
     return
   }
 
-  guard FileSystemUtilities.permissions(appContext, for: uri).contains(.read) && FileManager.default.isReadableFile(atPath: uri.path) else {
+  guard FileSystemUtilities.isReadableFile(appContext, uri) else {
     completion(nil, UnreadableAssetException(uri.absoluteString))
     return
   }

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -254,12 +254,11 @@ public final class AppContext: NSObject, @unchecked Sendable {
    Provides access to the image loader from legacy module registry.
    */
   public var imageLoader: EXImageLoaderInterface? {
-    guard let bridge = reactBridge else {
-      // TODO: Find a way to do this without a bridge
-      log.warn("Unable to get the image loader because the bridge is not available.")
+    guard let loader = hostWrapper?.findModule(withName: "RCTImageLoader", lazilyLoadIfNecessary: true) as? RCTImageLoader else {
+      log.warn("Unable to get the RCTImageLoader module.")
       return nil
     }
-    return ImageLoader(bridge: bridge)
+    return ImageLoader(rctImageLoader: loader)
   }
 
   /**

--- a/packages/expo-modules-core/ios/Fabric/EXHostWrapper.h
+++ b/packages/expo-modules-core/ios/Fabric/EXHostWrapper.h
@@ -18,5 +18,7 @@ NS_SWIFT_NAME(ExpoHostWrapper)
 
 - (nullable UIView *)findViewWithTag:(NSInteger)tag;
 
+- (id)findModuleWithName:(const char *)name lazilyLoadIfNecessary:(BOOL)lazilyLoadIfNecessary;
+
 @end
 

--- a/packages/expo-modules-core/ios/Fabric/EXHostWrapper.h
+++ b/packages/expo-modules-core/ios/Fabric/EXHostWrapper.h
@@ -18,7 +18,7 @@ NS_SWIFT_NAME(ExpoHostWrapper)
 
 - (nullable UIView *)findViewWithTag:(NSInteger)tag;
 
-- (id)findModuleWithName:(const char *)name lazilyLoadIfNecessary:(BOOL)lazilyLoadIfNecessary;
+- (nullable id)findModuleWithName:(nonnull NSString *)name lazilyLoadIfNecessary:(BOOL)lazilyLoadIfNecessary;
 
 @end
 

--- a/packages/expo-modules-core/ios/Fabric/EXHostWrapper.mm
+++ b/packages/expo-modules-core/ios/Fabric/EXHostWrapper.mm
@@ -19,7 +19,7 @@
   return self;
 }
 
-- (id)findModuleWithName:(const char *)name lazilyLoadIfNecessary:(BOOL)lazilyLoadIfNecessary
+- (nullable id)findModuleWithName:(nonnull NSString *)name lazilyLoadIfNecessary:(BOOL)lazilyLoadIfNecessary
 {
   RCTModuleRegistry *moduleRegistry = _host.moduleRegistry;
   return [moduleRegistry moduleForName:name lazilyLoadIfNecessary:lazilyLoadIfNecessary];

--- a/packages/expo-modules-core/ios/Fabric/EXHostWrapper.mm
+++ b/packages/expo-modules-core/ios/Fabric/EXHostWrapper.mm
@@ -19,6 +19,12 @@
   return self;
 }
 
+- (id)findModuleWithName:(const char *)name lazilyLoadIfNecessary:(BOOL)lazilyLoadIfNecessary
+{
+  RCTModuleRegistry *moduleRegistry = _host.moduleRegistry;
+  return [moduleRegistry moduleForName:name lazilyLoadIfNecessary:lazilyLoadIfNecessary];
+}
+
 - (nullable UIView *)findViewWithTag:(NSInteger)tag
 {
   RCTComponentViewRegistry *componentViewRegistry = _host.surfacePresenter.mountingManager.componentViewRegistry;

--- a/packages/expo-modules-core/ios/Fabric/EXHostWrapper.mm
+++ b/packages/expo-modules-core/ios/Fabric/EXHostWrapper.mm
@@ -22,7 +22,7 @@
 - (nullable id)findModuleWithName:(nonnull NSString *)name lazilyLoadIfNecessary:(BOOL)lazilyLoadIfNecessary
 {
   RCTModuleRegistry *moduleRegistry = _host.moduleRegistry;
-  return [moduleRegistry moduleForName:name lazilyLoadIfNecessary:lazilyLoadIfNecessary];
+  return [moduleRegistry moduleForName:[name UTF8String] lazilyLoadIfNecessary:lazilyLoadIfNecessary];
 }
 
 - (nullable UIView *)findViewWithTag:(NSInteger)tag

--- a/packages/expo-modules-core/ios/FileSystemUtilities/FileSystemUtilities.swift
+++ b/packages/expo-modules-core/ios/FileSystemUtilities/FileSystemUtilities.swift
@@ -6,6 +6,8 @@ public enum FileSystemPermissionFlags {
   case write
 }
 
+let validSchemas = ["assets-library", "http", "https", "ph"]
+
 public struct FileSystemUtilities {
   @discardableResult
   public static func ensureDirExists(at url: URL?) -> Bool {
@@ -38,7 +40,6 @@ public struct FileSystemUtilities {
     guard let scheme = uri.scheme else {
       return [.none]
     }
-    let validSchemas = ["assets-library", "http", "https", "ph"]
 
     if validSchemas.contains(scheme) {
       return [.read]
@@ -49,6 +50,24 @@ public struct FileSystemUtilities {
     }
 
     return [.none]
+  }
+
+  public static func isReadableFile(_ appContext: AppContext?, _ uri: URL) -> Bool {
+    if(!permissions(appContext, for: uri).contains(.read)) {
+      return false
+    }
+
+    let validSchemas = ["assets-library", "http", "https", "ph"]
+
+    guard let scheme = uri.scheme else {
+      return false
+    }
+
+    if validSchemas.contains(scheme) {
+      return true
+    }
+
+    return FileManager.default.isReadableFile(atPath: uri.path)
   }
 
   private static func getPathPermissions(_ appContext: AppContext?, for path: URL) -> [FileSystemPermissionFlags] {

--- a/packages/expo-modules-core/ios/Utilities/EXImageLoader.h
+++ b/packages/expo-modules-core/ios/Utilities/EXImageLoader.h
@@ -1,11 +1,14 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
 #import <React/RCTBridge.h>
+#import <React/RCTImageLoader.h>
 #import <ExpoModulesCore/EXImageLoaderInterface.h>
 
 NS_SWIFT_NAME(ImageLoader)
 @interface EXImageLoader : NSObject <EXImageLoaderInterface>
 
 - (nonnull instancetype)initWithBridge:(nonnull RCTBridge *)bridge;
+
+- (nonnull instancetype)initWithRCTImageLoader:(nonnull RCTImageLoader *)loader;
 
 @end

--- a/packages/expo-modules-core/ios/Utilities/EXImageLoader.m
+++ b/packages/expo-modules-core/ios/Utilities/EXImageLoader.m
@@ -16,6 +16,14 @@
   return self;
 }
 
+- (nonnull instancetype)initWithRCTImageLoader:(nonnull RCTImageLoader *)loader
+{
+  if (self = [super init]) {
+    _rctImageLoader = loader;
+  }
+  return self;
+}
+
 - (void)loadImageForURL:(NSURL *)imageURL
       completionHandler:(EXImageLoaderCompletionBlock)completionHandler
 {

--- a/packages/expo-sharing/ios/SharingModule.swift
+++ b/packages/expo-sharing/ios/SharingModule.swift
@@ -6,9 +6,7 @@ public final class SharingModule: Module {
     Name("ExpoSharing")
 
     AsyncFunction("shareAsync") { (url: URL, options: SharingOptions, promise: Promise) in
-      let grantedPermissions = FileSystemUtilities.permissions(appContext, for: url)
-
-      guard grantedPermissions.contains(.read) && FileManager.default.isReadableFile(atPath: url.path) else {
+      guard FileSystemUtilities.isReadableFile(appContext, url) else {
         throw FilePermissionException()
       }
 

--- a/packages/expo-video-thumbnails/ios/VideoThumbnailsModule.swift
+++ b/packages/expo-video-thumbnails/ios/VideoThumbnailsModule.swift
@@ -12,9 +12,7 @@ public class VideoThumbnailsModule: Module {
 
   internal func getVideoThumbnail(sourceFilename: URL, options: VideoThumbnailsOptions) throws -> [String: Any] {
     if sourceFilename.isFileURL {
-      guard
-        FileSystemUtilities.permissions(appContext, for: sourceFilename).contains(.read)
-        && FileManager.default.isReadableFile(atPath: sourceFilename.path) else {
+      guard FileSystemUtilities.isReadableFile(appContext, sourceFilename) else {
         throw FileSystemReadPermissionException(sourceFilename.absoluteString)
       }
     }


### PR DESCRIPTION
# Why

Fixes "Image Manipulator tests and API fails with “ImageLoader not found”"

# How

Reading RCTImageLoader from moduleRegistry from RCTHost. Also fixed another error with permissions

# Test Plan

Tested in expo go.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
