### PR TITLE
[sdk-53] fix(babel): Fix app root path resolution for hoisted expo-router

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Resolve app root for each file to support bun monorepos. ([#42315](https://github.com/expo/expo/pull/42315) by [@EvanBacon](https://github.com/EvanBacon)) ([#42351](https://github.com/expo/expo/pull/42351) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 13.2.4 — 2025-08-22


### PR DESCRIPTION
# Why

Backport diverges to **not** apply on top of #41693 and to avoid adding the extra invariant on `filename`, just in case.

# How

Backports #42315

# Test Plan

- Test update was picked; existing tests are expected to pass

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
