### PR TITLE
[docs] Add `hooks`

### DIFF
--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1145,130 +1145,26 @@ jobs:
 
 </Collapsible>
 
-<Collapsible summary="Build a tagged failed-flow summary from the Maestro Cloud API response">
+<Collapsible summary="Generate Maestro flows before uploading to Maestro Cloud">
 
-This workflow captures the Maestro Cloud API response, reads tags from your flow files, builds a compact summary string (failed and successful flows), and exposes it as a job output that you can use in Slack or other notifications.
+This workflow uses a hook to generate the `maestro_tests` directory right before it gets uploaded to Maestro Cloud.
 
-```yaml .eas/workflows/maestro-cloud-failed-flows.yml
-name: Maestro Cloud Failed Flow Summary
+```yaml .eas/workflows/maestro-cloud-hooks.yml
+name: Maestro Cloud Hooks
 
 jobs:
-  maestro_test:
+  maestro_tests:
     name: Run Maestro Cloud Tests
     type: maestro-cloud
     environment: preview
     params:
-      build_id: ${{ needs.build.outputs.build_id }}
-      maestro_project_id: proj_xyz
-      flows: ./maestro/flows
+      build_id: ${{ needs.build_ios_simulator.outputs.build_id }}
+      maestro_project_id: proj_01jw6hxgmdffrbye9fqn0pyzm0
+      flows: ./maestro_tests
     hooks:
-      after_maestro_cloud:
-        - name: Install yq
-          if: true
-          run: |
-            # yq lets us read flow metadata (name/tags) without writing a parser.
-            sudo apt-get update -y && sudo apt-get install -y yq || \
-              echo "yq not available; flow tags will be omitted."
-        - name: Build failed flow summary
-          id: build_failed_flow_summary
-          if: true
-          run: |
-            # Capture the API response once so we can parse it in Node.
-            MAESTRO_API_RESPONSE_JSON=$(cat <<'EOF'
-${{ toJSON(steps.results.outputs.maestro_cloud_api_response_json) }}
-EOF
-            )
-            SUMMARY="$(
-              node - <<'NODE'
-              const fs = require('fs');
-              const path = require('path');
-              const { execFileSync } = require('child_process');
-
-              // Flow results come from the Maestro Cloud API response.
-              const response = JSON.parse(process.env.MAESTRO_API_RESPONSE_JSON || '{}');
-
-              // Adjust this if your flows live elsewhere or you pass a single file path.
-              const flowDir = path.join(process.cwd(), 'maestro', 'flows');
-              const flowFiles = [];
-              const walk = (dir) => {
-                for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-                  const entryPath = path.join(dir, entry.name);
-                  if (entry.isDirectory()) {
-                    walk(entryPath);
-                  } else if (entry.isFile() && (entry.name.endsWith('.yml') || entry.name.endsWith('.yaml'))) {
-                    flowFiles.push(entryPath);
-                  }
-                }
-              };
-              if (fs.existsSync(flowDir)) {
-                walk(flowDir);
-              }
-
-              // Map flow name -> "#tag1, #tag2" from YAML. Failures are ignored to keep the job running.
-              const nameToTags = new Map();
-              for (const file of flowFiles) {
-                try {
-                  const json = execFileSync(
-                    'yq',
-                    ['select(documentIndex == 0)', '-o', 'json', file],
-                    { encoding: 'utf8' }
-                  );
-                  const doc = JSON.parse(json);
-                  if (!doc || !doc.name) {
-                    continue;
-                  }
-
-                  const tags = Array.isArray(doc.tags) ? doc.tags : [];
-                  nameToTags.set(doc.name, tags.map((tag) => `#${tag}`).join(', '));
-                } catch (error) {
-                  continue;
-                }
-              }
-
-              // Split flows by status so the summary is easy to scan in Slack.
-              const failedFlows = (response.flows || []).filter(
-                (flow) => flow.status === 'ERROR' || flow.status === 'STOPPED'
-              );
-              const successfulFlows = (response.flows || []).filter(
-                (flow) => flow.status === 'SUCCESS' || flow.status === 'WARNING'
-              );
-
-              // Include a placeholder when a section is empty.
-              let summary = '✅ Successful flows:';
-              if (successfulFlows.length === 0) {
-                summary += '\n- no successful flows';
-              } else {
-                for (const flow of successfulFlows) {
-                  const tags = nameToTags.get(flow.name);
-                  summary += `\n- ${flow.name}${tags ? ` (${tags})` : ''}`;
-                }
-              }
-              summary += '\n\n❌ Failed flows:';
-              if (failedFlows.length === 0) {
-                summary += '\n- no failed flows';
-              } else {
-                for (const flow of failedFlows) {
-                  const tags = nameToTags.get(flow.name);
-                  summary += `\n- ${flow.name}${tags ? ` (${tags})` : ''}`;
-                }
-              }
-
-              process.stdout.write(summary);
-              NODE
-            )"
-
-            # Expose the summary as a job output for notifications.
-            set-output failed_flow_summary "$SUMMARY"
-    outputs:
-      failed_flow_summary: ${{ steps.build_failed_flow_summary.outputs.failed_flow_summary }}
-
-  notify:
-    name: Send Summary
-    after: [maestro_test]
-    type: slack
-    params:
-      webhook_url: ${{ env.SLACK_WEBHOOK_URL }}
-      message: ${{ after.maestro_test.outputs.failed_flow_summary }}
+      before_maestro_cloud:
+        - name: Generate Maestro flows
+          run: npx tsx scripts/generate-maestro-tests.ts
 ```
 
 </Collapsible>

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1145,6 +1145,134 @@ jobs:
 
 </Collapsible>
 
+<Collapsible summary="Build a tagged failed-flow summary from the Maestro Cloud API response">
+
+This workflow captures the Maestro Cloud API response, reads tags from your flow files, builds a compact summary string (failed and successful flows), and exposes it as a job output that you can use in Slack or other notifications.
+
+```yaml .eas/workflows/maestro-cloud-failed-flows.yml
+name: Maestro Cloud Failed Flow Summary
+
+jobs:
+  maestro_test:
+    name: Run Maestro Cloud Tests
+    type: maestro-cloud
+    environment: preview
+    params:
+      build_id: ${{ needs.build.outputs.build_id }}
+      maestro_project_id: proj_xyz
+      flows: ./maestro/flows
+    hooks:
+      after_maestro_cloud:
+        - name: Install yq
+          if: true
+          run: |
+            # yq lets us read flow metadata (name/tags) without writing a parser.
+            sudo apt-get update -y && sudo apt-get install -y yq || \
+              echo "yq not available; flow tags will be omitted."
+        - name: Build failed flow summary
+          id: build_failed_flow_summary
+          if: true
+          run: |
+            # Capture the API response once so we can parse it in Node.
+            MAESTRO_API_RESPONSE_JSON=$(cat <<'EOF'
+${{ toJSON(steps.results.outputs.maestro_cloud_api_response_json) }}
+EOF
+            )
+            SUMMARY="$(
+              node - <<'NODE'
+              const fs = require('fs');
+              const path = require('path');
+              const { execFileSync } = require('child_process');
+
+              // Flow results come from the Maestro Cloud API response.
+              const response = JSON.parse(process.env.MAESTRO_API_RESPONSE_JSON || '{}');
+
+              // Adjust this if your flows live elsewhere or you pass a single file path.
+              const flowDir = path.join(process.cwd(), 'maestro', 'flows');
+              const flowFiles = [];
+              const walk = (dir) => {
+                for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+                  const entryPath = path.join(dir, entry.name);
+                  if (entry.isDirectory()) {
+                    walk(entryPath);
+                  } else if (entry.isFile() && (entry.name.endsWith('.yml') || entry.name.endsWith('.yaml'))) {
+                    flowFiles.push(entryPath);
+                  }
+                }
+              };
+              if (fs.existsSync(flowDir)) {
+                walk(flowDir);
+              }
+
+              // Map flow name -> "#tag1, #tag2" from YAML. Failures are ignored to keep the job running.
+              const nameToTags = new Map();
+              for (const file of flowFiles) {
+                try {
+                  const json = execFileSync(
+                    'yq',
+                    ['select(documentIndex == 0)', '-o', 'json', file],
+                    { encoding: 'utf8' }
+                  );
+                  const doc = JSON.parse(json);
+                  if (!doc || !doc.name) {
+                    continue;
+                  }
+
+                  const tags = Array.isArray(doc.tags) ? doc.tags : [];
+                  nameToTags.set(doc.name, tags.map((tag) => `#${tag}`).join(', '));
+                } catch (error) {
+                  continue;
+                }
+              }
+
+              // Split flows by status so the summary is easy to scan in Slack.
+              const failedFlows = (response.flows || []).filter(
+                (flow) => flow.status === 'ERROR' || flow.status === 'STOPPED'
+              );
+              const successfulFlows = (response.flows || []).filter(
+                (flow) => flow.status === 'SUCCESS' || flow.status === 'WARNING'
+              );
+
+              // Include a placeholder when a section is empty.
+              let summary = '✅ Successful flows:';
+              if (successfulFlows.length === 0) {
+                summary += '\n- no successful flows';
+              } else {
+                for (const flow of successfulFlows) {
+                  const tags = nameToTags.get(flow.name);
+                  summary += `\n- ${flow.name}${tags ? ` (${tags})` : ''}`;
+                }
+              }
+              summary += '\n\n❌ Failed flows:';
+              if (failedFlows.length === 0) {
+                summary += '\n- no failed flows';
+              } else {
+                for (const flow of failedFlows) {
+                  const tags = nameToTags.get(flow.name);
+                  summary += `\n- ${flow.name}${tags ? ` (${tags})` : ''}`;
+                }
+              }
+
+              process.stdout.write(summary);
+              NODE
+            )"
+
+            # Expose the summary as a job output for notifications.
+            set-output failed_flow_summary "$SUMMARY"
+    outputs:
+      failed_flow_summary: ${{ steps.build_failed_flow_summary.outputs.failed_flow_summary }}
+
+  notify:
+    name: Send Summary
+    after: [maestro_test]
+    type: slack
+    params:
+      webhook_url: ${{ env.SLACK_WEBHOOK_URL }}
+      message: ${{ after.maestro_test.outputs.failed_flow_summary }}
+```
+
+</Collapsible>
+
 ## Slack
 
 Send a message to a Slack channel using a [Slack webhook URL](https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks).

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -509,6 +509,9 @@ jobs:
     params:
       build_id: string # required
       profile: string # optional - default: production
+    hooks:
+      before_submit: step[] # optional - steps to run before the submission starts.
+      after_submit: step[] # optional - steps to run after the submission completes.
 ```
 
 #### Parameters
@@ -852,6 +855,9 @@ jobs:
       android_system_image_package: string # optional
       device_identifier: string | { android: string, ios: string } # optional
       output_format: string # optional - defaults to junit
+    hooks:
+      before_maestro_tests: step[] # optional - steps to run before the tests start.
+      after_maestro_tests: step[] # optional - steps to run after the tests complete.
 ```
 
 #### Parameters

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -946,6 +946,29 @@ jobs:
 
 </Collapsible>
 
+<Collapsible summary="Generate Maestro flows before running tests">
+
+This workflow uses a hook to generate the `maestro_tests` directory right before Maestro starts running tests.
+
+```yaml .eas/workflows/maestro-hooks.yml
+name: Maestro Hooks
+
+jobs:
+  test:
+    name: Run Maestro Tests
+    type: maestro
+    environment: preview
+    params:
+      build_id: ${{ needs.build_ios_simulator.outputs.build_id }}
+      flow_path: ./maestro_tests
+    hooks:
+      before_maestro_tests:
+        - name: Generate Maestro flows
+          run: npx tsx scripts/generate-maestro-tests.ts
+```
+
+</Collapsible>
+
 <Collapsible summary="Recording screen and using a specific device">
 
 This workflow runs Maestro tests on an Android emulator build with a specific device and records the screen.
@@ -985,6 +1008,32 @@ appId: com.myapp
 ```
 
 The assets will be available within the "Maestro Test Results" artifact in the Artifacts section.
+
+</Collapsible>
+
+<Collapsible summary="Report Maestro artifacts to an external service">
+
+This workflow saves screenshots and recordings to `MAESTRO_TESTS_DIR`, then runs a script after the tests finish to upload those files or send a summary to an external service.
+
+```yaml .eas/workflows/maestro-report-artifacts.yml
+name: Maestro Artifact Reporting
+
+jobs:
+  test:
+    name: Run Maestro Tests
+    type: maestro
+    environment: preview
+    env:
+      REPORTING_WEBHOOK_URL: ${{ env.REPORTING_WEBHOOK_URL }}
+    params:
+      build_id: ${{ needs.build_ios_simulator.outputs.build_id }}
+      flow_path: ./maestro/flows
+      record_screen: true
+    hooks:
+      after_maestro_tests:
+        - name: Report Maestro artifacts
+          run: npx tsx scripts/report-maestro-artifacts.ts "$MAESTRO_TESTS_DIR"
+```
 
 </Collapsible>
 
@@ -1141,30 +1190,6 @@ jobs:
     params:
       webhook_url: ${{ env.SLACK_WEBHOOK_URL }} # make sure to set it up in the right environment (see "environment: ..." above)
       message: 'Tests complete: ${{ after.maestro_test.outputs.successful_flows_count }}/${{ after.maestro_test.outputs.total_flows_count }} passed'
-```
-
-</Collapsible>
-
-<Collapsible summary="Generate Maestro flows before uploading to Maestro Cloud">
-
-This workflow uses a hook to generate the `maestro_tests` directory right before it gets uploaded to Maestro Cloud.
-
-```yaml .eas/workflows/maestro-cloud-hooks.yml
-name: Maestro Cloud Hooks
-
-jobs:
-  maestro_tests:
-    name: Run Maestro Cloud Tests
-    type: maestro-cloud
-    environment: preview
-    params:
-      build_id: ${{ needs.build_ios_simulator.outputs.build_id }}
-      maestro_project_id: proj_01jw6hxgmdffrbye9fqn0pyzm0
-      flows: ./maestro_tests
-    hooks:
-      before_maestro_cloud:
-        - name: Generate Maestro flows
-          run: npx tsx scripts/generate-maestro-tests.ts
 ```
 
 </Collapsible>

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -530,6 +530,15 @@ You can reference the following outputs in subsequent jobs:
 | ios_bundle_identifier | string | The iOS bundle identifier of the submitted build. |
 | android_package_id    | string | The Android package ID of the submitted build.    |
 
+#### Hooks
+
+Hooks are supported for this job. Available hooks:
+
+- `before_submit`: steps to run before the submission starts.
+- `after_submit`: steps to run after the submission completes.
+
+See [`jobs.<job_id>.hooks`](/eas/workflows/syntax/#jobsjob_idhooks) for the general hooks syntax.
+
 ### Examples
 
 Here are some practical examples of using the submit job:
@@ -864,6 +873,15 @@ You can pass the following parameters into the `params` list:
 | device_identifier            | string or `{ android?: string, ios?: string }` object | Optional. Device identifier to use for the tests. You can also use a single-value expression like `pixel_6`, `iPhone 16 Plus` or `${{ needs.build.outputs.platform == "android" ? "pixel_6" : "iPhone 16 Plus" }}` and an object like `device_identifier: { android: "pixel_6", ios: "iPhone 16 Plus" }`. Note that iOS devices availability differs across runner images. A list of available devices can be found in the jobs logs. |
 | skip_build_check             | boolean                                               | Optional. Skip validation of the build (whether an iOS build is a simulator build). Defaults to false.                                                                                                                                                                                                                                                                                                                                |
 
+#### Hooks
+
+Hooks are supported for this job. Available hooks:
+
+- `before_maestro_tests`: steps to run before the tests start.
+- `after_maestro_tests`: steps to run after the tests complete.
+
+See [`jobs.<job_id>.hooks`](/eas/workflows/syntax/#jobsjob_idhooks) for the general hooks syntax.
+
 ### Examples
 
 Here are some practical examples of using the Maestro job:
@@ -1000,6 +1018,9 @@ jobs:
       name: string # optional - name for the Maestro Cloud upload. Corresponds to `--name` param to `maestro cloud`.
       branch: string # optional - override for the branch the Maestro Cloud upload originated from. By default, if the workflow run has been triggered from GitHub, the branch of the workflow run will be used. Corresponds to `--branch` param to `maestro cloud`.
       async: boolean # optional - run the Maestro Cloud tests asynchronously. If true, the status of the job will only denote whether the upload was successful, _not_ whether the tests succeeded. Corresponds to `--async` param to `maestro cloud`.
+    hooks:
+      before_maestro_cloud: step[] # optional - steps to run before the Maestro Cloud upload.
+      after_maestro_cloud: step[] # optional - steps to run after the Maestro Cloud upload.
 ```
 
 #### Parameters
@@ -1026,6 +1047,13 @@ You can pass the following parameters into the `params` list:
 
 > **important** You need to either set `maestro_api_key` parameter or `MAESTRO_CLOUD_API_KEY` environment variable in the job environment. Go to "Settings" on [Maestro Cloud](https://app.maestro.dev/) to generate an API key and then to [Environment variables](https://expo.dev/accounts/[account]/projects/[project]/environment-variables) to add it to your project.
 
+Hooks are supported for this job. Available hooks:
+
+- `before_maestro_cloud`: steps to run before the Maestro Cloud upload.
+- `after_maestro_cloud`: steps to run after the Maestro Cloud upload.
+
+See [`jobs.<job_id>.hooks`](/eas/workflows/syntax/#jobsjob_idhooks) for the general hooks syntax.
+
 #### Outputs
 
 You can reference the following outputs in subsequent jobs:
@@ -1040,6 +1068,8 @@ You can reference the following outputs in subsequent jobs:
 | failed_flow_names_json     | string | JSON array containing the names of failed flows.                         |
 
 > **Note:** When using `async: true` mode, only the `maestro_cloud_url` output is guaranteed to be valid. Other outputs (flow counts and flow names) may be invalid or empty because the job does not wait for the upload to complete and the flows have not been executed yet.
+
+You can also define additional outputs for this job using [`jobs.<job_id>.outputs`](/eas/workflows/syntax/#jobsjob_idoutputs).
 
 ### Examples
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -968,6 +968,29 @@ jobs:
 
 </Collapsible>
 
+<Collapsible summary="Generate Maestro flows before running tests">
+
+This workflow uses a hook to generate the `maestro_tests` directory right before Maestro starts running tests.
+
+```yaml .eas/workflows/maestro-hooks.yml
+name: Maestro Hooks
+
+jobs:
+  test:
+    name: Run Maestro Tests
+    type: maestro
+    environment: preview
+    params:
+      build_id: ${{ needs.build_ios_simulator.outputs.build_id }}
+      flow_path: ./maestro_tests
+    hooks:
+      before_maestro_tests:
+        - name: Generate Maestro flows
+          run: npx tsx scripts/generate-maestro-tests.ts
+```
+
+</Collapsible>
+
 <Collapsible summary="Recording screen and using a specific device">
 
 This workflow runs Maestro tests on an Android emulator build with a specific device and records the screen.
@@ -1007,6 +1030,32 @@ appId: com.myapp
 ```
 
 The assets will be available within the "Maestro Test Results" artifact in the Artifacts section.
+
+</Collapsible>
+
+<Collapsible summary="Report Maestro artifacts to an external service">
+
+This workflow saves screenshots and recordings to `MAESTRO_TESTS_DIR`, then runs a script after the tests finish to upload those files or send a summary to an external service.
+
+```yaml .eas/workflows/maestro-report-artifacts.yml
+name: Maestro Artifact Reporting
+
+jobs:
+  test:
+    name: Run Maestro Tests
+    type: maestro
+    environment: preview
+    env:
+      REPORTING_WEBHOOK_URL: ${{ env.REPORTING_WEBHOOK_URL }}
+    params:
+      build_id: ${{ needs.build_ios_simulator.outputs.build_id }}
+      flow_path: ./maestro/flows
+      record_screen: true
+    hooks:
+      after_maestro_tests:
+        - name: Report Maestro artifacts
+          run: npx tsx scripts/report-maestro-artifacts.ts "$MAESTRO_TESTS_DIR"
+```
 
 </Collapsible>
 
@@ -1161,30 +1210,6 @@ jobs:
     params:
       webhook_url: ${{ env.SLACK_WEBHOOK_URL }} # make sure to set it up in the right environment (see "environment: ..." above)
       message: 'Tests complete: ${{ after.maestro_test.outputs.successful_flows_count }}/${{ after.maestro_test.outputs.total_flows_count }} passed'
-```
-
-</Collapsible>
-
-<Collapsible summary="Generate Maestro flows before uploading to Maestro Cloud">
-
-This workflow uses a hook to generate the `maestro_tests` directory right before it gets uploaded to Maestro Cloud.
-
-```yaml .eas/workflows/maestro-cloud-hooks.yml
-name: Maestro Cloud Hooks
-
-jobs:
-  maestro_tests:
-    name: Run Maestro Cloud Tests
-    type: maestro-cloud
-    environment: preview
-    params:
-      build_id: ${{ needs.build_ios_simulator.outputs.build_id }}
-      maestro_project_id: proj_01jw6hxgmdffrbye9fqn0pyzm0
-      flows: ./maestro_tests
-    hooks:
-      before_maestro_cloud:
-        - name: Generate Maestro flows
-          run: npx tsx scripts/generate-maestro-tests.ts
 ```
 
 </Collapsible>

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -542,6 +542,15 @@ You can reference the following outputs in subsequent jobs:
 | ios_bundle_identifier | string | The iOS bundle identifier of the submitted build. |
 | android_package_id    | string | The Android package ID of the submitted build.    |
 
+#### Hooks
+
+Hooks are supported for this job. Available hooks:
+
+- `before_submit`: steps to run before the submission starts.
+- `after_submit`: steps to run after the submission completes.
+
+See [`jobs.<job_id>.hooks`](/eas/workflows/syntax/#jobsjob_idhooks) for the general hooks syntax.
+
 ### Examples
 
 Here are some practical examples of using the submit job:
@@ -886,6 +895,15 @@ You can pass the following parameters into the `params` list:
 | device_identifier            | string or `{ android?: string, ios?: string }` object | Optional. Device identifier to use for the tests. You can also use a single-value expression like `pixel_6`, `iPhone 16 Plus` or `${{ needs.build.outputs.platform == "android" ? "pixel_6" : "iPhone 16 Plus" }}` and an object like `device_identifier: { android: "pixel_6", ios: "iPhone 16 Plus" }`. Note that iOS devices availability differs across runner images. A list of available devices can be found in the jobs logs. |
 | skip_build_check             | boolean                                               | Optional. Skip validation of the build (whether an iOS build is a simulator build). Defaults to false.                                                                                                                                                                                                                                                                                                                                |
 
+#### Hooks
+
+Hooks are supported for this job. Available hooks:
+
+- `before_maestro_tests`: steps to run before the tests start.
+- `after_maestro_tests`: steps to run after the tests complete.
+
+See [`jobs.<job_id>.hooks`](/eas/workflows/syntax/#jobsjob_idhooks) for the general hooks syntax.
+
 ### Examples
 
 Here are some practical examples of using the Maestro job:
@@ -1021,6 +1039,9 @@ jobs:
       name: string # optional - name for the Maestro Cloud upload. Corresponds to `--name` param to `maestro cloud`.
       branch: string # optional - override for the branch the Maestro Cloud upload originated from. By default, if the workflow run has been triggered from GitHub, the branch of the workflow run will be used. Corresponds to `--branch` param to `maestro cloud`.
       async: boolean # optional - run the Maestro Cloud tests asynchronously. If true, the status of the job will only denote whether the upload was successful, _not_ whether the tests succeeded. Corresponds to `--async` param to `maestro cloud`.
+    hooks:
+      before_maestro_cloud: step[] # optional - steps to run before the Maestro Cloud upload.
+      after_maestro_cloud: step[] # optional - steps to run after the Maestro Cloud upload.
 ```
 
 #### Parameters
@@ -1046,6 +1067,13 @@ You can pass the following parameters into the `params` list:
 
 > **important** You need to either set `maestro_api_key` parameter or `MAESTRO_CLOUD_API_KEY` environment variable in the job environment. Go to "Settings" on [Maestro Cloud](https://app.maestro.dev/) to generate an API key and then to [Environment variables](https://expo.dev/accounts/[account]/projects/[project]/environment-variables) to add it to your project.
 
+Hooks are supported for this job. Available hooks:
+
+- `before_maestro_cloud`: steps to run before the Maestro Cloud upload.
+- `after_maestro_cloud`: steps to run after the Maestro Cloud upload.
+
+See [`jobs.<job_id>.hooks`](/eas/workflows/syntax/#jobsjob_idhooks) for the general hooks syntax.
+
 #### Outputs
 
 You can reference the following outputs in subsequent jobs:
@@ -1060,6 +1088,8 @@ You can reference the following outputs in subsequent jobs:
 | failed_flow_names_json     | string | JSON array containing the names of failed flows.                         |
 
 > **Note:** When using `async: true` mode, only the `maestro_cloud_url` output is guaranteed to be valid. Other outputs (flow counts and flow names) may be invalid or empty because the job does not wait for the upload to complete and the flows have not been executed yet.
+
+You can also define additional outputs for this job using [`jobs.<job_id>.outputs`](/eas/workflows/syntax/#jobsjob_idoutputs).
 
 ### Examples
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -521,6 +521,9 @@ jobs:
     params:
       build_id: string # required
       profile: string # optional - default: production
+    hooks:
+      before_submit: step[] # optional - steps to run before the submission starts.
+      after_submit: step[] # optional - steps to run after the submission completes.
 ```
 
 #### Parameters
@@ -873,6 +876,9 @@ jobs:
       android_system_image_package: string # optional
       device_identifier: string | { android: string, ios: string } # optional
       output_format: string # optional - defaults to junit
+    hooks:
+      before_maestro_tests: step[] # optional - steps to run before the tests start.
+      after_maestro_tests: step[] # optional - steps to run after the tests complete.
 ```
 
 #### Parameters

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -874,7 +874,7 @@ jobs:
       exclude_tags: string | string[] # optional
       maestro_version: string # optional - defaults to latest
       android_system_image_package: string # optional
-      device_identifier: string | { android: string, ios: string } # optional
+      device_identifier: string | { android?: string, ios?: string } # optional
       output_format: string # optional - defaults to junit
     hooks:
       before_maestro_tests: step[] # optional - steps to run before the tests start.
@@ -1121,6 +1121,8 @@ You can pass the following parameters into the `params` list:
 | async              | boolean | Optional. Run the Maestro Cloud tests asynchronously. If true, the status of the job will only denote whether the upload was successful, _not_ whether the tests succeeded. Corresponds to `--async` param to `maestro cloud`.               |
 
 > **important** You need to either set `maestro_api_key` parameter or `MAESTRO_CLOUD_API_KEY` environment variable in the job environment. Go to "Settings" on [Maestro Cloud](https://app.maestro.dev/) to generate an API key and then to [Environment variables](https://expo.dev/accounts/[account]/projects/[project]/environment-variables) to add it to your project.
+
+#### Hooks
 
 The following hooks are supported for the Maestro Cloud job:
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -547,7 +547,7 @@ You can reference the following outputs in subsequent jobs:
 
 #### Hooks
 
-Hooks are supported for this job. Available hooks:
+The following hooks are supported for the Submit job:
 
 - `before_submit`: steps to run before the submission starts.
 - `after_submit`: steps to run after the submission completes.
@@ -851,7 +851,7 @@ jobs:
 
 ## Maestro
 
-Run Maestro tests on a Android emulator or iOS Simulator build.
+Run Maestro tests on an Android Emulator or iOS Simulator build.
 
 > **important** Maestro tests are in [alpha](/more/release-statuses/#alpha).
 
@@ -903,7 +903,7 @@ You can pass the following parameters into the `params` list:
 
 #### Hooks
 
-Hooks are supported for this job. Available hooks:
+The following hooks are supported for the Maestro job:
 
 - `before_maestro_tests`: steps to run before the tests start.
 - `after_maestro_tests`: steps to run after the tests complete.
@@ -935,7 +935,7 @@ jobs:
 
 <Collapsible summary="Maestro test with sharding">
 
-This workflow runs Maestro tests on an Android emulator build with 3 shards and 2 retries for failed tests.
+This workflow runs Maestro tests on an Android Emulator build with 3 shards and 2 retries for failed tests.
 
 ```yaml .eas/workflows/maestro-sharded.yml
 name: Sharded Maestro Test
@@ -999,7 +999,7 @@ jobs:
 
 <Collapsible summary="Recording screen and using a specific device">
 
-This workflow runs Maestro tests on an Android emulator build with a specific device and records the screen.
+This workflow runs Maestro tests on an Android Emulator build with a specific device and records the screen.
 
 ```yaml .eas/workflows/maestro-sharded.yml
 name: Pixel E2E Test
@@ -1039,9 +1039,9 @@ The assets will be available within the "Maestro Test Results" artifact in the A
 
 </Collapsible>
 
-<Collapsible summary="Report Maestro artifacts to an external service">
+<Collapsible summary="Report Maestro artifacts to Slack">
 
-This workflow saves screenshots and recordings to `MAESTRO_TESTS_DIR`, then runs a script after the tests finish to upload those files or send a summary to an external service.
+This workflow saves screenshots and recordings to `MAESTRO_TESTS_DIR`, then runs a script after the tests finish to upload those files or send a summary to Slack.
 
 ```yaml .eas/workflows/maestro-report-artifacts.yml
 name: Maestro Artifact Reporting
@@ -1052,7 +1052,7 @@ jobs:
     type: maestro
     environment: preview
     env:
-      REPORTING_WEBHOOK_URL: ${{ env.REPORTING_WEBHOOK_URL }}
+      SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
     params:
       build_id: ${{ needs.build_ios_simulator.outputs.build_id }}
       flow_path: ./maestro/flows
@@ -1122,7 +1122,7 @@ You can pass the following parameters into the `params` list:
 
 > **important** You need to either set `maestro_api_key` parameter or `MAESTRO_CLOUD_API_KEY` environment variable in the job environment. Go to "Settings" on [Maestro Cloud](https://app.maestro.dev/) to generate an API key and then to [Environment variables](https://expo.dev/accounts/[account]/projects/[project]/environment-variables) to add it to your project.
 
-Hooks are supported for this job. Available hooks:
+The following hooks are supported for the Maestro Cloud job:
 
 - `before_maestro_cloud`: steps to run before the Maestro Cloud upload.
 - `after_maestro_cloud`: steps to run after the Maestro Cloud upload.
@@ -1148,7 +1148,7 @@ You can also define additional outputs for this job using [`jobs.<job_id>.output
 
 ### Examples
 
-Here are some practical examples of using the Maestro job:
+Here are some practical examples of using the Maestro Cloud job:
 
 <Collapsible summary="Basic Maestro Cloud test">
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1165,130 +1165,26 @@ jobs:
 
 </Collapsible>
 
-<Collapsible summary="Build a tagged failed-flow summary from the Maestro Cloud API response">
+<Collapsible summary="Generate Maestro flows before uploading to Maestro Cloud">
 
-This workflow captures the Maestro Cloud API response, reads tags from your flow files, builds a compact summary string (failed and successful flows), and exposes it as a job output that you can use in Slack or other notifications.
+This workflow uses a hook to generate the `maestro_tests` directory right before it gets uploaded to Maestro Cloud.
 
-```yaml .eas/workflows/maestro-cloud-failed-flows.yml
-name: Maestro Cloud Failed Flow Summary
+```yaml .eas/workflows/maestro-cloud-hooks.yml
+name: Maestro Cloud Hooks
 
 jobs:
-  maestro_test:
+  maestro_tests:
     name: Run Maestro Cloud Tests
     type: maestro-cloud
     environment: preview
     params:
-      build_id: ${{ needs.build.outputs.build_id }}
-      maestro_project_id: proj_xyz
-      flows: ./maestro/flows
+      build_id: ${{ needs.build_ios_simulator.outputs.build_id }}
+      maestro_project_id: proj_01jw6hxgmdffrbye9fqn0pyzm0
+      flows: ./maestro_tests
     hooks:
-      after_maestro_cloud:
-        - name: Install yq
-          if: true
-          run: |
-            # yq lets us read flow metadata (name/tags) without writing a parser.
-            sudo apt-get update -y && sudo apt-get install -y yq || \
-              echo "yq not available; flow tags will be omitted."
-        - name: Build failed flow summary
-          id: build_failed_flow_summary
-          if: true
-          run: |
-            # Capture the API response once so we can parse it in Node.
-            MAESTRO_API_RESPONSE_JSON=$(cat <<'EOF'
-${{ toJSON(steps.results.outputs.maestro_cloud_api_response_json) }}
-EOF
-            )
-            SUMMARY="$(
-              node - <<'NODE'
-              const fs = require('fs');
-              const path = require('path');
-              const { execFileSync } = require('child_process');
-
-              // Flow results come from the Maestro Cloud API response.
-              const response = JSON.parse(process.env.MAESTRO_API_RESPONSE_JSON || '{}');
-
-              // Adjust this if your flows live elsewhere or you pass a single file path.
-              const flowDir = path.join(process.cwd(), 'maestro', 'flows');
-              const flowFiles = [];
-              const walk = (dir) => {
-                for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-                  const entryPath = path.join(dir, entry.name);
-                  if (entry.isDirectory()) {
-                    walk(entryPath);
-                  } else if (entry.isFile() && (entry.name.endsWith('.yml') || entry.name.endsWith('.yaml'))) {
-                    flowFiles.push(entryPath);
-                  }
-                }
-              };
-              if (fs.existsSync(flowDir)) {
-                walk(flowDir);
-              }
-
-              // Map flow name -> "#tag1, #tag2" from YAML. Failures are ignored to keep the job running.
-              const nameToTags = new Map();
-              for (const file of flowFiles) {
-                try {
-                  const json = execFileSync(
-                    'yq',
-                    ['select(documentIndex == 0)', '-o', 'json', file],
-                    { encoding: 'utf8' }
-                  );
-                  const doc = JSON.parse(json);
-                  if (!doc || !doc.name) {
-                    continue;
-                  }
-
-                  const tags = Array.isArray(doc.tags) ? doc.tags : [];
-                  nameToTags.set(doc.name, tags.map((tag) => `#${tag}`).join(', '));
-                } catch (error) {
-                  continue;
-                }
-              }
-
-              // Split flows by status so the summary is easy to scan in Slack.
-              const failedFlows = (response.flows || []).filter(
-                (flow) => flow.status === 'ERROR' || flow.status === 'STOPPED'
-              );
-              const successfulFlows = (response.flows || []).filter(
-                (flow) => flow.status === 'SUCCESS' || flow.status === 'WARNING'
-              );
-
-              // Include a placeholder when a section is empty.
-              let summary = '✅ Successful flows:';
-              if (successfulFlows.length === 0) {
-                summary += '\n- no successful flows';
-              } else {
-                for (const flow of successfulFlows) {
-                  const tags = nameToTags.get(flow.name);
-                  summary += `\n- ${flow.name}${tags ? ` (${tags})` : ''}`;
-                }
-              }
-              summary += '\n\n❌ Failed flows:';
-              if (failedFlows.length === 0) {
-                summary += '\n- no failed flows';
-              } else {
-                for (const flow of failedFlows) {
-                  const tags = nameToTags.get(flow.name);
-                  summary += `\n- ${flow.name}${tags ? ` (${tags})` : ''}`;
-                }
-              }
-
-              process.stdout.write(summary);
-              NODE
-            )"
-
-            # Expose the summary as a job output for notifications.
-            set-output failed_flow_summary "$SUMMARY"
-    outputs:
-      failed_flow_summary: ${{ steps.build_failed_flow_summary.outputs.failed_flow_summary }}
-
-  notify:
-    name: Send Summary
-    after: [maestro_test]
-    type: slack
-    params:
-      webhook_url: ${{ env.SLACK_WEBHOOK_URL }}
-      message: ${{ after.maestro_test.outputs.failed_flow_summary }}
+      before_maestro_cloud:
+        - name: Generate Maestro flows
+          run: npx tsx scripts/generate-maestro-tests.ts
 ```
 
 </Collapsible>

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1165,6 +1165,134 @@ jobs:
 
 </Collapsible>
 
+<Collapsible summary="Build a tagged failed-flow summary from the Maestro Cloud API response">
+
+This workflow captures the Maestro Cloud API response, reads tags from your flow files, builds a compact summary string (failed and successful flows), and exposes it as a job output that you can use in Slack or other notifications.
+
+```yaml .eas/workflows/maestro-cloud-failed-flows.yml
+name: Maestro Cloud Failed Flow Summary
+
+jobs:
+  maestro_test:
+    name: Run Maestro Cloud Tests
+    type: maestro-cloud
+    environment: preview
+    params:
+      build_id: ${{ needs.build.outputs.build_id }}
+      maestro_project_id: proj_xyz
+      flows: ./maestro/flows
+    hooks:
+      after_maestro_cloud:
+        - name: Install yq
+          if: true
+          run: |
+            # yq lets us read flow metadata (name/tags) without writing a parser.
+            sudo apt-get update -y && sudo apt-get install -y yq || \
+              echo "yq not available; flow tags will be omitted."
+        - name: Build failed flow summary
+          id: build_failed_flow_summary
+          if: true
+          run: |
+            # Capture the API response once so we can parse it in Node.
+            MAESTRO_API_RESPONSE_JSON=$(cat <<'EOF'
+${{ toJSON(steps.results.outputs.maestro_cloud_api_response_json) }}
+EOF
+            )
+            SUMMARY="$(
+              node - <<'NODE'
+              const fs = require('fs');
+              const path = require('path');
+              const { execFileSync } = require('child_process');
+
+              // Flow results come from the Maestro Cloud API response.
+              const response = JSON.parse(process.env.MAESTRO_API_RESPONSE_JSON || '{}');
+
+              // Adjust this if your flows live elsewhere or you pass a single file path.
+              const flowDir = path.join(process.cwd(), 'maestro', 'flows');
+              const flowFiles = [];
+              const walk = (dir) => {
+                for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+                  const entryPath = path.join(dir, entry.name);
+                  if (entry.isDirectory()) {
+                    walk(entryPath);
+                  } else if (entry.isFile() && (entry.name.endsWith('.yml') || entry.name.endsWith('.yaml'))) {
+                    flowFiles.push(entryPath);
+                  }
+                }
+              };
+              if (fs.existsSync(flowDir)) {
+                walk(flowDir);
+              }
+
+              // Map flow name -> "#tag1, #tag2" from YAML. Failures are ignored to keep the job running.
+              const nameToTags = new Map();
+              for (const file of flowFiles) {
+                try {
+                  const json = execFileSync(
+                    'yq',
+                    ['select(documentIndex == 0)', '-o', 'json', file],
+                    { encoding: 'utf8' }
+                  );
+                  const doc = JSON.parse(json);
+                  if (!doc || !doc.name) {
+                    continue;
+                  }
+
+                  const tags = Array.isArray(doc.tags) ? doc.tags : [];
+                  nameToTags.set(doc.name, tags.map((tag) => `#${tag}`).join(', '));
+                } catch (error) {
+                  continue;
+                }
+              }
+
+              // Split flows by status so the summary is easy to scan in Slack.
+              const failedFlows = (response.flows || []).filter(
+                (flow) => flow.status === 'ERROR' || flow.status === 'STOPPED'
+              );
+              const successfulFlows = (response.flows || []).filter(
+                (flow) => flow.status === 'SUCCESS' || flow.status === 'WARNING'
+              );
+
+              // Include a placeholder when a section is empty.
+              let summary = '✅ Successful flows:';
+              if (successfulFlows.length === 0) {
+                summary += '\n- no successful flows';
+              } else {
+                for (const flow of successfulFlows) {
+                  const tags = nameToTags.get(flow.name);
+                  summary += `\n- ${flow.name}${tags ? ` (${tags})` : ''}`;
+                }
+              }
+              summary += '\n\n❌ Failed flows:';
+              if (failedFlows.length === 0) {
+                summary += '\n- no failed flows';
+              } else {
+                for (const flow of failedFlows) {
+                  const tags = nameToTags.get(flow.name);
+                  summary += `\n- ${flow.name}${tags ? ` (${tags})` : ''}`;
+                }
+              }
+
+              process.stdout.write(summary);
+              NODE
+            )"
+
+            # Expose the summary as a job output for notifications.
+            set-output failed_flow_summary "$SUMMARY"
+    outputs:
+      failed_flow_summary: ${{ steps.build_failed_flow_summary.outputs.failed_flow_summary }}
+
+  notify:
+    name: Send Summary
+    after: [maestro_test]
+    type: slack
+    params:
+      webhook_url: ${{ env.SLACK_WEBHOOK_URL }}
+      message: ${{ after.maestro_test.outputs.failed_flow_summary }}
+```
+
+</Collapsible>
+
 ## Slack
 
 Send a message to a Slack channel using a [Slack webhook URL](https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks).

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -440,6 +440,25 @@ jobs:
     # @end #
 ```
 
+### `jobs.<job_id>.hooks`
+
+Some pre-packaged jobs support hooks to run additional steps before or after the main job action (for example, `maestro-cloud`, `maestro-test`, and `submit`). Hook names are job-specific; see the job's documentation for the available hook keys.
+
+```yaml
+jobs:
+  maestro_test:
+    type: maestro-cloud
+    params:
+      build_id: ${{ needs.build.outputs.build_id }}
+      maestro_project_id: proj_xyz
+      flows: ./maestro/flows
+    hooks:
+      before_maestro_cloud:
+        - run: echo "Before upload"
+      after_maestro_cloud:
+        - run: echo "After upload"
+```
+
 ### `jobs.<job_id>.defaults.run.working_directory`
 
 Sets the directory to run commands in for all steps in the job.
@@ -1152,6 +1171,9 @@ jobs:
       build_id: string # required
       profile: string # optional, default: production
       groups: string[] # optional
+    hooks:
+      before_submit: step[] # optional
+      after_submit: step[] # optional
 ```
 
 This job outputs the following properties:
@@ -1247,6 +1269,9 @@ jobs:
       android_system_image_package: string # optional. Android emulator system image package to use.
       device_identifier: string | { android?: string, ios?: string } # optional. Device identifier to use for the tests.
       output_format?: string # optional, defaults to junit. Maestro test report format. Will be passed to Maestro as `--format`. Can be `junit` or other supported formats.
+    hooks:
+      before_maestro_tests: step[] # optional
+      after_maestro_tests: step[] # optional
 ```
 
 #### `maestro-cloud`
@@ -1279,6 +1304,9 @@ jobs:
       name: string # optional. Name for the Maestro Cloud upload. Corresponds to `--name` param to `maestro cloud`.
       branch: string # optional. Override for the branch the Maestro Cloud upload originated from. By default, if the workflow run has been triggered from GitHub, the branch of the workflow run will be used. Corresponds to `--branch` param to `maestro cloud`.
       async: boolean # optional. Run the Maestro Cloud tests asynchronously. If true, the status of the job will only denote whether the upload was successful, *not* whether the tests succeeded. Corresponds to `--async` param to `maestro cloud`.
+    hooks:
+      before_maestro_cloud: step[] # optional. Steps to run before the Maestro Cloud upload.
+      after_maestro_cloud: step[] # optional. Steps to run after the Maestro Cloud upload.
 ```
 
 #### `slack`

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -441,6 +441,25 @@ jobs:
     # @end #
 ```
 
+### `jobs.<job_id>.hooks`
+
+Some pre-packaged jobs support hooks to run additional steps before or after the main job action (for example, `maestro-cloud`, `maestro-test`, and `submit`). Hook names are job-specific; see the job's documentation for the available hook keys.
+
+```yaml
+jobs:
+  maestro_test:
+    type: maestro-cloud
+    params:
+      build_id: ${{ needs.build.outputs.build_id }}
+      maestro_project_id: proj_xyz
+      flows: ./maestro/flows
+    hooks:
+      before_maestro_cloud:
+        - run: echo "Before upload"
+      after_maestro_cloud:
+        - run: echo "After upload"
+```
+
 ### `jobs.<job_id>.defaults.run.working_directory`
 
 Sets the directory to run commands in for all steps in the job.
@@ -1153,6 +1172,9 @@ jobs:
       build_id: string # required
       profile: string # optional, default: production
       groups: string[] # optional
+    hooks:
+      before_submit: step[] # optional
+      after_submit: step[] # optional
 ```
 
 This job outputs the following properties:
@@ -1249,6 +1271,9 @@ jobs:
       android_system_image_package: string # optional. Android emulator system image package to use.
       device_identifier: string | { android?: string, ios?: string } # optional. Device identifier to use for the tests.
       output_format?: string # optional, defaults to junit. Maestro test report format. Will be passed to Maestro as `--format`. Can be `junit` or other supported formats.
+    hooks:
+      before_maestro_tests: step[] # optional
+      after_maestro_tests: step[] # optional
 ```
 
 #### `maestro-cloud`
@@ -1280,6 +1305,9 @@ jobs:
       name: string # optional. Name for the Maestro Cloud upload. Corresponds to `--name` param to `maestro cloud`.
       branch: string # optional. Override for the branch the Maestro Cloud upload originated from. By default, if the workflow run has been triggered from GitHub, the branch of the workflow run will be used. Corresponds to `--branch` param to `maestro cloud`.
       async: boolean # optional. Run the Maestro Cloud tests asynchronously. If true, the status of the job will only denote whether the upload was successful, *not* whether the tests succeeded. Corresponds to `--async` param to `maestro cloud`.
+    hooks:
+      before_maestro_cloud: step[] # optional. Steps to run before the Maestro Cloud upload.
+      after_maestro_cloud: step[] # optional. Steps to run after the Maestro Cloud upload.
 ```
 
 #### `slack`

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -443,7 +443,7 @@ jobs:
 
 ### `jobs.<job_id>.hooks`
 
-Some pre-packaged jobs support hooks to run additional steps before or after the main job action (for example, `maestro-cloud`, `maestro-test`, and `submit`). Hook names are job-specific; see the job's documentation for the available hook keys.
+Some pre-packaged jobs support hooks to run additional steps before or after the main job action (for example, `maestro-cloud`, `maestro`, and `submit`). Hook names are job-specific. See the job's documentation for the available hook keys.
 
 ```yaml
 jobs:
@@ -1268,7 +1268,7 @@ jobs:
       include_tags: string | string[] # optional. Tags to include in the tests. Will be passed to Maestro as `--include-tags`.
       exclude_tags: string | string[] # optional. Tags to exclude from the tests. Will be passed to Maestro as `--exclude-tags`.
       maestro_version: string # optional. Version of Maestro to use for the tests. If not provided, the latest version will be used.
-      android_system_image_package: string # optional. Android emulator system image package to use.
+      android_system_image_package: string # optional. Android Emulator system image package to use.
       device_identifier: string | { android?: string, ios?: string } # optional. Device identifier to use for the tests.
       output_format?: string # optional, defaults to junit. Maestro test report format. Will be passed to Maestro as `--format`. Can be `junit` or other supported formats.
     hooks:


### PR DESCRIPTION
# Why

Document EAS Workflows job hooks more completely on the per-job docs page, and add concrete Maestro examples that show how to use hooks in practice.

# How

- added `hooks` to the applicable syntax blocks on the `pre-packaged-jobs` page (`submit`, `maestro`, and `maestro-cloud`)
- added Maestro examples for generating flows before tests and reporting artifacts after tests
- kept the pre-test hook example under the `maestro` job docs so it matches the hook being demonstrated

# Test Plan

- reviewed `docs/pages/eas/workflows/pre-packaged-jobs.mdx` to confirm every job on the page that documents hooks also includes them in its syntax block
- verified the Maestro examples use the correct job type and hook names

<img width="1151" height="636" alt="Zrzut ekranu 2026-04-16 o 17 31 34" src="https://github.com/user-attachments/assets/c2a59094-85b4-4350-9a38-b8629bc4fda9" />

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)