### PR TITLE
[go][Android] Fix `unordered_map::at: key not found`

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/fabric/FabricComponentsRegistry.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/fabric/FabricComponentsRegistry.cpp
@@ -22,11 +22,14 @@ AndroidExpoViewComponentDescriptor::Unique concreteExpoComponentDescriptorConstr
     react::RawPropsParser(/*useRawPropsJsiValue=*/true)
   );
 
-  descriptor->setStateProps(
-    statePropMap.at(
-      std::static_pointer_cast<std::string const>(parameters.flavor)
-    )
-  );
+  if (statePropMap.contains(std::static_pointer_cast<std::string const>(parameters.flavor))) {
+    descriptor->setStateProps(
+      statePropMap.at(
+        std::static_pointer_cast<std::string const>(parameters.flavor)
+      )
+    );
+  }
+
   return descriptor;
 }
 
@@ -51,8 +54,6 @@ void FabricComponentsRegistry::registerComponentsRegistry(
   jni::alias_ref<jni::JArrayClass<jni::JArrayClass<jni::JString>>> statePropNames,
   jni::alias_ref<jni::JArrayClass<jni::JArrayClass<ExpectedType>>> statePropTypes
 ) {
-  statePropMap.clear();
-
   // Inject the component to the CoreComponentsRegistry because we don't want to touch the MainApplicationReactNativeHost
   auto providerRegistry = react::CoreComponentsRegistry::sharedProviderRegistry();
 
@@ -79,7 +80,7 @@ void FabricComponentsRegistry::registerComponentsRegistry(
       propMap.emplace(propName, converter);
     }
 
-    statePropMap.emplace(
+    statePropMap.insert_or_assign(
       flavor,
       propMap
     );


### PR DESCRIPTION
# Why

Fixes `unordered_map::at: key not found`

# How

RN retains some information about registered views across reloads, which was causing problems with our custom component descriptor factory.

# Test Plan

- Expo Go ✅ 