### PR TITLE
[menu][Android] Add custom reload action

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
@@ -74,6 +74,7 @@ import org.json.JSONException
 import org.json.JSONObject
 import versioned.host.exp.exponent.ExponentPackageDelegate
 import versioned.host.exp.exponent.ReactUnthemedRootView
+import versioned.host.exp.exponent.VersionedUtils
 import java.lang.ref.WeakReference
 
 open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDelegate {
@@ -329,6 +330,9 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
           reactHostHolder = reactHost.weak(),
           goToHomeAction = {
             kernel.openHomeActivity()
+          },
+          reloadAction = {
+            VersionedUtils.reloadExpoApp()
           },
           appInfoProvider = { _, _ ->
             DevMenuState.AppInfo(

--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt
@@ -28,7 +28,7 @@ object VersionedUtils {
     }
   }
 
-  private fun reloadExpoApp() = synchronized(this) {
+  fun reloadExpoApp() = synchronized(this) {
     val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return run {
       FLog.e(
         ReactConstants.TAG,

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuFragment.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuFragment.kt
@@ -45,13 +45,15 @@ class DevMenuFragment(
   private val reactHostHolder: WeakReference<ReactHost>,
   private val preferences: DevMenuPreferences,
   private val goToHomeAction: GoHomeAction?,
+  private val reloadAction: (() -> Unit)?,
   private val appInfoProvider: AppInfoProvider
 ) : Fragment() {
   val viewModel by viewModels<DevMenuViewModel> {
     DevMenuViewModel.Factory(
       reactHostHolder,
       preferences,
-      goToHomeAction
+      goToHomeAction,
+      reloadAction
     )
   }
   private val shakeDetector = ShakeDetector(this::onShakeDetected)
@@ -260,6 +262,7 @@ class DevMenuFragment(
       reactHostHolder: WeakReference<ReactHost>,
       preferences: DevMenuPreferences,
       goToHomeAction: GoHomeAction?,
+      reloadAction: (() -> Unit)?,
       appInfoProvider: AppInfoProvider
     ): ViewGroup {
       val layout = object : FrameLayout(activity) {
@@ -275,6 +278,7 @@ class DevMenuFragment(
         reactHostHolder,
         preferences,
         goToHomeAction,
+        reloadAction,
         appInfoProvider
       )
 
@@ -287,6 +291,7 @@ class DevMenuFragment(
       reactHostHolder: WeakReference<ReactHost>,
       preferences: DevMenuPreferences,
       goToHomeAction: GoHomeAction?,
+      reloadAction: (() -> Unit)?,
       appInfoProvider: AppInfoProvider
     ) {
       val fragmentManager = (activity as FragmentActivity).supportFragmentManager
@@ -295,6 +300,7 @@ class DevMenuFragment(
         reactHostHolder,
         preferences,
         goToHomeAction,
+        reloadAction,
         appInfoProvider
       )
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/api/DevMenuApi.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/api/DevMenuApi.kt
@@ -47,6 +47,7 @@ object DevMenuApi {
     reactHostHolder: WeakReference<ReactHost>,
     preferences: DevMenuPreferences = DevMenuDefaultPreferences(activity.application),
     goToHomeAction: GoHomeAction? = null,
+    reloadAction: (() -> Unit)? = null,
     appInfoProvider: AppInfoProvider = { application, reactHost -> AppInfo.getAppInfo(application, reactHost) }
   ): ViewGroup {
     return DevMenuFragment.createFragmentHost(
@@ -54,6 +55,7 @@ object DevMenuApi {
       reactHostHolder,
       preferences,
       goToHomeAction,
+      reloadAction,
       appInfoProvider
     )
   }

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/DevMenuViewModel.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/DevMenuViewModel.kt
@@ -14,7 +14,8 @@ import java.lang.ref.WeakReference
 class DevMenuViewModel(
   val reactHostHolder: WeakReference<ReactHost>,
   val menuPreferences: DevMenuPreferences,
-  val goHomeAction: (() -> Unit)? = null
+  val goHomeAction: (() -> Unit)? = null,
+  val reloadAction: (() -> Unit)? = null
 ) : ViewModel() {
   private val reactHost
     get() = reactHostHolder.get()
@@ -129,14 +130,16 @@ class DevMenuViewModel(
   class Factory(
     private val reactHostHolder: WeakReference<ReactHost>,
     private val menuPreferences: DevMenuPreferences,
-    private val goHomeAction: (() -> Unit)?
+    private val goHomeAction: (() -> Unit)?,
+    private val reloadAction: (() -> Unit)?
   ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
       @Suppress("UNCHECKED_CAST")
       return DevMenuViewModel(
         reactHostHolder,
         menuPreferences,
-        goHomeAction
+        goHomeAction,
+        reloadAction
       ) as T
     }
   }

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/devtools/DevMenuDevToolsDelegate.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/devtools/DevMenuDevToolsDelegate.kt
@@ -50,7 +50,8 @@ class DevMenuDevToolsDelegate(
       ?.onAction(DevMenuAction.Close)
 
     UiThreadUtil.runOnUiThread {
-      devSupportManager?.handleReloadJS()
+      val reloadAction = viewModel?.reloadAction ?: { devSupportManager?.reloadExpoApp() }
+      reloadAction()
     }
   }
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/devtools/DevMenuDevToolsDelegate.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/devtools/DevMenuDevToolsDelegate.kt
@@ -50,7 +50,7 @@ class DevMenuDevToolsDelegate(
       ?.onAction(DevMenuAction.Close)
 
     UiThreadUtil.runOnUiThread {
-      val reloadAction = viewModel?.reloadAction ?: { devSupportManager?.reloadExpoApp() }
+      val reloadAction = viewModel?.reloadAction ?: { devSupportManager?.handleReloadJS() }
       reloadAction()
     }
   }


### PR DESCRIPTION
# Why

Adds the ability to provide a custom reload action. 
It's currently used in Expo Go. Actually, I don't think it's necessary, but to ensure we're not changing behavior in Expo Go, I decided to unify how we trigger reloads.

# Test Plan

- Expo Go ✅ 