### PR TITLE
[ci] reduce e2e flakiness with wrong deep link

### DIFF
--- a/apps/bare-expo/scripts/lib/e2e-common.ts
+++ b/apps/bare-expo/scripts/lib/e2e-common.ts
@@ -52,8 +52,8 @@ jsEngine: graaljs
   ];
   if (confirmFirstRunPromptIOS) {
     contents.push(`\
-# Run once to approve the first time deeplinking prompt on iOS
-- openLink: bareexpo://test-suite/run
+# Run once to approve the first time deeplinking prompt on iOS (clearState above resets this)
+- openLink: bareexpo://test-suite/run?tests=${testCases[0]}
 - tapOn:
     text: "Open"
     optional: true


### PR DESCRIPTION
# Why

sometimes we run into this situation were an invalid deep link (even though a new, valid link is opened later) persists longer than it should, failing the tests.


![screenshot-❌-1768900637624-(maestro-generated.yaml).png](https://app.graphite.com/user-attachments/assets/267ac005-f17d-4d28-8e5b-c51bb86083a9.png)

# How

- fix the invalid link

# Test Plan

- wait for green CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
