### PR TITLE
[core][iOS] Fix worklets integration when `useFramework = static`

### DIFF
--- a/packages/expo-modules-core/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ExpoModulesCore.podspec
@@ -108,7 +108,20 @@ Pod::Spec.new do |s|
       '"${PODS_CONFIGURATION_BUILD_DIR}/React-jsitooling/JSITooling.framework/Headers"',
       '"${PODS_CONFIGURATION_BUILD_DIR}/React-jserrorhandler/React_jserrorhandler.framework/Headers"',
     ])
+
+    if shouldEnableWorkletsIntegration
+      pods_root = Pod::Config.instance.project_pods_root
+      react_native_worklets_node_modules_dir = File.join(File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native-worklets/package.json')"`), '..')
+      react_native_worklets_dir_absolute = File.join(react_native_worklets_node_modules_dir, 'react-native-worklets')
+      workletsPath = Pathname.new(react_native_worklets_dir_absolute).relative_path_from(pods_root).to_s
+
+      header_search_paths.concat([
+        "\"$(PODS_ROOT)/#{workletsPath}/apple\"",
+        "\"$(PODS_ROOT)/#{workletsPath}/Common/cpp\"",
+      ])
+    end
   end
+
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {
     'USE_HEADERMAP' => 'YES',


### PR DESCRIPTION
# Why

Fixes worklets integration when `useFramework = static`.
This bug was reported by @tomekzaw.

# How

Adds `header_search_paths` when `USE_FRAMEWORKS` and worklets are added to the project. I'm not happy with this solution. I tried to use the headers that are part of the `.framework` created during compilation. That is not possible as it uses a different folder structure: `worklets/WorkletRuntime/WorkletRuntime.h` (expected path) -> `WorkletRuntime/WorkletRuntime.h` (path inside framework).

# Test Plan

- Created a fresh project with the canary version and enabled static framework ✅