### PR TITLE
chore(expo-router): remove deprecated `ExpoRequest` and `ExpoResponse` types

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -116,6 +116,7 @@
 - add `unstable_navigationEvents` to `globalThis.expo` ([#42238](https://github.com/expo/expo/pull/42238) by [@Ubax](https://github.com/Ubax))
 - Upgrade react-native-screens to 4.20.0 ([#42282](https://github.com/expo/expo/pull/42282) by [@Ubax](https://github.com/Ubax))
 - Change loader function signature to `(request, params)` ([#42318](https://github.com/expo/expo/pull/42318) by [@hassankhan](https://github.com/hassankhan))
+- Remove deprecated `ExpoRequest` and `ExpoResponse` types ([#42363](https://github.com/expo/expo/pull/42363) by [@hassankhan](https://github.com/hassankhan))
 
 ## 6.0.17 - 2025-12-05
 

--- a/packages/expo-router/server.d.ts
+++ b/packages/expo-router/server.d.ts
@@ -1,19 +1,5 @@
 export type { MiddlewareFunction } from 'expo-server';
 
-/**
- * @deprecated Use Fetch API `Request` instead.
- *
- * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request)
- */
-export type ExpoRequest = Request;
-
-/**
- * @deprecated Use Fetch API `Response` instead.
- *
- * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response)
- */
-export type ExpoResponse = Response;
-
 export type RequestHandler = (
   request: Request,
   params: Record<string, string>


### PR DESCRIPTION
# Why

The `ExpoRequest` and `ExpoResponse` types have been marked deprecated since at least SDK 53 and it should be safe to remove them.

# How

Deleted the types from `expo-router/server`.

# Test Plan

- CI

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
