### PR TITLE
[modules-core] Fix react-native-macos 0.81 support

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [iOS] Fix dev server discovery cancellation. ([#41555](https://github.com/expo/expo/pull/41555) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fixes an issue where a `nil` projectUrl could be passed to Expo Updates. ([#42126](https://github.com/expo/expo/pull/42126) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix launching deeplink with dev launcher. ([#42212](https://github.com/expo/expo/pull/42212) by [@jakex7](https://github.com/jakex7))
+- Fix react-native-macos 0.81 support ([#42366](https://github.com/expo/expo/pull/42366) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/Navigation/Navigation.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/Navigation/Navigation.swift
@@ -1,5 +1,6 @@
 // swiftlint:disable closure_body_length
 import SwiftUI
+import ExpoModulesCore
 
 class DevLauncherNavigation: ObservableObject {
   @Binding var showingUserProfile: Bool

--- a/packages/expo-dev-launcher/ios/SwiftUI/Utils/Avatar.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/Utils/Avatar.swift
@@ -1,6 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 import SwiftUI
+import ExpoModulesCore
 
 // [alan] Gravatar urls do not work with AsyncImage. We need to download the image ourseleves
 struct Avatar<Content: View, Placeholder: View>: View {

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -35,7 +35,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fixed DSL view props using stale state when updating. ([#41622](https://github.com/expo/expo/pull/41622) by [@kimchi-developer](https://github.com/kimchi-developer))
-- [core] Fixed `useReleasingSharedObject` to defer releasing until after render.
+  - [core] Fixed `useReleasingSharedObject` to defer releasing until after render.
 - [android] Fix source sets for events for functional view definitions. ([#41685](https://github.com/expo/expo/pull/41685) by [@aleqsio](https://github.com/aleqsio))
 - [iOS] Fix throwing `InvalidArgsNumberException` when declaring `AsyncFunction` with optional arguments and `Promise`. ([#41054](https://github.com/expo/expo/pull/41054) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] fix queue assertion crash ([#41296](https://github.com/expo/expo/pull/41296) by [@vonovak](https://github.com/vonovak))
@@ -49,6 +49,7 @@
 - Fixed `NativeModule` extending `Record<string, any>`, which made it not type-safe. ([#41320](https://github.com/expo/expo/pull/41320) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Fix missing headers when using static frameworks ([#41970](https://github.com/expo/expo/pull/41970) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Add shallow equality check before triggering view prop setters to avoid unnecessary calls. ([#39331](https://github.com/expo/expo/pull/39331) by [@nishan](https://github.com/intergalacticspacehighway))
+- Fix react-native-macos 0.81 support ([#42366](https://github.com/expo/expo/pull/42366) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/common/cpp/fabric/ExpoViewProps.cpp
+++ b/packages/expo-modules-core/common/cpp/fabric/ExpoViewProps.cpp
@@ -33,7 +33,11 @@ ExpoViewProps::ExpoViewProps(
   const ExpoViewProps &sourceProps,
   const react::RawProps &rawProps,
   const std::function<bool(const std::string &)> &filterObjectKeys
-) : react::ViewProps(context, sourceProps, rawProps, filterObjectKeys),
+) : react::ViewProps(context, sourceProps, rawProps
+#if REACT_NATIVE_TARGET_VERSION >= 83
+    , filterObjectKeys
+#endif
+  ),
     propsMap(propsMapFromProps(sourceProps, rawProps)) {}
 
 } // namespace expo

--- a/packages/expo-modules-core/ios/Platform/Platform.h
+++ b/packages/expo-modules-core/ios/Platform/Platform.h
@@ -14,6 +14,7 @@
 @compatibility_alias UIColor NSColor;
 @compatibility_alias UIWindow NSWindow;
 @compatibility_alias UIHostingController NSHostingController;
+@compatibility_alias UIImage NSImage;
 
 #ifndef UIApplication
 @compatibility_alias UIApplication NSApplication;


### PR DESCRIPTION
# Why

macOS 0.81 builds are broken 

# How

- In modules-core, add `NSImage` compatibility_alias to Platform.h, which previously was only added to Swift
- Add REACT_NATIVE_TARGET_VERSION check for ViewProps filterObjectKeys, related to the https://github.com/expo/expo/pull/41904 changes
- Add expo-modules-core imports to dev-launcher to fix macos support by including the Platform.swift file

# Test Plan

Run BareExpo on macos

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
