### PR TITLE
[template] Use new api for bottom tabs

### DIFF
--- a/templates/expo-template-default/src/components/app-tabs.native.tsx
+++ b/templates/expo-template-default/src/components/app-tabs.native.tsx
@@ -1,6 +1,6 @@
-import { NativeTabs, Icon, Label } from 'expo-router/unstable-native-tabs';
+import { NativeTabs } from 'expo-router/unstable-native-tabs';
 import React from 'react';
-import { Platform, useColorScheme } from 'react-native';
+import { useColorScheme } from 'react-native';
 
 import { Colors } from '@/constants/theme';
 
@@ -14,13 +14,13 @@ export default function AppTabs() {
       indicatorColor={colors.backgroundElement}
       labelStyle={{ selected: { color: colors.text } }}>
       <NativeTabs.Trigger name="index">
-        <Label>Home</Label>
-        <Icon src={require('@/assets/images/tabIcons/home.png')} />
+        <NativeTabs.Trigger.Label>Home</NativeTabs.Trigger.Label>
+        <NativeTabs.Trigger.Icon src={require('@/assets/images/tabIcons/home.png')} />
       </NativeTabs.Trigger>
 
       <NativeTabs.Trigger name="explore">
-        <Label>Explore</Label>
-        <Icon src={require('@/assets/images/tabIcons/explore.png')} />
+        <NativeTabs.Trigger.Label>Explore</NativeTabs.Trigger.Label>
+        <NativeTabs.Trigger.Icon src={require('@/assets/images/tabIcons/explore.png')} />
       </NativeTabs.Trigger>
     </NativeTabs>
   );


### PR DESCRIPTION
# Why

In SDK 55, the router native tabs no longer export `Icon` and `Label`. 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Use the new API for router bottom tabs label and icon.


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Create a new project using the latest canary
- Replace the contents of `src/components/app-tabs.native.tsx` with the changes in this PR
- `npx expo run:ios`

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
