### PR TITLE
[ios] feat(expo-dev-launcher): Implement bonjour service discovery

### DIFF
--- a/apps/bare-expo/ios/BareExpo/Info.plist
+++ b/apps/bare-expo/ios/BareExpo/Info.plist
@@ -157,5 +157,11 @@
     <array>
       <string>com.expo.modules.backgroundtask.processing</string>
     </array>
+    <key>NSBonjourServices</key>
+    <array>
+      <string>_expo._tcp.</string>
+    </array>
+    <key>NSLocalNetworkUsageDescription</key>
+    <string>Allow $(PRODUCT_NAME) to discover local development-only servers</string>
   </dict>
 </plist>

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Add Bonjour service discovery ([#42384](https://github.com/expo/expo/pull/42384) by [@kitten](https://github.com/kitten))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-dev-launcher/ios/SwiftUI/Data.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/Data.swift
@@ -1,16 +1,8 @@
 import Network
 
-struct DiscoveryResult: Hashable {
+struct DiscoveryResult {
   let name: String?
   let endpoint: NWEndpoint
-
-  var hashValue: Int {
-    return endpoint.hashValue
-  }
-
-  static func == (lhs: Self, rhs: Self) -> Bool {
-    return lhs.name == rhs.name && lhs.endpoint == rhs.endpoint
-  }
 }
 
 struct BranchWithUpdates {
@@ -20,10 +12,22 @@ struct BranchWithUpdates {
   let hasCompatibleUpdates: Bool
 }
 
-struct DevServer {
+struct DevServer: Hashable {
   let url: String
   let description: String
   let source: String
+
+  var hashValue: Int {
+    return url.hashValue
+  }
+
+  static func == (lhs: Self, rhs: Self) -> Bool {
+    return lhs.url == rhs.url && lhs.description == rhs.description && lhs.source == rhs.source
+  }
+
+  static func < (lhs: Self, rhs: Self) -> Bool {
+    return lhs.url < rhs.url
+  }
 }
 
 struct BuildInfo {

--- a/packages/expo-dev-launcher/ios/SwiftUI/Data.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/Data.swift
@@ -22,7 +22,7 @@ struct DevServer: Hashable {
   }
 
   static func == (lhs: Self, rhs: Self) -> Bool {
-    return lhs.url == rhs.url && lhs.description == rhs.description && lhs.source == rhs.source
+    return lhs.url == rhs.url
   }
 
   static func < (lhs: Self, rhs: Self) -> Bool {

--- a/packages/expo-dev-launcher/ios/SwiftUI/Data.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/Data.swift
@@ -1,3 +1,18 @@
+import Network
+
+struct DiscoveryResult: Hashable {
+  let name: String?
+  let endpoint: NWEndpoint
+
+  var hashValue: Int {
+    return endpoint.hashValue
+  }
+
+  static func == (lhs: Self, rhs: Self) -> Bool {
+    return lhs.name == rhs.name && lhs.endpoint == rhs.endpoint
+  }
+}
+
 struct BranchWithUpdates {
   let id: String
   let name: String

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
@@ -151,7 +151,12 @@ class DevLauncherViewModel: ObservableObject {
         self.pingTask?.cancel()
         self.pingTask = Task {
           defer { self.pingTask = nil }
-          await self.pingDiscoveryResults(results)
+          await self.pingDiscoveryResults(results.map { result in
+            DiscoveryResult(
+              name: NetworkUtilities.getNWBrowserResultName(result),
+              endpoint: result.endpoint
+            )
+          })
         }
       }
     }
@@ -166,7 +171,7 @@ class DevLauncherViewModel: ObservableObject {
     browser = nil
   }
 
-  private func pingDiscoveryResults(_ results: Set<NWBrowser.Result>) async {
+  private func pingDiscoveryResults(_ results: [DiscoveryResult]) async {
     guard !Task.isCancelled else {
       return
     }
@@ -191,7 +196,7 @@ class DevLauncherViewModel: ObservableObject {
     }
   }
 
-  private func pingDevServer(_ result: NWBrowser.Result) async -> DevServer? {
+  private func pingDevServer(_ result: DiscoveryResult) async -> DevServer? {
     do {
       if let host = try await NetworkUtilities.resolveBundlerEndpoint(
         endpoint: result.endpoint,
@@ -199,7 +204,7 @@ class DevLauncherViewModel: ObservableObject {
       ) {
         return DevServer(
           url: host,
-          description: NetworkUtilities.getNWBrowserResultName(result) ?? host,
+          description: result.name ?? host,
           source: "local"
         )
       }

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
@@ -175,7 +175,7 @@ class DevLauncherViewModel: ObservableObject {
     await withTaskGroup(of: DevServer?.self) { group in
       for result in results {
         group.addTask {
-          return await self.pingDevServer(endpoint: result.endpoint)
+          return await self.pingDevServer(result)
         }
       }
 
@@ -191,13 +191,17 @@ class DevLauncherViewModel: ObservableObject {
     }
   }
 
-  private func pingDevServer(endpoint: NWEndpoint) async -> DevServer? {
+  private func pingDevServer(_ result: NWBrowser.Result) async -> DevServer? {
     do {
       if let host = try await NetworkUtilities.resolveBundlerEndpoint(
-        endpoint: endpoint,
+        endpoint: result.endpoint,
         queue: DispatchQueue.main
       ) {
-        return DevServer(url: host, description: host, source: "local")
+        return DevServer(
+          url: host,
+          description: NetworkUtilities.getNWBrowserResultName(result) ?? host,
+          source: "local"
+        )
       }
     } catch {
       // Server not running or not reachable

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
@@ -3,11 +3,13 @@
 import ExpoModulesCore
 import Foundation
 import AuthenticationServices
+import Network
 
 private let selectedAccountKey = "expo-selected-account-id"
 private let sessionKey = "expo-session-secret"
 
 private let DEV_LAUNCHER_DEFAULT_SCHEME = "expo-dev-launcher"
+private let BONJOUR_TYPE = "_expo._tcp"
 
 @MainActor
 class DevLauncherViewModel: ObservableObject {
@@ -43,7 +45,9 @@ class DevLauncherViewModel: ObservableObject {
   @Published var user: User?
   @Published var selectedAccountId: String?
   @Published var isLoadingServer: Bool = false
-  private var discoveryTask: Task<Void, Never>?
+
+  private var browser: NWBrowser?
+  private var pingTask: Task<Void, Never>?
 
   #if !os(tvOS)
   private let presentationContext = DevLauncherAuthPresentationContext()
@@ -129,43 +133,49 @@ class DevLauncherViewModel: ObservableObject {
   }
 
   func startServerDiscovery() {
-    discoveryTask?.cancel()
-    discoveryTask = Task {
-      await discoverDevServers()
-      while !Task.isCancelled {
-        try? await Task.sleep(nanoseconds: 2_000_000_000)
-        if Task.isCancelled {
-          break
+    stopServerDiscovery()
+
+    let params = NWParameters()
+    params.includePeerToPeer = true
+    params.allowLocalEndpointReuse = true
+
+    browser = NWBrowser(
+      for: NWBrowser.Descriptor.bonjourWithTXTRecord(type: BONJOUR_TYPE, domain: nil),
+      using: params
+    )
+
+    browser?.browseResultsChangedHandler = { [weak self] results, _ in
+      guard let self = self else { return }
+      Task { @MainActor [weak self, results] in
+        guard let self else { return }
+        self.pingTask?.cancel()
+        self.pingTask = Task {
+          defer { self.pingTask = nil }
+          await self.pingDiscoveryResults(results)
         }
-        await discoverDevServers()
       }
     }
+
+    browser?.start(queue: .main)
   }
 
   func stopServerDiscovery() {
-    discoveryTask?.cancel()
-    discoveryTask = nil
+    pingTask?.cancel()
+    pingTask = nil
+    browser?.cancel()
+    browser = nil
   }
 
-  private func discoverDevServers() async {
+  private func pingDiscoveryResults(_ results: Set<NWBrowser.Result>) async {
     guard !Task.isCancelled else {
       return
     }
 
     var discoveredServers: [DevServer] = []
-
-    // swiftlint:disable number_separator
-    let portsToCheck = [8081, 8082, 8_083, 8084, 8085, 19000, 19001, 19002]
-    // swiftlint:enable number_separator
-
-    let ipsToScan = NetworkUtilities.getIPAddressesToScan()
     await withTaskGroup(of: DevServer?.self) { group in
-      for ip in ipsToScan {
-        for port in portsToCheck {
-          group.addTask {
-            let baseAddress = ip == "localhost" ? "http://localhost" : "http://\(ip)"
-            return await self.checkDevServer(url: "\(baseAddress):\(port)")
-          }
+      for result in results {
+        group.addTask {
+          return await self.pingDevServer(endpoint: result.endpoint)
         }
       }
 
@@ -176,33 +186,18 @@ class DevLauncherViewModel: ObservableObject {
       }
     }
 
-    guard !Task.isCancelled else {
-      return
-    }
-
     await MainActor.run {
       self.devServers = discoveredServers.sorted { $0.url < $1.url }
     }
   }
 
-  private func checkDevServer(url: String) async -> DevServer? {
-    guard let statusURL = URL(string: "\(url)/status") else {
-      return nil
-    }
-
+  private func pingDevServer(endpoint: NWEndpoint) async -> DevServer? {
     do {
-      let (data, response) = try await URLSession.shared.data(from: statusURL)
-
-      if let httpResponse = response as? HTTPURLResponse,
-        httpResponse.statusCode == 200 {
-        if let statusString = String(data: data, encoding: .utf8),
-          statusString.contains("packager-status:running") {
-          return DevServer(
-            url: url,
-            description: url,
-            source: "local"
-          )
-        }
+      if let host = try await NetworkUtilities.resolveBundlerEndpoint(
+        endpoint: endpoint,
+        queue: DispatchQueue.main
+      ) {
+        return DevServer(url: host, description: host, source: "local")
       }
     } catch {
       // Server not running or not reachable

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
@@ -173,8 +173,22 @@ struct DevServerRow: View {
           .fill(Color.green)
           .frame(width: 12, height: 12)
 
-        Text(server.description)
-          .foregroundColor(.primary)
+        if server.description == server.url {
+          Text(server.description)
+            .foregroundColor(.primary)
+            .lineLimit(1)
+        } else {
+          VStack(alignment: .leading) {
+            Text(server.description)
+              .font(.headline)
+              .foregroundColor(.primary)
+              .lineLimit(1)
+            Text(server.url)
+              .font(.caption)
+              .foregroundColor(.secondary)
+              .lineLimit(1)
+          }
+        }
 
         Spacer()
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
@@ -53,7 +53,7 @@ struct DevServersView: View {
             .padding()
           Divider()
         } else {
-          ForEach(viewModel.devServers, id: \.url) { server in
+          ForEach(viewModel.devServers, id: \.self) { server in
             DevServerRow(server: server) {
               viewModel.openApp(url: server.url)
             }

--- a/packages/expo-dev-launcher/ios/SwiftUI/NetworkUtilities.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/NetworkUtilities.swift
@@ -181,7 +181,6 @@ class NetworkUtilities {
   ) async throws -> String? {
     let params = NWParameters.tcp
     params.includePeerToPeer = true
-    params.allowFastOpen = true
     params.allowLocalEndpointReuse = true
     params.preferNoProxies = true
     params.requiredInterface = endpoint.interface

--- a/packages/expo-dev-launcher/ios/SwiftUI/NetworkUtilities.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/NetworkUtilities.swift
@@ -71,7 +71,7 @@ func connectionReceive(_ connection: NWConnection) async throws -> String {
     var responseData = Data()
     func receiveLoop() {
       connection.receive(minimumIncompleteLength: 1, maximumLength: 4096) { data, _, isComplete, error in
-          if let error {
+        if let error {
           cont.resume(throwing: error)
           return
         }
@@ -159,6 +159,20 @@ class NetworkUtilities {
       "localhost",
       "\(subnet).1"
     ]
+  }
+
+  static func getNWBrowserResultName(_ result: NWBrowser.Result) -> String? {
+    if case .bonjour(let txtRecord) = result.metadata {
+      return txtRecord.getEntry(for: "name").flatMap {
+        if case .string(let value) = $0 {
+          value
+        } else {
+          nil
+        }
+      }
+    } else {
+      return nil
+    }
   }
 
   static func resolveBundlerEndpoint(

--- a/packages/expo-dev-launcher/ios/SwiftUI/NetworkUtilities.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/NetworkUtilities.swift
@@ -3,6 +3,33 @@
 import Foundation
 import Network
 
+enum ConnectionError: Error {
+    case failedConnection
+    case noPathToHost
+    case invalidResponse
+}
+
+func buildHttpHost(endpoint: NWEndpoint) -> String? {
+  guard case let .hostPort(remoteHost, remotePort) = endpoint else {
+    return nil
+  }
+  let hostname: String? = switch remoteHost {
+    case .name(let name, _):
+      name
+    case .ipv4(IPv4Address.loopback):
+      "localhost"
+    case .ipv4(let ip):
+      IPv4Address(ip.rawValue)!.debugDescription // drop interface suffix
+    case .ipv6(IPv6Address.loopback):
+      "localhost"
+    case .ipv6(let ip):
+      "[\(ip.debugDescription)]"
+    default:
+      nil
+  }
+  return hostname.map { "http://\($0):\(remotePort)" }
+}
+
 class NetworkUtilities {
   // Same approach as expo-network just without throwing.
   static func getLocalIPAddress() -> String? {
@@ -69,5 +96,101 @@ class NetworkUtilities {
       "localhost",
       "\(subnet).1"
     ]
+  }
+
+  static func resolveBundlerEndpoint(
+    endpoint: NWEndpoint,
+    queue: DispatchQueue,
+  ) async throws -> String? {
+    let params = NWParameters.tcp
+    params.includePeerToPeer = true
+    params.allowFastOpen = true
+    params.allowLocalEndpointReuse = true
+    params.preferNoProxies = true
+    params.requiredInterface = endpoint.interface
+    params.expiredDNSBehavior = NWParameters.ExpiredDNSBehavior.allow
+
+    let connection = NWConnection(to: endpoint, using: params)
+    defer { connection.cancel() }
+
+    try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+      connection.stateUpdateHandler = { state in
+        let handler = connection.stateUpdateHandler
+        connection.stateUpdateHandler = nil
+        switch state {
+          case .ready:
+            cont.resume()
+          case .failed(let error):
+            cont.resume(throwing: error)
+          case .cancelled:
+            cont.resume(throwing: ConnectionError.failedConnection)
+          default:
+            connection.stateUpdateHandler = handler
+        }
+      }
+      connection.start(queue: queue)
+    }
+
+    guard let host = connection.currentPath
+      .flatMap({ $0.remoteEndpoint })
+      .flatMap({ buildHttpHost(endpoint: $0) })
+    else {
+      throw ConnectionError.noPathToHost
+    }
+
+    let requestString = """
+    GET /status HTTP/1.1\r
+    Host: \(host)\r
+    Connection: close\r
+    \r
+
+    """
+
+    let requestData = requestString.data(using: .utf8)!
+
+    try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+      connection.send(content: requestData, completion: .contentProcessed { error in
+        if let error = error {
+          cont.resume(throwing: error)
+        } else {
+          cont.resume()
+        }
+      })
+    }
+
+    let responseData = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Data, Error>) in
+      var responseData = Data()
+      func receiveLoop() {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 4096) { data, _, isComplete, error in
+          if let error = error {
+            cont.resume(throwing: error)
+            return
+          }
+
+          if let data = data {
+            responseData.append(data)
+          }
+
+          if isComplete {
+            cont.resume(returning: responseData)
+          } else {
+            receiveLoop()
+          }
+        }
+      }
+      receiveLoop()
+    }
+
+    guard let responseString = String(data: responseData, encoding: .utf8) else {
+      throw ConnectionError.invalidResponse
+    }
+
+    let parts = responseString.components(separatedBy: "\r\n\r\n")
+    let body = parts.dropFirst().joined(separator: "\r\n\r\n")
+    if body.contains("packager-status:running") {
+      return host
+    } else {
+      return nil
+    }
   }
 }

--- a/packages/expo-dev-launcher/ios/SwiftUI/NetworkUtilities.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/NetworkUtilities.swift
@@ -145,26 +145,20 @@ class NetworkUtilities {
     #endif
   }
 
-  static func getIPAddressesToScan() -> [String] {
-    if isSimulator() {
-      return ["localhost"]
+  static func getLocalEndpointsToScan() -> [DiscoveryResult] {
+    let portsToScan = ["8081", "8082", "8083"]
+    if !isSimulator() {
+      return []
     }
-
-    guard let localIP = getLocalIPAddress() else {
-      return ["localhost"]
+    return portsToScan.map { port in
+      DiscoveryResult(
+        name: nil,
+        endpoint: NWEndpoint.hostPort(
+          host: NWEndpoint.Host.init(getLocalIPAddress() ?? "localhost"),
+          port: NWEndpoint.Port.init(port)!
+        )
+      )
     }
-
-    let components = localIP.split(separator: ".")
-    guard components.count == 4 else {
-      return ["localhost"]
-    }
-
-    let subnet = components.prefix(3).joined(separator: ".")
-
-    return [
-      "localhost",
-      "\(subnet).1"
-    ]
   }
 
   static func getNWBrowserResultName(_ result: NWBrowser.Result) -> String? {


### PR DESCRIPTION
## Why

When an Expo app is now run with `EXPO_UNSTABLE_BONJOUR=1 expo start`, it's advertised via DNS service discovery via mDNS (Bonjour). We're looking to enable this by default in the CLI once the `dev-launcher` supports this natively.

This implements an initial Bonjour service discovery in `expo-dev-launcher` for iOS.

# How

Some changes have been made to the local port scanning as opposed to what's on `main`, to limit the amount of connections we open:
- We only scan parts on simulators
- We still port scan, but only on `8081-8083`
- We scan only on `getLocalIPAddress()` falling back to `localhost`
- We time out trying to establish a TCP connection after 2s

The additional ports to scan have been removed, since they're unlikely to still be in use even with Community CLI servers. 8081 is our default and we count up from there.

The additional `x.x.x.1` scan via the local IP address has been removed. It's exceedingly unlikely that a Metro server would be running on the gateway address (or rather, `.1` is usually the gateway by default). We can simply skip this as it's unlikely to find a server.

The Bonjour service discovery uses `NWBrowser` for Bonjour service discovery searching for our custom `_expo._tcp` type. We're then using a constructed `NWConnection` with the discovered endpoints to send the `/status` HTTP 1.1 request and close immediately after. The connection's `remoteEndpoint` is then used to generate the target IP address. We have to resolve the IP address in this way since `NWBrowser` does not perfom resolution itself and a real connection has to be opened to resolve the Bonjour hostname from the SRV record.

> [!NOTE]
> In macOS and iOS the mDNSResponder (used by `NWBrowser`) does not listen to advertisements on loopback. Usually this means that if you have no active network connections, Bonjour won't work. It needs at least one non-internal network to work, and iOS won't actually allow us to listen to more interfaces forcefully.

The UI has been updated to use the `name` (from the Bonjour TXT record) in the UI. The entry will mirror what the recently used app row will look like if it's set and we discovered the dev server via Bonjour.

It's possible to sometimes see duplicates, depending on the network structure, since we only deduplicate by `url`.

# Test Plan

- Build a sample app that uses `expo-dev-launcher`, e.g. `apps/bare-expo`
- Run the app and check discovered servers
  - With `expo start`: It should scan and show the `:8081` local server
  - With `EXPO_UNSTABLE_BONJOUR=1 expo start`: It should show the discovered dev server with a name
  - With two `expo start` instances: It should show both of them (with Bonjour a name will appear)
  - Quitting `expo start`: the instance should disappear

To test on device, we'll need the local network / bonjour entries in `Info.plist`

```
<key>NSBonjourServices</key>
<array>
  <string>_expo._tcp.</string>
</array>
<key>NSLocalNetworkUsageDescription</key>
<string>Allow $(PRODUCT_NAME) to discover local development-only servers</string>
```

> [!WARNING]
> I've discovered that both react-native and expo-dev-launcher (maybe more) have bugs when it comes to handling **IPv6 URLs**. They're often not assembled correctly and we're getting assertion faults in many places due to this.
> 
> It'll be a bit tedious to hunt down, since this is happening due to a mix of manual URL-building and some `URL` and `URLComponents` quirks. For now, this PR disables IPv6 advertising entirely: #42403
>
> This doesn't fix the problem, but the problem of IPv6 dev server URLs breaking dev clients isn't unique/specific to this PR and its changes. We can't force `NWConnection` to ignore IPv6 addresses or skip the IPv6 stack, it seems.
>
> Alternatively, we could use the Bonjour service URL, as provided by the PTR mDNS record, instead. But this wouldn't be entirely safe either, as this changes how errors could occur (resolution would fail) when the dev server shuts down.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
