### PR TITLE
patch(cli): Add `name` property to Bonjour TXT records

### DIFF
--- a/packages/@expo/cli/src/start/server/Bonjour.ts
+++ b/packages/@expo/cli/src/start/server/Bonjour.ts
@@ -38,7 +38,8 @@ export class Bonjour {
       hostname: exp.slug,
       port: this.port,
       txt: {
-        slug: exp.slug,
+        name: exp.name?.slice(0, 255),
+        slug: exp.slug?.slice(0, 255),
       },
     });
   }


### PR DESCRIPTION
# Why

Added, so we can show a name for Bonjour services, that hasn't been modified to not conflict with other network names.

# How

- Add trimmed `name` entry to `txt` data

No changelog entry added since this is unstable and only goes to `main`

# Test Plan

- n/a

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
