### PR TITLE
[expo-intent-launcher][android] Fixed Double to Long conversion for calendar timestamps.

### DIFF
--- a/packages/expo-intent-launcher/CHANGELOG.md
+++ b/packages/expo-intent-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed Double to Long conversion for intent extras to support calendar timestamps and other large numeric values. ([#42386](https://github.com/expo/expo/pull/42386) by [@brianomchugh](https://github.com/brianomchugh))
+
 ### 💡 Others
 
 - [Android] Removed unused `androidx.annotation:annotation` dependency. ([#39760](https://github.com/expo/expo/pull/39760) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.kt
+++ b/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.kt
@@ -68,7 +68,6 @@ class IntentLauncherModule : Module() {
               // JavaScript sends all numbers as doubles. We need to convert them appropriately:
               // - Large values (like calendar timestamps) need to be Long
               // - Smaller values should remain Int for backward compatibility
-              // Calendar timestamps in milliseconds exceed Int.MAX_VALUE (2,147,483,647)
               if (value > Int.MAX_VALUE || value < Int.MIN_VALUE) {
                 value.toLong()
               } else {

--- a/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.kt
+++ b/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.kt
@@ -63,7 +63,20 @@ class IntentLauncherModule : Module() {
 
       params.extra?.let {
         val valuesList = it.mapValues { (_, value) ->
-          if (value is Double) value.toInt() else value
+          when {
+            value is Double -> {
+              // JavaScript sends all numbers as doubles. We need to convert them appropriately:
+              // - Large values (like calendar timestamps) need to be Long
+              // - Smaller values should remain Int for backward compatibility
+              // Calendar timestamps in milliseconds exceed Int.MAX_VALUE (2,147,483,647)
+              if (value > Int.MAX_VALUE || value < Int.MIN_VALUE) {
+                value.toLong()
+              } else {
+                value.toInt()
+              }
+            }
+            else -> value
+          }
         }
         intent.putExtras(valuesList.toBundle())
       }


### PR DESCRIPTION
# Why

Fixes #16958 - Calendar event intents fail with ClassCastException when passing `beginTime`/`endTime` parameters because JavaScript numbers (doubles) were being converted to ints, but calendar timestamps exceed `Int.MAX_VALUE` and require `Long` type.

From the issue:
```
Key beginTime expected Long but value was a java.lang.Double. The default value -1 was returned.
java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.Long
```

# How

Modified `IntentLauncherModule.kt` to use magnitude-based type conversion:
- Values exceeding `Int.MAX_VALUE` or below `Int.MIN_VALUE` are converted to `Long`
- Smaller values remain as `Int` for backward compatibility
- This handles calendar timestamps (milliseconds since epoch) which are typically 13 digits and exceed the int range

# Test Plan

Tested with calendar intent using current timestamps:

```javascript
import * as IntentLauncher from 'expo-intent-launcher';

const now = Date.now(); // e.g., 1737463200000 (exceeds Int.MAX_VALUE: 2147483647)
const oneHourLater = now + (60 * 60 * 1000);

await IntentLauncher.startActivityAsync('android.intent.action.INSERT', {
  data: 'content://com.android.calendar/events',
  extra: {
    title: 'Test Event',
    beginTime: now,
    endTime: oneHourLater,
    allDay: false
  }
});
```

**Before fix:**
- ❌ ClassCastException in logcat
- ❌ Calendar opens but date/time fields are empty

**After fix:**
- ✅ No exceptions
- ✅ Calendar opens with date and time pre-filled correctly
- ✅ Backward compatibility maintained for smaller numeric values

---

**Checklist:**

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
