### PR TITLE
[docs] Add support for compound subcomponents  in TypeDoc

### DIFF
--- a/docs/components/plugins/api/APISectionCompoundNames.test.ts
+++ b/docs/components/plugins/api/APISectionCompoundNames.test.ts
@@ -1,5 +1,5 @@
 import { GeneratedData, PropData, TypeDefinitionData, TypeDocKind } from './APIDataTypes';
-import { buildCompoundNameByComponent } from './APISectionCompoundNames';
+import { buildCompoundNameByComponent, deriveComponentsFromProps } from './APISectionCompoundNames';
 
 const makeComponentType = (propsName: string): TypeDefinitionData => ({
   type: 'reference',
@@ -62,5 +62,38 @@ describe('buildCompoundNameByComponent', () => {
     expect(result).toEqual({
       Tab: 'Tabs.Tab',
     });
+  });
+});
+
+describe('deriveComponentsFromProps', () => {
+  test('derives components from prop types when not exported', () => {
+    const menu = makeComponent('Menu', 'MenuProps', [
+      makeProp('Item', makeComponentType('MenuItemProps')),
+    ]);
+
+    const result = deriveComponentsFromProps([menu]).map(entry => entry.name);
+
+    expect(result).toEqual(['Menu', 'MenuItem']);
+  });
+
+  test('derives nested components from compound component properties', () => {
+    const menuItem = makeComponent('MenuItem', 'MenuItemProps', [
+      makeProp('Icon', makeComponentType('MenuItemIconProps')),
+    ]);
+    const menu = makeComponent('Menu', 'MenuProps', [
+      makeProp('Item', makeComponentType('MenuItemProps')),
+    ]);
+
+    const result = deriveComponentsFromProps([menu, menuItem]).map(entry => entry.name);
+
+    expect(result).toEqual(['Menu', 'MenuItem', 'MenuItemIcon']);
+  });
+
+  test('derives components from string default values', () => {
+    const tabs = makeComponent('Tabs', 'TabsProps', [makeProp('Tab', undefined, 'Tab')]);
+
+    const result = deriveComponentsFromProps([tabs]).map(entry => entry.name);
+
+    expect(result).toEqual(['Tabs', 'Tab']);
   });
 });


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Docs should list nested components like `NativeTabs.Trigger.Icon` even when only `NativeTabs` is exported.

Example structure:

```ts
import type { FC } from 'react';

type NativeTabsProps = {};
type NativeTabTriggerProps = {};
type NativeTabsTriggerIconProps = {};

// leaf component
const NativeTabsTriggerIcon: FC<NativeTabsTriggerIconProps> = () => null;

// subcomponent
const NativeTabTrigger = Object.assign(
  (props: NativeTabTriggerProps) => null,
  {
    Icon: NativeTabsTriggerIcon,
  }
);

// parent component
export const NativeTabs = Object.assign(
  (props: NativeTabsProps) => null,
  {
    Trigger: NativeTabTrigger,
  }
);
```


# How

<!--
How did you build this feature or fix this bug and why?
-->

- Derive missing component entries from attached properties (so `NativeTabs.Trigger.*` still appears without direct exports).
- Keep compound display names via `buildCompoundNameByComponent`.
- Scope derivation to` expo-router*` package only for now. (While testing it, I've seen some changes in packages like Camera whic I am not sure are required to be exposed to docs or not -- requires in-depth analysis later)
- Refactor compound-name helpers to avoid duplication and add tests.
- Allow string `defaultValue` props to produce derived components.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn run test`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
