### PR TITLE
[image] Add tvOS SymbolEffectOptions availability check

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### 🐛 Bug fixes
 
 - [android] Fix loading delayed placeholder ([#40956](https://github.com/expo/expo/pull/40956) by [@kosmydel](https://github.com/kosmydel))
+- Fix tvOS SymbolEffectOptions availability check ([#42393](https://github.com/expo/expo/pull/42393) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -653,13 +653,13 @@ public final class ImageView: ExpoView {
       case .none: sdImageView.addSymbolEffect(.breathe, options: options)
       }
     default:
-      if #available(iOS 26.0, *) {
+      if #available(iOS 26.0, tvOS 26.0, *) {
         applySymbolEffectiOS26(effect: effect, scope: scope, options: options)
       }
     }
   }
 
-  @available(iOS 26.0, tvOS 17.0, *)
+  @available(iOS 26.0, tvOS 26.0, *)
   private func applySymbolEffectiOS26(effect: SFSymbolEffectType, scope: SFSymbolEffectScope?, options: SymbolEffectOptions) {
     switch effect {
     case .drawOn:

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -659,7 +659,7 @@ public final class ImageView: ExpoView {
     }
   }
 
-  @available(iOS 26.0, *)
+  @available(iOS 26.0, tvOS 17.0, *)
   private func applySymbolEffectiOS26(effect: SFSymbolEffectType, scope: SFSymbolEffectScope?, options: SymbolEffectOptions) {
     switch effect {
     case .drawOn:


### PR DESCRIPTION
# Why

tvOS CI is failing because `'SymbolEffectOptions' is only available in tvOS 17.0 or newer`

https://expo.dev/accounts/expo-ci/projects/expo-workflow-testing/workflows/019be18c-7cbb-7a69-8d46-5959e2d7b74b#job-019be18c-81ba-747e-bbbb-4ae29b0c253d

# How

Add tvOS SymbolEffectOptions availability check to expo-image

# Test Plan

CI should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
