### PR TITLE
patch(cli): Disable IPv6 Bonjour advertising for now

### DIFF
--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -74,7 +74,7 @@
     "compression": "^1.7.4",
     "connect": "^3.7.0",
     "debug": "^4.3.4",
-    "dnssd-advertise": "^1.0.8",
+    "dnssd-advertise": "^1.1.1",
     "env-editor": "^0.4.1",
     "expo-server": "^55.0.0",
     "freeport-async": "^2.0.0",

--- a/packages/@expo/cli/src/start/server/Bonjour.ts
+++ b/packages/@expo/cli/src/start/server/Bonjour.ts
@@ -37,6 +37,7 @@ export class Bonjour {
       protocol: 'tcp',
       hostname: exp.slug,
       port: this.port,
+      stack: 'IPv4',
       txt: {
         name: exp.name?.slice(0, 255),
         slug: exp.slug?.slice(0, 255),

--- a/yarn.lock
+++ b/yarn.lock
@@ -7315,10 +7315,10 @@ dlv@^1.1.3:
   resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
 
-dnssd-advertise@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/dnssd-advertise/-/dnssd-advertise-1.0.8.tgz#48f0c7076a428bc97d7a3d422378633da56b2275"
-  integrity sha512-0+ouQ7nB/MWx4Y4xvyORFehT3izvCTOaGWZOfHY+oX1wQ1MnmZMB/HPPh5mC8JiquFilHZgLsWGN1rVBHfEywQ==
+dnssd-advertise@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/dnssd-advertise/-/dnssd-advertise-1.1.1.tgz#5ed075133854c252b64eebeb784960c3994b0d3d"
+  integrity sha512-5lwwxSitFrESlnv0JQhmhFlBAD6I97ghwo/xfNio1SajbZgsqq3OQY4kELcJiK/j38fgJFbeIDotAjSGcI85eg==
 
 doctrine@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
# Why

Previous PRs for DNS-SD: #42385, #42138

This switches us to single-stack IPv4 advertising. While testing #42384 with a real iOS device I've noticed that react-native's and other URL-building/connection logic fail to parse/reuse valid IPv6 URLs which breaks apps.

Disabling IPv6 support here rather than in the `expo-dev-launcher` code isn't ideal, since launching an IPv6 URL will still break all dev clients, but this is an unrelated problem. We also can't force `NWConnection` to ignore IPv6 records, it seems.

# How

- Bump `dnssd-advertise` and pass `stack: 'IPv4', See: https://github.com/kitten/dnssd-advertise/pull/17

# Test Plan

- Can only be verified from a remote device that's on an IPv6 network; IPv6 advertising is disabled
- Alternatively, resolve with `dns-sd` CLI and check AAAA

# Checklist

Changelog skipped, since this is for an unstable feature and a patch.

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
