### PR TITLE
[templates] Add disableTransparentOnScrollEdge prop to NativeTabs

### DIFF
--- a/templates/expo-template-default/src/components/app-tabs.native.tsx
+++ b/templates/expo-template-default/src/components/app-tabs.native.tsx
@@ -12,7 +12,8 @@ export default function AppTabs() {
     <NativeTabs
       backgroundColor={colors.background}
       indicatorColor={colors.backgroundElement}
-      labelStyle={{ selected: { color: colors.text } }}>
+      labelStyle={{ selected: { color: colors.text } }}
+      disableTransparentOnScrollEdge>
       <NativeTabs.Trigger name="index">
         <NativeTabs.Trigger.Label>Home</NativeTabs.Trigger.Label>
         <NativeTabs.Trigger.Icon src={require('@/assets/images/tabIcons/home.png')} />


### PR DESCRIPTION
# Why

This prevents bottom tab being transparent on iOS 18

# Test Plan

<img width="524" height="1040" alt="Screenshot 2026-01-21 at 5 46 42 PM" src="https://github.com/user-attachments/assets/480c6894-d230-4184-9807-326fbcbfa506" />
