### PR TITLE
[cli] Fix crash when Expo Go URL is undefined for SDK version

### DIFF
--- a/packages/@expo/cli/src/utils/downloadExpoGoAsync.ts
+++ b/packages/@expo/cli/src/utils/downloadExpoGoAsync.ts
@@ -88,7 +88,13 @@ export async function downloadExpoGoAsync(
       const version = await getExpoGoVersionEntryAsync(sdkVersion);
 
       debug(`Installing Expo Go version for SDK ${sdkVersion} at URL: ${version[versionsKey]}`);
-      url = version[versionsKey] as string;
+      url = version[versionsKey] as string | undefined;
+
+      if (!url) {
+        throw new CommandError(
+          `Unable to find Expo Go URL for SDK ${sdkVersion} on ${platform}. The Expo Go client may not be available for this SDK version.`
+        );
+      }
     }
   } catch (error) {
     spinner.fail();


### PR DESCRIPTION
## Summary
- Add validation for Expo Go app URL before attempting to parse it
- Throws a clear error message instead of crashing with `TypeError: The "path" argument must be of type string. Received undefined`
- This can happen during beta release process when SDK versions are published before Expo Go builds are available

## Test plan
Tested locally by triggering the condition where an SDK version exists but doesn't have an `iosClientUrl` or `androidClientUrl` set.