### PR TITLE
[brownfield] Align commands with expo cli

### DIFF
--- a/docs/pages/versions/unversioned/sdk/brownfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/brownfield.mdx
@@ -142,11 +142,11 @@ The `expo-brownfield` library includes a CLI for building and publishing to Mave
 
 ### Commands
 
-#### `build-android`
+#### `build:android`
 
 Builds and publishes the brownfield library and its dependencies to Maven repositories.
 
-<Terminal cmd={['$ npx expo-brownfield build-android [options]']} />
+<Terminal cmd={['$ npx expo-brownfield build:android [options]']} />
 
 | Option                 | Description                                    |
 | ---------------------- | ---------------------------------------------- |
@@ -158,11 +158,11 @@ Builds and publishes the brownfield library and its dependencies to Maven reposi
 | `-t, --task`           | Specify Gradle publish tasks to run            |
 | `--verbose`            | Include all logs from subprocesses             |
 
-#### `build-ios`
+#### `build:ios`
 
 Builds the brownfield XCFramework and copies the Hermes XCFramework to the artifacts directory.
 
-<Terminal cmd={['$ npx expo-brownfield build-ios [options]']} />
+<Terminal cmd={['$ npx expo-brownfield build:ios [options]']} />
 
 | Option              | Description                                              |
 | ------------------- | -------------------------------------------------------- |
@@ -173,11 +173,11 @@ Builds the brownfield XCFramework and copies the Hermes XCFramework to the artif
 | `-x, --xcworkspace` | Xcode workspace path                                     |
 | `--verbose`         | Include all logs from subprocesses                       |
 
-#### `tasks-android`
+#### `tasks:android`
 
 Lists all available publish tasks and Maven repositories.
 
-<Terminal cmd={['$ npx expo-brownfield tasks-android']} />
+<Terminal cmd={['$ npx expo-brownfield tasks:android']} />
 
 ## API
 

--- a/packages/expo-brownfield/cli/build/commands/commands.js
+++ b/packages/expo-brownfield/cli/build/commands/commands.js
@@ -5,16 +5,16 @@ const android_1 = require("./android");
 const general_1 = require("./general");
 const ios_1 = require("./ios");
 exports.Commands = {
-    'build-android': {
+    'build:android': {
         run: android_1.runBuildAndroid,
     },
-    'build-ios': {
+    'build:ios': {
         run: ios_1.runBuildIos,
     },
     help: {
         run: general_1.runHelp,
     },
-    'tasks-android': {
+    'tasks:android': {
         run: android_1.runTasksAndroid,
     },
     version: {

--- a/packages/expo-brownfield/cli/build/commands/resolve.js
+++ b/packages/expo-brownfield/cli/build/commands/resolve.js
@@ -13,10 +13,10 @@ const resolveCommand = () => {
         return commands_1.Commands.version;
     }
     const command = args['_']?.length > 0 ? args['_'][0] : '';
-    if (command === 'build-android' || command === 'tasks-android') {
+    if (command === 'build:android' || command === 'tasks:android') {
         return (0, exports.resolveAndroid)(command);
     }
-    if (command === 'build-ios') {
+    if (command === 'build:ios') {
         return (0, exports.resolveIos)();
     }
     return constants_1.Errors.unknownCommand();
@@ -27,6 +27,6 @@ const resolveAndroid = (command) => {
 };
 exports.resolveAndroid = resolveAndroid;
 const resolveIos = () => {
-    return commands_1.Commands['build-ios'];
+    return commands_1.Commands['build:ios'];
 };
 exports.resolveIos = resolveIos;

--- a/packages/expo-brownfield/cli/build/commands/types.d.ts
+++ b/packages/expo-brownfield/cli/build/commands/types.d.ts
@@ -1,6 +1,6 @@
 export type GeneralCommand = 'help' | 'version';
-export type AndroidCommand = 'build-android' | 'tasks-android';
-export type IosCommand = 'build-ios';
+export type AndroidCommand = 'build:android' | 'tasks:android';
+export type IosCommand = 'build:ios';
 export type Command = GeneralCommand | AndroidCommand | IosCommand;
 export interface CommandEntry {
     run: () => Promise<void>;

--- a/packages/expo-brownfield/cli/build/constants/errors.js
+++ b/packages/expo-brownfield/cli/build/constants/errors.js
@@ -35,7 +35,7 @@ const parseArgsError = () => {
 const unknownCommandError = () => {
     console.error(`
 Error: unknown command
-Supported commands: build-android, build-ios, tasks-android`);
+Supported commands: build:android, build:ios, tasks:android`);
     return process.exit(1);
 };
 /**

--- a/packages/expo-brownfield/cli/build/constants/help.js
+++ b/packages/expo-brownfield/cli/build/constants/help.js
@@ -37,17 +37,17 @@ const commonBuildOptions = [
 const generalHelp = (0, utils_1.helpMessage)({
     commands: [
         {
-            command: 'build-android',
+            command: 'build:android',
             description: 'build and publish Android brownfield artifacts',
             hasOptions: true,
         },
         {
-            command: 'build-ios',
+            command: 'build:ios',
             description: 'build iOS brownfield artifacts',
             hasOptions: true,
         },
         {
-            command: 'tasks-android',
+            command: 'tasks:android',
             description: 'list available publishing tasks and repositories for android',
             hasOptions: true,
         },
@@ -62,12 +62,12 @@ const generalHelp = (0, utils_1.helpMessage)({
     ],
 });
 /**
- * Help message for 'build-android' command
+ * Help message for 'build:android' command
  */
 const buildAndroidHelp = (0, utils_1.helpMessage)({
-    promptCommand: 'build-android',
+    promptCommand: 'build:android',
     options: [
-        helpOption("'build-android'"),
+        helpOption("'build:android'"),
         ...commonBuildOptions,
         {
             description: 'build both debug and release configurations',
@@ -92,9 +92,9 @@ const buildAndroidHelp = (0, utils_1.helpMessage)({
     ],
 });
 const tasksAndroidHelp = (0, utils_1.helpMessage)({
-    promptCommand: 'tasks-android',
+    promptCommand: 'tasks:android',
     options: [
-        helpOption("'tasks-android'"),
+        helpOption("'tasks:android'"),
         {
             description: 'output all subcommands output to the terminal',
             option: '--verbose',
@@ -107,12 +107,12 @@ const tasksAndroidHelp = (0, utils_1.helpMessage)({
     ],
 });
 /**
- * Help message for 'build-ios' command
+ * Help message for 'build:ios' command
  */
 const buildIosHelp = (0, utils_1.helpMessage)({
-    promptCommand: 'build-ios',
+    promptCommand: 'build:ios',
     options: [
-        helpOption("'build-ios'"),
+        helpOption("'build:ios'"),
         ...commonBuildOptions,
         {
             description: 'path to artifacts directory',

--- a/packages/expo-brownfield/cli/src/commands/commands.ts
+++ b/packages/expo-brownfield/cli/src/commands/commands.ts
@@ -4,16 +4,16 @@ import { runBuildIos } from './ios';
 import { CommandsMap } from './types';
 
 export const Commands: CommandsMap = {
-  'build-android': {
+  'build:android': {
     run: runBuildAndroid,
   },
-  'build-ios': {
+  'build:ios': {
     run: runBuildIos,
   },
   help: {
     run: runHelp,
   },
-  'tasks-android': {
+  'tasks:android': {
     run: runTasksAndroid,
   },
   version: {

--- a/packages/expo-brownfield/cli/src/commands/resolve.ts
+++ b/packages/expo-brownfield/cli/src/commands/resolve.ts
@@ -14,10 +14,10 @@ export const resolveCommand = (): CommandEntry => {
   }
 
   const command = args['_']?.length > 0 ? args['_'][0] : '';
-  if (command === 'build-android' || command === 'tasks-android') {
+  if (command === 'build:android' || command === 'tasks:android') {
     return resolveAndroid(command);
   }
-  if (command === 'build-ios') {
+  if (command === 'build:ios') {
     return resolveIos();
   }
 
@@ -29,5 +29,5 @@ export const resolveAndroid = (command: AndroidCommand): CommandEntry => {
 };
 
 export const resolveIos = (): CommandEntry => {
-  return Commands['build-ios'];
+  return Commands['build:ios'];
 };

--- a/packages/expo-brownfield/cli/src/commands/types.ts
+++ b/packages/expo-brownfield/cli/src/commands/types.ts
@@ -1,6 +1,6 @@
 export type GeneralCommand = 'help' | 'version';
-export type AndroidCommand = 'build-android' | 'tasks-android';
-export type IosCommand = 'build-ios';
+export type AndroidCommand = 'build:android' | 'tasks:android';
+export type IosCommand = 'build:ios';
 
 export type Command = GeneralCommand | AndroidCommand | IosCommand;
 

--- a/packages/expo-brownfield/cli/src/constants/errors.ts
+++ b/packages/expo-brownfield/cli/src/constants/errors.ts
@@ -36,7 +36,7 @@ const parseArgsError = () => {
 const unknownCommandError = () => {
   console.error(`
 Error: unknown command
-Supported commands: build-android, build-ios, tasks-android`);
+Supported commands: build:android, build:ios, tasks:android`);
   return process.exit(1);
 };
 

--- a/packages/expo-brownfield/cli/src/constants/help.ts
+++ b/packages/expo-brownfield/cli/src/constants/help.ts
@@ -37,17 +37,17 @@ const commonBuildOptions = [
 const generalHelp = helpMessage({
   commands: [
     {
-      command: 'build-android',
+      command: 'build:android',
       description: 'build and publish Android brownfield artifacts',
       hasOptions: true,
     },
     {
-      command: 'build-ios',
+      command: 'build:ios',
       description: 'build iOS brownfield artifacts',
       hasOptions: true,
     },
     {
-      command: 'tasks-android',
+      command: 'tasks:android',
       description: 'list available publishing tasks and repositories for android',
       hasOptions: true,
     },
@@ -63,12 +63,12 @@ const generalHelp = helpMessage({
 });
 
 /**
- * Help message for 'build-android' command
+ * Help message for 'build:android' command
  */
 const buildAndroidHelp = helpMessage({
-  promptCommand: 'build-android',
+  promptCommand: 'build:android',
   options: [
-    helpOption("'build-android'"),
+    helpOption("'build:android'"),
     ...commonBuildOptions,
     {
       description: 'build both debug and release configurations',
@@ -94,9 +94,9 @@ const buildAndroidHelp = helpMessage({
 });
 
 const tasksAndroidHelp = helpMessage({
-  promptCommand: 'tasks-android',
+  promptCommand: 'tasks:android',
   options: [
-    helpOption("'tasks-android'"),
+    helpOption("'tasks:android'"),
     {
       description: 'output all subcommands output to the terminal',
       option: '--verbose',
@@ -110,12 +110,12 @@ const tasksAndroidHelp = helpMessage({
 });
 
 /**
- * Help message for 'build-ios' command
+ * Help message for 'build:ios' command
  */
 const buildIosHelp = helpMessage({
-  promptCommand: 'build-ios',
+  promptCommand: 'build:ios',
   options: [
-    helpOption("'build-ios'"),
+    helpOption("'build:ios'"),
     ...commonBuildOptions,
     {
       description: 'path to artifacts directory',


### PR DESCRIPTION
# Why

Expo cli commands use `:` instead of `-` to specify the platform. We should use the same pattern across expo tools

# How

Rename brownfield cli commands to use `:` instead of `-`

# Test Plan

Run `npx expo-brownfield build:android` and `npx expo-brownfield build:ios`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
