### PR TITLE
[modules-core][macos] Remove react-native-macos@0.79.0 workarounds

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [macos] Remove react-native-macos@0.79.0 workarounds ([#42409](https://github.com/expo/expo/pull/42409) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 55.0.1 — 2026-01-22
 
 _This version does not introduce any user-facing changes._
@@ -49,7 +51,13 @@ _This version does not introduce any user-facing changes._
 ### 🐛 Bug fixes
 
 - [Android] Fixed DSL view props using stale state when updating. ([#41622](https://github.com/expo/expo/pull/41622) by [@kimchi-developer](https://github.com/kimchi-developer))
+  <<<<<<< HEAD
 - [core] Fixed `useReleasingSharedObject` to defer releasing until after render.
+  ||||||| parent of b5ea16893de (Add changelog entry)
+  - [core] Fixed `useReleasingSharedObject` to defer releasing until after render.
+  =======
+  - [core] Fixed `useReleasingSharedObject` to defer releasing until after render.
+  > > > > > > > b5ea16893de (Add changelog entry)
 - [android] Fix source sets for events for functional view definitions. ([#41685](https://github.com/expo/expo/pull/41685) by [@aleqsio](https://github.com/aleqsio))
 - [iOS] Fix throwing `InvalidArgsNumberException` when declaring `AsyncFunction` with optional arguments and `Promise`. ([#41054](https://github.com/expo/expo/pull/41054) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] fix queue assertion crash ([#41296](https://github.com/expo/expo/pull/41296) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -51,13 +51,7 @@ _This version does not introduce any user-facing changes._
 ### 🐛 Bug fixes
 
 - [Android] Fixed DSL view props using stale state when updating. ([#41622](https://github.com/expo/expo/pull/41622) by [@kimchi-developer](https://github.com/kimchi-developer))
-  <<<<<<< HEAD
-- [core] Fixed `useReleasingSharedObject` to defer releasing until after render.
-  ||||||| parent of b5ea16893de (Add changelog entry)
-  - [core] Fixed `useReleasingSharedObject` to defer releasing until after render.
-  =======
-  - [core] Fixed `useReleasingSharedObject` to defer releasing until after render.
-  > > > > > > > b5ea16893de (Add changelog entry)
+- [core] Fixed `useReleasingSharedObject` to defer releasing until after render.
 - [android] Fix source sets for events for functional view definitions. ([#41685](https://github.com/expo/expo/pull/41685) by [@aleqsio](https://github.com/aleqsio))
 - [iOS] Fix throwing `InvalidArgsNumberException` when declaring `AsyncFunction` with optional arguments and `Promise`. ([#41054](https://github.com/expo/expo/pull/41054) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] fix queue assertion crash ([#41296](https://github.com/expo/expo/pull/41296) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
@@ -28,7 +28,6 @@ jsi::Value convertNSNumberToJSINumber(jsi::Runtime &runtime, NSNumber *value)
 
 jsi::String convertNSStringToJSIString(jsi::Runtime &runtime, NSString *value)
 {
-#if !TARGET_OS_OSX
   const uint8_t *utf8 = (const uint8_t *)[value UTF8String];
   const size_t length = [value length];
 
@@ -37,10 +36,6 @@ jsi::String convertNSStringToJSIString(jsi::Runtime &runtime, NSString *value)
   }
   // Using cStringUsingEncoding should be fine as long as we provide the length.
   return jsi::String::createFromUtf16(runtime, (const char16_t *)[value cStringUsingEncoding:NSUTF16StringEncoding], length);
-#else
-  // TODO(@jakex7): Remove after update to react-native-macos@0.79.0
-  return jsi::String::createFromUtf8(runtime, [value UTF8String]);
-#endif
 }
 
 jsi::String convertNSURLToJSIString(jsi::Runtime &runtime, NSURL *value)
@@ -228,7 +223,7 @@ id convertJSIValueToObjCObjectAsDictValue(jsi::Runtime &runtime, const jsi::Valu
     }
     return convertJSIObjectToNSDictionary(runtime, o, jsInvoker);
   }
-  
+
   throw std::runtime_error("Unsupported jsi::jsi::Value kind");
 }
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [macos] Remove react-native-macos@0.79.0 workarounds ([#42409](https://github.com/expo/expo/pull/42409) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [macOS] Remove react-native-macos@0.79.0 workarounds ([#42409](https://github.com/expo/expo/pull/42409) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 55.0.0-preview.2 — 2026-01-22
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [macos] Remove react-native-macos@0.79.0 workarounds ([#42409](https://github.com/expo/expo/pull/42409) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 55.0.0-preview.2 — 2026-01-22
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
@@ -13,8 +13,6 @@ public class ExpoReactNativeFactory: ExpoReactNativeFactoryObjC, ExpoReactNative
     )
   }()
 
-  // TODO: Remove check when react-native-macos 0.81 is released
-  #if !os(macOS)
   @objc public override init(delegate: any RCTReactNativeFactoryDelegate) {
     let releaseLevel = (Bundle.main.object(forInfoDictionaryKey: "ReactNativeReleaseLevel") as? String)
       .flatMap { [
@@ -27,7 +25,6 @@ public class ExpoReactNativeFactory: ExpoReactNativeFactoryObjC, ExpoReactNative
 
     super.init(delegate: delegate, releaseLevel: releaseLevel)
   }
-  #endif
 
   @MainActor
   @objc func createRCTRootViewFactory() -> RCTRootViewFactory {


### PR DESCRIPTION
# Why

Now that react-native-macos 0.81 is out, we no longer need to maintain the workaround in EXJSIConversions and ExpoReactNativeFactory

# How

Remove react-native-macos@0.79.0 workarounds

# Test Plan

Run BareExpo macos locally 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
