### PR TITLE
[expo] Add expo-brownfield to bundledNativeModules

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -26,6 +26,7 @@
   "expo-battery": "~55.0.0",
   "expo-blur": "~55.0.0",
   "expo-brightness": "~55.0.0",
+  "expo-brownfield": "~55.0.0",
   "expo-build-properties": "~55.0.0",
   "expo-calendar": "~55.0.0",
   "expo-camera": "~55.0.0",


### PR DESCRIPTION
# Why

We forgot to add `expo-brownfield` to bundledNativeModules.json

# How

Add expo-brownfield to bundledNativeModules

# Test Plan

N / A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
