### PR TITLE
[tools] Fix SDK tag assignment to use release version

### DIFF
--- a/tools/src/publish-packages/tasks/publishPackages.ts
+++ b/tools/src/publish-packages/tasks/publishPackages.ts
@@ -68,11 +68,11 @@ export const publishPackages = new Task<TaskArgs>(
         });
         // Assign SDK tag when package is a template
         if (pkg.isTemplate() && !options.canary) {
-          const sdkTag = `sdk-${semver.major(pkg.packageVersion)}`;
+          const sdkTag = `sdk-${semver.major(releaseVersion)}`;
           logger.log('  ', `Assigning ${yellow(sdkTag)} tag to ${green(pkg.packageName)}`);
           if (!options.dry) {
             await sleepAsync(1000); // wait for npm to process the package
-            await Npm.addTagAsync(pkg.packageName, pkg.packageVersion, sdkTag, {
+            await Npm.addTagAsync(pkg.packageName, releaseVersion, sdkTag, {
               stdio: requiresOTP ? 'inherit' : undefined,
             });
           }


### PR DESCRIPTION
## Summary
- Fix template SDK tag (e.g., `sdk-55`) being assigned to the wrong version during publish
- The bug caused tags to point to the pre-publish version (`pkg.packageVersion`) instead of the actual published version (`releaseVersion`)

### Root cause
The `updatePackageVersions` task writes the new version to `package.json` on disk but doesn't update the in-memory `pkg.packageJson.version`. When `publishPackages` runs later, `pkg.packageVersion` still returns the stale pre-publish version.

Example of the bug:
```
+ expo-template-blank@55.0.1
   Assigning sdk-55 tag to expo-template-blank
npm warn dist-tag add sdk-55 is already set to version 55.0.0  ← tried to tag 55.0.0 instead of 55.0.1
```

## Test plan
- [ ] Publish a template with a version bump and verify the SDK tag points to the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)