### PR TITLE
[cli] Move `start` QR code to end of output

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unpublished
 
+- Move `start` QR code to end of output. ([#42416](https://github.com/expo/expo/pull/42416)) by [@jonsamp](https://github.com/jonsamp)
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/packages/@expo/cli/src/start/interface/interactiveActions.ts
+++ b/packages/@expo/cli/src/start/interface/interactiveActions.ts
@@ -84,12 +84,11 @@ export class DevServerManagerActions {
     Log.log();
 
     if (options.devClient === false) {
-      Log.log(printItem('Scan the QR code below to open the project in Expo Go.'));
+      Log.log(printItem('Scan the QR code to open in Expo Go.'));
     } else {
       Log.log(
         printItem(
-          'Scan the QR code below to open the project in a development build. ' +
-            learnMore('https://expo.fyi/start')
+          'Scan the QR code to open in a development build. ' + learnMore('https://expo.fyi/start')
         )
       );
     }

--- a/packages/@expo/cli/src/start/interface/interactiveActions.ts
+++ b/packages/@expo/cli/src/start/interface/interactiveActions.ts
@@ -30,6 +30,8 @@ export class DevServerManagerActions {
   printDevServerInfo(
     options: Pick<StartOptions, 'devClient' | 'isWebSocketsEnabled' | 'platforms'>
   ) {
+    let qrCodeUrl: string | null = null;
+
     // If native dev server is running, print its URL.
     if (this.devServerManager.getNativeDevServerPort()) {
       const devServer = this.devServerManager.getDefaultDevServer();
@@ -37,7 +39,7 @@ export class DevServerManagerActions {
         const nativeRuntimeUrl = devServer.getNativeRuntimeUrl()!;
         const interstitialPageUrl = devServer.getRedirectUrl();
 
-        printQRCode(interstitialPageUrl ?? nativeRuntimeUrl);
+        qrCodeUrl = interstitialPageUrl ?? nativeRuntimeUrl;
 
         if (interstitialPageUrl) {
           Log.log(
@@ -55,17 +57,6 @@ export class DevServerManagerActions {
         }
 
         Log.log(printItem(chalk`Metro waiting on {underline ${nativeRuntimeUrl}}`));
-        if (options.devClient === false) {
-          // TODO: if development build, change this message!
-          Log.log(printItem('Scan the QR code above to open the project in Expo Go.'));
-        } else {
-          Log.log(
-            printItem(
-              'Scan the QR code above to open the project in a development build. ' +
-                learnMore('https://expo.fyi/start')
-            )
-          );
-        }
       } catch (error) {
         console.log('err', error);
         // @ts-ignore: If there is no development build scheme, then skip the QR code.
@@ -91,6 +82,20 @@ export class DevServerManagerActions {
     printUsage(options, { verbose: false });
     printHelp();
     Log.log();
+
+    if (options.devClient === false) {
+      Log.log(printItem('Scan the QR code below to open the project in Expo Go.'));
+    } else {
+      Log.log(
+        printItem(
+          'Scan the QR code below to open the project in a development build. ' +
+            learnMore('https://expo.fyi/start')
+        )
+      );
+    }
+    if (qrCodeUrl) {
+      printQRCode(qrCodeUrl);
+    }
   }
 
   async openJsInspectorAsync() {


### PR DESCRIPTION
# Why

When running `start`, the QR code is above the instructions for how to interact with the CLI. Since the QR code is required to connect to a local server, it causes users to have to scroll up a bit to see the full QR code. We can make this smoother by showing the QR code at the end of the output, so once a user runs `start`, they can just scan the code.

Also, the text about scanning the QR code currently is below the message about where Metro is running. I think we can put the QR code and its message next to each other.

# How

This PR moves the QR code to the end of the output, so that it's more likely to be visible. The instructions on how to use the CLI now appear above the QR code.

I also updated the copy about the QR code to be shorter.

# Test Plan

## Before
### Development build QR code

<img width="912" height="744" alt="Screenshot 2026-01-21 at 10 52 45 PM" src="https://github.com/user-attachments/assets/cfd2c01e-fabf-411c-9d9c-99a038c8efc9" />

### Expo Go QR code

<img width="912" height="744" alt="Screenshot 2026-01-21 at 10 52 47 PM" src="https://github.com/user-attachments/assets/b350e5f7-23d0-446e-b984-41a0a1baf5da" />

## After
### Development build QR code

<img width="912" height="744" alt="Screenshot 2026-01-21 at 11 06 51 PM" src="https://github.com/user-attachments/assets/093a26f6-99a5-4b26-9cdd-bae4fe19078c" />

### Expo Go QR code

<img width="912" height="744" alt="Screenshot 2026-01-21 at 11 06 53 PM" src="https://github.com/user-attachments/assets/5650f82e-0d33-4b6b-be0f-f80aaa161538" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
