### PR TITLE
docs: improve static and server rendering documentation

### DIFF
--- a/docs/pages/router/web/server-rendering.mdx
+++ b/docs/pages/router/web/server-rendering.mdx
@@ -1,5 +1,5 @@
 ---
-title: Server Rendering
+title: Server rendering
 description: Learn how to render Expo Router routes dynamically at request time using server-side rendering (SSR).
 isAlpha: true
 ---
@@ -17,7 +17,7 @@ Server-side rendering (SSR) generates HTML dynamically on each request, as oppos
 
 <Step label="1">
 
-Enable Metro bundler and server output in your project's [app config](/versions/latest/config/app/):
+Enable server rendering in your project's [app config](/versions/latest/config/app/):
 
 ```json app.json
 {
@@ -25,26 +25,8 @@ Enable Metro bundler and server output in your project's [app config](/versions/
     /* @hide ... */
     /* @end */
     "web": {
-      /* @info Server rendering requires Metro bundler */
-      "bundler": "metro",
-      /* @end */
       "output": "server"
-    }
-  }
-}
-```
-
-</Step>
-
-<Step label="2">
-
-Enable server rendering in the `expo-router` plugin configuration:
-
-```json app.json
-{
-  "expo": {
-    /* @hide ... */
-    /* @end */
+    },
     "plugins": [
       [
         "expo-router",
@@ -61,24 +43,7 @@ Enable server rendering in the `expo-router` plugin configuration:
 
 </Step>
 
-<Step label="3">
-
-If you have a **metro.config.js** file in your project, ensure it extends `expo/metro-config`:
-
-```js metro.config.js
-const { getDefaultConfig } = require('expo/metro-config');
-
-/** @type {import('expo/metro-config').MetroConfig} */
-const config = getDefaultConfig(__dirname, {
-  // Additional features...
-});
-
-module.exports = config;
-```
-
-</Step>
-
-<Step label="4">
+<Step label="2">
 
 Start the development server:
 
@@ -88,7 +53,7 @@ Start the development server:
 
 ## Production
 
-To export your app for production, run the universal export command:
+To export your app for production, run the export command:
 
 <Terminal cmd={['$ npx expo export --platform web']} />
 

--- a/docs/pages/router/web/static-rendering.mdx
+++ b/docs/pages/router/web/static-rendering.mdx
@@ -1,5 +1,5 @@
 ---
-title: Static Rendering
+title: Static rendering
 description: Learn how to render routes to static HTML and CSS files with Expo Router.
 ---
 
@@ -14,7 +14,7 @@ To enable Search Engine Optimization (SEO) on the web you must statically render
 
 <Step label="1">
 
-Enable metro bundler and static rendering in the project's [app config](/versions/latest/config/app/):
+Enable static rendering in your project's [app config](/versions/latest/config/app/):
 
 ```json app.json
 {
@@ -22,9 +22,6 @@ Enable metro bundler and static rendering in the project's [app config](/version
     /* @hide ... */
     /* @end */
     "web": {
-      /* @info Static rendering is only supported with Metro bundler and Expo Router */
-      "bundler": "metro",
-      /* @end */
       "output": "static"
     }
   }
@@ -35,31 +32,6 @@ Enable metro bundler and static rendering in the project's [app config](/version
 
 <Step label="2">
 
-If you have a **metro.config.js** file in your project, ensure it extends **expo/metro-config** as shown below:
-
-```js metro.config.js
-const { getDefaultConfig } = require('expo/metro-config');
-
-/** @type {import('expo/metro-config').MetroConfig} */
-const config = getDefaultConfig(__dirname, {
-  // Additional features...
-});
-
-module.exports = config;
-```
-
-You can also learn more about [customizing Metro](/guides/customizing-metro/) .
-
-</Step>
-
-<Step label="3">
-
-Ensure Fast Refresh is configured. Expo Router requires at least `react-refresh@0.14.0`. Ensure you **do not** have any overrides or resolutions for `react-refresh` in your **package.json**.
-
-</Step>
-
-<Step label="4">
-
 Start the development server:
 
 <Terminal cmd={['$ npx expo start']} />
@@ -68,7 +40,7 @@ Start the development server:
 
 ## Production
 
-To bundle your static website for production, run the universal export command:
+To bundle your static website for production, run the export command:
 
 <Terminal cmd={['$ npx expo export --platform web']} />
 
@@ -77,7 +49,7 @@ You can test the production build locally by running the following command and o
 
 <Terminal cmd={['$ npx serve dist']} />
 
-This project can be deployed to almost every hosting service. Note that this is not a single-page application, nor does it contain a custom server API. This means dynamic routes (**app/[id].tsx**) will not arbitrarily work. You may need to build a serverless function to handle dynamic routes.
+This project can be deployed to almost every hosting service. Note that this is not a single-page application, nor does it contain a custom server API. This means dynamic routes (for example **app/[id].tsx**) will not arbitrarily work. You may need to build a serverless function to handle dynamic routes.
 
 ## Dynamic Routes
 
@@ -109,7 +81,7 @@ This will output a file for each post in the **dist** directory. For example, if
 
 <PaddedAPIBox header="generateStaticParams">
 
-A server-only function evaluated at build-time in a Node.js environment by Expo CLI. This means it has access to `__dirname`, `process.cwd()`, `process.env`, and more. It also has access to every environment variable that's available in the process. However, the values prefixed with `EXPO_PUBLIC_.generateStaticParams` do not run in a browser environment, so it cannot access browser APIs such as `localStorage` or `document`. It also cannot access native Expo APIs such as `expo-camera` or `expo-location`.
+A server-only function evaluated at build-time in a Node.js environment by Expo CLI. This means it has access to `__dirname`, `process.cwd()`, `process.env`, and more. It also has access to every environment variable that's available in the process. However, the values prefixed with `EXPO_PUBLIC_` do not run in a browser environment, so it cannot access browser APIs such as `localStorage` or `document`. It also cannot access native Expo APIs such as `expo-camera` or `expo-location`.
 
 ```tsx app/[id].tsx
 export async function generateStaticParams(): Promise<Record<string, string>[]> {
@@ -156,19 +128,19 @@ Since Expo Router compiles your code into a separate directory you cannot use `_
 Instead, use `process.cwd()`, which gives you the directory where the project is being compiled.
 
 ```tsx app/[category].tsx
-import fs from 'fs/promises';
-import path from 'path';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 
 export async function generateStaticParams(params: {
   id: string;
 }): Promise<Record<string, string>[]> {
-  const directory = await fs.readdir(path.join(process.cwd(), './posts/', category));
+  const directory = await fs.readdir(path.join(process.cwd(), './posts/'));
   const posts = directory.filter(fileOrSubDirectory => return path.extname(fileOrSubDirectory) === '.md')
 
-  return {
+  return [{
     id,
     posts,
-  };
+  }];
 }
 ```
 

--- a/docs/pages/router/web/static-rendering.mdx
+++ b/docs/pages/router/web/static-rendering.mdx
@@ -49,7 +49,7 @@ You can test the production build locally by running the following command and o
 
 <Terminal cmd={['$ npx serve dist']} />
 
-This project can be deployed to almost every hosting service. Note that this is not a single-page application, nor does it contain a custom server API. This means dynamic routes (for example **app/[id].tsx**) will not arbitrarily work. You may need to build a serverless function to handle dynamic routes.
+This project can be deployed to almost every hosting service. Note that this is not a single-page application, nor does it contain a custom server API. This means dynamic routes (for example, **app/[id].tsx**) will not arbitrarily work. You may need to build a serverless function to handle dynamic routes.
 
 ## Dynamic Routes
 


### PR DESCRIPTION
# Why

The static and server rendering guides both instruct users to set their `web.bundler` option to Metro, but this is unnecessary since Metro is already the default.

Additionally, the step advising users to ensure their `metro.config.js` extends from `expo/metro-config` has also been removed, since the default template doesn't include that file.

# How

Remove unnecessary steps from both the static and server rendering guides.

# Test Plan

- CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
