### PR TITLE
[widgets] Handle combined string arrays

### DIFF
--- a/packages/expo-widgets/ios/Widgets/DynamicView.swift
+++ b/packages/expo-widgets/ios/Widgets/DynamicView.swift
@@ -36,13 +36,14 @@ public struct WidgetsDynamicView: View, ExpoSwiftUI.AnyChild {
   public var body: some View {
     switch node["type"] as? String {
     case "Text":
-      if let rawProps = node["props"] as? [String: Any],
-         let children = rawProps["children"] as? String {
-        render(TextView.self, TextViewProps.self) { props in
-          props.text = children
+      render(TextView.self, TextViewProps.self) { props in
+        if let rawProps = node["props"] as? [String: Any] {
+          if let children = rawProps["children"] as? String {
+            props.text = children
+          } else if let childrenArray = rawProps["children"] as? [String] {
+            props.text = childrenArray.joined(separator: "")
+          }
         }
-      } else {
-        EmptyView()
       }
     case "HStack":
       render(HStackView.self, HStackViewProps.self, updateProps: updateChildren)


### PR DESCRIPTION
# Why

Passing strings like 
```tsx
<Text>Count: {props.count}</Text>
```
produces 
```json
{
  "type": "Text",
  "props": {
    "children": [
      "Count: ",
      "{{count}}"
    ]
  }
}
```
instead of 
```json
{
  "type": "Text",
  "props": {
    "children": "Count: {{count}}"
  }
}
```

# How

Handle arrays in Text's prop children

# Test Plan

```tsx
import { Text, VStack } from '@expo/ui/swift-ui';
import { updateWidgetSnapshot, WidgetProps } from 'expo-widgets';

type MyWidgetProps = {
  count: number;
};
const MyWidget = (props: WidgetProps<MyWidgetProps>) => {
  return (
    <VStack>
      <Text>Count: {props.count}</Text>
    </VStack>
  );
};
updateWidgetSnapshot('Widget2', MyWidget, { count: 5 });
```

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
