### PR TITLE
[templates] remove disableTransparentOnScrollEdge and move ScrollView to root

### DIFF
--- a/templates/expo-template-default/src/app/explore.tsx
+++ b/templates/expo-template-default/src/app/explore.tsx
@@ -34,102 +34,95 @@ export default function TabTwoScreen() {
   });
 
   return (
-    <ThemedView style={styles.root}>
-      <ScrollView
-        style={styles.scrollView}
-        contentInset={insets}
-        contentContainerStyle={[styles.contentContainer, contentPlatformStyle]}>
-        <ThemedView style={styles.container}>
-          <ThemedView style={styles.titleContainer}>
-            <ThemedText type="subtitle">Explore</ThemedText>
-            <ThemedText style={styles.centerText} themeColor="textSecondary">
-              This starter app includes example{'\n'}code to help you get started.
-            </ThemedText>
+    <ScrollView
+      style={[styles.scrollView, { backgroundColor: theme.background }]}
+      contentInset={insets}
+      contentContainerStyle={[styles.contentContainer, contentPlatformStyle]}>
+      <ThemedView style={styles.container}>
+        <ThemedView style={styles.titleContainer}>
+          <ThemedText type="subtitle">Explore</ThemedText>
+          <ThemedText style={styles.centerText} themeColor="textSecondary">
+            This starter app includes example{'\n'}code to help you get started.
+          </ThemedText>
 
-            <ExternalLink href="https://docs.expo.dev" asChild>
-              <Pressable style={({ pressed }) => pressed && styles.pressed}>
-                <ThemedView type="backgroundElement" style={styles.linkButton}>
-                  <ThemedText type="link">Expo documentation</ThemedText>
-                  <IconSymbol color={theme.text} name="arrow.up.right.square" size={12} />
-                </ThemedView>
-              </Pressable>
-            </ExternalLink>
-          </ThemedView>
-
-          <ThemedView style={styles.sectionsWrapper}>
-            <Collapsible title="File-based routing">
-              <ThemedText type="small">
-                This app has two screens: <ThemedText type="code">src/app/index.tsx</ThemedText>{' '}
-                and <ThemedText type="code">src/app/explore.tsx</ThemedText>
-              </ThemedText>
-              <ThemedText type="small">
-                The layout file in <ThemedText type="code">src/app/_layout.tsx</ThemedText> sets up
-                the tab navigator.
-              </ThemedText>
-              <ExternalLink href="https://docs.expo.dev/router/introduction">
-                <ThemedText type="linkPrimary">Learn more</ThemedText>
-              </ExternalLink>
-            </Collapsible>
-
-            <Collapsible title="Android, iOS, and web support">
-              <ThemedView type="backgroundElement" style={styles.collapsibleContent}>
-                <ThemedText type="small">
-                  You can open this project on Android, iOS, and the web. To open the web version,
-                  press <ThemedText type="smallBold">w</ThemedText> in the terminal running this
-                  project.
-                </ThemedText>
-                <Image
-                  source={require('@/assets/images/tutorial-web.png')}
-                  style={styles.imageTutorial}
-                />
+          <ExternalLink href="https://docs.expo.dev" asChild>
+            <Pressable style={({ pressed }) => pressed && styles.pressed}>
+              <ThemedView type="backgroundElement" style={styles.linkButton}>
+                <ThemedText type="link">Expo documentation</ThemedText>
+                <IconSymbol color={theme.text} name="arrow.up.right.square" size={12} />
               </ThemedView>
-            </Collapsible>
-
-            <Collapsible title="Images">
-              <ThemedText type="small">
-                For static images, you can use the <ThemedText type="code">@2x</ThemedText> and{' '}
-                <ThemedText type="code">@3x</ThemedText> suffixes to provide files for different
-                screen densities.
-              </ThemedText>
-              <Image source={require('@/assets/images/react-logo.png')} style={styles.imageReact} />
-              <ExternalLink href="https://reactnative.dev/docs/images">
-                <ThemedText type="linkPrimary">Learn more</ThemedText>
-              </ExternalLink>
-            </Collapsible>
-
-            <Collapsible title="Light and dark mode components">
-              <ThemedText type="small">
-                This template has light and dark mode support. The{' '}
-                <ThemedText type="code">useColorScheme()</ThemedText> hook lets you inspect what the
-                user&apos;s current color scheme is, and so you can adjust UI colors accordingly.
-              </ThemedText>
-              <ExternalLink href="https://docs.expo.dev/develop/user-interface/color-themes/">
-                <ThemedText type="linkPrimary">Learn more</ThemedText>
-              </ExternalLink>
-            </Collapsible>
-
-            <Collapsible title="Animations">
-              <ThemedText type="small">
-                This template includes an example of an animated component. The{' '}
-                <ThemedText type="code">src/components/ui/collapsible.tsx</ThemedText> component uses
-                the powerful <ThemedText type="code">react-native-reanimated</ThemedText> library to
-                animate opening this hint.
-              </ThemedText>
-            </Collapsible>
-          </ThemedView>
-          {Platform.OS === 'web' && <WebBadge />}
+            </Pressable>
+          </ExternalLink>
         </ThemedView>
-      </ScrollView>
-    </ThemedView>
+
+        <ThemedView style={styles.sectionsWrapper}>
+          <Collapsible title="File-based routing">
+            <ThemedText type="small">
+              This app has two screens: <ThemedText type="code">src/app/index.tsx</ThemedText> and{' '}
+              <ThemedText type="code">src/app/explore.tsx</ThemedText>
+            </ThemedText>
+            <ThemedText type="small">
+              The layout file in <ThemedText type="code">src/app/_layout.tsx</ThemedText> sets up
+              the tab navigator.
+            </ThemedText>
+            <ExternalLink href="https://docs.expo.dev/router/introduction">
+              <ThemedText type="linkPrimary">Learn more</ThemedText>
+            </ExternalLink>
+          </Collapsible>
+
+          <Collapsible title="Android, iOS, and web support">
+            <ThemedView type="backgroundElement" style={styles.collapsibleContent}>
+              <ThemedText type="small">
+                You can open this project on Android, iOS, and the web. To open the web version,
+                press <ThemedText type="smallBold">w</ThemedText> in the terminal running this
+                project.
+              </ThemedText>
+              <Image
+                source={require('@/assets/images/tutorial-web.png')}
+                style={styles.imageTutorial}
+              />
+            </ThemedView>
+          </Collapsible>
+
+          <Collapsible title="Images">
+            <ThemedText type="small">
+              For static images, you can use the <ThemedText type="code">@2x</ThemedText> and{' '}
+              <ThemedText type="code">@3x</ThemedText> suffixes to provide files for different
+              screen densities.
+            </ThemedText>
+            <Image source={require('@/assets/images/react-logo.png')} style={styles.imageReact} />
+            <ExternalLink href="https://reactnative.dev/docs/images">
+              <ThemedText type="linkPrimary">Learn more</ThemedText>
+            </ExternalLink>
+          </Collapsible>
+
+          <Collapsible title="Light and dark mode components">
+            <ThemedText type="small">
+              This template has light and dark mode support. The{' '}
+              <ThemedText type="code">useColorScheme()</ThemedText> hook lets you inspect what the
+              user&apos;s current color scheme is, and so you can adjust UI colors accordingly.
+            </ThemedText>
+            <ExternalLink href="https://docs.expo.dev/develop/user-interface/color-themes/">
+              <ThemedText type="linkPrimary">Learn more</ThemedText>
+            </ExternalLink>
+          </Collapsible>
+
+          <Collapsible title="Animations">
+            <ThemedText type="small">
+              This template includes an example of an animated component. The{' '}
+              <ThemedText type="code">src/components/ui/collapsible.tsx</ThemedText> component uses
+              the powerful <ThemedText type="code">react-native-reanimated</ThemedText> library to
+              animate opening this hint.
+            </ThemedText>
+          </Collapsible>
+        </ThemedView>
+        {Platform.OS === 'web' && <WebBadge />}
+      </ThemedView>
+    </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
-  root: {
-    flex: 1,
-    flexDirection: 'row',
-    justifyContent: 'center',
-  },
   scrollView: {
     flex: 1,
   },

--- a/templates/expo-template-default/src/components/app-tabs.native.tsx
+++ b/templates/expo-template-default/src/components/app-tabs.native.tsx
@@ -1,11 +1,8 @@
-import { isLiquidGlassAvailable } from 'expo-glass-effect';
 import { NativeTabs } from 'expo-router/unstable-native-tabs';
 import React from 'react';
-import { Platform, useColorScheme } from 'react-native';
+import { useColorScheme } from 'react-native';
 
 import { Colors } from '@/constants/theme';
-
-const useLiquidGlass = Platform.OS === 'ios' && isLiquidGlassAvailable();
 
 export default function AppTabs() {
   const scheme = useColorScheme();
@@ -15,8 +12,7 @@ export default function AppTabs() {
     <NativeTabs
       backgroundColor={colors.background}
       indicatorColor={colors.backgroundElement}
-      labelStyle={{ selected: { color: colors.text } }}
-      disableTransparentOnScrollEdge={!useLiquidGlass}>
+      labelStyle={{ selected: { color: colors.text } }}>
       <NativeTabs.Trigger name="index">
         <NativeTabs.Trigger.Label>Home</NativeTabs.Trigger.Label>
         <NativeTabs.Trigger.Icon src={require('@/assets/images/tabIcons/home.png')} />


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/CNHBN8LNS/p1769035617437699

<img height="400" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-22 at 14 12 59" src="https://github.com/user-attachments/assets/c2ced4ee-2704-48fd-9969-7ea2d98cc520" />
<img height="400" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-22 at 14 12 57" src="https://github.com/user-attachments/assets/07105b26-d9b7-42ba-8313-48ce8b2803e2" />
<img height="400" alt="Simulator Screenshot - iPhone 16 Pro - 2026-01-22 at 14 12 40" src="https://github.com/user-attachments/assets/39572879-bd15-4987-a194-98cb32dc0900" />
<img height="400" alt="Simulator Screenshot - iPhone 16 Pro - 2026-01-22 at 14 12 37" src="https://github.com/user-attachments/assets/ae88754a-cfd4-4a06-b9de-d0b7b9ed4858" />
<img height="400" alt="Screenshot_20260122-135710" src="https://github.com/user-attachments/assets/c466868a-3139-49c4-b757-49f3c30ad4ff" />

# How

- Removed the `disableTransparentOnScrollEdge` prop and its related `useLiquidGlass` constant from `app-tabs.native.tsx`
- Moved `ScrollView` to be the root element in `explore.tsx`, eliminating the outer `ThemedView` wrapper - this fixes all the ScrollView issues

# Test Plan

1. Copy files from `expo-template-default` to a new project
2. `bun i`
3. Test the project using
  - Expo Go for SDK 55 beta
  - Development build
4. Test on iOS 18, 26 and Android

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
