### PR TITLE
[docs] add restore and save functions for wf and custom builds

### DIFF
--- a/docs/pages/custom-builds/functions.mdx
+++ b/docs/pages/custom-builds/functions.mdx
@@ -258,12 +258,61 @@ export default myFunction;
 
 </Step>
 
+## Using built-in cache functions
+
+You can combine custom functions with built-in EAS functions to optimize your builds. For example, you can use [`eas/restore_build_cache`](/custom-builds/schema/#easrestore_build_cache) and [`eas/save_build_cache`](/custom-builds/schema/#eassave_build_cache) to speed up builds by caching build artifacts:
+
+```yaml .eas/build/config.yml
+build:
+  name: Build with cache
+  steps:
+    - eas/checkout
+    - eas/install_node_modules
+    - eas/prebuild
+    # @info #
+    - eas/restore_build_cache:
+        inputs:
+          key: android-ccache-${{ hashFiles('package-lock.json') }}
+          restore_keys: android
+          path: /home/expo/.cache/ccache
+    # @end #
+    - my_function:
+        inputs:
+          num1: 1
+          num2: 2
+        id: sum_function
+    - run:
+        name: Build Android app
+        command: cd android && ./gradlew assembleRelease
+    # @info #
+    - eas/save_build_cache:
+        inputs:
+          key: android-ccache-${{ hashFiles('package-lock.json') }}
+          path: /home/expo/.cache/ccache
+    # @end #
+
+functions:
+  my_function:
+    name: My function
+    inputs:
+      - name: num1
+        type: number
+      - name: num2
+        type: number
+    outputs:
+      - name: sum
+    path: ./myFunction
+```
+
+This example shows how to restore a cache after prebuild, run your custom function, perform a build, and then save the cache for future builds.
+
 ## Summary
 
 - Writing functions is a great way to extend the functionality of custom builds with your own logic.
 - EAS Build functions are reusable — you can use them in multiple custom build configurations.
 - Using EAS Build functions is a great option for more advanced use cases that are not easy to do by writing shell scripts.
 - Most of the [built-in functions](/custom-builds/schema/#built-in-eas-functions) are open-source and can be forked or used as a reference for writing your own functions.
+- You can combine custom functions with built-in functions like [`eas/restore_build_cache`](/custom-builds/schema/#easrestore_build_cache) and [`eas/save_build_cache`](/custom-builds/schema/#eassave_build_cache) to optimize your build performance.
 
 Check out the **example repository** for more detailed examples:
 

--- a/docs/pages/custom-builds/functions.mdx
+++ b/docs/pages/custom-builds/functions.mdx
@@ -258,61 +258,12 @@ export default myFunction;
 
 </Step>
 
-## Using built-in cache functions
-
-You can combine custom functions with built-in EAS functions to optimize your builds. For example, you can use [`eas/restore_build_cache`](/custom-builds/schema/#easrestore_build_cache) and [`eas/save_build_cache`](/custom-builds/schema/#eassave_build_cache) to speed up builds by caching build artifacts:
-
-```yaml .eas/build/config.yml
-build:
-  name: Build with cache
-  steps:
-    - eas/checkout
-    - eas/install_node_modules
-    - eas/prebuild
-    # @info #
-    - eas/restore_build_cache:
-        inputs:
-          key: android-ccache-${{ hashFiles('package-lock.json') }}
-          restore_keys: android
-          path: /home/expo/.cache/ccache
-    # @end #
-    - my_function:
-        inputs:
-          num1: 1
-          num2: 2
-        id: sum_function
-    - run:
-        name: Build Android app
-        command: cd android && ./gradlew assembleRelease
-    # @info #
-    - eas/save_build_cache:
-        inputs:
-          key: android-ccache-${{ hashFiles('package-lock.json') }}
-          path: /home/expo/.cache/ccache
-    # @end #
-
-functions:
-  my_function:
-    name: My function
-    inputs:
-      - name: num1
-        type: number
-      - name: num2
-        type: number
-    outputs:
-      - name: sum
-    path: ./myFunction
-```
-
-This example shows how to restore a cache after prebuild, run your custom function, perform a build, and then save the cache for future builds.
-
 ## Summary
 
 - Writing functions is a great way to extend the functionality of custom builds with your own logic.
 - EAS Build functions are reusable — you can use them in multiple custom build configurations.
 - Using EAS Build functions is a great option for more advanced use cases that are not easy to do by writing shell scripts.
 - Most of the [built-in functions](/custom-builds/schema/#built-in-eas-functions) are open-source and can be forked or used as a reference for writing your own functions.
-- You can combine custom functions with built-in functions like [`eas/restore_build_cache`](/custom-builds/schema/#easrestore_build_cache) and [`eas/save_build_cache`](/custom-builds/schema/#eassave_build_cache) to optimize your build performance.
 
 Check out the **example repository** for more detailed examples:
 

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -1007,12 +1007,12 @@ build:
     # @end #
 ```
 
-| Property         | Type     | Description                                                                                                                                                                                                                                                                    |
-| ---------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `name`           | -        | The name of the step in the reusable function that shows in the build logs. Defaults to `Restore build cache`.                                                                                                                                                               |
-| `inputs.key`     | `string` | Required. The cache key to restore. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes.                                                                                                                                 |
-| `inputs.restore_keys` | `string` | Optional. A fallback key or prefix to use if the exact key is not found. If provided, the cache system will look for any cache entry that starts with this prefix.                                                                                                            |
-| `inputs.path`    | `string` | Required. The path where the cache should be restored. This should match the path used when saving the cache.                                                                                                                                                                  |
+| Property              | Type     | Description                                                                                                                                                        |
+| --------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `name`                | -        | The name of the step in the reusable function that shows in the build logs. Defaults to `Restore build cache`.                                                     |
+| `inputs.key`          | `string` | Required. The cache key to restore. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes.              |
+| `inputs.restore_keys` | `string` | Optional. A fallback key or prefix to use if the exact key is not found. If provided, the cache system will look for any cache entry that starts with this prefix. |
+| `inputs.path`         | `string` | Required. The path where the cache should be restored. This should match the path used when saving the cache.                                                      |
 
 <BoxLink
   title="eas/restore_build_cache source code"
@@ -1045,11 +1045,11 @@ build:
     # @end #
 ```
 
-| Property      | Type     | Description                                                                                                                                                                                                                                                                    |
-| ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `name`        | -        | The name of the step in the reusable function that shows in the build logs. Defaults to `Save build cache`.                                                                                                                                                                  |
-| `inputs.key`  | `string` | Required. The cache key to save the cache under. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes. This should match the key used when restoring the cache.                                                  |
-| `inputs.path` | `string` | Required. The path to the directory or files that should be cached. This should match the path used when restoring the cache.                                                                                                                                                 |
+| Property      | Type     | Description                                                                                                                                                                                                                 |
+| ------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`        | -        | The name of the step in the reusable function that shows in the build logs. Defaults to `Save build cache`.                                                                                                                 |
+| `inputs.key`  | `string` | Required. The cache key to save the cache under. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes. This should match the key used when restoring the cache. |
+| `inputs.path` | `string` | Required. The path to the directory or files that should be cached. This should match the path used when restoring the cache.                                                                                               |
 
 <BoxLink
   title="eas/save_build_cache source code"

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -972,6 +972,92 @@ build:
   href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/installNodeModules.ts"
 />
 
+#### `eas/restore_build_cache`
+
+Restores a previously saved build cache from a specified key. This is useful for speeding up builds by reusing cached artifacts like compiled dependencies, build tools, or other intermediate build outputs.
+
+```yaml example.yml
+build:
+  name: Build with cache
+  steps:
+    - eas/checkout
+    - eas/install_node_modules
+    - eas/prebuild
+    # @info #
+    - eas/restore_build_cache:
+        inputs:
+          key: android-ccache-${{ hashFiles('package-lock.json') }}
+          restore_keys: android
+          path: /home/expo/.cache/ccache
+    # @end #
+```
+
+```yaml example.yml
+build:
+  name: Build with cache
+  steps:
+    - eas/checkout
+    - eas/install_node_modules
+    - eas/prebuild
+    # @info #
+    - eas/restore_build_cache:
+        inputs:
+          key: android-ccache-${{ hashFiles('package-lock.json') }}
+          path: /home/expo/.cache/ccache
+    # @end #
+```
+
+| Property         | Type     | Description                                                                                                                                                                                                                                                                    |
+| ---------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `name`           | -        | The name of the step in the reusable function that shows in the build logs. Defaults to `Restore build cache`.                                                                                                                                                               |
+| `inputs.key`     | `string` | Required. The cache key to restore. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes.                                                                                                                                 |
+| `inputs.restore_keys` | `string` | Optional. A fallback key or prefix to use if the exact key is not found. If provided, the cache system will look for any cache entry that starts with this prefix.                                                                                                            |
+| `inputs.path`    | `string` | Required. The path where the cache should be restored. This should match the path used when saving the cache.                                                                                                                                                                  |
+
+<BoxLink
+  title="eas/restore_build_cache source code"
+  description="View the source code for the eas/restore_build_cache function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/restoreBuildCache.ts"
+/>
+
+#### `eas/save_build_cache`
+
+Saves a build cache to a specified key. This allows you to persist build artifacts, compiled dependencies, or other intermediate outputs that can be reused in subsequent builds to speed up the build process.
+
+```yaml example.yml
+build:
+  name: Build with cache
+  steps:
+    - eas/checkout
+    - eas/restore_build_cache:
+        inputs:
+          key: android-ccache-${{ hashFiles('package-lock.json') }}
+          path: /home/expo/.cache/ccache
+    - eas/install_node_modules
+    - eas/prebuild
+    - eas/run_gradle
+    # @info #
+    - eas/save_build_cache:
+        inputs:
+          key: android-ccache-${{ hashFiles('package-lock.json') }}
+          path: /home/expo/.cache/ccache
+    # @end #
+```
+
+| Property      | Type     | Description                                                                                                                                                                                                                                                                    |
+| ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `name`        | -        | The name of the step in the reusable function that shows in the build logs. Defaults to `Save build cache`.                                                                                                                                                                  |
+| `inputs.key`  | `string` | Required. The cache key to save the cache under. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes. This should match the key used when restoring the cache.                                                  |
+| `inputs.path` | `string` | Required. The path to the directory or files that should be cached. This should match the path used when restoring the cache.                                                                                                                                                 |
+
+<BoxLink
+  title="eas/save_build_cache source code"
+  description="View the source code for the eas/save_build_cache function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/saveBuildCache.ts"
+/>
+
 #### `eas/resolve_build_config`
 
 Resolves and prints the build configuration. If the build has been triggered by the GitHub integration, it will update the current `job` and `metadata` context values. It should be called after installing the dependencies because the config may be influenced by config plugins.

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -986,9 +986,9 @@ build:
     # @info #
     - eas/restore_build_cache:
         inputs:
-          key: android-ccache-${{ hashFiles('package-lock.json') }}
-          restore_keys: android
-          path: /home/expo/.cache/ccache
+          key: cache-${{ hashFiles('package-lock.json') }}
+          restore_keys: cache
+          path: /path/to/cache
     # @end #
 ```
 
@@ -1002,8 +1002,8 @@ build:
     # @info #
     - eas/restore_build_cache:
         inputs:
-          key: android-ccache-${{ hashFiles('package-lock.json') }}
-          path: /home/expo/.cache/ccache
+          key: cache-${{ hashFiles('package-lock.json') }}
+          path: /path/to/cache
     # @end #
 ```
 
@@ -1032,16 +1032,16 @@ build:
     - eas/checkout
     - eas/restore_build_cache:
         inputs:
-          key: android-ccache-${{ hashFiles('package-lock.json') }}
-          path: /home/expo/.cache/ccache
+          key: cache-${{ hashFiles('package-lock.json') }}
+          path: /path/to/cache
     - eas/install_node_modules
     - eas/prebuild
     - eas/run_gradle
     # @info #
     - eas/save_build_cache:
         inputs:
-          key: android-ccache-${{ hashFiles('package-lock.json') }}
-          path: /home/expo/.cache/ccache
+          key: cache-${{ hashFiles('package-lock.json') }}
+          path: /path/to/cache
     # @end #
 ```
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -1563,9 +1563,9 @@ jobs:
       # @info #
       - uses: eas/restore_cache
         with:
-          key: android-ccache-${{ hashFiles('package-lock.json') }}
-          restore_keys: android
-          path: /home/expo/.cache/ccache
+          key: cache-${{ hashFiles('package-lock.json') }}
+          restore_keys: cache
+          path: /path/to/cache
       # @end #
 ```
 
@@ -1579,8 +1579,8 @@ jobs:
       # @info #
       - uses: eas/restore_cache
         with:
-          key: android-ccache-${{ hashFiles('package-lock.json') }}
-          path: /home/expo/.cache/ccache
+          key: cache-${{ hashFiles('package-lock.json') }}
+          path: /path/to/cache
       # @end #
 ```
 
@@ -1610,15 +1610,15 @@ jobs:
       - uses: eas/prebuild
       - uses: eas/restore_cache
         with:
-          key: android-ccache-${{ hashFiles('package-lock.json') }}
-          path: /home/expo/.cache/ccache
+          key: cache-${{ hashFiles('package-lock.json') }}
+          path: /path/to/cache
       - name: Build Android app
         run: cd android && ./gradlew assembleRelease
       # @info #
       - uses: eas/save_cache
         with:
-          key: android-ccache-${{ hashFiles('package-lock.json') }}
-          path: /home/expo/.cache/ccache
+          key: cache-${{ hashFiles('package-lock.json') }}
+          path: /path/to/cache
       # @end #
 ```
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -1549,6 +1549,91 @@ jobs:
   href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/prebuild.ts"
 />
 
+#### `eas/restore_cache`
+
+Restores a previously saved cache from a specified key. This is useful for speeding up builds by reusing cached artifacts like compiled dependencies, build tools, or other intermediate build outputs.
+
+```yaml
+jobs:
+  my_job:
+    steps:
+      - uses: eas/checkout
+      - uses: eas/install_node_modules
+      - uses: eas/prebuild
+      # @info #
+      - uses: eas/restore_cache
+        with:
+          key: android-ccache-${{ hashFiles('package-lock.json') }}
+          restore_keys: android
+          path: /home/expo/.cache/ccache
+      # @end #
+```
+
+```yaml
+jobs:
+  my_job:
+    steps:
+      - uses: eas/checkout
+      - uses: eas/install_node_modules
+      - uses: eas/prebuild
+      # @info #
+      - uses: eas/restore_cache
+        with:
+          key: android-ccache-${{ hashFiles('package-lock.json') }}
+          path: /home/expo/.cache/ccache
+      # @end #
+```
+
+| Property       | Type     | Required | Description                                                                                                                                              |
+| -------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `key`          | `string` | Yes      | The cache key to restore. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes.              |
+| `restore_keys` | `string` | No       | A fallback key or prefix to use if the exact key is not found. If provided, the cache system will look for any cache entry that starts with this prefix. |
+| `path`         | `string` | Yes      | The path where the cache should be restored. This should match the path used when saving the cache.                                                      |
+
+<BoxLink
+  title="eas/restore_cache source code"
+  description="View the source code for the eas/restore_cache function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/restoreCache.ts"
+/>
+
+#### `eas/save_cache`
+
+Saves a cache to a specified key. This allows you to persist build artifacts, compiled dependencies, or other intermediate outputs that can be reused in subsequent builds to speed up the build process.
+
+```yaml
+jobs:
+  my_job:
+    steps:
+      - uses: eas/checkout
+      - uses: eas/install_node_modules
+      - uses: eas/prebuild
+      - uses: eas/restore_cache
+        with:
+          key: android-ccache-${{ hashFiles('package-lock.json') }}
+          path: /home/expo/.cache/ccache
+      - name: Build Android app
+        run: cd android && ./gradlew assembleRelease
+      # @info #
+      - uses: eas/save_cache
+        with:
+          key: android-ccache-${{ hashFiles('package-lock.json') }}
+          path: /home/expo/.cache/ccache
+      # @end #
+```
+
+| Property | Type     | Required | Description                                                                                                                                                                                                       |
+| -------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `key`    | `string` | Yes      | The cache key to save the cache under. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes. This should match the key used when restoring the cache. |
+| `path`   | `string` | Yes      | The path to the directory or files that should be cached. This should match the path used when restoring the cache.                                                                                               |
+
+<BoxLink
+  title="eas/save_cache source code"
+  description="View the source code for the eas/save_cache function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/saveCache.ts"
+/>
+
 #### `eas/send_slack_message`
 
 Sends a specified message to a configured [Slack webhook URL](https://api.slack.com/messaging/webhooks), which then posts it in the related Slack channel. The message can be specified as plaintext or as a [Slack Block Kit](https://api.slack.com/block-kit) message.


### PR DESCRIPTION
# Why

Documents the added functions and required parameters for `eas/restore_cache`, `eas/save_cache` for Workflows and `eas/restore_build_cache` and `eas/save_build_cache` for Custom Builds. 


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->



- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
