### PR TITLE
[ios][expo-go] Add fallback icon for recently opened apps

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -3854,7 +3854,7 @@ SPEC CHECKSUMS:
   EXUpdates: db4dfe3ac7737f426e6840b0a38fe316a3592edd
   EXUpdatesInterface: 34568cdec00dddd734d30fecf010830d9a17a8b3
   FBLazyVector: 3a7ea85f6009224ad89f7daeda516f189e6b5759
-  hermes-engine: 46fce5491dbe4962025d06f9bb2f860c231839f8
+  hermes-engine: 6bb3000824be2770010ae038914fa26721255c8e
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -3872,7 +3872,7 @@ SPEC CHECKSUMS:
   React: 4bc1f928568ad4bcfd147260f907b4ea5873a03b
   React-callinvoker: 8dd44c31888a314694efd0ef5f19ab7e0e855ef8
   React-Core: 0c1f3042e1204c0512b2e4263062c66550d7e6a3
-  React-Core-prebuilt: 083f4a23208b7c4789739103c467d04ced7cbdcc
+  React-Core-prebuilt: 7894b037a2f0fa699a44de6c88d20acd4235b255
   React-CoreModules: f6a626221d52f21b5eb8df2d79780b96f20240e5
   React-cxxreact: 2e3990595049d43dd1d59ccd6cb35545f0dc6f03
   React-debug: 60be0767f5672afc81bfd6a50d996507430f7906
@@ -3942,7 +3942,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: bfb12ead469222b022a2024f32aba47ce50de512
   ReactCodegen: b9b0ea5c72e425fa5a89a031ada3e64dfd839771
   ReactCommon: 0084791d25c4deae3d8b77efd4440fb2d5c38746
-  ReactNativeDependencies: fbc8678e9f0e4f553245e4669a3a8d19ba03bb13
+  ReactNativeDependencies: 17a617edb4d5883a4c48339514ccb8b765f8af4f
   RNCAsyncStorage: e85a99325df9eb0191a6ee2b2a842644c7eb29f4
   RNCMaskedView: 3c9d7586e2b9bbab573591dcb823918bc4668005
   RNCPicker: e0149590451d5eae242cf686014a6f6d808f93c7

--- a/apps/expo-go/ios/Client/SwiftUI/Rows/RecentlyOpenedAppRow.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Rows/RecentlyOpenedAppRow.swift
@@ -11,9 +11,7 @@ struct RecentlyOpenedAppRow: View {
       onTap()
     } label: {
       HStack(spacing: 12) {
-        if let iconUrl = app.iconUrl, let url = URL(string: iconUrl) {
-          RecentlyOpenedIconView(url: url)
-        }
+        RecentlyOpenedIconView(iconUrl: app.iconUrl)
 
         Text(app.name)
           .font(.body)
@@ -35,7 +33,7 @@ struct RecentlyOpenedAppRow: View {
 }
 
 private struct RecentlyOpenedIconView: View {
-  let url: URL
+  let iconUrl: String?
   private let size: CGFloat = 40
   @State private var image: UIImage?
   @State private var isLoading = false
@@ -49,9 +47,11 @@ private struct RecentlyOpenedIconView: View {
           .frame(width: size, height: size)
           .clipShape(RoundedRectangle(cornerRadius: BorderRadius.medium))
       } else {
-        RoundedRectangle(cornerRadius: BorderRadius.medium)
-          .fill(Color.expoSecondarySystemGroupedBackground)
+        Image("Icon")
+          .resizable()
+          .scaledToFill()
           .frame(width: size, height: size)
+          .clipShape(RoundedRectangle(cornerRadius: BorderRadius.medium))
       }
     }
     .task {
@@ -60,7 +60,7 @@ private struct RecentlyOpenedIconView: View {
   }
 
   private func loadImage() async {
-    guard !isLoading else { return }
+    guard let iconUrl, let url = URL(string: iconUrl), !isLoading else { return }
     isLoading = true
 
     do {

--- a/apps/expo-go/ios/Client/SwiftUI/Rows/RecentlyOpenedAppRow.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Rows/RecentlyOpenedAppRow.swift
@@ -37,6 +37,7 @@ private struct RecentlyOpenedIconView: View {
   private let size: CGFloat = 40
   @State private var image: UIImage?
   @State private var isLoading = false
+  @Environment(\.colorScheme) private var colorScheme
 
   var body: some View {
     Group {
@@ -47,11 +48,9 @@ private struct RecentlyOpenedIconView: View {
           .frame(width: size, height: size)
           .clipShape(RoundedRectangle(cornerRadius: BorderRadius.medium))
       } else {
-        Image("Icon")
-          .resizable()
-          .scaledToFill()
+        RoundedRectangle(cornerRadius: BorderRadius.medium)
+          .fill(colorScheme == .dark ? Color(white: 0.3) : Color(white: 0.7))
           .frame(width: size, height: size)
-          .clipShape(RoundedRectangle(cornerRadius: BorderRadius.medium))
       }
     }
     .task {

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -20,7 +20,7 @@ PODS:
   - EXManifests/Tests (55.0.0):
     - ExpoModulesCore
     - ExpoModulesTestCore
-  - Expo (55.0.0-preview.1):
+  - Expo (55.0.0-preview.2):
     - boost
     - DoubleConversion
     - ExpoModulesCore
@@ -113,7 +113,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - Expo/Tests (55.0.0-preview.1):
+  - Expo/Tests (55.0.0-preview.2):
     - boost
     - DoubleConversion
     - ExpoModulesCore
@@ -245,7 +245,7 @@ PODS:
     - React-Core
   - ExpoMeshGradient (55.0.0):
     - ExpoModulesCore
-  - ExpoModulesCore (55.0.0):
+  - ExpoModulesCore (55.0.1):
     - boost
     - DoubleConversion
     - ExpoModulesJSI
@@ -276,7 +276,7 @@ PODS:
     - RNWorklets
     - SocketRocket
     - Yoga
-  - ExpoModulesCore/Tests (55.0.0):
+  - ExpoModulesCore/Tests (55.0.1):
     - boost
     - DoubleConversion
     - ExpoModulesJSI
@@ -308,11 +308,11 @@ PODS:
     - RNWorklets
     - SocketRocket
     - Yoga
-  - ExpoModulesJSI (55.0.0):
+  - ExpoModulesJSI (55.0.1):
     - hermes-engine
     - React-Core
     - ReactCommon
-  - ExpoModulesJSI/Tests (55.0.0):
+  - ExpoModulesJSI/Tests (55.0.1):
     - hermes-engine
     - React-Core
     - ReactCommon
@@ -395,7 +395,7 @@ PODS:
     - ExpoModulesCore
   - EXStructuredHeaders (55.0.0)
   - EXStructuredHeaders/Tests (55.0.0)
-  - EXUpdates (55.0.0):
+  - EXUpdates (55.0.1):
     - boost
     - DoubleConversion
     - EASClient
@@ -429,7 +429,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - EXUpdates/Tests (55.0.0):
+  - EXUpdates/Tests (55.0.1):
     - boost
     - DoubleConversion
     - EASClient
@@ -4642,7 +4642,7 @@ SPEC CHECKSUMS:
   EXConstants: 65fe36b560cfb2ff76add4bc6589ff21630814c0
   EXJSONUtils: 0080c14b673cfa9a6be5e3fe429768ffe3d42dfb
   EXManifests: 57f815598cd5df5a39d5662f27d96bd4aa604c89
-  Expo: 1e4f043c2278d721d4aedbafb0bc0c1fa29e615f
+  Expo: d19d6f379555d2fa49a335eb0f2ed0a0df7d1db1
   expo-dev-menu: df2a3ff5f225a3b97c108a207624df436d67679a
   expo-dev-menu-interface: a98021861ad111a46dc6c9f816b55be01ea03c63
   ExpoAgeRange: 10c1735c6669ac73015d7767ce0a6b8492001c52
@@ -4683,8 +4683,8 @@ SPEC CHECKSUMS:
   ExpoMailComposer: a80ba3056d483d849fad5c627aaf660ec5026deb
   ExpoMediaLibrary: ec981ac3747f2ce04ac94fa7a6c6ce6435dd2cc9
   ExpoMeshGradient: 733bbcbcf8801f646637940da39cabc832ab50a4
-  ExpoModulesCore: 897d81b6873d79cbeaeda42b533684abcc603634
-  ExpoModulesJSI: 3c60e59da596ad296914ca6767e16f57558ba6ea
+  ExpoModulesCore: cd3a641bfe1538154e80e93269dfc6e3635ad1ed
+  ExpoModulesJSI: 3bbc9b9f3bad9da5ccfdf27f8eb0aab5ccbfb33e
   ExpoModulesTestCore: 2d11936a13dd02701ec2d5be6978ad5fd1116a9c
   ExpoNetwork: 1c5271acd933d6ad6f7390ab05f6bed44128b363
   ExpoNotifications: 85e04adb6e4c9dd64c56c09b726e9d2e79929c37
@@ -4707,7 +4707,7 @@ SPEC CHECKSUMS:
   ExpoVideoThumbnails: 45f0b89086a333b10331613b08b3812654dcbdd3
   ExpoWebBrowser: ec053554718af038909428329fc6d30c51583bdc
   EXStructuredHeaders: aa49a5557fa24aa61dda4ac665f3987bf3e9e35d
-  EXUpdates: 1013086c61ecef81bee6fddcc775a30733c5137c
+  EXUpdates: 41136e5d7aeacfc761290659e039305fc50a266b
   EXUpdatesInterface: 34568cdec00dddd734d30fecf010830d9a17a8b3
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: 309703e71d3f2f1ed7dc7889d58309c9d77a95a4


### PR DESCRIPTION
# Why
Adds a fallback icon to the recently opened apps when we don't have access to the manifest

# How
Use expo gos app icon. I'll ask Nico to design a better fallback for this

# Test Plan
<img width="450" height="978" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-22 at 15 57 51" src="https://github.com/user-attachments/assets/294ac0e5-30d0-4890-ad42-169edcc45393" />
<img width="450" height="978" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-22 at 15 57 49" src="https://github.com/user-attachments/assets/88ba74f6-b8f6-4040-b3b3-b6046dd57374" />

