### PR TITLE
[updates] Prevent logging on `DownloadProgress` event

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Prevent logging on download progress events to reduce log size.
+- Prevent logging on download progress events to reduce log size. ([#42436](https://github.com/expo/expo/pull/42436) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Prevent logging on download progress events to reduce log size.
+
 ### 💡 Others
 
 ## 55.0.1 — 2026-01-22

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
@@ -86,7 +86,9 @@ class UpdatesStateMachine(
   private fun processEvent(event: UpdatesStateEvent) {
     if (transition(event)) {
       context = reduceContext(context, event)
-      logger.info("Updates state change: ${event.type}, context = ${context.json}")
+      if (event !is UpdatesStateEvent.DownloadProgress) {
+        logger.info("Updates state change: ${event.type}, context = ${context.json}")
+      }
       UpdatesControllerRegistry.controller?.get()?.let {
         if (it is EnabledUpdatesController) {
           // Notify the controller state change listener

--- a/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
@@ -334,7 +334,9 @@ internal class UpdatesStateMachine {
     if transition(event) {
       // Only change context if transition succeeds
       context = reducedContext(context, event)
-      logger.info(message: "Updates state change: state = \(state), event = \(event.type), context = \(context)")
+      if event.type != .downloadProgress {
+        logger.info(message: "Updates state change: state = \(state), event = \(event.type), context = \(context)")
+      }
       // Notify the controller state change listener
       if let controller = UpdatesControllerRegistry.sharedInstance.controller as? EnabledAppController {
         controller.stateChangeListeners.keys.forEach {subscriptionId in


### PR DESCRIPTION
# Why
Closes #42421

# How
The download progress event is high frequency and because the logs write the entire manifest each time, this causes the log file to explode in size. I don't see value in logging on this event so we should omit it to prevent this.

# Test Plan
Should not have negative impact, just reduce the log files size
CI

