### PR TITLE
[ci] Optimize test-suite workflow to run only on affected platforms

### DIFF
--- a/.github/actions/detect-platform-change/action.yml
+++ b/.github/actions/detect-platform-change/action.yml
@@ -13,7 +13,7 @@ inputs:
   shared-ignores:
     description: 'Paths to ignore for all platforms'
     required: false
-    default: ''
+    default: '!{**/*.md,**/LICENSE*,**/.gitignore,**/CHANGELOG*,**/.npmignore,**/.eslintrc*,**/.prettierrc*,**/.gitattributes,**/.watchmanconfig,**/.fingerprintignore}'
 
 outputs:
   should_run_android:

--- a/.github/actions/detect-platform-change/action.yml
+++ b/.github/actions/detect-platform-change/action.yml
@@ -1,0 +1,42 @@
+name: 'Detect Platform Change'
+description: 'Detects whether to run Android, iOS, or both based on changed files'
+inputs:
+  android-paths:
+    description: 'Paths that trigger only Android tests'
+    required: true
+  ios-paths:
+    description: 'Paths that trigger only iOS tests'
+    required: true
+  common-paths:
+    description: 'Paths that trigger both platform tests'
+    required: true
+  shared-ignores:
+    description: 'Paths to ignore for all platforms'
+    required: false
+    default: ''
+
+outputs:
+  should_run_android:
+    value: ${{ steps.changes.outputs.android_any_changed == 'true' || steps.changes.outputs.common_any_changed == 'true' }}
+  should_run_ios:
+    value: ${{ steps.changes.outputs.ios_any_changed == 'true' || steps.changes.outputs.common_any_changed == 'true' }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 👀 Checkout
+      uses: actions/checkout@v5
+      with:
+        fetch-depth: 1000
+        filter: 'blob:none'
+    - name: 🧐 Check changes categories
+      id: changes
+      uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
+      with:
+        # If the number of commits from actions/checkout is not sufficient to find a base commit,
+        # tj-actions/changed-files tries 10 times to fetch more commits by this amount:
+        fetch_depth: 1000
+        files_yaml: |
+          ios: [ ${{ inputs.ios-paths }}, ${{ inputs.shared-ignores }} ]
+          android: [ ${{ inputs.android-paths }}, ${{ inputs.shared-ignores }} ]
+          common: [ ${{ inputs.common-paths }}, ${{ inputs.shared-ignores }} ]

--- a/.github/actions/detect-platform-change/action.yml
+++ b/.github/actions/detect-platform-change/action.yml
@@ -13,7 +13,8 @@ inputs:
   shared-ignores:
     description: 'Paths to ignore for all platforms'
     required: false
-    default: '!{**/*.md,**/LICENSE*,**/.gitignore,**/CHANGELOG*,**/.npmignore,**/.eslintrc*,**/.prettierrc*,**/.gitattributes,**/.watchmanconfig,**/.fingerprintignore}'
+    default: >-
+      "!{**/*.md,**/LICENSE*,**/.gitignore,**/CHANGELOG*,**/.npmignore,**/.eslintrc*,**/.prettierrc*,**/.gitattributes,**/.watchmanconfig,**/.fingerprintignore}"
 
 outputs:
   should_run_android:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -28,8 +28,49 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-platform-for-e2e:
+    runs-on: ubuntu-24.04
+    outputs:
+      should_run_ios: ${{ steps.changes.outputs.ios_only_any_changed == 'true' || steps.changes.outputs.common_any_changed == 'true' }}
+      should_run_android: ${{ steps.changes.outputs.android_only_any_changed == 'true' || steps.changes.outputs.common_any_changed == 'true' }}
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          filter: blob:none
+      - name: 🧐 Check changes categories
+        id: changes
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
+        with:
+          files_yaml: |
+            ios_only:
+              - 'packages/**/ios/**'
+              - 'apps/bare-expo/ios/**'
+              - '**/*.{swift,podspec,xcodeproj,xcworkspace,plist,m,mm}'
+              - '!{**.md,**/LICENSE*,**/.gitignore,**/CHANGELOG*}'
+            android_only:
+              - 'packages/**/android/**'
+              - 'apps/bare-expo/android/**'
+              - '**/*.{java,kt,gradle,xml,pro}'
+              - '!{**.md,**/LICENSE*,**/.gitignore,**/CHANGELOG*}'
+            common:
+              - .github/workflows/test-suite.yml
+              - .github/actions/use-android-emulator/action.yml
+              - 'apps/bare-expo/**'
+              - 'apps/test-suite/**'
+              - 'packages/**'
+              - 'yarn.lock'
+              - '!packages/**/{ios,android}/**'
+              - '!apps/bare-expo/{ios,android}/**'
+              - '!**/*.{swift,podspec,xcodeproj,xcworkspace,plist,m,mm}'
+              - '!**/*.{java,kt,gradle,xml,pro}'
+              - '!{**.md,**/LICENSE*,**/.gitignore,**/CHANGELOG*}'
+
   ios-build:
     runs-on: macos-15
+    needs: detect-platform-for-e2e
+    if: needs.detect-platform-for-e2e.outputs.should_run_ios == 'true'
     permissions:
       # REQUIRED: Allow updating fingerprint in action caches
       actions: write
@@ -213,6 +254,8 @@ jobs:
 
   android-build:
     runs-on: ubuntu-24.04
+    needs: detect-platform-for-e2e
+    if: needs.detect-platform-for-e2e.outputs.should_run_android == 'true'
     permissions:
       # REQUIRED: Allow updating fingerprint in action caches
       actions: write

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -46,14 +46,16 @@ jobs:
           files_yaml: |
             ios_only:
               - 'packages/**/ios/**'
-              - 'apps/bare-expo/ios/**'
-              - '**/*.{swift,podspec,xcodeproj,xcworkspace,plist,m,mm}'
-              - '!{**.md,**/LICENSE*,**/.gitignore,**/CHANGELOG*}'
+              - 'apps/bare-expo/**/ios/**'
+
+              - '!{**/*.md,**/LICENSE*,**/.gitignore,**/CHANGELOG*,**/.npmignore,**/.eslintrc*,**/.prettierrc*,**/.gitattributes,**/.watchmanconfig,**/.fingerprintignore}'
+
             android_only:
               - 'packages/**/android/**'
-              - 'apps/bare-expo/android/**'
-              - '**/*.{java,kt,gradle,xml,pro}'
-              - '!{**.md,**/LICENSE*,**/.gitignore,**/CHANGELOG*}'
+              - 'apps/bare-expo/**/android/**'
+
+              - '!{**/*.md,**/LICENSE*,**/.gitignore,**/CHANGELOG*,**/.npmignore,**/.eslintrc*,**/.prettierrc*,**/.gitattributes,**/.watchmanconfig,**/.fingerprintignore}'
+
             common:
               - .github/workflows/test-suite.yml
               - .github/actions/use-android-emulator/action.yml
@@ -61,12 +63,10 @@ jobs:
               - 'apps/test-suite/**'
               - 'packages/**'
               - 'yarn.lock'
-              - '!packages/**/{ios,android}/**'
-              - '!apps/bare-expo/{ios,android}/**'
-              - '!**/*.{swift,podspec,xcodeproj,xcworkspace,plist,m,mm}'
-              - '!**/*.{java,kt,gradle,xml,pro}'
-              - '!{**.md,**/LICENSE*,**/.gitignore,**/CHANGELOG*}'
 
+              - '!packages/**/{ios,android}/**'
+              - '!apps/bare-expo/**/{ios,android}/**'
+              - '!{**/*.md,**/LICENSE*,**/.gitignore,**/CHANGELOG*,**/.npmignore,**/.eslintrc*,**/.prettierrc*,**/.gitattributes,**/.watchmanconfig,**/.fingerprintignore}'
   ios-build:
     runs-on: macos-15
     needs: detect-platform-for-e2e

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -31,45 +31,36 @@ jobs:
   detect-platform-for-e2e:
     runs-on: ubuntu-24.04
     outputs:
-      should_run_ios: ${{ steps.changes.outputs.ios_only_any_changed == 'true' || steps.changes.outputs.common_any_changed == 'true' }}
-      should_run_android: ${{ steps.changes.outputs.android_only_any_changed == 'true' || steps.changes.outputs.common_any_changed == 'true' }}
+      should_run_ios: ${{ steps.changes.outputs.should_run_ios }}
+      should_run_android: ${{ steps.changes.outputs.should_run_android }}
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1000
-          filter: blob:none
-      - name: 🧐 Check changes categories
+        uses: actions/checkout@v5
+      - name: 🧐 Detect platform change
         id: changes
-        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
+        uses: ./.github/actions/detect-platform-change
         with:
-          # If the number of commits from actions/checkout is not sufficient to find a base commit,
-          # tj-actions/changed-files tries 10 times to fetch more commits by this amount:
-          fetch_depth: 1000
-          files_yaml: |
-            ios_only:
-              - 'packages/**/ios/**'
-              - 'apps/bare-expo/**/ios/**'
+          android-paths: >-
+            "packages/**/android/**",
+            "apps/bare-expo/**/android/**"
 
-              - '!{**/*.md,**/LICENSE*,**/.gitignore,**/CHANGELOG*,**/.npmignore,**/.eslintrc*,**/.prettierrc*,**/.gitattributes,**/.watchmanconfig,**/.fingerprintignore}'
+          ios-paths: >-
+            "packages/**/ios/**",
+            "apps/bare-expo/**/ios/**"
 
-            android_only:
-              - 'packages/**/android/**'
-              - 'apps/bare-expo/**/android/**'
+          common-paths: >-
+            .github/workflows/test-suite.yml,
+            .github/actions/use-android-emulator/action.yml,
+            "apps/bare-expo/**",
+            "apps/test-suite/**",
+            "packages/**",
+            yarn.lock,
+            "!packages/**/{ios,android}/**",
+            "!apps/bare-expo/**/{ios,android}/**"
 
-              - '!{**/*.md,**/LICENSE*,**/.gitignore,**/CHANGELOG*,**/.npmignore,**/.eslintrc*,**/.prettierrc*,**/.gitattributes,**/.watchmanconfig,**/.fingerprintignore}'
+          shared-ignores: >-
+            "!{**/*.md,**/LICENSE*,**/.gitignore,**/CHANGELOG*,**/.npmignore,**/.eslintrc*,**/.prettierrc*,**/.gitattributes,**/.watchmanconfig,**/.fingerprintignore}"
 
-            common:
-              - .github/workflows/test-suite.yml
-              - .github/actions/use-android-emulator/action.yml
-              - 'apps/bare-expo/**'
-              - 'apps/test-suite/**'
-              - 'packages/**'
-              - 'yarn.lock'
-
-              - '!packages/**/{ios,android}/**'
-              - '!apps/bare-expo/**/{ios,android}/**'
-              - '!{**/*.md,**/LICENSE*,**/.gitignore,**/CHANGELOG*,**/.npmignore,**/.eslintrc*,**/.prettierrc*,**/.gitattributes,**/.watchmanconfig,**/.fingerprintignore}'
   ios-build:
     runs-on: macos-15
     needs: detect-platform-for-e2e

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -57,10 +57,6 @@ jobs:
             yarn.lock,
             "!packages/**/{ios,android}/**",
             "!apps/bare-expo/**/{ios,android}/**"
-
-          shared-ignores: >-
-            "!{**/*.md,**/LICENSE*,**/.gitignore,**/CHANGELOG*,**/.npmignore,**/.eslintrc*,**/.prettierrc*,**/.gitattributes,**/.watchmanconfig,**/.fingerprintignore}"
-
   ios-build:
     runs-on: macos-15
     needs: detect-platform-for-e2e

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -37,12 +37,15 @@ jobs:
       - name: 👀 Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1000
           filter: blob:none
       - name: 🧐 Check changes categories
         id: changes
         uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
+          # If the number of commits from actions/checkout is not sufficient to find a base commit,
+          # tj-actions/changed-files tries 10 times to fetch more commits by this amount:
+          fetch_depth: 1000
           files_yaml: |
             ios_only:
               - 'packages/**/ios/**'


### PR DESCRIPTION
# Why
With this change, there won't be a situation where, for example, we only edit a .kt file but it also runs the entire iOS workflow.

# How
Firstly, it uses `actions/checkout@v4` with `fetch-depth: 1000` and `filter: blob:none` to download the latest 1000 commits. This is required by `tj-actions/changed-files` because we need to calculate the diff between the main branch and the last commit. Then it uses `files_yaml` to classify whether changes affect iOS, Android, or both. I analyzed all extensions in the repository and came to the conclusion that only `.md`, `LICENSE`, `.gitignore`, `CHANGELOG`, `.npmignore`, `.eslintrc`, `gitattributes`, `.fingerprintignore`, `.watchmanconfig`, `.prettierrc` can be safely ignored.

# Performance implications
This job takes around ~20s. It's a downside when we make PRs that affect both platforms, but on the other hand when the change is platform-specific it saves time and CI resources.

# Test Plan
Run the workflow using a stacked PR with different changes that trigger each logical state of the outputs.
I wrote a [test script ](https://github.com/user-attachments/files/24820714/v3.js) that uses micromatch (the pattern matching library in `tj-actions/changes-files`). It analyzes all files in the repository and creates JSON files which tell which E2E tests will run.
Both:  [trigger_both.json](https://github.com/user-attachments/files/24820652/trigger_both.json)
Only Android: [trigger_android.json](https://github.com/user-attachments/files/24820645/trigger_android.json)
Only iOS: [trigger_ios.json](https://github.com/user-attachments/files/24820660/trigger_ios.json)
None:  [ignored.json](https://github.com/user-attachments/files/24820661/ignored.json)



