### PR TITLE
[core][Android] Fix deallocation after runtime was cleared

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JNIDeallocatorTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JNIDeallocatorTest.kt
@@ -17,6 +17,6 @@ class JNIDeallocatorTest {
 
     val deallocator = runtimeHolder.get()!!.deallocator
 
-    Truth.assertThat(deallocator.inspectMemory()).contains(moduleObject)
+    Truth.assertThat(deallocator.inspectMemory()).contains(moduleObject.getHybridDataForJNIDeallocator())
   }
 }

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
@@ -123,6 +123,7 @@ internal inline fun withJSIInterop(
     // That’s why the JSIContext outlives the JS runtime.
     runtimeHolder.close()
     jsiContext.close()
+    callInvokerHolder.resetNative()
   }
   Truth.assertWithMessage("Memory leak detected").that(jniDeallocator.inspectMemory()).isEmpty()
 }

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/ReloadTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/ReloadTest.kt
@@ -23,7 +23,7 @@ class ReloadTest {
 
     val promiseResult = callAsync("f2")
     Truth.assertThat(promiseResult.isNumber()).isTrue()
-    Truth.assertThat(getLastPromiseResult().getInt()).isEqualTo(20)
+    Truth.assertThat(promiseResult.getInt()).isEqualTo(20)
   }
 
   @Test

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
@@ -124,14 +124,14 @@ class JSIContext @DoNotStrip internal constructor(
 
   @Throws(Throwable::class)
   protected fun finalize() {
-    deallocate()
-  }
-
-  override fun deallocate() {
-    mHybridData.resetNative()
+    close()
   }
 
   override fun close() {
-    deallocate()
+    mHybridData.resetNative()
+  }
+
+  override fun getHybridDataForJNIDeallocator(): HybridData {
+    return mHybridData
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaCallback.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaCallback.kt
@@ -115,10 +115,10 @@ class JavaCallback @DoNotStrip internal constructor(@DoNotStrip private val mHyb
 
   @Throws(Throwable::class)
   protected fun finalize() {
-    deallocate()
+    mHybridData.resetNative()
   }
 
-  override fun deallocate() {
-    mHybridData.resetNative()
+  override fun getHybridDataForJNIDeallocator(): HybridData {
+    return mHybridData
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptArrayBuffer.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptArrayBuffer.kt
@@ -26,10 +26,10 @@ class JavaScriptArrayBuffer @DoNotStrip private constructor(@DoNotStrip private 
 
   @Throws(Throwable::class)
   protected fun finalize() {
-    deallocate()
+    mHybridData.resetNative()
   }
 
-  override fun deallocate() {
-    mHybridData.resetNative()
+  override fun getHybridDataForJNIDeallocator(): HybridData {
+    return mHybridData
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptFunction.kt
@@ -42,10 +42,10 @@ class JavaScriptFunction<ReturnType : Any?> @DoNotStrip private constructor(@DoN
 
   @Throws(Throwable::class)
   protected fun finalize() {
-    deallocate()
+    mHybridData.resetNative()
   }
 
-  override fun deallocate() {
-    mHybridData.resetNative()
+  override fun getHybridDataForJNIDeallocator(): HybridData {
+    return mHybridData
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
@@ -34,14 +34,14 @@ class JavaScriptModuleObject(
 
   @Throws(Throwable::class)
   protected fun finalize() {
-    deallocate()
-  }
-
-  override fun deallocate() {
     mHybridData.resetNative()
   }
 
   override fun toString(): String {
     return "JavaScriptModuleObject_$name"
+  }
+
+  override fun getHybridDataForJNIDeallocator(): HybridData {
+    return mHybridData
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptObject.kt
@@ -144,11 +144,11 @@ open class JavaScriptObject @DoNotStrip internal constructor(@DoNotStrip private
 
   @Throws(Throwable::class)
   protected fun finalize() {
-    deallocate()
+    mHybridData.resetNative()
   }
 
-  override fun deallocate() {
-    mHybridData.resetNative()
+  override fun getHybridDataForJNIDeallocator(): HybridData {
+    return mHybridData
   }
 }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptValue.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptValue.kt
@@ -56,10 +56,10 @@ class JavaScriptValue @DoNotStrip private constructor(@DoNotStrip private val mH
 
   @Throws(Throwable::class)
   protected fun finalize() {
-    deallocate()
+    mHybridData.resetNative()
   }
 
-  override fun deallocate() {
-    mHybridData.resetNative()
+  override fun getHybridDataForJNIDeallocator(): HybridData {
+    return mHybridData
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptWeakObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptWeakObject.kt
@@ -12,11 +12,12 @@ import expo.modules.core.interfaces.DoNotStrip
 class JavaScriptWeakObject @DoNotStrip internal constructor(@DoNotStrip private val mHybridData: HybridData) : Destructible {
   @Throws(Throwable::class)
   protected fun finalize() {
-    deallocate()
-  }
-
-  override fun deallocate() {
     mHybridData.resetNative()
   }
+
+  override fun getHybridDataForJNIDeallocator(): HybridData {
+    return mHybridData
+  }
+
   external fun lock(): JavaScriptObject
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/NativeArrayBuffer.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/NativeArrayBuffer.kt
@@ -44,11 +44,11 @@ class NativeArrayBuffer : Destructible, ArrayBuffer {
 
   @Throws(Throwable::class)
   protected fun finalize() {
-    deallocate()
+    mHybridData.resetNative()
   }
 
-  override fun deallocate() {
-    mHybridData.resetNative()
+  override fun getHybridDataForJNIDeallocator(): HybridData {
+    return mHybridData
   }
 
   companion object {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/decorators/JSDecoratorsBridgingObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/decorators/JSDecoratorsBridgingObject.kt
@@ -98,13 +98,13 @@ class JSDecoratorsBridgingObject(jniDeallocator: JNIDeallocator) : Destructible 
     )
   }
 
-  override fun deallocate() {
+  @Throws(Throwable::class)
+  protected fun finalize() {
     mHybridData.resetNative()
   }
 
-  @Throws(Throwable::class)
-  protected fun finalize() {
-    deallocate()
+  override fun getHybridDataForJNIDeallocator(): HybridData {
+    return mHybridData
   }
 
   fun ObjectDefinitionData.exportConstants() {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/worklets/Serializable.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/worklets/Serializable.kt
@@ -36,10 +36,10 @@ class Serializable @DoNotStrip private constructor(
 
   @Throws(Throwable::class)
   protected fun finalize() {
-    deallocate()
+    mHybridData.resetNative()
   }
 
-  override fun deallocate() {
-    mHybridData.resetNative()
+  override fun getHybridDataForJNIDeallocator(): HybridData {
+    return mHybridData
   }
 }


### PR DESCRIPTION
# Why

Fixes the issue of deallocation after the runtime has been cleared. The current implementation of the `JNIDeallocator` causes a race condition where we're racing with the garbage collector. Essentially, when we call `JNIDeallocator.deallocate()`, `WeakRef.get()` can return null, even though `finalize()` hasn't run yet, deferring the deallocation. The problem arises when `finalize` is called after the runtime has been deallocated.

# How

Instead of holding a weak reference to the `Destructible`, we're storing the strong reference to `HybridData`. By doing this, we ensure that the `HybridData` will always be available. We're not leaking any memory as long as `JNIDeallocator.deallocate` is called before reload.

# Test Plan

- bare-expo ✅ 