### PR TITLE
[ios][expo-go] Fix status bar

### DIFF
--- a/apps/expo-go/ios/Client/SwiftUI/Services/SettingsManager.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Services/SettingsManager.swift
@@ -109,6 +109,7 @@ class SettingsManager: ObservableObject {
 
     UIView.transition(with: window, duration: 0.3, options: .transitionCrossDissolve) {
       window.overrideUserInterfaceStyle = style
+      window.rootViewController?.setNeedsStatusBarAppearanceUpdate()
     }
   }
 }

--- a/apps/expo-go/ios/Exponent/Supporting/Info.plist
+++ b/apps/expo-go/ios/Exponent/Supporting/Info.plist
@@ -166,6 +166,6 @@
 	<key>UIUserInterfaceStyle</key>
 	<string>Automatic</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<true/>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
# Why
React natives status bar requires setting `UIViewControllerBasedStatusBarAppearance` to false. We need to update the status bar manually


# Test Plan
Expo go

