### PR TITLE
[expo-doctor] Add check for trustedDependencies with bun/pnpm

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add check for trustedDependencies with bun/pnpm ([#42455](https://github.com/expo/expo/pull/42455) by [@brentvatne](https://github.com/brentvatne))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-doctor/src/checks/TrustedDependencyCheck.ts
+++ b/packages/expo-doctor/src/checks/TrustedDependencyCheck.ts
@@ -54,9 +54,7 @@ export class TrustedDependencyCheck extends DoctorMultiCheck<TrustedDependencyCh
       const result = this.checkBunTrustedDependencies(pkg, installedPackages);
       issues.push(...result.issues);
       advice.push(...result.advice);
-    }
-
-    if (hasPnpmLockfile) {
+    } else if (hasPnpmLockfile) {
       const result = this.checkPnpmOnlyBuiltDependencies(pkg, installedPackages);
       issues.push(...result.issues);
       advice.push(...result.advice);

--- a/packages/expo-doctor/src/checks/TrustedDependencyCheck.ts
+++ b/packages/expo-doctor/src/checks/TrustedDependencyCheck.ts
@@ -48,8 +48,7 @@ export class TrustedDependencyCheck extends DoctorMultiCheck<TrustedDependencyCh
     const root = resolveWorkspaceRoot(projectRoot) ?? projectRoot;
 
     // Detect package manager from lockfile
-    const hasBunLockfile =
-      fs.existsSync(`${root}/bun.lockb`) || fs.existsSync(`${root}/bun.lock`);
+    const hasBunLockfile = fs.existsSync(`${root}/bun.lockb`) || fs.existsSync(`${root}/bun.lock`);
     const hasPnpmLockfile = fs.existsSync(`${root}/pnpm-lock.yaml`);
 
     if (!hasBunLockfile && !hasPnpmLockfile) {

--- a/packages/expo-doctor/src/checks/TrustedDependencyCheck.ts
+++ b/packages/expo-doctor/src/checks/TrustedDependencyCheck.ts
@@ -1,0 +1,104 @@
+import fs from 'fs';
+import { resolveWorkspaceRoot } from 'resolve-workspace-root';
+
+import { DoctorMultiCheck, DoctorMultiCheckItemBase } from './DoctorMultiCheck';
+import { DoctorCheckParams, DoctorCheckResult } from './checks.types';
+
+export type TrustedDependencyCheckItem = { packageName: string } & DoctorMultiCheckItemBase;
+
+/**
+ * Packages that require postinstall scripts and need to be explicitly trusted
+ * when using bun or pnpm. Each entry specifies the package name and the SDK
+ * version range where this check applies.
+ */
+export const trustedDependencyCheckItems: TrustedDependencyCheckItem[] = [
+  {
+    packageName: '@shopify/react-native-skia',
+    getMessage: (packageName: string) =>
+      `The package "${packageName}" requires a postinstall script to function correctly.`,
+    sdkVersionRange: '>=55.0.0',
+  },
+];
+
+export class TrustedDependencyCheck extends DoctorMultiCheck<TrustedDependencyCheckItem> {
+  description = 'Check that dependencies with postinstall scripts are configured for bun/pnpm';
+
+  sdkVersionRange = '*';
+
+  checkItems = trustedDependencyCheckItems;
+
+  protected async runAsyncInner(
+    { pkg, projectRoot }: DoctorCheckParams,
+    checkItems: TrustedDependencyCheckItem[]
+  ): Promise<DoctorCheckResult> {
+    const issues: string[] = [];
+    const advice: string[] = [];
+
+    // Find which packages from our check list are actually installed
+    const installedPackages = checkItems.filter(
+      (item) =>
+        pkg.dependencies?.[item.packageName] !== undefined ||
+        pkg.devDependencies?.[item.packageName] !== undefined
+    );
+
+    if (installedPackages.length === 0) {
+      return { isSuccessful: true, issues, advice };
+    }
+
+    const root = resolveWorkspaceRoot(projectRoot) ?? projectRoot;
+
+    // Detect package manager from lockfile
+    const bunLockfile = fs.existsSync(`${root}/bun.lockb`)
+      ? 'bun.lockb'
+      : fs.existsSync(`${root}/bun.lock`)
+        ? 'bun.lock'
+        : null;
+    const hasPnpmLockfile = fs.existsSync(`${root}/pnpm-lock.yaml`);
+
+    if (!bunLockfile && !hasPnpmLockfile) {
+      return { isSuccessful: true, issues, advice };
+    }
+
+    const trustedDependencies: string[] = (pkg as any).trustedDependencies ?? [];
+    const onlyBuiltDependencies: string[] = (pkg as any).pnpm?.onlyBuiltDependencies ?? [];
+
+    const missingBunPackages: string[] = [];
+    const missingPnpmPackages: string[] = [];
+
+    for (const item of installedPackages) {
+      if (bunLockfile && !trustedDependencies.includes(item.packageName)) {
+        missingBunPackages.push(item.packageName);
+        issues.push(
+          `${item.getMessage(item.packageName)} ` +
+            `It is not listed in trustedDependencies, which is required for bun to run the postinstall script.`
+        );
+      }
+
+      if (hasPnpmLockfile && !onlyBuiltDependencies.includes(item.packageName)) {
+        missingPnpmPackages.push(item.packageName);
+        issues.push(
+          `${item.getMessage(item.packageName)} ` +
+            `It is not listed in pnpm.onlyBuiltDependencies, which is required for pnpm v10+ to run the postinstall script.`
+        );
+      }
+    }
+
+    if (missingBunPackages.length > 0) {
+      const packageList = missingBunPackages.join(' ');
+      advice.push(
+        `Run the following to trust the package and re-run its postinstall script:\n\nbun pm trust ${packageList}`
+      );
+    }
+
+    if (missingPnpmPackages.length > 0) {
+      const packageList = missingPnpmPackages.map((pkg) => `"${pkg}"`).join(',\n    ');
+      advice.push(
+        `Add the following to "pnpm.onlyBuiltDependencies" in your package.json:\n\n` +
+          `"pnpm": {\n  "onlyBuiltDependencies": [\n    ${packageList}\n  ]\n}\n\n` +
+          `Then run "pnpm install" to re-run the postinstall script.`
+      );
+    }
+
+    return { isSuccessful: issues.length === 0, issues, advice };
+  }
+}

--- a/packages/expo-doctor/src/checks/TrustedDependencyCheck.ts
+++ b/packages/expo-doctor/src/checks/TrustedDependencyCheck.ts
@@ -48,14 +48,11 @@ export class TrustedDependencyCheck extends DoctorMultiCheck<TrustedDependencyCh
     const root = resolveWorkspaceRoot(projectRoot) ?? projectRoot;
 
     // Detect package manager from lockfile
-    const bunLockfile = fs.existsSync(`${root}/bun.lockb`)
-      ? 'bun.lockb'
-      : fs.existsSync(`${root}/bun.lock`)
-        ? 'bun.lock'
-        : null;
+    const hasBunLockfile =
+      fs.existsSync(`${root}/bun.lockb`) || fs.existsSync(`${root}/bun.lock`);
     const hasPnpmLockfile = fs.existsSync(`${root}/pnpm-lock.yaml`);
 
-    if (!bunLockfile && !hasPnpmLockfile) {
+    if (!hasBunLockfile && !hasPnpmLockfile) {
       return { isSuccessful: true, issues, advice };
     }
 
@@ -66,7 +63,7 @@ export class TrustedDependencyCheck extends DoctorMultiCheck<TrustedDependencyCh
     const missingPnpmPackages: string[] = [];
 
     for (const item of installedPackages) {
-      if (bunLockfile && !trustedDependencies.includes(item.packageName)) {
+      if (hasBunLockfile && !trustedDependencies.includes(item.packageName)) {
         missingBunPackages.push(item.packageName);
         issues.push(
           `${item.getMessage(item.packageName)} ` +

--- a/packages/expo-doctor/src/checks/TrustedDependencyCheck.ts
+++ b/packages/expo-doctor/src/checks/TrustedDependencyCheck.ts
@@ -1,3 +1,4 @@
+import { PackageJSONConfig } from '@expo/config';
 import fs from 'fs';
 import { resolveWorkspaceRoot } from 'resolve-workspace-root';
 
@@ -46,48 +47,74 @@ export class TrustedDependencyCheck extends DoctorMultiCheck<TrustedDependencyCh
     }
 
     const root = resolveWorkspaceRoot(projectRoot) ?? projectRoot;
-
-    // Detect package manager from lockfile
     const hasBunLockfile = fs.existsSync(`${root}/bun.lockb`) || fs.existsSync(`${root}/bun.lock`);
     const hasPnpmLockfile = fs.existsSync(`${root}/pnpm-lock.yaml`);
 
-    if (!hasBunLockfile && !hasPnpmLockfile) {
-      return { isSuccessful: true, issues, advice };
+    if (hasBunLockfile) {
+      const result = this.checkBunTrustedDependencies(pkg, installedPackages);
+      issues.push(...result.issues);
+      advice.push(...result.advice);
     }
 
+    if (hasPnpmLockfile) {
+      const result = this.checkPnpmOnlyBuiltDependencies(pkg, installedPackages);
+      issues.push(...result.issues);
+      advice.push(...result.advice);
+    }
+
+    return { isSuccessful: issues.length === 0, issues, advice };
+  }
+
+  private checkBunTrustedDependencies(
+    pkg: PackageJSONConfig,
+    installedPackages: TrustedDependencyCheckItem[]
+  ): { issues: string[]; advice: string[] } {
+    const issues: string[] = [];
+    const advice: string[] = [];
     const trustedDependencies: string[] = (pkg as any).trustedDependencies ?? [];
-    const onlyBuiltDependencies: string[] = (pkg as any).pnpm?.onlyBuiltDependencies ?? [];
 
-    const missingBunPackages: string[] = [];
-    const missingPnpmPackages: string[] = [];
+    const missingPackages = installedPackages.filter(
+      (item) => !trustedDependencies.includes(item.packageName)
+    );
 
-    for (const item of installedPackages) {
-      if (hasBunLockfile && !trustedDependencies.includes(item.packageName)) {
-        missingBunPackages.push(item.packageName);
-        issues.push(
-          `${item.getMessage(item.packageName)} ` +
-            `It is not listed in trustedDependencies, which is required for bun to run the postinstall script.`
-        );
-      }
-
-      if (hasPnpmLockfile && !onlyBuiltDependencies.includes(item.packageName)) {
-        missingPnpmPackages.push(item.packageName);
-        issues.push(
-          `${item.getMessage(item.packageName)} ` +
-            `It is not listed in pnpm.onlyBuiltDependencies, which is required for pnpm v10+ to run the postinstall script.`
-        );
-      }
+    for (const item of missingPackages) {
+      issues.push(
+        `${item.getMessage(item.packageName)} ` +
+          `It is not listed in trustedDependencies, which is required for bun to run the postinstall script.`
+      );
     }
 
-    if (missingBunPackages.length > 0) {
-      const packageList = missingBunPackages.join(' ');
+    if (missingPackages.length > 0) {
+      const packageList = missingPackages.map((item) => item.packageName).join(' ');
       advice.push(
         `Run the following to trust the package and re-run its postinstall script:\n\nbun pm trust ${packageList}`
       );
     }
 
-    if (missingPnpmPackages.length > 0) {
-      const packageList = missingPnpmPackages.map((pkg) => `"${pkg}"`).join(',\n    ');
+    return { issues, advice };
+  }
+
+  private checkPnpmOnlyBuiltDependencies(
+    pkg: PackageJSONConfig,
+    installedPackages: TrustedDependencyCheckItem[]
+  ): { issues: string[]; advice: string[] } {
+    const issues: string[] = [];
+    const advice: string[] = [];
+    const onlyBuiltDependencies: string[] = (pkg as any).pnpm?.onlyBuiltDependencies ?? [];
+
+    const missingPackages = installedPackages.filter(
+      (item) => !onlyBuiltDependencies.includes(item.packageName)
+    );
+
+    for (const item of missingPackages) {
+      issues.push(
+        `${item.getMessage(item.packageName)} ` +
+          `It is not listed in pnpm.onlyBuiltDependencies, which is required for pnpm v10+ to run the postinstall script.`
+      );
+    }
+
+    if (missingPackages.length > 0) {
+      const packageList = missingPackages.map((item) => `"${item.packageName}"`).join(',\n    ');
       advice.push(
         `Add the following to "pnpm.onlyBuiltDependencies" in your package.json:\n\n` +
           `"pnpm": {\n  "onlyBuiltDependencies": [\n    ${packageList}\n  ]\n}\n\n` +
@@ -95,6 +122,6 @@ export class TrustedDependencyCheck extends DoctorMultiCheck<TrustedDependencyCh
       );
     }
 
-    return { isSuccessful: issues.length === 0, issues, advice };
+    return { issues, advice };
   }
 }

--- a/packages/expo-doctor/src/checks/__tests__/TrustedDependencyCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/TrustedDependencyCheck.test.ts
@@ -1,0 +1,269 @@
+import { vol } from 'memfs';
+import { resolveWorkspaceRoot } from 'resolve-workspace-root';
+
+import { TrustedDependencyCheck } from '../TrustedDependencyCheck';
+
+jest.mock('fs');
+jest.mock('resolve-workspace-root', () => ({
+  resolveWorkspaceRoot: jest.fn(() => null),
+}));
+
+const projectRoot = '/tmp/project';
+
+const additionalProjectProps = {
+  exp: { name: 'name', slug: 'slug', sdkVersion: '55.0.0' },
+  projectRoot,
+  hasUnusedStaticConfig: false,
+  staticConfigPath: null,
+  dynamicConfigPath: null,
+};
+
+const skiaPackage = { dependencies: { '@shopify/react-native-skia': '^2.0.0' } };
+
+describe('TrustedDependencyCheck', () => {
+  afterEach(() => {
+    vol.reset();
+    jest.resetAllMocks();
+  });
+
+  it('passes when skia is not installed', async () => {
+    vol.fromJSON({ [projectRoot + '/bun.lockb']: 'test' });
+    const check = new TrustedDependencyCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'test', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBe(true);
+  });
+
+  it('passes when using yarn (no trustedDependencies needed)', async () => {
+    vol.fromJSON({ [projectRoot + '/yarn.lock']: 'test' });
+    const check = new TrustedDependencyCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'test', version: '1.0.0', ...skiaPackage },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBe(true);
+  });
+
+  it('passes on SDK 54 (before SDK 55 requirement)', async () => {
+    vol.fromJSON({ [projectRoot + '/bun.lockb']: 'test' });
+    const check = new TrustedDependencyCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'test', version: '1.0.0', ...skiaPackage },
+      ...additionalProjectProps,
+      exp: { name: 'name', slug: 'slug', sdkVersion: '54.0.0' },
+    });
+    expect(result.isSuccessful).toBe(true);
+  });
+
+  describe('bun', () => {
+    it('fails and provides bun pm trust advice', async () => {
+      vol.fromJSON({ [projectRoot + '/bun.lockb']: 'test' });
+      const check = new TrustedDependencyCheck();
+      const result = await check.runAsync({
+        pkg: { name: 'test', version: '1.0.0', ...skiaPackage },
+        ...additionalProjectProps,
+      });
+      expect(result.isSuccessful).toBe(false);
+      expect(result.advice[0]).toMatchSnapshot();
+      expect(result.advice[0]).toContain('bun pm trust');
+    });
+
+    it('passes when trustedDependencies includes skia', async () => {
+      vol.fromJSON({ [projectRoot + '/bun.lockb']: 'test' });
+      const check = new TrustedDependencyCheck();
+      const result = await check.runAsync({
+        pkg: {
+          name: 'test',
+          version: '1.0.0',
+          ...skiaPackage,
+          trustedDependencies: ['@shopify/react-native-skia'],
+        } as any,
+        ...additionalProjectProps,
+      });
+      expect(result.isSuccessful).toBe(true);
+    });
+  });
+
+  describe('pnpm', () => {
+    it('fails and provides correct advice', async () => {
+      vol.fromJSON({ [projectRoot + '/pnpm-lock.yaml']: 'test' });
+      const check = new TrustedDependencyCheck();
+      const result = await check.runAsync({
+        pkg: { name: 'test', version: '1.0.0', ...skiaPackage },
+        ...additionalProjectProps,
+      });
+      expect(result.isSuccessful).toBe(false);
+      expect(result.advice[0]).toMatchSnapshot();
+    });
+
+    it('passes when pnpm.onlyBuiltDependencies includes skia', async () => {
+      vol.fromJSON({ [projectRoot + '/pnpm-lock.yaml']: 'test' });
+      const check = new TrustedDependencyCheck();
+      const result = await check.runAsync({
+        pkg: {
+          name: 'test',
+          version: '1.0.0',
+          ...skiaPackage,
+          pnpm: { onlyBuiltDependencies: ['@shopify/react-native-skia'] },
+        } as any,
+        ...additionalProjectProps,
+      });
+      expect(result.isSuccessful).toBe(true);
+    });
+  });
+
+  it('checks devDependencies too', async () => {
+    vol.fromJSON({ [projectRoot + '/bun.lockb']: 'test' });
+    const check = new TrustedDependencyCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'test', version: '1.0.0', devDependencies: skiaPackage.dependencies },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBe(false);
+  });
+
+  it('checks lockfile at monorepo root', async () => {
+    const monorepoRoot = '/monorepo-root';
+    vol.fromJSON({ [monorepoRoot + '/bun.lockb']: 'test' });
+    jest.mocked(resolveWorkspaceRoot).mockReturnValue(monorepoRoot);
+
+    const check = new TrustedDependencyCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'test', version: '1.0.0', ...skiaPackage },
+      ...additionalProjectProps,
+      projectRoot: '/monorepo-root/apps/my-app',
+    });
+    expect(result.isSuccessful).toBe(false);
+  });
+
+  describe('multiple packages', () => {
+    const multipleCheckItems = [
+      {
+        packageName: '@shopify/react-native-skia',
+        getMessage: (name: string) => `Package "${name}" requires postinstall.`,
+        sdkVersionRange: '>=55.0.0',
+      },
+      {
+        packageName: 'some-other-package',
+        getMessage: (name: string) => `Package "${name}" requires postinstall.`,
+        sdkVersionRange: '>=55.0.0',
+      },
+    ];
+
+    it('reports multiple missing packages for bun', async () => {
+      vol.fromJSON({ [projectRoot + '/bun.lockb']: 'test' });
+      const check = new TrustedDependencyCheck();
+      check.checkItems = multipleCheckItems;
+
+      const result = await check.runAsync({
+        pkg: {
+          name: 'test',
+          version: '1.0.0',
+          dependencies: {
+            '@shopify/react-native-skia': '^2.0.0',
+            'some-other-package': '^1.0.0',
+          },
+        },
+        ...additionalProjectProps,
+      });
+
+      expect(result.isSuccessful).toBe(false);
+      expect(result.issues).toHaveLength(2);
+      expect(result.issues[0]).toContain('@shopify/react-native-skia');
+      expect(result.issues[1]).toContain('some-other-package');
+      expect(result.advice[0]).toContain('bun pm trust @shopify/react-native-skia some-other-package');
+    });
+
+    it('reports multiple missing packages for pnpm', async () => {
+      vol.fromJSON({ [projectRoot + '/pnpm-lock.yaml']: 'test' });
+      const check = new TrustedDependencyCheck();
+      check.checkItems = multipleCheckItems;
+
+      const result = await check.runAsync({
+        pkg: {
+          name: 'test',
+          version: '1.0.0',
+          dependencies: {
+            '@shopify/react-native-skia': '^2.0.0',
+            'some-other-package': '^1.0.0',
+          },
+        },
+        ...additionalProjectProps,
+      });
+
+      expect(result.isSuccessful).toBe(false);
+      expect(result.issues).toHaveLength(2);
+      expect(result.advice[0]).toContain('@shopify/react-native-skia');
+      expect(result.advice[0]).toContain('some-other-package');
+    });
+
+    it('only reports packages that are missing from trustedDependencies', async () => {
+      vol.fromJSON({ [projectRoot + '/bun.lockb']: 'test' });
+      const check = new TrustedDependencyCheck();
+      check.checkItems = multipleCheckItems;
+
+      const result = await check.runAsync({
+        pkg: {
+          name: 'test',
+          version: '1.0.0',
+          dependencies: {
+            '@shopify/react-native-skia': '^2.0.0',
+            'some-other-package': '^1.0.0',
+          },
+          trustedDependencies: ['@shopify/react-native-skia'],
+        } as any,
+        ...additionalProjectProps,
+      });
+
+      expect(result.isSuccessful).toBe(false);
+      expect(result.issues).toHaveLength(1);
+      expect(result.issues[0]).toContain('some-other-package');
+      expect(result.issues[0]).not.toContain('@shopify/react-native-skia');
+    });
+
+    it('passes when all packages are in trustedDependencies', async () => {
+      vol.fromJSON({ [projectRoot + '/bun.lockb']: 'test' });
+      const check = new TrustedDependencyCheck();
+      check.checkItems = multipleCheckItems;
+
+      const result = await check.runAsync({
+        pkg: {
+          name: 'test',
+          version: '1.0.0',
+          dependencies: {
+            '@shopify/react-native-skia': '^2.0.0',
+            'some-other-package': '^1.0.0',
+          },
+          trustedDependencies: ['@shopify/react-native-skia', 'some-other-package'],
+        } as any,
+        ...additionalProjectProps,
+      });
+
+      expect(result.isSuccessful).toBe(true);
+    });
+
+    it('only checks packages that are installed', async () => {
+      vol.fromJSON({ [projectRoot + '/bun.lockb']: 'test' });
+      const check = new TrustedDependencyCheck();
+      check.checkItems = multipleCheckItems;
+
+      const result = await check.runAsync({
+        pkg: {
+          name: 'test',
+          version: '1.0.0',
+          dependencies: {
+            '@shopify/react-native-skia': '^2.0.0',
+            // some-other-package is NOT installed
+          },
+        },
+        ...additionalProjectProps,
+      });
+
+      expect(result.isSuccessful).toBe(false);
+      expect(result.issues).toHaveLength(1);
+      expect(result.issues[0]).toContain('@shopify/react-native-skia');
+    });
+  });
+});

--- a/packages/expo-doctor/src/checks/__tests__/__snapshots__/TrustedDependencyCheck.test.ts.snap
+++ b/packages/expo-doctor/src/checks/__tests__/__snapshots__/TrustedDependencyCheck.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`TrustedDependencyCheck bun fails and provides bun pm trust advice 1`] = `
 "Run the following to trust the package and re-run its postinstall script:
 
-bun pm trust @shopify/react-native-skia"
+bun pm trust test-package-with-postinstall"
 `;
 
 exports[`TrustedDependencyCheck pnpm fails and provides correct advice 1`] = `
@@ -11,7 +11,7 @@ exports[`TrustedDependencyCheck pnpm fails and provides correct advice 1`] = `
 
 "pnpm": {
   "onlyBuiltDependencies": [
-    "@shopify/react-native-skia"
+    "test-package-with-postinstall"
   ]
 }
 

--- a/packages/expo-doctor/src/checks/__tests__/__snapshots__/TrustedDependencyCheck.test.ts.snap
+++ b/packages/expo-doctor/src/checks/__tests__/__snapshots__/TrustedDependencyCheck.test.ts.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TrustedDependencyCheck bun fails and provides bun pm trust advice 1`] = `
+"Run the following to trust the package and re-run its postinstall script:
+
+bun pm trust @shopify/react-native-skia"
+`;
+
+exports[`TrustedDependencyCheck pnpm fails and provides correct advice 1`] = `
+"Add the following to "pnpm.onlyBuiltDependencies" in your package.json:
+
+"pnpm": {
+  "onlyBuiltDependencies": [
+    "@shopify/react-native-skia"
+  ]
+}
+
+Then run "pnpm install" to re-run the postinstall script."
+`;

--- a/packages/expo-doctor/src/utils/checkResolver.ts
+++ b/packages/expo-doctor/src/utils/checkResolver.ts
@@ -25,6 +25,7 @@ import { ProjectSetupCheck } from '../checks/ProjectSetupCheck';
 import { ReactNativeDirectoryCheck } from '../checks/ReactNativeDirectoryCheck';
 import { StoreCompatibilityCheck } from '../checks/StoreCompatibilityCheck';
 import { SupportPackageVersionCheck } from '../checks/SupportPackageVersionCheck';
+import { TrustedDependencyCheck } from '../checks/TrustedDependencyCheck';
 import { DoctorCheck } from '../checks/checks.types';
 
 /**
@@ -49,6 +50,7 @@ export function resolveChecksInScope(exp: ExpoConfig, pkg: PackageJSONConfig): D
     new IllegalPackageCheck(),
     new GlobalPackageInstalledLocallyCheck(),
     new DirectPackageInstallCheck(),
+    new TrustedDependencyCheck(),
     new PeerDependencyChecks(),
     new AutolinkingDependencyDuplicatesCheck(),
 


### PR DESCRIPTION
## Summary

Add `TrustedDependencyCheck` to warn when packages requiring postinstall scripts are not configured correctly for bun or pnpm package managers.

This addresses issues like https://github.com/Shopify/react-native-skia/issues/3461 where `@shopify/react-native-skia` fails to work correctly because its postinstall script doesn't run.

### What it checks

- **For bun**: Checks that the package is listed in `trustedDependencies` in package.json
- **For pnpm v10+**: Checks that the package is listed in `pnpm.onlyBuiltDependencies` in package.json

### Currently checked packages

| Package | SDK Version Range |
|---------|-------------------|
| `@shopify/react-native-skia` | `>=55.0.0` |

### Adding new packages

The check uses the `DoctorMultiCheck` pattern, making it easy to add more packages in the future:

```typescript
export const trustedDependencyCheckItems: TrustedDependencyCheckItem[] = [
  {
    packageName: '@shopify/react-native-skia',
    getMessage: (packageName: string) =>
      `The package "${packageName}" requires a postinstall script to function correctly.`,
    sdkVersionRange: '>=55.0.0',
  },
  // Add more packages here
];
```

## Test plan

- [x] Unit tests added (14 tests covering all scenarios)
- [x] Manual testing with bun project

<img width="1319" height="1042" alt="image" src="https://github.com/user-attachments/assets/d915597b-aca0-4350-b948-1d4a79ef548e" />

- [x] Manual testing with pnpm project

<img width="1317" height="842" alt="image" src="https://github.com/user-attachments/assets/ff63d47e-b53f-42f0-9a03-a2b1c2d40c13" />