### PR TITLE
test(@expo/config-plugins): fix test snapshots

### DIFF
--- a/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
+++ b/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`addGoogleMapsAppDelegateImport adds maps import to AppDelegate 1`] = `
-"import Expo
+"internal import Expo
 import React
 import ReactAppDependencyProvider
 
@@ -11,7 +11,7 @@ import GoogleMaps
 #endif
 // @generated end react-native-maps-import
 @main
-public class AppDelegate: ExpoAppDelegate {
+class AppDelegate: ExpoAppDelegate {
   var window: UIWindow?
 
   var reactNativeDelegate: ExpoReactNativeFactoryDelegate?
@@ -79,12 +79,12 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
 `;
 
 exports[`addGoogleMapsAppDelegateInit adds maps import to AppDelegate 1`] = `
-"import Expo
+"internal import Expo
 import React
 import ReactAppDependencyProvider
 
 @main
-public class AppDelegate: ExpoAppDelegate {
+class AppDelegate: ExpoAppDelegate {
   var window: UIWindow?
 
   var reactNativeDelegate: ExpoReactNativeFactoryDelegate?
@@ -157,12 +157,12 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
 `;
 
 exports[`addGoogleMapsAppDelegateInit adds maps import to AppDelegate 2`] = `
-"import Expo
+"internal import Expo
 import React
 import ReactAppDependencyProvider
 
 @main
-public class AppDelegate: ExpoAppDelegate {
+class AppDelegate: ExpoAppDelegate {
   var window: UIWindow?
 
   var reactNativeDelegate: ExpoReactNativeFactoryDelegate?


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/42449 introduced changes to `AppDelegate.swift` which invalidated the snapshots in `@expo/config-plugins`.

# How

Updated test snapshots

# Test Plan

- CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
