### PR TITLE
[core][Android] Remove unowning shared_ptr to `jsi::Runtime`

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
@@ -14,11 +14,7 @@ namespace expo {
 JavaScriptRuntime::JavaScriptRuntime(
   jsi::Runtime *runtime,
   std::shared_ptr<react::CallInvoker> jsInvoker
-) : jsInvoker(std::move(jsInvoker)) {
-  // Creating a shared pointer that points to the runtime but doesn't own it, thus doesn't release it.
-  // In this code flow, the runtime should be owned by something else like the CatalystInstance.
-  // See explanation for constructor (8): https://en.cppreference.com/w/cpp/memory/shared_ptr/shared_ptr
-  this->runtime = std::shared_ptr<jsi::Runtime>(std::shared_ptr<jsi::Runtime>(), runtime);
+) : runtime(runtime), jsInvoker(std::move(jsInvoker)) {
 }
 
 jsi::Runtime &JavaScriptRuntime::get() const noexcept {

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
@@ -76,6 +76,12 @@ public:
   std::shared_ptr<react::CallInvoker> jsInvoker;
 
 private:
-  std::shared_ptr<jsi::Runtime> runtime;
+  /**
+   * Raw pointer to the runtime. We do not own this - it's managed by React Native.
+   * The runtime's lifetime is guaranteed to exceed JavaScriptRuntime's lifetime,
+   * as JSIContext::prepareForDeallocation() invalidates all weak references before
+   * the runtime is deallocated.
+   */
+  jsi::Runtime *runtime;
 };
 } // namespace expo


### PR DESCRIPTION
# Why

Removes the unowned `shared_ptr` to `jsi::Runtime`. 
Creating a `shared_ptr` that only pretends to be a smart pointer is a bad pattern, so I've decided to remove it.

# Test Plan

- bare-expo ✅ 