### PR TITLE
[core][Android] Make `getJSIContext` thread safe

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
@@ -13,12 +13,12 @@
 #include <fbjni/fbjni.h>
 
 #include <memory>
+#include <shared_mutex>
 
 namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;
 
 namespace expo {
-
 
 void JSIContext::registerNatives() {
   registerHybrid({
@@ -154,7 +154,7 @@ void JSIContext::drainJSEventLoop() {
   runtimeHolder->drainJSEventLoop();
 }
 
-void JSIContext::registerSharedObject(
+void JSIContext:: registerSharedObject(
   jni::local_ref<jobject> native,
   jni::local_ref<JavaScriptObject::javaobject> js
 ) {
@@ -263,14 +263,26 @@ bool JSIContext::wasDeallocated() const noexcept {
   return wasDeallocated_;
 }
 
-std::unordered_map<uintptr_t, JSIContext *> jsiContexts;
+static std::unordered_map<uintptr_t, JSIContext *> jsiContexts;
+static std::shared_mutex jsiContextsMutex;
 
 void bindJSIContext(const jsi::Runtime &runtime, JSIContext *jsiContext) {
+  std::unique_lock lock(jsiContextsMutex);
   jsiContexts[reinterpret_cast<uintptr_t>(&runtime)] = jsiContext;
 }
 
 void unbindJSIContext(const jsi::Runtime &runtime) {
+  std::unique_lock lock(jsiContextsMutex);
   jsiContexts.erase(reinterpret_cast<uintptr_t>(&runtime));
+}
+
+JSIContext *getJSIContext(const jsi::Runtime &runtime) {
+  std::shared_lock lock(jsiContextsMutex);
+  const auto iterator = jsiContexts.find(reinterpret_cast<uintptr_t>(&runtime));
+  if (iterator == jsiContexts.end()) {
+    throw std::invalid_argument("JSIContext for the given runtime doesn't exist");
+  }
+  return iterator->second;
 }
 
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
@@ -154,7 +154,7 @@ void JSIContext::drainJSEventLoop() {
   runtimeHolder->drainJSEventLoop();
 }
 
-void JSIContext:: registerSharedObject(
+void JSIContext::registerSharedObject(
   jni::local_ref<jobject> native,
   jni::local_ref<JavaScriptObject::javaobject> js
 ) {

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
@@ -168,13 +168,8 @@ private:
 };
 
 /**
- * We are binding the JSIContext to the runtime using a thread-local map.
- * This is a simplification of how we're accessing the JSIContext from different places.
- */
-extern std::unordered_map<uintptr_t, JSIContext *> jsiContexts;
-
-/**
  * Binds the JSIContext to the runtime.
+ * Thread-safe: uses exclusive lock.
  * @param runtime
  * @param jsiContext
  */
@@ -182,22 +177,18 @@ void bindJSIContext(const jsi::Runtime &runtime, JSIContext *jsiContext);
 
 /**
  * Unbinds the JSIContext from the runtime.
+ * Thread-safe: uses exclusive lock.
  * @param runtime
  */
 void unbindJSIContext(const jsi::Runtime &runtime);
 
 /**
  * Gets the JSIContext for the given runtime.
+ * Thread-safe: uses exclusive lock.
  * @param runtime
  * @return JSIContext * - it should never be stored when received from this function.
- * It might throw an exception if the JSIContext for the given runtime doesn't exist.
+ * @throws std::invalid_argument if the JSIContext for the given runtime doesn't exist.
  */
-inline JSIContext *getJSIContext(const jsi::Runtime &runtime) {
-  const auto iterator = jsiContexts.find(reinterpret_cast<uintptr_t>(&runtime));
-  if (iterator == jsiContexts.end()) {
-    throw std::invalid_argument("JSIContext for the given runtime doesn't exist");
-  }
-  return iterator->second;
-}
+JSIContext *getJSIContext(const jsi::Runtime &runtime);
 
 } // namespace expo


### PR DESCRIPTION
# Why

Makes `getJSIContext` thread safe.
As we start accessing this function from multiple threads (because of the worklets integration), making it thread-safe is a logical step. 

Test Plan

- bare-expo ✅ 