### PR TITLE
[core][Android] Add missing checks in the promise implementation

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Added missing checks in the promise implementation.
+- [Android] Added missing checks in the promise implementation. ([#42467](https://github.com/expo/expo/pull/42467) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Added missing checks in the promise implementation.
+
 ### 💡 Others
 
 ## 55.0.3 — 2026-01-22

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/PromiseImpl.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/PromiseImpl.kt
@@ -45,11 +45,11 @@ class PromiseImpl @DoNotStrip internal constructor(
     callback.invoke(result)
   }
 
-  override fun resolve(result: Collection<Any?>) {
+  override fun resolve(result: Collection<Any?>) = checkIfWasSettled {
     callback.invoke(result)
   }
 
-  override fun resolve(result: Map<String, Any?>) {
+  override fun resolve(result: Map<String, Any?>) = checkIfWasSettled {
     callback.invoke(result)
   }
 
@@ -62,11 +62,11 @@ class PromiseImpl @DoNotStrip internal constructor(
   private inline fun checkIfWasSettled(body: () -> Unit) {
     if (wasSettled) {
       val exception = PromiseAlreadySettledException(fullFunctionName ?: "unknown")
-      val errorManager = appContextHolder?.get()?.errorManager
+      val jsLogger = appContextHolder?.get()?.jsLogger
       // We want to report that a promise was settled twice in the development build.
       // However, in production, the app should crash.
-      if (BuildConfig.DEBUG && errorManager != null) {
-        errorManager.reportExceptionToLogBox(exception)
+      if (BuildConfig.DEBUG && jsLogger != null) {
+        jsLogger.error("Trying to resolve promise that was already settled", exception)
         logger.error("Trying to resolve promise that was already settled", exception)
         return
       }


### PR DESCRIPTION
# Why

Adds missing checks in the promise implementation to ensure the promise won't be resolved twice.

# Test Plan

- bare-expo ✅ 