### PR TITLE
[brownfield] improve bundle loading error handling

### DIFF
--- a/apps/minimal-tester/android/app/src/main/AndroidManifest.xml
+++ b/apps/minimal-tester/android/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
     <meta-data android:name="expo.modules.updates.ENABLED" android:value="false"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>
-    <activity android:name=".MainActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen" android:exported="true" android:screenOrientation="portrait">
+    <activity android:name=".MainActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode|smallestScreenSize" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen" android:exported="true" android:screenOrientation="portrait">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>

--- a/apps/minimal-tester/android/brownfield/src/main/java/com/community/minimaltester/brownfield/ReactNativeHostManager.kt
+++ b/apps/minimal-tester/android/brownfield/src/main/java/com/community/minimaltester/brownfield/ReactNativeHostManager.kt
@@ -28,6 +28,26 @@ class ReactNativeHostManager {
       return
     }
 
+    // Ensure that `index.android.bundle` is available in the assets
+    // for release builds
+    if (!BuildConfig.DEBUG) {
+      val assets = application.applicationContext.assets.list("")?.toList()
+        ?: emptyList<String>()
+      if (!assets.contains("index.android.bundle")) {
+        val bundleList = assets
+          .filter { it.endsWith(".bundle") }
+          .map { "- $it" }.joinToString("\n")
+          ?: "None"
+
+          throw IllegalStateException("""
+          Cannot find `index.android.bundle` in the assets
+          Available JS bundles:
+          $bundleList
+          """.trimIndent()
+        )
+      }
+    }
+
     DefaultNewArchitectureEntryPoint.releaseLevel =
         try {
           ReleaseLevel.valueOf(BuildConfig.REACT_NATIVE_RELEASE_LEVEL.uppercase())

--- a/apps/minimal-tester/ios/Podfile.lock
+++ b/apps/minimal-tester/ios/Podfile.lock
@@ -6,9 +6,9 @@ PODS:
   - EXConstants (55.0.0):
     - ExpoModulesCore
   - EXJSONUtils (55.0.0)
-  - EXManifests (55.0.0):
+  - EXManifests (55.0.1):
     - ExpoModulesCore
-  - Expo (55.0.0-preview.2):
+  - Expo (55.0.0-preview.3):
     - boost
     - DoubleConversion
     - ExpoModulesCore
@@ -45,11 +45,11 @@ PODS:
     - expo-dev-menu
     - expo-dev-menu-interface
     - EXUpdatesInterface
-  - expo-dev-launcher (55.0.0):
+  - expo-dev-launcher (55.0.1):
     - boost
     - DoubleConversion
     - EXManifests
-    - expo-dev-launcher/Main (= 55.0.0)
+    - expo-dev-launcher/Main (= 55.0.1)
     - expo-dev-menu
     - expo-dev-menu-interface
     - ExpoModulesCore
@@ -82,7 +82,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-launcher/Main (55.0.0):
+  - expo-dev-launcher/Main (55.0.1):
     - boost
     - DoubleConversion
     - EXManifests
@@ -119,7 +119,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-launcher/Unsafe (55.0.0):
+  - expo-dev-launcher/Unsafe (55.0.1):
     - boost
     - DoubleConversion
     - EXManifests
@@ -224,7 +224,7 @@ PODS:
     - ExpoModulesCore
   - ExpoBlur (55.0.0):
     - ExpoModulesCore
-  - ExpoBrownfield (55.0.1):
+  - ExpoBrownfield (55.0.2):
     - ExpoModulesCore
   - ExpoCamera (55.0.0):
     - ExpoModulesCore
@@ -232,24 +232,24 @@ PODS:
     - ZXingObjC/PDF417
   - ExpoDomWebView (55.0.0):
     - ExpoModulesCore
-  - ExpoFileSystem (55.0.0):
+  - ExpoFileSystem (55.0.1):
     - ExpoModulesCore
-  - ExpoFont (55.0.0):
+  - ExpoFont (55.0.1):
     - ExpoModulesCore
-  - ExpoImage (55.0.0):
+  - ExpoImage (55.0.1):
     - ExpoModulesCore
     - libavif/libdav1d
     - SDWebImage (~> 5.21.0)
     - SDWebImageAVIFCoder (~> 0.11.0)
     - SDWebImageSVGCoder (~> 1.7.0)
     - SDWebImageWebPCoder (~> 0.14.6)
-  - ExpoKeepAwake (55.0.0):
+  - ExpoKeepAwake (55.0.1):
     - ExpoModulesCore
-  - ExpoLinearGradient (55.0.0):
+  - ExpoLinearGradient (55.0.1):
     - ExpoModulesCore
   - ExpoLogBox (55.0.0):
     - React-Core
-  - ExpoModulesCore (55.0.1):
+  - ExpoModulesCore (55.0.2):
     - boost
     - DoubleConversion
     - ExpoModulesJSI
@@ -279,16 +279,16 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - ExpoModulesJSI (55.0.1):
+  - ExpoModulesJSI (55.0.2):
     - hermes-engine
     - React-Core
     - ReactCommon
-  - ExpoSplashScreen (55.0.0):
+  - ExpoSplashScreen (55.0.1):
     - ExpoModulesCore
-  - ExpoVideo (55.0.0):
+  - ExpoVideo (55.0.1):
     - ExpoModulesCore
   - EXStructuredHeaders (55.0.0)
-  - EXUpdates (55.0.1):
+  - EXUpdates (55.0.2):
     - boost
     - DoubleConversion
     - EASClient
@@ -322,7 +322,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - EXUpdatesInterface (55.0.0):
+  - EXUpdatesInterface (55.1.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
   - FBLazyVector (0.83.1)
@@ -3147,112 +3147,112 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
-  EASClient: 0e92b35caff07b9c8b1e31b203d446cdd3eada4d
-  EXConstants: 65fe36b560cfb2ff76add4bc6589ff21630814c0
+  EASClient: 85fbd44cc0230ff1b1be0a1070ffe528a2303612
+  EXConstants: fea07f26ec3784e1e80c3f0888bad856928400f8
   EXJSONUtils: 0080c14b673cfa9a6be5e3fe429768ffe3d42dfb
-  EXManifests: 57f815598cd5df5a39d5662f27d96bd4aa604c89
-  Expo: cb6284319e4ed8d487cfb1853d10d7f9b39cd357
-  expo-dev-client: 6f2af592572f4fb88ab459fe0190b0a02ecfd16c
-  expo-dev-launcher: ffbb64642b32c5acd85488f95c57e0ea2884aa26
-  expo-dev-menu: eb8406a12274a2b07de2c83b934ac638090c3626
+  EXManifests: bf32133d6067a9e800c6c2c154eb7b2aa2d0c352
+  Expo: 4b3d21b46abe26b108644a0b17061a6b8f377257
+  expo-dev-client: bb4930c27e7d05e5ef8ff07e2d4e4d3990893be9
+  expo-dev-launcher: 83c95eaca062bebd43789a8f7d0e93a3a6d128f2
+  expo-dev-menu: 6f42ed93d2319113fb6f1435296ef824837221a9
   expo-dev-menu-interface: a98021861ad111a46dc6c9f816b55be01ea03c63
-  ExpoAppleAuthentication: 30e39816226b75f7e4c22002a1f0e2bdc894257c
-  ExpoAsset: 4455a4812233ad8de0284ab0b06155490685bda1
-  ExpoBlur: 5cf1b4bb03726956e2c76e0a20e58ac6eb25b786
-  ExpoBrownfield: 13aa0fc4a0c7d576921fda3cc5cc5a1f03a47247
-  ExpoCamera: 1c4d57b4b163dadc70a587735c1cc8c754d14274
-  ExpoDomWebView: 28a306bcba60b220381e4bc324ea0793ef9682e9
-  ExpoFileSystem: 86bd3c861e060cce60b4610a964b6614c79e6648
-  ExpoFont: bf7c1cbc058619b944341a19de4c8952f108cc87
-  ExpoImage: ecc380d844187c228560da595372240fa6722397
-  ExpoKeepAwake: ab792829740bf9b3177c9d4ebbe2504ffd20afdb
-  ExpoLinearGradient: 8074214771de6810927e4ed85bf4c6db83cfd91d
-  ExpoLogBox: c464ef6290089df4b83dd078f720956b6223a578
-  ExpoModulesCore: 100adb3ceb857bf416fe0b4d40bf2bad39b371f8
-  ExpoModulesJSI: d7757f506c64a5e79cb118b6ca1f2e9ccd4565d7
-  ExpoSplashScreen: 455d03265cfa12eb642465273b1485a46016eab8
-  ExpoVideo: 05ac6341fe41bf7c29156a403068c42c0bf88d53
+  ExpoAppleAuthentication: e120bb0b67b9e40185c30306cf22603abdbf65f4
+  ExpoAsset: 13e72f673d51931ffbdf0b511b58cc44cec61d6a
+  ExpoBlur: d932911a01492ed8a526a6646984eb44a8e342db
+  ExpoBrownfield: f2414b556eb9f1ca8d14a953b2da3930f41597ea
+  ExpoCamera: ca792b80d5f817586d12a19f3a3054e006fcca3a
+  ExpoDomWebView: 08df88d0c406fed01d05dc12e2af7bca1b42ff89
+  ExpoFileSystem: 82494c2f48c6433ffd434eef9f5696bc6e2b4a68
+  ExpoFont: 197fbba32b3c934bc6960bfb3f9cb3bb1b2a2c2a
+  ExpoImage: 7528b02051da76c353d62462a1561a32c69dadf5
+  ExpoKeepAwake: 25dfa60d8f1604c9a479fe7ae600edb531cb5427
+  ExpoLinearGradient: c0c6e3b0e930343fd0a458b6ebd59a1f2f7836af
+  ExpoLogBox: 699c0d4e01140b9acf3a6b303bc0820d4d7ed7a8
+  ExpoModulesCore: 12a32b9cd083b498361b2e33515b9af5d7558acd
+  ExpoModulesJSI: 4835f5f14791fe6352c478f638827026af99547f
+  ExpoSplashScreen: dc44ede0df50e25b9ab31f361fdd6de1123ab957
+  ExpoVideo: 5e250025d7f84a6e030fde3dd00aeae527c50b09
   EXStructuredHeaders: aa49a5557fa24aa61dda4ac665f3987bf3e9e35d
-  EXUpdates: 52016e679ec08effbddbfc4b95bacf1bdcfd9bf4
-  EXUpdatesInterface: 34568cdec00dddd734d30fecf010830d9a17a8b3
+  EXUpdates: d8e238e7f9e066e3450609be6231e67cf1296c28
+  EXUpdatesInterface: 0fc08601b9a6df1a22336168fb8ec24a9d217f26
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: 309703e71d3f2f1ed7dc7889d58309c9d77a95a4
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: 9a270294aaec03556862ee83edd0f490710bfbb2
+  hermes-engine: 89a68271007773750004d1af0538efdbb268f514
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
-  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
+  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: a41bbdd9af30bf2e5715796b313e44ec43eefff1
   RCTRequired: 7be34aabb0b77c3cefe644528df0fa0afad4e4d0
   RCTSwiftUI: a6c7271c39098bf00dbdad8f8ed997a59bbfbe44
-  RCTSwiftUIWrapper: 5ec163e8fde163d3fba714a992b50a266e1ece37
+  RCTSwiftUIWrapper: ff9098ccf7727e58218f2f8ea110349863f43438
   RCTTypeSafety: 27927d0ca04e419ed9467578b3e6297e37210b5c
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
   React: 4bc1f928568ad4bcfd147260f907b4ea5873a03b
   React-callinvoker: 87f8728235a0dc62e9dc19b3851c829d9347d015
-  React-Core: 19e0183e28d7a6613ecacebd7525fe6650efa3b6
-  React-CoreModules: 73cc86f2a0ff84b93d6325073ad2e4874d21ad40
-  React-cxxreact: 4bf734645c77c9b86e2f3e933e0411cf2f14d1ba
+  React-Core: 76bed73b02821e5630e7f2cb2e82432ee964695d
+  React-CoreModules: 752dbfdaeb096658aa0adc4a03ba6214815a08df
+  React-cxxreact: b6798528aa601c6db66e6adc7e2da2b059c8be74
   React-debug: b2c9f60a9b7a81cefd737cb61e31c2bc39fdfe17
-  React-defaultsnativemodule: d5577e030a746840c77d791f06382a5fd7c2b789
-  React-domnativemodule: cec896810e9856a07ae62682b2c4e699307f9f35
-  React-Fabric: ea457167d2bb9b8ceb31fd0882393ab08d32f0b8
-  React-FabricComponents: aa8cf0b3409a81222786fb6e2e45069f44e060ca
-  React-FabricImage: 7629c06d41d6dea01d152ce0077b15147169f48f
-  React-featureflags: 7f1e45dd4148aabba7b42b2d588fb45d432c0a6d
-  React-featureflagsnativemodule: cb1c09c4e3e4873f101bbdd9be2fa0f7906ec5ab
-  React-graphics: 163d15b019d7ff23032a1a8d2b37f5afdd561bbb
-  React-hermes: ec50b9fcea2c3bfdd42f8cec845eac3f35888572
-  React-idlecallbacksnativemodule: 1a358f7d16b9ff916a646ba184cded54f74439b8
-  React-ImageManager: 958477b5f4acc67f864111c55de84bcdbd1d6592
-  React-intersectionobservernativemodule: 189460858d6105bc44ded7fb02d19cd887f25bc6
-  React-jserrorhandler: 291eddd4e3dc80927c306e039ecbeb4dc515eb6f
-  React-jsi: 3216c876cd4c571a57909e22d77c8fd9530aa067
-  React-jsiexecutor: 475563c0042841a85930a455d3199f6b1483a5fe
-  React-jsinspector: 856aff364b569a4cd861605656de41d34c3cd92d
-  React-jsinspectorcdp: f34715c4c392e75f217bd5453aa8ff5bc394c111
-  React-jsinspectornetwork: 8a02d4d189476b1a92d6c49014fa83973b6fc24d
-  React-jsinspectortracing: 9a97753c772fbce4f2ed8d4fb684e507d7e49a5a
-  React-jsitooling: 6fda3ff1bfed7525e7be2f5ca152b6d2d378e4a8
-  React-jsitracing: a2dd6d6df9d017d5be176d5e71e09f8ce6f99594
-  React-logger: 6ac901f5c7f7321d2be1a40b203bccc2e23411e3
-  React-Mapbuffer: 9d33f0f79b6b5705d08d89d8fb9709d1ee655c81
-  React-microtasksnativemodule: 1a5a9488d2a05c74ea276c2012df632d8221d169
-  React-NativeModulesApple: dfce21d2c4b7eab44db0af861fcb8998d0b8ad16
-  React-networking: 26355121d0bf86d974dff5a3cc11f8aeb9f28a22
+  React-defaultsnativemodule: d9eb6790253633d37bab0dfd46994d772968be51
+  React-domnativemodule: eee0fbeb6828e86ad1d1a0f8d2d89bc604a62cc4
+  React-Fabric: 5eec4db4e42bbb55308900ee2aeb395d641f63b1
+  React-FabricComponents: 556077c756a43b0c0ab719b07a282bc0bb081fc6
+  React-FabricImage: 2ebf436bfe52bc6d9d2ae37a3d643280c8266e4e
+  React-featureflags: d3a2bd36b3763547e7887a30257191192ee789e6
+  React-featureflagsnativemodule: 9c06fad6d4f1def2dc7a45b56da2b96a0b7853a5
+  React-graphics: b116d3926d6c159565ea9ee96504d8c1d9cfbcdc
+  React-hermes: 32fc9c231c1aa5c2fcfe851b0d19ee9269f88f4c
+  React-idlecallbacksnativemodule: d8034c2adb86c8ff3c03be505cb9a20c8ced1737
+  React-ImageManager: 6c5cd273187a1f3ccf68f6d6bf57e06647baf50e
+  React-intersectionobservernativemodule: 1d8f1fe45ab8d45a82b08562ff412b6f128d41d3
+  React-jserrorhandler: c1455b7243cf6fed0a8fd82bfbb2ef7637372304
+  React-jsi: adf8527fec197ad9d0480cc5b8945eb56de627f0
+  React-jsiexecutor: 315fa2f879b43e3a9ca08f5f4b733472f7e4e8a4
+  React-jsinspector: 31fa81ccb390c1369acd545c3710ab6169ee77ff
+  React-jsinspectorcdp: 2d80f6c2d69b9b1809c272d999730dcc5b21a973
+  React-jsinspectornetwork: 3aed0076638835994bfce74ea3f05a901d3ab110
+  React-jsinspectortracing: 9f5ff99c584ae25d71ba158f852219e62dba8afc
+  React-jsitooling: 4e41ef5710527621ab85f2ee5a9c8ea05791aeee
+  React-jsitracing: f7f0e13dfa856460817b7f74f36c883dd0eb89b6
+  React-logger: b8483fa08e0d62e430c76d864309d90576ca2f68
+  React-Mapbuffer: d0c5f3793332ebec11bfbbbd962ea526ee85efff
+  React-microtasksnativemodule: 1a7d806e2ec20df1c6d88b29e72787fb48aeab70
+  React-NativeModulesApple: e554252d69442010807867cc7d70c0008048ad20
+  React-networking: 669cb54cc7e5b65d7dafeeb36970a1421adc8bb3
   React-oscompat: 80166b66da22e7af7fad94474e9997bd52d4c8c6
-  React-perflogger: 63c90e0d8c24df87ffa14dad01aeafc352847dd0
-  React-performancecdpmetrics: 5b0a0eb369b5fcb18109fba91bdd5ac2a2360753
-  React-performancetimeline: 9a45658d92ce7b30d41fa557bbe9fa7c399f301b
+  React-perflogger: d6797918d2b1031e91a9d8f5e7fdd2c8728fb390
+  React-performancecdpmetrics: 7706707d5dd49d708518a91abe456dcb585a5865
+  React-performancetimeline: c9807b559901c4298a92f6bcb069f49f518b7020
   React-RCTActionSheet: 3bd5f5db9f983cf38d51bb9a7a198e2ebea94821
-  React-RCTAnimation: 346865a809fa5132f6c594c8b376c6cf46b44e88
-  React-RCTAppDelegate: b2d1e0d3663c987f49f45094883b9e36fcbf0181
-  React-RCTBlob: 74759ebb7ff9077d19f60c301782c1f8c3eb2813
-  React-RCTFabric: 7a352dc4db7da5334b36d0074d3e44a112d4d168
-  React-RCTFBReactNativeSpec: f74fabd086f4a302a9883086ad1398a4408aecd4
-  React-RCTImage: 60763f56e8a5e45d861d7c4777e428bb820ec52a
-  React-RCTLinking: 52aee78b0b3163167c7fcf58f80a42943c03a056
-  React-RCTNetwork: f5e1e8ae5eff6982efff6289b06ec0a76d0a6ac2
-  React-RCTRuntime: b1c69249aab7cf0ff2b9cf7bd7d1cdc23c60c89f
-  React-RCTSettings: 298bb40d3412bf32e0b4f0797e48416b0b7278a1
-  React-RCTText: dfb74800e27d792d1188fa975a3b9807c3362e3e
-  React-RCTVibration: ffe5fd4f50a835e353a3b6869eb005dab11eea44
+  React-RCTAnimation: 46a9978f27dc434dbeed16afa7b82619b690a9af
+  React-RCTAppDelegate: 62ecd60a2b2a8cae26ce6a066bfa59cfde97af01
+  React-RCTBlob: 8285c859513023ee3cc8c806d9b59d4da078c4ba
+  React-RCTFabric: ab7096fa22eea969efe8947c6296d3c5e03bf51a
+  React-RCTFBReactNativeSpec: 7bddf0751b44174a60921dc680fa6396a0873de1
+  React-RCTImage: a5364d0f098692cfbf5bef1e8a63e7712ecb14b7
+  React-RCTLinking: 34b63b0aa0e92d30f5d7aa2c255a8f95fa75ee8f
+  React-RCTNetwork: 1ef88b7a5310b8f915d3556b5b247def113191ed
+  React-RCTRuntime: 5217917c3c456268a029c09af419b3c6d93bf6d4
+  React-RCTSettings: 2c45623d6c0f30851a123f621eb9d32298bcbb0c
+  React-RCTText: 0ee70f5dc18004b4d81b2c214267c6cbec058587
+  React-RCTVibration: 88557e21e7cc3fe76b5b174cba28ff45c6def997
   React-rendererconsistency: ac8a9e9ee3eb299458cc848944133ff4be46cc41
-  React-renderercss: 25ff740b0da15dab6ba505c702c86bfbe9cd764e
-  React-rendererdebug: 48afb7a15ed4f2a87760e63abdc70bb92f4165d0
-  React-RuntimeApple: bcc8fbdce32bc7100294bf9a4b741da233d38de2
-  React-RuntimeCore: 632c35fbe0980a390719470a9f6d2f1ba9dc3bd0
-  React-runtimeexecutor: 8151aae90978856b75f3c5079c428c00f795ffa6
-  React-RuntimeHermes: 1269317d3d7d899f27aa3c03a04d7ce017171837
-  React-runtimescheduler: 752209b337a93cd3a25ecea691308f6b801706cf
-  React-timing: 73729fab687aa4876d45707e9f7ddc9446effab1
-  React-utils: a60c501ec701ca062f3c5367ce766c4e5bfc363a
-  React-webperformancenativemodule: 7ec95df9690d9cc96e31f3282facecd39a3914a6
-  ReactAppDependencyProvider: bfb12ead469222b022a2024f32aba47ce50de512
-  ReactCodegen: 148faf1633ee5ba0f56a4028b6e08611019f86a8
-  ReactCommon: 136c3863bf14312a58944f674691f2c5874deafb
+  React-renderercss: f04cbe3b06ee071c6ca724f41a3c3aa31332601e
+  React-rendererdebug: 2a2e4f7d42abcbec2047e989a1afda5d62905679
+  React-RuntimeApple: ce2ae0ea88316a7c708be1e6601e4ec5f6febdce
+  React-RuntimeCore: 55b3dcac1c0e7acf98aaebb9b4c6a793bdc332e0
+  React-runtimeexecutor: e4bf693c55393af5c4c62ac775c7212552ccde7a
+  React-RuntimeHermes: a9e2538786653648830a0efb278d51237c1a8c27
+  React-runtimescheduler: 0142588a3aad9a8607f0de743330d6e459f604b8
+  React-timing: 95d4939cbcd64d05c94d7c18b9cfba7c931340fd
+  React-utils: 28158276c67b375d1b7546a342571cfffbea9770
+  React-webperformancenativemodule: 3aa0693c4d19898831317e17b005fad3444d2c99
+  ReactAppDependencyProvider: 0eb286cc274abb059ee601b862ebddac2e681d01
+  ReactCodegen: 0a54319cc6fb7e0a795241bc88f41cdea3ddf436
+  ReactCommon: 15e1e727fa34f760beb7dd52928687fda8edf8dc
   SDWebImage: e9c98383c7572d713c1a0d7dd2783b10599b9838
   SDWebImageAVIFCoder: afe194a084e851f70228e4be35ef651df0fc5c57
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c

--- a/apps/minimal-tester/ios/minimaltester.xcodeproj/project.pbxproj
+++ b/apps/minimal-tester/ios/minimaltester.xcodeproj/project.pbxproj
@@ -8,69 +8,69 @@
 
 /* Begin PBXBuildFile section */
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
-		1A9C3FEE176E76CD277616C1 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2A9FDF306E7C907693D4B2 /* ExpoModulesProvider.swift */; };
+		2254091221B84C9AA553974E /* ExpoAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA31C75083F7467797782A25 /* ExpoAppDelegate.swift */; };
+		34C5E0452A74357905ED5169 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 05BA831F9756B673C9BBE617 /* PrivacyInfo.xcprivacy */; };
+		3DF810F5FAA84349BA1369BD /* ReactNativeDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0D6AB536D248849877F7D3 /* ReactNativeDelegate.swift */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
-		47A1BC855300F66136D138B4 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 262C19D42E54D798E4633179 /* PrivacyInfo.xcprivacy */; };
-		50F6754CC0254DCD98440C05 /* ReactNativeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6847363B64614864AA15DEB2 /* ReactNativeView.swift */; };
-		5889114962A3424DB83B6225 /* ReactNativeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96AB130EB2184A7898B042A6 /* ReactNativeViewController.swift */; };
-		696195D211EC191B8C83FDA9 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55931CD212BCEECFD215B0C2 /* ExpoModulesProvider.swift */; };
-		7119BAFD4E3A4EBF86717FC4 /* ReactNativeDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36820F3E3AF14CF791BA1CB3 /* ReactNativeDelegate.swift */; };
-		85265E65994D47F8BC64346F /* Messaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C932C1D8344753A28370DC /* Messaging.swift */; };
-		909EDAECAFC24DAB50E82EBD /* Pods_minimaltester.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AB27F41467BD7870F805C79 /* Pods_minimaltester.framework */; };
-		AD4D1A1C56E998D480A7CAF0 /* Pods_minimaltester_minimaltesterbrownfield.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 32E133AAEF4A042D87EE9B20 /* Pods_minimaltester_minimaltesterbrownfield.framework */; };
+		435BDB3DC69840AE9B29F7F4 /* ReactNativeHostManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0DE02501DA4F2F85CE7C34 /* ReactNativeHostManager.swift */; };
+		5FE1EE223A124930AB42B6C0 /* ReactNativeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 423616B5ECC54DA588FA1C7E /* ReactNativeViewController.swift */; };
+		6339C9F34388DBB82F435CD3 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F86AC3DD43E6118B4DFF7D /* ExpoModulesProvider.swift */; };
+		9ADCE841A00849AA9354F08E /* Messaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28023188238A4ECAB556739F /* Messaging.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
-		C4745D87306D4F8DBCF824C2 /* ExpoAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2568F85EB0741EDAFF68809 /* ExpoAppDelegate.swift */; };
-		E9202CD8DB9645EF8A174B46 /* ReactNativeHostManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887FAA7343034328BD64D25C /* ReactNativeHostManager.swift */; };
+		C4527CC3DBDE587C78B5CB12 /* Pods_minimaltester.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 524602FD19ECF96E08A27B79 /* Pods_minimaltester.framework */; };
+		D19BEEDF3C6D4273BE5EE97B /* Pods_minimaltester_minimaltesterbrownfield.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E2E3F50EA16E330FDC9C56C /* Pods_minimaltester_minimaltesterbrownfield.framework */; };
+		E80B12B740014503A23B87CE /* ReactNativeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2236CCBA3DB94C06B0EF4C4C /* ReactNativeView.swift */; };
 		F11748422D0307B40044C1D9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11748412D0307B40044C1D9 /* AppDelegate.swift */; };
+		FD75274D2DFE9F49F0F5E7B6 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DFE6AE523FAACF5765097B /* ExpoModulesProvider.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		03C932C1D8344753A28370DC /* Messaging.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = Messaging.swift; path = minimaltesterbrownfield/Messaging.swift; sourceTree = "<group>"; };
-		08D6657006317D00C14874CA /* Pods-minimaltester-minimaltesterbrownfield.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-minimaltester-minimaltesterbrownfield.debug.xcconfig"; path = "Target Support Files/Pods-minimaltester-minimaltesterbrownfield/Pods-minimaltester-minimaltesterbrownfield.debug.xcconfig"; sourceTree = "<group>"; };
-		137610AC4E0E1793D95CDF3B /* Pods-minimaltester.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-minimaltester.release.xcconfig"; path = "Target Support Files/Pods-minimaltester/Pods-minimaltester.release.xcconfig"; sourceTree = "<group>"; };
+		05BA831F9756B673C9BBE617 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = minimaltester/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		06AF64CE8ECB2C1F3CF3E4B5 /* Pods-minimaltester.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-minimaltester.debug.xcconfig"; path = "Target Support Files/Pods-minimaltester/Pods-minimaltester.debug.xcconfig"; sourceTree = "<group>"; };
+		0C0D6AB536D248849877F7D3 /* ReactNativeDelegate.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ReactNativeDelegate.swift; path = minimaltesterbrownfield/ReactNativeDelegate.swift; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* minimaltester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = minimaltester.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = minimaltester/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = minimaltester/Info.plist; sourceTree = "<group>"; };
-		1AB27F41467BD7870F805C79 /* Pods_minimaltester.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_minimaltester.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		262C19D42E54D798E4633179 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = minimaltester/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		2728B7711F5D4724A425F4CC /* ReactNativeViewController.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ReactNativeViewController.swift; path = ReactNativeViewController.swift; sourceTree = "<group>"; };
-		32E133AAEF4A042D87EE9B20 /* Pods_minimaltester_minimaltesterbrownfield.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_minimaltester_minimaltesterbrownfield.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		36820F3E3AF14CF791BA1CB3 /* ReactNativeDelegate.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ReactNativeDelegate.swift; path = minimaltesterbrownfield/ReactNativeDelegate.swift; sourceTree = "<group>"; };
-		3A6E6C39EB4F43D7910747C1 /* ExpoAppDelegate.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ExpoAppDelegate.swift; path = ExpoAppDelegate.swift; sourceTree = "<group>"; };
-		3B68FB6BD1F44018B62A221D /* ReactNativeHostManager.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ReactNativeHostManager.swift; path = ReactNativeHostManager.swift; sourceTree = "<group>"; };
-		4C90341FAABB4AF3BD3EB5C4 /* minimaltesterbrownfield.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = undefined; name = minimaltesterbrownfield.framework; path = minimaltesterbrownfield.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		55931CD212BCEECFD215B0C2 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-minimaltester-minimaltesterbrownfield/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
-		5B220AF33CBA4C5EA6C16252 /* ReactNativeView.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ReactNativeView.swift; path = ReactNativeView.swift; sourceTree = "<group>"; };
-		5B8DFEF9E6448F852E586EF7 /* Pods-minimaltester.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-minimaltester.debug.xcconfig"; path = "Target Support Files/Pods-minimaltester/Pods-minimaltester.debug.xcconfig"; sourceTree = "<group>"; };
-		6847363B64614864AA15DEB2 /* ReactNativeView.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ReactNativeView.swift; path = minimaltesterbrownfield/ReactNativeView.swift; sourceTree = "<group>"; };
-		6D09C0EFC78846B49D5389AE /* Messaging.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = Messaging.swift; path = Messaging.swift; sourceTree = "<group>"; };
-		887FAA7343034328BD64D25C /* ReactNativeHostManager.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ReactNativeHostManager.swift; path = minimaltesterbrownfield/ReactNativeHostManager.swift; sourceTree = "<group>"; };
-		96AB130EB2184A7898B042A6 /* ReactNativeViewController.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ReactNativeViewController.swift; path = minimaltesterbrownfield/ReactNativeViewController.swift; sourceTree = "<group>"; };
-		9E7CC8A7802E4512BE8799E1 /* ReactNativeDelegate.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ReactNativeDelegate.swift; path = ReactNativeDelegate.swift; sourceTree = "<group>"; };
+		2236CCBA3DB94C06B0EF4C4C /* ReactNativeView.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ReactNativeView.swift; path = minimaltesterbrownfield/ReactNativeView.swift; sourceTree = "<group>"; };
+		28023188238A4ECAB556739F /* Messaging.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = Messaging.swift; path = minimaltesterbrownfield/Messaging.swift; sourceTree = "<group>"; };
+		3E2E3F50EA16E330FDC9C56C /* Pods_minimaltester_minimaltesterbrownfield.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_minimaltester_minimaltesterbrownfield.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		423616B5ECC54DA588FA1C7E /* ReactNativeViewController.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ReactNativeViewController.swift; path = minimaltesterbrownfield/ReactNativeViewController.swift; sourceTree = "<group>"; };
+		49DFE6AE523FAACF5765097B /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-minimaltester-minimaltesterbrownfield/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
+		4BEA1E871928440BAE9C963D /* ExpoAppDelegate.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ExpoAppDelegate.swift; path = ExpoAppDelegate.swift; sourceTree = "<group>"; };
+		524602FD19ECF96E08A27B79 /* Pods_minimaltester.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_minimaltester.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		57BD76673CFB456096412D4F /* ReactNativeViewController.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ReactNativeViewController.swift; path = ReactNativeViewController.swift; sourceTree = "<group>"; };
+		5F0DE02501DA4F2F85CE7C34 /* ReactNativeHostManager.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ReactNativeHostManager.swift; path = minimaltesterbrownfield/ReactNativeHostManager.swift; sourceTree = "<group>"; };
+		75D786E36F2849E58B20CB4C /* minimaltesterbrownfield.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = undefined; name = minimaltesterbrownfield.framework; path = minimaltesterbrownfield.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = minimaltester/SplashScreen.storyboard; sourceTree = "<group>"; };
-		AFA20A65B327003B5C2CB853 /* Pods-minimaltester-minimaltesterbrownfield.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-minimaltester-minimaltesterbrownfield.release.xcconfig"; path = "Target Support Files/Pods-minimaltester-minimaltesterbrownfield/Pods-minimaltester-minimaltesterbrownfield.release.xcconfig"; sourceTree = "<group>"; };
+		AA31C75083F7467797782A25 /* ExpoAppDelegate.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ExpoAppDelegate.swift; path = minimaltesterbrownfield/ExpoAppDelegate.swift; sourceTree = "<group>"; };
+		B40F6AB3378145C4936565D4 /* ReactNativeView.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ReactNativeView.swift; path = ReactNativeView.swift; sourceTree = "<group>"; };
+		B9F86AC3DD43E6118B4DFF7D /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-minimaltester/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
-		D2568F85EB0741EDAFF68809 /* ExpoAppDelegate.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ExpoAppDelegate.swift; path = minimaltesterbrownfield/ExpoAppDelegate.swift; sourceTree = "<group>"; };
+		BC33192A1BF1473ABE4B30FF /* ReactNativeHostManager.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ReactNativeHostManager.swift; path = ReactNativeHostManager.swift; sourceTree = "<group>"; };
+		C6A7E0A08C2073E007A6A4B6 /* Pods-minimaltester-minimaltesterbrownfield.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-minimaltester-minimaltesterbrownfield.debug.xcconfig"; path = "Target Support Files/Pods-minimaltester-minimaltesterbrownfield/Pods-minimaltester-minimaltesterbrownfield.debug.xcconfig"; sourceTree = "<group>"; };
+		CA4AA5814BAF40159CEEA350 /* Messaging.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = Messaging.swift; path = Messaging.swift; sourceTree = "<group>"; };
+		DC4DCCFA8FA7E79C4A057F36 /* Pods-minimaltester-minimaltesterbrownfield.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-minimaltester-minimaltesterbrownfield.release.xcconfig"; path = "Target Support Files/Pods-minimaltester-minimaltesterbrownfield/Pods-minimaltester-minimaltesterbrownfield.release.xcconfig"; sourceTree = "<group>"; };
+		E13162346AC08B1E87753822 /* Pods-minimaltester.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-minimaltester.release.xcconfig"; path = "Target Support Files/Pods-minimaltester/Pods-minimaltester.release.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		EFB260E88C5D41179427FB5F /* ReactNativeDelegate.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = ReactNativeDelegate.swift; path = ReactNativeDelegate.swift; sourceTree = "<group>"; };
 		F11748412D0307B40044C1D9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = minimaltester/AppDelegate.swift; sourceTree = "<group>"; };
 		F11748442D0722820044C1D9 /* minimaltester-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "minimaltester-Bridging-Header.h"; path = "minimaltester/minimaltester-Bridging-Header.h"; sourceTree = "<group>"; };
-		FB2A9FDF306E7C907693D4B2 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-minimaltester/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		0828A7B9316B632E46498FAD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D19BEEDF3C6D4273BE5EE97B /* Pods_minimaltester_minimaltesterbrownfield.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		13B07F8C1A680F5B00A75B9A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				909EDAECAFC24DAB50E82EBD /* Pods_minimaltester.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		3DB07664AF9E789CCE1C0F65 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				AD4D1A1C56E998D480A7CAF0 /* Pods_minimaltester_minimaltesterbrownfield.framework in Frameworks */,
+				C4527CC3DBDE587C78B5CB12 /* Pods_minimaltester.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -86,56 +86,50 @@
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
-				262C19D42E54D798E4633179 /* PrivacyInfo.xcprivacy */,
+				05BA831F9756B673C9BBE617 /* PrivacyInfo.xcprivacy */,
 			);
 			name = minimaltester;
 			sourceTree = "<group>";
 		};
-		283A6559C9BD0C32ACB98EBA /* Pods */ = {
+		297E74C9BE17A62984E294A1 /* ExpoModulesProviders */ = {
 			isa = PBXGroup;
 			children = (
-				5B8DFEF9E6448F852E586EF7 /* Pods-minimaltester.debug.xcconfig */,
-				137610AC4E0E1793D95CDF3B /* Pods-minimaltester.release.xcconfig */,
-				08D6657006317D00C14874CA /* Pods-minimaltester-minimaltesterbrownfield.debug.xcconfig */,
-				AFA20A65B327003B5C2CB853 /* Pods-minimaltester-minimaltesterbrownfield.release.xcconfig */,
+				BE7A8274E8BE715D5D44DA2B /* minimaltester */,
+				4C68D975F4B685E936979D27 /* minimaltesterbrownfield */,
 			);
-			name = Pods;
-			path = Pods;
+			name = ExpoModulesProviders;
 			sourceTree = "<group>";
 		};
 		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				1AB27F41467BD7870F805C79 /* Pods_minimaltester.framework */,
-				32E133AAEF4A042D87EE9B20 /* Pods_minimaltester_minimaltesterbrownfield.framework */,
+				524602FD19ECF96E08A27B79 /* Pods_minimaltester.framework */,
+				3E2E3F50EA16E330FDC9C56C /* Pods_minimaltester_minimaltesterbrownfield.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		3389A26AE8BB495F6CADEC31 /* minimaltester */ = {
+		487549DC9BB540479F11CE20 /* minimaltesterbrownfield */ = {
 			isa = PBXGroup;
 			children = (
-				FB2A9FDF306E7C907693D4B2 /* ExpoModulesProvider.swift */,
-			);
-			name = minimaltester;
-			sourceTree = "<group>";
-		};
-		45EAFC693BD6FB87155F7298 /* minimaltesterbrownfield */ = {
-			isa = PBXGroup;
-			children = (
-				55931CD212BCEECFD215B0C2 /* ExpoModulesProvider.swift */,
+				BC33192A1BF1473ABE4B30FF /* ReactNativeHostManager.swift */,
+				CA4AA5814BAF40159CEEA350 /* Messaging.swift */,
+				B40F6AB3378145C4936565D4 /* ReactNativeView.swift */,
+				57BD76673CFB456096412D4F /* ReactNativeViewController.swift */,
+				4BEA1E871928440BAE9C963D /* ExpoAppDelegate.swift */,
+				EFB260E88C5D41179427FB5F /* ReactNativeDelegate.swift */,
 			);
 			name = minimaltesterbrownfield;
+			path = "/Users/patrykmleczek/Desktop/expo/apps/minimal-tester/ios/minimaltesterbrownfield";
 			sourceTree = "<group>";
 		};
-		573B9DDA4E001A525324C855 /* ExpoModulesProviders */ = {
+		4C68D975F4B685E936979D27 /* minimaltesterbrownfield */ = {
 			isa = PBXGroup;
 			children = (
-				3389A26AE8BB495F6CADEC31 /* minimaltester */,
-				45EAFC693BD6FB87155F7298 /* minimaltesterbrownfield */,
+				49DFE6AE523FAACF5765097B /* ExpoModulesProvider.swift */,
 			);
-			name = ExpoModulesProviders;
+			name = minimaltesterbrownfield;
 			sourceTree = "<group>";
 		};
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
@@ -152,9 +146,9 @@
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
 				83CBBA001A601CBA00E9B192 /* Products */,
 				2D16E6871FA4F8E400B85C8A /* Frameworks */,
-				FE86CD13F02A4B72BE02CCCB /* minimaltesterbrownfield */,
-				283A6559C9BD0C32ACB98EBA /* Pods */,
-				573B9DDA4E001A525324C855 /* ExpoModulesProviders */,
+				487549DC9BB540479F11CE20 /* minimaltesterbrownfield */,
+				8CC6EF72273840051C403222 /* Pods */,
+				297E74C9BE17A62984E294A1 /* ExpoModulesProviders */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -165,9 +159,21 @@
 			isa = PBXGroup;
 			children = (
 				13B07F961A680F5B00A75B9A /* minimaltester.app */,
-				4C90341FAABB4AF3BD3EB5C4 /* minimaltesterbrownfield.framework */,
+				75D786E36F2849E58B20CB4C /* minimaltesterbrownfield.framework */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		8CC6EF72273840051C403222 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				06AF64CE8ECB2C1F3CF3E4B5 /* Pods-minimaltester.debug.xcconfig */,
+				E13162346AC08B1E87753822 /* Pods-minimaltester.release.xcconfig */,
+				C6A7E0A08C2073E007A6A4B6 /* Pods-minimaltester-minimaltesterbrownfield.debug.xcconfig */,
+				DC4DCCFA8FA7E79C4A057F36 /* Pods-minimaltester-minimaltesterbrownfield.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 		BB2F792B24A3F905000567C9 /* Supporting */ = {
@@ -179,18 +185,12 @@
 			path = minimaltester/Supporting;
 			sourceTree = "<group>";
 		};
-		FE86CD13F02A4B72BE02CCCB /* minimaltesterbrownfield */ = {
+		BE7A8274E8BE715D5D44DA2B /* minimaltester */ = {
 			isa = PBXGroup;
 			children = (
-				3B68FB6BD1F44018B62A221D /* ReactNativeHostManager.swift */,
-				6D09C0EFC78846B49D5389AE /* Messaging.swift */,
-				5B220AF33CBA4C5EA6C16252 /* ReactNativeView.swift */,
-				2728B7711F5D4724A425F4CC /* ReactNativeViewController.swift */,
-				3A6E6C39EB4F43D7910747C1 /* ExpoAppDelegate.swift */,
-				9E7CC8A7802E4512BE8799E1 /* ReactNativeDelegate.swift */,
+				B9F86AC3DD43E6118B4DFF7D /* ExpoModulesProvider.swift */,
 			);
-			name = minimaltesterbrownfield;
-			path = "/Users/gabriel/Workspace/expo/expo/apps/minimal-tester/ios/minimaltesterbrownfield";
+			name = minimaltester;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -201,13 +201,13 @@
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "minimaltester" */;
 			buildPhases = (
 				08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */,
-				03E3D0DADFA8895ED77DDD20 /* [Expo] Configure project */,
+				9A5BB747A7A0A3BCE47CBFD6 /* [Expo] Configure project */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				800E24972A6A228C8D4807E9 /* [CP] Copy Pods Resources */,
-				DB6D37822B4397986A3C77BF /* [CP] Embed Pods Frameworks */,
+				3BAA3C2E03DEEACEE5FFDB7D /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -218,16 +218,16 @@
 			productReference = 13B07F961A680F5B00A75B9A /* minimaltester.app */;
 			productType = "com.apple.product-type.application";
 		};
-		C64EFB1C0F1E4A858CC4EB88 /* minimaltesterbrownfield */ = {
+		E5BEE2A324BC46ED83724545 /* minimaltesterbrownfield */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 3F3CF946A38A4D568B7317D3 /* Build configuration list for PBXNativeTarget "minimaltesterbrownfield" */;
+			buildConfigurationList = 72735F0602E644009D135303 /* Build configuration list for PBXNativeTarget "minimaltesterbrownfield" */;
 			buildPhases = (
-				4BF6032E5BB36A4052CC904E /* [CP] Check Pods Manifest.lock */,
+				83C4C9E931EB9CA5F80E306B /* [CP] Check Pods Manifest.lock */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				1EFA602B21EF7C6070AB4088 /* [Expo] Configure project */,
-				450D95ADAF904BCA8AF66AAB /* Sources */,
-				3DB07664AF9E789CCE1C0F65 /* Frameworks */,
-				8BD298EC6B780D7CE8A7B59D /* [CP] Copy Pods Resources */,
+				3372E39F88D4C576647F322F /* [Expo] Configure project */,
+				970CF4F644384BF2AE05B4E1 /* Sources */,
+				0828A7B9316B632E46498FAD /* Frameworks */,
+				710C37F76C841A76844918C7 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -235,7 +235,7 @@
 			);
 			name = minimaltesterbrownfield;
 			productName = minimaltesterbrownfield;
-			productReference = 4C90341FAABB4AF3BD3EB5C4 /* minimaltesterbrownfield.framework */;
+			productReference = 75D786E36F2849E58B20CB4C /* minimaltesterbrownfield.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -265,7 +265,7 @@
 			projectRoot = "";
 			targets = (
 				13B07F861A680F5B00A75B9A /* minimaltester */,
-				C64EFB1C0F1E4A858CC4EB88 /* minimaltesterbrownfield */,
+				E5BEE2A324BC46ED83724545 /* minimaltesterbrownfield */,
 			);
 		};
 /* End PBXProject section */
@@ -278,7 +278,7 @@
 				BB2F792D24A3F905000567C9 /* Expo.plist in Resources */,
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
 				3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */,
-				47A1BC855300F66136D138B4 /* PrivacyInfo.xcprivacy in Resources */,
+				34C5E0452A74357905ED5169 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -302,30 +302,6 @@
 			shellPath = /bin/sh;
 			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n# The project root by default is one level up from the ios directory\nexport PROJECT_ROOT=\"$PROJECT_DIR\"/..\n\nif [[ \"$CONFIGURATION\" = *Debug* ]]; then\n  export SKIP_BUNDLING=1\nfi\nif [[ -z \"$ENTRY_FILE\" ]]; then\n  # Set the entry JS file using the bundler's entry resolution.\n  export ENTRY_FILE=\"$(\"$NODE_BINARY\" -e \"require('expo/scripts/resolveAppEntry')\" \"$PROJECT_ROOT\" ios absolute | tail -n 1)\"\nfi\n\nif [[ -z \"$CLI_PATH\" ]]; then\n  # Use Expo CLI\n  export CLI_PATH=\"$(\"$NODE_BINARY\" --print \"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\")\"\nfi\nif [[ -z \"$BUNDLE_COMMAND\" ]]; then\n  # Default Expo CLI command for bundling\n  export BUNDLE_COMMAND=\"export:embed\"\nfi\n\n# Source .xcode.env.updates if it exists to allow\n# SKIP_BUNDLING to be unset if needed\nif [[ -f \"$PODS_ROOT/../.xcode.env.updates\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.updates\"\nfi\n# Source local changes to allow overrides\n# if needed\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\n\n";
 		};
-		03E3D0DADFA8895ED77DDD20 /* [Expo] Configure project */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/.xcode.env",
-				"$(SRCROOT)/.xcode.env.local",
-				"$(SRCROOT)/minimaltester/minimaltester.entitlements",
-				"$(SRCROOT)/Pods/Target Support Files/Pods-minimaltester/expo-configure-project.sh",
-			);
-			name = "[Expo] Configure project";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(SRCROOT)/Pods/Target Support Files/Pods-minimaltester/ExpoModulesProvider.swift",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# This script configures Expo modules and generates the modules provider file.\nbash -l -c \"./Pods/Target\\ Support\\ Files/Pods-minimaltester/expo-configure-project.sh\"\n";
-		};
 		08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -348,7 +324,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		1EFA602B21EF7C6070AB4088 /* [Expo] Configure project */ = {
+		3372E39F88D4C576647F322F /* [Expo] Configure project */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -372,26 +348,62 @@
 			shellPath = /bin/sh;
 			shellScript = "# This script configures Expo modules and generates the modules provider file.\nbash -l -c \"./Pods/Target\\ Support\\ Files/Pods-minimaltester-minimaltesterbrownfield/expo-configure-project.sh\"\n";
 		};
-		4BF6032E5BB36A4052CC904E /* [CP] Check Pods Manifest.lock */ = {
+		3BAA3C2E03DEEACEE5FFDB7D /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
+				"${PODS_ROOT}/Target Support Files/Pods-minimaltester/Pods-minimaltester-frameworks.sh",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermesvm.framework/hermesvm",
 			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-minimaltester-minimaltesterbrownfield-checkManifestLockResult.txt",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermesvm.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-minimaltester/Pods-minimaltester-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		710C37F76C841A76844918C7 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-minimaltester-minimaltesterbrownfield/Pods-minimaltester-minimaltesterbrownfield-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/ExpoConstants_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoFileSystem/ExpoFileSystem_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/RCT-Folly/RCT-Folly_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ReachabilitySwift/ReachabilitySwift.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/React-Core_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/React-cxxreact/React-cxxreact_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/SDWebImage/SDWebImage.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/boost/boost_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/expo-dev-launcher/EXDevLauncher.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/glog/glog_privacy.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoConstants_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoFileSystem_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCT-Folly_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ReachabilitySwift.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-Core_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-cxxreact_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SDWebImage.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/boost_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXDevLauncher.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/glog_privacy.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-minimaltester-minimaltesterbrownfield/Pods-minimaltester-minimaltesterbrownfield-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		800E24972A6A228C8D4807E9 /* [CP] Copy Pods Resources */ = {
@@ -434,63 +446,51 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-minimaltester/Pods-minimaltester-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		8BD298EC6B780D7CE8A7B59D /* [CP] Copy Pods Resources */ = {
+		83C4C9E931EB9CA5F80E306B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-minimaltester-minimaltesterbrownfield/Pods-minimaltester-minimaltesterbrownfield-resources.sh",
-				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/ExpoConstants_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoFileSystem/ExpoFileSystem_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/RCT-Folly/RCT-Folly_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/ReachabilitySwift/ReachabilitySwift.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/React-Core_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/React-cxxreact/React-cxxreact_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/SDWebImage/SDWebImage.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/boost/boost_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/expo-dev-launcher/EXDevLauncher.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/glog/glog_privacy.bundle",
+			inputFileListPaths = (
 			);
-			name = "[CP] Copy Pods Resources";
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoConstants_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoFileSystem_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCT-Folly_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ReachabilitySwift.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-Core_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-cxxreact_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SDWebImage.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/boost_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXDevLauncher.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/glog_privacy.bundle",
+				"$(DERIVED_FILE_DIR)/Pods-minimaltester-minimaltesterbrownfield-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-minimaltester-minimaltesterbrownfield/Pods-minimaltester-minimaltesterbrownfield-resources.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		DB6D37822B4397986A3C77BF /* [CP] Embed Pods Frameworks */ = {
+		9A5BB747A7A0A3BCE47CBFD6 /* [Expo] Configure project */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-minimaltester/Pods-minimaltester-frameworks.sh",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermesvm.framework/hermesvm",
+			inputFileListPaths = (
 			);
-			name = "[CP] Embed Pods Frameworks";
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+				"$(SRCROOT)/minimaltester/minimaltester.entitlements",
+				"$(SRCROOT)/Pods/Target Support Files/Pods-minimaltester/expo-configure-project.sh",
+			);
+			name = "[Expo] Configure project";
+			outputFileListPaths = (
+			);
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermesvm.framework",
+				"$(SRCROOT)/Pods/Target Support Files/Pods-minimaltester/ExpoModulesProvider.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-minimaltester/Pods-minimaltester-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
+			shellScript = "# This script configures Expo modules and generates the modules provider file.\nbash -l -c \"./Pods/Target\\ Support\\ Files/Pods-minimaltester/expo-configure-project.sh\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -500,21 +500,21 @@
 			buildActionMask = 2147483647;
 			files = (
 				F11748422D0307B40044C1D9 /* AppDelegate.swift in Sources */,
-				1A9C3FEE176E76CD277616C1 /* ExpoModulesProvider.swift in Sources */,
+				6339C9F34388DBB82F435CD3 /* ExpoModulesProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		450D95ADAF904BCA8AF66AAB /* Sources */ = {
+		970CF4F644384BF2AE05B4E1 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E9202CD8DB9645EF8A174B46 /* ReactNativeHostManager.swift in Sources */,
-				85265E65994D47F8BC64346F /* Messaging.swift in Sources */,
-				50F6754CC0254DCD98440C05 /* ReactNativeView.swift in Sources */,
-				5889114962A3424DB83B6225 /* ReactNativeViewController.swift in Sources */,
-				C4745D87306D4F8DBCF824C2 /* ExpoAppDelegate.swift in Sources */,
-				7119BAFD4E3A4EBF86717FC4 /* ReactNativeDelegate.swift in Sources */,
-				696195D211EC191B8C83FDA9 /* ExpoModulesProvider.swift in Sources */,
+				435BDB3DC69840AE9B29F7F4 /* ReactNativeHostManager.swift in Sources */,
+				9ADCE841A00849AA9354F08E /* Messaging.swift in Sources */,
+				E80B12B740014503A23B87CE /* ReactNativeView.swift in Sources */,
+				5FE1EE223A124930AB42B6C0 /* ReactNativeViewController.swift in Sources */,
+				2254091221B84C9AA553974E /* ExpoAppDelegate.swift in Sources */,
+				3DF810F5FAA84349BA1369BD /* ReactNativeDelegate.swift in Sources */,
+				FD75274D2DFE9F49F0F5E7B6 /* ExpoModulesProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -523,7 +523,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5B8DFEF9E6448F852E586EF7 /* Pods-minimaltester.debug.xcconfig */;
+			baseConfigurationReference = 06AF64CE8ECB2C1F3CF3E4B5 /* Pods-minimaltester.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -559,7 +559,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 137610AC4E0E1793D95CDF3B /* Pods-minimaltester.release.xcconfig */;
+			baseConfigurationReference = E13162346AC08B1E87753822 /* Pods-minimaltester.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -586,6 +586,29 @@
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;
+		};
+		2D849B51D9384D6889D4F66D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C6A7E0A08C2073E007A6A4B6 /* Pods-minimaltester-minimaltesterbrownfield.debug.xcconfig */;
+			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_ENTITLEMENTS = minimaltesterbrownfield/minimaltesterbrownfield.entitlements;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_MODULE_VERIFIER = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = minimaltesterbrownfield/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = minimaltesterbrownfield;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
+				PRODUCT_BUNDLE_IDENTIFIER = com.community.minimaltesterbrownfield;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				USER_SCRIPT_SANDBOXING = NO;
+			};
+			name = Debug;
 		};
 		83CBBA201A601CBA00E9B192 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -733,32 +756,9 @@
 			};
 			name = Release;
 		};
-		9C62022FC8494E8DA4F20501 /* Debug */ = {
+		E03CDD14D62740C2915523EE /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 08D6657006317D00C14874CA /* Pods-minimaltester-minimaltesterbrownfield.debug.xcconfig */;
-			buildSettings = {
-				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
-				CODE_SIGN_ENTITLEMENTS = minimaltesterbrownfield/minimaltesterbrownfield.entitlements;
-				CURRENT_PROJECT_VERSION = 1;
-				ENABLE_MODULE_VERIFIER = NO;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = minimaltesterbrownfield/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = minimaltesterbrownfield;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
-				PRODUCT_BUNDLE_IDENTIFIER = com.community.minimaltesterbrownfield;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = NO;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				USER_SCRIPT_SANDBOXING = NO;
-			};
-			name = Debug;
-		};
-		DE92568556614392B78C5AB5 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = AFA20A65B327003B5C2CB853 /* Pods-minimaltester-minimaltesterbrownfield.release.xcconfig */;
+			baseConfigurationReference = DC4DCCFA8FA7E79C4A057F36 /* Pods-minimaltester-minimaltesterbrownfield.release.xcconfig */;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_ENTITLEMENTS = minimaltesterbrownfield/minimaltesterbrownfield.entitlements;
@@ -791,11 +791,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		3F3CF946A38A4D568B7317D3 /* Build configuration list for PBXNativeTarget "minimaltesterbrownfield" */ = {
+		72735F0602E644009D135303 /* Build configuration list for PBXNativeTarget "minimaltesterbrownfield" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				9C62022FC8494E8DA4F20501 /* Debug */,
-				DE92568556614392B78C5AB5 /* Release */,
+				2D849B51D9384D6889D4F66D /* Debug */,
+				E03CDD14D62740C2915523EE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/apps/minimal-tester/ios/minimaltesterbrownfield/ReactNativeDelegate.swift
+++ b/apps/minimal-tester/ios/minimaltesterbrownfield/ReactNativeDelegate.swift
@@ -2,7 +2,7 @@ internal import Expo
 internal import React
 
 class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
-  /// Extension point for config-plugins
+  // Extension point for config-plugins
   override func sourceURL(for bridge: RCTBridge) -> URL? {
     // Needed to return the correct URL for expo-dev-client
     bridge.bundleURL ?? bundleURL()
@@ -13,10 +13,28 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
       return RCTBundleURLProvider.sharedSettings().jsBundleURL(
         forBundleRoot: ".expo/.virtual-metro-entry")
     #else
-      /// `main.jsbundle` isn't part of the main app bundle
-      /// so we need to load it from the framework bundle
+      // `main.jsbundle` isn't part of the main app bundle
+      // so we need to load it from the framework bundle
+      // and ensure that it's present in the framework
       let frameworkBundle = Bundle(for: ReactNativeHostManager.self)
-      return frameworkBundle.url(forResource: "main", withExtension: "jsbundle")
+      if let bundleURL = frameworkBundle.url(forResource: "main", withExtension: "jsbundle") {
+        return bundleURL
+      }
+
+      let availableBundles =
+        frameworkBundle.urls(forResourcesWithExtension: "jsbundle", subdirectory: nil)
+        ?? []
+      let bundleList =
+        availableBundles.isEmpty
+        ? "None"
+        : availableBundles.map { "- \($0.lastPathComponent)" }.joined(separator: "\n")
+
+      fatalError(
+        """
+        Cannot find `main.jsbundle` in the XCFramework bundle
+        Available JS bundles:
+        \(bundleList)
+        """)
     #endif
   }
 }

--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -38,3 +38,4 @@ _This version does not introduce any user-facing changes._
 - Updated build configurations and resolved leftover TODOs in [#42072](https://github.com/expo/expo/pull/42072) by [@pmleczek](https://github.com/pmleczek)
 - [iOS] Symlink ExpoAppDelegate to iOS template ([#42240](https://github.com/expo/expo/pull/42240) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Remove ExpoModulesProvider patch ([#42317](https://github.com/expo/expo/pull/42317) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Improved bundle loading failure handling in [#42469](https://github.com/expo/expo/pull/42469) by [@pmleczek](https://github.com/pmleczek)

--- a/packages/expo-brownfield/plugin/templates/android/ReactNativeHostManager.kt
+++ b/packages/expo-brownfield/plugin/templates/android/ReactNativeHostManager.kt
@@ -28,6 +28,26 @@ class ReactNativeHostManager {
       return
     }
 
+    // Ensure that `index.android.bundle` is available in the assets
+    // for release builds
+    if (!BuildConfig.DEBUG) {
+      val assets = application.applicationContext.assets.list("")?.toList()
+        ?: emptyList<String>()
+      if (!assets.contains("index.android.bundle")) {
+        val bundleList = assets
+          .filter { it.endsWith(".bundle") }
+          .map { "- $it" }.joinToString("\n")
+          ?: "None"
+
+          throw IllegalStateException("""
+          Cannot find `index.android.bundle` in the assets
+          Available JS bundles:
+          $bundleList
+          """.trimIndent()
+        )
+      }
+    }
+
     DefaultNewArchitectureEntryPoint.releaseLevel =
         try {
           ReleaseLevel.valueOf(BuildConfig.REACT_NATIVE_RELEASE_LEVEL.uppercase())

--- a/packages/expo-brownfield/plugin/templates/ios/ReactNativeDelegate.swift
+++ b/packages/expo-brownfield/plugin/templates/ios/ReactNativeDelegate.swift
@@ -15,8 +15,26 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
     #else
       // `main.jsbundle` isn't part of the main app bundle
       // so we need to load it from the framework bundle
+      // and ensure that it's present in the framework
       let frameworkBundle = Bundle(for: ReactNativeHostManager.self)
-      return frameworkBundle.url(forResource: "main", withExtension: "jsbundle")
+      if let bundleURL = frameworkBundle.url(forResource: "main", withExtension: "jsbundle") {
+        return bundleURL
+      }
+
+      let availableBundles =
+        frameworkBundle.urls(forResourcesWithExtension: "jsbundle", subdirectory: nil)
+        ?? []
+      let bundleList =
+        availableBundles.isEmpty
+        ? "None"
+        : availableBundles.map { "- \($0.lastPathComponent)" }.joined(separator: "\n")
+
+      fatalError(
+        """
+        Cannot find `main.jsbundle` in the XCFramework bundle
+        Available JS bundles:
+        \(bundleList)
+        """)
     #endif
   }
 }

--- a/packages/expo-brownfield/plugin/templates/ios/ReactNativeDelegate.swift
+++ b/packages/expo-brownfield/plugin/templates/ios/ReactNativeDelegate.swift
@@ -2,7 +2,7 @@ internal import Expo
 internal import React
 
 class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
-  /// Extension point for config-plugins
+  // Extension point for config-plugins
   override func sourceURL(for bridge: RCTBridge) -> URL? {
     // Needed to return the correct URL for expo-dev-client
     bridge.bundleURL ?? bundleURL()
@@ -13,8 +13,8 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
       return RCTBundleURLProvider.sharedSettings().jsBundleURL(
         forBundleRoot: ".expo/.virtual-metro-entry")
     #else
-      /// `main.jsbundle` isn't part of the main app bundle
-      /// so we need to load it from the framework bundle
+      // `main.jsbundle` isn't part of the main app bundle
+      // so we need to load it from the framework bundle
       let frameworkBundle = Bundle(for: ReactNativeHostManager.self)
       return frameworkBundle.url(forResource: "main", withExtension: "jsbundle")
     #endif


### PR DESCRIPTION
# Why

We should clearly inform the user that the requested bundle cannot be loaded

# How

This approach implements a simple approach with just throwing an error with clear message when the bundle can't be loaded, but it can't be easily extended to e.g. display some fallback view instead. This solution is brownfield-only and doesn't interact with RN `RCTFatalError` handling

## Android

For `debug` builds that use bundle from Metro we can have the default red box from RN (which can't be overwritten), as it pretty clearly informs about the error:

<img width="437" height="785" alt="image" src="https://github.com/user-attachments/assets/43b7e430-95f3-4611-b813-e0e3ba6bad97" />

For `release` builds we can throw an error with a clear message and list available bundles:

```
Caused by: java.lang.IllegalStateException: Cannot find `indexx.android.bundle` in the assets
Available JS bundles:
- index.android.bundle
```

(In real-life scenario it would fail about `index.android.bundle` not being found in the application assets and list some other (or none) bundle(s) as available)

## iOS

For `debug` builds using bundle from Metro it probably doesn't make sens to display anything besides the default red box from React Native (which we cannot simply overwrite), as it pretty clearly informs about the error:

<img width="486" height="920" alt="image" src="https://github.com/user-attachments/assets/0fde21a6-bb06-4d6d-aebd-bfc0951b3672" />

For `release` builds we can throw a `fatalError` with a clear message that bundle couldn't be found and list of available bundles:

```
minimaltesterbrownfield/ReactNativeDelegate.swift:29: Fatal error: Cannot find `mainabcd.jsbundle` in the XCFramework bundle
Available JS bundles:
- main.jsbundle
```

(In real-life scenario it would fail about `main.jsbundle` not being found and list some other (or none) bundle(s) as available)

# Test Plan

Validated using `minimal-tester` on Android and iOS with both debug and release build types

# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
