### PR TITLE
[android][brightness] Fix system brightness mapping to support value 0

### DIFF
--- a/packages/expo-brightness/CHANGELOG.md
+++ b/packages/expo-brightness/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- **Android**: Fixed `setSystemBrightnessAsync` to support brightness value 0 by mapping [0,1] range to Android's valid [1,255] range. ([#42470](https://github.com/expo/expo/pull/42470) by [@davidalo](https://github.com/davidalo))
+
 ### 💡 Others
 
 ## 55.0.1 — 2026-01-22

--- a/packages/expo-brightness/android/src/main/java/expo/modules/brightness/BrightnessModule.kt
+++ b/packages/expo-brightness/android/src/main/java/expo/modules/brightness/BrightnessModule.kt
@@ -65,10 +65,12 @@ class BrightnessModule : Module() {
         Settings.System.SCREEN_BRIGHTNESS_MODE,
         Settings.System.SCREEN_BRIGHTNESS_MODE_MANUAL
       )
+      // Android's SCREEN_BRIGHTNESS accepts values from 1 to 255 (not 0 to 255)
+      // Map input range [0, 1] to Android's valid range [1, 255]
       Settings.System.putInt(
         currentActivity.contentResolver,
         Settings.System.SCREEN_BRIGHTNESS,
-        (brightnessValue * 255).roundToInt()
+        (brightnessValue * 254 + 1).roundToInt()
       )
     }
 
@@ -122,7 +124,8 @@ class BrightnessModule : Module() {
         currentActivity.contentResolver,
         Settings.System.SCREEN_BRIGHTNESS
       )
-      brightness.toInt() / 255f
+      // Map Android's range [1, 255] back to [0, 1]
+      (brightness.toInt() - 1) / 254f
     }
   }
 


### PR DESCRIPTION
* Android's SCREEN_BRIGHTNESS API accepts values from 1 to 255.
* `setSystemBrightnessAsync` range is from [0,1], which was converted to the [0,255] range. This caused that setting the brightness to zero didn't work.
* This commit fixes the range mapping, converting JS range [0,1] to Android's range [1,255] and viceversa.

# Why

Android's Settings.System.SCREEN_BRIGHTNESS API accepts values from 1 to 255 according to the
https://developer.android.com/reference/android/provider/Settings.System#SCREEN_BRIGHTNESS. However, 
expo-brightness's setSystemBrightnessAsync was mapping the JavaScript range [0, 1] directly to [0, 255],
causing brightness value 0 to not work properly on Android devices.

This prevented users from setting the minimum system brightness through the Expo Brightness API.


# How

Updated the conversion formula in BrightnessModule.kt:
  - Set brightness: Changed from (brightnessValue * 255).roundToInt() to (brightnessValue * 254 + 
  1).roundToInt() to map [0, 1] → [1, 255]
  - Get brightness: Changed from brightness.toInt() / 255f to (brightness.toInt() - 1) / 254f to map [1, 255] →
  [0, 1]

  This ensures roundtrip consistency: setting brightness to 0 stores Android value 1, and reading it back
  returns approximately 0
# Test Plan

Tested using `native-component-list` application with slider modifications  in Android 14.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
