### PR TITLE
[docs] remote ccache build reference

### DIFF
--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -72,7 +72,7 @@ To disable using our Maven cache server for your builds set the `EAS_BUILD_DISAB
 
 [ccache](https://ccache.dev/) is a compiler cache that speeds up recompilation by caching previous compilations. You can use remote caching to share ccache data across builds, which significantly speeds up builds that include results for native libraries used by React Native, Hermes, or other native modules.
 
-You can enable in builds to use cache automatically with these environment variables:
+You can configure builds to save and restore ccache automatically with these environment variables:
 
 - `EAS_USE_CACHE`: Enables saving and restoring cache on build jobs. By setting to `1`, it will enable both saving and restoring the cache during a build job. By setting to `0`, it will disable both saving and restoring the cache
 - `EAS_RESTORE_CACHE`: Controls restoring the cache at the beginning of a build. Set to `1` to enable or `0` to disable.
@@ -144,8 +144,7 @@ jobs:
           key: android-ccache-${{ hashFiles('package-lock.json') }}
           restore_keys: android
           path: /home/expo/.cache/ccache
-      - name: Build Android app
-        run: cd android && ./gradlew assembleRelease
+      - uses: eas/run_gradle
       - uses: eas/save_cache
         with:
           key: android-ccache-${{ hashFiles('package-lock.json') }}
@@ -166,8 +165,7 @@ jobs:
           key: ios-ccache-${{ hashFiles('package-lock.json') }}
           restore_keys: ios
           path: /Users/expo/Library/Caches/ccache
-      - name: Build iOS app
-        run: cd ios && fastlane build
+      - uses: eas/run_fastlane
       - uses: eas/save_cache
         with:
           key: ios-ccache-${{ hashFiles('package-lock.json') }}

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -78,98 +78,62 @@ You can configure builds to save and restore ccache cache automatically with the
 - `EAS_RESTORE_CACHE`: Controls restoring the cache at the beginning of a build. Set to `1` to enable or `0` to disable. Overrides `EAS_USE_CACHE`.
 - `EAS_SAVE_CACHE`: Controls whether to save the build cache at the end of a build. Set to `1` to enable or `0` to disable. Overrides `EAS_USE_CACHE`.
 
-#### Custom builds
-
-In custom builds where you manage the build steps, add [`eas/restore_build_cache`](/custom-builds/schema/#easrestore_build_cache) and [`eas/save_build_cache`](/custom-builds/schema/#eassave_build_cache) to enable ccache cache.
-
-**Android example:**
-
-```yaml .eas/build/config.yml
-build:
-  name: Android build with ccache
-  steps:
-    - eas/checkout
-    - eas/install_node_modules
-    - eas/prebuild
-    - eas/restore_build_cache:
-        inputs:
-          key: android-ccache-${{ hashFiles('package-lock.json') }}
-          restore_keys: android
-          path: /home/expo/.cache/ccache
-    - eas/inject_android_credentials
-    - eas/run_gradle
-    - eas/save_build_cache:
-        inputs:
-          key: android-ccache-${{ hashFiles('package-lock.json') }}
-          path: /home/expo/.cache/ccache
-```
-
-**iOS example:**
-
-```yaml .eas/build/config.yml
-build:
-  name: iOS build with ccache
-  steps:
-    - eas/checkout
-    - eas/install_node_modules
-    - eas/prebuild
-    - eas/restore_build_cache:
-        inputs:
-          key: ios-ccache-${{ hashFiles('package-lock.json') }}
-          restore_keys: ios
-          path: /Users/expo/Library/Caches/ccache
-    - eas/configure_ios_credentials
-    - eas/run_fastlane
-    - eas/save_build_cache:
-        inputs:
-          key: ios-ccache-${{ hashFiles('package-lock.json') }}
-          path: /Users/expo/Library/Caches/ccache
-```
-
 #### EAS Workflows
 
 For EAS Workflows, use [`eas/restore_cache`](/eas/workflows/syntax/#easrestore_cache) and [`eas/save_cache`](/eas/workflows/syntax/#eassave_cache).
 
 **Android example:**
 
-```yaml .eas/workflows/build-android-custom.yml
+```yaml .eas/workflows/build-android.yml
 jobs:
   build_android:
+    type: build
     steps:
       - uses: eas/checkout
-      - uses: eas/install_node_modules
-      - uses: eas/prebuild
       - uses: eas/restore_cache
         with:
-          key: android-ccache-${{ hashFiles('package-lock.json') }}
+          key: android-ccache-${{ hashFiles('yarn.lock') }}
           restore_keys: android
           path: /home/expo/.cache/ccache
-      - uses: eas/run_gradle
+      - uses: eas/build
       - uses: eas/save_cache
         with:
-          key: android-ccache-${{ hashFiles('package-lock.json') }}
+          key: android-ccache-${{ hashFiles('yarn.lock') }}
           path: /home/expo/.cache/ccache
 ```
 
 **iOS example:**
 
-```yaml .eas/workflows/build-ios-custom.yml
+```yaml .eas/workflows/build-ios.yml
 jobs:
   build_ios:
+    type: build
     steps:
       - uses: eas/checkout
-      - uses: eas/install_node_modules
-      - uses: eas/prebuild
       - uses: eas/restore_cache
         with:
-          key: ios-ccache-${{ hashFiles('package-lock.json') }}
+          key: ios-ccache-${{ hashFiles('yarn.lock') }}
           restore_keys: ios
           path: /Users/expo/Library/Caches/ccache
-      - uses: eas/run_fastlane
+      - uses: eas/build
       - uses: eas/save_cache
         with:
-          key: ios-ccache-${{ hashFiles('package-lock.json') }}
+          key: ios-ccache-${{ hashFiles('yarn.lock') }}
           path: /Users/expo/Library/Caches/ccache
+```
+
+#### Custom builds
+
+In custom builds where you manage the build steps, add [`eas/restore_build_cache`](/custom-builds/schema/#easrestore_build_cache) and [`eas/save_build_cache`](/custom-builds/schema/#eassave_build_cache) to enable ccache cache.
+
+```yaml .eas/build/custom.yml
+build:
+  name: Build with ccache
+  steps:
+    - eas/checkout
+    - eas/restore_build_cache:
+    - eas/build
+    - eas/save_build_cache:
 ```
 
 The cache key uses `hashFiles('package-lock.json')` to create a unique key based on your dependencies. When dependencies change, a new cache will be created while still allowing fallback to previous caches using `restore_keys`.
@@ -179,8 +143,7 @@ The cache key uses `hashFiles('package-lock.json')` to create a unique key based
 When restoring a cache, the cache system follows a specific search sequence to find matching cache entries:
 
 1. **Exact match**: First, it searches for an exact match to your provided `key`.
-2. **Partial match**: If no exact match is found, it will search for partial matches of the `key` (keys that start with your key as a prefix).
-3. **Restore keys**: If there is still no match found, and you've provided `restore_keys`, these keys will be checked sequentially for partial matches.
+2. **Restore keys**: If no exact match is found, `restore_keys` will be checked sequentially for prefix matches
 
 If there is an exact match to the provided `key`, this is considered a cache hit and the cache is restored immediately. If there is a partial match or a match from `restore_keys`, the cache is restored but this is considered a cache miss, which may trigger additional steps in your workflow.
 

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -90,16 +90,19 @@ jobs:
     type: build
     steps:
       - uses: eas/checkout
-      - uses: eas/restore_cache
-        with:
-          key: android-ccache-${{ hashFiles('yarn.lock') }}
-          restore_keys: android
-          path: /home/expo/.cache/ccache
+      - uses: eas/restore_build_cache
+      # This is equivalent to the step above. You can also use /restore_cache for other caching purposes by defining your own key pattern and path
+      # - uses: eas/restore_cache
+      #   with:
+      #     key: android-ccache-${{ hashFiles('yarn.lock') }}
+      #     restore_keys: android
+      #     path: /home/expo/.cache/ccache
       - uses: eas/build
-      - uses: eas/save_cache
-        with:
-          key: android-ccache-${{ hashFiles('yarn.lock') }}
-          path: /home/expo/.cache/ccache
+      - uses: eas/save_build_cache
+      # - uses: eas/save_cache
+      #   with:
+      #    key: android-ccache-${{ hashFiles('yarn.lock') }}
+      #    path: /home/expo/.cache/ccache
 ```
 
 **iOS example:**
@@ -110,16 +113,19 @@ jobs:
     type: build
     steps:
       - uses: eas/checkout
-      - uses: eas/restore_cache
-        with:
-          key: ios-ccache-${{ hashFiles('yarn.lock') }}
-          restore_keys: ios
-          path: /Users/expo/Library/Caches/ccache
+      - uses: eas/restore_build_cache
+      # This is equivalent to the step above. You can also use /restore_cache for other caching purposes by defining your own key pattern and path
+      # - uses: eas/restore_cache
+      #   with:
+      #     key: ios-ccache-${{ hashFiles('yarn.lock') }}
+      #     restore_keys: ios
+      #     path: /Users/expo/Library/Caches/ccache
       - uses: eas/build
-      - uses: eas/save_cache
-        with:
-          key: ios-ccache-${{ hashFiles('yarn.lock') }}
-          path: /Users/expo/Library/Caches/ccache
+      - uses: eas/save_build_cache
+      # - uses: eas/save_cache
+      #   with:
+      #    key: ios-ccache-${{ hashFiles('yarn.lock') }}
+      #    path: /Users/expo/Library/Caches/ccache
 ```
 
 #### Custom builds
@@ -140,14 +146,18 @@ The cache key uses a hash of the package manager lock file to create a unique ke
 
 ### Cache key matching
 
-When restoring a cache, the cache system follows a specific search sequence to find matching cache entries:
+When restoring a cache, the cache system follows a specific search sequence to find matching cache entries. The cache key is either automatically generated (when using `eas/restore_build_cache` or `eas/save_build_cache`) or explicitly provided via the `key` parameter (when using `eas/restore_cache` or `eas/save_cache` with custom configuration).
 
-1. **Exact match**: First, it searches for an exact match to your provided `key`.
-2. **Restore keys**: If no exact match is found, `restore_keys` will be checked sequentially for prefix matches
+The search sequence:
 
-If there is an exact match to the provided `key`, this is considered a cache hit and the cache is restored immediately. If there is a partial match or a match from `restore_keys`, the cache is restored but this is considered a cache miss, which may trigger additional steps in your workflow.
+1. **Exact match**: First, it searches for an exact match to the cache key (automatically generated or explicitly provided)
+2. **Restore keys**: If no exact match is found, `restore_keys` will be checked sequentially for the most recent prefix matches
+
+If there is an exact match to the provided `key`, this is considered a direct cache hit and the cache is restored immediately. If there is a partial match or a match from `restore_keys`, the cache is restored but may not perform as effectively
 
 #### Using restore keys
+
+> **Note:** Restore key matching is handled automatically by the cache system and does not require manual configuration. This is a reference to detail expected behavior.
 
 The restore key `android-ccache-` matches any key that starts with the string `android-ccache-`. For example, both of the keys `android-ccache-fd3052de` and `android-ccache-a9b253ff` match the restore key. The cache with the most recent creation date would be used. The keys in this example are searched in the following order:
 
@@ -173,6 +183,8 @@ When a build is triggered from `eas-cli`, caches are scoped to the user running 
 #### Default branch cache
 
 If a build doesn't restore a user-scoped cache, it will automatically fallback to restoring caches published from GitHub builds triggered on the default branch. This allows builds to benefit from caches created by trusted sources even when no user-scoped cache exists yet.
+
+#### Shared user behavior
 
 When a single user-actor is shared between multiple people (such as when using access tokens or triggering builds from GitHub Actions), user-scoped cache rules still apply. This means that builds operating under that shared account will no longer have isolated caches and run the risk of sharing unintended artifacts. We recommend avoiding this by having designated jobs to only save clean caches, while the development builds only restore.
 

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -194,7 +194,7 @@ The restore key `android-ccache-` matches any key that starts with the string `a
 
 ### Cache restrictions
 
-Access restrictions provide cache isolation and security by creating logical boundaries between different branches and builds. Understanding these restrictions helps you optimize your cache usage and avoid unexpected cache misses.
+Access restrictions provide cache isolation and security by creating logical boundaries between different Git branches or users. It is important for security of yours and your users to understand and leverage them when building your app.
 
 #### Branch-based access
 

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -70,7 +70,13 @@ To disable using our Maven cache server for your builds set the `EAS_BUILD_DISAB
 
 ### Caching C/C++ compilation artifacts with ccache
 
-[ccache](https://ccache.dev/) is a compiler cache that speeds up recompilation by caching previous compilations. You can use remote user-scoped caching to persist ccache data across builds, which significantly speeds up builds that include native C/C++ code.
+[ccache](https://ccache.dev/) is a compiler cache that speeds up recompilation by caching previous compilations. You can use remote caching to share ccache data across builds, which significantly speeds up builds that include results for native libraries used by React Native, Hermes, or other native modules.
+
+You can enable in builds to use cache automatically with these environment variables:
+
+- `EAS_USE_CACHE`: Enables saving and restoring cache on build jobs. By setting to `1`, it will enable both saving and restoring the cache during a build job. By setting to `0`, it will disable both saving and restoring the cache
+- `EAS_RESTORE_CACHE`: Controls restoring the cache at the beginning of a build. Set to `1` to enable or `0` to disable.
+- `EAS_SAVE_CACHE`: Controls whether to save the build cache at the end of a build. Set to `1` to enable or `0` to disable.
 
 #### Custom builds
 
@@ -201,12 +207,6 @@ Caches are scoped to the branch where they were created. Workflow runs can resto
 
 If a workflow run is triggered for a pull request, it can also restore caches created in the base branch. For example, if a pull request from `feature-b` targets `main`, the workflow can access caches created in the `main` branch.
 
-#### Default branch cache
-
-If a build doesn't restore a user-scoped cache, it will automatically fallback to restoring caches published from GitHub builds triggered on the default branch. This allows builds to benefit from caches created by automated workflows even when no user-scoped cache exists yet, or to only keep publishing caches from a designated job.
-
-This is particularly useful for build tools like ccache, where the compilation cache can be shared across different builds and branches and the performance benefits can be applied broadly.
-
 #### User-scoped caches
 
 User-scoped caches allow for publishing caches that are just accessible to builds or workflow jobs that are ran by that respective user. Allowing for isolation so that modifications to the build and its cache are not unintentionally shared during development. This means:
@@ -216,6 +216,12 @@ User-scoped caches allow for publishing caches that are just accessible to build
 - Each user’s build will have their own isolated cache even when on the same branch
 
 This ensures that builds between teammates will benefit from remote caching with the guarantee that they are isolated and limited to the proper scope.
+
+#### Default branch cache
+
+If a build doesn't restore a user-scoped cache, it will automatically fallback to restoring caches published from GitHub builds triggered on the default branch. This allows builds to benefit from caches created by automated workflows even when no user-scoped cache exists yet, or to only keep publishing caches from a designated job.
+
+This is particularly useful for build tools like ccache, where the compilation cache can be shared across different builds and branches and the performance benefits can be applied broadly.
 
 ## iOS dependencies
 

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -131,9 +131,9 @@ build:
   name: Build with ccache
   steps:
     - eas/checkout
-    - eas/restore_build_cache:
+    - eas/restore_build_cache
     - eas/build
-    - eas/save_build_cache:
+    - eas/save_build_cache
 ```
 
 The cache key uses a hash of the package manager lock file to create a unique key based on your dependencies. When dependencies change, a new cache will be created while still allowing fallback to previous caches using `restore_keys`.

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -215,7 +215,8 @@ User-scoped caches allow for publishing caches that are just accessible to build
 - Caches persist across different branches and builds
 - Each user’s build will have their own isolated cache even when on the same branch
 
-This ensures that builds between teammates will benefit from remote caching with the guarantee that they are isolated and limited to the proper scope. 
+This ensures that builds between teammates will benefit from remote caching with the guarantee that they are isolated and limited to the proper scope.
+
 ## iOS dependencies
 
 EAS Build serves most CocoaPods artifacts from a cache server. This improves the consistency of `pod install` times and generally improves speed. The cache will be bypassed automatically if you provide your own **.netrc** or **.curlrc** files.

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -182,20 +182,6 @@ If there is an exact match to the provided `key`, this is considered a cache hit
 
 #### Using restore keys
 
-`restore_keys` allows you to specify a list of alternate restore keys to use when there is a cache miss on `key`. You can create multiple restore keys ordered from the most specific to least specific. The cache system searches the `restore_keys` in sequential order. When a key doesn't match directly, the system searches for keys prefixed with the restore key. If there are multiple partial matches for a restore key, the system returns the most recently created cache.
-
-**Example using multiple restore keys:**
-
-```yaml
-- uses: eas/restore_cache
-  with:
-    key: android-ccache-${{ hashFiles('package-lock.json') }}
-    restore_keys: |
-      android-ccache-${{ hashFiles('package-lock.json') }}
-      android-ccache-
-      android-
-```
-
 The restore key `android-ccache-` matches any key that starts with the string `android-ccache-`. For example, both of the keys `android-ccache-fd3052de` and `android-ccache-a9b253ff` match the restore key. The cache with the most recent creation date would be used. The keys in this example are searched in the following order:
 
 1. **`android-ccache-${{ hashFiles('package-lock.json') }}`** matches a specific hash.
@@ -211,24 +197,25 @@ Access restrictions provide cache isolation and security by creating logical bou
 Caches are scoped to the branch where they were created. Workflow runs can restore caches created in:
 
 - The current branch
-- The default branch (usually `main` or `master`)
+- The default branch (`main` or `master`)
 
 If a workflow run is triggered for a pull request, it can also restore caches created in the base branch. For example, if a pull request from `feature-b` targets `main`, the workflow can access caches created in the `main` branch.
 
 #### Default branch cache
 
-If a build doesn't find a user-scoped cache (created with `eas/restore_cache` and `eas/save_cache` or `eas/restore_build_cache` and `eas/save_build_cache`), it will automatically fallback to restoring caches published from GitHub builds triggered on the `main` branch. This allows builds to benefit from caches created by automated workflows even when no user-scoped cache exists yet.
+If a build doesn't restore a user-scoped cache, it will automatically fallback to restoring caches published from GitHub builds triggered on the default branch. This allows builds to benefit from caches created by automated workflows even when no user-scoped cache exists yet, or to only keep publishing caches from a designated job.
+
+This is particularly useful for build tools like ccache, where the compilation cache can be shared across different builds and branches and the performance benefits can be applied broadly.
 
 #### User-scoped caches
 
-Remote user-scoped caches (created with `eas/restore_cache` and `eas/save_cache` or `eas/restore_build_cache` and `eas/save_build_cache`) are scoped to your user account. This means:
+User-scoped caches allow for publishing caches that are just accessible to builds or workflow jobs that are ran by that respective user. Allowing for isolation so that modifications to the build and its cache are not unintentionally shared during development. This means:
 
-- Caches are shared across all builds and workflows for your account
-- Caches persist across different branches and projects
-- You can reuse caches across multiple builds to maximize cache hit rates
+- Caches are shared just between the builds and workflows for an account
+- Caches persist across different branches and builds
+- Each user’s build will have their own isolated cache even when on the same branch
 
-This is particularly useful for build tools like ccache, where the compilation cache can be shared across different projects and branches.
-
+This ensures that builds between teammates will benefit from remote caching with the guarantee that they are isolated and limited to the proper scope. 
 ## iOS dependencies
 
 EAS Build serves most CocoaPods artifacts from a cache server. This improves the consistency of `pod install` times and generally improves speed. The cache will be bypassed automatically if you provide your own **.netrc** or **.curlrc** files.

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -186,9 +186,9 @@ If a build doesn't restore a user-scoped cache, it will automatically fallback t
 
 #### Shared user behavior
 
-When a single user-actor is shared between multiple people (such as when using access tokens or triggering builds from GitHub Actions), user-scoped cache rules still apply. This means that builds operating under that shared account will no longer have isolated caches and run the risk of sharing unintended artifacts. We recommend avoiding this by having designated jobs to only save clean caches, while the development builds only restore.
+When a single user-actor is shared between multiple people (such as when using access tokens or triggering builds from GitHub Actions), user-scoped cache rules still apply. This means that builds operating under that shared account will no longer have isolated caches and run the risk of sharing unintended artifacts. To avoid this, we recommend not restoring cache for production builds under a shared user, and to have designated jobs to only save clean, new caches.
 
-#### Cache publishing
+#### Designated jobs for cache creation
 
 You can configure a job to publish clean, new caches by disabling cache restoration and only saving the cache.
 
@@ -216,7 +216,7 @@ You can disable cache restoration for specific build profiles by configuring the
 
 **Only save cache from designated jobs:**
 
-To ensure only trusted sources publish cache, you can configure workflows to only save cache from specific jobs on the main branch:
+To ensure only trusted sources publish cache, you can configure a workflow to only save cache from specific job on the main branch.
 
 ```yaml .eas/workflows/build.yml
 jobs:
@@ -230,6 +230,8 @@ jobs:
       platform: android
       profile: production
 ```
+
+> **Note:** Setting `EAS_SAVE_CACHE: '1'` does not make cache saving exclusive to this job, other jobs with the same environment variable can still save and overwrite the cache.
 
 ## iOS dependencies
 

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -68,7 +68,7 @@ To disable using our Maven cache server for your builds set the `EAS_BUILD_DISAB
 }
 ```
 
-### Caching C/C++ compilation artifacts with ccache
+## Caching C/C++ compilation artifacts with ccache
 
 [ccache](https://ccache.dev/) is a compiler cache that speeds up recompilation of native code by caching previous compilation results. EAS supports ccache configuration out of the box.
 
@@ -136,7 +136,7 @@ build:
     - eas/save_build_cache:
 ```
 
-The cache key uses `hashFiles('package-lock.json')` to create a unique key based on your dependencies. When dependencies change, a new cache will be created while still allowing fallback to previous caches using `restore_keys`.
+The cache key uses a hash of the package manager lock file to create a unique key based on your dependencies. When dependencies change, a new cache will be created while still allowing fallback to previous caches using `restore_keys`.
 
 ### Cache key matching
 

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -68,6 +68,167 @@ To disable using our Maven cache server for your builds set the `EAS_BUILD_DISAB
 }
 ```
 
+### Caching C/C++ compilation artifacts with ccache
+
+[ccache](https://ccache.dev/) is a compiler cache that speeds up recompilation by caching previous compilations. You can use remote user-scoped caching to persist ccache data across builds, which significantly speeds up builds that include native C/C++ code.
+
+#### Custom builds
+
+For custom builds, use [`eas/restore_build_cache`](/custom-builds/schema/#easrestore_build_cache) and [`eas/save_build_cache`](/custom-builds/schema/#eassave_build_cache) to cache the ccache directory.
+
+**Android example:**
+
+```yaml .eas/build/config.yml
+build:
+  name: Android build with ccache
+  steps:
+    - eas/checkout
+    - eas/install_node_modules
+    - eas/prebuild
+    - eas/restore_build_cache:
+        inputs:
+          key: android-ccache-${{ hashFiles('package-lock.json') }}
+          restore_keys: android
+          path: /home/expo/.cache/ccache
+    - eas/inject_android_credentials
+    - eas/run_gradle
+    - eas/save_build_cache:
+        inputs:
+          key: android-ccache-${{ hashFiles('package-lock.json') }}
+          path: /home/expo/.cache/ccache
+```
+
+**iOS example:**
+
+```yaml .eas/build/config.yml
+build:
+  name: iOS build with ccache
+  steps:
+    - eas/checkout
+    - eas/install_node_modules
+    - eas/prebuild
+    - eas/restore_build_cache:
+        inputs:
+          key: ios-ccache-${{ hashFiles('package-lock.json') }}
+          restore_keys: ios
+          path: /Users/expo/Library/Caches/ccache
+    - eas/configure_ios_credentials
+    - eas/run_fastlane
+    - eas/save_build_cache:
+        inputs:
+          key: ios-ccache-${{ hashFiles('package-lock.json') }}
+          path: /Users/expo/Library/Caches/ccache
+```
+
+#### EAS Workflows
+
+For EAS Workflows, use [`eas/restore_cache`](/eas/workflows/syntax/#easrestore_cache) and [`eas/save_cache`](/eas/workflows/syntax/#eassave_cache).
+
+**Android example:**
+
+```yaml .eas/workflows/build-android-custom.yml
+jobs:
+  build_android:
+    steps:
+      - uses: eas/checkout
+      - uses: eas/install_node_modules
+      - uses: eas/prebuild
+      - uses: eas/restore_cache
+        with:
+          key: android-ccache-${{ hashFiles('package-lock.json') }}
+          restore_keys: android
+          path: /home/expo/.cache/ccache
+      - name: Build Android app
+        run: cd android && ./gradlew assembleRelease
+      - uses: eas/save_cache
+        with:
+          key: android-ccache-${{ hashFiles('package-lock.json') }}
+          path: /home/expo/.cache/ccache
+```
+
+**iOS example:**
+
+```yaml .eas/workflows/build-ios-custom.yml
+jobs:
+  build_ios:
+    steps:
+      - uses: eas/checkout
+      - uses: eas/install_node_modules
+      - uses: eas/prebuild
+      - uses: eas/restore_cache
+        with:
+          key: ios-ccache-${{ hashFiles('package-lock.json') }}
+          restore_keys: ios
+          path: /Users/expo/Library/Caches/ccache
+      - name: Build iOS app
+        run: cd ios && fastlane build
+      - uses: eas/save_cache
+        with:
+          key: ios-ccache-${{ hashFiles('package-lock.json') }}
+          path: /Users/expo/Library/Caches/ccache
+```
+
+The cache key uses `hashFiles('package-lock.json')` to create a unique key based on your dependencies. When dependencies change, a new cache will be created while still allowing fallback to previous caches using `restore_keys`.
+
+### Cache key matching
+
+When restoring a cache, the cache system follows a specific search sequence to find matching cache entries:
+
+1. **Exact match**: First, it searches for an exact match to your provided `key`.
+2. **Partial match**: If no exact match is found, it will search for partial matches of the `key` (keys that start with your key as a prefix).
+3. **Restore keys**: If there is still no match found, and you've provided `restore_keys`, these keys will be checked sequentially for partial matches.
+
+If there is an exact match to the provided `key`, this is considered a cache hit and the cache is restored immediately. If there is a partial match or a match from `restore_keys`, the cache is restored but this is considered a cache miss, which may trigger additional steps in your workflow.
+
+#### Using restore keys
+
+`restore_keys` allows you to specify a list of alternate restore keys to use when there is a cache miss on `key`. You can create multiple restore keys ordered from the most specific to least specific. The cache system searches the `restore_keys` in sequential order. When a key doesn't match directly, the system searches for keys prefixed with the restore key. If there are multiple partial matches for a restore key, the system returns the most recently created cache.
+
+**Example using multiple restore keys:**
+
+```yaml
+- uses: eas/restore_cache
+  with:
+    key: android-ccache-${{ hashFiles('package-lock.json') }}
+    restore_keys: |
+      android-ccache-${{ hashFiles('package-lock.json') }}
+      android-ccache-
+      android-
+```
+
+The restore key `android-ccache-` matches any key that starts with the string `android-ccache-`. For example, both of the keys `android-ccache-fd3052de` and `android-ccache-a9b253ff` match the restore key. The cache with the most recent creation date would be used. The keys in this example are searched in the following order:
+
+1. **`android-ccache-${{ hashFiles('package-lock.json') }}`** matches a specific hash.
+2. **`android-ccache-`** matches cache keys prefixed with `android-ccache-`.
+3. **`android-`** matches any keys prefixed with `android-`.
+
+### Cache restrictions
+
+Access restrictions provide cache isolation and security by creating logical boundaries between different branches and builds. Understanding these restrictions helps you optimize your cache usage and avoid unexpected cache misses.
+
+#### Branch-based access
+
+Caches are scoped to the branch where they were created. Workflow runs can restore caches created in:
+
+- The current branch
+- The default branch (usually `main` or `master`)
+
+If a workflow run is triggered for a pull request, it can also restore caches created in the base branch. For example, if a pull request from `feature-b` targets `main`, the workflow can access caches created in the `main` branch.
+
+#### Default branch cache
+
+If a build doesn't find a user-scoped cache (created with `eas/restore_cache` and `eas/save_cache` or `eas/restore_build_cache` and `eas/save_build_cache`), it will automatically fallback to restoring caches published from GitHub builds triggered on the `main` branch. This allows builds to benefit from caches created by automated workflows even when no user-scoped cache exists yet.
+
+#### User-scoped caches
+
+Remote user-scoped caches (created with `eas/restore_cache` and `eas/save_cache` or `eas/restore_build_cache` and `eas/save_build_cache`) are scoped to your user account. This means:
+
+- Caches are shared across all builds and workflows for your account
+- Caches persist across different branches and projects
+- You can reuse caches across multiple builds to maximize cache hit rates
+
+This is particularly useful for build tools like ccache, where the compilation cache can be shared across different projects and branches.
+
 ## iOS dependencies
 
 EAS Build serves most CocoaPods artifacts from a cache server. This improves the consistency of `pod install` times and generally improves speed. The cache will be bypassed automatically if you provide your own **.netrc** or **.curlrc** files.

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -70,17 +70,17 @@ To disable using our Maven cache server for your builds set the `EAS_BUILD_DISAB
 
 ### Caching C/C++ compilation artifacts with ccache
 
-[ccache](https://ccache.dev/) is a compiler cache that speeds up recompilation by caching previous compilations. You can use remote caching to share ccache data across builds, which significantly speeds up builds that include results for native libraries used by React Native, Hermes, or other native modules.
+[ccache](https://ccache.dev/) is a compiler cache that speeds up recompilation of native code by caching previous compilation results. EAS supports ccache configuration out of the box.
 
-You can configure builds to save and restore ccache automatically with these environment variables:
+You can configure builds to save and restore ccache cache automatically with these environment variables:
 
-- `EAS_USE_CACHE`: Enables saving and restoring cache on build jobs. By setting to `1`, it will enable both saving and restoring the cache during a build job. By setting to `0`, it will disable both saving and restoring the cache
-- `EAS_RESTORE_CACHE`: Controls restoring the cache at the beginning of a build. Set to `1` to enable or `0` to disable.
-- `EAS_SAVE_CACHE`: Controls whether to save the build cache at the end of a build. Set to `1` to enable or `0` to disable.
+- `EAS_USE_CACHE`: When set to `1`, enables both restoring and saving the cache results during a build job.
+- `EAS_RESTORE_CACHE`: Controls restoring the cache at the beginning of a build. Set to `1` to enable or `0` to disable. Overrides `EAS_USE_CACHE`.
+- `EAS_SAVE_CACHE`: Controls whether to save the build cache at the end of a build. Set to `1` to enable or `0` to disable. Overrides `EAS_USE_CACHE`.
 
 #### Custom builds
 
-For custom builds, use [`eas/restore_build_cache`](/custom-builds/schema/#easrestore_build_cache) and [`eas/save_build_cache`](/custom-builds/schema/#eassave_build_cache) to cache the ccache directory.
+In custom builds where you manage the build steps, add [`eas/restore_build_cache`](/custom-builds/schema/#easrestore_build_cache) and [`eas/save_build_cache`](/custom-builds/schema/#eassave_build_cache) to enable ccache cache.
 
 **Android example:**
 

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -168,7 +168,7 @@ When a build is run from GitHub, caches get scoped to the branch the build is ru
 
 #### EAS CLI run
 
-When a build is triggered from `eas-cli`, caches are scoped to the user running the build. These user-scoped caches allow for isolation so that modifications to the build and its cache are not unintentionally shared during development.
+When a build is triggered from `eas-cli`, caches are scoped to the user running the build. These user-scoped caches allow for isolation so that modifications to the build and its cache are not unintentionally shared during development or between users.
 
 #### Default branch cache
 

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -203,7 +203,6 @@ When build is run from GitHub, caches get scoped to the branch the build is runn
 - The current branch
 - The default branch (`main` or `master`)
 
-
 #### User-scoped caches
 
 When a build is triggered from `eas-cli`, caches are scoped to the user running the build.

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -203,11 +203,10 @@ Caches are scoped to the branch where they were created. Workflow runs can resto
 - The current branch
 - The default branch (`main` or `master`)
 
-If a workflow run is triggered for a pull request, it can also restore caches created in the base branch. For example, if a pull request from `feature-b` targets `main`, the workflow can access caches created in the `main` branch.
 
 #### User-scoped caches
 
-User-scoped caches allow for publishing caches that are just accessible to builds or workflow jobs that are ran by that respective user. Allowing for isolation so that modifications to the build and its cache are not unintentionally shared during development. This means:
+When a build is triggered from `eas-cli`, caches are scoped to the user running the build.
 
 - Caches are shared just between the builds and workflows for an account
 - Caches persist across different branches and builds
@@ -218,8 +217,6 @@ This ensures that builds between teammates will benefit from remote caching with
 #### Default branch cache
 
 If a build doesn't restore a user-scoped cache, it will automatically fallback to restoring caches published from GitHub builds triggered on the default branch. This allows builds to benefit from caches created by automated workflows even when no user-scoped cache exists yet, or to only keep publishing caches from a designated job.
-
-This is particularly useful for build tools like ccache, where the compilation cache can be shared across different builds and branches and the performance benefits can be applied broadly.
 
 ## iOS dependencies
 

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -151,7 +151,7 @@ If there is an exact match to the provided `key`, this is considered a cache hit
 
 The restore key `android-ccache-` matches any key that starts with the string `android-ccache-`. For example, both of the keys `android-ccache-fd3052de` and `android-ccache-a9b253ff` match the restore key. The cache with the most recent creation date would be used. The keys in this example are searched in the following order:
 
-1. **`android-ccache-${{ hashFiles('package-lock.json') }}`** matches a specific hash.
+1. **`android-ccache-${{ hashFiles('yarn.lock') }}`** matches a specific hash.
 2. **`android-ccache-`** matches cache keys prefixed with `android-ccache-`.
 3. **`android-`** matches any keys prefixed with `android-`.
 
@@ -159,20 +159,65 @@ The restore key `android-ccache-` matches any key that starts with the string `a
 
 Access restrictions provide cache isolation and security by creating logical boundaries between different Git branches or users. It is important for security of yours and your users to understand and leverage them when building your app.
 
-#### Branch-based access
+#### GitHub run
 
-When build is run from GitHub, caches get scoped to the branch the build is running from. A build can restore caches created in:
+When a build is run from GitHub, caches get scoped to the branch the build is running from. A build can restore caches created in:
 
 - The current branch
 - The default branch (`main` or `master`)
 
-#### User-scoped caches
+#### EAS CLI run
 
-When a build is triggered from `eas-cli`, caches are scoped to the user running the build.
+When a build is triggered from `eas-cli`, caches are scoped to the user running the build. These user-scoped caches allow for isolation so that modifications to the build and its cache are not unintentionally shared during development.
 
 #### Default branch cache
 
-If a build doesn't restore a user-scoped cache, it will automatically fallback to restoring caches published from GitHub builds triggered on the default branch. This allows builds to benefit from caches created by automated workflows even when no user-scoped cache exists yet, or to only keep publishing caches from a designated job.
+If a build doesn't restore a user-scoped cache, it will automatically fallback to restoring caches published from GitHub builds triggered on the default branch. This allows builds to benefit from caches created by trusted sources even when no user-scoped cache exists yet.
+
+When a single user-actor is shared between multiple people (such as when using access tokens or triggering builds from GitHub Actions), user-scoped cache rules still apply. This means that builds operating under that shared account will no longer have isolated caches and run the risk of sharing unintended artifacts. We recommend avoiding this by having designated jobs to only save clean caches, while the development builds only restore.
+
+#### Cache publishing
+
+You can configure a job to publish clean, new caches by disabling cache restoration and only saving the cache.
+
+**Disable restoring cache for production builds:**
+
+You can disable cache restoration for specific build profiles by configuring these environment variables:
+
+```json eas.json
+{
+  "build": {
+    "production": {
+      "env": {
+        "EAS_RESTORE_CACHE": "0",
+        "EAS_SAVE_CACHE": "1"
+      }
+    },
+    "preview": {
+      "env": {
+        "EAS_USE_CACHE": "1"
+      }
+    }
+  }
+}
+```
+
+**Only save cache from designated jobs:**
+
+To ensure only trusted sources publish cache, you can configure workflows to only save cache from specific jobs on the main branch:
+
+```yaml .eas/workflows/build.yml
+jobs:
+  build_production:
+    type: build
+    if: ${{ github.ref_name == 'main' }}
+    env:
+      EAS_RESTORE_CACHE: '0'
+      EAS_SAVE_CACHE: '1'
+    params:
+      platform: android
+      profile: production
+```
 
 ## iOS dependencies
 

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -188,7 +188,7 @@ If a build doesn't restore a user-scoped cache, it will automatically fallback t
 
 When a single user-actor is shared between multiple people (such as when using access tokens or triggering builds from GitHub Actions), user-scoped cache rules still apply. This means that builds operating under that shared account will no longer have isolated caches and run the risk of sharing unintended artifacts. To avoid this, we recommend not restoring cache for production builds under a shared user, and to have designated jobs to only save clean, new caches.
 
-#### Designated jobs for cache creation
+### Designated jobs for cache creation
 
 You can configure a job to publish clean, new caches by disabling cache restoration and only saving the cache.
 

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -78,7 +78,7 @@ You can configure builds to save and restore ccache cache automatically with the
 - `EAS_RESTORE_CACHE`: Controls restoring the cache at the beginning of a build. Set to `1` to enable or `0` to disable. Overrides `EAS_USE_CACHE`.
 - `EAS_SAVE_CACHE`: Controls whether to save the build cache at the end of a build. Set to `1` to enable or `0` to disable. Overrides `EAS_USE_CACHE`.
 
-#### EAS Workflows
+### EAS Workflows
 
 For EAS Workflows, use [`eas/restore_cache`](/eas/workflows/syntax/#easrestore_cache) and [`eas/save_cache`](/eas/workflows/syntax/#eassave_cache).
 
@@ -128,7 +128,7 @@ jobs:
       #    path: /Users/expo/Library/Caches/ccache
 ```
 
-#### Custom builds
+### Custom builds
 
 In custom builds where you manage the build steps, add [`eas/restore_build_cache`](/custom-builds/schema/#easrestore_build_cache) and [`eas/save_build_cache`](/custom-builds/schema/#eassave_build_cache) to enable ccache cache.
 
@@ -146,7 +146,7 @@ The cache key uses a hash of the package manager lock file to create a unique ke
 
 ### Cache key matching
 
-When restoring a cache, the cache system follows a specific search sequence to find matching cache entries. The cache key is either automatically generated (when using `eas/restore_build_cache` or `eas/save_build_cache`) or explicitly provided via the `key` parameter (when using `eas/restore_cache` or `eas/save_cache` with custom configuration).
+When restoring a cache, the cache system follows a specific search sequence to find matching cache entries. The cache key is either automatically generated (when using `eas/restore_build_cache` or `eas/save_build_cache`) or explicitly provided via the `key` parameter (when using `eas/restore_cache` or `eas/save_cache`).
 
 The search sequence:
 

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -211,7 +211,7 @@ User-scoped caches allow for publishing caches that are just accessible to build
 
 - Caches are shared just between the builds and workflows for an account
 - Caches persist across different branches and builds
-- Each user’s build will have their own isolated cache even when on the same branch
+- Each user's build will have their own isolated cache even when on the same branch
 
 This ensures that builds between teammates will benefit from remote caching with the guarantee that they are isolated and limited to the proper scope.
 

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -208,12 +208,6 @@ Caches are scoped to the branch where they were created. Workflow runs can resto
 
 When a build is triggered from `eas-cli`, caches are scoped to the user running the build.
 
-- Caches are shared just between the builds and workflows for an account
-- Caches persist across different branches and builds
-- Each user's build will have their own isolated cache even when on the same branch
-
-This ensures that builds between teammates will benefit from remote caching with the guarantee that they are isolated and limited to the proper scope.
-
 #### Default branch cache
 
 If a build doesn't restore a user-scoped cache, it will automatically fallback to restoring caches published from GitHub builds triggered on the default branch. This allows builds to benefit from caches created by automated workflows even when no user-scoped cache exists yet, or to only keep publishing caches from a designated job.

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -198,7 +198,7 @@ Access restrictions provide cache isolation and security by creating logical bou
 
 #### Branch-based access
 
-Caches are scoped to the branch where they were created. Workflow runs can restore caches created in:
+When build is run from GitHub, caches get scoped to the branch the build is running from. A build can restore caches created in:
 
 - The current branch
 - The default branch (`main` or `master`)


### PR DESCRIPTION
# Why

Add a reference for restoring and saving ccache under https://docs.expo.dev/build-reference/caching/ This will detail how to use it for builds, workflows, and the behavior of user scoped and default branch caches

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
