### PR TITLE
[build-properties] Validate hermes-compiler version when enabling hermes V1

### DIFF
--- a/packages/expo-build-properties/CHANGELOG.md
+++ b/packages/expo-build-properties/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Validate `hermes-compiler` version when enabling hermes V1 ([#42477](https://github.com/expo/expo/pull/42477) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 55.0.3 — 2026-01-26
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-build-properties/build/pluginConfig.d.ts
+++ b/packages/expo-build-properties/build/pluginConfig.d.ts
@@ -530,4 +530,4 @@ export interface PluginConfigTypeAndroidQueriesData {
 /**
  * @ignore
  */
-export declare function validateConfig(config: unknown): PluginConfigType;
+export declare function validateConfig(config: unknown, projectRoot?: string): PluginConfigType;

--- a/packages/expo-build-properties/build/pluginConfig.js
+++ b/packages/expo-build-properties/build/pluginConfig.js
@@ -285,7 +285,7 @@ const fixupDeprecatedEnableProguardInReleaseBuilds = (config) => {
  * @ignore
  */
 function getHermesCompilerVersion(projectRoot) {
-    const hermesCompilerPackageJsonPath = resolve_from_1.default.silent(projectRoot, 'hermes-compiler/package.json');
+    const hermesCompilerPackageJsonPath = resolve_from_1.default.silent(resolve_from_1.default.silent(projectRoot, 'react-native/package.json') ?? projectRoot, 'hermes-compiler/package.json');
     if (!hermesCompilerPackageJsonPath || !fs_1.default.existsSync(hermesCompilerPackageJsonPath)) {
         return null;
     }

--- a/packages/expo-build-properties/build/pluginConfig.js
+++ b/packages/expo-build-properties/build/pluginConfig.js
@@ -285,8 +285,9 @@ const fixupDeprecatedEnableProguardInReleaseBuilds = (config) => {
  * @ignore
  */
 function getHermesCompilerVersion(projectRoot) {
-    const hermesCompilerPackageJsonPath = resolve_from_1.default.silent(resolve_from_1.default.silent(projectRoot, 'react-native/package.json') ?? projectRoot, 'hermes-compiler/package.json');
-    if (!hermesCompilerPackageJsonPath || !fs_1.default.existsSync(hermesCompilerPackageJsonPath)) {
+    const reactNativePath = resolve_from_1.default.silent(projectRoot, 'react-native/package.json');
+    const hermesCompilerPackageJsonPath = reactNativePath && resolve_from_1.default.silent(reactNativePath, 'hermes-compiler/package.json');
+    if (!hermesCompilerPackageJsonPath) {
         return null;
     }
     try {

--- a/packages/expo-build-properties/build/pluginConfig.js
+++ b/packages/expo-build-properties/build/pluginConfig.js
@@ -311,14 +311,13 @@ function validateConfig(config, projectRoot) {
     }
     const androidUseHermesV1 = resolveConfigValue(config, 'android', 'useHermesV1');
     const iosUseHermesV1 = resolveConfigValue(config, 'ios', 'useHermesV1');
+    // TODO(gabrieldonadel): Revisit this before releasing SDK 56
     // Hermes v1 requires a specific hermes-compiler version
     if ((androidUseHermesV1 || iosUseHermesV1) && projectRoot) {
         const hermesCompilerVersion = getHermesCompilerVersion(projectRoot);
-        if (hermesCompilerVersion !== HERMES_V1_COMPILER_VERSION) {
+        if (hermesCompilerVersion && hermesCompilerVersion !== HERMES_V1_COMPILER_VERSION) {
             throw new Error(`\`useHermesV1\` requires setting the hermes-compiler version to ${HERMES_V1_COMPILER_VERSION} through resolutions. ` +
-                (hermesCompilerVersion
-                    ? `Found version "${hermesCompilerVersion}" instead.`
-                    : 'hermes-compiler dependency not found.'));
+                `Found version "${hermesCompilerVersion}" instead.`);
         }
     }
     // Validate useHermesV1 requires buildReactNativeFromSource for Android

--- a/packages/expo-build-properties/build/withBuildProperties.js
+++ b/packages/expo-build-properties/build/withBuildProperties.js
@@ -10,7 +10,8 @@ const pluginConfig_1 = require("./pluginConfig");
  * @param props Configuration for the build properties plugin.
  */
 const withBuildProperties = (config, props) => {
-    const pluginConfig = (0, pluginConfig_1.validateConfig)(props || {});
+    const projectRoot = config._internal?.projectRoot;
+    const pluginConfig = (0, pluginConfig_1.validateConfig)(props || {}, projectRoot);
     config = (0, android_1.withAndroidBuildProperties)(config, pluginConfig);
     config = (0, android_1.withAndroidProguardRules)(config, pluginConfig);
     config = (0, android_1.withAndroidCleartextTraffic)(config, pluginConfig);

--- a/packages/expo-build-properties/package.json
+++ b/packages/expo-build-properties/package.json
@@ -32,6 +32,7 @@
   "homepage": "https://docs.expo.dev/versions/latest/sdk/build-properties",
   "dependencies": {
     "@expo/schema-utils": "^55.0.2",
+    "resolve-from": "^5.0.0",
     "semver": "^7.6.0"
   },
   "devDependencies": {

--- a/packages/expo-build-properties/src/pluginConfig.ts
+++ b/packages/expo-build-properties/src/pluginConfig.ts
@@ -873,7 +873,7 @@ const fixupDeprecatedEnableProguardInReleaseBuilds = (config: unknown) => {
  */
 function getHermesCompilerVersion(projectRoot: string): string | null {
   const hermesCompilerPackageJsonPath = resolveFrom.silent(
-    projectRoot,
+    resolveFrom.silent(projectRoot, 'react-native/package.json') ?? projectRoot,
     'hermes-compiler/package.json'
   );
   if (!hermesCompilerPackageJsonPath || !fs.existsSync(hermesCompilerPackageJsonPath)) {

--- a/packages/expo-build-properties/src/pluginConfig.ts
+++ b/packages/expo-build-properties/src/pluginConfig.ts
@@ -872,11 +872,9 @@ const fixupDeprecatedEnableProguardInReleaseBuilds = (config: unknown) => {
  * @ignore
  */
 function getHermesCompilerVersion(projectRoot: string): string | null {
-  const hermesCompilerPackageJsonPath = resolveFrom.silent(
-    resolveFrom.silent(projectRoot, 'react-native/package.json') ?? projectRoot,
-    'hermes-compiler/package.json'
-  );
-  if (!hermesCompilerPackageJsonPath || !fs.existsSync(hermesCompilerPackageJsonPath)) {
+  const reactNativePath = resolveFrom.silent(projectRoot, 'react-native/package.json');
+  const hermesCompilerPackageJsonPath = reactNativePath && resolveFrom.silent(reactNativePath, 'hermes-compiler/package.json');
+  if (!hermesCompilerPackageJsonPath) {
     return null;
   }
 

--- a/packages/expo-build-properties/src/pluginConfig.ts
+++ b/packages/expo-build-properties/src/pluginConfig.ts
@@ -873,7 +873,8 @@ const fixupDeprecatedEnableProguardInReleaseBuilds = (config: unknown) => {
  */
 function getHermesCompilerVersion(projectRoot: string): string | null {
   const reactNativePath = resolveFrom.silent(projectRoot, 'react-native/package.json');
-  const hermesCompilerPackageJsonPath = reactNativePath && resolveFrom.silent(reactNativePath, 'hermes-compiler/package.json');
+  const hermesCompilerPackageJsonPath =
+    reactNativePath && resolveFrom.silent(reactNativePath, 'hermes-compiler/package.json');
   if (!hermesCompilerPackageJsonPath) {
     return null;
   }
@@ -910,12 +911,10 @@ export function validateConfig(config: unknown, projectRoot?: string): PluginCon
   // Hermes v1 requires a specific hermes-compiler version
   if ((androidUseHermesV1 || iosUseHermesV1) && projectRoot) {
     const hermesCompilerVersion = getHermesCompilerVersion(projectRoot);
-    if (hermesCompilerVersion !== HERMES_V1_COMPILER_VERSION) {
+    if (hermesCompilerVersion && hermesCompilerVersion !== HERMES_V1_COMPILER_VERSION) {
       throw new Error(
         `\`useHermesV1\` requires setting the hermes-compiler version to ${HERMES_V1_COMPILER_VERSION} through resolutions. ` +
-          (hermesCompilerVersion
-            ? `Found version "${hermesCompilerVersion}" instead.`
-            : 'hermes-compiler dependency not found.')
+          `Found version "${hermesCompilerVersion}" instead.`
       );
     }
   }

--- a/packages/expo-build-properties/src/pluginConfig.ts
+++ b/packages/expo-build-properties/src/pluginConfig.ts
@@ -906,6 +906,7 @@ export function validateConfig(config: unknown, projectRoot?: string): PluginCon
   const androidUseHermesV1 = resolveConfigValue(config, 'android', 'useHermesV1');
   const iosUseHermesV1 = resolveConfigValue(config, 'ios', 'useHermesV1');
 
+  // TODO(gabrieldonadel): Revisit this before releasing SDK 56
   // Hermes v1 requires a specific hermes-compiler version
   if ((androidUseHermesV1 || iosUseHermesV1) && projectRoot) {
     const hermesCompilerVersion = getHermesCompilerVersion(projectRoot);

--- a/packages/expo-build-properties/src/withBuildProperties.ts
+++ b/packages/expo-build-properties/src/withBuildProperties.ts
@@ -18,7 +18,8 @@ import { PluginConfigType, validateConfig } from './pluginConfig';
  * @param props Configuration for the build properties plugin.
  */
 export const withBuildProperties: ConfigPlugin<PluginConfigType> = (config, props) => {
-  const pluginConfig = validateConfig(props || {});
+  const projectRoot = config._internal?.projectRoot;
+  const pluginConfig = validateConfig(props || {}, projectRoot);
 
   config = withAndroidBuildProperties(config, pluginConfig);
 


### PR DESCRIPTION
# Why

Using Hermes V1 requires users to set a yarn resolution to use hermes-compiler 250829098.0.4. To prevent confusion around uses trying to enable this option, we should validate the hermes-compiler version when enabling hermes V1.

# How

Add hermes-compiler version validation to expo-build-properties when enabling hermes V1 

# Test Plan

Enable hermesV1 and run `npx expo prebuild` locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
