### PR TITLE
refactor(cli): Drop trivial `freeport-async` dependency

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Drop `freeport-async` dependency ([#42478](https://github.com/expo/expo/pull/42478) by [@kitten](https://github.com/kitten))
+
 ## 55.0.2 — 2026-01-23
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -77,7 +77,6 @@
     "dnssd-advertise": "^1.1.1",
     "env-editor": "^0.4.1",
     "expo-server": "^55.0.1",
-    "freeport-async": "^2.0.0",
     "getenv": "^2.0.0",
     "glob": "^13.0.0",
     "lan-network": "^0.1.6",

--- a/packages/@expo/cli/src/utils/__tests__/port.test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/port.test.ts
@@ -1,12 +1,13 @@
-// @ts-expect-error
-import freeportAsync from 'freeport-async';
-
+import { testPortAsync } from '../freeport';
 import { getRunningProcess } from '../getRunningProcess';
 import { choosePortAsync, ensurePortAvailabilityAsync } from '../port';
 import { confirmAsync } from '../prompts';
 
+jest.mock('../freeport', () => ({
+  testPortAsync: jest.fn(async (port) => port),
+}));
+
 jest.mock('../../log');
-jest.mock('freeport-async', () => jest.fn(async (port) => port));
 jest.mock('../prompts');
 jest.mock('../getRunningProcess', () => ({
   getRunningProcess: jest.fn(() => null),
@@ -14,7 +15,7 @@ jest.mock('../getRunningProcess', () => ({
 
 describe(ensurePortAvailabilityAsync, () => {
   it(`returns true if the port is available`, async () => {
-    jest.mocked(freeportAsync).mockResolvedValueOnce(8081);
+    jest.mocked(testPortAsync).mockResolvedValueOnce(8081);
     expect(await ensurePortAvailabilityAsync('/', { port: 8081 })).toBe(true);
   });
   it(`returns false if the port is unavailable due to running the same process`, async () => {
@@ -23,7 +24,7 @@ describe(ensurePortAvailabilityAsync, () => {
       directory: '/me',
       command: 'npx expo',
     });
-    jest.mocked(freeportAsync).mockResolvedValueOnce(8082);
+    jest.mocked(testPortAsync).mockResolvedValueOnce(8082);
     expect(await ensurePortAvailabilityAsync('/me', { port: 8081 })).toBe(false);
   });
   it(`asserts if the port is busy because it's running a different process`, async () => {
@@ -32,26 +33,26 @@ describe(ensurePortAvailabilityAsync, () => {
       directory: '/other',
       command: 'npx expo',
     });
-    jest.mocked(freeportAsync).mockResolvedValueOnce(8082);
+    jest.mocked(testPortAsync).mockResolvedValueOnce(8082);
     await expect(ensurePortAvailabilityAsync('/me', { port: 8081 })).rejects.toThrow();
   });
 });
 
 describe(choosePortAsync, () => {
   it(`returns any port when given port is 0`, async () => {
-    jest.mocked(freeportAsync).mockResolvedValueOnce(1000);
+    jest.mocked(testPortAsync).mockResolvedValueOnce(1000);
     const port = await choosePortAsync('/', { defaultPort: 0 });
     expect(port).toBe(1000);
     expect(confirmAsync).not.toHaveBeenCalled();
   });
   it(`returns same port when given port is available`, async () => {
-    jest.mocked(freeportAsync).mockResolvedValueOnce(8081);
+    jest.mocked(testPortAsync).mockResolvedValueOnce(8081);
     const port = await choosePortAsync('/', { defaultPort: 8081 });
     expect(port).toBe(8081);
     expect(confirmAsync).not.toHaveBeenCalled();
   });
   it(`chooses a new port if the default port is taken and isn't running the same process`, async () => {
-    jest.mocked(freeportAsync).mockResolvedValueOnce(8082);
+    jest.mocked(testPortAsync).mockResolvedValueOnce(8082);
     jest.mocked(getRunningProcess).mockReturnValueOnce({
       pid: 1,
       directory: '/other/project',
@@ -63,7 +64,7 @@ describe(choosePortAsync, () => {
     expect(confirmAsync).toHaveBeenCalledWith({ initial: true, message: 'Use port 8082 instead?' });
   });
   it(`returns null if the new suggested port is rejected`, async () => {
-    jest.mocked(freeportAsync).mockResolvedValueOnce(8082);
+    jest.mocked(testPortAsync).mockResolvedValueOnce(8082);
     jest.mocked(getRunningProcess).mockReturnValueOnce({
       pid: 1,
       directory: '/other/project',
@@ -75,7 +76,7 @@ describe(choosePortAsync, () => {
     expect(confirmAsync).toHaveBeenCalledWith({ initial: true, message: 'Use port 8082 instead?' });
   });
   it(`returns null if the taken port is running the same process`, async () => {
-    jest.mocked(freeportAsync).mockResolvedValueOnce(8082);
+    jest.mocked(testPortAsync).mockResolvedValueOnce(8082);
     jest.mocked(getRunningProcess).mockReturnValueOnce({
       pid: 1,
       directory: '/me',

--- a/packages/@expo/cli/src/utils/freeport.ts
+++ b/packages/@expo/cli/src/utils/freeport.ts
@@ -1,0 +1,31 @@
+import net from 'node:net';
+
+async function testHostPortAsync(port: number, host: string | null): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.listen({ port, host }, () => {
+      server.once('close', () => {
+        setTimeout(() => resolve(true), 0);
+      });
+      server.close();
+    });
+    server.once('error', (_error) => {
+      setTimeout(() => resolve(false), 0);
+    });
+  });
+}
+
+export async function testPortAsync(
+  port: number,
+  hostnames?: (string | null)[]
+): Promise<number | null> {
+  if (!hostnames?.length) {
+    hostnames = [null];
+  }
+  for (const host of hostnames) {
+    if (!(await testHostPortAsync(port, host))) {
+      return null;
+    }
+  }
+  return port;
+}

--- a/packages/@expo/cli/src/utils/port.ts
+++ b/packages/@expo/cli/src/utils/port.ts
@@ -1,13 +1,13 @@
 import chalk from 'chalk';
-import freeportAsync from 'freeport-async';
 
 import { env } from './env';
 import { CommandError } from './errors';
+import { testPortAsync } from './freeport';
 import * as Log from '../log';
 
 /** Get a free port or assert a CLI command error. */
 export async function getFreePortAsync(rangeStart: number): Promise<number> {
-  const port = await freeportAsync(rangeStart, { hostnames: [null, 'localhost'] });
+  const port = await testPortAsync(rangeStart, [null, 'localhost']);
   if (!port) {
     throw new CommandError('NO_PORT_FOUND', 'No available port found');
   }
@@ -20,7 +20,7 @@ export async function ensurePortAvailabilityAsync(
   projectRoot: string,
   { port }: { port: number }
 ): Promise<boolean> {
-  const freePort = await freeportAsync(port, { hostnames: [null] });
+  const freePort = await testPortAsync(port, [null]);
   // Check if port has become busy during the build.
   if (freePort === port) {
     return true;
@@ -78,12 +78,12 @@ export async function choosePortAsync(
   }
 ): Promise<number | null> {
   try {
-    const port = await freeportAsync(defaultPort, { hostnames: [host ?? null] });
+    const port = await testPortAsync(defaultPort, [host ?? null]);
     if (port === defaultPort || defaultPort === 0) {
       return port;
     }
 
-    const isRestricted = isRestrictedPort(port);
+    const isRestricted = port && isRestrictedPort(port);
 
     let message = isRestricted
       ? `Admin permissions are required to run a server on a port below 1024`

--- a/packages/@expo/cli/ts-declarations/freeport-async/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/freeport-async/index.d.ts
@@ -1,8 +1,0 @@
-declare module 'freeport-async' {
-  interface FreePortOptions {
-    hostnames?: Array<string | null>;
-  }
-
-  function freePortAsync(rangeStart: number, options?: FreePortOptions): Promise<number>;
-  export = freePortAsync;
-}


### PR DESCRIPTION
# Why

This is a trivial dependency, and we don't use it to scan multiple ports. This would however also be trivial to implement since it's an added loop. We can drop `freeport-async` and instead do our own check. We only used it to test whether a port is free, and didn't even use a range check.

# How

- Replace `freeport-async` with `freeport.ts` utility
- Drop `freeport-async` dependency and manual typings

# Test Plan

- Existing E2E tests and unit tests cover this

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
