### PR TITLE
refactor(cli): Drop `pretty-bytes` for `Intl.NumberFormat` call

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Drop `freeport-async` dependency ([#42478](https://github.com/expo/expo/pull/42478) by [@kitten](https://github.com/kitten))
+- Drop `pretty-bytes` for `Intl.NumberFormat` call with fallback ([#42482](https://github.com/expo/expo/pull/42482) by [@kitten](https://github.com/kitten))
 
 ## 55.0.2 — 2026-01-23
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -85,7 +85,6 @@
     "npm-package-arg": "^11.0.0",
     "ora": "^3.4.0",
     "picomatch": "^3.0.1",
-    "pretty-bytes": "^5.6.0",
     "pretty-format": "^29.7.0",
     "progress": "^2.0.3",
     "prompts": "^2.3.2",

--- a/packages/@expo/cli/src/export/saveAssets.ts
+++ b/packages/@expo/cli/src/export/saveAssets.ts
@@ -9,10 +9,37 @@ import type { SerialAsset } from '@expo/metro-config/build/serializer/serializer
 import chalk from 'chalk';
 import fs from 'fs';
 import path from 'path';
-import prettyBytes from 'pretty-bytes';
 
 import { Log } from '../log';
 import { env } from '../utils/env';
+
+let bytesFormatter: Intl.NumberFormat | undefined | null;
+
+const prettyBytes = (bytes: number): string => {
+  try {
+    if (bytesFormatter === undefined && typeof Intl === 'object') {
+      bytesFormatter = new Intl.NumberFormat('en', {
+        notation: 'compact',
+        style: 'unit',
+        unit: 'byte',
+        unitDisplay: 'narrow',
+      });
+    }
+    if (bytesFormatter != null) {
+      return bytesFormatter.format(bytes);
+    }
+  } catch {
+    bytesFormatter = null;
+  }
+  // Fall back if ICU is unavailable, which is rare but possible with custom Node.js builds
+  if (bytes >= 900_000) {
+    return `${(bytes / 1_000_000).toFixed(1)}MB`;
+  } else if (bytes >= 900) {
+    return `${(bytes / 1_000).toFixed(1)}KB`;
+  } else {
+    return `${bytes}B`;
+  }
+};
 
 const BLT = '\u203A';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13021,11 +13021,6 @@ prettier@^3.0.3, prettier@^3.2.5, prettier@^3.4.2, prettier@^3.5.3:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.5.3.tgz#4fc2ce0d657e7a02e602549f053b239cb7dfe1b5"
   integrity sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==
 
-pretty-bytes@^5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
-  integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==
-
 pretty-format@^27.0.2:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"


### PR DESCRIPTION
# Why

Using `pretty-bytes` here is redundant as `Intl.NumberFormat` has support for the bytes unit. We can fall back to a primitive formatter when ICU data is unavailable or support is left-out, which should be extremely rare and unlikely.

# How

- Replace `pretty-bytes` with `Intl.NumberFormat` call
- Drop `pretty-bytes`

# Test Plan

- Run export / existing E2E tests cover the call itself

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
