### PR TITLE
[tools] Exclude expo-modules-scripts from publish

### DIFF
--- a/tools/src/commands/PublishPackages.ts
+++ b/tools/src/commands/PublishPackages.ts
@@ -54,6 +54,11 @@ export default (program: Command) => {
       'Restrict publishing to template packages under templates/. Dependencies will not be auto-included.',
       false
     )
+    .option(
+      '--include-expo-module-scripts',
+      'Include expo-module-scripts in publishing (excluded by default).',
+      false
+    )
 
     /* exclusive options */
     .option(

--- a/tools/src/publish-packages/tasks/loadRequestedParcels.ts
+++ b/tools/src/publish-packages/tasks/loadRequestedParcels.ts
@@ -46,6 +46,11 @@ export const loadRequestedParcels = new Task<TaskArgs>(
       const isPrivate = pkg.packageJson.private;
       const isIncluded = packageNames.length === 0 || packageNames.includes(pkg.packageName);
       const isTemplate = pkg.isTemplate();
+
+      const isExpoModuleScripts = pkg.packageName === 'expo-module-scripts';
+      if (isExpoModuleScripts && !options.includeExpoModuleScripts) {
+        return false;
+      }
       if (options.templatesOnly) {
         // Only include templates when the flag is on
         return !isPrivate && isIncluded && isTemplate;

--- a/tools/src/publish-packages/types.ts
+++ b/tools/src/publish-packages/types.ts
@@ -21,6 +21,8 @@ export type CommandOptions = {
   deps: boolean;
   /** Publish only template packages under `templates/` */
   templatesOnly: boolean;
+  /** Include expo-module-scripts in publishing (excluded by default) */
+  includeExpoModuleScripts: boolean;
   skipAndroidArtifacts: boolean;
   /**
    * When true, automatically selects packages whose current package.json version


### PR DESCRIPTION
# Why
Closes ENG-18945

When publishing it is almost always a mistake to publish expo-modules-scripts. We should exclude it by default so it cannot be accidentally published.

# How
New flag `--include-expo-module-scripts` to include it in the publish if you need it, otherwise omit it
