### PR TITLE
make expo go RN deps optional on iOS

### DIFF
--- a/apps/expo-go/ios/Exponent/Kernel/Views/EXAppViewController.mm
+++ b/apps/expo-go/ios/Exponent/Kernel/Views/EXAppViewController.mm
@@ -22,7 +22,9 @@
 #import <React/RCTAppearance.h>
 #import <React/RCTDevSettings.h>
 
+#if __has_include(<RNScreens/RNSScreenWindowTraits.h>)
 #import <RNScreens/RNSScreenWindowTraits.h>
+#endif
 
 #define EX_INTERFACE_ORIENTATION_USE_MANIFEST 0
 
@@ -529,7 +531,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)shouldUseRNScreenOrientation
 {
+#if __has_include(<RNScreens/RNSScreenWindowTraits.h>)
   return [RNSScreenWindowTraits shouldAskScreensForScreenOrientationInViewController:self];
+#else
+  return NO;
+#endif
 }
 
 - (UIInterfaceOrientationMask)orientationMaskFromManifestOrDefault

--- a/apps/expo-go/ios/Exponent/Versioned/Core/EXVersionManagerObjC.mm
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/EXVersionManagerObjC.mm
@@ -45,8 +45,13 @@
 #endif
 
 // Import 3rd party modules that need to be scoped.
+#if __has_include(<RNCAsyncStorage/RNCAsyncStorage.h>)
 #import <RNCAsyncStorage/RNCAsyncStorage.h>
+#endif
+
+#if __has_include(<RNCWebViewManager.h>)
 #import <RNCWebViewManager.h>
+#endif
 
 #import "EXScopedModuleRegistry.h"
 #import "EXScopedModuleRegistryAdapter.h"
@@ -102,7 +107,9 @@ RCT_EXTERN void EXRegisterScopedModule(Class, ...);
 {
   // Register scoped 3rd party modules. Some of them are separate pods that
   // don't have access to EXScopedModuleRegistry and so they can't register themselves.
+#if __has_include(<RNCWebViewManager.h>)
   EXRegisterScopedModule([RNCWebViewManager class], EX_KERNEL_SERVICE_NONE, nil);
+#endif
 }
 
 - (void)hostDidStart:(NSURL *)bundleURL
@@ -406,7 +413,9 @@ RCT_EXTERN void EXRegisterScopedModule(Class, ...);
     } else {
       RCTLogWarn(@"No exceptions manager provided when building extra modules.");
     }
-  } else if (moduleClass == RNCAsyncStorage.class) {
+  }
+#if __has_include(<RNCAsyncStorage/RNCAsyncStorage.h>)
+  else if (moduleClass == RNCAsyncStorage.class) {
     NSString *documentDirectory;
     if (_params[@"fileSystemDirectories"]) {
       documentDirectory = _params[@"fileSystemDirectories"][@"documentDirectory"];
@@ -417,6 +426,7 @@ RCT_EXTERN void EXRegisterScopedModule(Class, ...);
     NSString *localStorageDirectory = [documentDirectory stringByAppendingPathComponent:@"RCTAsyncLocalStorage"];
     return [[moduleClass alloc] initWithStorageDirectory:localStorageDirectory];
   }
+#endif
 
   return [moduleClass new];
 }


### PR DESCRIPTION
# Why

Make it a bit easier to disable expensive Expo Go deps so Expo Go builds faster
