### PR TITLE
[cli] Add --source-maps inline support to expo export

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `--source-maps inline` option to `expo export` for embedding source maps in JavaScript bundles. ([#42492](https://github.com/expo/expo/pull/42492) by [@brentvatne](https://github.com/brentvatne))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/@expo/cli/e2e/__tests__/export.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export.test.ts
@@ -64,7 +64,7 @@ it('runs `npx expo export --help`', async () => {
         --dump-assetmap            Emit an asset map for further processing
         --no-ssg, --api-only       Skip exporting static HTML files and only export API routes for web
         -p, --platform <platform>  Options: android, ios, web, all. Default: all
-        -s, --source-maps [mode]   Emit JavaScript source maps. [mode]: true (default), inline
+        -s, --source-maps [mode]   Emit JavaScript source maps. mode: external (when omitted), inline
         -c, --clear                Clear the bundler cache
         -h, --help                 Usage info
     "

--- a/packages/@expo/cli/e2e/__tests__/export.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export.test.ts
@@ -64,7 +64,7 @@ it('runs `npx expo export --help`', async () => {
         --dump-assetmap            Emit an asset map for further processing
         --no-ssg, --api-only       Skip exporting static HTML files and only export API routes for web
         -p, --platform <platform>  Options: android, ios, web, all. Default: all
-        -s, --source-maps          Emit JavaScript source maps
+        -s, --source-maps [mode]   Emit JavaScript source maps. [mode]: true (default), inline
         -c, --clear                Clear the bundler cache
         -h, --help                 Usage info
     "

--- a/packages/@expo/cli/src/export/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/resolveOptions-test.ts
@@ -93,6 +93,17 @@ describe(resolveOptionsAsync, () => {
     });
   });
 
+  it(`parses source maps option as boolean true`, async () => {
+    await expect(
+      resolveOptionsAsync('/', {
+        '--source-maps': true,
+      })
+    ).resolves.toMatchObject({
+      sourceMaps: true,
+      inlineSourceMaps: false,
+    });
+  });
+
   it(`parses default options`, async () => {
     await expect(resolveOptionsAsync('/', {})).resolves.toEqual({
       clear: false,

--- a/packages/@expo/cli/src/export/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/resolveOptions-test.ts
@@ -63,7 +63,7 @@ describe(resolveOptionsAsync, () => {
         '--clear': true,
         '--dev': true,
         '--dump-assetmap': true,
-        '--source-maps': true,
+        '--source-maps': 'true',
         '--max-workers': 2,
       })
     ).resolves.toEqual({
@@ -74,10 +74,22 @@ describe(resolveOptionsAsync, () => {
       dumpAssetmap: true,
       hostedNative: false,
       sourceMaps: true,
+      inlineSourceMaps: false,
       maxWorkers: 2,
       skipSSG: false,
       outputDir: 'foobar',
       platforms: ['android'],
+    });
+  });
+
+  it(`parses inline source maps option`, async () => {
+    await expect(
+      resolveOptionsAsync('/', {
+        '--source-maps': 'inline',
+      })
+    ).resolves.toMatchObject({
+      sourceMaps: true,
+      inlineSourceMaps: true,
     });
   });
 
@@ -90,6 +102,7 @@ describe(resolveOptionsAsync, () => {
       dumpAssetmap: false,
       hostedNative: false,
       sourceMaps: false,
+      inlineSourceMaps: false,
       maxWorkers: undefined,
       skipSSG: false,
       outputDir: 'dist',

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -54,6 +54,7 @@ export async function exportAppAsync(
     dev,
     dumpAssetmap,
     sourceMaps,
+    inlineSourceMaps,
     minify,
     bytecode,
     maxWorkers,
@@ -63,6 +64,7 @@ export async function exportAppAsync(
     Options,
     | 'dumpAssetmap'
     | 'sourceMaps'
+    | 'inlineSourceMaps'
     | 'dev'
     | 'clear'
     | 'outputDir'
@@ -196,7 +198,8 @@ export async function exportAppAsync(
                 }),
                 mode: dev ? 'development' : 'production',
                 engine: isHermes ? 'hermes' : undefined,
-                serializerIncludeMaps: sourceMaps,
+                serializerIncludeMaps: sourceMaps || inlineSourceMaps,
+                inlineSourceMap: inlineSourceMaps,
                 bytecode: bytecode && isHermes,
                 reactCompiler: !!exp.experiments?.reactCompiler,
                 hosted: hostedNative,

--- a/packages/@expo/cli/src/export/index.ts
+++ b/packages/@expo/cli/src/export/index.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 import arg from 'arg';
 import chalk from 'chalk';
+import path from 'path';
 
 import { Command } from '../../bin/cli';
-import { assertWithOptionsArgs, getProjectRoot, printHelp } from '../utils/args';
+import { assertWithOptionsArgs, printHelp } from '../utils/args';
 import { logCmdError } from '../utils/errors';
 
 const rawArgsMap: arg.Spec = {
@@ -68,7 +69,7 @@ export const expoExport: Command = async (argv) => {
     '--dump-sourcemap': '--source-maps',
   }).catch(logCmdError);
 
-  const projectRoot = getProjectRoot(args);
+  const projectRoot = path.resolve(parsed.projectRoot);
   const { resolveOptionsAsync } = await import('./resolveOptions.js');
   const options = await resolveOptionsAsync(projectRoot, {
     ...args,

--- a/packages/@expo/cli/src/export/index.ts
+++ b/packages/@expo/cli/src/export/index.ts
@@ -56,7 +56,7 @@ export const expoExport: Command = async (argv) => {
         `--dump-assetmap            Emit an asset map for further processing`,
         `--no-ssg, --api-only       Skip exporting static HTML files and only export API routes for web`,
         chalk`-p, --platform <platform>  Options: android, ios, web, all. {dim Default: all}`,
-        chalk`-s, --source-maps [mode]   Emit JavaScript source maps. {dim [mode]: true (default), inline}`,
+        chalk`-s, --source-maps [mode]   Emit JavaScript source maps. {dim mode: external (when omitted), inline}`,
         `-c, --clear                Clear the bundler cache`,
         `-h, --help                 Usage info`,
       ].join('\n')

--- a/packages/@expo/cli/src/export/index.ts
+++ b/packages/@expo/cli/src/export/index.ts
@@ -30,7 +30,7 @@ function preprocessSourceMapsArg(argv: string[]): string[] {
 export const expoExport: Command = async (argv) => {
   // Preprocess argv to handle --source-maps with optional value
   // If --source-maps is followed by another flag or end of args, insert 'true' as the value
-  const processedArgv = preprocessSourceMapsArg(argv);
+  const processedArgv = argv ? preprocessSourceMapsArg(argv) : undefined;
 
   const args = assertArgs(
     {

--- a/packages/@expo/cli/src/export/index.ts
+++ b/packages/@expo/cli/src/export/index.ts
@@ -1,43 +1,70 @@
 #!/usr/bin/env node
-import arg from 'arg';
 import chalk from 'chalk';
-import path from 'path';
 
 import { Command } from '../../bin/cli';
-import { assertWithOptionsArgs, printHelp } from '../utils/args';
+import { assertArgs, getProjectRoot, printHelp } from '../utils/args';
 import { logCmdError } from '../utils/errors';
 
-const rawArgsMap: arg.Spec = {
-  // Types
-  '--help': Boolean,
-  '--clear': Boolean,
-  '--dump-assetmap': Boolean,
-  '--dev': Boolean,
-  '--max-workers': Number,
-  '--output-dir': String,
-  '--platform': [String],
-  '--no-minify': Boolean,
-  '--no-bytecode': Boolean,
-  '--no-ssg': Boolean,
-  '--api-only': Boolean,
-  '--unstable-hosted-native': Boolean,
+/**
+ * Preprocess argv to handle --source-maps with optional value.
+ * If --source-maps, -s, or --dump-sourcemap is followed by another flag or end of args,
+ * insert 'true' as the default value.
+ */
+function preprocessSourceMapsArg(argv: string[]): string[] {
+  const result: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    result.push(arg);
 
-  // Hack: This is added because EAS CLI always includes the flag.
-  // If supplied, we'll do nothing with the value, but at least the process won't crash.
-  // Note that we also don't show this value in the `--help` prompt since we don't want people to use it.
-  '--experimental-bundle': Boolean,
-
-  // Aliases
-  '-h': '--help',
-  // '-d': '--dump-assetmap',
-  '-c': '--clear',
-  '-p': '--platform',
-  // Interop with Metro docs and RedBox errors.
-  '--reset-cache': '--clear',
-};
+    if (arg === '--source-maps' || arg === '-s' || arg === '--dump-sourcemap') {
+      const nextArg = argv[i + 1];
+      // If no next arg or next arg is a flag, insert 'true' as the value
+      if (nextArg === undefined || nextArg.startsWith('-')) {
+        result.push('true');
+      }
+    }
+  }
+  return result;
+}
 
 export const expoExport: Command = async (argv) => {
-  const args = assertWithOptionsArgs(rawArgsMap, { argv, permissive: true });
+  const args = assertArgs(
+    {
+      // Types
+      '--help': Boolean,
+      '--clear': Boolean,
+      '--dump-assetmap': Boolean,
+      '--dev': Boolean,
+      '--source-maps': String,
+      '--max-workers': Number,
+      '--output-dir': String,
+      '--platform': [String],
+      '--no-minify': Boolean,
+      '--no-bytecode': Boolean,
+      '--no-ssg': Boolean,
+      '--api-only': Boolean,
+      '--unstable-hosted-native': Boolean,
+
+      // Hack: This is added because EAS CLI always includes the flag.
+      // If supplied, we'll do nothing with the value, but at least the process won't crash.
+      // Note that we also don't show this value in the `--help` prompt since we don't want people to use it.
+      '--experimental-bundle': Boolean,
+
+      // Aliases
+      '-h': '--help',
+      '-s': '--source-maps',
+      // '-d': '--dump-assetmap',
+      '-c': '--clear',
+      '-p': '--platform',
+      // Interop with Metro docs and RedBox errors.
+      '--reset-cache': '--clear',
+
+      // Deprecated
+      '--dump-sourcemap': '--source-maps',
+    },
+    // Preprocess argv to handle --source-maps with optional value
+    argv ? preprocessSourceMapsArg(argv) : undefined
+  );
 
   if (args['--help']) {
     printHelp(
@@ -60,21 +87,9 @@ export const expoExport: Command = async (argv) => {
     );
   }
 
-  // Handle --source-maps which can be a string or boolean
-  const { resolveStringOrBooleanArgsAsync } = await import('../utils/resolveArgs.js');
-  const parsed = await resolveStringOrBooleanArgsAsync(argv ?? [], rawArgsMap, {
-    '--source-maps': Boolean,
-    '-s': '--source-maps',
-    // Deprecated
-    '--dump-sourcemap': '--source-maps',
-  }).catch(logCmdError);
-
-  const projectRoot = path.resolve(parsed.projectRoot);
+  const projectRoot = getProjectRoot(args);
   const { resolveOptionsAsync } = await import('./resolveOptions.js');
-  const options = await resolveOptionsAsync(projectRoot, {
-    ...args,
-    '--source-maps': parsed.args['--source-maps'],
-  }).catch(logCmdError);
+  const options = await resolveOptionsAsync(projectRoot, args).catch(logCmdError);
 
   const { exportAsync } = await import('./exportAsync.js');
   return exportAsync(projectRoot, options).catch(logCmdError);

--- a/packages/@expo/cli/src/export/index.ts
+++ b/packages/@expo/cli/src/export/index.ts
@@ -1,46 +1,70 @@
 #!/usr/bin/env node
-import arg from 'arg';
 import chalk from 'chalk';
-import path from 'path';
 
 import { Command } from '../../bin/cli';
-import { assertWithOptionsArgs, printHelp } from '../utils/args';
+import { assertArgs, getProjectRoot, printHelp } from '../utils/args';
 import { logCmdError } from '../utils/errors';
 
+/**
+ * Preprocess argv to handle --source-maps with optional value.
+ * If --source-maps, -s, or --dump-sourcemap is followed by another flag or end of args,
+ * insert 'true' as the default value.
+ */
+function preprocessSourceMapsArg(argv: string[]): string[] {
+  const result: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    result.push(arg);
+
+    if (arg === '--source-maps' || arg === '-s' || arg === '--dump-sourcemap') {
+      const nextArg = argv[i + 1];
+      // If no next arg or next arg is a flag, insert 'true' as the value
+      if (nextArg === undefined || nextArg.startsWith('-')) {
+        result.push('true');
+      }
+    }
+  }
+  return result;
+}
+
 export const expoExport: Command = async (argv) => {
-  const rawArgsMap: arg.Spec = {
-    // Types
-    '--help': Boolean,
-    '--clear': Boolean,
-    '--dump-assetmap': Boolean,
-    '--dev': Boolean,
-    '--max-workers': Number,
-    '--output-dir': String,
-    '--platform': [String],
-    '--no-minify': Boolean,
-    '--no-bytecode': Boolean,
-    '--no-ssg': Boolean,
-    '--api-only': Boolean,
-    '--unstable-hosted-native': Boolean,
+  const args = assertArgs(
+    {
+      // Types
+      '--help': Boolean,
+      '--clear': Boolean,
+      '--dump-assetmap': Boolean,
+      '--dev': Boolean,
+      '--source-maps': String,
+      '--max-workers': Number,
+      '--output-dir': String,
+      '--platform': [String],
+      '--no-minify': Boolean,
+      '--no-bytecode': Boolean,
+      '--no-ssg': Boolean,
+      '--api-only': Boolean,
+      '--unstable-hosted-native': Boolean,
 
-    // Hack: This is added because EAS CLI always includes the flag.
-    // If supplied, we'll do nothing with the value, but at least the process won't crash.
-    // Note that we also don't show this value in the `--help` prompt since we don't want people to use it.
-    '--experimental-bundle': Boolean,
+      // Hack: This is added because EAS CLI always includes the flag.
+      // If supplied, we'll do nothing with the value, but at least the process won't crash.
+      // Note that we also don't show this value in the `--help` prompt since we don't want people to use it.
+      '--experimental-bundle': Boolean,
 
-    // Aliases
-    '-h': '--help',
-    // '-d': '--dump-assetmap',
-    '-c': '--clear',
-    '-p': '--platform',
-    // Interop with Metro docs and RedBox errors.
-    '--reset-cache': '--clear',
-  };
+      // Aliases
+      '-h': '--help',
+      '-s': '--source-maps',
+      // '-d': '--dump-assetmap',
+      '-c': '--clear',
+      '-p': '--platform',
+      // Interop with Metro docs and RedBox errors.
+      '--reset-cache': '--clear',
 
-  const args = assertWithOptionsArgs(rawArgsMap, {
-    argv,
-    permissive: true,
-  });
+      // Deprecated
+      '--dump-sourcemap': '--source-maps',
+    },
+    // Preprocess argv to handle --source-maps with optional value
+    argv ? preprocessSourceMapsArg(argv) : undefined
+  );
 
   if (args['--help']) {
     printHelp(
@@ -63,21 +87,9 @@ export const expoExport: Command = async (argv) => {
     );
   }
 
-  // Handle --source-maps which can be a string or boolean (e.g., --source-maps or --source-maps inline)
-  const { resolveStringOrBooleanArgsAsync } = await import('../utils/resolveArgs.js');
-  const parsed = await resolveStringOrBooleanArgsAsync(argv ?? [], rawArgsMap, {
-    '--source-maps': Boolean,
-    '-s': '--source-maps',
-    // Deprecated
-    '--dump-sourcemap': '--source-maps',
-  }).catch(logCmdError);
-
-  const projectRoot = path.resolve(parsed.projectRoot);
+  const projectRoot = getProjectRoot(args);
   const { resolveOptionsAsync } = await import('./resolveOptions.js');
-  const options = await resolveOptionsAsync(projectRoot, {
-    ...args,
-    '--source-maps': parsed.args['--source-maps'],
-  }).catch(logCmdError);
+  const options = await resolveOptionsAsync(projectRoot, args).catch(logCmdError);
 
   const { exportAsync } = await import('./exportAsync.js');
   return exportAsync(projectRoot, options).catch(logCmdError);

--- a/packages/@expo/cli/src/export/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/resolveOptions.ts
@@ -83,7 +83,7 @@ export async function resolveOptionsAsync(projectRoot: string, args: any): Promi
 
   const platforms = resolvePlatformOption(exp, platformBundlers, args['--platform']);
 
-  // --source-maps can be "true" or "inline"
+  // --source-maps can be true, "external", or "inline"
   const sourceMapsArg = args['--source-maps'];
   const sourceMaps = !!sourceMapsArg;
   const inlineSourceMaps = sourceMapsArg === 'inline';

--- a/packages/@expo/cli/src/export/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/resolveOptions.ts
@@ -13,6 +13,7 @@ export type Options = {
   bytecode: boolean;
   dumpAssetmap: boolean;
   sourceMaps: boolean;
+  inlineSourceMaps: boolean;
   skipSSG: boolean;
   hostedNative: boolean;
 };
@@ -81,6 +82,12 @@ export async function resolveOptionsAsync(projectRoot: string, args: any): Promi
   const platformBundlers = getPlatformBundlers(projectRoot, exp);
 
   const platforms = resolvePlatformOption(exp, platformBundlers, args['--platform']);
+
+  // --source-maps can be "true" or "inline"
+  const sourceMapsArg = args['--source-maps'];
+  const sourceMaps = !!sourceMapsArg;
+  const inlineSourceMaps = sourceMapsArg === 'inline';
+
   return {
     platforms,
     hostedNative: !!args['--unstable-hosted-native'],
@@ -91,7 +98,8 @@ export async function resolveOptionsAsync(projectRoot: string, args: any): Promi
     dev: !!args['--dev'],
     maxWorkers: args['--max-workers'],
     dumpAssetmap: !!args['--dump-assetmap'],
-    sourceMaps: !!args['--source-maps'],
+    sourceMaps,
+    inlineSourceMaps,
     skipSSG: !!args['--no-ssg'] || !!args['--api-only'],
   };
 }

--- a/packages/@expo/cli/src/utils/__tests__/resolveArgs-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/resolveArgs-test.ts
@@ -186,6 +186,30 @@ describe(resolveStringOrBooleanArgsAsync, () => {
       projectRoot: 'custom-root',
     });
   });
+
+  it(`treats value after string-or-boolean flag as the flag value, not project root`, async () => {
+    // This documents a limitation: `--source-maps custom-root` treats `custom-root`
+    // as the value for --source-maps, not as the project root.
+    // To use a project root with --source-maps as boolean, put it before the flag
+    // or use an explicit value like `--source-maps inline custom-root`.
+    await expect(
+      resolveStringOrBooleanArgsAsync(
+        ['-p', 'web', '--source-maps', 'custom-root'],
+        {
+          '--platform': [String],
+          '-p': '--platform',
+        },
+        {
+          '--source-maps': Boolean,
+        }
+      )
+    ).resolves.toEqual({
+      args: {
+        '--source-maps': 'custom-root', // NOT true
+      },
+      projectRoot: '.', // NOT 'custom-root'
+    });
+  });
 });
 
 describe(assertDuplicateArgs, () => {

--- a/packages/@expo/cli/src/utils/array.ts
+++ b/packages/@expo/cli/src/utils/array.ts
@@ -22,6 +22,10 @@ export function replaceValue<T>(values: T[], original: T, replacement: T): T[] {
   return values;
 }
 
+export function replaceAllValues<T>(values: T[], original: T, replacement: T): T[] {
+  return values.map((value) => (value === original ? replacement : value));
+}
+
 /** lodash.uniqBy */
 export function uniqBy<T>(array: T[], key: (item: T) => string): T[] {
   const seen: { [key: string]: boolean } = {};

--- a/packages/@expo/cli/src/utils/resolveArgs.ts
+++ b/packages/@expo/cli/src/utils/resolveArgs.ts
@@ -47,7 +47,7 @@ export async function resolveStringOrBooleanArgsAsync(
   );
 
   // Collapse aliases into fully qualified arguments.
-  args = collapseAliases(extraArgs, args);
+  args = collapseAliases({ ...rawMap, ...extraArgs }, args);
 
   // Resolve all of the string or boolean arguments and the project root.
   return _resolveStringOrBooleanArgs({ ...rawMap, ...extraArgs }, args);

--- a/packages/@expo/cli/src/utils/resolveArgs.ts
+++ b/packages/@expo/cli/src/utils/resolveArgs.ts
@@ -198,7 +198,11 @@ function filterOutArrayArgs(args: string[], spec: Spec): string[] {
 }
 
 /** Asserts that a duplicate flag has been used, this naively throws without knowing if an alias or flag were used as the duplicate. */
-export function assertDuplicateArgs(args: string[], argNameAliasTuple: [string, string][], spec?: Spec) {
+export function assertDuplicateArgs(
+  args: string[],
+  argNameAliasTuple: [string, string][],
+  spec?: Spec
+) {
   for (const [argName, argNameAlias] of argNameAliasTuple) {
     // Skip array-type arguments (like --platform) which can have multiple values
     if (spec && Array.isArray(spec[argNameAlias])) {

--- a/packages/@expo/cli/src/utils/resolveArgs.ts
+++ b/packages/@expo/cli/src/utils/resolveArgs.ts
@@ -1,6 +1,6 @@
 import arg, { Spec } from 'arg';
 
-import { replaceValue } from './array';
+import { replaceAllValues } from './array';
 import { CommandError } from './errors';
 
 /** Split up arguments that are formatted like `--foo=bar` or `-f="bar"` to `['--foo', 'bar']` */
@@ -37,20 +37,20 @@ export async function resolveStringOrBooleanArgsAsync(
 ) {
   args = splitArgs(args);
 
+  const combinedSpec = { ...rawMap, ...extraArgs };
+
   // Assert any missing arguments
-  assertUnknownArgs(
-    {
-      ...rawMap,
-      ...extraArgs,
-    },
-    args
-  );
+  assertUnknownArgs(combinedSpec, args);
 
   // Collapse aliases into fully qualified arguments.
-  args = collapseAliases({ ...rawMap, ...extraArgs }, args);
+  args = collapseAliases(combinedSpec, args);
+
+  // Filter out array-type arguments so _resolveStringOrBooleanArgs can process the rest.
+  // This is necessary because _resolveStringOrBooleanArgs can't handle array-type args like --platform.
+  const filteredArgs = filterOutArrayArgs(args, combinedSpec);
 
   // Resolve all of the string or boolean arguments and the project root.
-  return _resolveStringOrBooleanArgs({ ...rawMap, ...extraArgs }, args);
+  return _resolveStringOrBooleanArgs(combinedSpec, filteredArgs);
 }
 
 /**
@@ -145,11 +145,12 @@ export function collapseAliases(arg: Spec, args: string[]): string[] {
   const aliasMap = getAliasTuples(arg);
 
   for (const [arg, alias] of aliasMap) {
-    args = replaceValue(args, arg, alias);
+    args = replaceAllValues(args, arg, alias);
   }
 
   // Assert if there are duplicate flags after we collapse the aliases.
-  assertDuplicateArgs(args, aliasMap);
+  // Skip array-type arguments (like --platform) which can have multiple values.
+  assertDuplicateArgs(args, aliasMap, arg);
   return args;
 }
 
@@ -166,9 +167,43 @@ function getAliasTuples(arg: Spec): [string, string][] {
   return Object.entries(arg).filter(([, value]) => typeof value === 'string') as [string, string][];
 }
 
+/** Filter out array-type arguments from the spec (and their values).
+ * This is needed because _resolveStringOrBooleanArgs can't handle array args like --platform.
+ */
+function filterOutArrayArgs(args: string[], spec: Spec): string[] {
+  // Get the set of flag names that are array types
+  const arrayFlags = new Set(
+    Object.entries(spec)
+      .filter(([, value]) => Array.isArray(value))
+      .map(([key]) => key)
+  );
+
+  if (arrayFlags.size === 0) {
+    return args;
+  }
+
+  const result: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arrayFlags.has(arg)) {
+      // Skip this flag and its value if it has one
+      if (i + 1 < args.length && !args[i + 1].startsWith('-')) {
+        i++;
+      }
+    } else {
+      result.push(arg);
+    }
+  }
+  return result;
+}
+
 /** Asserts that a duplicate flag has been used, this naively throws without knowing if an alias or flag were used as the duplicate. */
-export function assertDuplicateArgs(args: string[], argNameAliasTuple: [string, string][]) {
+export function assertDuplicateArgs(args: string[], argNameAliasTuple: [string, string][], spec?: Spec) {
   for (const [argName, argNameAlias] of argNameAliasTuple) {
+    // Skip array-type arguments (like --platform) which can have multiple values
+    if (spec && Array.isArray(spec[argNameAlias])) {
+      continue;
+    }
     if (args.filter((a) => [argName, argNameAlias].includes(a)).length > 1) {
       throw new CommandError(
         'BAD_ARGS',


### PR DESCRIPTION
## Summary
- Adds `--source-maps inline` support to `expo export` - to embed source maps directly in the JavaScript bundle

## Test plan
```bash
npx expo export --no-bytecode --source-maps inline # Inline sourcemaps are produced, open up JS to verify
npx expo export --source-maps # External sourcemaps are produced
```

Verify the output `.js` files contain inline source maps as data URLs.