### PR TITLE
feat(expo-dev-client): Add Source Map Explorer to iOS dev menu

### DIFF
--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add sources button to dev client on iOS.
+- Add sources button to dev client on iOS. ([#42493](https://github.com/expo/expo/pull/42493) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add sources button to dev client on iOS.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add "Source Code Explorer" screen to iOS dev menu ([#42493](https://github.com/expo/expo/pull/42493) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuDeveloperTools.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuDeveloperTools.swift
@@ -57,7 +57,7 @@ struct DevMenuDeveloperTools: View {
               .foregroundColor(.primary)
               .opacity(0.6)
 
-            Text("Source map explorer")
+            Text("Source code explorer")
               .foregroundColor(.primary)
 
             Spacer()

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuDeveloperTools.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuDeveloperTools.swift
@@ -47,6 +47,29 @@ struct DevMenuDeveloperTools: View {
           action: viewModel.toggleFastRefresh,
           disabled: !(viewModel.devSettings?.isHotLoadingAvailable ?? true)
         )
+
+        Divider()
+
+        NavigationLink(destination: SourceMapExplorerView()) {
+          HStack {
+            Image(systemName: "map")
+              .frame(width: 24, height: 24)
+              .foregroundColor(.primary)
+              .opacity(0.6)
+
+            Text("Source map explorer")
+              .foregroundColor(.primary)
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+          .padding()
+          .background(Color.expoSecondarySystemBackground)
+        }
+        .buttonStyle(.plain)
       }
       .background(Color.expoSystemBackground)
       .cornerRadius(18)

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuMainView.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuMainView.swift
@@ -42,5 +42,7 @@ struct DevMenuMainView: View {
       .padding()
     }
     .environmentObject(viewModel)
+    .navigationTitle("Dev Menu")
+    .navigationBarHidden(true)
   }
 }

--- a/packages/expo-dev-menu/ios/SwiftUI/SourceMapExplorerView.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/SourceMapExplorerView.swift
@@ -1,0 +1,271 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import SwiftUI
+import ExpoModulesCore
+
+struct SourceMapExplorerView: View {
+  @StateObject private var viewModel = SourceMapExplorerViewModel()
+
+  var body: some View {
+    Group {
+      switch viewModel.loadingState {
+      case .idle, .loading:
+        loadingView
+      case .loaded:
+        FolderListView(
+          title: "Source Map Explorer",
+          nodes: viewModel.filteredFileTree,
+          sourceMap: viewModel.sourceMap,
+          stats: viewModel.sourceMapStats,
+          searchText: $viewModel.searchText
+        )
+      case .error(let error):
+        errorView(error)
+      }
+    }
+    .navigationTitle("Source Map Explorer")
+    .navigationBarTitleDisplayMode(.inline)
+    .task {
+      await viewModel.loadSourceMap()
+    }
+  }
+
+  private var loadingView: some View {
+    VStack(spacing: 12) {
+      ProgressView()
+      Text("Loading source map...")
+        .font(.subheadline)
+        .foregroundColor(.secondary)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+
+  private func errorView(_ error: SourceMapError) -> some View {
+    VStack(spacing: 16) {
+      Image(systemName: "exclamationmark.triangle")
+        .font(.system(size: 40))
+        .foregroundColor(.orange)
+
+      Text("Failed to load source map")
+        .font(.headline)
+
+      Text(error.errorDescription ?? "Unknown error")
+        .font(.subheadline)
+        .foregroundColor(.secondary)
+        .multilineTextAlignment(.center)
+
+      Button("Retry") {
+        Task { await viewModel.loadSourceMap() }
+      }
+      .buttonStyle(.borderedProminent)
+    }
+    .padding()
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+}
+
+struct FolderListView: View {
+  let title: String
+  let nodes: [FileTreeNode]
+  let sourceMap: SourceMap?
+  let stats: (files: Int, totalSize: String)?
+  @Binding var searchText: String
+
+  private var isSearching: Bool {
+    !searchText.isEmpty
+  }
+
+  private var displayedNodes: [FileTreeNode] {
+    guard isSearching else { return nodes }
+    return findMatchingFiles(in: nodes, searchText: searchText.lowercased())
+  }
+
+  private func findMatchingFiles(in nodes: [FileTreeNode], searchText: String) -> [FileTreeNode] {
+    var results: [FileTreeNode] = []
+    for node in nodes {
+      if node.isDirectory {
+        results.append(contentsOf: findMatchingFiles(in: node.children, searchText: searchText))
+      } else {
+        if node.name.lowercased().contains(searchText) || node.path.lowercased().contains(searchText) {
+          results.append(node)
+        }
+      }
+    }
+    return results
+  }
+
+  var body: some View {
+    List {
+      if isSearching && displayedNodes.isEmpty {
+        Text("No files found")
+          .foregroundColor(.secondary)
+      } else {
+        ForEach(displayedNodes) { node in
+          if node.isDirectory {
+            NavigationLink(destination: FolderListView(
+              title: node.name,
+              nodes: node.children,
+              sourceMap: sourceMap,
+              stats: nil,
+              searchText: $searchText
+            )) {
+              FileRow(node: node, showPath: isSearching)
+            }
+          } else {
+            NavigationLink(destination: CodeFileView(node: node, sourceMap: sourceMap)) {
+              FileRow(node: node, showPath: isSearching)
+            }
+          }
+        }
+      }
+    }
+    .listStyle(.insetGrouped)
+    .navigationTitle(isSearching ? "Search Results" : title)
+    .navigationBarTitleDisplayMode(.inline)
+    .searchable(text: $searchText, placement: .automatic, prompt: "Search files")
+    .toolbar {
+      ToolbarItem(placement: .navigationBarTrailing) {
+        if let stats = stats {
+          Menu {
+            Label("\(stats.files) files", systemImage: "doc.on.doc")
+            Label(stats.totalSize, systemImage: "internaldrive")
+          } label: {
+            Image(systemName: "info.circle")
+          }
+        }
+      }
+    }
+  }
+}
+
+struct FileRow: View {
+  let node: FileTreeNode
+  var showPath: Bool = false
+
+  private var parentDirectory: String? {
+    let path = node.path
+    guard let lastSlash = path.lastIndex(of: "/") else { return nil }
+    let parent = String(path[..<lastSlash])
+    return parent.isEmpty ? nil : parent
+  }
+
+  var body: some View {
+    Label {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(node.name)
+          .lineLimit(1)
+        if showPath, let parent = parentDirectory {
+          Text(parent)
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .lineLimit(1)
+        }
+      }
+    } icon: {
+      Image(systemName: node.isDirectory ? "folder.fill" : fileIcon)
+        .foregroundColor(node.isDirectory ? .blue : iconColor)
+    }
+  }
+
+  private var fileIcon: String {
+    let ext = (node.name as NSString).pathExtension.lowercased()
+    switch ext {
+    case "ts", "tsx", "js", "jsx": return "curlybraces"
+    case "json": return "doc.text"
+    case "css", "scss", "sass": return "paintbrush"
+    case "png", "jpg", "jpeg", "gif", "svg": return "photo"
+    case "md", "txt": return "doc.plaintext"
+    default: return "doc"
+    }
+  }
+
+  private var iconColor: Color {
+    let ext = (node.name as NSString).pathExtension.lowercased()
+    switch ext {
+    case "ts", "tsx": return .blue
+    case "js", "jsx": return .yellow
+    case "json": return .orange
+    case "css", "scss", "sass": return .pink
+    default: return .secondary
+    }
+  }
+}
+
+struct CodeFileView: View {
+  let node: FileTreeNode
+  let sourceMap: SourceMap?
+  @Environment(\.colorScheme) private var colorScheme
+
+  private var content: String {
+    guard let contentIndex = node.contentIndex,
+          let sourceMap = sourceMap,
+          let sourcesContent = sourceMap.sourcesContent,
+          contentIndex < sourcesContent.count,
+          let code = sourcesContent[contentIndex] else {
+      return "// Content not available"
+    }
+    return code
+  }
+
+  private var lines: [String] {
+    content.components(separatedBy: "\n")
+  }
+
+  private var theme: SyntaxHighlighter.Theme {
+    colorScheme == .dark ? .dark : .light
+  }
+
+  private var lineNumberWidth: CGFloat {
+    let digits = String(lines.count).count
+    return CGFloat(digits * 10 + 16)
+  }
+
+  var body: some View {
+    GeometryReader { geometry in
+      ScrollView(.vertical) {
+        ScrollView(.horizontal, showsIndicators: false) {
+          HStack(alignment: .top, spacing: 0) {
+            lineNumbersColumn
+            codeColumn
+          }
+          .frame(minWidth: geometry.size.width, alignment: .leading)
+        }
+      }
+    }
+    .background(theme.background)
+    .navigationTitle(node.name)
+    .navigationBarTitleDisplayMode(.inline)
+  }
+
+  private var lineNumbersColumn: some View {
+    VStack(alignment: .trailing, spacing: 0) {
+      ForEach(0..<lines.count, id: \.self) { index in
+        Text("\(index + 1)")
+          .font(.system(size: 13, weight: .regular, design: .monospaced))
+          .foregroundColor(theme.lineNumber)
+          .frame(height: 20)
+      }
+    }
+    .frame(width: lineNumberWidth)
+    .padding(.vertical, 12)
+    .background(theme.background.opacity(0.8))
+  }
+
+  private var codeColumn: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      ForEach(0..<lines.count, id: \.self) { index in
+        Text(SyntaxHighlighter.highlight(lines[index].isEmpty ? " " : lines[index], theme: theme))
+          .font(.system(size: 13, weight: .regular, design: .monospaced))
+          .frame(height: 20, alignment: .leading)
+      }
+    }
+    .padding(.vertical, 12)
+    .padding(.trailing, 16)
+  }
+}
+
+#Preview {
+  NavigationView {
+    SourceMapExplorerView()
+  }
+}

--- a/packages/expo-dev-menu/ios/SwiftUI/SourceMapExplorerView.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/SourceMapExplorerView.swift
@@ -17,7 +17,7 @@ struct SourceMapExplorerView: View {
         loadingView
       case .loaded:
         FolderListView(
-          title: "Source Map Explorer",
+          title: "Source Code Explorer",
           nodes: viewModel.filteredFileTree,
           sourceMap: viewModel.sourceMap,
           stats: viewModel.sourceMapStats,
@@ -27,7 +27,7 @@ struct SourceMapExplorerView: View {
         errorView(error)
       }
     }
-    .navigationTitle("Source Map Explorer")
+    .navigationTitle("Source Code Explorer")
     .navigationBarTitleDisplayMode(.inline)
     .searchable(text: $viewModel.searchText, placement: .automatic, prompt: "Search files")
     .task {

--- a/packages/expo-dev-menu/ios/SwiftUI/SourceMapExplorerViewModel.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/SourceMapExplorerViewModel.swift
@@ -19,12 +19,14 @@ class SourceMapExplorerViewModel: ObservableObject {
   }
 
   func loadSourceMap() async {
+    if case .loaded = loadingState { return }
+
     loadingState = .loading
 
     do {
       let sourceMap = try await service.fetchSourceMap()
       self.sourceMap = sourceMap
-      self.fileTree = service.buildFileTree(from: sourceMap)
+      self.fileTree = await service.buildFileTree(from: sourceMap)
       loadingState = .loaded(sourceMap)
     } catch let error as SourceMapError {
       loadingState = .error(error)
@@ -53,7 +55,7 @@ class SourceMapExplorerViewModel: ObservableObject {
         results.append(contentsOf: findMatchingFiles(in: node.children, searchText: searchText))
       } else {
         // Check if file name or path matches
-        if node.name.lowercased().contains(searchText) || node.path.lowercased().contains(searchText) {
+        if node.searchableName.contains(searchText) || node.searchablePath.contains(searchText) {
           results.append(node)
         }
       }

--- a/packages/expo-dev-menu/ios/SwiftUI/SourceMapExplorerViewModel.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/SourceMapExplorerViewModel.swift
@@ -1,0 +1,64 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+import Combine
+
+@MainActor
+class SourceMapExplorerViewModel: ObservableObject {
+  @Published var loadingState: SourceMapLoadingState = .idle
+  @Published var fileTree: [FileTreeNode] = []
+  @Published var searchText: String = ""
+
+  private let service = SourceMapService()
+  private(set) var sourceMap: SourceMap?
+
+  var filteredFileTree: [FileTreeNode] {
+    guard !searchText.isEmpty else { return fileTree }
+    // When searching, flatten to show matching files directly
+    return findMatchingFiles(in: fileTree, searchText: searchText.lowercased())
+  }
+
+  func loadSourceMap() async {
+    loadingState = .loading
+
+    do {
+      let sourceMap = try await service.fetchSourceMap()
+      self.sourceMap = sourceMap
+      self.fileTree = service.buildFileTree(from: sourceMap)
+      loadingState = .loaded(sourceMap)
+    } catch let error as SourceMapError {
+      loadingState = .error(error)
+    } catch {
+      loadingState = .error(.networkError(error))
+    }
+  }
+
+  var sourceMapStats: (files: Int, totalSize: String)? {
+    guard case .loaded(let sourceMap) = loadingState else { return nil }
+
+    let fileCount = sourceMap.sources.count
+    let totalChars = sourceMap.sourcesContent?.compactMap { $0?.count }.reduce(0, +) ?? 0
+    let sizeString = ByteCountFormatter.string(fromByteCount: Int64(totalChars), countStyle: .file)
+
+    return (fileCount, sizeString)
+  }
+
+  /// Finds all matching files and returns them as a flat list with full paths
+  private func findMatchingFiles(in nodes: [FileTreeNode], searchText: String) -> [FileTreeNode] {
+    var results: [FileTreeNode] = []
+
+    for node in nodes {
+      if node.isDirectory {
+        // Recursively search children
+        results.append(contentsOf: findMatchingFiles(in: node.children, searchText: searchText))
+      } else {
+        // Check if file name or path matches
+        if node.name.lowercased().contains(searchText) || node.path.lowercased().contains(searchText) {
+          results.append(node)
+        }
+      }
+    }
+
+    return results
+  }
+}

--- a/packages/expo-dev-menu/ios/SwiftUI/SourceMapModels.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/SourceMapModels.swift
@@ -13,20 +13,24 @@ struct SourceMap: Codable {
 
 /// Represents a node in the file tree (file or directory)
 struct FileTreeNode: Identifiable, Hashable {
-  let id: UUID
+  var id: String { path }
   let name: String
   let path: String
   let isDirectory: Bool
   var children: [FileTreeNode]
   let contentIndex: Int?
 
+  let searchableName: String
+  let searchablePath: String
+
   init(name: String, path: String, isDirectory: Bool, children: [FileTreeNode] = [], contentIndex: Int? = nil) {
-    self.id = UUID()
     self.name = name
     self.path = path
     self.isDirectory = isDirectory
     self.children = children
     self.contentIndex = contentIndex
+    self.searchableName = name.lowercased()
+    self.searchablePath = path.lowercased()
   }
 
   func hash(into hasher: inout Hasher) {

--- a/packages/expo-dev-menu/ios/SwiftUI/SourceMapModels.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/SourceMapModels.swift
@@ -1,0 +1,77 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+
+/// Represents the parsed source map from Metro bundler
+struct SourceMap: Codable {
+  let version: Int
+  let sources: [String]
+  let sourcesContent: [String?]?
+  let mappings: String
+  let names: [String]
+}
+
+/// Represents a node in the file tree (file or directory)
+struct FileTreeNode: Identifiable, Hashable {
+  let id: UUID
+  let name: String
+  let path: String
+  let isDirectory: Bool
+  var children: [FileTreeNode]
+  let contentIndex: Int?
+
+  init(name: String, path: String, isDirectory: Bool, children: [FileTreeNode] = [], contentIndex: Int? = nil) {
+    self.id = UUID()
+    self.name = name
+    self.path = path
+    self.isDirectory = isDirectory
+    self.children = children
+    self.contentIndex = contentIndex
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(id)
+  }
+
+  static func == (lhs: FileTreeNode, rhs: FileTreeNode) -> Bool {
+    lhs.id == rhs.id
+  }
+}
+
+/// Loading states for the source map explorer
+enum SourceMapLoadingState {
+  case idle
+  case loading
+  case loaded(SourceMap)
+  case error(SourceMapError)
+}
+
+/// Errors that can occur when fetching source maps
+enum SourceMapError: Error, LocalizedError {
+  case noBundleURL
+  case invalidSourceMapURL
+  case networkError(Error)
+  case parseError(Error)
+  case httpError(Int)
+  case noSourceMapFound
+  case invalidInlineSourceMap
+
+  var errorDescription: String? {
+    switch self {
+    case .noBundleURL:
+      return "No bundle URL available. Make sure the app is connected to Metro."
+    case .invalidSourceMapURL:
+      return "Could not construct source map URL."
+    case .networkError(let error):
+      return "Network error: \(error.localizedDescription)"
+    case .parseError(let error):
+      return "Failed to parse source map: \(error.localizedDescription)"
+    case .httpError(let code):
+      return "HTTP error: \(code)"
+    case .noSourceMapFound:
+      return "No source map found. Enable inline source maps in your Metro config or ensure the bundle is stored locally."
+    case .invalidInlineSourceMap:
+      return "Found inline source map but failed to decode it."
+    }
+  }
+}

--- a/packages/expo-dev-menu/ios/SwiftUI/SourceMapService.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/SourceMapService.swift
@@ -1,0 +1,295 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+import ObjectiveC
+
+@MainActor
+class SourceMapService {
+  private let devMenuManager = DevMenuManager.shared
+
+  /// Checks if a URL is an EAS CDN URL (assets.eascdn.net)
+  private func isEASCDNURL(_ url: URL) -> Bool {
+    return url.host == "assets.eascdn.net"
+  }
+
+  /// Constructs the source map URL from the bundle URL
+  /// Bundle: http://localhost:8081/index.bundle?platform=ios&dev=true
+  /// SourceMap: http://localhost:8081/index.map?platform=ios&dev=true
+  func getSourceMapURL() -> URL? {
+    guard let bundleURL = devMenuManager.currentBridge?.bundleURL else {
+      return nil
+    }
+
+    var urlString = bundleURL.absoluteString
+
+    // Replace .bundle with .map
+    if urlString.contains(".bundle") {
+      urlString = urlString.replacingOccurrences(of: ".bundle", with: ".map")
+    } else {
+      // If no .bundle extension, insert .map before query params
+      if let queryIndex = urlString.firstIndex(of: "?") {
+        urlString.insert(contentsOf: ".map", at: queryIndex)
+      } else {
+        urlString += ".map"
+      }
+    }
+
+    return URL(string: urlString)
+  }
+
+  // MARK: - Expo Go Integration via EXKernel
+
+  /// Gets the local bundle path from Expo Go's EXKernel
+  /// Path: EXKernel.sharedInstance.visibleApp.appLoader.appLauncher.launchAssetUrl
+  private func getLaunchAssetURLFromExpoGoKernel() -> URL? {
+    guard let kernelClass = NSClassFromString("EXKernel") else {
+      return nil
+    }
+
+    let sharedInstanceSelector = NSSelectorFromString("sharedInstance")
+    guard let metaClass = object_getClass(kernelClass),
+          class_respondsToSelector(metaClass, sharedInstanceSelector),
+          let kernel = (kernelClass as AnyObject).perform(sharedInstanceSelector)?.takeUnretainedValue() else {
+      return nil
+    }
+
+    guard let visibleApp = (kernel as AnyObject).value(forKey: "visibleApp"),
+          let appLoader = (visibleApp as AnyObject).value(forKey: "appLoader"),
+          let appLauncher = (appLoader as AnyObject).value(forKey: "appLauncher") else {
+      return nil
+    }
+
+    let launchAssetUrlSelector = NSSelectorFromString("launchAssetUrl")
+    if (appLauncher as AnyObject).responds(to: launchAssetUrlSelector),
+       let url = (appLauncher as AnyObject).perform(launchAssetUrlSelector)?.takeUnretainedValue() as? URL {
+      return url
+    }
+
+    return nil
+  }
+
+  // MARK: - expo-updates Integration via EXUpdatesInterface
+
+  /// Gets the local file URL from UpdatesControllerRegistry (for dev clients)
+  private func getLaunchAssetURLFromUpdatesController() -> URL? {
+    guard let registryClass = NSClassFromString("EXUpdatesControllerRegistry") else {
+      return nil
+    }
+
+    let sharedInstanceSelector = NSSelectorFromString("sharedInstance")
+    guard let metaClass = object_getClass(registryClass),
+          class_respondsToSelector(metaClass, sharedInstanceSelector),
+          let registry = (registryClass as AnyObject).perform(sharedInstanceSelector)?.takeUnretainedValue(),
+          let controller = (registry as AnyObject).value(forKey: "controller"),
+          let launchAssetURL = (controller as AnyObject).value(forKey: "launchAssetURL") as? URL else {
+      return nil
+    }
+
+    return launchAssetURL
+  }
+
+  /// Gets the local file URL from AppController (for standalone apps)
+  private func getLaunchAssetURLFromAppController() -> URL? {
+    guard let appControllerClass = NSClassFromString("EXUpdatesAppController") else {
+      return nil
+    }
+
+    // Check if it's initialized
+    let isInitializedSelector = NSSelectorFromString("isInitialized")
+    if let metaClass = object_getClass(appControllerClass),
+       class_respondsToSelector(metaClass, isInitializedSelector) {
+      typealias IsInitializedMethod = @convention(c) (AnyClass, Selector) -> Bool
+      let methodIMP = class_getMethodImplementation(metaClass, isInitializedSelector)
+      let isInitialized = unsafeBitCast(methodIMP, to: IsInitializedMethod.self)(appControllerClass, isInitializedSelector)
+      if !isInitialized {
+        return nil
+      }
+    }
+
+    let sharedInstanceSelector = NSSelectorFromString("sharedInstance")
+    guard let metaClass = object_getClass(appControllerClass),
+          class_respondsToSelector(metaClass, sharedInstanceSelector),
+          let controller = (appControllerClass as AnyObject).perform(sharedInstanceSelector)?.takeUnretainedValue() else {
+      return nil
+    }
+
+    let launchAssetUrlSelector = NSSelectorFromString("launchAssetUrl")
+    if (controller as AnyObject).responds(to: launchAssetUrlSelector),
+       let url = (controller as AnyObject).perform(launchAssetUrlSelector)?.takeUnretainedValue() as? URL {
+      return url
+    }
+
+    return nil
+  }
+
+  // MARK: - Source Map Fetching
+
+  /// Fetches and parses the source map, trying multiple strategies
+  func fetchSourceMap() async throws -> SourceMap {
+    let bundleURL = devMenuManager.currentBridge?.bundleURL
+
+    // Strategy 1: If the bundle is from Metro dev server, try to fetch external .map file
+    if let bundleURL = bundleURL,
+       !bundleURL.isFileURL,
+       !isEASCDNURL(bundleURL),
+       let externalSourceMap = try? await fetchExternalSourceMap() {
+      return externalSourceMap
+    }
+
+    // Strategy 2: Check if expo-updates or Expo Go has downloaded the bundle locally
+    // Try Expo Go kernel first, then UpdatesControllerRegistry, then AppController
+    let localBundleURL = getLaunchAssetURLFromExpoGoKernel()
+                      ?? getLaunchAssetURLFromUpdatesController()
+                      ?? getLaunchAssetURLFromAppController()
+    if let localBundleURL = localBundleURL, localBundleURL.isFileURL {
+      return try extractInlineSourceMapFromLocalFile(localBundleURL)
+    }
+
+    // Strategy 3: Check if bridge's bundle URL is a local file
+    if let bundleURL = bundleURL, bundleURL.isFileURL {
+      return try extractInlineSourceMapFromLocalFile(bundleURL)
+    }
+
+    throw SourceMapError.noSourceMapFound
+  }
+
+  /// Attempts to fetch an external .map file (used in dev mode)
+  private func fetchExternalSourceMap() async throws -> SourceMap {
+    guard let sourceMapURL = getSourceMapURL() else {
+      throw SourceMapError.invalidSourceMapURL
+    }
+
+    let (data, response) = try await URLSession.shared.data(from: sourceMapURL)
+
+    if let httpResponse = response as? HTTPURLResponse,
+       !(200...299).contains(httpResponse.statusCode) {
+      throw SourceMapError.httpError(httpResponse.statusCode)
+    }
+
+    return try JSONDecoder().decode(SourceMap.self, from: data)
+  }
+
+  /// Reads a local bundle file and extracts inline source map
+  private func extractInlineSourceMapFromLocalFile(_ fileURL: URL) throws -> SourceMap {
+    let data = try Data(contentsOf: fileURL)
+
+    guard let bundleContent = String(data: data, encoding: .utf8) else {
+      throw SourceMapError.noSourceMapFound
+    }
+
+    return try extractInlineSourceMap(from: bundleContent)
+  }
+
+  /// Extracts and decodes an inline source map from bundle content
+  /// Looks for: //# sourceMappingURL=data:application/json;charset=utf-8;base64,<base64data>
+  private func extractInlineSourceMap(from bundleContent: String) throws -> SourceMap {
+    let patterns = [
+      "//# sourceMappingURL=data:application/json;charset=utf-8;base64,",
+      "//# sourceMappingURL=data:application/json;base64,",
+    ]
+
+    for pattern in patterns {
+      if let range = bundleContent.range(of: pattern) {
+        let base64Start = range.upperBound
+        let endIndex = bundleContent[base64Start...].firstIndex(where: { $0.isNewline }) ?? bundleContent.endIndex
+        let base64String = String(bundleContent[base64Start..<endIndex])
+
+        guard let decodedData = Data(base64Encoded: base64String) else {
+          throw SourceMapError.invalidInlineSourceMap
+        }
+
+        do {
+          return try JSONDecoder().decode(SourceMap.self, from: decodedData)
+        } catch {
+          throw SourceMapError.parseError(error)
+        }
+      }
+    }
+
+    throw SourceMapError.noSourceMapFound
+  }
+
+  // MARK: - File Tree Building
+
+  /// Builds a file tree from the source map sources array
+  func buildFileTree(from sourceMap: SourceMap) -> [FileTreeNode] {
+    var rootChildren: [String: FileTreeNode] = [:]
+
+    for (index, sourcePath) in sourceMap.sources.enumerated() {
+      insertPath(sourcePath, contentIndex: index, into: &rootChildren)
+    }
+
+    let sorted = sortNodes(Array(rootChildren.values))
+    return collapseSingleChildFolders(sorted)
+  }
+
+  /// Collapses folder chains that have only a single child folder
+  private func collapseSingleChildFolders(_ nodes: [FileTreeNode]) -> [FileTreeNode] {
+    return nodes.map { node in
+      var current = node
+
+      while current.isDirectory && current.children.count == 1 && current.children[0].isDirectory {
+        let child = current.children[0]
+        current = FileTreeNode(
+          name: "\(current.name)/\(child.name)",
+          path: child.path,
+          isDirectory: true,
+          children: child.children,
+          contentIndex: nil
+        )
+      }
+
+      if current.isDirectory && !current.children.isEmpty {
+        var collapsed = current
+        collapsed.children = collapseSingleChildFolders(current.children)
+        return collapsed
+      }
+
+      return current
+    }
+  }
+
+  private func insertPath(_ path: String, contentIndex: Int, into nodes: inout [String: FileTreeNode]) {
+    let components = path.split(separator: "/").map(String.init)
+    guard !components.isEmpty else { return }
+
+    let firstName = components[0]
+
+    if components.count == 1 {
+      nodes[firstName] = FileTreeNode(
+        name: firstName,
+        path: path,
+        isDirectory: false,
+        contentIndex: contentIndex
+      )
+    } else {
+      var existingNode = nodes[firstName] ?? FileTreeNode(
+        name: firstName,
+        path: firstName,
+        isDirectory: true
+      )
+
+      let remainingPath = components.dropFirst().joined(separator: "/")
+      var childrenDict = Dictionary(uniqueKeysWithValues: existingNode.children.map { ($0.name, $0) })
+      insertPath(remainingPath, contentIndex: contentIndex, into: &childrenDict)
+      existingNode.children = Array(childrenDict.values)
+
+      nodes[firstName] = existingNode
+    }
+  }
+
+  private func sortNodes(_ nodes: [FileTreeNode]) -> [FileTreeNode] {
+    var sorted = nodes.sorted { node1, node2 in
+      if node1.isDirectory != node2.isDirectory {
+        return node1.isDirectory
+      }
+      return node1.name.localizedCaseInsensitiveCompare(node2.name) == .orderedAscending
+    }
+
+    for i in sorted.indices {
+      sorted[i].children = sortNodes(sorted[i].children)
+    }
+
+    return sorted
+  }
+}

--- a/packages/expo-dev-menu/ios/SwiftUI/SyntaxHighlighter.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/SyntaxHighlighter.swift
@@ -1,0 +1,198 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+/// Lightweight JavaScript/TypeScript syntax highlighter
+struct SyntaxHighlighter {
+
+  struct Theme {
+    let keyword: Color
+    let string: Color
+    let number: Color
+    let comment: Color
+    let punctuation: Color
+    let property: Color
+    let plain: Color
+    let background: Color
+    let lineNumber: Color
+
+    static var light: Theme {
+      Theme(
+        keyword: Color(red: 0.67, green: 0.05, blue: 0.57),   // purple
+        string: Color(red: 0.77, green: 0.10, blue: 0.09),    // red
+        number: Color(red: 0.11, green: 0.44, blue: 0.69),    // blue
+        comment: Color(red: 0.42, green: 0.47, blue: 0.44),   // gray
+        punctuation: Color(red: 0.31, green: 0.31, blue: 0.31),
+        property: Color(red: 0.15, green: 0.44, blue: 0.56),  // teal
+        plain: Color(red: 0.15, green: 0.15, blue: 0.15),
+        background: Color(red: 0.98, green: 0.98, blue: 0.98),
+        lineNumber: Color(red: 0.6, green: 0.6, blue: 0.6)
+      )
+    }
+
+    static var dark: Theme {
+      Theme(
+        keyword: Color(red: 0.78, green: 0.56, blue: 0.90),   // purple
+        string: Color(red: 0.80, green: 0.58, blue: 0.46),    // orange
+        number: Color(red: 0.71, green: 0.84, blue: 0.65),    // green
+        comment: Color(red: 0.50, green: 0.55, blue: 0.52),   // gray
+        punctuation: Color(red: 0.80, green: 0.80, blue: 0.80),
+        property: Color(red: 0.61, green: 0.80, blue: 0.92),  // light blue
+        plain: Color(red: 0.92, green: 0.92, blue: 0.92),
+        background: Color(red: 0.11, green: 0.12, blue: 0.13),
+        lineNumber: Color(red: 0.45, green: 0.45, blue: 0.45)
+      )
+    }
+  }
+
+  private static let keywords = Set([
+    "async", "await", "break", "case", "catch", "class", "const", "continue",
+    "debugger", "default", "delete", "do", "else", "enum", "export", "extends",
+    "false", "finally", "for", "from", "function", "if", "implements", "import",
+    "in", "instanceof", "interface", "let", "new", "null", "of", "package",
+    "private", "protected", "public", "return", "static", "super", "switch",
+    "this", "throw", "true", "try", "type", "typeof", "undefined", "var",
+    "void", "while", "with", "yield"
+  ])
+
+  enum TokenType {
+    case keyword, string, number, comment, punctuation, property, plain
+
+    func color(in theme: Theme) -> Color {
+      switch self {
+      case .keyword: return theme.keyword
+      case .string: return theme.string
+      case .number: return theme.number
+      case .comment: return theme.comment
+      case .punctuation: return theme.punctuation
+      case .property: return theme.property
+      case .plain: return theme.plain
+      }
+    }
+  }
+
+  struct Token {
+    let text: String
+    let type: TokenType
+  }
+
+  static func tokenize(_ code: String) -> [Token] {
+    var tokens: [Token] = []
+    var index = code.startIndex
+
+    while index < code.endIndex {
+      let remaining = code[index...]
+
+      // Single-line comment
+      if remaining.hasPrefix("//") {
+        let end = remaining.firstIndex(of: "\n") ?? remaining.endIndex
+        tokens.append(Token(text: String(remaining[..<end]), type: .comment))
+        index = end
+        continue
+      }
+
+      // Multi-line comment
+      if remaining.hasPrefix("/*") {
+        if let endRange = remaining.range(of: "*/") {
+          let end = endRange.upperBound
+          tokens.append(Token(text: String(remaining[..<end]), type: .comment))
+          index = end
+          continue
+        }
+      }
+
+      // Strings
+      let quote = remaining.first
+      if quote == "\"" || quote == "'" || quote == "`" {
+        var end = remaining.index(after: index)
+        var escaped = false
+        while end < remaining.endIndex {
+          let char = remaining[end]
+          if escaped {
+            escaped = false
+          } else if char == "\\" {
+            escaped = true
+          } else if char == quote {
+            end = remaining.index(after: end)
+            break
+          } else if quote != "`" && char == "\n" {
+            break
+          }
+          end = remaining.index(after: end)
+        }
+        tokens.append(Token(text: String(remaining[index..<end]), type: .string))
+        index = end
+        continue
+      }
+
+      // Numbers
+      let char = remaining.first!
+      if char.isNumber || (char == "." && remaining.dropFirst().first?.isNumber == true) {
+        var end = index
+        var hasDecimal = char == "."
+        while end < remaining.endIndex {
+          let c = remaining[end]
+          if c.isNumber {
+            end = remaining.index(after: end)
+          } else if c == "." && !hasDecimal {
+            hasDecimal = true
+            end = remaining.index(after: end)
+          } else if c == "x" || c == "X" || c == "e" || c == "E" ||
+                    c == "b" || c == "B" || c == "o" || c == "O" ||
+                    (c >= "a" && c <= "f") || (c >= "A" && c <= "F") {
+            end = remaining.index(after: end)
+          } else {
+            break
+          }
+        }
+        tokens.append(Token(text: String(remaining[index..<end]), type: .number))
+        index = end
+        continue
+      }
+
+      // Identifiers and keywords
+      if char.isLetter || char == "_" || char == "$" {
+        var end = index
+        while end < remaining.endIndex {
+          let c = remaining[end]
+          if c.isLetter || c.isNumber || c == "_" || c == "$" {
+            end = remaining.index(after: end)
+          } else {
+            break
+          }
+        }
+        let word = String(remaining[index..<end])
+        let type: TokenType = keywords.contains(word) ? .keyword : .plain
+        tokens.append(Token(text: word, type: type))
+        index = end
+        continue
+      }
+
+      // Punctuation
+      if "{}[]();:,.<>+-*/%=!&|?@#~^".contains(char) {
+        tokens.append(Token(text: String(char), type: .punctuation))
+        index = remaining.index(after: index)
+        continue
+      }
+
+      // Whitespace and other
+      tokens.append(Token(text: String(char), type: .plain))
+      index = remaining.index(after: index)
+    }
+
+    return tokens
+  }
+
+  static func highlight(_ code: String, theme: Theme) -> AttributedString {
+    let tokens = tokenize(code)
+    var result = AttributedString()
+
+    for token in tokens {
+      var attributed = AttributedString(token.text)
+      attributed.foregroundColor = token.type.color(in: theme)
+      result.append(attributed)
+    }
+
+    return result
+  }
+}

--- a/packages/expo-dev-menu/ios/SwiftUI/SyntaxHighlighter.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/SyntaxHighlighter.swift
@@ -55,6 +55,8 @@ struct SyntaxHighlighter {
     "void", "while", "with", "yield"
   ])
 
+  private static let punctuationChars: Set<Character> = Set("{}[]();:,.<>+-*/%=!&|?@#~^")
+
   enum TokenType {
     case keyword, string, number, comment, punctuation, property, plain
 
@@ -169,7 +171,7 @@ struct SyntaxHighlighter {
       }
 
       // Punctuation
-      if "{}[]();:,.<>+-*/%=!&|?@#~^".contains(char) {
+      if punctuationChars.contains(char) {
         tokens.append(Token(text: String(char), type: .punctuation))
         index = remaining.index(after: index)
         continue
@@ -194,5 +196,11 @@ struct SyntaxHighlighter {
     }
 
     return result
+  }
+
+  static func highlightLines(_ lines: [String], theme: Theme) async -> [AttributedString] {
+    lines.map { line in
+      highlight(line.isEmpty ? " " : line, theme: theme)
+    }
   }
 }


### PR DESCRIPTION
# How

Introduces a Source Map Explorer feature in the iOS dev menu, allowing users to browse and view source files from the Metro source map with syntax highlighting. Updates UI to include a navigation link to the explorer, adds supporting models, view models, services, and a syntax highlighter. Also updates the dev client changelog and minor navigation improvements.

# Test Plan

- Build Expo Go from source
- `npx uri-scheme open --ios exp://u.expo.dev/17bcbd54-564a-4091-ae94-a1887ee3fc25/group/d6170f31-07bc-4c6e-bed3-52e1ed682935`
- Open dev client -> source map explorer