### PR TITLE
[iOS][image] Fix `useImage` crashing on SVGs without the max size set

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed `useImage` crashing on SVGs when the max dimensions are not set. ([#42496](https://github.com/expo/expo/pull/42496) by [@tsapeta](https://github.com/tsapeta))
+
 ### 💡 Others
 
 ## 55.0.1 — 2026-01-22

--- a/packages/expo-image/ios/ImageLoadOptions.swift
+++ b/packages/expo-image/ios/ImageLoadOptions.swift
@@ -3,10 +3,16 @@
 import ExpoModulesCore
 
 internal struct ImageLoadOptions: Record {
-  @Field var maxWidth: Int = .max
-  @Field var maxHeight: Int = .max
+  @Field var maxWidth: Int?
+  @Field var maxHeight: Int?
 
-  func getMaxSize() -> CGSize {
-    return CGSize(width: maxWidth, height: maxHeight)
+  func getMaxSize() -> CGSize? {
+    // If none of max dimensions are provided, just use the original image without the upper limit.
+    // This is important for vector images, where using `CGSize(.max, .max)`
+    // would actually try to create a bitmap of that size and cause a crash.
+    if maxWidth == nil && maxHeight == nil {
+      return nil
+    }
+    return CGSize(width: maxWidth ?? .max, height: maxHeight ?? .max)
   }
 }

--- a/packages/expo-image/ios/ImageLoadTask.swift
+++ b/packages/expo-image/ios/ImageLoadTask.swift
@@ -4,18 +4,18 @@ import ExpoModulesCore
 
 internal final class ImageLoadTask: SharedObject {
   private let source: ImageSource
-  private let maxSize: CGSize?
+  private let options: ImageLoadOptions
   private var task: Task<UIImage, any Error>?
 
-  init(_ source: ImageSource, maxSize: CGSize? = nil) {
+  init(_ source: ImageSource, options: ImageLoadOptions) {
     self.source = source
-    self.maxSize = maxSize
+    self.options = options
     super.init()
   }
 
   func load() async throws -> UIImage {
-    let task = self.task ?? Task { [source, maxSize] in
-      return try await ImageLoader.shared.load(source, maxSize: maxSize)
+    let task = self.task ?? Task { [source, options] in
+      return try await ImageLoader.shared.load(source, options: options)
     }
     self.task = task
     return try await task.value

--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -246,7 +246,7 @@ public final class ImageModule: Module {
     }
 
     AsyncFunction("loadAsync") { (source: ImageSource, options: ImageLoadOptions?) -> Image? in
-      let image = try await ImageLoadTask(source, maxSize: options?.getMaxSize()).load()
+      let image = try await ImageLoadTask(source, options: options ?? ImageLoadOptions()).load()
       return Image(image)
     }
 


### PR DESCRIPTION
# Why

`useImage` used to load an SVG causes a crash on iOS when none of `maxWidth` and `maxHeight` were provided in the options object. This happens because the max size defaults to `Int.max, Int.max` and the underlying SVG coder tries to create a bitmap of such size. In this case, the `imageThumbnailPixelSize` context option passed to `SDWebImage` should stay unset.

# How

The max size is now optional with `nil` being the default. When only one max dimension is provided, the other defaults to `Int.max` (`SDWebImage` later preserves the aspect ratio).

# Test Plan

`const img = useImage("https://simpleicons.org/icons/expo.svg");` no longer crashes the app. Our example using shared refs also works as expected (with and without options provided).