### PR TITLE
Code review for #42490

### DIFF
--- a/packages/expo-dev-menu/ios/SwiftUI/SourceMapExplorerViewModel.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/SourceMapExplorerViewModel.swift
@@ -19,12 +19,14 @@ class SourceMapExplorerViewModel: ObservableObject {
   }
 
   func loadSourceMap() async {
+    if case .loaded = loadingState { return }
+
     loadingState = .loading
 
     do {
       let sourceMap = try await service.fetchSourceMap()
       self.sourceMap = sourceMap
-      self.fileTree = service.buildFileTree(from: sourceMap)
+      self.fileTree = await service.buildFileTree(from: sourceMap)
       loadingState = .loaded(sourceMap)
     } catch let error as SourceMapError {
       loadingState = .error(error)
@@ -53,7 +55,7 @@ class SourceMapExplorerViewModel: ObservableObject {
         results.append(contentsOf: findMatchingFiles(in: node.children, searchText: searchText))
       } else {
         // Check if file name or path matches
-        if node.name.lowercased().contains(searchText) || node.path.lowercased().contains(searchText) {
+        if node.searchableName.contains(searchText) || node.searchablePath.contains(searchText) {
           results.append(node)
         }
       }

--- a/packages/expo-dev-menu/ios/SwiftUI/SourceMapModels.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/SourceMapModels.swift
@@ -13,20 +13,24 @@ struct SourceMap: Codable {
 
 /// Represents a node in the file tree (file or directory)
 struct FileTreeNode: Identifiable, Hashable {
-  let id: UUID
+  var id: String { path }
   let name: String
   let path: String
   let isDirectory: Bool
   var children: [FileTreeNode]
   let contentIndex: Int?
 
+  let searchableName: String
+  let searchablePath: String
+
   init(name: String, path: String, isDirectory: Bool, children: [FileTreeNode] = [], contentIndex: Int? = nil) {
-    self.id = UUID()
     self.name = name
     self.path = path
     self.isDirectory = isDirectory
     self.children = children
     self.contentIndex = contentIndex
+    self.searchableName = name.lowercased()
+    self.searchablePath = path.lowercased()
   }
 
   func hash(into hasher: inout Hasher) {

--- a/packages/expo-dev-menu/ios/SwiftUI/SyntaxHighlighter.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/SyntaxHighlighter.swift
@@ -55,6 +55,8 @@ struct SyntaxHighlighter {
     "void", "while", "with", "yield"
   ])
 
+  private static let punctuationChars: Set<Character> = Set("{}[]();:,.<>+-*/%=!&|?@#~^")
+
   enum TokenType {
     case keyword, string, number, comment, punctuation, property, plain
 
@@ -169,7 +171,7 @@ struct SyntaxHighlighter {
       }
 
       // Punctuation
-      if "{}[]();:,.<>+-*/%=!&|?@#~^".contains(char) {
+      if punctuationChars.contains(char) {
         tokens.append(Token(text: String(char), type: .punctuation))
         index = remaining.index(after: index)
         continue
@@ -194,5 +196,11 @@ struct SyntaxHighlighter {
     }
 
     return result
+  }
+
+  static func highlightLines(_ lines: [String], theme: Theme) async -> [AttributedString] {
+    lines.map { line in
+      highlight(line.isEmpty ? " " : line, theme: theme)
+    }
   }
 }


### PR DESCRIPTION
# Why
Code review for #42490

# How
Biggest wins came from these changes:
- Service was marked as `@MainActor` running I/O on the main thread. Fetching source maps, JSON decoding, building the file tree etc. Removed the attribute
- Syntax highlighting was running on the main thread. Navigation was freezing on larger files. Made file highlighting async and run in a `.task` when the view appears.
- Building the file tree was using arrays to store children causing insertion to be expensive. Changing this to a dictionary gives us fast insertion.

Fixes:
- Searching was not working, this is fixed.

Minor improvements:
- Extracted some computed views to their own structs. Computed views run on every render of the parent regardless of dependency changes.
- Prevent refetching the source map every time we return to the root of the explorer.
- Changed `FileTreeNode` to use the path for identity instead of allocating UUIDs
- `findMatchingFiles` was duplicated. This is removed.
- Used `LazyVStack`

# Test Plan
Expo go. 

