### PR TITLE
[expo-widgets] Fix build issue with "ambiguous implicit access level for import"

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix build issue with "ambiguous implicit access level for import" ([#42507](https://github.com/expo/expo/pull/42507) by [@garygcchiu](https://github.com/garygcchiu))
+
 ### 💡 Others
 
 ## 55.0.0-alpha.2 — 2026-01-23

--- a/packages/expo-widgets/plugin/src/withWidgetSourceFiles.ts
+++ b/packages/expo-widgets/plugin/src/withWidgetSourceFiles.ts
@@ -49,7 +49,7 @@ const createIndexSwift = (widgets: WidgetConfig[], targetPath: string): string =
   const numberOfBundles = Math.ceil(numberOfWidgets / 4);
   let output = `import WidgetKit
 import SwiftUI
-import ExpoWidgets
+internal import ExpoWidgets
 `;
 
   for (let i = 0; i < numberOfBundles; i++) {
@@ -91,7 +91,7 @@ struct ExportWidgets${index}: WidgetBundle {
 
 const widgetSwift = (widget: WidgetConfig): string => `import WidgetKit
 import SwiftUI
-import ExpoWidgets
+internal import ExpoWidgets
 
 struct ${widget.name}: Widget {
   let name: String = "${widget.name}"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

I was testing out the `expo-widgets` alpha and installed it to my Expo 55 beta app. When I deleted my `ios/` and ran `npx expo run:ios`, it resulted in the following error:

<details><summary>`npx expo run:ios` Error Logs</summary>
<p>

```
› Compiling Pods/Pods-ExpoWidgetsTarget » Pods-ExpoWidgetsTarget-dummy.m
› Packaging Pods/Pods-ExpoWidgetsTarget » libPods-ExpoWidgetsTarget.a
› Executing RecallKit/ExpoWidgetsTarget » [CP] Check Pods Manifest.lock
› Preparing RecallKit/ExpoWidgetsTarget » Info.plist
› Executing RecallKit/ExpoWidgetsTarget » [Expo] Configure project
› Compiling expo-dev-menu Pods/expo-dev-menu » RCTKeyCommands.m
› Compiling expo-dev-menu Pods/expo-dev-menu » expo-dev-menu-dummy.m
› Linking   RecallKit/ExpoWidgetsTarget » __preview.dylib

❌  (ios/ExpoWidgetsTarget/index.swift:3:8)

  1 | import WidgetKit
  2 | import SwiftUI
> 3 | import ExpoWidgets
    |        ^ ambiguous implicit access level for import of 'ExpoWidgets'; it is imported as 'internal' elsewhere
  4 |
  5 | @main
  6 | struct ExportWidgets0: WidgetBundle {


❌  (ios/ExpoWidgetsTarget/RecallKit.swift:3:8)

  1 | import WidgetKit
  2 | import SwiftUI
> 3 | import ExpoWidgets
    |        ^ ambiguous implicit access level for import of 'ExpoWidgets'; it is imported as 'internal' elsewhere
  4 |
  5 | struct RecallKit: Widget {
  6 |   let name: String = "RecallKit"


❌  (ios/ExpoWidgetsTarget/index.swift:3:8)

  1 | import WidgetKit
  2 | import SwiftUI
> 3 | import ExpoWidgets
    |        ^ ambiguous implicit access level for import of 'ExpoWidgets'; it is imported as 'internal' elsewhere
  4 |
  5 | @main
  6 | struct ExportWidgets0: WidgetBundle {


❌  (ios/ExpoWidgetsTarget/RecallKit.swift:3:8)

  1 | import WidgetKit
  2 | import SwiftUI
> 3 | import ExpoWidgets
    |        ^ ambiguous implicit access level for import of 'ExpoWidgets'; it is imported as 'internal' elsewhere
  4 |
  5 | struct RecallKit: Widget {
  6 |   let name: String = "RecallKit"


❌  (ios/ExpoWidgetsTarget/index.swift:3:8)

  1 | import WidgetKit
  2 | import SwiftUI
> 3 | import ExpoWidgets
    |        ^ ambiguous implicit access level for import of 'ExpoWidgets'; it is imported as 'internal' elsewhere
  4 |
  5 | @main
  6 | struct ExportWidgets0: WidgetBundle {


❌  (ios/ExpoWidgetsTarget/RecallKit.swift:3:8)

  1 | import WidgetKit
  2 | import SwiftUI
> 3 | import ExpoWidgets
    |        ^ ambiguous implicit access level for import of 'ExpoWidgets'; it is imported as 'internal' elsewhere
  4 |
  5 | struct RecallKit: Widget {
  6 |   let name: String = "RecallKit"


❌  (ios/ExpoWidgetsTarget/index.swift:3:8)

  1 | import WidgetKit
  2 | import SwiftUI
> 3 | import ExpoWidgets
    |        ^ ambiguous implicit access level for import of 'ExpoWidgets'; it is imported as 'internal' elsewhere
  4 |
  5 | @main
  6 | struct ExportWidgets0: WidgetBundle {


❌  (ios/ExpoWidgetsTarget/RecallKit.swift:3:8)

  1 | import WidgetKit
  2 | import SwiftUI
> 3 | import ExpoWidgets
    |        ^ ambiguous implicit access level for import of 'ExpoWidgets'; it is imported as 'internal' elsewhere
  4 |
  5 | struct RecallKit: Widget {
  6 |   let name: String = "RecallKit"

› Compiling expo-dev-menu Pods/expo-dev-menu » EXDevMenuAppInfo.m
› Packaging expo-dev-menu Pods/expo-dev-menu » libexpo-dev-menu.a
› Executing expo-dev-menu Pods/expo-dev-menu » Copy generated compatibility header
    Run script build phase '[CP-User] [Hermes] Replace Hermes for the right configuration, if needed' will be run during every build because it does not specify any outputs. To address this issue, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'hermes-engine' from project 'Pods')
    Run script build phase 'Upload Debug Symbols to Sentry' will be run during every build because it does not specify any outputs. To address this issue, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'RecallKit' from project 'RecallKit')
    Run script build phase '[CP-User] Generate updates resources for expo-updates' will be run during every build because it does not specify any outputs. To address this issue, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'EXUpdates' from project 'Pods')

› 8 error(s), and 3 warning(s)

CommandError: Failed to build iOS project. "xcodebuild" exited with error code 65.
```

</p>
</details> 

I am not an iOS dev, but based on my brief investigation:
- This is because `expo-modules-autolinking` generates `internal import ${moduleName}` for all Swift modules. 
  - I do see this in the source code for `expo-modules-autolinking@55.0.1` at `src/platforms/apple/apple.ts`: [[npm source code](https://www.npmjs.com/package/expo-modules-autolinking/v/55.0.1?activeTab=code)]. I'm not sure which branch this version is published from
  - Before 55.0.1, it used `@_implementationOnly import ${moduleName}` instead: [[source code on main](https://github.com/expo/expo/blob/main/packages/expo-modules-autolinking/src/platforms/apple/apple.ts#L194-L196)]
- `expo-widgets` generates `import ExpoWidgets` via [`withWidgetSourceFiles.ts `](https://github.com/expo/expo/blob/main/packages/expo-widgets/plugin/src/withWidgetSourceFiles.ts#L50-L52)
- `internal import` syntax is a Swift 6 feature [[SE-0409]](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md)
- Thus, `expo-modules-autolinking` was updated to use `internal import` for Swift 6 compatibility, but `expo-widgets` config plugin wasn't updated to match yet
- The differing access levels results in the the compiler throwing "ambiguous implicit access level for import".

Relevant environment details:
```
expo: 55.0.0-preview.5
expo-widgets: 55.0.0-alpha.2
XCode 26
```

> [!NOTE]
>  EDIT: I see this was introduced https://github.com/expo/expo/pull/42449! But was reverted. So the revert likely didn't get published yet? See comment below as we might not need this PR.


# How

<!--
How did you build this feature or fix this bug and why?
-->

The solution here is to also update `expo-widgets` to use `internal import` to match the output from `expo-module-autolinking`. Apologies for the lazy commit messages.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Used to get the error when running `npx expo run:ios` on my app, after patching with this fix, it compiled perfectly and I was able to use the `expo-widget` functionality.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
