### PR TITLE
fix(cli): Add missing port scan

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Reallow connections on `/expo-dev-plugins/broadcast` broadcast socket to local connections ([#42538](https://github.com/expo/expo/pull/42538) by [@kitten](https://github.com/kitten))
+- Fix `freeport-async` replacement ([#42509](https://github.com/expo/expo/pull/42509) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/utils/__tests__/port.test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/port.test.ts
@@ -1,10 +1,11 @@
-import { testPortAsync } from '../freeport';
+import { freePortAsync, testPortAsync } from '../freeport';
 import { getRunningProcess } from '../getRunningProcess';
 import { choosePortAsync, ensurePortAvailabilityAsync } from '../port';
 import { confirmAsync } from '../prompts';
 
 jest.mock('../freeport', () => ({
-  testPortAsync: jest.fn(async (port) => port),
+  testPortAsync: jest.fn(async (_port) => true),
+  freePortAsync: jest.fn(async (port) => port),
 }));
 
 jest.mock('../../log');
@@ -15,7 +16,7 @@ jest.mock('../getRunningProcess', () => ({
 
 describe(ensurePortAvailabilityAsync, () => {
   it(`returns true if the port is available`, async () => {
-    jest.mocked(testPortAsync).mockResolvedValueOnce(8081);
+    jest.mocked(testPortAsync).mockResolvedValueOnce(true);
     expect(await ensurePortAvailabilityAsync('/', { port: 8081 })).toBe(true);
   });
   it(`returns false if the port is unavailable due to running the same process`, async () => {
@@ -24,7 +25,7 @@ describe(ensurePortAvailabilityAsync, () => {
       directory: '/me',
       command: 'npx expo',
     });
-    jest.mocked(testPortAsync).mockResolvedValueOnce(8082);
+    jest.mocked(testPortAsync).mockResolvedValueOnce(false);
     expect(await ensurePortAvailabilityAsync('/me', { port: 8081 })).toBe(false);
   });
   it(`asserts if the port is busy because it's running a different process`, async () => {
@@ -33,26 +34,26 @@ describe(ensurePortAvailabilityAsync, () => {
       directory: '/other',
       command: 'npx expo',
     });
-    jest.mocked(testPortAsync).mockResolvedValueOnce(8082);
+    jest.mocked(testPortAsync).mockResolvedValueOnce(false);
     await expect(ensurePortAvailabilityAsync('/me', { port: 8081 })).rejects.toThrow();
   });
 });
 
 describe(choosePortAsync, () => {
   it(`returns any port when given port is 0`, async () => {
-    jest.mocked(testPortAsync).mockResolvedValueOnce(1000);
+    jest.mocked(freePortAsync).mockResolvedValueOnce(1000);
     const port = await choosePortAsync('/', { defaultPort: 0 });
     expect(port).toBe(1000);
     expect(confirmAsync).not.toHaveBeenCalled();
   });
   it(`returns same port when given port is available`, async () => {
-    jest.mocked(testPortAsync).mockResolvedValueOnce(8081);
+    jest.mocked(freePortAsync).mockResolvedValueOnce(8081);
     const port = await choosePortAsync('/', { defaultPort: 8081 });
     expect(port).toBe(8081);
     expect(confirmAsync).not.toHaveBeenCalled();
   });
   it(`chooses a new port if the default port is taken and isn't running the same process`, async () => {
-    jest.mocked(testPortAsync).mockResolvedValueOnce(8082);
+    jest.mocked(freePortAsync).mockResolvedValueOnce(8082);
     jest.mocked(getRunningProcess).mockReturnValueOnce({
       pid: 1,
       directory: '/other/project',
@@ -64,7 +65,7 @@ describe(choosePortAsync, () => {
     expect(confirmAsync).toHaveBeenCalledWith({ initial: true, message: 'Use port 8082 instead?' });
   });
   it(`returns null if the new suggested port is rejected`, async () => {
-    jest.mocked(testPortAsync).mockResolvedValueOnce(8082);
+    jest.mocked(freePortAsync).mockResolvedValueOnce(8082);
     jest.mocked(getRunningProcess).mockReturnValueOnce({
       pid: 1,
       directory: '/other/project',
@@ -76,7 +77,7 @@ describe(choosePortAsync, () => {
     expect(confirmAsync).toHaveBeenCalledWith({ initial: true, message: 'Use port 8082 instead?' });
   });
   it(`returns null if the taken port is running the same process`, async () => {
-    jest.mocked(testPortAsync).mockResolvedValueOnce(8082);
+    jest.mocked(freePortAsync).mockResolvedValueOnce(8082);
     jest.mocked(getRunningProcess).mockReturnValueOnce({
       pid: 1,
       directory: '/me',

--- a/packages/@expo/cli/src/utils/freeport.ts
+++ b/packages/@expo/cli/src/utils/freeport.ts
@@ -15,17 +15,26 @@ async function testHostPortAsync(port: number, host: string | null): Promise<boo
   });
 }
 
-export async function testPortAsync(
-  port: number,
-  hostnames?: (string | null)[]
-): Promise<number | null> {
+export async function testPortAsync(port: number, hostnames?: (string | null)[]): Promise<boolean> {
   if (!hostnames?.length) {
     hostnames = [null];
   }
   for (const host of hostnames) {
     if (!(await testHostPortAsync(port, host))) {
-      return null;
+      return false;
     }
   }
-  return port;
+  return true;
+}
+
+export async function freePortAsync(
+  portStart: number,
+  hostnames?: (string | null)[]
+): Promise<number | null> {
+  for (let port = portStart; port <= 65_535; port++) {
+    if (await testPortAsync(port, hostnames)) {
+      return port;
+    }
+  }
+  return null;
 }

--- a/packages/@expo/cli/src/utils/port.ts
+++ b/packages/@expo/cli/src/utils/port.ts
@@ -2,12 +2,12 @@ import chalk from 'chalk';
 
 import { env } from './env';
 import { CommandError } from './errors';
-import { testPortAsync } from './freeport';
+import { testPortAsync, freePortAsync } from './freeport';
 import * as Log from '../log';
 
 /** Get a free port or assert a CLI command error. */
 export async function getFreePortAsync(rangeStart: number): Promise<number> {
-  const port = await testPortAsync(rangeStart, [null, 'localhost']);
+  const port = await freePortAsync(rangeStart, [null, 'localhost']);
   if (!port) {
     throw new CommandError('NO_PORT_FOUND', 'No available port found');
   }
@@ -20,9 +20,9 @@ export async function ensurePortAvailabilityAsync(
   projectRoot: string,
   { port }: { port: number }
 ): Promise<boolean> {
-  const freePort = await testPortAsync(port, [null]);
+  const isFreePort = await testPortAsync(port, [null]);
   // Check if port has become busy during the build.
-  if (freePort === port) {
+  if (isFreePort) {
     return true;
   }
 
@@ -78,7 +78,7 @@ export async function choosePortAsync(
   }
 ): Promise<number | null> {
   try {
-    const port = await testPortAsync(defaultPort, [host ?? null]);
+    const port = await freePortAsync(defaultPort, [host ?? null]);
     if (port === defaultPort || defaultPort === 0) {
       return port;
     }


### PR DESCRIPTION
# Why

Follow-up/Fix for #42478

I missed that this was also doing a port-scan, since I misunderstood what the range was for (it's for finding a contiguous range of ports rather than the max attempts at finding a free port). When reading the check using `port === defaultPort`, I assumed that the next available one is counted up in our own logic.

# How

- Add differentiation between `testPortAsync` and (new) `freePortAsync` to make difference clear and readd port scanning

# Test Plan

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
