### PR TITLE
[ios][expo-go] Fix menu issues

### DIFF
--- a/apps/expo-go/ios/Client/EXRootViewController.m
+++ b/apps/expo-go/ios/Client/EXRootViewController.m
@@ -267,11 +267,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)appDidFinishLoadingSuccessfully:(EXKernelAppRecord *)appRecord
 {
-  // show nux if needed
-  if (!self.isNuxFinished && appRecord == [EXKernel sharedInstance].visibleApp) {
-    [DevMenuManager.shared openMenu];
-  }
-
   // Re-apply the default orientation after the app has been loaded (eq. after a reload)
   [self _applySupportedInterfaceOrientations];
 }

--- a/apps/expo-go/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
+++ b/apps/expo-go/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
@@ -430,11 +430,9 @@ NSString *const RCTInstanceDidLoadBundle = @"RCTInstanceDidLoadBundle";
 
 - (void)showDevMenu
 {
-  if ([self enablesDeveloperTools]) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [[DevMenuManager shared] toggleMenu];
-    });
-  }
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [[DevMenuManager shared] toggleMenu];
+  });
 }
 
 - (void)reloadApp

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -4724,7 +4724,7 @@ SPEC CHECKSUMS:
   GoogleAppMeasurement: 8a82b93a6400c8e6551c0bcd66a9177f2e067aed
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 5fe31775fd37ae963dff271e227decb44d08e843
+  hermes-engine: d7a9424b7191b73c5c774d04fc2e147dd400e67f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -89,6 +89,11 @@ open class DevMenuManager: NSObject {
     manifestSubject.eraseToAnyPublisher()
   }
 
+  private let menuWillShowSubject = PassthroughSubject<Void, Never>()
+  public var menuWillShowPublisher: AnyPublisher<Void, Never> {
+    menuWillShowSubject.eraseToAnyPublisher()
+  }
+
   @objc
   public private(set) var currentManifest: Manifest? {
     didSet {
@@ -358,6 +363,7 @@ open class DevMenuManager: NSObject {
       return false
     }
     if visible {
+      menuWillShowSubject.send()
       setCurrentScreen(screen)
       DispatchQueue.main.async {
 #if os(macOS)

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuRootView.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuRootView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 struct DevMenuRootView: View {
   @StateObject private var viewModel = DevMenuViewModel()
+  @State private var navigationId = UUID()
 
   var body: some View {
     let mainView = VStack(spacing: 0) {
@@ -24,10 +25,19 @@ struct DevMenuRootView: View {
 #if !os(macOS)
     NavigationView {
       mainView
-    }.navigationViewStyle(.stack)
+    }
+    .navigationViewStyle(.stack)
+    .id(navigationId)
+    .onReceive(DevMenuManager.shared.menuWillShowPublisher) { _ in
+      navigationId = UUID()
+    }
 #else
     NavigationStack {
       mainView
+    }
+    .id(navigationId)
+    .onReceive(DevMenuManager.shared.menuWillShowPublisher) { _ in
+      navigationId = UUID()
     }
 #endif
   }


### PR DESCRIPTION
# Why
Fixes a number of issues with the dev menu in expo go

# How
- The `nux` check is outdated and no longer needed. Because it was never updated it is always set to true so the menu would show on every reload. The dev menu has its own onboarding check now so this can be removed. I'll follow up with full removal.
- Fixes dev menu not responding when a update is loaded
- Reset the state of the dev menu before it opens. This prevents the source explorer from having stale data and it's strange to close the menu and for it open deep in a file tree that you left.

# Test Plan
Expo go

