### PR TITLE
[tools] Update expoVersion after publish

### DIFF
--- a/tools/src/Versions.ts
+++ b/tools/src/Versions.ts
@@ -1,8 +1,27 @@
+import semver from 'semver';
+
 import logger from './Logger';
 
 /**
  * Utilities for versions API.
  */
+
+/**
+ * Normalizes an SDK version string - e.g. "54" becomes "54.0.0".
+ */
+export function normalizeSdkVersion(input: string): string {
+  if (/^\d+$/.test(input)) {
+    return `${input}.0.0`;
+  }
+  return input;
+}
+
+/**
+ * Returns sorted SDK version keys from a versions schema, in descending order.
+ */
+export function getSortedSdkVersionKeys(versions: VersionsSchema): string[] {
+  return Object.keys(versions.sdkVersions).sort(semver.rcompare);
+}
 
 export enum VersionsApiHost {
   PRODUCTION = 'api.expo.dev',

--- a/tools/src/commands/UpdateVersionsEndpoint.ts
+++ b/tools/src/commands/UpdateVersionsEndpoint.ts
@@ -117,8 +117,10 @@ async function applyChangesToRootAsync(options: ActionOptions, versions: any) {
 }
 
 async function applyChangesToSDKVersionAsync(options: ActionOptions, versions: any) {
-  const sdkVersions = Object.keys(versions.sdkVersions).sort(semver.rcompare);
-  const sdkVersion = options.sdkVersion || (await chooseSdkVersionAsync(sdkVersions));
+  const sdkVersions = Versions.getSortedSdkVersionKeys(versions);
+  const sdkVersion = Versions.normalizeSdkVersion(
+    options.sdkVersion || (await chooseSdkVersionAsync(sdkVersions))
+  );
   const containsSdk = sdkVersions.includes(sdkVersion);
 
   if (!semver.valid(sdkVersion)) {

--- a/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
+++ b/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
@@ -20,6 +20,7 @@ import { updateIosProjects } from './updateIosProjects';
 import { updateModuleTemplate } from './updateModuleTemplate';
 import { updatePackageVersions } from './updatePackageVersions';
 import { updateProjectTemplates } from './updateProjectTemplates';
+import { updateVersionsEndpoint } from './updateVersionsEndpoint';
 import { updateWorkspaceProjects } from './updateWorkspaceProjects';
 import Git from '../../Git';
 import logger from '../../Logger';
@@ -89,6 +90,7 @@ export const publishPackagesPipeline = new Task<TaskArgs>(
       pushCommittedChanges,
       publishAndroidArtifacts,
       publishPackages,
+      updateVersionsEndpoint,
       grantTeamAccessToPackages,
       addPublishedLabelToPullRequests,
       cleanWorkingTree,

--- a/tools/src/publish-packages/tasks/updateVersionsEndpoint.ts
+++ b/tools/src/publish-packages/tasks/updateVersionsEndpoint.ts
@@ -1,0 +1,113 @@
+import chalk from 'chalk';
+import inquirer from 'inquirer';
+import semver from 'semver';
+
+import { publishPackages } from './publishPackages';
+import logger from '../../Logger';
+import { Task } from '../../TasksRunner';
+import * as Versions from '../../Versions';
+import { CommandOptions, Parcel, TaskArgs } from '../types';
+
+const { cyan, green, yellow } = chalk;
+
+function normalizeSdkVersion(input: string): string {
+  if (/^\d+$/.test(input)) {
+    return `${input}.0.0`;
+  }
+  return input;
+}
+
+/**
+ * Updates the versions endpoint with the published expo package version.
+ * This runs after packages are published and prompts to update the `expoVersion`
+ * key for a target SDK version.
+ */
+export const updateVersionsEndpoint = new Task<TaskArgs>(
+  {
+    name: 'updateVersionsEndpoint',
+    dependsOn: [publishPackages],
+  },
+  async (parcels: Parcel[], options: CommandOptions) => {
+    const expoParcel = parcels.find((parcel) => parcel.pkg.packageName === 'expo');
+
+    if (!expoParcel || !expoParcel.state.published) {
+      return;
+    }
+
+    const publishedVersion = expoParcel.state.releaseVersion;
+    if (!publishedVersion) {
+      logger.warn(
+        '\n📡 Skipping versions endpoint update - could not determine published version.'
+      );
+      return;
+    }
+
+    const expoVersionValue = `~${publishedVersion}`;
+    const versions = await Versions.getVersionsAsync();
+    const sdkVersions = Object.keys(versions.sdkVersions).sort(semver.rcompare);
+    const recentSdks = sdkVersions.slice(0, 3);
+
+    logger.info(`\n📡 Expo package published: ${green(publishedVersion)}`);
+
+    const ENTER_SDK = 'Enter SDK version';
+    const SKIP = 'Skip';
+
+    const sdkChoices = [...recentSdks, new inquirer.Separator(), ENTER_SDK, SKIP];
+
+    const { selectedSdk } = await inquirer.prompt<{ selectedSdk: string }>([
+      {
+        type: 'list',
+        name: 'selectedSdk',
+        message: `Update versions endpoint with expoVersion ${green(expoVersionValue)}?`,
+        choices: sdkChoices,
+        default: recentSdks[0],
+      },
+    ]);
+
+    if (selectedSdk === SKIP) {
+      logger.info(yellow('  Skipping versions endpoint update.'));
+      return;
+    }
+
+    let targetSdkVersion = selectedSdk;
+
+    if (selectedSdk === ENTER_SDK) {
+      const { customSdk } = await inquirer.prompt<{ customSdk: string }>([
+        {
+          type: 'input',
+          name: 'customSdk',
+          message: 'Enter SDK version:',
+          validate: (input) => {
+            const normalized = normalizeSdkVersion(input.trim());
+            if (!semver.valid(normalized)) {
+              return 'Please enter a valid SDK version (e.g., 54 or 54.0.0)';
+            }
+            return true;
+          },
+        },
+      ]);
+      targetSdkVersion = normalizeSdkVersion(customSdk.trim());
+    }
+
+    logger.info(
+      `\n📡 Updating versions endpoint for SDK ${cyan(targetSdkVersion)} with expoVersion ${green(expoVersionValue)}...`
+    );
+
+    if (options.dry) {
+      logger.info(yellow('  Dry run - skipping version update.'));
+      return;
+    }
+
+    try {
+      await Versions.modifySdkVersionsAsync(targetSdkVersion, (sdkVersions) => ({
+        ...sdkVersions,
+        expoVersion: expoVersionValue,
+      }));
+      logger.success(
+        `\n📡 Successfully updated versions endpoint: SDK ${cyan(targetSdkVersion)} → expoVersion: ${green(expoVersionValue)}`
+      );
+    } catch (error) {
+      logger.error(`\n📡 Failed to update versions endpoint: ${error.message}`);
+    }
+  }
+);

--- a/tools/src/publish-packages/tasks/updateVersionsEndpoint.ts
+++ b/tools/src/publish-packages/tasks/updateVersionsEndpoint.ts
@@ -10,13 +10,6 @@ import { CommandOptions, Parcel, TaskArgs } from '../types';
 
 const { cyan, green, yellow } = chalk;
 
-function normalizeSdkVersion(input: string): string {
-  if (/^\d+$/.test(input)) {
-    return `${input}.0.0`;
-  }
-  return input;
-}
-
 /**
  * Updates the versions endpoint with the published expo package version.
  * This runs after packages are published and prompts to update the `expoVersion`
@@ -44,7 +37,7 @@ export const updateVersionsEndpoint = new Task<TaskArgs>(
 
     const expoVersionValue = `~${publishedVersion}`;
     const versions = await Versions.getVersionsAsync();
-    const sdkVersions = Object.keys(versions.sdkVersions).sort(semver.rcompare);
+    const sdkVersions = Versions.getSortedSdkVersionKeys(versions);
     const recentSdks = sdkVersions.slice(0, 3);
 
     logger.info(`\n📡 Expo package published: ${green(publishedVersion)}`);
@@ -78,7 +71,7 @@ export const updateVersionsEndpoint = new Task<TaskArgs>(
           name: 'customSdk',
           message: 'Enter SDK version:',
           validate: (input) => {
-            const normalized = normalizeSdkVersion(input.trim());
+            const normalized = Versions.normalizeSdkVersion(input.trim());
             if (!semver.valid(normalized)) {
               return 'Please enter a valid SDK version (e.g., 54 or 54.0.0)';
             }
@@ -86,7 +79,7 @@ export const updateVersionsEndpoint = new Task<TaskArgs>(
           },
         },
       ]);
-      targetSdkVersion = normalizeSdkVersion(customSdk.trim());
+      targetSdkVersion = Versions.normalizeSdkVersion(customSdk.trim());
     }
 
     logger.info(


### PR DESCRIPTION
# Why
It's easy to forget to update the versions endpoint after publishing the expo package. This should make sure it does not happen

# How
Add a new step to the publish pipeline, determine if the expo package was published, and update the selected sdk version.

