### PR TITLE
fix(@expo/cli): use `require.resolve` to resolve `@expo/router-server` path

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Reallow connections on `/expo-dev-plugins/broadcast` broadcast socket to local connections ([#42538](https://github.com/expo/expo/pull/42538) by [@kitten](https://github.com/kitten))
 - Fix `freeport-async` replacement ([#42509](https://github.com/expo/expo/pull/42509) by [@kitten](https://github.com/kitten))
+- Use `require.resolve` to resolve `@expo/router-server` path ([#42516](https://github.com/expo/expo/pull/42516) by [@hassankhan](https://github.com/hassankhan))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -362,10 +362,13 @@ export class MetroBundlerDevServer extends BundlerDevServer {
     includeSourceMaps?: boolean;
     platform?: string;
   }) {
-    const renderModule = await this.ssrLoadModuleContents('@expo/router-server/node/render.js', {
-      environment: 'node',
-      platform,
-    });
+    const renderModule = await this.ssrLoadModuleContents(
+      require.resolve('@expo/router-server/node/render.js'),
+      {
+        environment: 'node',
+        platform,
+      }
+    );
 
     await this.exportServerRouteAsync({
       contents: renderModule,
@@ -447,7 +450,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
     // NOTE: This could probably be folded back into `renderStaticContent` when expo-asset and font support RSC.
     const { getBuildTimeServerManifestAsync, getManifest } = await this.ssrLoadModule<
       typeof import('@expo/router-server/build/static/getServerManifest')
-    >('@expo/router-server/build/static/getServerManifest.js', {
+    >(require.resolve('@expo/router-server/build/static/getServerManifest.js'), {
       // Only use react-server environment when the routes are using react-server rendering by default.
       environment: this.isReactServerRoutesEnabled ? 'react-server' : 'node',
     });
@@ -483,7 +486,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
     const { getStaticContent, getManifest, getBuildTimeServerManifestAsync } =
       await this.ssrLoadModule<
         typeof import('@expo/router-server/build/static/renderStaticContent')
-      >('@expo/router-server/node/render.js', {
+      >(require.resolve('@expo/router-server/node/render.js'), {
         // This must always use the legacy rendering resolution (no `react-server`) because it leverages
         // the previous React SSG utilities which aren't available in React 19.
         environment: 'node',
@@ -611,7 +614,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
     const bundleStaticHtml = async (): Promise<string> => {
       const { getStaticContent } = await this.ssrLoadModule<
         typeof import('@expo/router-server/build/static/renderStaticContent')
-      >('@expo/router-server/node/render.js', {
+      >(require.resolve('@expo/router-server/node/render.js'), {
         // This must always use the legacy rendering resolution (no `react-server`) because it leverages
         // the previous React SSG utilities which aren't available in React 19.
         environment: 'node',

--- a/packages/@expo/cli/src/start/server/metro/createServerComponentsMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/createServerComponentsMiddleware.ts
@@ -66,8 +66,8 @@ export function createServerComponentsMiddleware(
   }
 ) {
   const routerModule = useClientRouter
-    ? '@expo/router-server/build/rsc/router/noopRouter'
-    : '@expo/router-server/build/rsc/router/expo-definedRouter';
+    ? require.resolve('@expo/router-server/build/rsc/router/noopRouter')
+    : require.resolve('@expo/router-server/build/rsc/router/expo-definedRouter');
 
   const rscMiddleware = getRscMiddleware({
     config: {},
@@ -469,7 +469,7 @@ export function createServerComponentsMiddleware(
     // TODO: Extract CSS Modules / Assets from the bundler process
     const renderer = await ssrLoadModule<
       typeof import('@expo/router-server/build/rsc/rsc-renderer')
-    >('@expo/router-server/build/rsc/rsc-renderer', {
+    >(require.resolve('@expo/router-server/build/rsc/rsc-renderer'), {
       environment: 'react-server',
       platform,
     });

--- a/packages/@expo/cli/src/start/server/metro/fetchRouterManifest.ts
+++ b/packages/@expo/cli/src/start/server/metro/fetchRouterManifest.ts
@@ -5,13 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 import type { Options as RoutesManifestOptions } from '@expo/router-server/build/routes-manifest';
-import { type MiddlewareInfo, type RouteInfo, type RoutesManifest } from 'expo-server/private';
-import resolveFrom from 'resolve-from';
+import { type RoutesManifest } from 'expo-server/private';
 
 import { getRoutePaths } from './router';
 
 function getExpoRouteManifestBuilderAsync(projectRoot: string) {
-  return require(resolveFrom(projectRoot, '@expo/router-server/build/routes-manifest'))
+  return require('@expo/router-server/build/routes-manifest')
     .createRoutesManifest as typeof import('@expo/router-server/build/routes-manifest').createRoutesManifest;
 }
 

--- a/packages/@expo/cli/src/start/server/type-generation/routes.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/routes.ts
@@ -1,7 +1,6 @@
 import type Server from '@expo/metro/metro/Server';
 import fs from 'fs/promises';
 import path from 'path';
-import resolveFrom from 'resolve-from';
 
 import { directoryExistsAsync } from '../../../utils/dir';
 import { unsafeTemplate } from '../../../utils/template';
@@ -42,11 +41,12 @@ export async function setupTypedRoutes(options: SetupTypedRoutesOptions) {
    *
    * TODO (@marklawlor): Remove this check in SDK 53, only support Expo Router v4 and above.
    */
-  const typedRoutesModule = resolveFrom.silent(
-    options.projectRoot,
-    '@expo/router-server/build/typed-routes'
-  );
-  return typedRoutesModule ? typedRoutes(typedRoutesModule, options) : legacyTypedRoutes(options);
+  try {
+    const typedRoutesModule = require.resolve('@expo/router-server/build/typed-routes');
+    return typedRoutes(typedRoutesModule, options);
+  } catch {
+    return legacyTypedRoutes(options);
+  }
 }
 
 async function typedRoutes(


### PR DESCRIPTION
# Why

npm installs dependencies slightly differently compared to Bun/pnpm; when using npm, the `@expo/router-server` package would get installed under `node_modules/@expo/cli/node_modules` rather than being hoisted to the top-level `node_modules/`.

Because we were using `resolve-from` to resolve the package from the project root, it wasn't able to find the package, hence causing the error.

Fixes https://github.com/expo/expo/issues/42505.

# How

Replace usages of `resolve-from` with `require.resolve` when trying to resolve `@expo/router-server`.

# Test Plan

1. Built `expo-router` with the changes in this PR and packed them with `npm pack`
2. Created new projects with:
    - `npx create-expo-app@latest --template default@next`
    - `bunx create-expo-app@latest --template default@next`
    - `pnpx create-expo-app@latest --template default@next`
3. Installed the tarball from Step 1 into each of the newly-created projects and ran the `web` package script

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
