### PR TITLE
Add allowedValues validation for string-or-boolean args

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 💡 Others
 
+- Add allowedValues validation for string-or-boolean args ([#42523](https://github.com/expo/expo/pull/42523) by [@brentvatne](https://github.com/brentvatne))
 - Drop `freeport-async` dependency ([#42478](https://github.com/expo/expo/pull/42478) by [@kitten](https://github.com/kitten))
 - Drop `pretty-bytes` for `Intl.NumberFormat` call with fallback ([#42482](https://github.com/expo/expo/pull/42482) by [@kitten](https://github.com/kitten))
 

--- a/packages/@expo/cli/e2e/__tests__/export.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export.test.ts
@@ -64,7 +64,7 @@ it('runs `npx expo export --help`', async () => {
         --dump-assetmap            Emit an asset map for further processing
         --no-ssg, --api-only       Skip exporting static HTML files and only export API routes for web
         -p, --platform <platform>  Options: android, ios, web, all. Default: all
-        -s, --source-maps [mode]   Emit JavaScript source maps. mode: external (when omitted), inline
+        -s, --source-maps [mode]   Emit JavaScript source maps. Options: true, false, inline, external. Default: false
         -c, --clear                Clear the bundler cache
         -h, --help                 Usage info
     "

--- a/packages/@expo/cli/src/export/index.ts
+++ b/packages/@expo/cli/src/export/index.ts
@@ -56,7 +56,7 @@ export const expoExport: Command = async (argv) => {
         `--dump-assetmap            Emit an asset map for further processing`,
         `--no-ssg, --api-only       Skip exporting static HTML files and only export API routes for web`,
         chalk`-p, --platform <platform>  Options: android, ios, web, all. {dim Default: all}`,
-        chalk`-s, --source-maps [mode]   Emit JavaScript source maps. {dim mode: external (when omitted), inline}`,
+        chalk`-s, --source-maps [mode]   Emit JavaScript source maps. {dim Options: true, false, inline, external. Default: false}`,
         `-c, --clear                Clear the bundler cache`,
         `-h, --help                 Usage info`,
       ].join('\n')
@@ -66,7 +66,8 @@ export const expoExport: Command = async (argv) => {
   // Handle --source-maps which can be a string or boolean (e.g., --source-maps or --source-maps inline)
   const { resolveStringOrBooleanArgsAsync } = await import('../utils/resolveArgs.js');
   const parsed = await resolveStringOrBooleanArgsAsync(argv ?? [], rawArgsMap, {
-    '--source-maps': Boolean,
+    // Restrict to 'true', 'false', 'inline', 'external'. Other values are treated as project root.
+    '--source-maps': [Boolean, 'inline', 'external'],
     '-s': '--source-maps',
     // Deprecated
     '--dump-sourcemap': '--source-maps',


### PR DESCRIPTION
This PR makes it so that we can parse out a boolean or an allowed value from `--source-maps [opt]` - and if the `opt` is not either `true`, `false`, `external`, `inline`, then we treat it as the project root.

I'm not so excited about this PR but if we want to avoid adding an `--inline-source-maps` flag then I think the behavior from this PR is important to ensure that `--source-maps [opt]` works nicely with the existing project root param.