### PR TITLE
[expo] update @sentry/react-native version to ~7.10.0

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -115,6 +115,6 @@
   "unimodules-image-loader-interface": "~6.1.0",
   "@shopify/react-native-skia": "2.4.14",
   "@shopify/flash-list": "2.0.2",
-  "@sentry/react-native": "~7.2.0",
+  "@sentry/react-native": "~7.10.0",
   "react-native-bootsplash": "^6.3.10"
 }


### PR DESCRIPTION
# Why

Closes #42494

# How

Upgraded recommended Sentry dep to latest stable version.

# Test Plan

I bumped Sentry on my project and rebuilt it.
