### PR TITLE
[docs] Add EAS Hosting deployment support to github-comment workflow job

### DIFF
--- a/docs/pages/eas/hosting/workflows.mdx
+++ b/docs/pages/eas/hosting/workflows.mdx
@@ -39,7 +39,7 @@ You can also test this workflow by triggering it manually:
 
 ## Create a PR preview workflow
 
-Add the following file to **.eas/workflows/pr-preview.yml**. This will automatically deploy a preview of your website whenever a pull request is created or updated, and post a comment to the PR with the preview URL.
+Add the following file to **.eas/workflows/pr-preview.yml**. This will automatically deploy a preview of your website whenever a pull request is created or updated, and post a comment to the PR with the deployment details.
 
 ```yaml .eas/workflows/pr-preview.yml
 name: PR Preview
@@ -55,8 +55,6 @@ jobs:
   comment:
     needs: [deploy]
     type: github-comment
-    params:
-      message: 'Preview URL: ${{ needs.deploy.outputs.deploy_url }}'
 ```
 
-This workflow will run whenever a pull request is opened, reopened, or synchronized. The `comment` job will automatically post the preview URL to the pull request, making it easy for reviewers to test your changes.
+This workflow will run whenever a pull request is opened, reopened, or synchronized. The `comment` job will automatically discover the deployment and post its details to the pull request, making it easy for reviewers to test your changes.

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1210,7 +1210,7 @@ jobs:
 
 ## GitHub Comment
 
-Automatically post reports of your workflow's completed builds and updates to GitHub pull requests. It's particularly useful for providing instant feedback on PR builds, sharing test builds with QR codes for easy device testing, and automating deployment notifications. You can also override the comment contents by providing the `payload` parameter.
+Automatically post reports of your workflow's completed builds, updates, and deployments to GitHub pull requests. It's particularly useful for providing instant feedback on PR builds, sharing test builds with QR codes for easy device testing, displaying EAS Hosting deployment previews, and automating deployment notifications. You can also override the comment contents by providing the `payload` parameter.
 
 ### Prerequisites
 
@@ -1226,8 +1226,9 @@ jobs:
       message: string # optional - custom message to include in the report
       build_ids: string[] # optional - specific build IDs to include, defaults to all related to the running workflow
       update_group_ids: string[] # optional - specific update group IDs to include, defaults to all related to the workflow
+      deployment_ids: string[] # optional - specific deployment IDs to include, defaults to all related to the workflow
 
-  # instead of using message and the builds and updates table, you can also override the comment contents with `payload`
+  # instead of using message and the builds, updates, and deployments table, you can also override the comment contents with `payload`
   custom_github_comment:
     type: github-comment
     params:
@@ -1244,11 +1245,12 @@ Default behavior is auto discovery builds and updates, you can specify any of th
 
 | Parameter        | Type     | Description                                                                                                                                                      |
 | ---------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| message          | string   | Optional. Custom message to include at the top of the comment. Defaults to "Your builds and updates are ready for testing!"                                      |
+| message          | string   | Optional. Custom message to include at the top of the comment. Defaults to "Your builds, updates, and deployments are ready for testing!"                        |
 | build_ids        | string[] | Optional. Array of specific build IDs to include. If not specified, auto-discovers all completed/failed/canceled builds. Use empty array `[]` to exclude builds. |
 | update_group_ids | string[] | Optional. Array of specific update group IDs to include. If not specified, auto-discovers all successful updates. Use empty array `[]` to exclude updates.       |
+| deployment_ids   | string[] | Optional. Array of specific deployment IDs to include. If not specified, auto-discovers all successful deployments. Use empty array `[]` to exclude deployments. |
 
-> **Auto-discovery behavior**: When `build_ids` or `update_group_ids` are not specified (undefined), the job automatically discovers all relevant builds and updates from the current workflow. To explicitly exclude builds or updates, pass an empty array `[]`.
+> **Auto-discovery behavior**: When `build_ids`, `update_group_ids`, or `deployment_ids` are not specified (undefined), the job automatically discovers all relevant builds, updates, and deployments from the current workflow. To explicitly exclude builds, updates, or deployments, pass an empty array `[]`.
 
 ##### Mode 2: Payload mode
 
@@ -1272,9 +1274,9 @@ Here are practical examples demonstrating both modes of the GitHub Comment job:
 
 #### Auto-with-overrides mode examples
 
-<Collapsible summary="Auto-discover all builds and updates">
+<Collapsible summary="Auto-discover all builds, updates, and deployments">
 
-This is the simplest usage - automatically discovers and posts all builds and updates from the workflow.
+This is the simplest usage - automatically discovers and posts all builds, updates, and deployments from the workflow.
 
 ```yaml .eas/workflows/pr-auto-comment.yml
 name: PR Auto Comment
@@ -1287,16 +1289,16 @@ jobs:
 
   comment_on_pr:
     name: Post Results to PR
-    after: [build_ios, build_android, publish_update]
+    after: [build_ios, build_android, publish_update, deploy]
     type: github-comment
-    # No params needed - auto-discovers all builds and updates
+    # No params needed - auto-discovers all builds, updates, and deployments
 ```
 
 </Collapsible>
 
 <Collapsible summary="Custom message with auto-discovery">
 
-Adds a custom message while still auto-discovering all builds and updates.
+Adds a custom message while still auto-discovering all builds, updates, and deployments.
 
 ```yaml .eas/workflows/pr-custom-message.yml
 name: PR Custom Message
@@ -1309,11 +1311,33 @@ jobs:
 
   comment_on_pr:
     name: Post Build to PR
-    after: [build_ios, build_android, publish_update]
+    after: [build_ios, build_android, publish_update, deploy]
     type: github-comment
     params:
       message: '🎉 Preview builds are ready! Please test these changes before approving the PR.'
-      # build_ids and update_group_ids are undefined, so auto-discovery is enabled
+      # build_ids, update_group_ids, and deployment_ids are undefined, so auto-discovery is enabled
+```
+
+</Collapsible>
+
+<Collapsible summary="PR preview with EAS Hosting deployment">
+
+This workflow deploys a preview of your website using EAS Hosting and posts the deployment details to the pull request.
+
+```yaml .eas/workflows/pr-preview.yml
+name: PR Preview
+
+on:
+  pull_request: {}
+
+jobs:
+  deploy:
+    type: deploy
+    name: Deploy PR Preview
+
+  comment:
+    needs: [deploy]
+    type: github-comment
 ```
 
 </Collapsible>
@@ -1346,7 +1370,7 @@ jobs:
 
 </Collapsible>
 
-<Collapsible summary="Exclude builds or updates">
+<Collapsible summary="Exclude builds, updates, or deployments">
 
 Use empty arrays to exclude specific content types.
 
@@ -1366,6 +1390,7 @@ jobs:
     params:
       message: 'New update available for testing!'
       build_ids: [] # Empty array excludes all builds
+      deployment_ids: [] # Empty array excludes all deployments
       # update_group_ids undefined = auto-discover updates
 ```
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -1146,7 +1146,7 @@ jobs:
 
 #### `github-comment`
 
-Automatically posts comprehensive reports of your workflow's completed builds and updates to GitHub pull requests or content provided by you. See [GitHub Comment job documentation](/eas/workflows/pre-packaged-jobs#github-comment) for detailed information and examples.
+Automatically posts comprehensive reports of your workflow's completed builds, updates, and deployments to GitHub pull requests or content provided by you. See [GitHub Comment job documentation](/eas/workflows/pre-packaged-jobs#github-comment) for detailed information and examples.
 
 ```yaml
 jobs:
@@ -1158,8 +1158,9 @@ jobs:
       message: string # optional - custom message to include in the report
       build_ids: string[] # optional - specific build IDs to include, defaults to all related to the running workflow
       update_group_ids: string[] # optional - specific update group IDs to include, defaults to all related to the workflow
+      deployment_ids: string[] # optional - specific deployment IDs to include, defaults to all related to the workflow
 
-  # instead of using message and the builds and updates table, you can also override the comment contents with `payload`
+  # instead of using message and the builds, updates, and deployments table, you can also override the comment contents with `payload`
   custom_github_comment:
     type: github-comment
     params:


### PR DESCRIPTION
# Why

The `github-comment` workflow job now supports auto-discovery of EAS Hosting deployments, but the documentation doesn't reflect this new capability.

Closes ENG-18932

# How

  - Update `github-comment` documentation to include deployments alongside builds and updates
  - Add `deployment_ids` parameter to the syntax reference
  - Add "PR preview with EAS Hosting deployment" example
  - Simplify the PR preview example in hosting/workflows.mdx by removing manual `message` parameter
  - Update syntax.mdx to match

# Test Plan

- Verified locally by running `yarn dev`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
