### PR TITLE
fix(expo-modules-core): reorder initializer list in `JavaScriptRuntime` constructor

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
@@ -14,7 +14,7 @@ namespace expo {
 JavaScriptRuntime::JavaScriptRuntime(
   jsi::Runtime *runtime,
   std::shared_ptr<react::CallInvoker> jsInvoker
-) : runtime(runtime), jsInvoker(std::move(jsInvoker)) {
+) : jsInvoker(std::move(jsInvoker)), runtime(runtime) {
 }
 
 jsi::Runtime &JavaScriptRuntime::get() const noexcept {


### PR DESCRIPTION
# Why

This PR fixes the following warning when building Expo prebuild app for Android:

```
> Task :expo-modules-core:buildCMakeDebug[arm64-v8a]
C/C++: ninja: Entering directory `/Users/tomekzaw/Private/OdjazdowyKrk/node_modules/expo-modules-core/android/.cxx/Debug/6h6ze2qr/arm64-v8a'
C/C++: /Users/tomekzaw/Private/OdjazdowyKrk/node_modules/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp:17:5: warning: field 'runtime' will be initialized after field 'jsInvoker' [-Wreorder-ctor]
C/C++:    17 | ) : runtime(runtime), jsInvoker(std::move(jsInvoker)) {
C/C++:       |     ^~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C/C++:       |     jsInvoker(std::move(jsInvoker)) runtime(runtime)
C/C++: 1 warning generated.
```

# How

I swapped `runtime` and `jsInvoker` in the initializer list.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
