### PR TITLE
[expo-router][ios] activate native zoom preventDismissal only when hook is used

### DIFF
--- a/apps/router-e2e/__e2e__/link-preview/app/zoom-dest-list.tsx
+++ b/apps/router-e2e/__e2e__/link-preview/app/zoom-dest-list.tsx
@@ -1,22 +1,9 @@
-import { Link, usePreventZoomTransitionDismissal } from 'expo-router';
-import { useState } from 'react';
+import { Link } from 'expo-router';
 import { Image, ScrollView, View } from 'react-native';
 
 export default function ZoomDestScreen() {
-  const [shouldPrevent, setShouldPrevent] = useState(false);
-  usePreventZoomTransitionDismissal(
-    shouldPrevent
-      ? undefined
-      : {
-          unstable_dismissalBoundsRect: { minX: 0, minY: 0 },
-        }
-  );
   return (
-    <ScrollView
-      style={{ flex: 1 }}
-      onScroll={(event) => {
-        setShouldPrevent(event.nativeEvent.contentOffset.y > 1);
-      }}>
+    <ScrollView style={{ flex: 1 }}>
       <Link.AppleZoomTarget>
         <View style={{ width: '100%', aspectRatio: 1 }}>
           <Image

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - fix toolbar placement updates ([#42585](https://github.com/expo/expo/pull/42585) by [@Ubax](https://github.com/Ubax))
+- [ios] activate native zoom preventDismissal only when hook is used ([#42533](https://github.com/expo/expo/pull/42533) by [@Ubax](https://github.com/Ubax))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/42255

When using the native zoom transition in expo-router on iOS, the `interactiveDismissShouldBegin` callback was always set, even when `usePreventZoomTransitionDismissal` hook wasn't used. This caused issues, especially when integrating with `ScrollView`

**Before**


https://github.com/user-attachments/assets/0cd5ba48-4234-4afa-80c1-8b603fdcf9ed



**After**

https://github.com/user-attachments/assets/b7c06978-c5b2-4bc8-a081-69c5ba80d3f0

# How

Modified `LinkZoomTransitionEnabler.swift` to only set the `interactiveDismissShouldBegin` callback when `dismissalBoundsRect` is explicitly provided via the hook. When the hook isn't used (or when `dismissalBoundsRect` is nil), iOS now uses its default dismissal behavior.

# Test Plan

Manual testing

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
