### PR TITLE
[ios][screen-orientation] Restore orientationMask when orientationController re-register

### DIFF
--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] [New Architecture] Restore orientationMask after app transition from background to foreground ([#42536](https://github.com/expo/expo/pull/42536) by [@LongyuW](https://github.com/LongyuW))
+
 ### 💡 Others
 
 ## 55.0.4 — 2026-02-03

--- a/packages/expo-screen-orientation/ios/ScreenOrientationModule.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationModule.swift
@@ -3,6 +3,7 @@ import ExpoModulesCore
 public class ScreenOrientationModule: Module, ScreenOrientationController {
   static let didUpdateDimensionsEvent = "expoDidUpdateDimensions"
   let screenOrientationRegistry = ScreenOrientationRegistry.shared
+  private var lastSetOrientationMask: UIInterfaceOrientationMask?
 
   public func definition() -> ModuleDefinition {
     Name("ExpoScreenOrientation")
@@ -19,7 +20,7 @@ public class ScreenOrientationModule: Module, ScreenOrientationController {
       guard orientationMask.isSupportedByDevice() else {
         throw UnsupportedOrientationLockException(orientationLock)
       }
-
+      self.lastSetOrientationMask = orientationMask
       screenOrientationRegistry.setMask(orientationMask, forController: self)
     }
 
@@ -40,7 +41,7 @@ public class ScreenOrientationModule: Module, ScreenOrientationController {
       guard allowedOrientationsMask.isSupportedByDevice() else {
         throw UnsupportedOrientationLockException(nil)
       }
-
+      self.lastSetOrientationMask = allowedOrientationsMask
       screenOrientationRegistry.setMask(allowedOrientationsMask, forController: self)
     }
 
@@ -83,6 +84,11 @@ public class ScreenOrientationModule: Module, ScreenOrientationController {
 
     OnAppEntersForeground {
       screenOrientationRegistry.registerController(self)
+
+      // Re-apply the last set orientation mask when the app comes to foreground
+      if let lastMask = self.lastSetOrientationMask {
+        screenOrientationRegistry.setMask(lastMask, forController: self)
+      }
     }
 
     OnAppEntersBackground {


### PR DESCRIPTION
Fix for **NEW ARCHITECTURE** only, restore the orientationMask after iOS app background/foreground transition.

# Why
- **Problem:** 
On the new architecture the ScreenOrientationController is explicitly unregistered when the app goes to background and re-registered on foreground. That lifecycle causes the controller to lose its transient orientation lock state (the lastSetOrientationMask) that was set by the previously visible screen, producing incorrect orientation after returning to foreground.

Also noticed a flicker issue happen on iOS 26 if any ts/js code changes tried to restore previous lock rule by checking app active status. 

- **Root cause:** 
The new-architecture controller instance is not persistent across background/foreground transitions, so any in-memory orientation mask previously applied is lost when the controller is unregistered.

- **Contrast with old architecture:** 
The old architecture kept the orientation controller (and its orientationMask) alive across background/foreground, so no re-application was necessary and the lock persisted.


Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This iOS native fix resolved new architecture react native iOS app issue. 
Haven't found an exiting issue related it, if needed, please let me know if I could open an issue for it. Thanks team!

# How

- **Fix:** Persist and re-apply the last orientation mask when the app re-enters foreground (re-register path). This ensures the previously applied lock is restored immediately after re-registration.

- **Result:** Prevents orientation flicker or unexpected rotations when returning from background and preserves the intended orientation lock behavior on the new architecture.

# Test Plan
Would like to generate test version for iOS app testing.

The solution was tested on iOS version 16, 18 and 26. It was working well.

**Steps to reproduce issue:**
1. New architecture react native iOS app with expo-screen-orientation library.
2. Set orientation config as default (unlock app).
3. Set the lockAsync as PORTRAIT_UP or LANDSCAPE_LEFT
4. Switch app from foreground -> background -> foreground 
(Note: do not fully close the iOS app)

**Expected:**
The app screen is keeping on the previous screen, and the orientation should keep previous lock rule: PORTRAIT_UP or LANDSCAPE_LEFT

**Actual:**
The app is as unlock.


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
