### PR TITLE
[dev-launcher] fix safe area sometimes not applied

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- fix safe area sometimes not applied ([#42537](https://github.com/expo/expo/pull/42537) by [@vonovak](https://github.com/vonovak))
+
 ### 💡 Others
 
 ## 55.0.2 — 2026-01-22

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -222,7 +222,7 @@
   [self.delegate destroyReactInstance];
 
   if (_devLauncherViewController != nil) {
-    [_devLauncherViewController resetHostingController];
+    [_devLauncherViewController restoreHostingControllerView];
   }
 }
 

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -4,40 +4,6 @@ import ExpoModulesCore
 import EXUpdatesInterface
 import React
 
-private class DevLauncherWrapperView: UIView {
-  weak var devLauncherViewController: UIViewController?
-
-#if !os(macOS)
-  override func didMoveToWindow() {
-    super.didMoveToWindow()
-
-    guard let devLauncherViewController,
-      let window,
-      let rootViewController = window.rootViewController else {
-      return
-    }
-
-    let isSwiftUIController = NSStringFromClass(type(of: rootViewController)).contains("UIHostingController")
-    // TODO(pmleczek): Revisit this for a more reliable solution
-    let isBrownfield = NSStringFromClass(type(of: rootViewController)).contains("UINavigationController")
-    if !isSwiftUIController && !isBrownfield && devLauncherViewController.parent != rootViewController {
-      rootViewController.addChild(devLauncherViewController)
-      devLauncherViewController.didMove(toParent: rootViewController)
-      devLauncherViewController.view.setNeedsLayout()
-      devLauncherViewController.view.layoutIfNeeded()
-    }
-  }
-
-  override func willMove(toWindow newWindow: UIWindow?) {
-    super.willMove(toWindow: newWindow)
-    if newWindow == nil {
-      devLauncherViewController?.willMove(toParent: nil)
-      devLauncherViewController?.removeFromParent()
-    }
-  }
-#endif
-}
-
 @objc
 public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, EXDevLauncherControllerDelegate {
   private weak var reactNativeFactory: RCTReactNativeFactory?
@@ -75,8 +41,7 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, EXDe
     rootViewController = viewController
 
     // We need to create a wrapper View because React Native Factory will reassign rootViewController later
-    let wrapperView = DevLauncherWrapperView()
-    wrapperView.devLauncherViewController = viewController
+    let wrapperView = UIView()
     wrapperView.addSubview(viewController.view)
     viewController.view.translatesAutoresizingMaskIntoConstraints = false
     NSLayoutConstraint.activate([

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewController.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewController.swift
@@ -2,62 +2,85 @@ import SwiftUI
 import ExpoModulesCore
 
 @objc public class DevLauncherViewController: UIViewController {
-  private var hostingController: UIHostingController<DevLauncherRootView>?
   var viewModel = DevLauncherViewModel()
+
+  private lazy var hostingController: UIHostingController<DevLauncherRootView> = {
+    let rootView = DevLauncherRootView(viewModel: viewModel)
+    let controller = UIHostingController(rootView: rootView)
+    controller.view.backgroundColor = UIColor.clear
+#if os(macOS)
+    controller.view.appearance = NSAppearance(named: .aqua)
+#endif
+    return controller
+  }()
 
   public override func viewDidLoad() {
     super.viewDidLoad()
-    addHostingController()
+    ensureHostingControllerInHierarchy()
   }
 
-  private func setupViewController() {
-    view.backgroundColor = UIColor.white
-
-    let rootView = DevLauncherRootView(viewModel: viewModel)
-    hostingController = UIHostingController(rootView: rootView)
-    hostingController?.view.backgroundColor = UIColor.clear
-#if os(macOS)
-    hostingController?.view.appearance = NSAppearance(named: .aqua)
-#endif
-  }
-
-  @objc public func resetHostingController() {
 #if !os(macOS)
-    if let hostingController {
-      hostingController.willMove(toParent: nil)
-      hostingController.view.removeFromSuperview()
-      hostingController.removeFromParent()
-    }
-#endif
-    hostingController = nil
-    if isViewLoaded {
-      addHostingController()
-    }
+  public override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    addToViewControllerHierarchyIfNeeded()
   }
 
-  private func addHostingController() {
-    if hostingController == nil {
-      setupViewController()
-    }
-
-    guard let hostingController else {
+  private func addToViewControllerHierarchyIfNeeded() {
+    guard let window = view.window,
+          let rootViewController = window.rootViewController else {
       return
     }
 
-    addChild(hostingController)
-    hostingController.view.translatesAutoresizingMaskIntoConstraints = false
-    view.addSubview(hostingController.view)
+    let isSwiftUIController = NSStringFromClass(type(of: rootViewController)).contains("UIHostingController")
+    let isBrownfield = NSStringFromClass(type(of: rootViewController)).contains("UINavigationController")
 
-    NSLayoutConstraint.activate([
-      hostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-      hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-      hostingController.view.topAnchor.constraint(equalTo: view.topAnchor),
-      hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-    ])
+    if !isSwiftUIController && !isBrownfield && parent != rootViewController {
+      rootViewController.addChild(self)
+      didMove(toParent: rootViewController)
+      view.setNeedsLayout()
+      view.layoutIfNeeded()
+    }
+  }
+
+  public override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+    // Only remove if actually being dismissed
+    if (isBeingDismissed || isMovingFromParent) && parent != nil {
+      willMove(toParent: nil)
+      removeFromParent()
+    }
+  }
+#endif
+
+  // Restores the hosting controller's view to the hierarchy after it was orphaned
+  // by the React root view replacing DevLauncherViewController.view.
+  @objc public func restoreHostingControllerView() {
+    ensureHostingControllerInHierarchy()
+  }
+
+  private func ensureHostingControllerInHierarchy() {
+    // Add as child VC if not already
+    if hostingController.parent == nil {
+      addChild(hostingController)
+#if !os(macOS)
+      hostingController.didMove(toParent: self)
+#endif
+    }
+
+    // Add view if not already in hierarchy (ExpoDevLauncherReactDelegateHandler.devLauncherController(_:didStartWithSuccess:) replaces DevLauncherViewController.view with the React root view)
+    if hostingController.view.superview == nil {
+      hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+      view.addSubview(hostingController.view)
+      NSLayoutConstraint.activate([
+        hostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+        hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+        hostingController.view.topAnchor.constraint(equalTo: view.topAnchor),
+        hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+      ])
+    }
 
 #if !os(macOS)
     navigationController?.setNavigationBarHidden(true, animated: false)
-    hostingController.didMove(toParent: self)
 #endif
   }
 }

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
@@ -96,7 +96,7 @@ public class ExpoReactNativeFactory: ExpoReactNativeFactoryObjC, ExpoReactNative
     initialProps: [AnyHashable: Any]?,
     launchOptions: [AnyHashable: Any]?
   ) -> UIView {
-    guard let delegate = self.delegate else {
+    guard self.delegate != nil else {
       fatalError("recreateRootView: Missing RCTReactNativeFactoryDelegate")
     }
 


### PR DESCRIPTION
# Why

sdk 55 dev client sometimes doesn't factor in safe area in the header

repro: run app with metro running, kill app and metro, start app again.


# How

`resetHostingController` (now `restoreHostingControllerView`) previously destroyed and recreated the hosting controller (losing proper safe area spacing). The new one just ensures it's in the hierarchy - it never tears it down. 

# Test Plan

- tested this with the notification tester app

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
