### PR TITLE
fix(cli): Reallow connections on `/expo-dev-plugins/broadcast` broadcast socket to local connections

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Reallow connections on `/expo-dev-plugins/broadcast` broadcast socket to local connections ([#42538](https://github.com/expo/expo/pull/42538) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 - Drop `freeport-async` dependency ([#42478](https://github.com/expo/expo/pull/42478) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/cli/src/start/server/metro/DevToolsPluginWebsocketEndpoint.ts
+++ b/packages/@expo/cli/src/start/server/metro/DevToolsPluginWebsocketEndpoint.ts
@@ -1,6 +1,6 @@
 import { WebSocket, WebSocketServer } from 'ws';
 
-import { isLocalSocket, isMatchingOrigin } from '../../../utils/net';
+import { isMatchingOrigin } from '../../../utils/net';
 
 interface DevToolsPluginWebsocketEndpointParams {
   serverBaseUrl: string;
@@ -13,7 +13,7 @@ export function createDevToolsPluginWebsocketEndpoint({
 
   wss.on('connection', (ws, request) => {
     // Explicitly limit devtools websocket to loopback requests
-    if (!isLocalSocket(request.socket) || !isMatchingOrigin(request, serverBaseUrl)) {
+    if (request.headers.origin && !isMatchingOrigin(request, serverBaseUrl)) {
       // NOTE: `socket.close` nicely closes the websocket, which will still allow incoming messages
       // `socket.terminate` instead forcefully closes down the socket
       ws.terminate();


### PR DESCRIPTION
# Why

Reverts part of #42156 for `expo-dev-plugins` and only leaves behind a conditional `Origin` check since the broadcast socket doesn't differentiate between the Web UI and clients.

Must be backported to the same branches (`sdk-54`, `sdk-53`, `sdk-52`)

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
