### PR TITLE
[dev-launcher] Fix safe area

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -3854,7 +3854,7 @@ SPEC CHECKSUMS:
   EXUpdates: de8bb2659b9861c6ee4e39b9c90d15d72601e1f4
   EXUpdatesInterface: 48272cb8995e613f0843fe531347e2f783e1df5f
   FBLazyVector: 3a7ea85f6009224ad89f7daeda516f189e6b5759
-  hermes-engine: 46fce5491dbe4962025d06f9bb2f860c231839f8
+  hermes-engine: 6bb3000824be2770010ae038914fa26721255c8e
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -3872,7 +3872,7 @@ SPEC CHECKSUMS:
   React: 4bc1f928568ad4bcfd147260f907b4ea5873a03b
   React-callinvoker: 8dd44c31888a314694efd0ef5f19ab7e0e855ef8
   React-Core: 0c1f3042e1204c0512b2e4263062c66550d7e6a3
-  React-Core-prebuilt: 083f4a23208b7c4789739103c467d04ced7cbdcc
+  React-Core-prebuilt: 7894b037a2f0fa699a44de6c88d20acd4235b255
   React-CoreModules: f6a626221d52f21b5eb8df2d79780b96f20240e5
   React-cxxreact: 2e3990595049d43dd1d59ccd6cb35545f0dc6f03
   React-debug: 60be0767f5672afc81bfd6a50d996507430f7906
@@ -3942,7 +3942,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: bfb12ead469222b022a2024f32aba47ce50de512
   ReactCodegen: b9b0ea5c72e425fa5a89a031ada3e64dfd839771
   ReactCommon: 0084791d25c4deae3d8b77efd4440fb2d5c38746
-  ReactNativeDependencies: fbc8678e9f0e4f553245e4669a3a8d19ba03bb13
+  ReactNativeDependencies: 17a617edb4d5883a4c48339514ccb8b765f8af4f
   RNCAsyncStorage: e85a99325df9eb0191a6ee2b2a842644c7eb29f4
   RNCMaskedView: 3c9d7586e2b9bbab573591dcb823918bc4668005
   RNCPicker: e0149590451d5eae242cf686014a6f6d808f93c7

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix issue where the header would overlap the safe area. ([#42540](https://github.com/expo/expo/pull/42540) by [@alanjhughes](https://github.com/alanjhughes))
+
 ### 💡 Others
 
 ## 55.0.3 — 2026-01-26

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewController.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewController.swift
@@ -10,6 +10,23 @@ import ExpoModulesCore
     addHostingController()
   }
 
+#if !os(macOS)
+  public override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+    updateTopSafeAreaInset()
+  }
+
+  private func updateTopSafeAreaInset() {
+    let hostingViewInset = hostingController?.view.safeAreaInsets.top ?? 0
+    let windowInset = view.window?.safeAreaInsets.top ?? 0
+    let newInset: CGFloat = hostingViewInset > 0 ? 0 : windowInset
+
+    if newInset != viewModel.topSafeAreaInset {
+      viewModel.topSafeAreaInset = newInset
+    }
+  }
+#endif
+
   private func setupViewController() {
     view.backgroundColor = UIColor.white
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
@@ -11,6 +11,8 @@ private let DEV_LAUNCHER_DEFAULT_SCHEME = "expo-dev-launcher"
 
 @MainActor
 class DevLauncherViewModel: ObservableObject {
+  /// Safe area inset for when VC hierarchy doesn't propagate it (e.g., SwiftUI/brownfield apps)
+  @Published var topSafeAreaInset: CGFloat = 0
   @Published var recentlyOpenedApps: [RecentlyOpenedApp] = []
   @Published var buildInfo: [AnyHashable: Any] = [:]
   @Published var updatesConfig: [AnyHashable: Any] = [:]

--- a/packages/expo-dev-launcher/ios/SwiftUI/Navigation/Navigation.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/Navigation/Navigation.swift
@@ -2,6 +2,17 @@
 import SwiftUI
 import ExpoModulesCore
 
+private struct SafeAreaTopPadding: View {
+  let manualInset: CGFloat
+
+  var body: some View {
+    if manualInset > 0 {
+      Color.expoSystemBackground
+        .frame(height: manualInset)
+    }
+  }
+}
+
 class DevLauncherNavigation: ObservableObject {
   @Binding var showingUserProfile: Bool
 
@@ -27,6 +38,13 @@ struct DevLauncherNavigationHeader: View {
   @EnvironmentObject var navigation: DevLauncherNavigation
 
   var body: some View {
+    VStack(spacing: 0) {
+      SafeAreaTopPadding(manualInset: viewModel.topSafeAreaInset)
+      headerContent
+    }
+  }
+
+  private var headerContent: some View {
     HStack {
       HStack(spacing: 12) {
         if let path = viewModel.buildInfo["appIcon"] as? String,


### PR DESCRIPTION
# Why
For some reason, when the app launches without any active dev servers, the hosting controller loses track of the safe area causing the navigation header to go inside the safe area. When there are active servers this doesn't happen. I haven't found the root cause.

# How
We track the safe area manually, if the hostingVCs safe area is 0, we inject the value from the window. If not, we inject 0 and let swift ui manage the safe area itself.

# Test Plan
Bare expo

