### PR TITLE
[dev-menu] Add delegate method to disable showing rn menu

### DIFF
--- a/packages/expo-dev-menu-interface/ios/DevMenuHostDelegate.swift
+++ b/packages/expo-dev-menu-interface/ios/DevMenuHostDelegate.swift
@@ -18,4 +18,10 @@ public protocol DevMenuHostDelegate: NSObjectProtocol {
    Optional function to toggle the element inspector.
    */
   @objc optional func devMenuToggleElementInspector()
+
+  /**
+   Optional function to control whether the "Open React Native dev menu" option is shown.
+   Defaults to `true` if not implemented.
+   */
+  @objc optional func devMenuShouldShowReactNativeDevMenu() -> Bool
 }

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Add delegate method to control visibility of "Open React Native dev menu" option. ([#42541](https://github.com/expo/expo/pull/42541) by [@alanjhughes](https://github.com/alanjhughes))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -271,6 +271,15 @@ open class DevMenuManager: NSObject {
   }
 
   @objc
+  public var shouldShowReactNativeDevMenu: Bool {
+    guard let delegate = hostDelegate,
+      delegate.responds(to: #selector(DevMenuHostDelegate.devMenuShouldShowReactNativeDevMenu)) else {
+      return true
+    }
+    return delegate.devMenuShouldShowReactNativeDevMenu?() ?? true
+  }
+
+  @objc
   public func navigateHome() {
     guard let delegate = hostDelegate,
       delegate.responds(to: #selector(DevMenuHostDelegate.devMenuNavigateHome)) else {

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuMainView.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuMainView.swift
@@ -37,7 +37,9 @@ struct DevMenuMainView: View {
 
         DevMenuAppInfo()
 
-        DevMenuRNDevMenu(onOpenRNDevMenu: viewModel.openRNDevMenu)
+        if viewModel.shouldShowReactNativeDevMenu {
+          DevMenuRNDevMenu(onOpenRNDevMenu: viewModel.openRNDevMenu)
+        }
       }
       .padding()
     }

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
@@ -165,6 +165,10 @@ class DevMenuViewModel: ObservableObject {
     return devMenuManager.canNavigateHome
   }
 
+  var shouldShowReactNativeDevMenu: Bool {
+    return devMenuManager.shouldShowReactNativeDevMenu
+  }
+
   private func checkOnboardingStatus() {
     isOnboardingFinished = devMenuManager.isOnboardingFinished
   }


### PR DESCRIPTION
# Why
Adds a delegate method so you can choose to disable the "Open React Native dev menu" option.

# How
Add method to `DevMenuHostDelegate`

# Test Plan
Expo go. Option is disabled.
