### PR TITLE
[expo-go] Disable showing rn menu option

### DIFF
--- a/apps/expo-go/ios/Exponent/Kernel/Core/EXKernel.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Core/EXKernel.m
@@ -301,6 +301,10 @@ NSString * const kEXReloadActiveAppRequest = @"EXReloadActiveAppRequest";
   [[self visibleApp].appManager toggleElementInspector];
 }
 
+- (BOOL)devMenuShouldShowReactNativeDevMenu {
+  return NO;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -4724,7 +4724,7 @@ SPEC CHECKSUMS:
   GoogleAppMeasurement: 8a82b93a6400c8e6551c0bcd66a9177f2e067aed
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 5fe31775fd37ae963dff271e227decb44d08e843
+  hermes-engine: 452f2dd7422b2fd7973ae9ca103898d28d7744f0
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8


### PR DESCRIPTION
# Why
Implement new `DevMenuHostDelegate` method to disable "Open React Native dev menu" option in dev menu

# Test Plan
Expo go
