### PR TITLE
[iOS][widgets] Fix availability check

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Fixed availability check.
+
 ## 55.0.0-alpha.3 — 2026-01-26
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-widgets/ios/Widgets/LiveActivity.swift
+++ b/packages/expo-widgets/ios/Widgets/LiveActivity.swift
@@ -65,7 +65,7 @@ public struct WidgetLiveActivity: Widget {
 
 extension WidgetConfiguration {
   func supplementalActivityFamiliesIfAvailable() -> some WidgetConfiguration {
-    if #available(iOSApplicationExtension 18.0, *) {
+    if #available(iOS 18.0, iOSApplicationExtension 18.0, *) {
       return self.supplementalActivityFamilies([.small, .medium])
     } else {
       return self


### PR DESCRIPTION
# Why

Fixes CI: https://github.com/expo/expo/actions/runs/21346140051/job/61434136331

# How

Availability check should also include the platform requirement, not only `iOSApplicationExtension`. Currently, if `iOSApplicationExtension 18.0` is not met (when compiling for non-extension target), the entire check passes anyway as `*` matches all unlisted platforms.

# Test Plan

CI passes now: https://github.com/expo/expo/actions/runs/21358092293/job/61470220857