### PR TITLE
[docs] add zoom-transition docs to sidebar

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -270,6 +270,7 @@ export const general = [
       makePage('router/advanced/apple-handoff.mdx'),
       makePage('router/advanced/custom-tabs.mdx'),
       makePage('router/advanced/stack-toolbar.mdx'),
+      makePage('router/advanced/zoom-transition.mdx'),
     ]),
     makeGroup('Web', [
       makePage('router/web/api-routes.mdx'),

--- a/docs/pages/router/advanced/zoom-transition.mdx
+++ b/docs/pages/router/advanced/zoom-transition.mdx
@@ -6,7 +6,7 @@ description: Learn how to use the zoom transition to create fluid animations bet
 import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-> **important** Zoom transition is currently in [alpha](/more/release-statuses/#alpha) and available in [canary releases](/versions/latest/#using-pre-release-versions) of `expo-router`.
+> **important** Zoom transition is an alpha API available on **iOS only** in **Expo SDK 55** and later. The API is subject to breaking changes.
 
 <ContentSpotlight
   alt="A video presenting simple gallery with zoom transitions."


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
