### PR TITLE
[go][quest] Fix QR scanner in new expo-go for devices with no play services

### DIFF
--- a/apps/expo-go/android/expoview/src/main/AndroidManifest.xml
+++ b/apps/expo-go/android/expoview/src/main/AndroidManifest.xml
@@ -135,6 +135,11 @@
         <data android:scheme="expauth" />
       </intent-filter>
     </activity>
+
+    <activity
+      android:name="host.exp.exponent.home.qrScanner.QRScannerActivity"
+      android:exported="false"
+      android:theme="@style/Theme.AppCompat.NoActionBar" />
   </application>
 
 </manifest>

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/HomeScreen.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/HomeScreen.kt
@@ -1,6 +1,7 @@
 package host.exp.exponent.home
 
 import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -28,6 +29,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import host.exp.exponent.home.qrScanner.QRScannerActivity
 import host.exp.expoview.R
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -52,6 +54,11 @@ fun HomeScreen(
 
   val context = LocalContext.current
   val uriHandler = LocalUriHandler.current
+  val fallbackQrScannerLauncher = rememberLauncherForActivityResult(
+    contract = QRScannerActivity.Contract()
+  ) { url ->
+    url?.let { uriHandler.openUri(it) }
+  }
 
   val state = rememberPullToRefreshState()
   val onRefresh: () -> Unit = {
@@ -135,6 +142,9 @@ fun HomeScreen(
                 },
                 onError = { error ->
                   Toast.makeText(context, error, Toast.LENGTH_LONG).show()
+                },
+                onNoPlayServices = {
+                  fallbackQrScannerLauncher.launch(Unit)
                 }
               )
             }

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/qrScanner/DrawingUtils.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/qrScanner/DrawingUtils.kt
@@ -1,0 +1,41 @@
+package host.exp.exponent.home.qrScanner
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+
+fun DrawScope.drawRoundedCorner(
+  offset: Offset,
+  startAngle: Float,
+  strokeWidth: Float,
+  cornerRadius: Float,
+  horizontalLineStart: Offset,
+  horizontalLineEnd: Offset,
+  verticalLineStart: Offset,
+  verticalLineEnd: Offset,
+  color: Color = Color.White
+) {
+  drawArc(
+    color = color,
+    startAngle = startAngle,
+    sweepAngle = 90f,
+    useCenter = false,
+    topLeft = offset,
+    size = Size(cornerRadius * 2, cornerRadius * 2),
+    style = Stroke(width = strokeWidth)
+  )
+  drawLine(
+    color = color,
+    start = horizontalLineStart,
+    end = horizontalLineEnd,
+    strokeWidth = strokeWidth
+  )
+  drawLine(
+    color = color,
+    start = verticalLineStart,
+    end = verticalLineEnd,
+    strokeWidth = strokeWidth
+  )
+}

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/qrScanner/QRScannerActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/qrScanner/QRScannerActivity.kt
@@ -1,0 +1,155 @@
+package host.exp.exponent.home.qrScanner
+
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.mlkit.vision.MlKitAnalyzer
+import androidx.camera.view.PreviewView
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+import com.google.mlkit.vision.barcode.BarcodeScannerOptions
+import com.google.mlkit.vision.barcode.BarcodeScanning
+import com.google.mlkit.vision.barcode.common.Barcode
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+
+class QRScannerActivity : ComponentActivity() {
+  class Contract: ActivityResultContract<Unit, String?>() {
+    override fun createIntent(context: Context, input: Unit): Intent {
+      return Intent(context, QRScannerActivity::class.java)
+    }
+
+    override fun parseResult(resultCode: Int, intent: Intent?): String? {
+      return if (resultCode == RESULT_OK) {
+        intent?.getStringExtra("data")
+      } else {
+        null
+      }
+    }
+  }
+
+  private lateinit var cameraExecutor: ExecutorService
+  private val isScanned = AtomicBoolean(false)
+
+  private val requestPermissionLauncher =
+    registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted: Boolean ->
+      if (isGranted) {
+        startCamera()
+      } else {
+        Toast.makeText(this, "Camera permission required", Toast.LENGTH_SHORT).show()
+        finish()
+      }
+    }
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    cameraExecutor = Executors.newSingleThreadExecutor()
+
+    val cameraPermission = ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA)
+    if (cameraPermission == PackageManager.PERMISSION_GRANTED) {
+      startCamera()
+    } else {
+      requestPermissionLauncher.launch(Manifest.permission.CAMERA)
+    }
+  }
+
+  private fun startCamera() {
+    setContent {
+      Box(modifier = Modifier.fillMaxSize()) {
+        CameraPreview(
+          onBarcodeDetected = { url ->
+            if (isScanned.compareAndSet(false, true)) {
+              setResult(Activity.RESULT_OK, Intent().apply { putExtra("data", url) })
+              finish()
+            }
+          }
+        )
+        QRScannerOverlay()
+      }
+    }
+  }
+
+  override fun onDestroy() {
+    super.onDestroy()
+    cameraExecutor.shutdown()
+  }
+
+  @Composable
+  private fun CameraPreview(onBarcodeDetected: (String) -> Unit) {
+    AndroidView(
+      factory = { context ->
+        val previewView = PreviewView(context)
+        previewView.layoutParams = ViewGroup.LayoutParams(
+          ViewGroup.LayoutParams.MATCH_PARENT,
+          ViewGroup.LayoutParams.MATCH_PARENT
+        )
+        previewView.scaleType = PreviewView.ScaleType.FILL_CENTER
+
+        val cameraProviderFuture = ProcessCameraProvider.getInstance(context)
+        cameraProviderFuture.addListener({
+          val cameraProvider = cameraProviderFuture.get()
+          val preview = Preview.Builder().build()
+          preview.surfaceProvider = previewView.surfaceProvider
+
+          val options = BarcodeScannerOptions.Builder()
+            .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
+            .build()
+          val barcodeScanner = BarcodeScanning.getClient(options)
+
+          val imageAnalysis = ImageAnalysis.Builder()
+            .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+            .build()
+
+          val analyzer = MlKitAnalyzer(
+            listOf(barcodeScanner),
+            ImageAnalysis.COORDINATE_SYSTEM_ORIGINAL,
+            ContextCompat.getMainExecutor(context)
+          ) { result: MlKitAnalyzer.Result? ->
+            val barcodeResults = result?.getValue(barcodeScanner)
+            if (!barcodeResults.isNullOrEmpty()) {
+              val first = barcodeResults.first()
+              first.rawValue?.let {
+                onBarcodeDetected(it)
+              }
+            }
+          }
+
+          imageAnalysis.setAnalyzer(cameraExecutor, analyzer)
+
+          try {
+            cameraProvider.unbindAll()
+            cameraProvider.bindToLifecycle(
+              this,
+              CameraSelector.DEFAULT_BACK_CAMERA,
+              preview,
+              imageAnalysis
+            )
+          } catch (exc: Exception) {
+            exc.printStackTrace()
+          }
+        }, ContextCompat.getMainExecutor(context))
+
+        previewView
+      },
+      modifier = Modifier.fillMaxSize()
+    )
+  }
+}

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/qrScanner/QRScannerActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/qrScanner/QRScannerActivity.kt
@@ -32,7 +32,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
 
 class QRScannerActivity : ComponentActivity() {
-  class Contract: ActivityResultContract<Unit, String?>() {
+  class Contract : ActivityResultContract<Unit, String?>() {
     override fun createIntent(context: Context, input: Unit): Intent {
       return Intent(context, QRScannerActivity::class.java)
     }

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/qrScanner/QRScannerOverlay.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/qrScanner/QRScannerOverlay.kt
@@ -1,0 +1,101 @@
+package host.exp.exponent.home.qrScanner
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun QRScannerOverlay(modifier: Modifier = Modifier) {
+  val configuration = LocalConfiguration.current
+  val screenWidth = configuration.screenWidthDp.dp
+  val screenHeight = configuration.screenHeightDp.dp
+  val minDimension = minOf(screenWidth, screenHeight)
+  val scannerSize = (minDimension * 0.7f).coerceIn(150.dp, 250.dp)
+
+  Box(
+    modifier = modifier.fillMaxSize(),
+    contentAlignment = Alignment.Center
+  ) {
+    Column(
+      horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+      Canvas(
+        modifier = Modifier.size(scannerSize)
+      ) {
+        val strokeWidth = 6f
+        val cornerLength = 50f
+        val squareSize = size.minDimension
+        val cornerRadius = 16f
+
+        // Top-left corner
+        drawRoundedCorner(
+          offset = Offset(0f, 0f),
+          startAngle = 180f,
+          strokeWidth = strokeWidth,
+          cornerRadius = cornerRadius,
+          horizontalLineStart = Offset(cornerRadius, 0f),
+          horizontalLineEnd = Offset(cornerLength, 0f),
+          verticalLineStart = Offset(0f, cornerRadius),
+          verticalLineEnd = Offset(0f, cornerLength)
+        )
+
+        // Top-right corner
+        drawRoundedCorner(
+          offset = Offset(squareSize - cornerRadius * 2, 0f),
+          startAngle = 270f,
+          strokeWidth = strokeWidth,
+          cornerRadius = cornerRadius,
+          horizontalLineStart = Offset(squareSize - cornerRadius, 0f),
+          horizontalLineEnd = Offset(squareSize - cornerLength, 0f),
+          verticalLineStart = Offset(squareSize, cornerRadius),
+          verticalLineEnd = Offset(squareSize, cornerLength)
+        )
+
+        // Bottom-left corner
+        drawRoundedCorner(
+          offset = Offset(0f, squareSize - cornerRadius * 2),
+          startAngle = 90f,
+          strokeWidth = strokeWidth,
+          cornerRadius = cornerRadius,
+          horizontalLineStart = Offset(cornerRadius, squareSize),
+          horizontalLineEnd = Offset(cornerLength, squareSize),
+          verticalLineStart = Offset(0f, squareSize - cornerRadius),
+          verticalLineEnd = Offset(0f, squareSize - cornerLength)
+        )
+
+        // Bottom-right corner
+        drawRoundedCorner(
+          offset = Offset(squareSize - cornerRadius * 2, squareSize - cornerRadius * 2),
+          startAngle = 0f,
+          strokeWidth = strokeWidth,
+          cornerRadius = cornerRadius,
+          horizontalLineStart = Offset(squareSize - cornerRadius, squareSize),
+          horizontalLineEnd = Offset(squareSize - cornerLength, squareSize),
+          verticalLineStart = Offset(squareSize, squareSize - cornerRadius),
+          verticalLineEnd = Offset(squareSize, squareSize - cornerLength)
+        )
+      }
+
+      Text(
+        text = "Scan an Expo Go QR code",
+        color = Color.White,
+        fontSize = 12.sp,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.padding(top = 24.dp)
+      )
+    }
+  }
+}


### PR DESCRIPTION
# Why

Expo Go uses the QR scanner which requires PlayServices. This means that Expo Go can't scan on devices such as Meta Quest.

# How

Add a basic fallback scanner activity that can be used on devices without Play Services.

<img  height="300" alt="fallback_scanner" src="https://github.com/user-attachments/assets/5e7b3cff-a4a9-4160-b6a7-f48cbb778cda" />


# Test Plan

Tested in Expo Go on a quest and a device with Play Services.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
