### PR TITLE
[go][quest] Fix auth flow on Quest

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/auth/AuthIndicatorScreen.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/auth/AuthIndicatorScreen.kt
@@ -37,7 +37,7 @@ fun AuthIndicatorScreen(
       Spacer(modifier = Modifier.height(24.dp))
       Text(
         text = "Authenticating in the browser...",
-        style = MaterialTheme.typography.bodyLarge,
+        style = MaterialTheme.typography.bodyLarge
       )
       Spacer(modifier = Modifier.height(32.dp))
       Button(

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/auth/AuthIndicatorScreen.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/auth/AuthIndicatorScreen.kt
@@ -1,0 +1,50 @@
+package host.exp.exponent.home.auth
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun AuthIndicatorScreen(
+  onCancel: () -> Unit,
+  modifier: Modifier = Modifier
+) {
+  Box(
+    modifier = modifier
+      .fillMaxSize(),
+    contentAlignment = Alignment.Center
+  ) {
+    Column(
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement = Arrangement.Center,
+      modifier = Modifier.padding(32.dp)
+    ) {
+      CircularProgressIndicator(
+        color = MaterialTheme.colorScheme.primary
+      )
+      Spacer(modifier = Modifier.height(24.dp))
+      Text(
+        text = "Authenticating in the browser...",
+        style = MaterialTheme.typography.bodyLarge,
+      )
+      Spacer(modifier = Modifier.height(32.dp))
+      Button(
+        onClick = onCancel
+      ) {
+        Text("Cancel Login")
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Why

Quest can return to the app without doing a valid action in the browser (such as cancelling the login or logging in). Because of this our current logic, which relies on `onResume` event, fails on Quest.
 
# How

On Quest, do not rely on `onResume` event to determine the login cancellation. Instead, during login display a loading screen, where the user has to manually press a button to cancel the request. The loading screen is enabled for all devices but visible only on Quest, since all other supported platforms have proper Custom Tabs support.

# Test Plan

Tested in Quest and a regular phone

https://github.com/user-attachments/assets/5f854619-8d0c-4383-b292-9786b05ac97b
