### PR TITLE
[dev-menu] Minor source explorer improvements

### DIFF
--- a/packages/expo-dev-menu/ios/SwiftUI/SourceMapService.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/SourceMapService.swift
@@ -234,7 +234,14 @@ class SourceMapService {
 
     let nodes = root.children.values.map { convertToNode($0) }
     let sorted = sortNodes(nodes)
-    return collapseSingleChildFolders(sorted)
+    let collapsed = collapseSingleChildFolders(sorted)
+
+    let directories = collapsed.filter { $0.isDirectory }
+    if directories.count == 1, let mainDir = directories.first {
+      return mainDir.children
+    }
+
+    return collapsed
   }
 
   private func convertToNode(_ builder: Node) -> FileTreeNode {
@@ -255,7 +262,7 @@ class SourceMapService {
       while current.isDirectory && current.children.count == 1 && current.children[0].isDirectory {
         let child = current.children[0]
         current = FileTreeNode(
-          name: "\(current.name)/\(child.name)",
+          name: child.name,
           path: child.path,
           isDirectory: true,
           children: child.children,


### PR DESCRIPTION
# Why
Two minor improvements to the source explorer

# How
- Don't show the full path to collapsed directories. The last childs name is fine.
- Start one folder down from the root. The root typically contains the project directory, and stuff like metros `__prelude__` and polyfills that are of no interest so we start from the project directory.

# Test Plan
Expo go 

<img width="450" height="978" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-26 at 14 32 18" src="https://github.com/user-attachments/assets/5b2c0c20-07a6-4fd1-a970-06860cee4ee0" />

