### PR TITLE
[ci] Add detect-platform-change to test-suite-brownfield workflow

### DIFF
--- a/.github/workflows/test-suite-brownfield.yml
+++ b/.github/workflows/test-suite-brownfield.yml
@@ -40,8 +40,8 @@ jobs:
         uses: ./.github/actions/expo-caches
         id: expo-caches
         with:
-          yarn-workspace: "true"
-          yarn-tools: "true"
+          yarn-workspace: 'true'
+          yarn-tools: 'true'
       - name: 🧶 Install node modules in root dir
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
@@ -65,7 +65,7 @@ jobs:
         if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
         with:
           webhook: ${{ secrets.slack_webhook_ios }}
-          channel: "#expo-ios"
+          channel: '#expo-ios'
           author_name: Brownfield Test Suite (iOS)
   android-build:
     strategy:
@@ -88,16 +88,16 @@ jobs:
       - name: 🔨 Use JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: "temurin"
-          java-version: "17"
+          distribution: 'temurin'
+          java-version: '17'
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches
         with:
-          gradle: "true"
-          yarn-workspace: "true"
-          yarn-tools: "true"
-          react-native-gradle-downloads: "true"
+          gradle: 'true'
+          yarn-workspace: 'true'
+          yarn-tools: 'true'
+          react-native-gradle-downloads: 'true'
       - name: 🧶 Install node modules in root dir
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
@@ -120,5 +120,5 @@ jobs:
         if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
         with:
           webhook: ${{ secrets.slack_webhook_android }}
-          channel: "#expo-android"
+          channel: '#expo-android'
           author_name: Brownfield Test Suite (Android)

--- a/.github/workflows/test-suite-brownfield.yml
+++ b/.github/workflows/test-suite-brownfield.yml
@@ -16,7 +16,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-platform-for-e2e:
+    runs-on: ubuntu-24.04
+    outputs:
+      should_run_ios: ${{ steps.changes.outputs.should_run_ios }}
+      should_run_android: ${{ steps.changes.outputs.should_run_android }}
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v5
+      - name: 🧐 Detect platform change
+        id: changes
+        uses: ./.github/actions/detect-platform-change
+        with:
+          android-paths: >-
+            "apps/brownfield-tester/**/android/**",
+            "packages/{expo,expo-modules-core,expo-dev-client,expo-updates}/**/android/**"
+          ios-paths: >-
+            "apps/brownfield-tester/**/ios/**",
+            "packages/{expo,expo-modules-core,expo-dev-client,expo-updates}/**/ios/**"
+          common-paths: >-
+            .github/workflows/test-suite-brownfield.yml,
+            "apps/brownfield-tester/**",
+            "!apps/brownfield-tester/**/{ios,android}/**",
+            "packages/{expo,expo-modules-core,expo-dev-client,expo-updates}/**",
+            "!packages/{expo,expo-modules-core,expo-dev-client,expo-updates}/**/{ios,android}/**"
   ios-build:
+    needs: detect-platform-for-e2e
+    if: needs.detect-platform-for-e2e.outputs.should_run_ios == 'true'
     strategy:
       fail-fast: true
       matrix:
@@ -68,6 +94,8 @@ jobs:
           channel: '#expo-ios'
           author_name: Brownfield Test Suite (iOS)
   android-build:
+    needs: detect-platform-for-e2e
+    if: needs.detect-platform-for-e2e.outputs.should_run_android == 'true'
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
# Why
Follow-up to #42438. The same pattern applies to the expo-brownfield tests.

# How
Uses the `./.github/actions/detect-platform-change` action to detect which platforms are affected by the change.

# Test Plan
Run the workflow using a stacked PR with different changes that trigger each logical output state.