### PR TITLE
[widgets] Fix autolinking when building react-native from source

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Fixed autolinking when building react-native from source.
+
 ## 55.0.0-alpha.3 — 2026-01-26
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Fixed autolinking when building react-native from source.
+- Fixed autolinking when building react-native from source. ([#42553](https://github.com/expo/expo/pull/42553) by [@jakex7](https://github.com/jakex7))
 
 ## 55.0.0-alpha.3 — 2026-01-26
 

--- a/packages/expo-widgets/scripts/autolinking.rb
+++ b/packages/expo-widgets/scripts/autolinking.rb
@@ -25,7 +25,7 @@ end
 
 def expo_widgets_post_install(installer)
   installer.pods_project.targets.each do |target|
-    if target.name == 'ExpoModulesCore' || target.name == 'ExpoUI'
+    if target.name == 'ExpoModulesCore' || target.name == 'ExpoUI' || target.name.start_with?('React-')
       target.build_configurations.each do |config|
         config.build_settings['APPLICATION_EXTENSION_API_ONLY'] = 'No'
       end


### PR DESCRIPTION
# Why

Fixes #42474

When building react-native from sources, `React-Core` and `React-RCTFabric` fails to compile as `UIApplication sharedApplication` (used in `RCTScrollView`) is not available in widget extension.

# How

We can safely ignore this, as this part can't be executed in widget anyway, so we set `'APPLICATION_EXTENSION_API_ONLY' = 'NO'`

# Test Plan

Use `expo-build-properties` to build from source:
```json
[
  "expo-build-properties",
  {
    "buildReactNativeFromSource": true,
    "useHermesV1": true
  }
],
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
