### PR TITLE
[go][ios] Change code explorer root

### DIFF
--- a/packages/expo-dev-menu/ios/SwiftUI/SourceMapExplorerViewModel.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/SourceMapExplorerViewModel.swift
@@ -26,7 +26,8 @@ class SourceMapExplorerViewModel: ObservableObject {
     do {
       let sourceMap = try await service.fetchSourceMap()
       self.sourceMap = sourceMap
-      self.fileTree = await service.buildFileTree(from: sourceMap)
+      let tree = await service.buildFileTree(from: sourceMap)
+      self.fileTree = tree.first(where: { $0.isDirectory })?.children ?? tree
       loadingState = .loaded(sourceMap)
     } catch let error as SourceMapError {
       loadingState = .error(error)


### PR DESCRIPTION
# Why

Changes code explorer to start in root project directory of the bundle.

https://exponent-internal.slack.com/archives/C02T514E4RK/p1769391867355619?thread_ts=1769391285.510569&cid=C02T514E4RK

This is what the initial state looks like
<img width="400" alt="simulator_screenshot_8773DE46-09BB-41AB-BA9B-0C06349B61F8" src="https://github.com/user-attachments/assets/b7e5be92-b2d7-433d-9cb0-c2da38c904e4" />

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
