### PR TITLE
[docs] Improve EAS Build introduction

### DIFF
--- a/docs/pages/build/introduction.mdx
+++ b/docs/pages/build/introduction.mdx
@@ -1,21 +1,113 @@
 ---
 title: EAS Build
 sidebar_title: Introduction
-hideTOC: true
 description: EAS Build is a hosted service for building app binaries for your Expo and React Native projects.
 ---
 
 import { Cube01Icon } from '@expo/styleguide-icons/outline/Cube01Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { Collapsible } from '~/ui/components/Collapsible';
+import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
+import { Terminal } from '~/ui/components/Snippet';
 
-**EAS Build** is a hosted service for building app binaries for your Expo and React Native projects.
+**EAS Build** is a hosted Expo Application Services (EAS) service that builds app binaries for your Expo and React Native projects.
 
-It makes building your apps for distribution simple and easy to automate by providing defaults that work well for Expo and React Native projects out of the box, and by handling your app signing credentials for you (if you wish). It also makes sharing builds with your team easier than ever with [internal distribution](/build/internal-distribution/) (using ad hoc and/or enterprise "universal" provisioning), deeply integrates with EAS Submit for app store submissions, and has first-class support for the [`expo-updates`](/build/updates/) library.
+It makes building your apps for distribution simple and easy to automate by providing defaults that work well for Expo and React Native projects out of the box, and by handling your app signing credentials for you (if you wish). It also makes sharing builds with your team easier than ever with [internal distribution](/build/internal-distribution/) (using [ad hoc](/build/internal-distribution/) and/or enterprise "universal" provisioning), deeply integrates with EAS Submit for app store submissions, and has first-class support for the [`expo-updates`](/build/updates/) library.
 
-It's designed to work for any native project, whether or not you use Expo and React Native. It's the fastest way to get from `npx create-expo-app` or `npx @react-native-community/cli@latest init` to app stores.
+It is also designed to work for any native project, whether or not you use Expo and React Native. It's the fastest way to get from `npx create-expo-app` or `npx @react-native-community/cli@latest init` to app stores.
 
-### Get started
+## Quick start
+
+To build your app, run the following command:
+
+<Terminal cmd={['$ eas build --platform all']} />
+
+This command sends your project to EAS Build and produces installable binaries for Android and iOS. For complete setup instructions, see [Create your first build](/build/setup/).
+
+## Key features
+
+- Cloud builds for Android and iOS with consistent environments
+- Manage app signing credentials or use your own
+- Shareable [internal distribution](/build/internal-distribution/) builds with a URL
+- Automate builds with build profiles in **eas.json** and integrations with [EAS Workflows](/eas/workflows/get-started/) or CI pipelines
+- Auto-submit successful builds to app stores via [`--auto-submit`](/build/automate-submissions/) and EAS Submit
+- First-class [`expo-updates` integration](/build/updates/) with per-profile channels and runtime version guidance
+- Faster builds via [dependency caching and custom cache paths](/build-reference/caching/)
+
+## When to use EAS Build
+
+| Scenario                                                                                     | Recommendation |
+| -------------------------------------------------------------------------------------------- | -------------- |
+| Build production-ready binaries for app stores                                               | <YesIcon />    |
+| Share builds with testers via [internal distribution](/build/internal-distribution/) | <YesIcon />    |
+| Consistent builds across team members without local environment setup                        | <YesIcon />    |
+| Automate builds from CI or [EAS Workflows](/eas/workflows/get-started/)                      | <YesIcon />    |
+| Managed app signing credentials                                                              | <YesIcon />    |
+| Debugging native code locally                                                                | <NoIcon />     |
+
+## Frequently asked questions
+
+<Collapsible summary="How do I share builds with my team before submitting to app stores?">
+
+Use [internal distribution](/build/internal-distribution/) to share builds with a URL. Set `"distribution": "internal"` in your build profile in **eas.json** to generate installable Android Package (APK) files for Android or [ad hoc builds](/build/internal-distribution/) for iOS.
+
+</Collapsible>
+
+<Collapsible summary="Can I use EAS Build with existing React Native projects?">
+
+Yes. You can use EAS Build with existing React Native projects created with `npx react-native init` or similar tools. See [Overview of using Expo with existing React Native apps](/bare/overview/) for more information.
+
+</Collapsible>
+
+<Collapsible summary="Does EAS Build handle app signing credentials?">
+
+Yes. You can let EAS Build generate and manage Android [keystores](/app-signing/app-credentials/#android), iOS [provisioning profiles](/app-signing/app-credentials/#ios) and [distribution certificates](/app-signing/app-credentials/#ios), or you can provide your own. See [App signing credentials](/app-signing/app-credentials/) for more information.
+
+</Collapsible>
+
+<Collapsible summary="Can I run builds locally instead of in the cloud?">
+
+Yes. Use [local builds](/build-reference/local-builds/) with `eas build --local` to run builds on your machine. This is useful for debugging or for security policies that require local builds.
+
+</Collapsible>
+
+<Collapsible summary="Can I use EAS Build with EAS Workflows or CI pipelines?">
+
+Yes. EAS Build integrates with [EAS Workflows](/eas/workflows/get-started/) using the `build` job type. Add a build job to your workflow configuration, for example:
+
+```yaml
+jobs:
+  build_ios:
+    type: build
+    params:
+      platform: ios
+```
+
+You can build for both platforms or make builds conditional based on the branch:
+
+```yaml
+jobs:
+  build:
+    type: build
+    params:
+      platform: all
+      profile: ${{ github.ref_name == 'main' && 'production' || 'preview' }}
+```
+
+For more information, see the [EAS Workflows build job](/eas/workflows/pre-packaged-jobs#build).
+
+You can also configure [builds from GitHub](/build/building-from-github/) and use [building on CI](/build/building-on-ci/) with any provider.
+
+</Collapsible>
+
+<Collapsible summary="What build server infrastructure does EAS Build use?">
+
+Android builds run on Linux runners hosted in Google Cloud Platform, and iOS builds run on macOS runners hosted in Expo's macOS cloud. See [Build server infrastructure](/build-reference/infrastructure/).
+
+</Collapsible>
+
+## Get started
 
 <BoxLink
   title="Create your first build"

--- a/docs/pages/build/introduction.mdx
+++ b/docs/pages/build/introduction.mdx
@@ -11,7 +11,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
 import { Terminal } from '~/ui/components/Snippet';
 
-**EAS Build** is a hosted Expo Application Services (EAS) service that builds app binaries for your Expo and React Native projects.
+**EAS Build** is a hosted Expo Application Services (EAS) service that builds app binaries (also called [standalone apps](/more/glossary-of-terms/#standalone-app)) for your Expo and React Native projects.
 
 EAS Build makes building your apps for distribution simple and easy to automate by providing defaults that work well for Expo and React Native projects out of the box, and by handling your app signing credentials for you (if you wish). It also makes sharing builds with your team easier than ever with [internal distribution](/build/internal-distribution/) (using [ad hoc](/build/internal-distribution/) and/or enterprise "universal" provisioning), deeply integrates with EAS Submit for app store submissions, and has first-class support for the [`expo-updates`](/build/updates/) library.
 
@@ -30,9 +30,9 @@ This command sends your project to EAS Build and produces installable binaries f
 - Cloud builds for Android and iOS with consistent environments
 - Manage app signing credentials or use your own
 - Shareable [internal distribution](/build/internal-distribution/) builds with a URL
-- Automate builds with build profiles in **eas.json** and integrations with [EAS Workflows](/eas/workflows/get-started/) or CI pipelines
+- Automate builds with [build profiles](/build/eas-json/#build-profiles) in **eas.json** (named sets of build settings) and integrations with [EAS Workflows](/eas/workflows/get-started/) or CI pipelines
 - Auto-submit successful builds to app stores via [`--auto-submit`](/build/automate-submissions/) and EAS Submit
-- First-class [`expo-updates` integration](/build/updates/) with per-profile channels and runtime version guidance
+- First-class [`expo-updates` integration](/build/updates/) with per-profile channels and [runtime version](/eas-update/runtime-versions/) guidance
 - Faster builds via [dependency caching and custom cache paths](/build-reference/caching/)
 
 ## When to use EAS Build
@@ -50,19 +50,19 @@ This command sends your project to EAS Build and produces installable binaries f
 
 <Collapsible summary="How do I share builds with my team before submitting to app stores?">
 
-Use [internal distribution](/build/internal-distribution/) to share builds with a URL. Set `"distribution": "internal"` in your build profile in **eas.json** to generate installable Android Package (APK) files for Android or [ad hoc builds](/build/internal-distribution/) for iOS.
+Use [internal distribution](/build/internal-distribution/) to share builds with a URL. Set `"distribution": "internal"` in your [build profile](/build/eas-json/#build-profiles) in **eas.json** to generate installable Android Package (APK) files for Android or [ad hoc builds](/build/internal-distribution/) for iOS.
 
 </Collapsible>
 
 <Collapsible summary="Can I use EAS Build with existing React Native projects?">
 
-Yes. You can use EAS Build with existing React Native projects created with `npx react-native init` or similar tools. See [Overview of using Expo with existing React Native apps](/bare/overview/) for more information.
+Yes. EAS Build works with existing React Native projects created with `npx react-native init` or similar tools. See [Overview of using Expo with existing React Native apps](/bare/overview/) for more information.
 
 </Collapsible>
 
 <Collapsible summary="Does EAS Build handle app signing credentials?">
 
-Yes. You can let EAS Build generate and manage Android [keystores](/app-signing/app-credentials/#android), iOS [provisioning profiles](/app-signing/app-credentials/#ios) and [distribution certificates](/app-signing/app-credentials/#ios), or you can provide your own. See [App signing credentials](/app-signing/app-credentials/) for more information.
+Yes. EAS Build can generate and manage Android [keystores](/app-signing/app-credentials/#android), iOS [provisioning profiles](/app-signing/app-credentials/#ios) and [distribution certificates](/app-signing/app-credentials/#ios), or use credentials you provide. See [App signing credentials](/app-signing/app-credentials/) for more information.
 
 </Collapsible>
 
@@ -84,7 +84,7 @@ jobs:
       platform: ios
 ```
 
-You can build for both platforms or make builds conditional based on the branch:
+The build job supports builds for both platforms or conditional builds based on the branch:
 
 ```yaml
 jobs:
@@ -97,7 +97,7 @@ jobs:
 
 For more information and other usage examples, see the [EAS Workflows build job](/eas/workflows/pre-packaged-jobs#build).
 
-You can also configure [builds from GitHub](/build/building-from-github/) and use [building on CI](/build/building-on-ci/) with any provider.
+EAS Build supports [builds from GitHub](/build/building-from-github/) and [building on CI](/build/building-on-ci/) with any provider.
 
 </Collapsible>
 
@@ -125,7 +125,7 @@ Android builds run on Linux runners hosted in Google Cloud Platform, and iOS bui
 
 <BoxLink
   title="Automate submissions"
-  description="Learn how you can have the service take your successful builds and handle uploading them to app stores for you automatically."
+  description="Learn how EAS Build can take your successful builds and handle uploading them to app stores automatically."
   href="/build/automate-submissions"
   Icon={Cube01Icon}
 />
@@ -139,7 +139,7 @@ Android builds run on Linux runners hosted in Google Cloud Platform, and iOS bui
 
 <BoxLink
   title="Run builds locally or on your own infrastructure"
-  description="EAS Build is a hosted service, but you can also run it on your own machine, for example, to debug or to comply with any company security policies."
+  description="EAS Build is a hosted service, and it can also run on your own machine, for example, to debug or to comply with company security policies."
   href="/build-reference/local-builds"
   Icon={Cube01Icon}
 />

--- a/docs/pages/build/introduction.mdx
+++ b/docs/pages/build/introduction.mdx
@@ -37,14 +37,14 @@ This command sends your project to EAS Build and produces installable binaries f
 
 ## When to use EAS Build
 
-| Scenario                                                                                     | Recommendation |
-| -------------------------------------------------------------------------------------------- | -------------- |
-| Build production-ready binaries for app stores                                               | <YesIcon />    |
+| Scenario                                                                             | Recommendation |
+| ------------------------------------------------------------------------------------ | -------------- |
+| Build production-ready binaries for app stores                                       | <YesIcon />    |
 | Share builds with testers via [internal distribution](/build/internal-distribution/) | <YesIcon />    |
-| Consistent builds across team members without local environment setup                        | <YesIcon />    |
-| Automate builds from CI or [EAS Workflows](/eas/workflows/get-started/)                      | <YesIcon />    |
-| Managed app signing credentials                                                              | <YesIcon />    |
-| Debugging native code locally                                                                | <NoIcon />     |
+| Consistent builds across team members without local environment setup                | <YesIcon />    |
+| Automate builds from CI or [EAS Workflows](/eas/workflows/get-started/)              | <YesIcon />    |
+| Managed app signing credentials                                                      | <YesIcon />    |
+| Debugging native code locally                                                        | <NoIcon />     |
 
 ## Frequently asked questions
 

--- a/docs/pages/build/introduction.mdx
+++ b/docs/pages/build/introduction.mdx
@@ -13,9 +13,9 @@ import { Terminal } from '~/ui/components/Snippet';
 
 **EAS Build** is a hosted Expo Application Services (EAS) service that builds app binaries for your Expo and React Native projects.
 
-It makes building your apps for distribution simple and easy to automate by providing defaults that work well for Expo and React Native projects out of the box, and by handling your app signing credentials for you (if you wish). It also makes sharing builds with your team easier than ever with [internal distribution](/build/internal-distribution/) (using [ad hoc](/build/internal-distribution/) and/or enterprise "universal" provisioning), deeply integrates with EAS Submit for app store submissions, and has first-class support for the [`expo-updates`](/build/updates/) library.
+EAS Build makes building your apps for distribution simple and easy to automate by providing defaults that work well for Expo and React Native projects out of the box, and by handling your app signing credentials for you (if you wish). It also makes sharing builds with your team easier than ever with [internal distribution](/build/internal-distribution/) (using [ad hoc](/build/internal-distribution/) and/or enterprise "universal" provisioning), deeply integrates with EAS Submit for app store submissions, and has first-class support for the [`expo-updates`](/build/updates/) library.
 
-It is also designed to work for any native project, whether or not you use Expo and React Native. It's the fastest way to get from `npx create-expo-app` or `npx @react-native-community/cli@latest init` to app stores.
+EAS Build is also designed to work for any native project, whether or not you use Expo and React Native. It's the fastest way to get from `npx create-expo-app` or `npx @react-native-community/cli@latest init` to app stores.
 
 ## Quick start
 
@@ -95,7 +95,7 @@ jobs:
       profile: ${{ github.ref_name == 'main' && 'production' || 'preview' }}
 ```
 
-For more information, see the [EAS Workflows build job](/eas/workflows/pre-packaged-jobs#build).
+For more information and other usage examples, see the [EAS Workflows build job](/eas/workflows/pre-packaged-jobs#build).
 
 You can also configure [builds from GitHub](/build/building-from-github/) and use [building on CI](/build/building-on-ci/) with any provider.
 

--- a/docs/pages/build/introduction.mdx
+++ b/docs/pages/build/introduction.mdx
@@ -23,17 +23,19 @@ To build your app, run the following command:
 
 <Terminal cmd={['$ eas build --platform all']} />
 
-This command sends your project to EAS Build and produces installable binaries for Android and iOS. For complete setup instructions, see [Create your first build](/build/setup/).
+This command sends your project to EAS Build and produces installable binaries for Android and iOS. You can also build for one platform at a time by passing in `--platform android` or `--platform ios` as desired. For complete setup instructions, see [Create your first build](/build/setup/).
 
 ## Key features
 
 - Cloud builds for Android and iOS with consistent environments
-- Manage app signing credentials or use your own
-- Shareable [internal distribution](/build/internal-distribution/) builds with a URL
-- Automate builds with [build profiles](/build/eas-json/#build-profiles) in **eas.json** (named sets of build settings) and integrations with [EAS Workflows](/eas/workflows/get-started/) or CI pipelines
+- Automatically provision and manage app signing credentials or use your own
+- Share [internal distribution](/build/internal-distribution/) builds with a URL
+- Automate builds with [build profiles](/build/eas-json/#build-profiles) in **eas.json** (named sets of build settings) and integrations with [EAS Workflows](/eas/workflows/get-started/) or [CI pipelines](/build/building-on-ci/)
 - Auto-submit successful builds to app stores via [`--auto-submit`](/build/automate-submissions/) and EAS Submit
 - First-class [`expo-updates` integration](/build/updates/) with per-profile channels and [runtime version](/eas-update/runtime-versions/) guidance
+- Reuse [development builds](/develop/development-builds/introduction/) across your team. When two team members run `eas build:dev` and the project fingerprint matches, the existing build is downloaded from EAS instead of creating a new one
 - Faster builds via [dependency caching and custom cache paths](/build-reference/caching/)
+- Install builds and updates on devices with [Expo Orbit](https://expo.dev/orbit)
 
 ## When to use EAS Build
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18489

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add a Quick start section with the `eas build --platform` all command using the Terminal snippet component.
- Introduce Key features bullets plus a "When to use EAS Build" table with Yes/No icons for common scenarios.
- Add collapsible FAQ entries covering internal distribution, existing RN projects, credential management, local builds, CI/EAS Workflows usage, and build infrastructure.
- Kept the existing "Get started" BoxLink CTA section, now following the new overview content.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
