### PR TITLE
[docs] Remove `isNew` from `react-native-keyboard-controller` reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/keyboard-controller.mdx
+++ b/docs/pages/versions/unversioned/sdk/keyboard-controller.mdx
@@ -5,7 +5,6 @@ sourceCodeUrl: 'https://github.com/kirillzyusko/react-native-keyboard-controller
 packageName: react-native-keyboard-controller
 platforms: ['android', 'ios', 'expo-go']
 inExpoGo: true
-isNew: true
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';

--- a/docs/pages/versions/v55.0.0/sdk/keyboard-controller.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/keyboard-controller.mdx
@@ -5,7 +5,6 @@ sourceCodeUrl: 'https://github.com/kirillzyusko/react-native-keyboard-controller
 packageName: react-native-keyboard-controller
 platforms: ['android', 'ios', 'expo-go']
 inExpoGo: true
-isNew: true
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

`react-native-keyboard-controller` reference was introduced in SDK 54. Remove `isNew` frontmatter property from its `unversioned` and SDK 55 references.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
