### PR TITLE
[dev-menu][quest] Make FAB always enabled on Quest

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Make the Action Button always enabled on Quest. ([#42562](https://github.com/expo/expo/pull/42562) by [@behenate](https://github.com/behenate))
+
 ## 55.0.2 — 2026-01-26
 
 ### 🎉 New features

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuPreferences.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuPreferences.kt
@@ -3,6 +3,7 @@ package expo.modules.devmenu
 import android.app.Application
 import android.content.Context.MODE_PRIVATE
 import android.content.SharedPreferences
+import expo.modules.core.utilities.VRUtilities
 import expo.modules.devmenu.helpers.preferences
 
 private const val DEV_SETTINGS_PREFERENCES = "expo.modules.devmenu.sharedpreferences"
@@ -88,7 +89,6 @@ class DevMenuDefaultPreferences(
   override var isOnboardingFinished: Boolean
     by preferences(sharedPreferences, false)
 
-  // TODO: @behenate, on VR this value should be true by default
   override var showFab: Boolean
-    by preferences(sharedPreferences, false)
+    by preferences(sharedPreferences, VRUtilities.isQuest())
 }

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/DevMenuState.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/DevMenuState.kt
@@ -1,5 +1,6 @@
 package expo.modules.devmenu.compose
 
+import expo.modules.core.utilities.VRUtilities
 import expo.modules.devmenu.DevToolsSettings
 import org.json.JSONObject
 
@@ -8,7 +9,7 @@ data class DevMenuState(
   val isOpen: Boolean = false,
   val devToolsSettings: DevToolsSettings = DevToolsSettings(),
   val isOnboardingFinished: Boolean = false,
-  val showFab: Boolean = false,
+  val showFab: Boolean = VRUtilities.isQuest(),
   val customItems: List<CustomItem> = emptyList(),
   val hasGoHomeAction: Boolean = false,
   val isInPictureInPictureMode: Boolean = false

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/ui/ToolsSection.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/ui/ToolsSection.kt
@@ -3,6 +3,7 @@ package expo.modules.devmenu.compose.ui
 import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
+import expo.modules.core.utilities.VRUtilities
 import expo.modules.devmenu.DevToolsSettings
 import expo.modules.devmenu.compose.DevMenuAction
 import expo.modules.devmenu.compose.DevMenuActionHandler
@@ -111,30 +112,33 @@ fun ToolsSection(
 //        }
 //      )
 
-      Divider(thickness = 0.5.dp)
+      // Hide FAB toggle on Quest devices since FAB is always on there
+      if (!VRUtilities.isQuest()) {
+        Divider(thickness = 0.5.dp)
 
-      NewMenuButton(
-        withSurface = false,
-        icon = {
-          MenuIcons.Fab(
-            size = 20.dp,
-            tint = NewAppTheme.colors.icon.tertiary
-          )
-        },
-        content = {
-          NewText(
-            text = "Action button"
-          )
-        },
-        rightComponent = {
-          ToggleSwitch(
-            isToggled = showFab
-          )
-        },
-        onClick = {
-          onAction(DevMenuAction.ToggleFab)
-        }
-      )
+        NewMenuButton(
+          withSurface = false,
+          icon = {
+            MenuIcons.Fab(
+              size = 20.dp,
+              tint = NewAppTheme.colors.icon.tertiary
+            )
+          },
+          content = {
+            NewText(
+              text = "Action button"
+            )
+          },
+          rightComponent = {
+            ToggleSwitch(
+              isToggled = showFab
+            )
+          },
+          onClick = {
+            onAction(DevMenuAction.ToggleFab)
+          }
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
# Why

The Floating Action Button should always be enabled on Quest devices, because it is the only device-level way to open the dev menu.

# How

Make the button on by default and remove options to disable it for Quest devices.

# Test Plan

Tested on a Meta Quest device and a Pixel 8
