### PR TITLE
[dev-menu][quest] Fix Floating action button not responding to presses

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix dev menu not opening when pressing m key in CLI. ([#42566](https://github.com/expo/expo/pull/42566) by [@lukmccall](https://github.com/lukmccall))
+- [Quest] Fix Floating action button not responding to presses. ([#42563](https://github.com/expo/expo/pull/42563) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/fab/FloatingActionButtonContent.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/fab/FloatingActionButtonContent.kt
@@ -86,16 +86,16 @@ fun FloatingActionButtonContent(
             interactionSource = interactionSource,
             indication = null,
             onClick = {
-              onRefreshPress()
               scope.launch {
                 animatedRotation.animateTo(
                   targetValue = 360f,
                   animationSpec = spring(
                     dampingRatio = Spring.DampingRatioLowBouncy,
                     stiffness = Spring.StiffnessVeryLow,
-                    visibilityThreshold = 2f
+                    visibilityThreshold = 5f
                   )
                 )
+                onRefreshPress()
                 animatedRotation.snapTo(0f)
               }
             }

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/fab/MovableFloatingActionButton.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/fab/MovableFloatingActionButton.kt
@@ -123,7 +123,6 @@ fun MovableFloatingActionButton(
                       .coerceIn(maxX = bounds.x, maxY = bounds.y)
                     dragDistance += change.positionChange().getDistance()
                     velocityTracker.registerPosition(dragOffset.x, dragOffset.y)
-                    change.consume()
 
                     if (dragDistance > ClickDragTolerance) {
                       launch {


### PR DESCRIPTION
# Why

This has been previously fixed in https://github.com/expo/expo/pull/39481, back when FAB was separate for Expo Go and didn't support Quest in dev-client builds. 

The FAB doesn't respond to press events on Quest, also in Expo Go on refresh the activity gets restarted, because of this the refresh is very sudden and jarring.

# How

- Don't consume the press event
- Wait for the spin animation to (almost) finish, thanks to that the user gets a visual feedback that the refresh is coming

# Test Plan

Tested in Expo Go and BareExpo on a Quest device and Pixel 8
