### PR TITLE
[plugin][brownfield] add warning about using dev-client

### DIFF
--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -45,3 +45,4 @@ _This version does not introduce any user-facing changes._
 - [iOS] Symlink ExpoAppDelegate to iOS template ([#42240](https://github.com/expo/expo/pull/42240) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Remove ExpoModulesProvider patch ([#42317](https://github.com/expo/expo/pull/42317) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Improved bundle loading failure handling in [#42469](https://github.com/expo/expo/pull/42469) by [@pmleczek](https://github.com/pmleczek)
+- Added `expo-dev-client` warning message in [#42564](https://github.com/expo/expo/pull/42564) by [@pmleczek](https://github.com/pmleczek)

--- a/packages/expo-brownfield/plugin/build/common/index.d.ts
+++ b/packages/expo-brownfield/plugin/build/common/index.d.ts
@@ -1,1 +1,2 @@
 export * from './filesystem';
+export * from './plugins';

--- a/packages/expo-brownfield/plugin/build/common/index.js
+++ b/packages/expo-brownfield/plugin/build/common/index.js
@@ -15,3 +15,4 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 __exportStar(require("./filesystem"), exports);
+__exportStar(require("./plugins"), exports);

--- a/packages/expo-brownfield/plugin/build/common/plugins/index.d.ts
+++ b/packages/expo-brownfield/plugin/build/common/plugins/index.d.ts
@@ -1,0 +1,1 @@
+export { default as withDevLauncherWarning } from './withDevLauncherWarning';

--- a/packages/expo-brownfield/plugin/build/common/plugins/index.js
+++ b/packages/expo-brownfield/plugin/build/common/plugins/index.js
@@ -1,0 +1,8 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withDevLauncherWarning = void 0;
+var withDevLauncherWarning_1 = require("./withDevLauncherWarning");
+Object.defineProperty(exports, "withDevLauncherWarning", { enumerable: true, get: function () { return __importDefault(withDevLauncherWarning_1).default; } });

--- a/packages/expo-brownfield/plugin/build/common/plugins/withDevLauncherWarning.d.ts
+++ b/packages/expo-brownfield/plugin/build/common/plugins/withDevLauncherWarning.d.ts
@@ -1,0 +1,3 @@
+import { ExpoConfig } from 'expo/config';
+declare const withDevLauncherWarning: (config: ExpoConfig) => void;
+export default withDevLauncherWarning;

--- a/packages/expo-brownfield/plugin/build/common/plugins/withDevLauncherWarning.js
+++ b/packages/expo-brownfield/plugin/build/common/plugins/withDevLauncherWarning.js
@@ -13,7 +13,7 @@ const withDevLauncherWarning = (config) => {
         DID_NOTIFY = true;
         console.warn("⚠ It seems that you're using `expo-dev-client` with `expo-brownfield`");
         console.warn("`expo-dev-client` isn't currently supported in the isolated brownfield setup");
-        console.warn('Please instead use `expo-dev-menu`');
+        console.warn('Please use `expo-dev-menu` instead');
     }
 };
 const maybeGetFromPlugins = (config) => {

--- a/packages/expo-brownfield/plugin/build/common/plugins/withDevLauncherWarning.js
+++ b/packages/expo-brownfield/plugin/build/common/plugins/withDevLauncherWarning.js
@@ -1,0 +1,50 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs_1 = __importDefault(require("fs"));
+const path_1 = __importDefault(require("path"));
+const EXPO_DEV_CLIENT = 'expo-dev-client';
+// We only want to notify the user once
+let DID_NOTIFY = false;
+const withDevLauncherWarning = (config) => {
+    if (!DID_NOTIFY && (maybeGetFromPlugins(config) || maybeGetFromPackageJson(config))) {
+        DID_NOTIFY = true;
+        console.warn("⚠ It seems that you're using `expo-dev-client` with `expo-brownfield`");
+        console.warn("`expo-dev-client` isn't currently supported in the isolated brownfield setup");
+        console.warn('Please instead use `expo-dev-menu`');
+    }
+};
+const maybeGetFromPlugins = (config) => {
+    if (!config.plugins) {
+        return false;
+    }
+    config.plugins.forEach((plugin) => {
+        if ((Array.isArray(plugin) && plugin[0] === EXPO_DEV_CLIENT) || plugin === EXPO_DEV_CLIENT) {
+            return true;
+        }
+    });
+    return false;
+};
+const maybeGetFromPackageJson = (config) => {
+    const packageJsonPath = [
+        config._internal?.packageJsonPath,
+        config._internal?.projectRoot
+            ? path_1.default.join(config._internal?.projectRoot, 'package.json')
+            : undefined,
+        path_1.default.join(process.cwd(), 'package.json'),
+    ].find(ensureIsValidPath);
+    if (!packageJsonPath) {
+        return false;
+    }
+    const packageJson = JSON.parse(fs_1.default.readFileSync(packageJsonPath, 'utf8'));
+    if (packageJson.dependencies?.[EXPO_DEV_CLIENT]) {
+        return true;
+    }
+    return false;
+};
+const ensureIsValidPath = (path) => {
+    return path && fs_1.default.existsSync(path);
+};
+exports.default = withDevLauncherWarning;

--- a/packages/expo-brownfield/plugin/build/index.js
+++ b/packages/expo-brownfield/plugin/build/index.js
@@ -4,8 +4,11 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const android_1 = __importDefault(require("./android"));
+const common_1 = require("./common");
 const ios_1 = __importDefault(require("./ios"));
 const withExpoBrownfieldTargetPlugin = (config, props) => {
+    // Warn the user that `expo-dev-launcher` is not supported with `expo-brownfield` yet
+    (0, common_1.withDevLauncherWarning)(config);
     config = (0, android_1.default)(config, props?.android);
     return (0, ios_1.default)(config, props?.ios);
 };

--- a/packages/expo-brownfield/plugin/src/common/index.ts
+++ b/packages/expo-brownfield/plugin/src/common/index.ts
@@ -1,1 +1,2 @@
 export * from './filesystem';
+export * from './plugins';

--- a/packages/expo-brownfield/plugin/src/common/plugins/index.ts
+++ b/packages/expo-brownfield/plugin/src/common/plugins/index.ts
@@ -1,0 +1,1 @@
+export { default as withDevLauncherWarning } from './withDevLauncherWarning';

--- a/packages/expo-brownfield/plugin/src/common/plugins/withDevLauncherWarning.ts
+++ b/packages/expo-brownfield/plugin/src/common/plugins/withDevLauncherWarning.ts
@@ -1,0 +1,57 @@
+import { ExpoConfig } from 'expo/config';
+import fs from 'fs';
+import path from 'path';
+
+const EXPO_DEV_CLIENT = 'expo-dev-client';
+// We only want to notify the user once
+let DID_NOTIFY = false;
+
+const withDevLauncherWarning = (config: ExpoConfig) => {
+  if (!DID_NOTIFY && (maybeGetFromPlugins(config) || maybeGetFromPackageJson(config))) {
+    DID_NOTIFY = true;
+
+    console.warn("⚠ It seems that you're using `expo-dev-client` with `expo-brownfield`");
+    console.warn("`expo-dev-client` isn't currently supported in the isolated brownfield setup");
+    console.warn('Please use `expo-dev-menu` instead');
+  }
+};
+
+const maybeGetFromPlugins = (config: ExpoConfig): boolean => {
+  if (!config.plugins) {
+    return false;
+  }
+
+  config.plugins.forEach((plugin) => {
+    if ((Array.isArray(plugin) && plugin[0] === EXPO_DEV_CLIENT) || plugin === EXPO_DEV_CLIENT) {
+      return true;
+    }
+  });
+
+  return false;
+};
+
+const maybeGetFromPackageJson = (config: ExpoConfig): boolean => {
+  const packageJsonPath = [
+    config._internal?.packageJsonPath,
+    config._internal?.projectRoot
+      ? path.join(config._internal?.projectRoot, 'package.json')
+      : undefined,
+    path.join(process.cwd(), 'package.json'),
+  ].find(ensureIsValidPath);
+  if (!packageJsonPath) {
+    return false;
+  }
+
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  if (packageJson.dependencies?.[EXPO_DEV_CLIENT]) {
+    return true;
+  }
+
+  return false;
+};
+
+const ensureIsValidPath = (path: string) => {
+  return path && fs.existsSync(path);
+};
+
+export default withDevLauncherWarning;

--- a/packages/expo-brownfield/plugin/src/index.ts
+++ b/packages/expo-brownfield/plugin/src/index.ts
@@ -1,10 +1,13 @@
 import type { ConfigPlugin } from 'expo/config-plugins';
 
 import withAndroidPlugin from './android';
+import { withDevLauncherWarning } from './common';
 import withIosPlugin from './ios';
 import type { PluginProps } from './types';
 
 const withExpoBrownfieldTargetPlugin: ConfigPlugin<PluginProps> = (config, props) => {
+  // Warn the user that `expo-dev-launcher` is not supported with `expo-brownfield` yet
+  withDevLauncherWarning(config);
   config = withAndroidPlugin(config, props?.android);
   return withIosPlugin(config, props?.ios);
 };


### PR DESCRIPTION
# Why

Currently `expo-dev-client` isn't supported in isolated brownfield setup (using `expo-brownfield`) and only `expo-dev-menu` is (dev-client would crash in UIKit with any view controller different than `UINavigationController` and in all Android apps). We should be warning the user about this if we detect that they're using dev client 

# How

Extended the config plugin to check and (once per prebuild) display warning that `expo-dev-client` is being used along with `expo-brownfield`, using the plugins configuration from `app.json` or information from `package.json`.

# Test Plan

Tested using `minimal-tester`:

1. With `dev-menu` instead of `dev-client` as dependency specified in `package.json`:

``` bash
> npx expo prebuild --clean / npx expo prebuild -p ios --clean / npx expo prebuild -p android --clean
✔ Cleared android, ios code
✔ Created native directories
› Using symlinked expo instead of recommended expo@~55.0.0-preview.6.
✔ Updated package.json | no changes
» android: userInterfaceStyle: Install expo-system-ui in your project to enable this feature.
✔ Finished prebuild
✔ Installed CocoaPods
```


2. With `dev-client` as dependency specified in `package.json` (or also in `app.json`):

``` bash
> npx expo prebuild --clean / npx expo prebuild -p ios --clean / npx expo prebuild -p android --clean
⚠ It seems that you're using `expo-dev-client` with `expo-brownfield`
`expo-dev-client` isn't currently supported in the isolated brownfield setup
Please use `expo-dev-menu` instead
✔ Cleared android, ios code
✔ Created native directories
› Using symlinked expo instead of recommended expo@~55.0.0-preview.6.
✔ Updated package.json | no changes
» android: userInterfaceStyle: Install expo-system-ui in your project to enable this feature.
✔ Finished prebuild
✔ Installed CocoaPods
```

# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
