### PR TITLE
[menu][Android] Fix dev menu does not open when pressing m in terminal

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix dev menu not opening when pressing m key in CLI.
+- [Android] Fix dev menu not opening when pressing m key in CLI. ([#42566](https://github.com/expo/expo/pull/42566) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix dev menu not opening when pressing m key in CLI.
+
 ### 💡 Others
 
 ## 55.0.2 — 2026-01-26


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/42499.

# How

In the current React Native version, there's one packager connection that we can't kill. When a new web socket command is sent, we execute it twice, which cancels its effect.

# Test Plan

- new app using preview 6 ✅ 