### PR TITLE
[ios][dev-menu] Move connection info lower in the menu

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### 💡 Others
 
 - Make the Action Button always enabled on Quest. ([#42562](https://github.com/expo/expo/pull/42562) by [@behenate](https://github.com/behenate))
+- [ios] Moves connection info lower in the menu.
 
 ## 55.0.2 — 2026-01-26
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -17,7 +17,7 @@
 ### 💡 Others
 
 - Make the Action Button always enabled on Quest. ([#42562](https://github.com/expo/expo/pull/42562) by [@behenate](https://github.com/behenate))
-- [ios] Moves connection info lower in the menu.
+- [ios] Moves connection info lower in the menu. ([#42568](https://github.com/expo/expo/pull/42568) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 55.0.2 — 2026-01-26
 

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuMainView.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuMainView.swift
@@ -6,21 +6,11 @@ struct DevMenuMainView: View {
   var body: some View {
     ScrollView {
       VStack(spacing: 32) {
-        VStack {
-          if viewModel.configuration.showHostUrl, let hostUrl = viewModel.appInfo?.hostUrl {
-            HostUrl(
-              hostUrl: hostUrl,
-              onCopy: viewModel.copyToClipboard,
-              copiedMessage: viewModel.hostUrlCopiedMessage
-            )
-          }
-
-          DevMenuActions(
-            canNavigateHome: viewModel.canNavigateHome,
-            onReload: viewModel.reload,
-            onGoHome: viewModel.goHome
-          )
-        }
+        DevMenuActions(
+          canNavigateHome: viewModel.canNavigateHome,
+          onReload: viewModel.reload,
+          onGoHome: viewModel.goHome
+        )
 
         if !viewModel.registeredCallbacks.isEmpty {
           CustomItems(
@@ -33,6 +23,14 @@ struct DevMenuMainView: View {
 
         if viewModel.configuration.showDebuggingTip && viewModel.appInfo?.engine == "Hermes" {
           HermesDebuggerTip()
+        }
+
+        if viewModel.configuration.showHostUrl, let hostUrl = viewModel.appInfo?.hostUrl {
+          HostUrl(
+            hostUrl: hostUrl,
+            onCopy: viewModel.copyToClipboard,
+            copiedMessage: viewModel.hostUrlCopiedMessage
+          )
         }
 
         DevMenuAppInfo()


### PR DESCRIPTION
# Why
Moves the connection info lower in the menu.

# Test Plan
Bare expo

<img width="450" height="978" alt="simulator_screenshot_39EEF5B3-56FC-4838-8A7B-CF3FDDF23C7D" src="https://github.com/user-attachments/assets/9ede5649-8f05-4022-9aec-894d8bfc7edc" />