### PR TITLE
[android][dev-menu] Move connection info lower in the menu

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -17,7 +17,7 @@
 ### 💡 Others
 
 - Make the Action Button always enabled on Quest. ([#42562](https://github.com/expo/expo/pull/42562) by [@behenate](https://github.com/behenate))
-- [ios] Moves connection info lower in the menu. ([#42568](https://github.com/expo/expo/pull/42568) by [@alanjhughes](https://github.com/alanjhughes))
+- Moves connection info lower in the menu. ([#42568](https://github.com/expo/expo/pull/42568) and [#42569](https://github.com/expo/expo/pull/42569) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 55.0.2 — 2026-01-26
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/ui/DevMenuScreen.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/compose/ui/DevMenuScreen.kt
@@ -38,10 +38,6 @@ fun DevMenuScreen(
   }
 
   Column {
-    BundlerInfo(bundlerIp = appInfo.hostUrl)
-
-    Spacer(NewAppTheme.spacing.`2`)
-
     Row(
       horizontalArrangement = Arrangement.spacedBy(NewAppTheme.spacing.`2`),
       verticalAlignment = Alignment.CenterVertically
@@ -83,6 +79,10 @@ fun DevMenuScreen(
         Tip("Debugging not working? Try manually reloading first.")
       }
     }
+
+    BundlerInfo(bundlerIp = appInfo.hostUrl)
+
+    Spacer(NewAppTheme.spacing.`5`)
 
     SystemSection(
       appInfo.appVersion,


### PR DESCRIPTION
# Why
Moves the connection info lower in the menu.

# Test Plan
Bare expo

<img width="450" height="1010" alt="Screenshot_1769455531" src="https://github.com/user-attachments/assets/ffb183f5-9f1a-4f29-ade6-94a2ee1eb396" />
