### PR TITLE
[go][iOS] Enable swift Internal import by default

### DIFF
--- a/apps/expo-go/ios/Client/SwiftUI/HomeRootView.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/HomeRootView.swift
@@ -9,7 +9,7 @@ enum HomeTab: Hashable {
   case settings
 }
 
-public struct HomeRootView: View {
+struct HomeRootView: View {
   @ObservedObject var viewModel: HomeViewModel
   @State private var showingUserProfile = false
   @State private var selectedTab: HomeTab = .home

--- a/apps/expo-go/ios/Exponent.xcodeproj/project.pbxproj
+++ b/apps/expo-go/ios/Exponent.xcodeproj/project.pbxproj
@@ -750,6 +750,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
 				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
+				SWIFT_UPCOMING_FEATURE_INTERNAL_IMPORTS_BY_DEFAULT = YES;
 				USE_HERMES = true;
 			};
 			name = Debug;
@@ -818,6 +819,7 @@
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../../react-native-lab/react-native/packages/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
+				SWIFT_UPCOMING_FEATURE_INTERNAL_IMPORTS_BY_DEFAULT = YES;
 				USE_HERMES = true;
 				VALIDATE_PRODUCT = YES;
 			};

--- a/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/EXScopedNotificationSerializer.swift
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/EXScopedNotificationSerializer.swift
@@ -3,7 +3,7 @@
 import UserNotifications
 import ExpoNotifications
 
-public class EXScopedNotificationSerializer {
+class EXScopedNotificationSerializer {
 
     public static func serializedNotification(_ notification: UNNotification) -> NotificationRecord {
         let scopedSerializedNotification = NotificationRecord(from: notification)

--- a/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsCategoriesModule.swift
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsCategoriesModule.swift
@@ -3,7 +3,7 @@
 import ExpoModulesCore
 import ExpoNotifications
 
-public final class ExpoGoNotificationsCategoriesModule: CategoriesModule {
+final class ExpoGoNotificationsCategoriesModule: CategoriesModule {
   private let scopeKey: String
   // swiftlint:disable:next unavailable_function
   required init(appContext: AppContext) {

--- a/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsEmitterModule.swift
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsEmitterModule.swift
@@ -3,7 +3,7 @@
 import ExpoModulesCore
 import ExpoNotifications
 
-public final class ExpoGoNotificationsEmitterModule: EmitterModule {
+final class ExpoGoNotificationsEmitterModule: EmitterModule {
   private let scopeKey: String
   // swiftlint:disable:next unavailable_function
   required init(appContext: AppContext) {

--- a/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsHandlerModule.swift
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsHandlerModule.swift
@@ -3,7 +3,7 @@
 import ExpoModulesCore
 import ExpoNotifications
 
-public final class ExpoGoNotificationsHandlerModule: HandlerModule {
+final class ExpoGoNotificationsHandlerModule: HandlerModule {
   private let scopeKey: String
   // swiftlint:disable:next unavailable_function
   required init(appContext: AppContext) {

--- a/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsPresentationModule.swift
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsPresentationModule.swift
@@ -3,7 +3,7 @@
 import ExpoModulesCore
 import ExpoNotifications
 
-public final class ExpoGoNotificationsPresentationModule: PresentationModule {
+final class ExpoGoNotificationsPresentationModule: PresentationModule {
   private let scopeKey: String
   // swiftlint:disable:next unavailable_function
   required init(appContext: AppContext) {

--- a/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsSchedulerModule.swift
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsSchedulerModule.swift
@@ -3,7 +3,7 @@
 import ExpoModulesCore
 import ExpoNotifications
 
-public final class ExpoGoNotificationsSchedulerModule: SchedulerModule {
+final class ExpoGoNotificationsSchedulerModule: SchedulerModule {
   private let scopeKey: String
   // swiftlint:disable:next unavailable_function
   required init(appContext: AppContext) {

--- a/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsServerRegistrationModule.swift
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsServerRegistrationModule.swift
@@ -4,7 +4,7 @@ import ExpoModulesCore
 import ExpoNotifications
 
 // swiftlint:disable:next type_name
-public final class ExpoGoNotificationsServerRegistrationModule: ServerRegistrationModule {
+final class ExpoGoNotificationsServerRegistrationModule: ServerRegistrationModule {
   private let scopeKey: String
   // swiftlint:disable:next unavailable_function
   required init(appContext: AppContext) {

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -4724,7 +4724,7 @@ SPEC CHECKSUMS:
   GoogleAppMeasurement: 8a82b93a6400c8e6551c0bcd66a9177f2e067aed
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 452f2dd7422b2fd7973ae9ca103898d28d7744f0
+  hermes-engine: 2853aea4922d43f84b721631947e9b25da43eabd
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8


### PR DESCRIPTION
# Why

To allow us to land https://github.com/expo/expo/pull/42449 again we need to update Expo Go to support internal importing Expo modules 

# How

Enable swift Internal import by default in Expo Go's Xcode project and remove the explicit `public` declaration from classes that inherited from ExpoModuels 


# Test Plan

Run Expo Go locally after cherry picking a047cf3ee630784816903ff7a0677798d039b10f

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
