### PR TITLE
[dev-menu][iOS] Fix source map explorer horizontal scroll

### DIFF
--- a/packages/expo-dev-menu/ios/SwiftUI/SourceMapExplorerView.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/SourceMapExplorerView.swift
@@ -209,14 +209,11 @@ struct CodeFileView: View {
   }
 
   var body: some View {
-    GeometryReader { geometry in
-      ScrollView(.vertical) {
-        ScrollView(.horizontal, showsIndicators: false) {
-          HStack(alignment: .top, spacing: 0) {
-            LineNumbersColumn(lines: lines, theme: theme, lineNumberWidth: lineNumberWidth)
-            CodeColumn(lines: lines, highlightedLines: highlightedLines, theme: theme)
-          }
-          .frame(minWidth: geometry.size.width, alignment: .leading)
+    ScrollView(.vertical) {
+      ScrollView(.horizontal, showsIndicators: false) {
+        HStack(alignment: .top, spacing: 0) {
+          LineNumbersColumn(lines: lines, theme: theme, lineNumberWidth: lineNumberWidth)
+          CodeColumn(lines: lines, highlightedLines: highlightedLines, theme: theme)
         }
       }
     }
@@ -235,9 +232,9 @@ struct LineNumbersColumn: View {
   let lines: [String]
   let theme: SyntaxHighlighter.Theme
   let lineNumberWidth: CGFloat
-  
+
   var body: some View {
-    LazyVStack(alignment: .trailing, spacing: 0) {
+    VStack(alignment: .trailing, spacing: 0) {
       ForEach(0..<lines.count, id: \.self) { index in
         Text("\(index + 1)")
           .font(.system(size: 13, weight: .regular, design: .monospaced))
@@ -255,9 +252,9 @@ struct CodeColumn: View {
   let lines: [String]
   let highlightedLines: [AttributedString]?
   let theme: SyntaxHighlighter.Theme
-  
+
   var body: some View {
-    LazyVStack(alignment: .leading, spacing: 0) {
+    VStack(alignment: .leading, spacing: 0) {
       ForEach(0..<lines.count, id: \.self) { index in
         if let highlightedLines, index < highlightedLines.count {
           Text(highlightedLines[index])
@@ -271,6 +268,7 @@ struct CodeColumn: View {
         }
       }
     }
+    .fixedSize(horizontal: true, vertical: false)
     .padding(.vertical, 12)
     .padding(.trailing, 16)
   }


### PR DESCRIPTION
# Why

Users can't horizontally scroll through code in the new source map explorer, and the text gets wrapped

https://github.com/user-attachments/assets/9541f20c-c9fd-4113-9a7b-20864642fe48

# How

Replaced `LazyVStack` with regular `VStack` and used fixedSize horizontal: true to prevent text wrapping 

# Test Plan

Run Expo Go locally 

https://github.com/user-attachments/assets/37c0d101-50c9-47a7-99db-44a83568354f



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
