### PR TITLE
[expo-go] Add dev menu config options api

### DIFF
--- a/apps/expo-go/ios/Client/EXRootViewController.m
+++ b/apps/expo-go/ios/Client/EXRootViewController.m
@@ -353,6 +353,21 @@ NS_ASSUME_NONNULL_BEGIN
     if (isShowingApp && appRecord.appManager.reactHost) {
       [[DevMenuManager shared] updateCurrentBridge:[RCTBridge currentBridge]];
       [[DevMenuManager shared] updateCurrentManifest:appRecord.appLoader.manifest manifestURL:appRecord.appLoader.manifestUrl];
+
+      DevMenuConfiguration *config = [DevMenuManager shared].configuration;
+
+      BOOL isDev = appRecord.appLoader.manifest.isDevelopmentMode || appRecord.appLoader.manifest.isUsingDeveloperTool;
+      BOOL isSnack = [self _isSnackURL:appRecord.appLoader.manifestUrl];
+
+      if (!isDev) {
+        config.showDebuggingTip = NO;
+        config.showFastRefresh = NO;
+        config.showHostUrl = isSnack;
+      } else {
+        config.showDebuggingTip = YES;
+        config.showFastRefresh = YES;
+        config.showHostUrl = NO;
+      }
     }
   }
 
@@ -411,6 +426,15 @@ NS_ASSUME_NONNULL_BEGIN
     UIInterfaceOrientationMask orientationMask = [self supportedInterfaceOrientations];
     [ScreenOrientationRegistry.shared enforceDesiredDeviceOrientationWithOrientationMask:orientationMask];
   }
+}
+
+- (BOOL)_isSnackURL:(nullable NSURL *)url
+{
+  if (!url) {
+    return NO;
+  }
+  NSString *query = [url query];
+  return query && ([query containsString:@"snack"] || [query containsString:@"snack-channel"]);
 }
 
 @end

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -7,6 +7,27 @@ import CoreGraphics
 import CoreMedia
 import Combine
 
+/**
+ Configuration options for customizing the dev menu appearance.
+ Host apps (e.g., Expo Go) can set these to tailor the menu for their context.
+ The defaults match the standard dev menu behavior.
+ */
+@objc
+public class DevMenuConfiguration: NSObject {
+  /// Whether to show the debugging tip (e.g., "Debugging not working? Try manually reloading first.")
+  @objc public var showDebuggingTip: Bool = true
+
+  /// Whether to show the "Connected to:" host URL section
+  @objc public var showHostUrl: Bool = true
+
+  /// Whether to show the Fast Refresh toggle
+  @objc public var showFastRefresh: Bool = true
+
+  /// Custom title for the onboarding text. Use to replace "development builds" with e.g. "Expo Go".
+  /// When nil, the default "development builds" text is used.
+  @objc public var onboardingAppName: String?
+}
+
 class Dispatch {
   static func mainSync<T>(_ closure: () -> T) -> T {
     if Thread.isMainThread {
@@ -50,6 +71,8 @@ open class DevMenuManager: NSObject {
 
   var packagerConnectionHandler: DevMenuPackagerConnectionHandler?
   var canLaunchDevMenuOnStart = true
+
+  @objc public var configuration = DevMenuConfiguration()
 
   static public var wasInitilized = false
 

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuDeveloperTools.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuDeveloperTools.swift
@@ -38,15 +38,17 @@ struct DevMenuDeveloperTools: View {
           )
         }
 
-        Divider()
+        if viewModel.configuration.showFastRefresh {
+          Divider()
 
-        DevMenuToggleButton(
-          title: "Fast refresh",
-          icon: "figure.run",
-          isEnabled: viewModel.devSettings?.isHotLoadingEnabled ?? false,
-          action: viewModel.toggleFastRefresh,
-          disabled: !(viewModel.devSettings?.isHotLoadingAvailable ?? true)
-        )
+          DevMenuToggleButton(
+            title: "Fast refresh",
+            icon: "figure.run",
+            isEnabled: viewModel.devSettings?.isHotLoadingEnabled ?? false,
+            action: viewModel.toggleFastRefresh,
+            disabled: !(viewModel.devSettings?.isHotLoadingAvailable ?? true)
+          )
+        }
 
         Divider()
 

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuMainView.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuMainView.swift
@@ -7,7 +7,7 @@ struct DevMenuMainView: View {
     ScrollView {
       VStack(spacing: 32) {
         VStack {
-          if let hostUrl = viewModel.appInfo?.hostUrl {
+          if viewModel.configuration.showHostUrl, let hostUrl = viewModel.appInfo?.hostUrl {
             HostUrl(
               hostUrl: hostUrl,
               onCopy: viewModel.copyToClipboard,
@@ -31,7 +31,7 @@ struct DevMenuMainView: View {
 
         DevMenuDeveloperTools()
 
-        if viewModel.appInfo?.engine == "Hermes" {
+        if viewModel.configuration.showDebuggingTip && viewModel.appInfo?.engine == "Hermes" {
           HermesDebuggerTip()
         }
 
@@ -47,6 +47,7 @@ struct DevMenuMainView: View {
     .navigationTitle("Dev Menu")
 #if !os(macOS)
     .navigationBarHidden(true)
+    .navigationBarTitleDisplayMode(.inline)
 #endif
   }
 }

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
@@ -169,6 +169,10 @@ class DevMenuViewModel: ObservableObject {
     return devMenuManager.shouldShowReactNativeDevMenu
   }
 
+  var configuration: DevMenuConfiguration {
+    return devMenuManager.configuration
+  }
+
   private func checkOnboardingStatus() {
     isOnboardingFinished = devMenuManager.isOnboardingFinished
   }


### PR DESCRIPTION
# Why
Closes ENG-18972
Closes ENG-18976
Closes ENG-18975
Adds a configuration api to control what elements the dev menu will display.

# How
Add `DevMenuConfiguration` that host apps can use to customise more of the menu

# Test Plan
Expo go

