### PR TITLE
[expo-go] Configure onboarding app name

### DIFF
--- a/apps/expo-go/ios/Exponent/Kernel/Core/EXKernel.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Core/EXKernel.m
@@ -62,6 +62,7 @@ NSString * const kEXReloadActiveAppRequest = @"EXReloadActiveAppRequest";
     _serviceRegistry = [[EXKernelServiceRegistry alloc] init];
 
     [DevMenuManager.shared setDelegate:self];
+    [DevMenuManager shared].configuration.onboardingAppName = @"Expo Go";
 
     // Register keyboard commands (e.g., Cmd+D) for simulator
     [[EXKernelDevKeyCommands sharedInstance] registerDevCommands];

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuOnboardingView.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuOnboardingView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct DevMenuOnboardingView: View {
   let onFinish: () -> Void
+  var appName: String = "development builds"
   @State private var isVisible = true
 
   var body: some View {
@@ -16,7 +17,7 @@ struct DevMenuOnboardingView: View {
   private var onboardingOverlay: some View {
     VStack(spacing: 24) {
       VStack(spacing: 16) {
-        Text("This is the developer menu. It gives you access to useful tools in your development builds.")
+        Text("This is the developer menu. It gives you access to useful tools in \(appName).")
           .frame(maxWidth: .infinity, alignment: .leading)
           .font(.callout)
 

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuRootView.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuRootView.swift
@@ -17,7 +17,10 @@ struct DevMenuRootView: View {
 
         #if !os(tvOS)
         if !viewModel.isOnboardingFinished {
-          DevMenuOnboardingView(onFinish: viewModel.finishOnboarding)
+          DevMenuOnboardingView(
+            onFinish: viewModel.finishOnboarding,
+            appName: viewModel.configuration.onboardingAppName ?? "your development builds"
+          )
         }
         #endif
       }


### PR DESCRIPTION
# Why
Closes ENG-18974

# How
Use new api to set `onboardingAppName`

# Test Plan
<img width="450" height="978" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-27 at 10 52 40" src="https://github.com/user-attachments/assets/83be3db0-89a0-47b6-b6c2-50e55f15dd23" />

