### PR TITLE
[expo-go] Enable editing source in explorer

### DIFF
--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -4724,7 +4724,7 @@ SPEC CHECKSUMS:
   GoogleAppMeasurement: 8a82b93a6400c8e6551c0bcd66a9177f2e067aed
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 2853aea4922d43f84b721631947e9b25da43eabd
+  hermes-engine: 452f2dd7422b2fd7973ae9ca103898d28d7744f0
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8

--- a/packages/expo-dev-menu/ios/EXDevMenuDevSettings.swift
+++ b/packages/expo-dev-menu/ios/EXDevMenuDevSettings.swift
@@ -31,7 +31,7 @@ class EXDevMenuDevSettings: NSObject {
       devSettings["isHotLoadingEnabled"] = bridgeSettings.isHotLoadingEnabled
       devSettings["isPerfMonitorShown"] = bridgeSettings.isPerfMonitorShown
       devSettings["isHotLoadingAvailable"] = bridgeSettings.isHotLoadingAvailable
-      devSettings["isPerfMonitorAvailable"] = isPerfMonitorAvailable
+      devSettings["isPerfMonitorAvailable"] = isPerfMonitorAvailable && manager.currentManifest?.isDevelopmentMode() == true
       devSettings["isJSInspectorAvailable"] = bridgeSettings.isDeviceDebuggingAvailable
 
       let isElementInspectorAvailable = manager.currentManifest?.isDevelopmentMode()

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuAppInfo.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuAppInfo.swift
@@ -43,6 +43,7 @@ struct DevMenuAppInfo: View {
           .disabled(viewModel.clipboardMessage != nil)
         }
       }
+      .padding(.horizontal)
       .background(Color.expoSystemBackground)
       .cornerRadius(18)
     }

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
@@ -205,6 +205,7 @@ class DevMenuViewModel: ObservableObject {
       .receive(on: DispatchQueue.main)
       .sink { [weak self] _ in
         self?.loadAppInfo()
+        self?.loadDevSettings()
       }
       .store(in: &cancellables)
   }


### PR DESCRIPTION
# Why
Closes ENG-18979
Make source code editable in the explorer.

# How
This is only an in-memory edit and does not persist once you leave the screen.

# Test Plan
Expo go

