### PR TITLE
refactor(@expo/cli): remove legacy typed routes logic

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Remove legacy typed routes logic for SDK 51 projects ([#42604](https://github.com/expo/expo/pull/42604) by [@hassankhan](https://github.com/hassankhan))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes


### PR DESCRIPTION
# Why

`@expo/cli` still had logic for the SDK 51 method of generating typed routes. Since SDK 51 is now unsupported, it should be safe to remove this.

# How

Removed the "legacy" method of generating typed routes from `type-generation/routes.ts`.

# Test Plan

- CI

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
