### PR TITLE
[docs] Adds database docs

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -60,6 +60,7 @@ exceptions:
   - '.*CNG.*'
   - '.*CocoaPods.*'
   - '.*CodePush.*'
+  - '.*Convex.*'
   - '.*Command Line Tools.*'
   - '.*Config Plugin.*'
   - '.*CORS.*'

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -129,6 +129,7 @@ export const home = [
       ],
       { expanded: false }
     ),
+    makePage('develop/database.mdx'),
     makePage('develop/authentication.mdx'),
     makePage('develop/unit-testing.mdx'),
   ]),
@@ -357,6 +358,7 @@ export const general = [
     ]),
     makeGroup('CMS', [makePage('guides/using-a-cms.mdx')]),
     makeGroup('Database and SDKs', [
+      makePage('guides/using-convex.mdx'),
       makePage('guides/using-firebase.mdx'),
       makePage('guides/using-supabase.mdx'),
     ]),

--- a/docs/pages/develop/database.mdx
+++ b/docs/pages/develop/database.mdx
@@ -1,0 +1,44 @@
+---
+title: Databases in Expo and React Native apps
+description: Learn about adding a database to your Expo project.
+sidebar_title: Database
+---
+
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+
+Most apps need to persist data beyond the lifetime of a single session. You can use a cloud-hosted database to store your app's data and sync it across devices and users.
+
+## Convex
+
+[Convex](https://www.convex.dev/) is a TypeScript-based database that requires no cluster management, SQL, or ORMs. Convex provides real-time updates over a WebSocket, making it perfect for reactive apps.
+
+<BoxLink
+  title="Using Convex"
+  description="Add a database to your app with Convex."
+  href="/guides/using-convex/"
+  Icon={BookOpen02Icon}
+/>
+
+## Supabase
+
+[Supabase](https://supabase.com/) is an app development platform that provides hosted backend services such as a Postgres database, user authentication, file storage, edge functions, realtime syncing, and a vector and AI toolkit.
+
+<BoxLink
+  title="Using Supabase"
+  description="Add a Postgres database and user authentication to your app with Supabase."
+  href="/guides/using-supabase/"
+  Icon={BookOpen02Icon}
+/>
+
+## Firebase
+
+[Firebase](https://firebase.google.com/) is an app development platform that provides hosted backend services such as real-time database, cloud storage, authentication, crash reporting, analytics, and more. It is built on Google's infrastructure and scales automatically.
+
+<BoxLink
+  title="Using Firebase"
+  description="Get started with Firebase JS SDK and React Native Firebase."
+  href="/guides/using-firebase/"
+  Icon={BookOpen02Icon}
+/>

--- a/docs/pages/guides/using-convex.mdx
+++ b/docs/pages/guides/using-convex.mdx
@@ -45,7 +45,11 @@ Leave this command running in one terminal window so that it can sync your funct
 
 Running `npx convex dev` saves your deployment URL to a **.env.local** file as `EXPO_PUBLIC_CONVEX_URL`. To make it available in your app builds, add it as an [EAS environment variable](/eas/environment-variables/) in a new terminal session:
 
-<Terminal cmd={["$ eas env:create --name EXPO_PUBLIC_CONVEX_URL --value https://YOUR_DEPLOYMENT_URL.convex.cloud --visibility plaintext --environment production --environment preview --environment development"]} />
+<Terminal
+  cmd={[
+    '$ eas env:create --name EXPO_PUBLIC_CONVEX_URL --value https://YOUR_DEPLOYMENT_URL.convex.cloud --visibility plaintext --environment production --environment preview --environment development',
+  ]}
+/>
 
 Replace `https://YOUR_DEPLOYMENT_URL.convex.cloud` with the `EXPO_PUBLIC_CONVEX_URL` value from your **.env.local** file. To learn more, see [Environment variables](/guides/environment-variables/).
 

--- a/docs/pages/guides/using-convex.mdx
+++ b/docs/pages/guides/using-convex.mdx
@@ -1,0 +1,144 @@
+---
+title: Using Convex
+description: Add a database to your app with Convex.
+---
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
+
+[Convex](https://www.convex.dev/) is a TypeScript-based database that requires no cluster management, SQL, or ORMs. Convex provides real-time updates over a WebSocket, making it perfect for reactive apps.
+
+<Step label="1">
+
+## Install Convex
+
+After you have created your [Expo project](/get-started/create-a-project/), install `convex` using the following command:
+
+<Terminal cmd={['$ npx expo install convex']} />
+
+</Step>
+
+<Step label="2">
+
+## Set up a Convex dev deployment
+
+Run the following command to set up your Convex project:
+
+<Terminal cmd={['$ npx convex dev']} />
+
+This command:
+
+- Creates a Convex account or allows you to log in.
+- Creates a project on Convex.
+- Saves your production and deployment URLs.
+
+It also creates a **convex/** folder where you can write backend API functions that Convex will host.
+
+Leave this command running in one terminal window so that it can sync your functions with your dev deployment in Convex's cloud.
+
+</Step>
+
+<Step label="3">
+
+## Seed your database
+
+In a new terminal session, create a **sampleData.jsonl** file with the following sample data:
+
+```json sampleData.jsonl
+{"text": "Buy groceries", "isCompleted": true}
+{"text": "Go for a swim", "isCompleted": true}
+{"text": "Integrate Convex", "isCompleted": false}
+```
+
+To send this data to Convex, run:
+
+<Terminal cmd={['$ npx convex import --table tasks sampleData.jsonl']} />
+
+</Step>
+
+<Step label="4">
+
+## Query the database
+
+All queries in Convex are TypeScript code. Create a **convex/tasks.ts** file with the following contents:
+
+```ts convex/tasks.ts
+import { query } from './_generated/server';
+
+export const get = query({
+  args: {},
+  handler: async tx > {
+    return await ctx.db.query('tasks').collect();
+  },
+});
+```
+
+</Step>
+
+<Step label="5">
+
+## Connect your app
+
+In the top-level **app/\\\_layout.tsx** file in your app, create a `ConvexReactClient` and pass it to a `ConvexProvider` wrapping your component tree:
+
+```tsx app/_layout.tsx
+import { ConvexProvider, ConvexReactClient } from 'convex/react';
+import { Stack } from 'expo-router';
+
+const convex = new ConvexReactClient(process.env.EXPO_PUBLIC_CONVEX_URL!, {
+  unsavedChangesWarning: false,
+});
+
+export default function RootLayout() {
+  return (
+    <ConvexProvider client={convex}>
+      <Stack>
+        <Stack.Screen name="index" />
+      </Stack>
+    </ConvexProvider>
+  );
+}
+```
+
+</Step>
+
+<Step label="6">
+
+## Display the data in your app
+
+In your app, use the `useQuery` hook to fetch data from your `api.tasks.get` API:
+
+```tsx app/index.tsx
+import { api } from '@/convex/_generated/api';
+import { useQuery } from 'convex/react';
+import { Text, View } from 'react-native';
+
+export default function Index() {
+  const tasks = useQuery(api.tasks.get);
+
+  return (
+    <View
+      style={{
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}  {tasks?.map(({ _id, text }) => (
+        <Text key={_id}>{text}</Text (
+       >
+      )
+      ))}
+    </View>
+  );
+}
+```
+
+</Step>
+
+## Next steps
+
+<BoxLink
+  title="Learn how to use Convex"
+  description="Learn how Convex works while building a chat app."
+  href="https://docs.convex.dev/tutorial/"
+/>

--- a/docs/pages/guides/using-convex.mdx
+++ b/docs/pages/guides/using-convex.mdx
@@ -41,9 +41,21 @@ Leave this command running in one terminal window so that it can sync your funct
 
 <Step label="3">
 
+## Save the Convex URL as an EAS environment variable
+
+Running `npx convex dev` saves your deployment URL to a **.env.local** file as `EXPO_PUBLIC_CONVEX_URL`. To make it available in your app builds, add it as an [EAS environment variable](/eas/environment-variables/) in a new terminal session:
+
+<Terminal cmd={["$ eas env:create --name EXPO_PUBLIC_CONVEX_URL --value https://YOUR_DEPLOYMENT_URL.convex.cloud --visibility plaintext --environment production --environment preview --environment development"]} />
+
+Replace `https://YOUR_DEPLOYMENT_URL.convex.cloud` with the `EXPO_PUBLIC_CONVEX_URL` value from your **.env.local** file. To learn more, see [Environment variables](/guides/environment-variables/).
+
+</Step>
+
+<Step label="4">
+
 ## Seed your database
 
-In a new terminal session, create a **sampleData.jsonl** file with the following sample data:
+Next, create a **sampleData.jsonl** file with the following sample data:
 
 ```json sampleData.jsonl
 {"text": "Buy groceries", "isCompleted": true}
@@ -57,7 +69,7 @@ To send this data to Convex, run:
 
 </Step>
 
-<Step label="4">
+<Step label="5">
 
 ## Query the database
 
@@ -76,13 +88,13 @@ export const get = query({
 
 </Step>
 
-<Step label="5">
+<Step label="6">
 
 ## Connect your app
 
-In the top-level **app/\\\_layout.tsx** file in your app, create a `ConvexReactClient` and pass it to a `ConvexProvider` wrapping your component tree:
+In the top-level **src/app/\_layout.tsx** file in your app, create a `ConvexReactClient` and pass it to a `ConvexProvider` wrapping your component tree:
 
-```tsx app/_layout.tsx
+```tsx src/app/_layout.tsx
 import { ConvexProvider, ConvexReactClient } from 'convex/react';
 import { Stack } from 'expo-router';
 
@@ -103,13 +115,13 @@ export default function RootLayout() {
 
 </Step>
 
-<Step label="6">
+<Step label="7">
 
 ## Display the data in your app
 
 In your app, use the `useQuery` hook to fetch data from your `api.tasks.get` API:
 
-```tsx app/index.tsx
+```tsx src/app/index.tsx
 import { api } from '@/convex/_generated/api';
 import { useQuery } from 'convex/react';
 import { Text, View } from 'react-native';

--- a/docs/pages/guides/using-convex.mdx
+++ b/docs/pages/guides/using-convex.mdx
@@ -68,7 +68,7 @@ import { query } from './_generated/server';
 
 export const get = query({
   args: {},
-  handler: async tx > {
+  handler: async ctx => {
     return await ctx.db.query('tasks').collect();
   },
 });
@@ -123,10 +123,9 @@ export default function Index() {
         flex: 1,
         justifyContent: 'center',
         alignItems: 'center',
-      }}  {tasks?.map(({ _id, text }) => (
-        <Text key={_id}>{text}</Text (
-       >
-      )
+      }}>
+      {tasks?.map(({ _id, text }) => (
+        <Text key={_id}>{text}</Text>
       ))}
     </View>
   );


### PR DESCRIPTION
# Why

We'd like to inform users how to set up a database in their project. This PR adds a new page to the main home docs page named "Database", which links to docs for how to set up Convex, Supabase, and Firebase.

# Test Plan

Make sure the changes read well on /develop/database/ and /guides/using-convex/.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive guide for database options available for Expo and React Native apps, covering Convex, Supabase, and Firebase
  * Added step-by-step integration guide for implementing Convex with code examples and sample data
  * Updated navigation to include new database documentation sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->