### PR TITLE
[expo-go][dev-launcher] Fix account screen layout shift

### DIFF
--- a/apps/expo-go/ios/Client/SwiftUI/Account/AccountSheet.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Account/AccountSheet.swift
@@ -101,11 +101,6 @@ struct AccountSheet: View {
         signInButton
         signUpButton
       }
-
-      if viewModel.isAuthenticating {
-        ProgressView()
-          .scaleEffect(0.8)
-      }
     }
   }
 
@@ -116,12 +111,22 @@ struct AccountSheet: View {
         await viewModel.signIn()
       }
     } label: {
-      Text("Log In")
-        .font(.headline)
-        .fontWeight(.semibold)
-        .foregroundColor(.white)
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 12)
+      HStack(spacing: 8) {
+        if viewModel.isAuthenticating {
+          ProgressView()
+            .tint(.white)
+            .scaleEffect(0.8)
+            .transition(.scale.combined(with: .opacity))
+        }
+
+        Text("Log In")
+          .font(.headline)
+          .fontWeight(.semibold)
+      }
+      .foregroundColor(.white)
+      .frame(maxWidth: .infinity)
+      .padding(.vertical, 12)
+      .animation(.easeInOut(duration: 0.2), value: viewModel.isAuthenticating)
     }
     .background(Color.black)
     .cornerRadius(12)

--- a/packages/expo-dev-launcher/ios/SwiftUI/AccountSheet.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/AccountSheet.swift
@@ -108,11 +108,6 @@ struct AccountSheet: View {
         signUpButton
       }
       #endif
-
-      if viewModel.isAuthenticating {
-        ProgressView()
-          .scaleEffect(0.8)
-      }
     }
   }
 
@@ -123,12 +118,22 @@ struct AccountSheet: View {
       }
     }
     label: {
-      Text("Log In")
-        .font(.headline)
-        .fontWeight(.semibold)
-        .foregroundColor(.white)
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 12)
+      HStack(spacing: 8) {
+        if viewModel.isAuthenticating {
+          ProgressView()
+            .tint(.white)
+            .scaleEffect(0.8)
+            .transition(.scale.combined(with: .opacity))
+        }
+
+        Text("Log In")
+          .font(.headline)
+          .fontWeight(.semibold)
+      }
+      .foregroundColor(.white)
+      .frame(maxWidth: .infinity)
+      .padding(.vertical, 12)
+      .animation(.easeInOut(duration: 0.2), value: viewModel.isAuthenticating)
     }
     .background(Color.black)
     .cornerRadius(12)


### PR DESCRIPTION
# Why
Currently in expo go and dev launcher when you tap "Log in" the progress indicator appears below the buttons causing a layout shift.

# How
Move the progress indicator inside the log in button and animate its appearance.

# Test Plan
Expo go
