### PR TITLE
[expo-go][dev-launcher] Clear recently opened on account change

### DIFF
--- a/apps/expo-go/ios/Client/SwiftUI/HomeViewModel.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/HomeViewModel.swift
@@ -105,12 +105,14 @@ class HomeViewModel: ObservableObject {
 
   func signOut() {
     authService.signOut()
+    clearRecentlyOpenedApps()
     dataService.clearData()
     dataService.stopPolling()
   }
 
   func selectAccount(accountId: String) {
     authService.selectAccount(accountId: accountId)
+    clearRecentlyOpenedApps()
     if let account = selectedAccount {
       dataService.startPolling(accountName: account.name)
     }

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
@@ -356,6 +356,7 @@ class DevLauncherViewModel: ObservableObject {
     UserDefaults.standard.removeObject(forKey: sessionKey)
     UserDefaults.standard.removeObject(forKey: selectedAccountKey)
     APIClient.shared.setSession(nil)
+    clearRecentlyOpenedApps()
     isAuthenticated = false
     user = nil
     selectedAccountId = nil
@@ -364,6 +365,7 @@ class DevLauncherViewModel: ObservableObject {
   func selectAccount(accountId: String) {
     selectedAccountId = accountId
     UserDefaults.standard.set(accountId, forKey: selectedAccountKey)
+    clearRecentlyOpenedApps()
   }
 
   private func performAuthentication(isSignUp: Bool) async throws -> Bool {


### PR DESCRIPTION
# Why
When the signed in account changes, we should clear the recently opened apps list to prevent unaccessible projects showing up when you are on a different account

# How
Clear the list when selecting an account and sign out

# Test Plan
Expo go

