### PR TITLE
[expo cli] Add --browser option to expo login

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `--browser` option to `expo login`. ([#42614](https://github.com/expo/expo/pull/42614) by [@byronkarlen](https://github.com/byronkarlen))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/@expo/cli/e2e/__tests__/login-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/login-test.ts
@@ -41,6 +41,7 @@ it('runs `npx expo login --help`', async () => {
         -p, --password <string>  Password
         --otp <string>           One-time password from your 2FA device
         -s, --sso                Log in with SSO
+        -b, --browser            Log in with a browser
         -h, --help               Usage info
     "
   `);

--- a/packages/@expo/cli/src/api/user/__mocks__/user.ts
+++ b/packages/@expo/cli/src/api/user/__mocks__/user.ts
@@ -1,8 +1,9 @@
 export const getUserAsync = jest.fn(async () => ({}));
 export const loginAsync = jest.fn();
+export const browserLoginAsync = jest.fn();
 export const ANONYMOUS_USERNAME = 'anonymous';
 
 jest.mock('../user', () => ({
   loginAsync: jest.fn(),
-  ssoLoginAsync: jest.fn(),
+  browserLoginAsync: jest.fn(),
 }));

--- a/packages/@expo/cli/src/api/user/__tests__/actions-test.ts
+++ b/packages/@expo/cli/src/api/user/__tests__/actions-test.ts
@@ -2,7 +2,7 @@ import { promptAsync } from '../../../utils/prompts';
 import { ApiV2Error } from '../../rest/client';
 import { showLoginPromptAsync } from '../actions';
 import { retryUsernamePasswordAuthWithOTPAsync, UserSecondFactorDeviceMethod } from '../otp';
-import { loginAsync, ssoLoginAsync } from '../user';
+import { loginAsync, browserLoginAsync } from '../user';
 
 jest.mock('../../../log');
 jest.mock('../../../utils/prompts');
@@ -22,7 +22,7 @@ beforeEach(() => {
   });
 
   jest.mocked(loginAsync).mockClear();
-  jest.mocked(ssoLoginAsync).mockClear();
+  jest.mocked(browserLoginAsync).mockClear();
 });
 
 describe(showLoginPromptAsync, () => {
@@ -103,10 +103,19 @@ describe(showLoginPromptAsync, () => {
     expect(loginAsync).toHaveBeenCalledTimes(1);
   });
 
-  it('calls SSO login if the sso flag is true', async () => {
+  it('calls browser login with sso=true if the sso flag is true', async () => {
     jest.mocked(promptAsync);
     await showLoginPromptAsync({ username: 'hello', password: 'world', sso: true });
 
-    expect(ssoLoginAsync).toHaveBeenCalledTimes(1);
+    expect(browserLoginAsync).toHaveBeenCalledTimes(1);
+    expect(browserLoginAsync).toHaveBeenCalledWith({ sso: true });
+  });
+
+  it('calls browser login with sso=false if the browser flag is true', async () => {
+    jest.mocked(promptAsync);
+    await showLoginPromptAsync({ username: 'hello', password: 'world', browser: true });
+
+    expect(browserLoginAsync).toHaveBeenCalledTimes(1);
+    expect(browserLoginAsync).toHaveBeenCalledWith({ sso: false });
   });
 });

--- a/packages/@expo/cli/src/api/user/__tests__/user-test.ts
+++ b/packages/@expo/cli/src/api/user/__tests__/user-test.ts
@@ -14,7 +14,7 @@ import {
   getUserAsync,
   loginAsync,
   logoutAsync,
-  ssoLoginAsync,
+  browserLoginAsync,
 } from '../user';
 
 jest.mock('../expoSsoLauncher', () => ({
@@ -125,11 +125,11 @@ describe(loginAsync, () => {
   });
 });
 
-describe(ssoLoginAsync, () => {
+describe(browserLoginAsync, () => {
   it('saves user data to ~/.expo/state.json', async () => {
     jest.mocked(getSessionUsingBrowserAuthFlowAsync).mockResolvedValue('SESSION_SECRET');
 
-    await ssoLoginAsync();
+    await browserLoginAsync({ sso: false });
 
     expect(await fs.promises.readFile(getSettingsFilePath(), 'utf8')).toMatchInlineSnapshot(`
       "{
@@ -142,6 +142,16 @@ describe(ssoLoginAsync, () => {
       }
       "
     `);
+  });
+
+  it('passes sso parameter to getSessionUsingBrowserAuthFlowAsync', async () => {
+    jest.mocked(getSessionUsingBrowserAuthFlowAsync).mockResolvedValue('SESSION_SECRET');
+
+    await browserLoginAsync({ sso: true });
+
+    expect(getSessionUsingBrowserAuthFlowAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ sso: true })
+    );
   });
 });
 

--- a/packages/@expo/cli/src/api/user/actions.ts
+++ b/packages/@expo/cli/src/api/user/actions.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import chalk from 'chalk';
 
 import { retryUsernamePasswordAuthWithOTPAsync } from './otp';
-import { Actor, getUserAsync, loginAsync, ssoLoginAsync } from './user';
+import { Actor, getUserAsync, loginAsync, browserLoginAsync } from './user';
 import * as Log from '../../log';
 import { env } from '../../utils/env';
 import { CommandError } from '../../utils/errors';
@@ -21,19 +21,21 @@ export async function showLoginPromptAsync({
   password?: string;
   otp?: string;
   sso?: boolean | undefined;
+  browser?: boolean | undefined;
 } = {}): Promise<void> {
   if (env.EXPO_OFFLINE) {
     throw new CommandError('OFFLINE', 'Cannot authenticate in offline-mode');
   }
   const hasCredentials = options.username && options.password;
   const sso = options.sso;
+  const browser = options.browser;
 
   if (printNewLine) {
     Log.log();
   }
 
-  if (sso) {
-    await ssoLoginAsync();
+  if (sso || browser) {
+    await browserLoginAsync({ sso: !!sso });
     return;
   }
 

--- a/packages/@expo/cli/src/api/user/expoSsoLauncher.ts
+++ b/packages/@expo/cli/src/api/user/expoSsoLauncher.ts
@@ -18,10 +18,10 @@ export async function getSessionUsingBrowserAuthFlowAsync({
   const path = '/auth/callback';
 
   const buildExpoLoginUrl = (port: number, sso: boolean): string => {
-    const data = {
+    const params = querystring.stringify({
+      confirm_account: 'true',
       app_redirect_uri: `${scheme}://${hostname}:${port}${path}`,
-    };
-    const params = querystring.stringify(data);
+    });
     return `${expoWebsiteUrl}${sso ? '/sso-login' : '/login'}?${params}`;
   };
 

--- a/packages/@expo/cli/src/api/user/expoSsoLauncher.ts
+++ b/packages/@expo/cli/src/api/user/expoSsoLauncher.ts
@@ -6,51 +6,23 @@ import querystring from 'querystring';
 
 import * as Log from '../../log';
 
-const successBody = `
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>Expo SSO Login</title>
-  <meta charset="utf-8">
-  <style type="text/css">
-    html {
-      margin: 0;
-      padding: 0
-    }
-
-    body {
-      background-color: #fff;
-      font-family: Tahoma,Verdana;
-      font-size: 16px;
-      color: #000;
-      max-width: 100%;
-      box-sizing: border-box;
-      padding: .5rem;
-      margin: 1em;
-      overflow-wrap: break-word
-    }
-  </style>
-</head>
-<body>
-  SSO login complete. You may now close this tab and return to the command prompt.
-</body>
-</html>`;
-
 export async function getSessionUsingBrowserAuthFlowAsync({
   expoWebsiteUrl,
+  sso = false,
 }: {
   expoWebsiteUrl: string;
+  sso?: boolean;
 }): Promise<string> {
   const scheme = 'http';
   const hostname = 'localhost';
   const path = '/auth/callback';
 
-  const buildExpoSsoLoginUrl = (port: number): string => {
+  const buildExpoLoginUrl = (port: number, sso: boolean): string => {
     const data = {
       app_redirect_uri: `${scheme}://${hostname}:${port}${path}`,
     };
     const params = querystring.stringify(data);
-    return `${expoWebsiteUrl}/sso-login?${params}`;
+    return `${expoWebsiteUrl}${sso ? '/sso-login' : '/login'}?${params}`;
   };
 
   // Start server and begin auth flow
@@ -60,9 +32,19 @@ export async function getSessionUsingBrowserAuthFlowAsync({
 
       const server = http.createServer(
         (request: http.IncomingMessage, response: http.ServerResponse) => {
+          const redirectAndCleanup = (result: 'success' | 'error'): void => {
+            const redirectUrl = `${expoWebsiteUrl}/oauth/expo-cli?result=${result}`;
+            response.writeHead(302, { Location: redirectUrl });
+            response.end();
+            server.close();
+            for (const connection of connections) {
+              connection.destroy();
+            }
+          };
+
           try {
-            if (!(request.method === 'GET' && request.url?.includes(path))) {
-              throw new Error('Unexpected SSO login response.');
+            if (!(request.method === 'GET' && request.url?.includes('/auth/callback'))) {
+              throw new Error('Unexpected login response.');
             }
             const url = new URL(request.url, `http:${request.headers.host}`);
             const sessionSecret = url.searchParams.get('session_secret');
@@ -71,17 +53,10 @@ export async function getSessionUsingBrowserAuthFlowAsync({
               throw new Error('Request missing session_secret search parameter.');
             }
             resolve(sessionSecret);
-            response.writeHead(200, { 'Content-Type': 'text/html' });
-            response.write(successBody);
-            response.end();
+            redirectAndCleanup('success');
           } catch (error) {
+            redirectAndCleanup('error');
             reject(error);
-          } finally {
-            server.close();
-            // Ensure that the server shuts down
-            for (const connection of connections) {
-              connection.destroy();
-            }
           }
         }
       );
@@ -95,7 +70,7 @@ export async function getSessionUsingBrowserAuthFlowAsync({
           'Server address and port should be set after listening has begun'
         );
         const port = address.port;
-        const authorizeUrl = buildExpoSsoLoginUrl(port);
+        const authorizeUrl = buildExpoLoginUrl(port, sso);
         openBrowserAsync(authorizeUrl);
       });
 

--- a/packages/@expo/cli/src/api/user/user.ts
+++ b/packages/@expo/cli/src/api/user/user.ts
@@ -66,9 +66,10 @@ export async function loginAsync(credentials: {
   });
 }
 
-export async function ssoLoginAsync(): Promise<void> {
+export async function browserLoginAsync({ sso = false }): Promise<void> {
   const sessionSecret = await getSessionUsingBrowserAuthFlowAsync({
     expoWebsiteUrl: getExpoWebsiteBaseUrl(),
+    sso,
   });
   const userData = await UserQuery.meUserActorAsync({
     'expo-session': sessionSecret,

--- a/packages/@expo/cli/src/login/index.ts
+++ b/packages/@expo/cli/src/login/index.ts
@@ -12,11 +12,13 @@ export const expoLogin: Command = async (argv) => {
       '--password': String,
       '--otp': String,
       '--sso': Boolean,
+      '--browser': Boolean,
       // Aliases
       '-h': '--help',
       '-u': '--username',
       '-p': '--password',
       '-s': '--sso',
+      '-b': '--browser',
     },
     argv
   );
@@ -30,6 +32,7 @@ export const expoLogin: Command = async (argv) => {
         `-p, --password <string>  Password`,
         `--otp <string>           One-time password from your 2FA device`,
         `-s, --sso                Log in with SSO`,
+        // -b, --browser is hidden for soft launch
         `-h, --help               Usage info`,
       ].join('\n')
     );
@@ -42,5 +45,6 @@ export const expoLogin: Command = async (argv) => {
     password: args['--password'],
     otp: args['--otp'],
     sso: !!args['--sso'],
+    browser: !!args['--browser'],
   }).catch(logCmdError);
 };

--- a/packages/@expo/cli/src/login/index.ts
+++ b/packages/@expo/cli/src/login/index.ts
@@ -32,7 +32,7 @@ export const expoLogin: Command = async (argv) => {
         `-p, --password <string>  Password`,
         `--otp <string>           One-time password from your 2FA device`,
         `-s, --sso                Log in with SSO`,
-        // -b, --browser is hidden for soft launch
+        `-b, --browser            Log in with a browser`,
         `-h, --help               Usage info`,
       ].join('\n')
     );


### PR DESCRIPTION
# Why
Parity with https://github.com/expo/eas-cli/pull/3312. 

# How
Mirrored the changes from eas-cli.

# Test Plan
Modified tests and ran locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
