### PR TITLE
[video][android] Fix unintialised `firstFrameEventGenerator` exception 

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix uninitialized `firstFrameEventGenerator` exception in VideoView when setting the `player` prop. ([#42615](https://github.com/expo/expo/pull/42615) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 ## 55.0.2 — 2026-01-26


### PR DESCRIPTION
# Why

We have a race condition, where the `player` prop of the `VideoView` is not running on the main queue, but the `firstFrameEventGenerator` is initialised on the main queue. 

# How

Initialise the generator on the current queue, pass the app context into the generator in order to access the `player` properties on the main thread when needed, instead of doing the whole initialisation on the main thread.

# Test Plan

Tested in Bare Expo on Android

