### PR TITLE
[dev-menu] Various action button fixes

### DIFF
--- a/packages/expo-dev-menu/ios/Modules/DevMenuPreferences.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuPreferences.swift
@@ -33,7 +33,7 @@ public class DevMenuPreferences: Module {
       keyCommandsEnabledKey: true,
       showsAtLaunchKey: false,
       isOnboardingFinishedKey: true,
-      showFloatingActionButtonKey: false
+      showFloatingActionButtonKey: true
     ])
     #else
     UserDefaults.standard.register(defaults: [
@@ -42,7 +42,7 @@ public class DevMenuPreferences: Module {
       keyCommandsEnabledKey: true,
       showsAtLaunchKey: false,
       isOnboardingFinishedKey: false,
-      showFloatingActionButtonKey: false
+      showFloatingActionButtonKey: true
     ])
     #endif
 

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuDeveloperTools.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuDeveloperTools.swift
@@ -12,6 +12,29 @@ struct DevMenuDeveloperTools: View {
         .foregroundColor(.primary.opacity(0.6))
 
       VStack(spacing: 0) {
+        NavigationLink(destination: SourceMapExplorerView()) {
+          HStack {
+            Image(systemName: "map")
+              .frame(width: 24, height: 24)
+              .foregroundColor(.primary)
+              .opacity(0.6)
+
+            Text("Source code explorer")
+              .foregroundColor(.primary)
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+          .padding()
+          .background(Color.expoSecondarySystemBackground)
+        }
+        .buttonStyle(.plain)
+
+        Divider()
+
         DevMenuActionButton(
           title: "Toggle performance monitor",
           icon: "speedometer",
@@ -60,29 +83,6 @@ struct DevMenuDeveloperTools: View {
           action: viewModel.toggleFloatingActionButton
         )
         #endif
-
-        Divider()
-
-        NavigationLink(destination: SourceMapExplorerView()) {
-          HStack {
-            Image(systemName: "map")
-              .frame(width: 24, height: 24)
-              .foregroundColor(.primary)
-              .opacity(0.6)
-
-            Text("Source code explorer")
-              .foregroundColor(.primary)
-
-            Spacer()
-
-            Image(systemName: "chevron.right")
-              .font(.caption)
-              .foregroundColor(.secondary)
-          }
-          .padding()
-          .background(Color.expoSecondarySystemBackground)
-        }
-        .buttonStyle(.plain)
       }
       .background(Color.expoSystemBackground)
       .cornerRadius(18)


### PR DESCRIPTION
# Why
Fixes various issues with the new action button

# How
- Prevent dragging into the safe area
- Prevent showing anywhere except the user app
- Improve drag animation feeling
- Remove opacity
- Fix it from disappearing when the menu is dismissed by touching the backdrop
- On by default
- Move source explorer to the top of the tools section

# Test Plan
Bare expo
Expo go

