### PR TITLE
[video][ios] Fix caching issues on iOS

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix only one player getting released when reloading with multiple players present. ([#42780](https://github.com/expo/expo/pull/42780) by [@behenate](https://github.com/behenate))
+- [iOS] Fix data getting corrupted when caching is enabled. ([#42621](https://github.com/expo/expo/pull/42621) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/ios/Cache/CachedResource.swift
+++ b/packages/expo-video/ios/Cache/CachedResource.swift
@@ -5,6 +5,25 @@ import AVFoundation
 import ExpoModulesCore
 
 /**
+ * Actor to serialize write operations to file and metadata
+ */
+private actor WriteCoordinator {
+  func performWrite(
+    data: Data,
+    offset: Int64,
+    fileHandle: MediaFileHandle,
+    mediaInfo: MediaInfo?
+  ) throws {
+    try fileHandle.write(data: data, atOffset: offset)
+
+    let endOffset = offset + Int64(data.count)
+
+    mediaInfo?.addDataRange(newDataRange: (offset, endOffset))
+    mediaInfo?.saveToFile()
+  }
+}
+
+/**
  * Class used to manage a single cached resource.  Stores a fileHandle to saved video data, and
  * allows saving/loading data used to correctly decode the data.
  */
@@ -13,6 +32,8 @@ class CachedResource {
   private let dataPath: String
   private let fileHandle: MediaFileHandle
   private(set) var mediaInfo: MediaInfo?
+
+  private let writeCoordinator = WriteCoordinator()
 
   init(dataFileUrl: String, resourceUrl: URL, dataPath: String) {
     self.dataPath = dataPath
@@ -51,22 +72,52 @@ class CachedResource {
   }
 
   func writeData(data: Data, offset: Int64) async {
+    guard !data.isEmpty else {
+      log.warn("Attempted to write empty data at offset \(offset), skipping")
+      return
+    }
+
+    guard offset >= 0 else {
+      log.error("Invalid negative offset: \(offset)")
+      return
+    }
+
     do {
-      mediaInfo?.addDataRange(newDataRange: (Int(offset), Int(offset) + data.count))
-      mediaInfo?.saveToFile()
-      try fileHandle.write(data: data, atOffset: Int(offset))
+      try await writeCoordinator.performWrite(
+        data: data,
+        offset: offset,
+        fileHandle: fileHandle,
+        mediaInfo: mediaInfo
+      )
     } catch {
-      log.warn("Failed to write at offset with the file handle")
+      log.warn("Failed to write at offset \(offset) with the file handle: \(error)")
     }
   }
 
+  // Returns data for the requested range if fully cached
+  // Expects 'from' and 'to' as inclusive byte positions
   func requestData(from: Int64, to: Int64) -> Data? {
+    guard from <= to else {
+      log.error("Invalid range: from=\(from) > to=\(to)")
+      return nil
+    }
+
     if canRespondWithData(from: from, to: to) {
-      return fileHandle.readData(withOffset: Int(from), forLength: Int(to - from) + 1)
+      let length64 = to - from + 1
+
+      guard length64 >= 0 && length64 <= Int.max else {
+        log.error("Requested range length \(length64) exceeds Int.max")
+        return nil
+      }
+
+      let length = Int(length64)
+      return fileHandle.readData(withOffset: from, forLength: length)
     }
     return nil
   }
 
+  // Returns partial data from the beginning of the first cached range that contains 'from'
+  // Returns data up to the end of that cached range (may be less than requested)
   func requestBeginningOfData(from: Int64, to: Int64) -> Data? {
     guard let dataRange = mediaInfo?.loadedDataRanges.first(where: { dataStart, dataEnd in
       from >= dataStart && from < dataEnd
@@ -74,15 +125,31 @@ class CachedResource {
       return nil
     }
 
-    return fileHandle.readData(withOffset: Int(from), forLength: Int(dataRange.1 - Int(from)) + 1)
+    // Calculate available length from 'from' to the end of this cached range (exclusive)
+    let availableLength = dataRange.1 - from
+    guard availableLength > 0 else {
+      return nil
+    }
+
+    // Validate length fits in Int
+    guard availableLength <= Int.max else {
+      log.error("Available length \(availableLength) exceeds Int.max")
+      return nil
+    }
+
+    return fileHandle.readData(withOffset: from, forLength: Int(availableLength))
   }
 
+  // Checks if the requested range [from, to] is fully contained in cached data
+  // 'from' and 'to' are inclusive byte positions
+  // Stored ranges are half-open [start, end), so we check if (to + 1) <= end
   func canRespondWithData(from: Int64, to: Int64) -> Bool {
     guard let loadedDataRanges = mediaInfo?.loadedDataRanges else {
       return false
     }
+    let exclusiveEnd = to + 1
     return loadedDataRanges.contains(where: { loadedDataRangeStart, loadedDataRangeEnd in
-      from >= loadedDataRangeStart && to <= loadedDataRangeEnd
+      from >= loadedDataRangeStart && exclusiveEnd <= loadedDataRangeEnd
     })
   }
 

--- a/packages/expo-video/ios/Cache/CachedResource.swift
+++ b/packages/expo-video/ios/Cache/CachedResource.swift
@@ -73,7 +73,7 @@ class CachedResource {
 
   func writeData(data: Data, offset: Int64) async {
     guard !data.isEmpty else {
-      log.warn("Attempted to write empty data at offset \(offset), skipping")
+      log.warn("[expo-video] Attempted to write empty data at offset \(offset), skipping")
       return
     }
 
@@ -90,7 +90,7 @@ class CachedResource {
         mediaInfo: mediaInfo
       )
     } catch {
-      log.warn("Failed to write at offset \(offset) with the file handle: \(error)")
+      log.warn("[expo-video] Failed to write at offset \(offset) with the file handle: \(error)")
     }
   }
 

--- a/packages/expo-video/ios/Cache/CachingHelpers.swift
+++ b/packages/expo-video/ios/Cache/CachingHelpers.swift
@@ -68,7 +68,7 @@ internal extension Data {
       return nil
     }
 
-    guard requestStart >= responseStart, requestStart <= responseEnd else {
+    guard responseStart <= responseEnd, (responseStart...responseEnd).contains(requestStart) else {
       return nil
     }
 

--- a/packages/expo-video/ios/Cache/CachingHelpers.swift
+++ b/packages/expo-video/ios/Cache/CachingHelpers.swift
@@ -20,7 +20,7 @@ internal func getRangeFromResponse(response: HTTPURLResponse) -> (Int?, Int?) {
 }
 
 internal func getRangeFromRequest(request: URLRequest) -> (Int?, Int?) {
-  guard let fullString = request.allHTTPHeaderFields?["Range"] else {
+  guard let fullString = request.allHTTPHeaderFields?["Range"] ?? request.allHTTPHeaderFields?["range"] else {
     return (nil, nil)
   }
   let rangeString = fullString.replacingOccurrences(of: "bytes=", with: "")
@@ -28,7 +28,14 @@ internal func getRangeFromRequest(request: URLRequest) -> (Int?, Int?) {
   let first = rangeStringComponents.first ?? ""
   let second = rangeStringComponents.count > 1 ? rangeStringComponents[1] : ""
 
-  return (Int(first), Int(second))
+  // Range formats:
+  // "1000-2000" -> (1000, 2000)
+  // "1000-" -> (1000, nil) - open-ended
+  // "-500" -> (nil, 500) - suffix range (last 500 bytes)
+  let firstInt = first.isEmpty ? nil : Int(first)
+  let secondInt = second.isEmpty ? nil : Int(second)
+
+  return (firstInt, secondInt)
 }
 
 internal func mimeTypeToExtension(mimeType: String?) -> String? {
@@ -60,22 +67,30 @@ internal extension Data {
     guard let responseStart, let responseEnd, let requestStart else {
       return nil
     }
-    // Error handling checks would actually occur here, similar to Objective-C version
-    guard requestStart >= responseStart, requestStart < responseEnd else {
+
+    guard requestStart >= responseStart, requestStart <= responseEnd else {
       return nil
     }
 
-    let startIndex = requestStart - responseStart // Corrected start index calculation
-    var endIndex: Int // Define endIndex outside of conditional logic
+    let startIndex = requestStart - responseStart
+
+    guard startIndex >= 0 && startIndex < self.count else {
+      return nil
+    }
+
+    var endIndex: Int
 
     if let requestEnd = requestEnd {
-      endIndex = startIndex + (requestEnd - requestStart) + 1 // Use safely unwrapped requestEnd
+      let requestedLength = requestEnd - requestStart + 1
+      endIndex = startIndex + requestedLength
     } else {
-      // If requestEnd is nil, assume data to the end of resource is needed
+      // If requestEnd is nil, return data to the end
       endIndex = self.count
     }
 
-    if endIndex > self.count {
+    endIndex = Swift.min(endIndex, self.count)
+
+    guard startIndex <= endIndex else {
       return nil
     }
 

--- a/packages/expo-video/ios/Cache/MediaFileHandle.swift
+++ b/packages/expo-video/ios/Cache/MediaFileHandle.swift
@@ -17,7 +17,7 @@ internal class MediaFileHandle {
     do {
       return try FileManager.default.attributesOfItem(atPath: filePath)
     } catch let error as NSError {
-      log.warn("An error occured while reading the file attributes at \(filePath) error: \(error)")
+      log.warn("[expo-video] An error occured while reading the file attributes at \(filePath) error: \(error)")
     }
     return nil
   }
@@ -45,10 +45,10 @@ internal class MediaFileHandle {
     self.writeHandle = FileHandle(forWritingAtPath: filePath)
 
     if readHandle == nil {
-      log.warn("Failed to open file for reading at: \(filePath)")
+      log.warn("[expo-video] Failed to open file for reading at: \(filePath)")
     }
     if writeHandle == nil {
-      log.warn("Failed to open file for writing at: \(filePath)")
+      log.warn("[expo-video] Failed to open file for writing at: \(filePath)")
     }
   }
 
@@ -68,18 +68,18 @@ internal class MediaFileHandle {
     defer { lock.unlock() }
 
     guard let readHandle = readHandle else {
-      log.warn("Read handle not available for file at: \(filePath)")
+      log.warn("[expo-video] Read handle not available for file at: \(filePath)")
       return nil
     }
 
     guard offset >= 0 else {
-      log.warn("Invalid negative offset: \(offset)")
+      log.warn("[expo-video] Invalid negative offset: \(offset)")
       return nil
     }
 
     let currentSize = fileSize
     guard offset <= currentSize else {
-      log.warn("Offset \(offset) exceeds file size \(currentSize)")
+      log.warn("[expo-video] Offset \(offset) exceeds file size \(currentSize)")
       return nil
     }
 
@@ -88,12 +88,12 @@ internal class MediaFileHandle {
       let data = readHandle.readData(ofLength: length)
 
       if data.count < length && offset + Int64(data.count) < currentSize {
-        log.warn("Read \(data.count) bytes but expected \(length) bytes")
+        log.warn("[expo-video] Read \(data.count) bytes but expected \(length) bytes")
       }
 
       return data
     } catch {
-      log.warn("Failed to read data at offset \(offset): \(error)")
+      log.warn("[expo-video] Failed to read data at offset \(offset): \(error)")
       return nil
     }
   }

--- a/packages/expo-video/ios/Cache/MediaFileHandle.swift
+++ b/packages/expo-video/ios/Cache/MediaFileHandle.swift
@@ -38,7 +38,10 @@ internal class MediaFileHandle {
     }
 
     if !FileManager.default.fileExists(atPath: filePath) {
-      FileManager.default.createFile(atPath: filePath, contents: nil, attributes: nil)
+      let fileCreated = FileManager.default.createFile(atPath: filePath, contents: nil, attributes: nil)
+      if !fileCreated {
+        log.error("[expo-video] Failed to create cache file at: \(filePath)")
+      }
     }
 
     self.readHandle = FileHandle(forReadingAtPath: filePath)

--- a/packages/expo-video/ios/Cache/MediaFileHandle.swift
+++ b/packages/expo-video/ios/Cache/MediaFileHandle.swift
@@ -10,8 +10,8 @@ import ExpoModulesCore
 internal class MediaFileHandle {
   private let filePath: String
   private let lock = NSLock()
-  private lazy var readHandle = FileHandle(forReadingAtPath: filePath)
-  private lazy var writeHandle = FileHandle(forWritingAtPath: filePath)
+  private var readHandle: FileHandle?
+  private var writeHandle: FileHandle?
 
   var attributes: [FileAttributeKey: Any]? {
     do {
@@ -40,6 +40,16 @@ internal class MediaFileHandle {
     if !FileManager.default.fileExists(atPath: filePath) {
       FileManager.default.createFile(atPath: filePath, contents: nil, attributes: nil)
     }
+
+    self.readHandle = FileHandle(forReadingAtPath: filePath)
+    self.writeHandle = FileHandle(forWritingAtPath: filePath)
+
+    if readHandle == nil {
+      log.warn("Failed to open file for reading at: \(filePath)")
+    }
+    if writeHandle == nil {
+      log.warn("Failed to open file for writing at: \(filePath)")
+    }
   }
 
   deinit {
@@ -53,20 +63,52 @@ internal class MediaFileHandle {
     close()
   }
 
-  func readData(withOffset offset: Int, forLength length: Int) -> Data? {
+  func readData(withOffset offset: Int64, forLength length: Int) -> Data? {
     lock.lock()
     defer { lock.unlock() }
 
-    readHandle?.seek(toFileOffset: UInt64(offset))
-    return readHandle?.readData(ofLength: length)
+    guard let readHandle = readHandle else {
+      log.warn("Read handle not available for file at: \(filePath)")
+      return nil
+    }
+
+    guard offset >= 0 else {
+      log.warn("Invalid negative offset: \(offset)")
+      return nil
+    }
+
+    let currentSize = fileSize
+    guard offset <= currentSize else {
+      log.warn("Offset \(offset) exceeds file size \(currentSize)")
+      return nil
+    }
+
+    do {
+      try readHandle.seek(toOffset: UInt64(offset))
+      let data = readHandle.readData(ofLength: length)
+
+      if data.count < length && offset + Int64(data.count) < currentSize {
+        log.warn("Read \(data.count) bytes but expected \(length) bytes")
+      }
+
+      return data
+    } catch {
+      log.warn("Failed to read data at offset \(offset): \(error)")
+      return nil
+    }
   }
 
-  func write(data: Data, atOffset offset: Int) throws {
+  func write(data: Data, atOffset offset: Int64) throws {
     lock.lock()
     defer { lock.unlock() }
 
     guard let writeHandle = writeHandle else {
-      return
+      throw VideoCacheException("Failed to write data to cache file handle: Write handle not available for file at: \(filePath)")
+    }
+
+    // Validate offset is non-negative
+    guard offset >= 0 else {
+      throw VideoCacheException("Failed to write data to cache file handle: Invalid negative offset: \(offset)")
     }
 
     try writeHandle.seek(toOffset: UInt64(offset))

--- a/packages/expo-video/ios/Cache/MediaInfo.swift
+++ b/packages/expo-video/ios/Cache/MediaInfo.swift
@@ -142,6 +142,15 @@ class MediaInfo: Codable {
       let tempURL = URL(fileURLWithPath: tempPath)
       let finalURL = URL(fileURLWithPath: savePath)
 
+      let parentDirectory = finalURL.deletingLastPathComponent()
+      if !FileManager.default.fileExists(atPath: parentDirectory.path) {
+        try FileManager.default.createDirectory(at: parentDirectory, withIntermediateDirectories: true, attributes: nil)
+      }
+
+      if !FileManager.default.fileExists(atPath: tempPath) && FileManager.default.fileExists(atPath: savePath) {
+        try FileManager.default.copyItem(at: finalURL, to: tempURL)
+      }
+
       // Write to temporary file first
       try data.write(to: tempURL, options: .atomic)
 

--- a/packages/expo-video/ios/Cache/MediaInfo.swift
+++ b/packages/expo-video/ios/Cache/MediaInfo.swift
@@ -86,7 +86,7 @@ class MediaInfo: Codable {
 
     // Validate empty or invalid ranges
     guard newDataRange.1 > newDataRange.0 else {
-      log.warn("Invalid range: [\(newDataRange.0), \(newDataRange.1)) - end must be > start")
+      log.warn("[expo-video] Invalid range: [\(newDataRange.0), \(newDataRange.1)) - end must be > start")
       return
     }
 
@@ -124,7 +124,7 @@ class MediaInfo: Codable {
     do {
       return try JSONEncoder().encode(self)
     } catch {
-      log.warn("Error encoding MediaInfo object: \(error)")
+      log.warn("[expo-video] Error encoding MediaInfo object: \(error)")
       return nil
     }
   }
@@ -134,7 +134,7 @@ class MediaInfo: Codable {
   func saveToFile() {
     do {
       guard let data = self.encodeToData() else {
-        log.warn("Failed to encode MediaInfo for saving at: \(savePath)")
+        log.warn("[expo-video] Failed to encode MediaInfo for saving at: \(savePath)")
         return
       }
 
@@ -153,7 +153,7 @@ class MediaInfo: Codable {
       // Atomically move temp file to final location
       try FileManager.default.moveItem(at: tempURL, to: finalURL)
     } catch {
-      log.warn("Failed to save media info at: \(savePath), error: \(error)")
+      log.warn("[expo-video] Failed to save media info at: \(savePath), error: \(error)")
     }
   }
 

--- a/packages/expo-video/ios/Cache/MediaInfo.swift
+++ b/packages/expo-video/ios/Cache/MediaInfo.swift
@@ -8,13 +8,21 @@ class MediaInfo: Codable {
   var headerFields: [String: String]?
   var savePath: String
 
+  // Lock to protect loadedDataRanges from concurrent access
+  private let lock = NSLock()
+
   // Tuples can't be encoded/decoded, so we workaround that with an array
-  private var loadedDataRangesArr: [[Int]] = []
-  private(set) var loadedDataRanges: [(Int, Int)] {
+  // Ranges are stored as half-open intervals: [start, end) where end is exclusive
+  private var loadedDataRangesArr: [[Int64]] = []
+  private(set) var loadedDataRanges: [(Int64, Int64)] {
     get {
+      lock.lock()
+      defer { lock.unlock() }
       return loadedDataRangesArrayToTuple()
     }
     set {
+      lock.lock()
+      defer { lock.unlock() }
       loadedDataRangesArr = loadedDataRangesTupleToArray(newValue)
     }
   }
@@ -29,7 +37,6 @@ class MediaInfo: Codable {
     self.expectedContentLength = expectedContentLength
     self.headerFields = headerFields
     self.savePath = savePath
-    self.loadedDataRanges = loadedDataRanges
 
     if let url = URL(string: savePath) {
       VideoCacheManager.shared.registerOpenFile(at: url)
@@ -72,32 +79,45 @@ class MediaInfo: Codable {
     self.init(at: mediaInfoPath)
   }
 
-  func addDataRange(newDataRange: (Int, Int)) {
-    var i = 0
-    var merged = [(Int, Int)]()
+  // Adds a new data range and merges with overlapping/adjacent ranges
+  func addDataRange(newDataRange: (Int64, Int64)) {
+    lock.lock()
+    defer { lock.unlock() }
 
-    // Add all intervals before newInterval starts
-    while i < loadedDataRanges.count && loadedDataRanges[i].1 < newDataRange.0 {
-      merged.append(loadedDataRanges[i])
+    // Validate empty or invalid ranges
+    guard newDataRange.1 > newDataRange.0 else {
+      log.warn("Invalid range: [\(newDataRange.0), \(newDataRange.1)) - end must be > start")
+      return
+    }
+
+    // Access the array directly to avoid deadlock (the getter acquires the lock)
+    let currentRanges = loadedDataRangesArrayToTuple()
+
+    var i = 0
+    var merged = [(Int64, Int64)]()
+
+    // Add all intervals that end before the new interval starts (non-adjacent)
+    while i < currentRanges.count && currentRanges[i].1 < newDataRange.0 {
+      merged.append(currentRanges[i])
       i += 1
     }
 
-    // Merge all overlapping intervals to one new Interval
+    // Merge all overlapping or adjacent intervals to one new interval
     var newStart = newDataRange.0
     var newEnd = newDataRange.1
-    while i < loadedDataRanges.count && loadedDataRanges[i].0 <= newDataRange.1 {
-      newStart = min(newStart, loadedDataRanges[i].0)
-      newEnd = max(newEnd, loadedDataRanges[i].1)
+    while i < currentRanges.count && currentRanges[i].0 <= newDataRange.1 {
+      newStart = min(newStart, currentRanges[i].0)
+      newEnd = max(newEnd, currentRanges[i].1)
       i += 1
     }
     merged.append((newStart, newEnd))
 
     // Add remaining intervals
-    while i < loadedDataRanges.count {
-      merged.append(loadedDataRanges[i])
+    while i < currentRanges.count {
+      merged.append(currentRanges[i])
       i += 1
     }
-    loadedDataRanges = merged
+    loadedDataRangesArr = loadedDataRangesTupleToArray(merged)
   }
 
   func encodeToData() -> Data? {
@@ -110,20 +130,34 @@ class MediaInfo: Codable {
   }
 
   // Saves the mime type of a video fetched from the server into a file. This allows playing videos without an extension in the
-  // url.
+  // url. Writes to a temporary file first, then atomically replaces the original
   func saveToFile() {
     do {
-      if FileManager.default.fileExists(atPath: savePath) {
-        try FileManager.default.removeItem(atPath: savePath)
+      guard let data = self.encodeToData() else {
+        log.warn("Failed to encode MediaInfo for saving at: \(savePath)")
+        return
       }
 
-      FileManager.default.createFile(atPath: savePath, contents: self.encodeToData())
+      let tempPath = savePath + ".tmp"
+      let tempURL = URL(fileURLWithPath: tempPath)
+      let finalURL = URL(fileURLWithPath: savePath)
+
+      // Write to temporary file first
+      try data.write(to: tempURL, options: .atomic)
+
+      // If original file exists, remove it first
+      if FileManager.default.fileExists(atPath: savePath) {
+        try FileManager.default.removeItem(at: finalURL)
+      }
+
+      // Atomically move temp file to final location
+      try FileManager.default.moveItem(at: tempURL, to: finalURL)
     } catch {
-      log.warn("Failed to save media info at: \(savePath)")
+      log.warn("Failed to save media info at: \(savePath), error: \(error)")
     }
   }
 
-  private func loadedDataRangesArrayToTuple() -> [(Int, Int)] {
+  private func loadedDataRangesArrayToTuple() -> [(Int64, Int64)] {
     // The filter shouldn't be necessary, but we can't be too careful
     let filteredDataRanges = loadedDataRangesArr.filter { rangeArray in
       rangeArray.count == 2
@@ -134,7 +168,7 @@ class MediaInfo: Codable {
     }
   }
 
-  private func loadedDataRangesTupleToArray(_ loadedDataRanges: [(Int, Int)]) -> [[Int]] {
+  private func loadedDataRangesTupleToArray(_ loadedDataRanges: [(Int64, Int64)]) -> [[Int64]] {
     return loadedDataRanges.map { from, to in
       return [from, to]
     }

--- a/packages/expo-video/ios/Cache/ResourceLoaderDelegate.swift
+++ b/packages/expo-video/ios/Cache/ResourceLoaderDelegate.swift
@@ -167,7 +167,7 @@ final class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URL
     let (remainingRequest, dataReceived) = attemptToRespondFromCache(forRequest: loadingRequest)
 
     // Cache fulfilled the entire request
-    if dataReceived != nil && remainingRequest == nil {
+    if dataReceived != nil && dataReceived?.isEmpty != true && remainingRequest == nil {
       return
     }
 

--- a/packages/expo-video/ios/Cache/ResourceLoaderDelegate.swift
+++ b/packages/expo-video/ios/Cache/ResourceLoaderDelegate.swift
@@ -84,7 +84,7 @@ final class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URL
 
     if dataRequest.requestsAllDataToEndOfResource {
       guard currentOffset >= requestedOffset else {
-        log.warn("Current offset (\(currentOffset)) < requested offset (\(requestedOffset))")
+        log.warn("[expo-video] Current offset (\(currentOffset)) < requested offset (\(requestedOffset))")
         return
       }
 
@@ -101,7 +101,7 @@ final class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URL
 
       let endOffset = currentDataResponseOffset + currentDataResponseLength
       guard endOffset <= cachableRequest.receivedData.count else {
-        log.warn("End offset (\(endOffset)) exceeds receivedData.count (\(cachableRequest.receivedData.count))")
+        log.warn("[expo-video] End offset (\(endOffset)) exceeds receivedData.count (\(cachableRequest.receivedData.count))")
         return
       }
 
@@ -117,7 +117,7 @@ final class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URL
 
       let endOffset = rangeStart + rangeLength
       guard endOffset <= cachableRequest.receivedData.count else {
-        log.warn("End offset (\(endOffset)) exceeds receivedData.count (\(cachableRequest.receivedData.count))")
+        log.warn("[expo-video] End offset (\(endOffset)) exceeds receivedData.count (\(cachableRequest.receivedData.count))")
         return
       }
 
@@ -193,7 +193,7 @@ final class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URL
       }
       cachableRequests.add(cachableRequest)
     } else {
-      log.warn("ResourceLoaderDelegate has received a loading request without a data request")
+      log.warn("[expo-video] ResourceLoaderDelegate has received a loading request without a data request")
     }
     dataTask.resume()
   }

--- a/packages/expo-video/ios/Cache/VideoCacheManager.swift
+++ b/packages/expo-video/ios/Cache/VideoCacheManager.swift
@@ -48,7 +48,7 @@ class VideoCacheManager {
       do {
         try self.limitCacheSize(to: maxCacheSize)
       } catch {
-        log.warn("Failed to auto clean expo-video cache")
+        log.warn("[expo-video] Failed to auto clean expo-video cache")
       }
     }
   }

--- a/packages/expo-video/ios/NowPlayingManager.swift
+++ b/packages/expo-video/ios/NowPlayingManager.swift
@@ -270,13 +270,13 @@ class NowPlayingManager: VideoPlayerObserverDelegate {
 private func fetchArtwork(url: URL, completion: @escaping (MPMediaItemArtwork?) -> Void) -> URLSessionDataTask {
   let task = URLSession.shared.dataTask(with: url) { data, response, error in
     if let error = error {
-      log.warn("ExpoVideo - Couldn't fetch the artwork: \(error.localizedDescription)")
+      log.warn("[expo-video] Couldn't fetch the artwork: \(error.localizedDescription)")
       completion(nil)
       return
     }
 
     guard let data, response is HTTPURLResponse else {
-      log.warn("ExpoVideo - Couldn't display the artwork: the response was empty")
+      log.warn("[expo-video] Couldn't display the artwork: the response was empty")
       completion(nil)
       return
     }

--- a/packages/expo-video/ios/VideoAsset.swift
+++ b/packages/expo-video/ios/VideoAsset.swift
@@ -57,6 +57,8 @@ internal class VideoAsset: AVURLAsset, @unchecked Sendable {
 
     // Enable caching
     useCaching = true
+    VideoCacheManager.shared.ensureCacheIntegrity(forSavePath: saveFilePath)
+    Self.createCacheDirectoryIfNeeded()
     resourceLoaderDelegate = ResourceLoaderDelegate(url: url, saveFilePath: saveFilePath, fileExtension: fileExtension, urlRequestHeaders: urlRequestHeaders)
     super.init(url: urlWithCustomScheme, options: assetOptions)
 
@@ -64,8 +66,6 @@ internal class VideoAsset: AVURLAsset, @unchecked Sendable {
       self?.cachingError = error
     }
     self.resourceLoader.setDelegate(resourceLoaderDelegate, queue: VideoCacheManager.shared.cacheQueue)
-    self.createCacheDirectoryIfNeeded()
-    VideoCacheManager.shared.ensureCacheIntegrity(forSavePath: saveFilePath)
   }
 
   deinit {
@@ -107,7 +107,7 @@ internal class VideoAsset: AVURLAsset, @unchecked Sendable {
     return videoSource.drm == nil
   }
 
-  private func createCacheDirectoryIfNeeded() {
+  private static func createCacheDirectoryIfNeeded() {
     guard var cachesDirectory = try? FileManager.default.url(
       for: .cachesDirectory,
       in: .userDomainMask,

--- a/packages/expo-video/ios/VideoAsset.swift
+++ b/packages/expo-video/ios/VideoAsset.swift
@@ -37,15 +37,15 @@ internal class VideoAsset: AVURLAsset, @unchecked Sendable {
     let canCache = Self.canCache(videoSource: videoSource)
 
     if saveFilePath == nil && videoSource.useCaching {
-      log.warn("Failed to create a cache file path for the provided source with uri: \(videoSource.uri?.absoluteString ?? "null")")
+      log.warn("[expo-video] Failed to create a cache file path for the provided source with uri: \(videoSource.uri?.absoluteString ?? "null")")
     }
 
     if !canCache && videoSource.useCaching {
-      log.warn("Provided source with uri: \(videoSource.uri?.absoluteString ?? "null") cannot be cached. Caching will be disabled")
+      log.warn("[expo-video] Provided source with uri: \(videoSource.uri?.absoluteString ?? "null") cannot be cached. Caching will be disabled")
     }
 
     if urlWithCustomScheme == nil && videoSource.useCaching {
-      log.warn("CachingPlayerItem error: Urls without a scheme are not supported, the resource won't be cached")
+      log.warn("[expo-video] CachingPlayerItem error: Urls without a scheme are not supported, the resource won't be cached")
     }
 
     guard let saveFilePath, let urlWithCustomScheme, videoSource.useCaching else {
@@ -90,7 +90,7 @@ internal class VideoAsset: AVURLAsset, @unchecked Sendable {
       appropriateFor: nil,
       create: true)
     else {
-      log.warn("CachingPlayerItem error: Can't access default cache directory")
+      log.warn("[expo-video] CachingPlayerItem error: Can't access default cache directory")
       return nil
     }
 

--- a/packages/expo-video/ios/VideoManager.swift
+++ b/packages/expo-video/ios/VideoManager.swift
@@ -106,7 +106,7 @@ class VideoManager {
       do {
         try audioSession.setCategory(.playback, mode: .moviePlayback, options: audioSessionCategoryOptions)
       } catch {
-        log.warn("Failed to set audio session category. This might cause issues with audio playback and Picture in Picture. \(error.localizedDescription)")
+        log.warn("[expo-video] Failed to set audio session category. This might cause issues with audio playback and Picture in Picture. \(error.localizedDescription)")
       }
     }
 
@@ -115,7 +115,7 @@ class VideoManager {
       do {
         try audioSession.setActive(true)
       } catch {
-        log.warn("Failed to activate the audio session. This might cause issues with audio playback. \(error.localizedDescription)")
+        log.warn("[expo-video] Failed to activate the audio session. This might cause issues with audio playback. \(error.localizedDescription)")
       }
     }
   }

--- a/packages/expo-video/ios/VideoPlayerItem.swift
+++ b/packages/expo-video/ios/VideoPlayerItem.swift
@@ -65,7 +65,7 @@ class VideoPlayerItem: AVPlayerItem {
           tracks = try await self.fetchHlsVideoTracks()
         } catch {
           tracks = []
-          log.warn("Failed to fetch HLS video tracks, this is not required for playback, but `expo-video` will have no knowledge of the available tracks: \(error.localizedDescription)")
+          log.warn("[expo-video] Failed to fetch HLS video tracks, this is not required for playback, but `expo-video` will have no knowledge of the available tracks: \(error.localizedDescription)")
         }
       } else {
         let avAssetTracks = (try? await asset.loadTracks(withMediaType: .video)) ?? []


### PR DESCRIPTION
# Why

Due to some tricky byte operations in the caching mechanism, we would sometimes read/write the data with 1 byte offset leading to corrupted files. 

# How

- Fix data range access isues
- Remove NSLock deadlock - addDataRange() was calling loadedDataRanges property getter which tried to re-acquire the lock
- Added a bunch of checks and logs to make debugging easier in the future if needed
- Improved data access thread safety
- Use Int64 to avoid issues for large files

# Test Plan

Tested in BareExpo on iOS
