### PR TITLE
[dev-menu] Show button after content appears

### DIFF
--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -76,6 +76,8 @@ open class DevMenuManager: NSObject {
 
   static public var wasInitilized = false
 
+  private var contentDidAppearObserver: NSObjectProtocol?
+
   /**
    Shared singleton instance.
    */
@@ -111,10 +113,28 @@ open class DevMenuManager: NSObject {
       if let currentBridge {
         DispatchQueue.main.async {
           self.disableRNDevMenuHoykeys(for: currentBridge)
-          self.updateFABVisibility()
         }
+        observeContentDidAppear()
       } else {
         updateFABVisibility()
+      }
+    }
+  }
+
+  private func observeContentDidAppear() {
+    if let observer = contentDidAppearObserver {
+      NotificationCenter.default.removeObserver(observer)
+    }
+
+    contentDidAppearObserver = NotificationCenter.default.addObserver(
+      forName: NSNotification.Name.RCTContentDidAppear,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      self?.updateFABVisibility()
+      if let observer = self?.contentDidAppearObserver {
+        NotificationCenter.default.removeObserver(observer)
+        self?.contentDidAppearObserver = nil
       }
     }
   }


### PR DESCRIPTION
# Why
Add RCTContentDidAppear observer so we don't show the action button until after the splashscreen is dismissed

# Test Plan
Expo go
