### PR TITLE
[expo-go] Only show review prompt on physical device

### DIFF
--- a/apps/expo-go/ios/Client/SwiftUI/Services/UserReviewManager.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Services/UserReviewManager.swift
@@ -70,11 +70,15 @@ final class UserReviewManager: ObservableObject {
     let hasFeedbackForm = info.showFeedbackFormDate != nil
     let meetsUsageThreshold = info.appOpenedCounter >= 50 || appsCount >= 5 || snacksCount >= 5
 
+    #if targetEnvironment(simulator)
+    shouldShowReviewSection = false
+    #else
     shouldShowReviewSection = noRecentDismisses
       && !hasAskedForReview
       && !hasFeedbackForm
       && noRecentCrashes
       && meetsUsageThreshold
+    #endif
   }
 
   private func requestStoreReview() {


### PR DESCRIPTION
# Why
The user review prompt should not appear on simulators as store reviews are not available

# Test Plan
Expo go

