### PR TITLE
[cli] Add export:check-for-process-env subcommand

### DIFF
--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -27,6 +27,8 @@ const commands: { [command: string]: () => Promise<Command> } = {
   export: () => import('../src/export/index.js').then((i) => i.expoExport),
   'export:web': () => import('../src/export/web/index.js').then((i) => i.expoExportWeb),
   'export:embed': () => import('../src/export/embed/index.js').then((i) => i.expoExportEmbed),
+  'export:check-for-process-env': () =>
+    import('../src/export/checkForProcessEnv/index.js').then((i) => i.expoExportCheckForProcessEnv),
 
   serve: () => import('../src/serve/index.js').then((i) => i.expoServe),
 
@@ -96,6 +98,8 @@ if (!isSubcommand && args['--help']) {
     'export:embed': exportEmbed_unused,
     // The export:web command is deprecated. Hide it from the help prompt.
     'export:web': exportWeb_unused,
+    // Internal command for checking process.env usage in bundles.
+    'export:check-for-process-env': exportCheckForProcessEnv_unused,
     // Other ignored commands, these are intentially not listed in the `--help` output
     run: _run,
     // NOTE(cedric): Still pending the migration to ESLint's flat config

--- a/packages/@expo/cli/src/export/checkForProcessEnv/__tests__/checkForProcessEnvAsync-test.ts
+++ b/packages/@expo/cli/src/export/checkForProcessEnv/__tests__/checkForProcessEnvAsync-test.ts
@@ -1,0 +1,109 @@
+describe('process.env pattern matching', () => {
+  // The pattern used in checkForProcessEnvAsync to match process.env.VARIABLE_NAME
+  const processEnvPattern = /process\.env\.([A-Z_][A-Z0-9_]*)/gi;
+
+  const findEnvVars = (source: string): string[] => {
+    const found: string[] = [];
+    let match;
+    // Reset lastIndex for global regex
+    processEnvPattern.lastIndex = 0;
+    while ((match = processEnvPattern.exec(source)) !== null) {
+      found.push(match[1]);
+    }
+    return found;
+  };
+
+  it(`matches simple process.env references`, () => {
+    const source = `const x = process.env.NODE_ENV;`;
+    expect(findEnvVars(source)).toEqual(['NODE_ENV']);
+  });
+
+  it(`matches multiple process.env references`, () => {
+    const source = `
+      const env = process.env.NODE_ENV;
+      const key = process.env.API_KEY;
+      const secret = process.env.SECRET_TOKEN;
+    `;
+    expect(findEnvVars(source)).toEqual(['NODE_ENV', 'API_KEY', 'SECRET_TOKEN']);
+  });
+
+  it(`matches EXPO_PUBLIC prefixed variables`, () => {
+    const source = `const url = process.env.EXPO_PUBLIC_API_URL;`;
+    expect(findEnvVars(source)).toEqual(['EXPO_PUBLIC_API_URL']);
+  });
+
+  it(`matches variables with underscores and numbers`, () => {
+    const source = `
+      const a = process.env.MY_VAR_123;
+      const b = process.env._PRIVATE_VAR;
+      const c = process.env.VAR2;
+    `;
+    expect(findEnvVars(source)).toEqual(['MY_VAR_123', '_PRIVATE_VAR', 'VAR2']);
+  });
+
+  it(`matches lowercase variable names due to case-insensitive flag`, () => {
+    // The pattern has the 'i' flag, so it matches lowercase variable names too
+    const source = `const x = process.env.lowercase;`;
+    expect(findEnvVars(source)).toEqual(['lowercase']);
+  });
+
+  it(`does not match empty process.env access`, () => {
+    const source = `const x = process.env;`;
+    expect(findEnvVars(source)).toEqual([]);
+  });
+
+  it(`does not match bracket notation access`, () => {
+    // Bracket notation like process.env["VAR"] is not matched by the pattern
+    const source = `const x = process.env["NODE_ENV"];`;
+    expect(findEnvVars(source)).toEqual([]);
+  });
+
+  it(`matches in minified code`, () => {
+    const source = `var a=process.env.NODE_ENV,b=process.env.API_KEY;`;
+    expect(findEnvVars(source)).toEqual(['NODE_ENV', 'API_KEY']);
+  });
+
+  it(`returns empty array when no matches`, () => {
+    const source = `const x = "hello world";`;
+    expect(findEnvVars(source)).toEqual([]);
+  });
+
+  it(`handles case insensitivity in process.env but preserves variable name case`, () => {
+    // The 'i' flag makes process.env case insensitive, but we capture the actual variable name
+    const source = `const x = PROCESS.ENV.MY_VAR;`;
+    expect(findEnvVars(source)).toEqual(['MY_VAR']);
+  });
+});
+
+describe('unresolved environment variable detection', () => {
+  const checkUnresolved = (
+    envVars: string[],
+    currentEnv: Record<string, string | undefined>
+  ): string[] => {
+    return envVars.filter((envVar) => currentEnv[envVar] === undefined);
+  };
+
+  it(`identifies unresolved variables`, () => {
+    const found = ['NODE_ENV', 'API_KEY', 'SECRET'];
+    const env = { NODE_ENV: 'production' };
+    expect(checkUnresolved(found, env)).toEqual(['API_KEY', 'SECRET']);
+  });
+
+  it(`returns empty when all variables are resolved`, () => {
+    const found = ['NODE_ENV', 'API_KEY'];
+    const env = { NODE_ENV: 'production', API_KEY: 'key123' };
+    expect(checkUnresolved(found, env)).toEqual([]);
+  });
+
+  it(`returns all when no variables are resolved`, () => {
+    const found = ['API_KEY', 'SECRET'];
+    const env = {};
+    expect(checkUnresolved(found, env)).toEqual(['API_KEY', 'SECRET']);
+  });
+
+  it(`handles empty string as resolved`, () => {
+    const found = ['EMPTY_VAR'];
+    const env = { EMPTY_VAR: '' };
+    expect(checkUnresolved(found, env)).toEqual([]);
+  });
+});

--- a/packages/@expo/cli/src/export/checkForProcessEnv/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/export/checkForProcessEnv/__tests__/resolveOptions-test.ts
@@ -1,0 +1,86 @@
+import { getConfig } from '@expo/config';
+
+import { resolveOptionsAsync } from '../resolveOptions';
+
+jest.mock('@expo/config', () => ({
+  getConfig: jest.fn(() => ({
+    pkg: {},
+    exp: {
+      sdkVersion: '45.0.0',
+      name: 'my-app',
+      slug: 'my-app',
+      platforms: ['ios', 'android'],
+    },
+  })),
+}));
+
+describe(resolveOptionsAsync, () => {
+  it(`asserts unknown platform`, async () => {
+    await expect(resolveOptionsAsync('/', { '--platform': ['foobar'] })).rejects.toThrow(
+      /^Unsupported platform "foobar"\./
+    );
+  });
+
+  it(`asserts not-configured platform`, async () => {
+    jest.mocked(getConfig).mockReturnValueOnce({
+      // @ts-expect-error
+      exp: { web: { bundler: 'webpack' }, platforms: ['ios', 'android', 'web'] },
+    });
+    await expect(resolveOptionsAsync('/', { '--platform': ['web'] })).rejects.toThrow(
+      /^Platform "web" is not configured to use the Metro bundler in the project Expo config,/
+    );
+  });
+
+  it(`allows multiple platform flags`, async () => {
+    await expect(
+      resolveOptionsAsync('/', { '--platform': ['android', 'ios'] })
+    ).resolves.toMatchObject({
+      platforms: ['android', 'ios'],
+    });
+  });
+
+  it(`filters duplicated platform flags`, async () => {
+    await expect(
+      resolveOptionsAsync('/', { '--platform': ['android', 'android', 'ios', 'ios'] })
+    ).resolves.toMatchObject({
+      platforms: ['android', 'ios'],
+    });
+  });
+
+  it(`parses qualified options`, async () => {
+    await expect(
+      resolveOptionsAsync('/', {
+        '--platform': ['android'],
+        '--clear': true,
+        '--dev': true,
+        '--max-workers': 2,
+      })
+    ).resolves.toEqual({
+      clear: true,
+      dev: true,
+      maxWorkers: 2,
+      platforms: ['android'],
+    });
+  });
+
+  it(`parses default options`, async () => {
+    await expect(resolveOptionsAsync('/', {})).resolves.toEqual({
+      clear: false,
+      dev: false,
+      maxWorkers: undefined,
+      platforms: ['ios', 'android'],
+    });
+  });
+
+  it(`parses default options with web enabled`, async () => {
+    jest.mocked(getConfig).mockReturnValueOnce({
+      // @ts-expect-error
+      exp: { web: { bundler: 'metro' }, platforms: ['ios', 'android', 'web'] },
+    });
+    await expect(resolveOptionsAsync('/', {})).resolves.toEqual(
+      expect.objectContaining({
+        platforms: ['ios', 'android', 'web'],
+      })
+    );
+  });
+});

--- a/packages/@expo/cli/src/export/checkForProcessEnv/checkForProcessEnvAsync.ts
+++ b/packages/@expo/cli/src/export/checkForProcessEnv/checkForProcessEnvAsync.ts
@@ -1,0 +1,98 @@
+import { getConfig } from '@expo/config';
+import assert from 'assert';
+
+import { Options } from './resolveOptions';
+import { getPublicExpoManifestAsync } from '../getPublicExpoManifest';
+import { isEnableHermesManaged, assertEngineMismatchAsync } from '../exportHermes';
+import * as Log from '../../log';
+import { DevServerManager } from '../../start/server/DevServerManager';
+import { MetroBundlerDevServer } from '../../start/server/metro/MetroBundlerDevServer';
+import { getEntryWithServerRoot } from '../../start/server/middleware/ManifestMiddleware';
+import { setNodeEnv } from '../../utils/nodeEnv';
+
+export async function checkForProcessEnvAsync(
+  projectRoot: string,
+  { platforms, clear, dev, maxWorkers }: Options
+): Promise<void> {
+  // Force the environment during export and do not allow overriding it.
+  const environment = dev ? 'development' : 'production';
+  process.env.NODE_ENV = environment;
+  setNodeEnv(environment);
+
+  require('@expo/env').load(projectRoot);
+
+  const projectConfig = getConfig(projectRoot);
+  const exp = await getPublicExpoManifestAsync(projectRoot, {
+    // Web doesn't require validation.
+    skipValidation: platforms.length === 1 && platforms[0] === 'web',
+  });
+
+  const mode = dev ? 'development' : 'production';
+
+  const devServerManager = await DevServerManager.startMetroAsync(projectRoot, {
+    minify: true,
+    mode,
+    port: 8081,
+    isExporting: true,
+    location: {},
+    resetDevServer: clear,
+    maxWorkers,
+  });
+
+  const devServer = devServerManager.getDefaultDevServer();
+  assert(devServer instanceof MetroBundlerDevServer);
+
+  let hasProcessEnvRef = false;
+  const processEnvPattern = /process\.env\./;
+
+  try {
+    for (const platform of platforms) {
+      const isHermes = isEnableHermesManaged(exp, platform);
+      if (isHermes) {
+        await assertEngineMismatchAsync(projectRoot, exp, platform);
+      }
+
+      try {
+        const bundle = await devServer.nativeExportBundleAsync(
+          exp,
+          {
+            platform,
+            splitChunks: false,
+            mainModuleName: getEntryWithServerRoot(projectRoot, {
+              platform,
+              pkg: projectConfig.pkg,
+            }),
+            mode,
+            engine: isHermes ? 'hermes' : undefined,
+            serializerIncludeMaps: false,
+            bytecode: isHermes,
+            reactCompiler: !!exp.experiments?.reactCompiler,
+          },
+          new Map()
+        );
+
+        for (const artifact of bundle.artifacts) {
+          if (artifact.type === 'js' && processEnvPattern.test(artifact.source)) {
+            hasProcessEnvRef = true;
+            break;
+          }
+        }
+
+        if (hasProcessEnvRef) break;
+      } catch (error) {
+        Log.log('');
+        if (error instanceof Error) {
+          Log.exception(error);
+        } else {
+          Log.error('Failed to bundle the app');
+          Log.log(error as any);
+        }
+        process.exit(1);
+      }
+    }
+  } finally {
+    await devServerManager.stopAsync();
+  }
+
+  Log.log(hasProcessEnvRef ? 'true' : 'false');
+}

--- a/packages/@expo/cli/src/export/checkForProcessEnv/checkForProcessEnvAsync.ts
+++ b/packages/@expo/cli/src/export/checkForProcessEnv/checkForProcessEnvAsync.ts
@@ -2,13 +2,13 @@ import { getConfig } from '@expo/config';
 import assert from 'assert';
 
 import { Options } from './resolveOptions';
-import { getPublicExpoManifestAsync } from '../getPublicExpoManifest';
-import { isEnableHermesManaged, assertEngineMismatchAsync } from '../exportHermes';
 import * as Log from '../../log';
 import { DevServerManager } from '../../start/server/DevServerManager';
 import { MetroBundlerDevServer } from '../../start/server/metro/MetroBundlerDevServer';
 import { getEntryWithServerRoot } from '../../start/server/middleware/ManifestMiddleware';
 import { setNodeEnv } from '../../utils/nodeEnv';
+import { isEnableHermesManaged, assertEngineMismatchAsync } from '../exportHermes';
+import { getPublicExpoManifestAsync } from '../getPublicExpoManifest';
 
 export async function checkForProcessEnvAsync(
   projectRoot: string,
@@ -43,7 +43,7 @@ export async function checkForProcessEnvAsync(
   assert(devServer instanceof MetroBundlerDevServer);
 
   // Pattern to match process.env.VARIABLE_NAME and capture the variable name
-  const processEnvPattern = /process\.env\.([A-Z_][A-Z0-9_]*)/gi;
+  const processEnvPattern = /process\.env\.EXPO_PUBLIC_([A-Z_][A-Z0-9_]*)/gi;
   const foundEnvVars = new Set<string>();
 
   try {

--- a/packages/@expo/cli/src/export/checkForProcessEnv/index.ts
+++ b/packages/@expo/cli/src/export/checkForProcessEnv/index.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+import arg from 'arg';
+import chalk from 'chalk';
+import path from 'path';
+
+import { Command } from '../../../bin/cli';
+import { assertWithOptionsArgs, printHelp } from '../../utils/args';
+
+export const expoExportCheckForProcessEnv: Command = async (argv) => {
+  const rawArgsMap: arg.Spec = {
+    // Types
+    '--help': Boolean,
+    '--clear': Boolean,
+    '--dev': Boolean,
+    '--max-workers': Number,
+    '--platform': [String],
+
+    // Aliases
+    '-h': '--help',
+    '-c': '--clear',
+    '-p': '--platform',
+  };
+
+  const args = assertWithOptionsArgs(rawArgsMap, {
+    argv,
+    permissive: true,
+  });
+
+  if (args['--help']) {
+    printHelp(
+      `Check if the exported bundle contains process.env.* references`,
+      chalk`npx expo export:check-for-process-env {dim <dir>}`,
+      [
+        chalk`<dir>                      Directory of the Expo project. {dim Default: Current working directory}`,
+        `--dev                      Configure static files for developing locally using a non-https server`,
+        `--max-workers <number>     Maximum number of tasks to allow the bundler to spawn`,
+        chalk`-p, --platform <platform>  Options: android, ios, web, all. {dim Default: all}`,
+        `-c, --clear                Clear the bundler cache`,
+        `-h, --help                 Usage info`,
+      ].join('\n')
+    );
+  }
+
+  const [{ checkForProcessEnvAsync }, { resolveOptionsAsync }, { logCmdError }] = await Promise.all(
+    [
+      import('./checkForProcessEnvAsync.js'),
+      import('./resolveOptions.js'),
+      import('../../utils/errors.js'),
+    ]
+  );
+
+  return (async () => {
+    const projectRoot = path.resolve(args._[0] || '.');
+    const options = await resolveOptionsAsync(projectRoot, args);
+    return checkForProcessEnvAsync(projectRoot, options);
+  })().catch(logCmdError);
+};

--- a/packages/@expo/cli/src/export/checkForProcessEnv/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/checkForProcessEnv/resolveOptions.ts
@@ -1,8 +1,7 @@
-import { Platform } from '@expo/config';
+import { Platform, getConfig } from '@expo/config';
 
-import { resolvePlatformOption } from '../resolveOptions';
 import { getPlatformBundlers } from '../../start/server/platformBundlers';
-import { getConfig } from '@expo/config';
+import { resolvePlatformOption } from '../resolveOptions';
 
 export type Options = {
   platforms: Platform[];

--- a/packages/@expo/cli/src/export/checkForProcessEnv/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/checkForProcessEnv/resolveOptions.ts
@@ -1,0 +1,26 @@
+import { Platform } from '@expo/config';
+
+import { resolvePlatformOption } from '../resolveOptions';
+import { getPlatformBundlers } from '../../start/server/platformBundlers';
+import { getConfig } from '@expo/config';
+
+export type Options = {
+  platforms: Platform[];
+  maxWorkers?: number;
+  dev: boolean;
+  clear: boolean;
+};
+
+export async function resolveOptionsAsync(projectRoot: string, args: any): Promise<Options> {
+  const { exp } = getConfig(projectRoot, { skipPlugins: true, skipSDKVersionRequirement: true });
+  const platformBundlers = getPlatformBundlers(projectRoot, exp);
+
+  const platforms = resolvePlatformOption(exp, platformBundlers, args['--platform']);
+
+  return {
+    platforms,
+    clear: !!args['--clear'],
+    dev: !!args['--dev'],
+    maxWorkers: args['--max-workers'],
+  };
+}


### PR DESCRIPTION
# Why

Added to support changes to `eas update` where we need to check if the user is doing `process.env` variable substitution during bundling, and warn about unresolved variables.

# How

Implemented this as a new hidden subcommand, `export:check-for-process-env`.

# Test Plan

- Added unit tests
- Will be testing against real Expo projects to verify the functionality, and make sure this isn't too large a performance hit on `eas update`
