### PR TITLE
[ios][core] Fixed crash when unmounting Fabric views

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed a crash in Fabric when unmounting a view while a geometry change event is being dispatched. ([#42628](https://github.com/expo/expo/issues/42628) by [@danishshaik](https://github.com/danishshaik))
+
 ### 💡 Others
 
 ## 55.0.5 — 2026-01-27

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed a crash in Fabric when unmounting a view while a geometry change event is being dispatched. ([#42628](https://github.com/expo/expo/issues/42628) by [@danishshaik](https://github.com/danishshaik))
+- [iOS] Fixed a crash in Fabric when unmounting a view while a geometry change event is being dispatched. ([#42628](https://github.com/expo/expo/issues/42628) by [@danishshaik](https://github.com/danishshaik)) ([#42634](https://github.com/expo/expo/pull/42634) by [@danishshaik](https://github.com/danishshaik))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
@@ -144,6 +144,9 @@ static std::unordered_map<std::string, ExpoViewComponentDescriptor::Flavor> _com
 
 - (void)dispatchEvent:(nonnull NSString *)eventName payload:(nullable id)payload
 {
+  if (!_eventEmitter) {
+    return;
+  }
   const auto &eventEmitter = static_cast<const ExpoViewEventEmitter &>(*_eventEmitter);
 
   eventEmitter.dispatch([normalizeEventName(eventName) UTF8String], [payload](jsi::Runtime &runtime) {


### PR DESCRIPTION
# Why

 Fixes a crash (EXC_BAD_ACCESS) in Fabric that occurs when unmounting a view that uses @expo/ui (specifically HostView with GeometryChangeModifier). This happens because React Native invalidates the _eventEmitter (sets it to null) immediately during unmount, but SwiftUI triggers a final geometry change event as the view is removed.
https://github.com/expo/expo/issues/42628

# How

  Added a null check for _eventEmitter in ExpoFabricViewObjC.mm's dispatchEvent method. If the emitter is already null (which happens during the unmount race condition), we safely return instead of attempting to dereference the null pointer.

# Test Plan

   1. Created a reproduction repository: https://github.com/danishshaik/expo-ui-slider-repro
   2. Verified that without this fix, unmounting the slider component crashes the app on iOS Simulator (specifically reproduced on slower machines)
   3. Applied the fix and confirmed the crash no longer occurs when unmounting.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
