### PR TITLE
[core][ios] Update Dynamic array/dict converters to convert nested results

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 💡 Others
 
+- [iOS] Improved conversions of returned arrays and dictionaries with mixed element types. ([#42641](https://github.com/expo/expo/pull/42641) by [@barthap](https://github.com/barthap))
+
 ## 55.0.12 — 2026-02-25
 
 _This version does not introduce any user-facing changes._
@@ -75,8 +77,6 @@ _This version does not introduce any user-facing changes._
 - [iOS] Fixed a crash in Fabric when unmounting a view while a geometry change event is being dispatched. ([#42628](https://github.com/expo/expo/issues/42628) by [@danishshaik](https://github.com/danishshaik)) ([#42634](https://github.com/expo/expo/pull/42634) by [@danishshaik](https://github.com/danishshaik))
 - [iOS] Fix crashes when converting a single JSValue into an Array. ([#42694](https://github.com/expo/expo/pull/42694) by [@behenate](https://github.com/behenate))
 - Added more Jetpack Compose support. ([#42734](https://github.com/expo/expo/pull/42734) by [@kudo](https://github.com/kudo))
-
-- [iOS] Improved conversions of returned arrays and dictionaries with mixed element types. ([#42641](https://github.com/expo/expo/pull/42641) by [@barthap](https://github.com/barthap))
 
 ## 55.0.5 — 2026-01-27
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -76,6 +76,8 @@ _This version does not introduce any user-facing changes._
 - [iOS] Fix crashes when converting a single JSValue into an Array. ([#42694](https://github.com/expo/expo/pull/42694) by [@behenate](https://github.com/behenate))
 - Added more Jetpack Compose support. ([#42734](https://github.com/expo/expo/pull/42734) by [@kudo](https://github.com/kudo))
 
+- [iOS] Improved conversions of returned arrays and dictionaries with mixed element types. ([#42641](https://github.com/expo/expo/pull/42641) by [@barthap](https://github.com/barthap))
+
 ## 55.0.5 — 2026-01-27
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicArrayType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicArrayType.swift
@@ -37,9 +37,7 @@ internal struct DynamicArrayType: AnyDynamicType {
 
   func convertResult<ResultType>(_ result: ResultType, appContext: AppContext) throws -> Any {
     if let result = result as? [Any] {
-      return try result.map({ element in
-        return try elementType.convertResult(element, appContext: appContext)
-      })
+      return result.map({ Conversions.convertFunctionResult($0, appContext: appContext) })
     }
     return result
   }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicArrayType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicArrayType.swift
@@ -37,7 +37,7 @@ internal struct DynamicArrayType: AnyDynamicType {
 
   func convertResult<ResultType>(_ result: ResultType, appContext: AppContext) throws -> Any {
     if let result = result as? [Any] {
-      return result.map({ Conversions.convertFunctionResult($0, appContext: appContext) })
+      return result.map { Conversions.convertFunctionResult($0, appContext: appContext) }
     }
     return result
   }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicDictionaryType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicDictionaryType.swift
@@ -43,7 +43,7 @@ internal struct DynamicDictionaryType: AnyDynamicType {
 
   func convertResult<ResultType>(_ result: ResultType, appContext: AppContext) throws -> Any {
     if let result = result as? [AnyHashable: Any] {
-      return result.mapValues({ Conversions.convertFunctionResult($0, appContext: appContext) })
+      return result.mapValues { Conversions.convertFunctionResult($0, appContext: appContext) }
     }
     return result
   }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicDictionaryType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicDictionaryType.swift
@@ -41,6 +41,13 @@ internal struct DynamicDictionaryType: AnyDynamicType {
     throw Conversions.CastingException<[AnyHashable: Any]>(value)
   }
 
+  func convertResult<ResultType>(_ result: ResultType, appContext: AppContext) throws -> Any {
+    if let result = result as? [AnyHashable: Any] {
+      return result.mapValues({ Conversions.convertFunctionResult($0, appContext: appContext) })
+    }
+    return result
+  }
+
   var description: String {
     "[Hashable: \(valueType.description)]"
   }


### PR DESCRIPTION
# Why

When returning arrays/dictionaries to JS, their dynamic types only shallow-convert arguments, which breaks for more complex returned types.

- When an array of mixed values is returned, the [`elementType`](https://github.com/expo/expo/blob/bf5c4aefbf6b67f37f5f6870a6f80c2efa4c8171/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicArrayType.swift#L41) is of type [`DynamicRawType`](https://github.com/expo/expo/blob/main/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicRawType.swift) even if array elements have their own dynamic type converters
- The [`DynamicDictionaryType`](https://github.com/expo/expo/blob/main/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicDictionaryType.swift) is missing the `convertResults` at all

Example where this matters:
[This return](https://github.com/expo/expo/blob/bf5c4aefbf6b67f37f5f6870a6f80c2efa4c8171/packages/expo-sqlite/ios/SQLiteModule.swift#L419) can be of type:
```js
{
   lastInsertRowId: 1,
   changes: 0,
   firstRowValues: [1, <<ArrayBuffer>>]
}
```

Primitives and nested arrays are converted, but ArrayBuffer is being `undefined` because, without this change, the `value` inside [`convertObjCObjectToJSIValue`](https://github.com/expo/expo/blob/bf5c4aefbf6b67f37f5f6870a6f80c2efa4c8171/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm#L100) is of type [`ExpoModulesCore.NativeArrayBuffer`](https://github.com/expo/expo/blob/7cac70926cb456f8a1a7673d68d4a84800099071/packages/expo-modules-core/ios/Core/ArrayBuffers/ArrayBuffer.swift#L7) instead of `EXArrayBuffer` and the conditional is skipped.
This is caused by [`DynamicArrayBufferType.convertResult()`](https://github.com/expo/expo/blob/7cac70926cb456f8a1a7673d68d4a84800099071/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicArrayBufferType.swift#L35) not being called when converting array/dict

# How

**Note**: this change might negatively affect conversion performance, but I'm unsure how big the impact of using [`convertFunctionResult()`](https://github.com/expo/expo/blob/bf5c4aefbf6b67f37f5f6870a6f80c2efa4c8171/packages/expo-modules-core/ios/Core/Conversions.swift#L182) is.

- Updated array dynamic type's convertResult to use `Conversions.convertFunctionResult()` which respects value types
- Added `convertResult` to dictionary dynamic type as it was missing there

# Test Plan

- Tested on the SQLite stack (#42642) which required this change.
- Added unit test for `DynamicArrayType` and a test suite for `DynamicDictionaryType`

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
