### PR TITLE
[sqlite][ios] Use ArrayBuffers for returning blob columns

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Session changesets now use native `ArrayBuffer`s. ([#42638](https://github.com/expo/expo/pull/42638) by [@barthap](https://github.com/barthap))
 - Statement bind params now use native `ArrayBuffer`s for blob columns. ([#42639](https://github.com/expo/expo/pull/42639) by [@barthap](https://github.com/barthap))
 - [Android] Returned blob columns now use native `ArrayBuffer`s. ([#42640](https://github.com/expo/expo/pull/42640) by [@barthap](https://github.com/barthap))
+- [iOS] Returned blob columns now use native `ArrayBuffer`s. ([#42642](https://github.com/expo/expo/pull/42642) by [@barthap](https://github.com/barthap))
 
 ## 55.0.10 — 2026-02-25
 

--- a/packages/expo-sqlite/ios/SQLiteModule.swift
+++ b/packages/expo-sqlite/ios/SQLiteModule.swift
@@ -615,10 +615,10 @@ public final class SQLiteModule: Module {
       return String(cString: text)
     case SQLITE_BLOB:
       guard let blob = exsqlite3_column_blob(instance, index) else {
-        return Data()
+        return NativeArrayBuffer.allocate(size: 0)
       }
       let size = exsqlite3_column_bytes(instance, index)
-      return Data(bytes: blob, count: Int(size))
+      return NativeArrayBuffer.copy(of: blob, count: Int(size))
     case SQLITE_NULL:
       return NSNull()
     default:


### PR DESCRIPTION
# Why

Follow up #42640. Replace copying `Uint8Array` with `NativeArrayBuffer`.

# How

- Updated native code to return `ArrayBuffer`

# Test Plan

- iOS test suite
- Manual testing

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
