### PR TITLE
[iOS][gl] Fix a crash on missing module registry

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -375,6 +375,7 @@ PODS:
     - ExpoModulesCore
   - ExpoGL (55.0.3):
     - ExpoModulesCore
+    - ExpoModulesJSI
     - ReactCommon/turbomodule/core
   - ExpoGlassEffect (55.0.3):
     - ExpoModulesCore
@@ -3806,7 +3807,7 @@ SPEC CHECKSUMS:
   ExpoDomWebView: 2cb9e9bed46799fa8f36b6284ce7799f1dbff297
   ExpoFileSystem: fbc1b6c573adea694db76bcfdec603952d96b0d5
   ExpoFont: 4e2967170d6ee7316c5efd62dd06aabd7b4593d2
-  ExpoGL: 995034ac1bf272589a7f0670dddf6c646c3842af
+  ExpoGL: 5c4ead68e3ccad2ff5d71a9afe6b332af5da6233
   ExpoGlassEffect: 3f4ba89f21a3077d598777608808c5bde0d7de43
   ExpoHaptics: f919ee984bb7617ddb9819856dd662b2f4248f71
   ExpoImage: eb2443489a4e380def23857653e170054ecec49c

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed a crash caused by the missing module registry.
+
 ### 💡 Others
 
 ## 55.0.3 — 2026-01-27

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed a crash caused by the missing module registry.
+- [iOS] Fixed a crash caused by the missing module registry. ([#42653](https://github.com/expo/expo/pull/42653) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-gl/ExpoGL.podspec
+++ b/packages/expo-gl/ExpoGL.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
+  s.dependency 'ExpoModulesJSI'
   s.dependency 'ReactCommon/turbomodule/core'
 
   s.compiler_flags = '-x objective-c++ -std=c++20'

--- a/packages/expo-gl/ios/EXGLContext.h
+++ b/packages/expo-gl/ios/EXGLContext.h
@@ -3,6 +3,8 @@
 #import <OpenGLES/EAGL.h>
 #import <ExpoGL/EXGLNativeApi.h>
 #import <ExpoModulesCore/EXModuleRegistry.h>
+#import <ExpoModulesCore/EXFileSystemInterface.h>
+#import <ExpoModulesJSI/EXJavaScriptRuntime.h>
 
 @class EXGLContext;
 
@@ -18,7 +20,8 @@
 @interface EXGLContext : NSObject
 
 - (nonnull instancetype)initWithDelegate:(nullable id<EXGLContextDelegate>)delegate
-                       andModuleRegistry:(nonnull EXModuleRegistry *)moduleRegistry;
+                                 runtime:(nullable EXJavaScriptRuntime *)runtime
+                              fileSystem:(nullable id<EXFileSystemInterface>)fileSystemManager;
 - (void)prepare:(nullable void(^)(BOOL))callback andEnableExperimentalWorkletSupport:(BOOL)enableExperimentalWorkletSupport;
 - (BOOL)isInitialized;
 - (nonnull EAGLContext *)createSharedEAGLContext;

--- a/packages/expo-gl/ios/ExpoGLModule.swift
+++ b/packages/expo-gl/ios/ExpoGLModule.swift
@@ -16,11 +16,11 @@ public final class ExpoGLModule: Module {
     }
 
     AsyncFunction("createContextAsync") { (promise: Promise) in
-      guard let legacyModuleRegistry = appContext?.legacyModuleRegistry else {
-        promise.reject("E_GL_MODULE_REGISTRY_NOT_FOUND", "ExpoGL.createContextAsync: Unable to find the module registry")
+      guard let runtime = try? appContext?.runtime, let fileSystem = appContext?.fileSystem else {
+        promise.reject("E_GL_APP_CONTEXT_NOT_FOUND", "ExpoGL.createContextAsync: Unable to get the app context")
         return
       }
-      let glContext = EXGLContext(delegate: nil, andModuleRegistry: legacyModuleRegistry)
+      let glContext = EXGLContext(delegate: nil, runtime: runtime, fileSystem: fileSystem)
 
       glContext.prepare({ success in
         if success {

--- a/packages/expo-gl/ios/GLView.swift
+++ b/packages/expo-gl/ios/GLView.swift
@@ -4,10 +4,10 @@ import ExpoModulesCore
 
 internal final class GLView: ExpoView, EXGLContextDelegate {
   lazy var glContext: EXGLContext = {
-    guard let legacyModuleRegistry = appContext?.legacyModuleRegistry else {
-      fatalError("Legacy module registry is not available")
+    guard let runtime = try? appContext?.runtime, let fileSystem = appContext?.fileSystem else {
+      fatalError("[expo-gl] Unable to get the app context, JS runtime or file system manager")
     }
-    return EXGLContext(delegate: self, andModuleRegistry: legacyModuleRegistry)
+    return EXGLContext(delegate: self, runtime: runtime, fileSystem: fileSystem)
   }()
 
   lazy var eaglContext: EAGLContext = glContext.createSharedEAGLContext()


### PR DESCRIPTION
# Why

Fixes a crash in `expo-gl` caused by the missing legacy module registry.

# How

Removed the usage of `legacyModuleRegistry` as it's no longer available after removing some legacy code in `expo-modules-core`. Instead, I pass the JS runtime and file system manager to `EXGLContext`.

# Test Plan

Examples in bare-expo work fine now (were crashing previously)