### PR TITLE
[menu][Android] Fix `null cannot be cast to non-null type expo.module…

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix `null cannot be cast to non-null type expo.modules.devmenu.DevMenuFragment`.
+- [Android] Fix `null cannot be cast to non-null type expo.modules.devmenu.DevMenuFragment`. ([#42660](https://github.com/expo/expo/pull/42660) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `null cannot be cast to non-null type expo.modules.devmenu.DevMenuFragment`.
+
 ### 💡 Others
 
 ## 55.0.3 — 2026-01-27

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuFragment.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuFragment.kt
@@ -312,7 +312,7 @@ class DevMenuFragment(
 
     internal fun findIn(activity: Activity?): DevMenuFragment? {
       val activity = activity ?: return null
-      return (activity as FragmentActivity).supportFragmentManager.findFragmentByTag(TAG) as DevMenuFragment
+      return (activity as FragmentActivity).supportFragmentManager.findFragmentByTag(TAG) as? DevMenuFragment
     }
 
     private data class KeyCommand(val code: Int, val withShift: Boolean = false)


### PR DESCRIPTION
…s.devmenu.DevMenuFragment`

# Why

Fixes crash in Expo Go:
```
2026-01-27 17:49:00.220 21417-21417 MessageQueue-JNI        host.exp.exponent                    E  Exception in MessageQueue callback: handleReceiveCallback
2026-01-27 17:49:00.220 21417-21417 MessageQueue-JNI        host.exp.exponent                    E  java.lang.NullPointerException: null cannot be cast to non-null type expo.modules.devmenu.DevMenuFragment (Ask Gemini)
                                                                                                    	at expo.modules.devmenu.DevMenuFragment$Companion.findIn$expo_dev_menu_release(r8-map-id-729244c2c702b12ab82c9b924bd7600a43848511c8bdcfc0f245ffcf2662a0e5:19)
                                                                                                    	at expo.modules.devmenu.api.FragmentDelegate.getValue(r8-map-id-729244c2c702b12ab82c9b924bd7600a43848511c8bdcfc0f245ffcf2662a0e5:1)
                                                                                                    	at expo.modules.devmenu.api.FragmentDelegate.getValue(r8-map-id-729244c2c702b12ab82c9b924bd7600a43848511c8bdcfc0f245ffcf2662a0e5:3)
                                                                                                    	at host.exp.exponent.experience.ExperienceActivity.i1(r8-map-id-729244c2c702b12ab82c9b924bd7600a43848511c8bdcfc0f245ffcf2662a0e5:8)
                                                                                                    	at host.exp.exponent.experience.ExperienceActivity.dispatchKeyEvent(r8-map-id-729244c2c702b12ab82c9b924bd7600a43848511c8bdcfc0f245ffcf2662a0e5:25)
```
Fixes https://github.com/expo/expo/issues/42503 (probably, I wasn't able to reproduce it)

# How

On `dispatchKeyEvent` can be dispatched before the dev menu is set up. In this case, we're going to ignore the received key command

# Test Plan

- expo go ✅ 