### PR TITLE
[expo-sharing] Share-into: make the extension disabled by default

### DIFF
--- a/packages/expo-sharing/CHANGELOG.md
+++ b/packages/expo-sharing/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix the share into extension being enabled by default. ([#42661](https://github.com/expo/expo/pull/42661) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 ## 55.0.4 — 2026-01-27

--- a/packages/expo-sharing/plugin/build/index.js
+++ b/packages/expo-sharing/plugin/build/index.js
@@ -16,8 +16,8 @@ const EXPO_SHARE_EXTENSION_TARGET_NAME = 'expo-sharing-extension';
 const pkg = require('expo-sharing/package.json');
 const withShareExtension = (config, props) => {
     let plugins = [];
-    const iosEnabled = props?.ios?.enabled ?? true;
-    const androidEnabled = props?.android?.enabled ?? true;
+    const iosEnabled = props?.ios?.enabled ?? false;
+    const androidEnabled = props?.android?.enabled ?? false;
     if (iosEnabled) {
         const deploymentTarget = '15.1';
         const bundleIdentifier = config.ios?.bundleIdentifier;

--- a/packages/expo-sharing/plugin/src/index.ts
+++ b/packages/expo-sharing/plugin/src/index.ts
@@ -18,8 +18,8 @@ type ShareExtensionConfigPlugin = ConfigPlugin<ShareExtensionConfigPluginProps>;
 
 const withShareExtension: ShareExtensionConfigPlugin = (config, props?) => {
   let plugins: (StaticPlugin | ConfigPlugin | string)[] = [];
-  const iosEnabled = props?.ios?.enabled ?? true;
-  const androidEnabled = props?.android?.enabled ?? true;
+  const iosEnabled = props?.ios?.enabled ?? false;
+  const androidEnabled = props?.android?.enabled ?? false;
 
   if (iosEnabled) {
     const deploymentTarget = '15.1';


### PR DESCRIPTION
# Why

We have accidentaly made the share-into extension enabled by default for SDK 55

# How

Make the extension disabled by default

# Test Plan

Tested in a test app by running `npx expo prebuild --clean`
