### PR TITLE
[sharing] Fix the entitlements shape in eas config

### DIFF
--- a/packages/expo-sharing/CHANGELOG.md
+++ b/packages/expo-sharing/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix the share into extension being enabled by default. ([#42661](https://github.com/expo/expo/pull/42661) by [@behenate](https://github.com/behenate))
+- [plugin] Fix the entitlements shape in eas config. ([#42663](https://github.com/expo/expo/pull/42663) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-sharing/plugin/build/withConfig.js
+++ b/packages/expo-sharing/plugin/build/withConfig.js
@@ -46,7 +46,7 @@ const withConfig = (config, { bundleIdentifier, targetName, groupIdentifier }) =
                                 {
                                     targetName,
                                     bundleIdentifier,
-                                    entitlements: [],
+                                    entitlements: {},
                                 },
                             ],
                         },
@@ -54,7 +54,7 @@ const withConfig = (config, { bundleIdentifier, targetName, groupIdentifier }) =
                 },
             },
         };
-        configIndex = 0;
+        configIndex = config.extra.eas.build.experimental.ios.appExtensions.length - 1;
     }
     if (config.extra) {
         const widgetsExtensionConfig = config.extra.eas.build.experimental.ios.appExtensions[configIndex];

--- a/packages/expo-sharing/plugin/src/withConfig.ts
+++ b/packages/expo-sharing/plugin/src/withConfig.ts
@@ -1,4 +1,5 @@
 import { ConfigPlugin, InfoPlist } from '@expo/config-plugins';
+import * as console from 'node:console';
 
 import { createEntitlements, ShareIntoEntitlements } from './ios/createEntitlements';
 
@@ -61,7 +62,7 @@ export const withConfig: ConfigPlugin<{
                 {
                   targetName,
                   bundleIdentifier,
-                  entitlements: [],
+                  entitlements: {},
                 },
               ],
             },
@@ -69,7 +70,7 @@ export const withConfig: ConfigPlugin<{
         },
       },
     };
-    configIndex = 0;
+    configIndex = config.extra.eas.build.experimental.ios.appExtensions.length - 1;
   }
 
   if (config.extra) {

--- a/packages/expo-sharing/plugin/src/withConfig.ts
+++ b/packages/expo-sharing/plugin/src/withConfig.ts
@@ -1,5 +1,4 @@
 import { ConfigPlugin, InfoPlist } from '@expo/config-plugins';
-import * as console from 'node:console';
 
 import { createEntitlements, ShareIntoEntitlements } from './ios/createEntitlements';
 


### PR DESCRIPTION
# Why

The entitlements we add into eas extra is an empty array instead of an empty object.

# How

Change the type to an object.

# Test Plan

Tested by running `npx expo prebuild -p ios` in a test app
