### PR TITLE
[dev-menu][iOS] Fix null current bridge in standalone mode

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix `null cannot be cast to non-null type expo.modules.devmenu.DevMenuFragment`. ([#42660](https://github.com/expo/expo/pull/42660) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Fix null current bridge in standalone mode ([#42666](https://github.com/expo/expo/pull/42666) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/ios/ReactDelegateHandler/ExpoDevMenuReactDelegateHandler.swift
+++ b/packages/expo-dev-menu/ios/ReactDelegateHandler/ExpoDevMenuReactDelegateHandler.swift
@@ -5,12 +5,7 @@ import ExpoModulesCore
 
 @objc
 public class ExpoDevMenuReactDelegateHandler: ExpoReactDelegateHandler {
-  public override func createReactRootView(
-    reactDelegate: ExpoReactDelegate,
-    moduleName: String,
-    initialProperties: [AnyHashable: Any]?,
-    launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-  ) -> UIView? {
+  public override func createRootViewController() -> UIViewController? {
     if EXAppDefines.APP_DEBUG {
       DevMenuManager.shared.updateCurrentBridge(RCTBridge.current())
     }


### PR DESCRIPTION
# Why

When running dev-menu as a standalone library, the menu triggers don't work because `currentBridge` is always `null

# How

Update `ExpoDevMenuReactDelegateHandler` to get the current bridge in `createRootViewController()` instead of `createReactRootView()`. The problem with calling `RCTBridge.current()` in `createReactRootView()` is that the react-native instead is not created at this point yet, always resulting in `RCTBridge.current()` returning null.

# Test Plan


Install `expo-dev-menu` in mininal tester and remove dev-client then run locally  

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
