### PR TITLE
[filesystem] Document fs behavior with large buffers

### DIFF
--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFileHandle.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFileHandle.kt
@@ -28,9 +28,7 @@ class FileSystemFileHandle(file: FileSystemFile) : SharedRef<FileChannel>(Random
     try {
       val currentPosition = fileChannel.position()
       val totalSize = fileChannel.size()
-
       val available = totalSize - currentPosition
-
       val readAmount = min(length, available).coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
 
       if (readAmount <= 0) {

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
@@ -255,7 +255,7 @@ class FileSystemModule : Module() {
       Constructor { file: FileSystemFile ->
         FileSystemFileHandle(file)
       }
-      Function("readBytes") { fileHandle: FileSystemFileHandle, bytes: Int ->
+      Function("readBytes") { fileHandle: FileSystemFileHandle, bytes: Long ->
         fileHandle.read(bytes)
       }
       Function("writeBytes") { fileHandle: FileSystemFileHandle, data: ByteArray ->

--- a/packages/expo-file-system/src/ExpoFileSystem.types.ts
+++ b/packages/expo-file-system/src/ExpoFileSystem.types.ts
@@ -356,7 +356,7 @@ export declare class FileHandle {
    */
   close(): void;
   /*
-   * Reads the specified amount of bytes from the file at the current offset.
+   * Reads the specified amount of bytes from the file at the current offset. Max amount of bytes read at once is capped by ArrayBuffer max size (32 bit signed MAX_INT on Android and 64 bit on iOS), but you can read from a FileHandle multiple times.
    * @param length The number of bytes to read.
    */
   readBytes(length: number): Uint8Array<ArrayBuffer>;


### PR DESCRIPTION
# Why

https://github.com/expo/expo/issues/42327

# How

Made passing larger read size than MAX_INT read up to MAX_INT, so that it can be called multiple times on the same file handle.

# Test Plan

Tested on Android.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
