### PR TITLE
[docs] Fix lint-prose warnings

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -168,6 +168,7 @@ exceptions:
   - '.*Remote JS.*'
   - '.*Router.*'
   - ".*Router's.*"
+  - '.*RxDB.*'
   - '.*SAF.*'
   - '.*SASS.*'
   - '.*SDK.*'
@@ -293,3 +294,4 @@ exceptions:
   - Live Activities
   - Starting a Live Activity
   - Updating a Live Activity
+  - Hiding the Tab bar

--- a/docs/pages/router/advanced/native-tabs.mdx
+++ b/docs/pages/router/advanced/native-tabs.mdx
@@ -466,7 +466,7 @@ Since the native tab layout's appearance varies by platform, the customization o
 
 > **info** `hidden` property is available in SDK 55 and later.
 
-You can hide the tab bar using `hidden` prop on the `NativeTabs` component. In order to hide tab bar for specific screens, you can use context API to set the `hidden` prop dynamically.
+You can hide the tab bar using `hidden` prop on the `NativeTabs` component. To hide tab bar for specific screens, you can use context API to set the `hidden` prop dynamically.
 
 ```tsx context/TabBarContext.tsx
 import { createContext } from 'react';

--- a/docs/pages/versions/unversioned/sdk/sharing.mdx
+++ b/docs/pages/versions/unversioned/sdk/sharing.mdx
@@ -31,31 +31,34 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 You can configure `expo-sharing` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([Continuous Native Generation (CNG)](/workflow/continuous-native-generation/)). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect. If your app does **not** use CNG, then you'll need to manually configure the library.
 
 <ConfigPluginExample>
-    The following example shows a configuration that allows sharing a single or multiple images on iOS and Android::
-  ```json app.json
-  {
-    "expo": {
-      "plugins": [
-        [
-          "expo-sharing",
-          {
-            "ios": {
-              "enabled": true,
-              "activationRule": {
-                "supportsImageWithMaxCount": 5
-              }
-            },
-            "android": {
-              "enabled": true,
-              "singleShareMimeTypes": ["image/*"],
-              "multipleShareMimeTypes": ["image/*"]
+
+The following example shows a configuration that allows sharing a single or multiple images on Android and iOS:
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-sharing",
+        {
+          "ios": {
+            "enabled": true,
+            "activationRule": {
+              "supportsImageWithMaxCount": 5
             }
+          },
+          "android": {
+            "enabled": true,
+            "singleShareMimeTypes": ["image/*"],
+            "multipleShareMimeTypes": ["image/*"]
           }
-        ]
+        }
       ]
-    }
+    ]
   }
-  ```
+}
+```
+
 </ConfigPluginExample>
 
 <ConfigPluginProperties
@@ -111,7 +114,7 @@ When an app user shares content with your app, the operating system launches you
 
 ### Expo Router
 
-If you are using [Expo Router](/router/introduction/), you can use the [`+native-intent.ts`](/router/advanced/native-intent/) file to handle the incoming share intent. This allows you to inspect the incoming path and redirect to a specific route.
+If you are using [Expo Router](/router/introduction/), you can use the [**+native-intent.ts**](/router/advanced/native-intent/) file to handle the incoming share intent. This allows you to inspect the incoming path and redirect to a specific route.
 
 ```tsx app/+native-intent.ts
 import { getSharedPayloads } from 'expo-sharing';

--- a/docs/pages/versions/v55.0.0/sdk/sharing.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/sharing.mdx
@@ -31,31 +31,34 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 You can configure `expo-sharing` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([Continuous Native Generation (CNG)](/workflow/continuous-native-generation/)). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect. If your app does **not** use CNG, then you'll need to manually configure the library.
 
 <ConfigPluginExample>
-    The following example shows a configuration that allows sharing a single or multiple images on iOS and Android::
-  ```json app.json
-  {
-    "expo": {
-      "plugins": [
-        [
-          "expo-sharing",
-          {
-            "ios": {
-              "enabled": true,
-              "activationRule": {
-                "supportsImageWithMaxCount": 5
-              }
-            },
-            "android": {
-              "enabled": true,
-              "singleShareMimeTypes": ["image/*"],
-              "multipleShareMimeTypes": ["image/*"]
+
+The following example shows a configuration that allows sharing a single or multiple images on Android and iOS:
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-sharing",
+        {
+          "ios": {
+            "enabled": true,
+            "activationRule": {
+              "supportsImageWithMaxCount": 5
             }
+          },
+          "android": {
+            "enabled": true,
+            "singleShareMimeTypes": ["image/*"],
+            "multipleShareMimeTypes": ["image/*"]
           }
-        ]
+        }
       ]
-    }
+    ]
   }
-  ```
+}
+```
+
 </ConfigPluginExample>
 
 <ConfigPluginProperties
@@ -111,7 +114,7 @@ When an app user shares content with your app, the operating system launches you
 
 ### Expo Router
 
-If you are using [Expo Router](/router/introduction/), you can use the [`+native-intent.ts`](/router/advanced/native-intent/) file to handle the incoming share intent. This allows you to inspect the incoming path and redirect to a specific route.
+If you are using [Expo Router](/router/introduction/), you can use the [**+native-intent.ts**](/router/advanced/native-intent/) file to handle the incoming share intent. This allows you to inspect the incoming path and redirect to a specific route.
 
 ```tsx app/+native-intent.ts
 import { getSharedPayloads } from 'expo-sharing';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

<img width="1578" height="1006" alt="CleanShot 2026-01-29 at 01 37 24@2x" src="https://github.com/user-attachments/assets/41344fcd-f278-4698-b213-780596d974b7" />


# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix warnings manually in each doc.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn run lint-prose`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
