### PR TITLE
[macOS][core] Add `NSEdgeInsets.zero` extension to better match `UIEdgeInsets`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- [macOS] Added `NSEdgeInsets.zero` extension to better match `UIEdgeInsets`.
+
 ### 🐛 Bug fixes
 
 - [iOS] Fixed a crash in Fabric when unmounting a view while a geometry change event is being dispatched. ([#42628](https://github.com/expo/expo/issues/42628) by [@danishshaik](https://github.com/danishshaik)) ([#42634](https://github.com/expo/expo/pull/42634) by [@danishshaik](https://github.com/danishshaik))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- [macOS] Added `NSEdgeInsets.zero` extension to better match `UIEdgeInsets`.
+- [macOS] Added `NSEdgeInsets.zero` extension to better match `UIEdgeInsets`. ([#42675](https://github.com/expo/expo/pull/42675) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Platform/Platform.swift
+++ b/packages/expo-modules-core/ios/Platform/Platform.swift
@@ -40,4 +40,10 @@ extension NSPasteboard {
   }
 }
 
+extension NSEdgeInsets {
+  public static var zero: NSEdgeInsets {
+    return NSEdgeInsetsZero
+  }
+}
+
 #endif // os(macOS)


### PR DESCRIPTION
# Why

Fixes CI failures: https://github.com/expo/expo/actions/runs/21449600517/job/61774535085?pr=42665

# How

Added extension to `NSEdgeInsets` to expose a static member `zero`, which is available in `UIEdgeInsets` and used in our SwiftUI hosting view.

# Test Plan

Compiling for macOS succeeds 