### PR TITLE
[ios][dev-launcher] Fix text color in url input

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix sometimes two dev menus would open. ([#42567](https://github.com/expo/expo/pull/42567) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Fix color of placeholder text in URL input.
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix sometimes two dev menus would open. ([#42567](https://github.com/expo/expo/pull/42567) by [@lukmccall](https://github.com/lukmccall))
-- [iOS] Fix color of placeholder text in URL input.
+- [iOS] Fix color of placeholder text in URL input. ([#42677](https://github.com/expo/expo/pull/42677) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/ServerUrlInput.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/ServerUrlInput.kt
@@ -84,7 +84,7 @@ fun ServerUrlInput(
       TextInput(
         placeholder = {
           NewText(
-            text = "http://localhost:8081",
+            text = "exp://",
             style = NewAppTheme.font.md,
             color = NewAppTheme.colors.text.secondary
           )

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
@@ -91,7 +91,7 @@ struct DevServersView: View {
       }
 
       if showingURLInput {
-        TextField("http://10.0.0.25:8081", text: $urlText)
+        TextField("exp://", text: $urlText)
         #if !os(macOS)
           .autocapitalization(.none)
         #endif
@@ -99,7 +99,6 @@ struct DevServersView: View {
           .padding(.horizontal, 16)
           .padding(.vertical, 12)
           .foregroundColor(.primary)
-          .onSubmit(connectToURL)
         #if !os(tvOS)
           .overlay(
             RoundedRectangle(cornerRadius: 5)
@@ -143,7 +142,9 @@ struct DevServersView: View {
   }
 
   private var connectButton: some View {
-    Button(action: connectToURL) {
+    Button {
+      connectToURL()
+    } label: {
       Text("Connect")
         .font(.headline)
         .foregroundColor(.white)
@@ -153,7 +154,7 @@ struct DevServersView: View {
         .clipShape(RoundedRectangle(cornerRadius: 8))
     }
     .disabled(urlText.isEmpty)
-    .buttonStyle(PlainButtonStyle())
+    .buttonStyle(.plain)
   }
 }
 

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_runUpdate.yml
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_runUpdate.yml
@@ -19,7 +19,7 @@ onFlowStart:
           text: Enter URL manually
       - tapOn:
           label: Tap on "Updates URL" text field
-          text: '.*http:.*'
+          text: '.*exp:.*'
           below: Enter URL manually
 - runFlow:
     when:
@@ -30,7 +30,7 @@ onFlowStart:
           text: New development server
       - tapOn:
           label: Tap on "Updates URL" text field
-          text: '.*http:.*'
+          text: '.*exp:.*'
           below: New development server
 - inputText:
     label: Input local update server URL


### PR DESCRIPTION
# Why
Fixes the placeholder text being blue in the url input.

# How
SwiftUI automatically highlights valid urls in the primary color even if they are in the placeholder and non-interactive 🤦‍♂️
Changed the placeholder so this does not happen

# Test Plan
Bare expo
