### PR TITLE
[modules-core][macos] Add SwiftUI Color extension

### DIFF
--- a/packages/expo-dev-menu/ios/SwiftUI/SourceMapExplorerView.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/SourceMapExplorerView.swift
@@ -67,7 +67,9 @@ struct SourceMapExplorerView: View {
     }
     .navigationTitle(showNavigationBar ? "Source code explorer" : "")
     .inlineNavigationBar()
+#if !os(macOS)
     .navigationBarHidden(!showNavigationBar)
+#endif
     .modifier(ConditionalSearchable(isEnabled: showContent, text: $viewModel.searchText))
   }
 
@@ -88,7 +90,11 @@ struct SourceMapExplorerView: View {
         .foregroundColor(.secondary)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
+#if !os(macOS)
     .background(Color(uiColor: .systemGroupedBackground))
+#else
+    .background(Color(uiColor: .windowBackgroundColor))
+#endif
     .ignoresSafeArea()
   }
 
@@ -326,7 +332,11 @@ struct CodeFileView: View {
     }
     .foregroundColor(Color(uiColor: .label))
     .padding(.vertical, 10)
+#if !os(macOS)
     .background(Color(uiColor: .secondarySystemBackground))
+#else
+    .background(Color(uiColor: .controlBackgroundColor))
+#endif
   }
 
   var body: some View {
@@ -345,7 +355,11 @@ struct CodeFileView: View {
         }
       }
     }
+#if !os(macOS)
     .background(isImageFile ? Color(uiColor: .systemGroupedBackground) : theme.background)
+#else
+    .background(isImageFile ? Color(uiColor: .windowBackgroundColor) : theme.background)
+#endif
     .navigationTitle(node.name)
     .inlineNavigationBar()
     .toolbar {

--- a/packages/expo-modules-core/ios/Platform/Platform.swift
+++ b/packages/expo-modules-core/ios/Platform/Platform.swift
@@ -26,6 +26,18 @@ extension Image {
   }
 }
 
+public extension Color {
+  init(uiColor: NSColor) {
+    self.init(nsColor: uiColor)
+  }
+}
+
+public extension NSColor {
+  static var label: NSColor {
+    return NSColor.labelColor
+  }
+}
+
 extension NSPasteboard {
   public var string: String? {
     get {


### PR DESCRIPTION
# Why

macOS CI is failing due to our new changes onthe  dev-menu

# How

- update modules-core Platform compatibility file to extend `Color` to use the same initializer on macOS as on iOS
- Add platform checks for colors inside SourceMapExplorerView

# Test Plan

cherry-pick https://github.com/expo/expo/pull/42675 and Run BareExpo locally 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
