### PR TITLE
[docs][ui] - Add single/double tap interaction note in `Menu` and `ContextMenu`

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/contextmenu.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/contextmenu.mdx
@@ -9,7 +9,7 @@ platforms: ['ios', 'tvos']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-Expo UI ContextMenu matches the official SwiftUI [contextMenu API](<https://developer.apple.com/documentation/swiftui/view/contextmenu(menuitems:)>) and displays a menu when long-pressed.
+Expo UI ContextMenu matches the official SwiftUI [contextMenu API](<https://developer.apple.com/documentation/swiftui/view/contextmenu(menuitems:)>) and displays a menu when long-pressed. For single-tap menu interactions, use [`Menu`](menu) instead.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/menu.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/menu.mdx
@@ -9,7 +9,7 @@ platforms: ['ios', 'tvos']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-Expo UI Menu matches the official SwiftUI [Menu API](https://developer.apple.com/documentation/swiftui/menu) and supports styling via the [`buttonStyle`](modifiers/#buttonstylestyle) modifier.
+Expo UI Menu matches the official SwiftUI [Menu API](https://developer.apple.com/documentation/swiftui/menu) and supports styling via the [`buttonStyle`](modifiers/#buttonstylestyle) modifier. Menu opens on a single tap. For long-press interactions, use [`ContextMenu`](contextmenu) instead.
 
 > **Note:** On tvOS, Menu requires tvOS 17.0 or later.
 

--- a/docs/pages/versions/v55.0.0/sdk/ui/swift-ui/contextmenu.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/ui/swift-ui/contextmenu.mdx
@@ -9,7 +9,7 @@ platforms: ['ios', 'tvos']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-Expo UI ContextMenu matches the official SwiftUI [contextMenu API](<https://developer.apple.com/documentation/swiftui/view/contextmenu(menuitems:)>) and displays a menu when long-pressed.
+Expo UI ContextMenu matches the official SwiftUI [contextMenu API](<https://developer.apple.com/documentation/swiftui/view/contextmenu(menuitems:)>) and displays a menu when long-pressed. For single-tap menu interactions, use [`Menu`](menu) instead.
 
 ## Installation
 

--- a/docs/pages/versions/v55.0.0/sdk/ui/swift-ui/menu.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/ui/swift-ui/menu.mdx
@@ -9,7 +9,7 @@ platforms: ['ios', 'tvos']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-Expo UI Menu matches the official SwiftUI [Menu API](https://developer.apple.com/documentation/swiftui/menu) and supports styling via the [`buttonStyle`](modifiers/#buttonstylestyle) modifier.
+Expo UI Menu matches the official SwiftUI [Menu API](https://developer.apple.com/documentation/swiftui/menu) and supports styling via the [`buttonStyle`](modifiers/#buttonstylestyle) modifier. Menu opens on a single tap. For long-press interactions, use [`ContextMenu`](contextmenu) instead.
 
 > **Note:** On tvOS, Menu requires tvOS 17.0 or later.
 


### PR DESCRIPTION
# Why

Previously we supported single and double tap interactions in a common `ContextMenu` component, which was changed [here](https://github.com/expo/expo/pull/42027#issuecomment-3814368929). It is causing confusion, so mentioning it in the documentation would be helpful.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested docs locally
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
