### PR TITLE
[docs] Display extended/empty interfaces in API reference

### DIFF
--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -114,11 +114,6 @@ const renderInterface = (
   sdkVersion: string
 ) => {
   const interfaceChildren = children?.filter(child => !child?.inheritedFrom) || [];
-
-  if (interfaceChildren.length === 0) {
-    return null;
-  }
-
   const interfaceMethods = interfaceChildren.filter(child => child.signatures);
   const interfaceFields = interfaceChildren.filter(child => !child.signatures);
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/expo/pull/42645

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Render interfaces even when they only extend other types and have no own members, so `ImmutableHeaders` (and similar) appear in the Expo Server reference.
- Removed the early return in `APISectionInterfaces.tsx` that skipped interfaces with no non‑inherited children.
- A few additional "empty" interface boxes may appear across SDK reference pages (e.g., `ImmutableHeaders`, `StackSearchBarProps`, `NativeModuleType`).

(Note for the reviewers: I don't think any of the additional properties displayed are harmful in any sense. If some property should not be displayed, as a package maintainer, either let me know or use `@hideType` in TypeDoc comments in that package).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs app locally and visit: 
- http://localhost:3002/versions/v55.0.0/sdk/server/#immutableheaders
- http://localhost:3002/versions/v55.0.0/sdk/expo/#nativemoduletype
- http://localhost:3002/versions/v55.0.0/sdk/router/#stacksearchbar

### Preview

From: http://localhost:3002/versions/v55.0.0/sdk/server/#immutableheaders

<img width="4112" height="2398" alt="CleanShot 2026-01-29 at 13 28 34@2x" src="https://github.com/user-attachments/assets/008c84eb-7a73-43b5-a4c3-c8ef996a7f46" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
