### PR TITLE
[ci] Update macOS workflow to ignore Android files

### DIFF
--- a/.github/workflows/test-suite-macos.yml
+++ b/.github/workflows/test-suite-macos.yml
@@ -28,6 +28,8 @@ on:
       - packages/expo-updates/**
       - packages/expo-updates-interface/**
       - packages/expo-web-browser/**
+      - '!packages/**/android/**'
+      - '!{**/*.md,**/LICENSE*,**/.gitignore,**/CHANGELOG*,**/.npmignore,**/.eslintrc*,**/.prettierrc*,**/.gitattributes,**/.watchmanconfig,**/.fingerprintignore}'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/test-suite-macos.yml
+++ b/.github/workflows/test-suite-macos.yml
@@ -29,7 +29,17 @@ on:
       - packages/expo-updates-interface/**
       - packages/expo-web-browser/**
       - '!packages/**/android/**'
-      - '!{**/*.md,**/LICENSE*,**/.gitignore,**/CHANGELOG*,**/.npmignore,**/.eslintrc*,**/.prettierrc*,**/.gitattributes,**/.watchmanconfig,**/.fingerprintignore}'
+      # Common ignores from detect-platform-change action
+      - '!**/*.md'
+      - '!**/LICENSE*'
+      - '!**/.gitignore'
+      - '!**/CHANGELOG*'
+      - '!**/.npmignore'
+      - '!**/.eslintrc*'
+      - '!**/.prettierrc*'
+      - '!**/.gitattributes'
+      - '!**/.watchmanconfig'
+      - '!**/.fingerprintignore'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}


### PR DESCRIPTION
# Why
There's no need to run the macOS workflow for android changes.

# How
Add an exclusion to paths based on this:
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-including-and-excluding-paths

# Test Plan
Verified in a stacked PR.