### PR TITLE
[docs] Refactor locale assignment with optional chaining

### DIFF
--- a/docs/pages/guides/localization.mdx
+++ b/docs/pages/guides/localization.mdx
@@ -83,7 +83,7 @@ const i18n = new I18n({
 });
 
 // Set the locale once at the beginning of your app.
-i18n.locale = getLocales()[0].languageCode;
+i18n.locale = getLocales().at(0)?.languageCode ?? 'en' ; // you can also do getLocales()[0].languageCode ?? 'en'
 
 console.log(i18n.t('welcome'));
 ```

--- a/docs/pages/guides/localization.mdx
+++ b/docs/pages/guides/localization.mdx
@@ -83,7 +83,7 @@ const i18n = new I18n({
 });
 
 // Set the locale once at the beginning of your app.
-i18n.locale = getLocales().at(0)?.languageCode ?? 'en' ; // you can also do getLocales()[0].languageCode ?? 'en'
+i18n.locale = getLocales().at(0)?.languageCode ?? 'en'; // you can also do getLocales()[0].languageCode ?? 'en'
 
 console.log(i18n.t('welcome'));
 ```


### PR DESCRIPTION
Updated locale setting to use optional chaining and fallback. Because in typescript the old code give an error, also there is the support for .at which is safer to use.

# Why

The code is not copy past, so I want to add the small fix so that new developer have easier time 

# How
Added the .at function (which is safer) and added the ?? so even if you get null or undefined you can still run error free 

