### PR TITLE
[core][ios] Fix crashes when converting a single `JSValue` into an `Array`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fixed a crash in Fabric when unmounting a view while a geometry change event is being dispatched. ([#42628](https://github.com/expo/expo/issues/42628) by [@danishshaik](https://github.com/danishshaik)) ([#42634](https://github.com/expo/expo/pull/42634) by [@danishshaik](https://github.com/danishshaik))
+- [iOS] Fix crashes when converting a single JSValue into an Array. ([#42694](https://github.com/expo/expo/pull/42694) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicArrayType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicArrayType.swift
@@ -22,7 +22,7 @@ internal struct DynamicArrayType: AnyDynamicType {
   }
 
   func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
-    let value = jsValue.getArray()
+    let value = jsValue.isArray() ? jsValue.getArray() : [jsValue]
     return try value.map { try elementType.cast(jsValue: $0, appContext: appContext) }
   }
 

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.h
@@ -39,6 +39,7 @@ NS_SWIFT_NAME(JavaScriptValue)
 - (BOOL)isSymbol;
 - (BOOL)isObject;
 - (BOOL)isFunction;
+- (BOOL)isArray;
 - (BOOL)isTypedArray;
 - (BOOL)isArrayBuffer;
 

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
@@ -78,6 +78,15 @@
   return false;
 }
 
+- (BOOL)isArray
+{
+  if (_value.isObject()) {
+    jsi::Runtime *runtime = [_runtime get];
+    return _value.getObject(*runtime).isArray(*runtime);
+  }
+  return false;
+}
+
 - (BOOL)isTypedArray
 {
   if (_value.isObject()) {

--- a/packages/expo-modules-core/ios/Tests/DynamicTypeTests.swift
+++ b/packages/expo-modules-core/ios/Tests/DynamicTypeTests.swift
@@ -208,6 +208,14 @@ struct DynamicTypeTests {
     }
 
     @Test
+    func `arrayizes a single JS value`() throws {
+      let jsInt = try appContext.runtime.eval("67")
+      let jsString = try appContext.runtime.eval("'Expo'")
+      #expect(try (~[Int].self).cast(jsValue: jsInt, appContext: appContext) as? [Int] == [67])
+      #expect(try (~[String].self).cast(jsValue: jsString, appContext: appContext) as? [String] == ["Expo"])
+    }
+
+    @Test
     func `arrayizes single element`() throws {
       // The dynamic array type can arrayize the single element
       // if only the array element's dynamic type can cast it.


### PR DESCRIPTION
# Why

On iOS, when using a method that accepts an array as an argument we convert calls which only provide a single, non-array argument into an array. e.g.:

`function processArray(arr: Int[]) { ... }`
call:
`processArray(1)` should be equivalent to `processArray([1])`

Our current implementation of `cast(jsValue: JavaScriptValue, appContext: AppContext)` doesn't take this into account, leading to crashes.

# How

Handle this case in `DynamicArrayType.swift`

# Test Plan

Tested in BareExpo on iOS, added a couple of unit tests.

