### PR TITLE
[web-browser] Add support for auth universal links callback

### DIFF
--- a/apps/bare-expo/app.json
+++ b/apps/bare-expo/app.json
@@ -34,7 +34,8 @@
       "requireFullScreen": false,
       "entitlements": {
         "com.apple.security.application-groups": ["group.dev.expo.Payments"]
-      }
+      },
+      "associatedDomains": ["applinks:bare-expo.expo.app", "webcredentials:bare-expo.expo.app"]
     },
     "web": {
       "bundler": "metro"

--- a/apps/bare-expo/ios/BareExpo/BareExpo.entitlements
+++ b/apps/bare-expo/ios/BareExpo/BareExpo.entitlements
@@ -9,7 +9,12 @@
       <string>Default</string>
     </array>
     <key>com.apple.developer.declared-age-range</key>
-    <true/>
+    <true />
+    <key>com.apple.developer.associated-domains</key>
+    <array>
+      <string>applinks:bare-expo.expo.app</string>
+      <string>webcredentials:bare-expo.expo.app</string>
+    </array>
     <key>com.apple.security.application-groups</key>
     <array>
       <string>group.dev.expo.Payments</string>

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add support for auth universal links callback ([#42695](https://github.com/expo/expo/pull/42695) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-web-browser/ios/WebAuthSession.swift
+++ b/packages/expo-web-browser/ios/WebAuthSession.swift
@@ -24,17 +24,36 @@ final internal class WebAuthSession {
   private var presentationContextProvider = PresentationContextProvider()
 
   init(authUrl: URL, redirectUrl: URL?, options: AuthSessionOptions) {
-    self.authSession = ASWebAuthenticationSession(
-      url: authUrl,
-      callbackURLScheme: redirectUrl?.scheme,
-      completionHandler: { callbackUrl, error in
-        self.finish(with: [
-          "type": callbackUrl != nil ? "success" : "cancel",
-          "url": callbackUrl?.absoluteString,
-          "error": error?.localizedDescription
-        ])
-      }
-    )
+    let completionHandler: ASWebAuthenticationSession.CompletionHandler = { callbackUrl, error in
+      self.finish(with: [
+        "type": callbackUrl != nil ? "success" : "cancel",
+        "url": callbackUrl?.absoluteString,
+        "error": error?.localizedDescription
+      ])
+    }
+
+    // iOS 17.4+/macOS 14.4+ supports HTTPS callbacks with host/path matching
+    if #available(iOS 17.4, macOS 14.4, *),
+       let redirectUrl = redirectUrl,
+       redirectUrl.scheme == "https",
+       let host = redirectUrl.host(percentEncoded: false),
+       !host.isEmpty {
+      // Use the new callback API for HTTPS universal links
+      // Pass empty string for path to match any path under the host if no specific path is provided
+      let path = redirectUrl.path.isEmpty ? "" : redirectUrl.path
+      self.authSession = ASWebAuthenticationSession(
+        url: authUrl,
+        callback: .https(host: host, path: path),
+        completionHandler: completionHandler
+      )
+    } else {
+      // Fallback to the old API for custom schemes or older iOS versions
+      self.authSession = ASWebAuthenticationSession(
+        url: authUrl,
+        callbackURLScheme: redirectUrl?.scheme,
+        completionHandler: completionHandler
+      )
+    }
     self.authSession?.prefersEphemeralWebBrowserSession = options.preferEphemeralSession
   }
 

--- a/packages/expo-web-browser/ios/WebAuthSession.swift
+++ b/packages/expo-web-browser/ios/WebAuthSession.swift
@@ -34,16 +34,15 @@ final internal class WebAuthSession {
 
     // iOS 17.4+/macOS 14.4+ supports HTTPS callbacks with host/path matching
     if #available(iOS 17.4, macOS 14.4, *),
-       let redirectUrl = redirectUrl,
+       let redirectUrl,
        redirectUrl.scheme == "https",
        let host = redirectUrl.host(percentEncoded: false),
        !host.isEmpty {
       // Use the new callback API for HTTPS universal links
-      // Pass empty string for path to match any path under the host if no specific path is provided
-      let path = redirectUrl.path.isEmpty ? "" : redirectUrl.path
+      // Pass an empty string for the path to match any path under the host if no specific path is provided
       self.authSession = ASWebAuthenticationSession(
         url: authUrl,
-        callback: .https(host: host, path: path),
+        callback: .https(host: host, path: redirectUrl.path),
         completionHandler: completionHandler
       )
     } else {


### PR DESCRIPTION
# Why

`openAuthSessionAsync` currently uses `ASWebAuthenticationSession` with `callbackURLScheme`, which only supports custom URL scheme callbacks. Starting with iOS 17.4/macOS 14.4, Apple introduced a new callback API (`.https(host:path:)`) that supports HTTPS universal link callbacks, enabling more secure auth flows without relying on custom URL schemes.

# How

- On iOS 17.4+/macOS 14.4+, when the redirect URL has an `https` scheme with a non-empty host, `WebAuthSession` now uses the new `ASWebAuthenticationSession(url:callback:completionHandler:)` initializer with `.https(host:path:)` callback matching. On older OS versions or when using custom scheme redirect URLs, keep using the existing `callbackURLScheme` API.
- Updated the NCL `OpenAuthSessionAsyncDemo` to use real GitHub OAuth instead of `fake-auth.netlify.com`, which was no longer working.
- Configured `bare-expo` with associated domains (`applinks` + `webcredentials` for `bare-expo.expo.app`) to enable HTTPS callback testing.

# Test Plan

- Open the WebBrowser screen in NCL/bare-expo
- In the `openAuthSessionAsync` section, select **Custom Scheme** redirect URL → tap **GitHub** → verify the GitHub OAuth page opens and the auth flow completes with a `success` result
- Switch to **HTTPS (Universal Link)** redirect URL → tap **GitHub** → verify the auth flow works using the HTTPS callback path (requires associated domains to be properly configured for `bare-expo.expo.app`) 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
