### PR TITLE
[ios][dev-menu] Default action button to false

### DIFF
--- a/apps/expo-go/ios/Exponent/Kernel/Core/EXKernel.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Core/EXKernel.m
@@ -63,6 +63,7 @@ NSString * const kEXReloadActiveAppRequest = @"EXReloadActiveAppRequest";
 
     [DevMenuManager.shared setDelegate:self];
     [DevMenuManager shared].configuration.onboardingAppName = @"Expo Go";
+    [[DevMenuManager shared] setShowFloatingActionButton:YES];
 
     // Register keyboard commands (e.g., Cmd+D) for simulator
     [[EXKernelDevKeyCommands sharedInstance] registerDevCommands];

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -189,6 +189,11 @@ open class DevMenuManager: NSObject {
   }
 
   @objc
+  public func setShowFloatingActionButton(_ enabled: Bool) {
+    DevMenuPreferences.showFloatingActionButton = enabled
+  }
+
+  @objc
   public func updateCurrentBridge(_ bridge: RCTBridge?) {
     currentBridge = bridge
     if bridge != nil {

--- a/packages/expo-dev-menu/ios/Modules/DevMenuPreferences.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuPreferences.swift
@@ -33,7 +33,7 @@ public class DevMenuPreferences: Module {
       keyCommandsEnabledKey: true,
       showsAtLaunchKey: false,
       isOnboardingFinishedKey: true,
-      showFloatingActionButtonKey: true
+      showFloatingActionButtonKey: false
     ])
     #else
     UserDefaults.standard.register(defaults: [
@@ -42,7 +42,7 @@ public class DevMenuPreferences: Module {
       keyCommandsEnabledKey: true,
       showsAtLaunchKey: false,
       isOnboardingFinishedKey: false,
-      showFloatingActionButtonKey: true
+      showFloatingActionButtonKey: false
     ])
     #endif
 


### PR DESCRIPTION
# Why
We only want the action button to default to on in expo go, off by default in normal projects

# How
Switch the default. Add an api for expo go to change it

# Test Plan
Bare expo
Expo go
