### PR TITLE
Update 3rd party server section with valid Express wildcard

### DIFF
--- a/docs/pages/router/web/api-routes.mdx
+++ b/docs/pages/router/web/api-routes.mdx
@@ -638,7 +638,7 @@ app.use(
 app.use(morgan('tiny'));
 
 app.all(
-  '/{*all}',
+  '*',
   createRequestHandler({
     build: SERVER_BUILD_DIR,
   })


### PR DESCRIPTION
changed from '/{*all}' to ' * '

# Why

The Express catch-all pattern in the docs used `/{*all}`, which is not a valid Express wildcard and causes 404s for all routes. This change updates the example to use the correct `*` pattern so the handler receives requests as intended.

# How

Updated the Express example to use `app.all('*', ...)` instead of `app.all('/{*all}', ...)`.

# Test Plan

- Verified locally by exporting and running the Express server with the updated route pattern.
- Confirmed non-404 responses when requesting `/` and dynamic routes.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
