### PR TITLE
fix(cli): Reallow connections on /expo-dev-plugins/broadcast

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ### 🐛 Bug fixes
 
-- Reallow connections on `/expo-dev-plugins/broadcast` broadcast socket to local connections ([#42538](https://github.com/expo/expo/pull/42538) by [@kitten](https://github.com/kitten))
+- Reallow connections on `/expo-dev-plugins/broadcast` broadcast socket to local connections ([#42538](https://github.com/expo/expo/pull/42538) by [@kitten](https://github.com/kitten)), ([#42705](https://github.com/expo/expo/pull/42705) by [@vonovak](https://github.com/vonovak))
 - Fix `freeport-async` replacement ([#42509](https://github.com/expo/expo/pull/42509) by [@kitten](https://github.com/kitten))
 - Use `require.resolve` to resolve `@expo/router-server` path ([#42516](https://github.com/expo/expo/pull/42516) by [@hassankhan](https://github.com/hassankhan))
 

--- a/packages/@expo/cli/src/start/server/metro/DevToolsPluginWebsocketEndpoint.ts
+++ b/packages/@expo/cli/src/start/server/metro/DevToolsPluginWebsocketEndpoint.ts
@@ -1,25 +1,9 @@
 import { WebSocket, WebSocketServer } from 'ws';
 
-import { isMatchingOrigin } from '../../../utils/net';
-
-interface DevToolsPluginWebsocketEndpointParams {
-  serverBaseUrl: string;
-}
-
-export function createDevToolsPluginWebsocketEndpoint({
-  serverBaseUrl,
-}: DevToolsPluginWebsocketEndpointParams): Record<string, WebSocketServer> {
+export function createDevToolsPluginWebsocketEndpoint(): Record<string, WebSocketServer> {
   const wss = new WebSocketServer({ noServer: true });
 
   wss.on('connection', (ws, request) => {
-    // Explicitly limit devtools websocket to loopback requests
-    if (request.headers.origin && !isMatchingOrigin(request, serverBaseUrl)) {
-      // NOTE: `socket.close` nicely closes the websocket, which will still allow incoming messages
-      // `socket.terminate` instead forcefully closes down the socket
-      ws.terminate();
-      return;
-    }
-
     ws.on('message', (message, isBinary) => {
       // Broadcast the received message to all other connected clients
       wss.clients.forEach((client) => {

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -283,7 +283,7 @@ export async function instantiateMetroAsync(
       return middleware.use(metroMiddleware);
     };
 
-    const devtoolsWebsocketEndpoints = createDevToolsPluginWebsocketEndpoint({ serverBaseUrl });
+    const devtoolsWebsocketEndpoints = createDevToolsPluginWebsocketEndpoint();
     Object.assign(websocketEndpoints, devtoolsWebsocketEndpoints);
   }
 


### PR DESCRIPTION
# Why

continuation of https://github.com/expo/expo/pull/42538, the current behavior blocks connections from devtool plugins (e.g. from `http://192.168.1.250:8081/_expo/plugins/expo-sqlite/`)

# How

remove the origin check

# Test Plan

- tested locally with expo-sqlite devtool plugin

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
