### PR TITLE
[docs] Add `OnViewDestroys` definition

### DIFF
--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -535,7 +535,7 @@ View(MyView::class) {
 
 <PaddedAPIBox header="OnViewDestroys" platforms={["android"]}>
 
-Creates view's lifecycle listener that is called right after the view isn't longer used by React Native.
+Creates a view's lifecycle listener that is called right after the view is no longer used by React Native.
 
 ```kotlin
 View(MyView::class) {

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -533,6 +533,22 @@ View(MyView::class) {
 
 </PaddedAPIBox>
 
+<PaddedAPIBox header="OnViewDestroys" platforms={["android"]}>
+
+Creates view's lifecycle listener that is called right after the view isn't longer used by React Native.
+
+```kotlin
+View(MyView::class) {
+  OnViewDestroys { view: MyView ->
+    /* @hide ... */ /* @end */
+  }
+}
+```
+
+> **Note:** This function is not available on iOS — you may want to use a class deinitializer instead.
+
+</PaddedAPIBox>
+
 <PaddedAPIBox header="(View) AsyncFunction">
 
 Similarly to the [`AsyncFunction`](#asyncfunction) inside the module definition, you can define functions attached to the view ref to allow direct modification of the native view.

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -545,7 +545,7 @@ View(MyView::class) {
 }
 ```
 
-> **Note:** This function is not available on iOS — you may want to use a class deinitializer instead.
+> **Note:** This function is not available on iOS. You may want to use the destructor of the native view to achieve similar results.
 
 </PaddedAPIBox>
 


### PR DESCRIPTION
# Why

Module API Reference is missing important `View` definition component for Android.

Closes https://github.com/expo/expo/issues/38921

# How

Added definition to markdown file following proper documentation writing style

# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new View lifecycle API section, “OnViewDestroys,” under View definition components.
  * Documents an Android-only listener that fires when a view is no longer used by React Native.
  * Includes a Kotlin example and notes iOS does not support this hook, suggesting a class deinitializer alternative.
  * Clarifies platform availability and expected behavior for view destruction handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->