### PR TITLE
test(@expo/cli): improve Playwright E2E test times on CI

### DIFF
--- a/packages/@expo/cli/e2e/utils/package.ts
+++ b/packages/@expo/cli/e2e/utils/package.ts
@@ -27,7 +27,8 @@ export async function createPackageTarball(fixtureRoot: string, packagePath: str
   const { stdout } = await execa(
     'npm',
     // Run `npm pack --json` without the script logging (see: https://github.com/npm/cli/issues/7354)
-    ['--foreground-scripts=false', 'pack', '--json', '--pack-destination', outputDir],
+    // Use `--ignore-scripts` to skip lifecycle scripts and avoid race conditions when packing in parallel
+    ['--foreground-scripts=false', '--ignore-scripts', 'pack', '--json', '--pack-destination', outputDir],
     { cwd: packageDir, stdio: boolish('CI', false) ? 'pipe' : undefined }
   );
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
