### PR TITLE
[core][Android] Refactor `JNIToJSIConverter`

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/concepts/jni.h
+++ b/packages/expo-modules-core/android/src/main/cpp/concepts/jni.h
@@ -1,0 +1,43 @@
+// Copyright © 2026-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include <concepts>
+#include <fbjni/fbjni.h>
+#include "jni_deref.h"
+
+namespace jni = facebook::jni;
+
+namespace expo {
+
+template<typename T>
+concept HasCthis = requires(T &t) { t->cthis(); };
+
+template<typename T>
+concept HasToStdString = requires(T &t) { t->toStdString(); };
+
+template<typename T>
+concept HasValue = requires(T &t) { t->value(); };
+
+template<typename T>
+concept HasGetRegion = requires(T &t, jsize s) { t->getRegion(s, s); };
+
+template<typename T>
+concept IsJBoolean = std::is_same_v<jni_deref_t<T>, jni::JBoolean>;
+
+template<typename T>
+concept JniRef =
+  std::is_same_v<T, jni::local_ref<jni_deref_t<T>>> ||
+  std::is_same_v<T, jni::global_ref<jni_deref_t<T>>> ||
+  std::is_same_v<T, jni::alias_ref<jni_deref_t<T>>>;
+
+template<typename T, typename Inner>
+concept JniRefTo = JniRef<T> && std::is_same_v<jni_deref_t<T>, Inner>;
+
+template<typename T, typename Inner>
+concept JCollectionRef = JniRefTo<T, jni::JCollection<Inner>>;
+
+template<typename T, typename Key, typename Value>
+concept JMapRef = JniRefTo<T, jni::JMap<Key, Value>>;
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/concepts/jni_deref.h
+++ b/packages/expo-modules-core/android/src/main/cpp/concepts/jni_deref.h
@@ -1,0 +1,39 @@
+// Copyright © 2026-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include <concepts>
+#include <fbjni/fbjni.h>
+
+namespace jni = facebook::jni;
+
+namespace expo::jni_deref_impl {
+
+template<typename T>
+struct deref {
+  using type = T;
+};
+
+template<typename T>
+struct deref<jni::local_ref<T>> {
+  using type = T;
+};
+
+template<typename T>
+struct deref<jni::global_ref<T>> {
+  using type = T;
+};
+
+template<typename T>
+struct deref<jni::alias_ref<T>> {
+  using type = T;
+};
+
+} // namespace expo::jni_deref_impl
+
+namespace expo {
+
+template<typename T>
+using jni_deref_t = typename jni_deref_impl::deref<std::remove_cvref_t<T>>::type;
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/concepts/jsi.h
+++ b/packages/expo-modules-core/android/src/main/cpp/concepts/jsi.h
@@ -1,0 +1,20 @@
+// Copyright © 2026-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include <concepts>
+#include <jsi/jsi.h>
+
+namespace jsi = facebook::jsi;
+
+namespace expo {
+
+template<typename T>
+concept TriviallyConvertibleToJSI = std::is_constructible_v<jsi::Value, T>;
+
+template<typename T>
+concept ConvertibleToJSI =
+  std::is_constructible_v<jsi::Value, jsi::Runtime &, T> &&
+  !std::is_constructible_v<jsi::Value, T>;
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.h
@@ -9,10 +9,14 @@
 #include "../javaclasses/Collections.h"
 #include "../JavaScriptArrayBuffer.h"
 #include "../NativeArrayBuffer.h"
+#include "../concepts/jni_deref.h"
+#include "../concepts/jni.h"
+#include "../concepts/jsi.h"
 
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
 #include <optional>
+#include <concepts>
 
 #include <react/jni/ReadableNativeMap.h>
 #include <react/jni/ReadableNativeArray.h>
@@ -32,238 +36,94 @@ jsi::Value convert(
   const jni::local_ref<jobject> &value
 );
 
-template<typename RefType>
-std::vector<jsi::Value> convertArray(
-  JNIEnv *env,
+std::optional<jsi::Value> convertStringToFollyDynamicIfNeeded(
   jsi::Runtime &rt,
-  RefType &values
-) {
-  size_t size = values->size();
-  std::vector<jsi::Value> convertedValues;
-  convertedValues.reserve(size);
+  const std::string &string
+);
 
-  for (size_t i = 0; i < size; i++) {
-    jni::local_ref<jobject> value = values->getElement(i);
-    convertedValues.push_back(convert(env, rt, value));
-  }
-
-  return convertedValues;
-}
-
-/**
- * Convert a string with FollyDynamicExtensionConverter support.
- */
-std::optional<jsi::Value>
-convertStringToFollyDynamicIfNeeded(jsi::Runtime &rt, const std::string &string);
-
-/**
- * Decorate jsi::Value with FollyDynamicExtensionConverter support.
- */
-std::optional<jsi::Value>
-decorateValueForDynamicExtension(jsi::Runtime &rt, const jsi::Value &value);
-
-template<typename T, typename = void>
-struct has_cthis : std::false_type {
-};
-
-template<typename T>
-struct has_cthis<T, std::void_t<decltype(std::declval<T &>()->cthis())>> : std::true_type {
-};
-
-template<typename T, typename = void>
-struct has_toStdString : std::false_type {
-};
-
-template<typename T>
-struct has_toStdString<T, std::void_t<decltype(std::declval<T &>()->toStdString())>>
-  : std::true_type {
-};
-
-template<typename T, typename = void>
-struct has_value : std::false_type {
-};
-
-template<typename T>
-struct has_value<T, std::void_t<decltype(std::declval<T &>()->value())>>
-  : std::true_type {
-};
-
-template<typename T, typename = void>
-struct has_get_region : std::false_type {
-};
-
-template<typename T>
-struct has_get_region<T, std::void_t<decltype(std::declval<T &>()->getRegion(std::declval<jsize>(),
-                                                                             std::declval<jsize>()))>>
-  : std::true_type {
-};
+std::optional<jsi::Value> decorateValueForDynamicExtension(
+  jsi::Runtime &rt,
+  const jsi::Value &value
+);
 
 template<typename T>
 struct RawArray {
-  typedef T element_type;
+  using element_type = T;
 
   std::shared_ptr<T[]> data;
   size_t size;
 };
 
 template<typename T>
-struct deref {
-  typedef T type;
-};
-
-template<typename T>
-struct deref<jni::local_ref<T>> {
-  typedef T type;
-};
-
-template<typename T>
-struct deref<jni::local_ref<T>&> {
-  typedef T type;
-};
-
-template<typename T>
-struct deref<jni::global_ref<T>> {
-  typedef T type;
-};
-
-template<typename T>
-struct deref<jni::global_ref<T>&> {
-  typedef T type;
-};
-
-template<typename T>
-struct deref<jni::alias_ref<T>> {
-  typedef T type;
-};
-
-template<typename T>
-struct deref<jni::alias_ref<T>&> {
-  typedef T type;
-};
-
-template<typename T>
-inline auto unwrapJNIRef(
-  T &&value
-) {
-  if constexpr (has_cthis<T>::value) {
+inline auto unwrapJNIRef(T &&value) {
+  if constexpr (HasCthis<T>) {
     return value->cthis();
-  } else if constexpr (has_toStdString<T>::value) {
+  } else if constexpr (HasToStdString<T>) {
     return value->toStdString();
-  } else if constexpr (std::is_same<typename deref<T>::type, jni::JBoolean>::value) {
-    return (bool) value->value();
-  } else if constexpr (has_value<T>::value) {
+  } else if constexpr (IsJBoolean<T>) {
+    return static_cast<bool>(value->value());
+  } else if constexpr (HasValue<T>) {
     return value->value();
-  } else if constexpr (has_get_region<T>::value) {
+  } else if constexpr (HasGetRegion<T>) {
     size_t size = value->size();
     auto region = value->getRegion(0, size);
-    RawArray<typename decltype(region)::element_type> rawArray;
-    rawArray.size = size;
-    rawArray.data = std::move(region);
-    return rawArray;
+    return RawArray<typename decltype(region)::element_type>{
+      .data = std::move(region),
+      .size = size
+    };
   } else {
     return value;
   }
 }
 
-template<class T>
-using is_trivially_convertible = std::enable_if_t<std::is_constructible_v<jsi::Value, T>>;
-
 template<typename T, typename Enable = void>
-class JNIToJSIConverter;
+struct JNIToJSIConverter;
 
-struct SimpleConverter;
-struct RefConverter;
-
-template<typename T>
-class JNIToJSIConverter<T, is_trivially_convertible<T>> {
-public:
-  typedef SimpleConverter converterType;
-
-  static inline jsi::Value convert(
-    JNIEnv *env,
-    jsi::Runtime &rt,
-    T value
-  ) {
-    return {value};
+template<TriviallyConvertibleToJSI T>
+struct JNIToJSIConverter<T> {
+  static jsi::Value convert(JNIEnv *, jsi::Runtime &, T value) {
+    return jsi::Value{value};
   }
 };
 
-template<typename T>
-using is_convertible_using_runtime = std::enable_if_t<
-  std::is_constructible_v<jsi::Value, jsi::Runtime &, T> &&
-  !std::is_constructible_v<jsi::Value, T>
->;
-
-template<typename T>
-class JNIToJSIConverter<T, is_convertible_using_runtime<T>> {
-public:
-  typedef SimpleConverter converterType;
-
-  static inline jsi::Value convert(
-    JNIEnv *env,
-    jsi::Runtime &rt,
-    T value
-  ) {
-    return {rt, value};
+template<ConvertibleToJSI T>
+struct JNIToJSIConverter<T> {
+  static jsi::Value convert(JNIEnv *, jsi::Runtime &rt, T value) {
+    return jsi::Value{rt, value};
   }
 };
 
-template<typename T>
-class JNIToJSIConverter<T, std::enable_if_t<std::is_same_v<T, std::nullptr_t>>> {
-public:
-  typedef SimpleConverter converterType;
-
-  static inline jsi::Value convert(
-    JNIEnv *env,
-    jsi::Runtime &rt,
-    T value
-  ) {
+template<>
+struct JNIToJSIConverter<std::nullptr_t> {
+  static jsi::Value convert(JNIEnv *, jsi::Runtime &, std::nullptr_t) {
     return jsi::Value::null();
   }
 };
 
 template<>
-class JNIToJSIConverter<long> {
-public:
-  typedef SimpleConverter converterType;
-
-  static inline jsi::Value convert(
-    JNIEnv *env,
-    jsi::Runtime &rt,
-    long value
-  ) {
-    return {static_cast<double>(value)};
+struct JNIToJSIConverter<long> {
+  static jsi::Value convert(JNIEnv *, jsi::Runtime &, long value) {
+    return jsi::Value{static_cast<double>(value)};
   }
 };
 
 template<>
-class JNIToJSIConverter<long long> {
-public:
-  typedef SimpleConverter converterType;
-
-  static inline jsi::Value convert(
-    JNIEnv *env,
-    jsi::Runtime &rt,
-    long long value
-  ) {
-    return {static_cast<double>(value)};
+struct JNIToJSIConverter<long long> {
+  static jsi::Value convert(JNIEnv *, jsi::Runtime &, long long value) {
+    return jsi::Value{static_cast<double>(value)};
   }
 };
 
 template<>
-class JNIToJSIConverter<JavaScriptModuleObject *> {
-public:
-  typedef RefConverter converterType;
-
-  static inline jsi::Value convert(
-    JNIEnv *env,
+struct JNIToJSIConverter<JavaScriptModuleObject *> {
+  static jsi::Value convert(
+    JNIEnv *,
     jsi::Runtime &rt,
     JavaScriptModuleObject *value,
     const jni::local_ref<JavaScriptModuleObject::javaobject> &ref
   ) {
     auto jsiObject = value->getJSIObject(rt);
-
-    jni::global_ref<jobject> globalRef = jni::make_global(ref);
+    auto globalRef = jni::make_global(ref);
 
     common::setDeallocator(
       rt,
@@ -273,185 +133,95 @@ public:
       }
     );
 
-    return {rt, *jsiObject};
-  }
-};
-
-template<>
-class JNIToJSIConverter<jni::local_ref<JSharedObject::javaobject>> {
-public:
-  typedef SimpleConverter converterType;
-
-  static inline jsi::Value convert(
-    JNIEnv *env,
-    jsi::Runtime &rt,
-    const jni::local_ref<JSharedObject::javaobject> &value
-  ) {
-    JSIContext *jsiContext = getJSIContext(rt);
-    return convertSharedObject(value, rt, jsiContext);
-  }
-};
-
-template<>
-class JNIToJSIConverter<jni::global_ref<JSharedObject::javaobject>> {
-public:
-  typedef SimpleConverter converterType;
-
-  static inline jsi::Value convert(
-    JNIEnv *env,
-    jsi::Runtime &rt,
-    const jni::global_ref<JSharedObject::javaobject> &value
-  ) {
-    JSIContext *jsiContext = getJSIContext(rt);
-    return convertSharedObject(jni::make_local(value), rt, jsiContext);
-  }
-};
-
-template<>
-class JNIToJSIConverter<jni::alias_ref<JSharedObject::javaobject>> {
-public:
-  typedef SimpleConverter converterType;
-
-  static inline jsi::Value convert(
-    JNIEnv *env,
-    jsi::Runtime &rt,
-    const jni::alias_ref<JSharedObject::javaobject> &value
-  ) {
-    JSIContext *jsiContext = getJSIContext(rt);
-    return convertSharedObject(jni::make_local(value), rt, jsiContext);
-  }
-};
-
-template<>
-class JNIToJSIConverter<JavaScriptTypedArray *> {
-public:
-  typedef SimpleConverter converterType;
-
-  static inline jsi::Value convert(
-    JNIEnv *env,
-    jsi::Runtime &rt,
-    JavaScriptTypedArray *value
-  ) {
-    auto jsTypedArray = value->get();
-    return {rt, *jsTypedArray};
-  }
-};
-
-template<>
-class JNIToJSIConverter<JavaScriptArrayBuffer *> {
-public:
-  typedef SimpleConverter converterType;
-
-  static inline jsi::Value convert(
-    JNIEnv *env,
-    jsi::Runtime &rt,
-    JavaScriptArrayBuffer *value
-  ) {
-    auto jsArrayBuffer = value->jsiArrayBuffer();
-    return {rt, *jsArrayBuffer};
-  }
-};
-
-template<>
-class JNIToJSIConverter<NativeArrayBuffer *> {
-public:
-  typedef SimpleConverter converterType;
-
-  static inline jsi::Value convert(
-    JNIEnv *env,
-    jsi::Runtime &rt,
-    NativeArrayBuffer *value
-  ) {
-    auto buffer = value->jsiMutableBuffer();
-    jsi::ArrayBuffer arrayBuffer(rt, buffer);
-    return {rt, arrayBuffer};
-  }
-};
-
-template<>
-class JNIToJSIConverter<react::WritableNativeArray *> {
-public:
-  typedef SimpleConverter converterType;
-
-  static inline jsi::Value convert(
-    JNIEnv *env,
-    jsi::Runtime &rt,
-    react::WritableNativeArray *value
-  ) {
-    auto dynamic = value->consume();
-    auto arg = jsi::valueFromDynamic(rt, dynamic);
-    auto enhancedArg = decorateValueForDynamicExtension(rt, arg);
-    if (enhancedArg) {
-      arg = std::move(*enhancedArg);
-    }
-    return arg;
-  }
-};
-
-template<>
-class JNIToJSIConverter<react::WritableNativeMap *> {
-public:
-  typedef SimpleConverter converterType;
-
-  static inline jsi::Value convert(
-    JNIEnv *env,
-    jsi::Runtime &rt,
-    react::WritableNativeMap *value
-  ) {
-    auto dynamic = value->consume();
-    auto arg = jsi::valueFromDynamic(rt, dynamic);
-    auto enhancedArg = decorateValueForDynamicExtension(rt, arg);
-    if (enhancedArg) {
-      arg = std::move(*enhancedArg);
-    }
-    return arg;
-  }
-};
-
-template<>
-class JNIToJSIConverter<std::string> {
-public:
-  typedef SimpleConverter converterType;
-
-  static inline jsi::Value convert(
-    JNIEnv *env,
-    jsi::Runtime &rt,
-    const std::string &value
-  ) {
-    auto enhancedValue = convertStringToFollyDynamicIfNeeded(rt, value);
-    return enhancedValue ? std::move(*enhancedValue) : jsi::String::createFromUtf8(rt, value);
-  }
-};
-
-template<>
-class JNIToJSIConverter<folly::dynamic> {
-public:
-  typedef SimpleConverter converterType;
-
-  static inline jsi::Value convert(
-    JNIEnv *env,
-    jsi::Runtime &rt,
-    const folly::dynamic &value
-  ) {
-    auto arg = jsi::valueFromDynamic(rt, value);
-    auto enhancedArg = decorateValueForDynamicExtension(rt, arg);
-    if (enhancedArg) {
-      arg = std::move(*enhancedArg);
-    }
-    return arg;
+    return jsi::Value{rt, *jsiObject};
   }
 };
 
 template<typename T>
-class JNIToJSIConverter<RawArray<T>> {
-public:
-  typedef SimpleConverter converterType;
+concept SharedObjectRef = JniRefTo<T, JSharedObject::javaobject>;
 
-  static inline jsi::Value convert(
-    JNIEnv *env,
-    jsi::Runtime &rt,
-    const RawArray<T> &value
-  ) {
+template<SharedObjectRef T>
+struct JNIToJSIConverter<T> {
+  static jsi::Value convert(JNIEnv *, jsi::Runtime &rt, const T &value) {
+    JSIContext *jsiContext = getJSIContext(rt);
+    if constexpr (std::is_same_v<T, jni::local_ref<JSharedObject::javaobject>>) {
+      return convertSharedObject(value, rt, jsiContext);
+    } else {
+      return convertSharedObject(jni::make_local(value), rt, jsiContext);
+    }
+  }
+};
+
+template<>
+struct JNIToJSIConverter<JavaScriptTypedArray *> {
+  static jsi::Value convert(JNIEnv *, jsi::Runtime &rt, JavaScriptTypedArray *value) {
+    return jsi::Value{rt, *value->get()};
+  }
+};
+
+template<>
+struct JNIToJSIConverter<JavaScriptArrayBuffer *> {
+  static jsi::Value convert(JNIEnv *, jsi::Runtime &rt, JavaScriptArrayBuffer *value) {
+    return jsi::Value{rt, *value->jsiArrayBuffer()};
+  }
+};
+
+template<>
+struct JNIToJSIConverter<NativeArrayBuffer *> {
+  static jsi::Value convert(JNIEnv *, jsi::Runtime &rt, NativeArrayBuffer *value) {
+    jsi::ArrayBuffer arrayBuffer(rt, value->jsiMutableBuffer());
+    return jsi::Value{rt, arrayBuffer};
+  }
+};
+
+template<>
+struct JNIToJSIConverter<react::WritableNativeArray *> {
+  static jsi::Value convert(JNIEnv *, jsi::Runtime &rt, react::WritableNativeArray *value) {
+    auto dynamic = value->consume();
+    auto result = jsi::valueFromDynamic(rt, dynamic);
+    if (auto enhanced = decorateValueForDynamicExtension(rt, result)) {
+      return std::move(*enhanced);
+    }
+    return result;
+  }
+};
+
+template<>
+struct JNIToJSIConverter<react::WritableNativeMap *> {
+  static jsi::Value convert(JNIEnv *, jsi::Runtime &rt, react::WritableNativeMap *value) {
+    auto dynamic = value->consume();
+    auto result = jsi::valueFromDynamic(rt, dynamic);
+    if (auto enhanced = decorateValueForDynamicExtension(rt, result)) {
+      return std::move(*enhanced);
+    }
+    return result;
+  }
+};
+
+template<>
+struct JNIToJSIConverter<std::string> {
+  static jsi::Value convert(JNIEnv *, jsi::Runtime &rt, const std::string &value) {
+    if (auto enhanced = convertStringToFollyDynamicIfNeeded(rt, value)) {
+      return std::move(*enhanced);
+    }
+    return jsi::String::createFromUtf8(rt, value);
+  }
+};
+
+template<>
+struct JNIToJSIConverter<folly::dynamic> {
+  static jsi::Value convert(JNIEnv *, jsi::Runtime &rt, const folly::dynamic &value) {
+    auto result = jsi::valueFromDynamic(rt, value);
+    if (auto enhanced = decorateValueForDynamicExtension(rt, result)) {
+      return std::move(*enhanced);
+    }
+    return result;
+  }
+};
+
+template<typename T>
+struct JNIToJSIConverter<RawArray<T>> {
+  static jsi::Value convert(JNIEnv *env, jsi::Runtime &rt, const RawArray<T> &value) {
     auto jsArray = jsi::Array(rt, value.size);
     for (size_t i = 0; i < value.size; i++) {
       jsArray.setValueAtIndex(rt, i, JNIToJSIConverter<T>::convert(env, rt, value.data[i]));
@@ -460,120 +230,63 @@ public:
   }
 };
 
-template<>
-class JNIToJSIConverter<jni::global_ref<jni::JCollection<jobject>>> {
-public:
-  typedef SimpleConverter converterType;
-
-  static inline jsi::Value convert(
-    JNIEnv *env,
-    jsi::Runtime &rt,
-    const jni::global_ref<jni::JCollection<jobject>> &list
-  ) {
+template<JCollectionRef<jobject> T>
+struct JNIToJSIConverter<T> {
+  static jsi::Value convert(JNIEnv *env, jsi::Runtime &rt, const T &list) {
     size_t size = list->size();
     auto jsArray = jsi::Array(rt, size);
     size_t index = 0;
 
     for (const auto &item: *list) {
-      jsArray.setValueAtIndex(
-        rt,
-        index++,
-        ::expo::convert(env, rt, item)
-      );
+      jsArray.setValueAtIndex(rt, index++, ::expo::convert(env, rt, item));
     }
     return jsArray;
   }
 };
 
-template<>
-class JNIToJSIConverter<jni::local_ref<jni::JCollection<jobject>>> {
-public:
-  typedef SimpleConverter converterType;
-
-  static inline jsi::Value convert(
-    JNIEnv *env,
-    jsi::Runtime &rt,
-    const jni::local_ref<jni::JCollection<jobject>> &list
-  ) {
-    size_t size = list->size();
-    auto jsArray = jsi::Array(rt, size);
-    size_t index = 0;
-
-    for (const auto &item: *list) {
-      jsArray.setValueAtIndex(
-        rt,
-        index++,
-        ::expo::convert(env, rt, item)
-      );
-    }
-    return jsArray;
-  }
-};
-
-template<>
-class JNIToJSIConverter<jni::global_ref<jni::JMap<jstring, jobject>>> {
-public:
-  typedef SimpleConverter converterType;
-
-  static inline jsi::Value convert(
-    JNIEnv *env,
-    jsi::Runtime &rt,
-    const jni::global_ref<jni::JMap<jstring, jobject>> &map
-  ) {
+template<JMapRef<jstring, jobject> T>
+struct JNIToJSIConverter<T> {
+  static jsi::Value convert(JNIEnv *env, jsi::Runtime &rt, const T &map) {
     jsi::Object jsObject(rt);
 
     for (const auto &entry: *map) {
-      auto key = entry.first->toStdString();
-      auto value = entry.second;
       jsObject.setProperty(
         rt,
-        key.c_str(),
-        ::expo::convert(env, rt, value)
+        entry.first->toStdString().c_str(),
+        ::expo::convert(env, rt, entry.second)
       );
     }
-
     return jsObject;
   }
 };
 
-template<>
-class JNIToJSIConverter<jni::local_ref<jni::JMap<jstring, jobject>>> {
-public:
-  typedef SimpleConverter converterType;
+template<typename RefType>
+std::vector<jsi::Value> convertArray(JNIEnv *env, jsi::Runtime &rt, RefType &values) {
+  size_t size = values->size();
+  std::vector<jsi::Value> result;
+  result.reserve(size);
 
-  static inline jsi::Value convert(
-    JNIEnv *env,
-    jsi::Runtime &rt,
-    const jni::local_ref<jni::JMap<jstring, jobject>> &map
-  ) {
-    jsi::Object jsObject(rt);
-
-    for (const auto &entry: *map) {
-      auto key = entry.first->toStdString();
-      auto value = entry.second;
-      jsObject.setProperty(
-        rt,
-        key.c_str(),
-        ::expo::convert(env, rt, value)
-      );
-    }
-
-    return jsObject;
+  for (size_t i = 0; i < size; i++) {
+    result.push_back(convert(env, rt, values->getElement(i)));
   }
+  return result;
+}
+
+template<typename Converter, typename T>
+concept SimpleConversion = requires(JNIEnv *env, jsi::Runtime &rt, T value) {
+  { Converter::convert(env, rt, value) } -> std::same_as<jsi::Value>;
 };
 
 template<typename T>
-inline jsi::Value convertToJS(JNIEnv *env, jsi::Runtime &rt, T &&value) {
-  if constexpr (std::is_same_v<SimpleConverter, typename JNIToJSIConverter<
-    decltype(unwrapJNIRef(std::declval<T>()))
-  >::converterType>) {
-    return JNIToJSIConverter<
-      decltype(unwrapJNIRef(std::declval<T>()))
-    >::convert(env, rt, unwrapJNIRef(std::forward<T>(value)));
+jsi::Value convertToJS(JNIEnv *env, jsi::Runtime &rt, T &&value) {
+  using UnwrappedType = decltype(unwrapJNIRef(std::declval<T>()));
+  using Converter = JNIToJSIConverter<UnwrappedType>;
+
+  if constexpr (SimpleConversion<Converter, UnwrappedType>) {
+    return Converter::convert(env, rt, unwrapJNIRef(std::forward<T>(value)));
   } else {
-    return JNIToJSIConverter<
-      decltype(unwrapJNIRef(std::declval<T>()))
-    >::convert(env, rt, unwrapJNIRef(value), value);
+    return Converter::convert(env, rt, unwrapJNIRef(value), value);
   }
 }
+
 } // namespace expo


### PR DESCRIPTION
# Why

Refactors `JNIToJSIConverter` to use modern concepts.

# How

- Extracted some concepts to separate files 
- Simplified logic 

# Test Plan

- unit tests ✅ 