### PR TITLE
fix(router-server,cli,log-box): Fix `@expo/router-server` causing auto-install of `expo-router@latest`, `@expo/log-box` causing auto-install of `react-dom`/`react-native-web`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix RSC support in development ([#42617](https://github.com/expo/expo/pull/42617) by [@hassankhan](https://github.com/hassankhan))
 - Fix loader URL resolution for nested `/index` paths ([#42629](https://github.com/expo/expo/pull/42629) by [@hassankhan](https://github.com/hassankhan))
 - [web] Ensure `<Head>` component re-renders when focus changes ([#42681](https://github.com/expo/expo/pull/42681) by [@hassankhan](https://github.com/hassankhan))
+- Mark `expo-router` as optional peer to prevent auto-installation ([#42728](https://github.com/expo/expo/pull/42728) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/log-box/CHANGELOG.md
+++ b/packages/@expo/log-box/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Drop `react-native-web` and `react-dom` peers ([#42728](https://github.com/expo/expo/pull/42728) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 55.0.3 — 2026-01-27

--- a/packages/@expo/log-box/package.json
+++ b/packages/@expo/log-box/package.json
@@ -36,12 +36,10 @@
     "typescript-plugin-css-modules": "^5.2.0"
   },
   "peerDependencies": {
-    "@expo/dom-webview": "*",
+    "@expo/dom-webview": "^55.0.2",
     "expo": "*",
     "react": "*",
-    "react-dom": "*",
-    "react-native": "*",
-    "react-native-web": "*"
+    "react-native": "*"
   },
   "license": "MIT",
   "author": "Expo",

--- a/packages/@expo/router-server/CHANGELOG.md
+++ b/packages/@expo/router-server/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Mark `expo-router` as optional peer to prevent auto-installation ([#42728](https://github.com/expo/expo/pull/42728) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 - Deprecate undocumented `expo-router/rsc/headers` RSC API in favor of `expo-server`'s `requestHeaders` runtime API ([#42678](https://github.com/expo/expo/pull/42678) by [@hassankhan](https://github.com/hassankhan))

--- a/packages/@expo/router-server/package.json
+++ b/packages/@expo/router-server/package.json
@@ -39,16 +39,19 @@
     "react-dom": "*",
     "expo": "*",
     "expo-constants": "^55.0.2",
-    "expo-font": "*",
+    "expo-font": "~55.0.3",
     "expo-router": "*",
-    "expo-server": "*",
+    "expo-server": "^55.0.2",
     "react-server-dom-webpack": "~19.0.1 || ~19.1.2 || ~19.2.1"
   },
   "peerDependenciesMeta": {
-    "react-dom": {
+    "@expo/metro-runtime": {
       "optional": true
     },
-    "react-native-web": {
+    "expo-router": {
+      "optional": true
+    },
+    "react-dom": {
       "optional": true
     },
     "react-server-dom-webpack": {

--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -53,7 +53,6 @@ const SPECIAL_DEPENDENCIES: Record<string, Record<string, IgnoreKind | void> | v
 
   'expo-router': {
     'expect/build/matchers': 'ignore-dev', // TODO: Unsure how to replace safely. Dep/Peer won't work. Globals and `@jest/globals` unclear
-    'expo-font': 'ignore-dev', // TODO: Remove
   },
 
   '@expo/image-utils': {

--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -77,7 +77,7 @@ const SPECIAL_DEPENDENCIES: Record<string, Record<string, IgnoreKind | void> | v
   },
 
   '@expo/log-box': {
-    'react-dom': 'ignore-dev', // TODO: temp
+    'react-dom': 'ignore-dev', // TODO: This peer dependency was removed due to this chain installing `react-dom`: `@expo/router-server -> @expo/log-box -> react-dom` which is not intended
   },
 
   'babel-preset-expo': {

--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -76,6 +76,10 @@ const SPECIAL_DEPENDENCIES: Record<string, Record<string, IgnoreKind | void> | v
     'expo-constants': 'ignore-dev', // TODO: Should probably be a peer, but it's both installed in templates and also a dep of expo (needs discussion)
   },
 
+  '@expo/log-box': {
+    'react-dom': 'ignore-dev', // TODO: temp
+  },
+
   'babel-preset-expo': {
     '@babel/core': 'types-only',
     '@expo/metro-config/build/babel-transformer': 'types-only',


### PR DESCRIPTION
# Why

The `expo-router` peer in `@expo/router-server` wasn't marked as optional, but `@expo/router-server` is installed in `@expo/cli` as a regular dependency. This means that it then auto-installs `expo-router@latest`

# How

- Add missing versions and mark `expo-router` as an optional dependency in `@expo/router-server`

# Test Plan

- n/a

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
