### PR TITLE
[core] fix view updates for expo-ui jetpack-compose

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Fixed view updates for Jetpack Compose integration. ([#42732](https://github.com/expo/expo/pull/42732) by [@kudo](https://github.com/kudo))
+
 ## 55.0.9 — 2026-02-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.RecomposeScope
+import androidx.compose.runtime.currentRecomposeScope
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.platform.ComposeView
@@ -45,6 +47,7 @@ abstract class ExpoComposeView<T : ComposeProps>(
   private val withHostingView: Boolean = false
 ) : ExpoView(context, appContext) {
   open val props: T? = null
+  protected var recomposeScope: RecomposeScope? = null
 
   @Composable
   abstract fun ComposableScope.Content()
@@ -78,6 +81,7 @@ abstract class ExpoComposeView<T : ComposeProps>(
 
   @Composable
   fun Children(composableScope: ComposableScope?) {
+    recomposeScope = currentRecomposeScope
     for (index in 0..<this.size) {
       val child = getChildAt(index) as? ExpoComposeView<*> ?: continue
       with(composableScope ?: ComposableScope()) {
@@ -90,6 +94,7 @@ abstract class ExpoComposeView<T : ComposeProps>(
 
   @Composable
   fun Child(composableScope: ComposableScope, index: Int) {
+    recomposeScope = currentRecomposeScope
     val child = getChildAt(index) as? ExpoComposeView<*> ?: return
     with(composableScope) {
       with(child) {
@@ -139,6 +144,16 @@ abstract class ExpoComposeView<T : ComposeProps>(
       child
     }
     super.addView(view, index, params)
+  }
+
+  override fun onViewAdded(child: View?) {
+    super.onViewAdded(child)
+    recomposeScope?.invalidate()
+  }
+
+  override fun onViewRemoved(child: View?) {
+    super.onViewRemoved(child)
+    recomposeScope?.invalidate()
   }
 }
 


### PR DESCRIPTION
# Why

fix jetpack compose doesn't update views

# How

when view is added/removed, we should trigger recompose

# Test Plan

```tsx
const [visible, setVisible] = useState(false);

return (
  <Host style={{ flex: 1 }}>
    <Column>
      <Button onPress={() => { setVisible(!visible); }}>toggle</Button>
      {vislble ? <Text>visible</Text> : null>
    </Column>
  </Host>
)
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
