### PR TITLE
[dev-menu][expo] Restore tvOS functionality for SDK 55

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [Android] Fix `null cannot be cast to non-null type expo.modules.devmenu.DevMenuFragment`. ([#42660](https://github.com/expo/expo/pull/42660) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Fix null current bridge in standalone mode ([#42666](https://github.com/expo/expo/pull/42666) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Fix `cmd + m` not opening the dev menu. ([#42701](https://github.com/expo/expo/pull/42701) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Restore dev menu on tvOS. ([#42737](https://github.com/expo/expo/pull/42737) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -446,6 +446,8 @@ open class DevMenuManager: NSObject {
       DispatchQueue.main.async {
 #if os(macOS)
         self.window?.makeKeyAndOrderFront(nil)
+#elseif os(tvOS)
+        self.window?.makeKeyAndVisible()
 #else
         self.updateFABVisibility()
 

--- a/packages/expo-dev-menu/ios/DevMenuViewController.swift
+++ b/packages/expo-dev-menu/ios/DevMenuViewController.swift
@@ -46,7 +46,12 @@ class DevMenuViewController: UIViewController {
     let rootView = DevMenuRootView()
     let hostingController = UIHostingController(rootView: rootView)
 
+    #if os(tvOS)
+    hostingController.view.backgroundColor =
+      preferredUserInterfaceStyle == .dark ? UIColor.systemGray.withAlphaComponent(0.8) : UIColor.white.withAlphaComponent(0.8)
+    #else
     hostingController.view.backgroundColor = UIColor.clear
+    #endif
 
     addChild(hostingController)
     view.addSubview(hostingController.view)

--- a/packages/expo-dev-menu/ios/DevMenuWindow-default.swift
+++ b/packages/expo-dev-menu/ios/DevMenuWindow-default.swift
@@ -26,7 +26,7 @@ class DevMenuWindow: UIWindow, PresentationControllerDelegate {
     self.rootViewController = UIViewController()
     self.backgroundColor = UIColor(white: 0, alpha: 0.4)
     #if os(tvOS)
-    self.windowLevel = .normal
+    self.windowLevel = .normal + 1
     #else
     self.windowLevel = .statusBar
     #endif

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuDeveloperTools.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuDeveloperTools.swift
@@ -12,6 +12,7 @@ struct DevMenuDeveloperTools: View {
         .foregroundColor(.primary.opacity(0.6))
 
       VStack(spacing: 0) {
+        #if !os(tvOS)
         NavigationLink(destination: SourceMapExplorerView()) {
           HStack {
             Image(systemName: "map")
@@ -34,7 +35,8 @@ struct DevMenuDeveloperTools: View {
         .buttonStyle(.plain)
 
         Divider()
-
+        #endif
+        
         DevMenuActionButton(
           title: "Toggle performance monitor",
           icon: "speedometer",

--- a/packages/expo-dev-menu/ios/SwiftUI/SourceMapExplorerView.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/SourceMapExplorerView.swift
@@ -453,7 +453,7 @@ struct CodeFileView: View {
 
   private func editingView() -> some View {
     #if os(tvOS)
-    Text(displayContent)
+    readOnlyView()
     #else
     TextEditor(text: $displayContent)
       .font(.system(size: fontSize, weight: .regular, design: .monospaced))

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Restore dev menu on tvOS. ([#42737](https://github.com/expo/expo/pull/42737) by [@douglowder](https://github.com/douglowder))
+
 ### 💡 Others
 
 - Replace `URL` and `URLSearchParams` implementation ([#42706](https://github.com/expo/expo/pull/42706) by [@kitten](https://github.com/kitten))

--- a/packages/expo/ios/AppDelegates/EXReactRootViewFactory.h
+++ b/packages/expo/ios/AppDelegates/EXReactRootViewFactory.h
@@ -24,7 +24,7 @@ NS_SWIFT_NAME(ExpoReactRootViewFactory)
 /**
  Calls super `viewWithModuleName:initialProperties:launchOptions:` from `RCTRootViewFactory`.
  */
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS || TARGET_OS_TV
 - (UIView *)superViewWithModuleName:(NSString *)moduleName
                   initialProperties:(nullable NSDictionary *)initialProperties
                       launchOptions:(nullable NSDictionary *)launchOptions

--- a/packages/expo/ios/AppDelegates/EXReactRootViewFactory.mm
+++ b/packages/expo/ios/AppDelegates/EXReactRootViewFactory.mm
@@ -31,7 +31,7 @@
   return self;
 }
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS || TARGET_OS_TV
 - (UIView *)viewWithModuleName:(NSString *)moduleName
              initialProperties:(nullable NSDictionary *)initialProperties
                  launchOptions:(nullable NSDictionary *)launchOptions

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
@@ -111,7 +111,7 @@ public class ExpoReactNativeFactory: ExpoReactNativeFactoryObjC, ExpoReactNative
     let rootView: UIView
     if let factory = self.rootViewFactory as? ExpoReactRootViewFactory {
       // RCTDevMenuConfiguration is only available in react-native 0.83+
-#if os(iOS)
+#if os(iOS) || os(tvOS)
       // When calling `recreateRootViewWithBundleURL:` from `EXReactRootViewFactory`,
       // we don't want to loop the ReactDelegate again. Otherwise, it will be an infinite loop.
       rootView = factory.superView(
@@ -128,7 +128,7 @@ public class ExpoReactNativeFactory: ExpoReactNativeFactoryObjC, ExpoReactNative
       )
 #endif
     } else {
-#if os(iOS)
+#if os(iOS) || os(tvOS)
       rootView = rootViewFactory.view(
         withModuleName: moduleName ?? defaultModuleName,
         initialProperties: initialProps,


### PR DESCRIPTION
# Why

The dev menu and dev launcher were disabled for tvOS in #40949, since at that time RNTV did not have a 0.83 release. This PR restores that functionality and makes other changes to fix dev menu behavior on tvOS.

# How

- Fix up EXReactRootViewFactory and other iOS code in the expo module to restore dev launcher for tvOS
- Adjust styles for tvOS
- Stub out the source code explorer on tvOS for now

TODO:

- The source code explorer actually works on tvOS in read only mode, but does not scroll. Once adjustments are made to support scrolling, we can reenable that.
- There is a problem invoking the dev menu with command-D on some projects, but typing 'm' in the packager invokes it as expected.

# Test Plan

- Tested with a new SDK 55 project
- Tested with the TV project created by our TV compile test

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
