### PR TITLE
fix(expo,expo-modules-core): Fix forced type-chain on `@types/node` and `metro-require.d.ts`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix global type declaration chain to point to `expo -> expo-modules-core/types -> ./build/global` rather than `types="node"` ([#42751](https://github.com/expo/expo/pull/42751) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 55.0.6 — 2026-02-03

--- a/packages/expo-modules-core/types.d.ts
+++ b/packages/expo-modules-core/types.d.ts
@@ -1,3 +1,5 @@
+import './build/ts-declarations/global';
+
 export type { EventEmitter } from './build/ts-declarations/EventEmitter';
 export type { SharedObject } from './build/ts-declarations/SharedObject';
 export type { SharedRef } from './build/ts-declarations/SharedRef';

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix global type declaration chain to point to `expo -> expo-modules-core/types -> ./build/global` rather than `types="node"` ([#42751](https://github.com/expo/expo/pull/42751) by [@kitten](https://github.com/kitten))
+- Fix missing `module` type declaration when `@types/node` is missing ([#42751](https://github.com/expo/expo/pull/42751) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix global type declaration chain to point to `expo -> expo-modules-core/types -> ./build/global` rather than `types="node"` ([#42751](https://github.com/expo/expo/pull/42751) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 55.0.0-preview.8 — 2026-02-03

--- a/packages/expo/types/global.d.ts
+++ b/packages/expo/types/global.d.ts
@@ -1,9 +1,12 @@
-/// <reference types="node" />
+/// <reference types="expo-modules-core/types" />
 
 // Extend the NodeJS namespace
 declare namespace NodeJS {
-  interface ProcessEnv {
+  export interface ProcessEnv {
     readonly NODE_ENV: 'development' | 'production' | 'test';
+  }
+  export interface Process {
+    env: ProcessEnv;
   }
 }
 

--- a/packages/expo/types/global.d.ts
+++ b/packages/expo/types/global.d.ts
@@ -1,14 +1,4 @@
-/// <reference types="expo-modules-core/types" />
-
-// Extend the NodeJS namespace
-declare namespace NodeJS {
-  export interface ProcessEnv {
-    readonly NODE_ENV: 'development' | 'production' | 'test';
-  }
-  export interface Process {
-    env: ProcessEnv;
-  }
-}
+/* eslint-disable */
 
 // Create types for CSS modules
 declare module '*.module.css' {

--- a/packages/expo/types/index.d.ts
+++ b/packages/expo/types/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="expo-modules-core/types" />
+
 /// <reference types="./global" />
 /// <reference types="./metro-require" />
 /// <reference types="./react-native-web" />

--- a/packages/expo/types/metro-require.d.ts
+++ b/packages/expo/types/metro-require.d.ts
@@ -1,11 +1,20 @@
-// Based on https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/webpack-env/index.d.ts
-// Adds support for the runtime `require.context` method.
-// https://github.com/facebook/metro/pull/822/
+/* eslint-disable */
 
-declare var module: NodeModule;
+// NOTE: This module is named `metro-require.d.ts` for backwards compatibility, since it's accessible to users
+// However, it's supposed to be understood more as a "Metro environment" typings file that provides types for `require` and `module`,
+// regardless of if `@types/node` is present, and/or, to enhance `@types/node` if it's present
 
 declare namespace __MetroModuleApi {
-  interface RequireContext {
+  export interface ProcessEnv {
+    readonly NODE_ENV: 'development' | 'production' | 'test';
+    [key: string]: string | undefined;
+  }
+
+  export interface Process {
+    env: ProcessEnv;
+  }
+
+  export interface RequireContext {
     /** Return the keys that can be resolved. */
     keys(): string[];
     (id: string): any;
@@ -16,7 +25,8 @@ declare namespace __MetroModuleApi {
     id: string;
   }
 
-  interface RequireFunction {
+  // Adds support for the runtime `require.context` method.
+  export interface RequireFunction {
     /**
      * Returns the exports from a dependency. The call is sync. No request to the server is fired. The compiler ensures that the dependency is available.
      */
@@ -40,13 +50,19 @@ declare namespace __MetroModuleApi {
       mode?: 'sync' | 'eager' | 'weak' | 'lazy' | 'lazy-once'
     ): RequireContext;
   }
+
+  export interface Module {
+    exports: any;
+  }
 }
 
-/**
- * Declare process variable
- */
 declare namespace NodeJS {
-  interface Require extends __MetroModuleApi.RequireFunction {}
+  export interface Require extends __MetroModuleApi.RequireFunction {}
+  export interface Module extends __MetroModuleApi.Module {}
+  export interface ProcessEnv extends __MetroModuleApi.ProcessEnv {}
+  export interface Process extends __MetroModuleApi.Process {}
 }
 
-declare var require: NodeRequire;
+declare var require: NodeJS.Require;
+declare var module: NodeJS.Module;
+declare var process: NodeJS.Process;

--- a/packages/expo/types/react-native-web.d.ts
+++ b/packages/expo/types/react-native-web.d.ts
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 import { StyleProp } from 'react-native';
 import * as RN from 'react-native';
 


### PR DESCRIPTION
# Why

Resolves #40765
Resolves DVT-53

~~**Note: This is a breaking change and shouldn't be backported.**~~

**Edit: This is potentially not a breaking change, due to globals referencing `NodeJS` namespace in current `@types/node`. Maybe a candidate for backporting to SDK 54**

---

The `expo/types` pull in `@types/node` via a type reference. However, it's not desirable for `@types/*` references to be pulled in explicitly and this can lead to type pollution, unless the requesting typings declaration actually must rely on these types. This is not the case for Expo as a whole.

`expo-modules-core` already defines a subset of `process.env.*` it needs and doesn't cause `@types/node` to be explicitly requested. It's better for us to be explicit about the `expo/types -> expo-modules-core/types -> expo-modules-core/build/ts-declarations/global` relationship instead.

`metro-require.d.ts` doesn't sufficiently define the NodeJS and environment types it's trying to enhance. Notably `NodeModule` it references doesn't exist in its scope (or at all, really). It also is a better place for the `process.env.NODE_ENV` enhancement that's currently in `global.d.ts`.

# How

- Remove `types="node"` reference from `expo/types`
- Add explicit import for `global` types in `expo-modules-core/types`
- Move `process.env` type declaration to `metro-require.d.ts` and leave comment
- Fix up `metro-require.d.ts` structure to fix deprecations
- Add missing `Process` and `ProcessEnv` enhancements to mirror `expo-modules-core`'s types and correctly extend `env`

# Test Plan

There's two problems that make this hard to test and guarantee to be working:
- we're shipping `.ts` for now, which causes many problems, including that it makes typings behave more like if the user declared them and can bypass some isolation in TypeScript
- Metro via `jest-worker` and `jest-validate`, and `react-native` via Jest itself depend on `@types/node` so it's often picked up already and not optional / hard to exclude
- This behaves differently in isolated and non-isolated dependencies (expected)

Tested in both isolated pnpm and hoisted installations. The `process.env.NODE_ENV` types are correct once `expo-env.d.ts` is generated. Otherwise, they point primarily to `expo-modules-core`'s `ts` files. (Not intended but acceptable given that they're raw TS files)

Easiest way to test this:
- `pnpx create-expo-app --no-install`
- delete `pnpm-workspace.yaml` and use isolated install
- apply modifications
- check `process.env.NODE_ENV`, `require`, `require.context`, and `module.exports` types

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)