### PR TITLE
fix(babel-preset-env): Add support for inlining env vars from `OptionalMemberExpression`s

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Add missing support for inlining environment variables as optional member expressions ([#42752](https://github.com/expo/expo/pull/42752) by [@kitten](https://github.com/kitten))
+
 ## 55.0.2 — 2026-01-26
 
 _This version does not introduce any user-facing changes._

--- a/packages/babel-preset-expo/build/inline-env-vars.js
+++ b/packages/babel-preset-expo/build/inline-env-vars.js
@@ -6,8 +6,54 @@ const debug = require('debug')('expo:babel:env-vars');
 function expoInlineEnvVars(api) {
     const { types: t } = api;
     const isProduction = api.caller(common_1.getIsProd);
-    function isFirstInAssign(path) {
+    function isProcessEnv(path) {
+        const { object } = path.node;
+        if (!t.isMemberExpression(object) ||
+            !t.isIdentifier(object.object) ||
+            object.object.name !== 'process') {
+            return false;
+        }
+        const { property } = object;
+        if (t.isIdentifier(property)) {
+            return property.name === 'env';
+        }
+        else if (t.isStringLiteral(property)) {
+            return property.value === 'env';
+        }
+        else {
+            return false;
+        }
+    }
+    function toMemberProperty(path) {
+        const { property } = path.node;
+        if (t.isStringLiteral(property)) {
+            return property.value;
+        }
+        else if (t.isIdentifier(property)) {
+            return property.name;
+        }
+        else {
+            return undefined;
+        }
+    }
+    /** If the `path.node` being assigned to (`left = right`) */
+    function isAssignment(path) {
         return t.isAssignmentExpression(path.parent) && path.parent.left === path.node;
+    }
+    function memberExpressionVisitor(path, state) {
+        if (!isProcessEnv(path) || isAssignment(path))
+            return;
+        const key = toMemberProperty(path);
+        if (key != null && key.startsWith('EXPO_PUBLIC_')) {
+            debug(`${isProduction ? 'Inlining' : 'Referencing'} environment variable in %s: %s`, state.filename, key);
+            publicEnvVars.add(key);
+            if (isProduction) {
+                path.replaceWith(t.valueToNode(process.env[key]));
+            }
+            else {
+                path.replaceWith(t.memberExpression(addEnvImport(), t.identifier(key)));
+            }
+        }
     }
     let addEnvImport;
     const publicEnvVars = new Set();
@@ -20,25 +66,8 @@ function expoInlineEnvVars(api) {
             };
         },
         visitor: {
-            MemberExpression(path, state) {
-                const filename = state.filename;
-                if (path.get('object').matchesPattern('process.env')) {
-                    const key = path.toComputedKey();
-                    if (t.isStringLiteral(key) &&
-                        !isFirstInAssign(path) &&
-                        key.value.startsWith('EXPO_PUBLIC_')) {
-                        const envVar = key.value;
-                        debug(`${isProduction ? 'Inlining' : 'Referencing'} environment variable in %s: %s`, filename, envVar);
-                        publicEnvVars.add(envVar);
-                        if (isProduction) {
-                            path.replaceWith(t.valueToNode(process.env[envVar]));
-                        }
-                        else {
-                            path.replaceWith(t.memberExpression(addEnvImport(), t.identifier(envVar)));
-                        }
-                    }
-                }
-            },
+            OptionalMemberExpression: memberExpressionVisitor,
+            MemberExpression: memberExpressionVisitor,
         },
         post(file) {
             assertExpoMetadata(file.metadata);

--- a/packages/babel-preset-expo/src/__tests__/__snapshots__/inline-env-vars.test.ts.snap
+++ b/packages/babel-preset-expo/src/__tests__/__snapshots__/inline-env-vars.test.ts.snap
@@ -7,6 +7,9 @@ process.env.ABC;
 console.log("production");
 console.log("development");
 "bar";
+"bar";
+"bar";
+"bar";
 
 env.EXPO_PUBLIC_URL;
 
@@ -19,6 +22,9 @@ var foo = process.env.JEST_WORKER_ID;
 process.env.ABC;
 console.log(process.env.NODE_ENV);
 console.log(_env2.env.EXPO_PUBLIC_NODE_ENV);
+_env2.env.EXPO_PUBLIC_FOO;
+_env2.env.EXPO_PUBLIC_FOO;
+_env2.env.EXPO_PUBLIC_FOO;
 _env2.env.EXPO_PUBLIC_FOO;
 
 env.EXPO_PUBLIC_URL;

--- a/packages/babel-preset-expo/src/__tests__/inline-env-vars.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/inline-env-vars.test.ts
@@ -94,6 +94,9 @@ process.env.ABC;
 console.log(process.env.NODE_ENV);
 console.log(process.env.EXPO_PUBLIC_NODE_ENV);
 process.env.EXPO_PUBLIC_FOO;
+process.env['EXPO_PUBLIC_FOO'];
+process.env?.EXPO_PUBLIC_FOO;
+process.env?.['EXPO_PUBLIC_FOO'];
 
 env.EXPO_PUBLIC_URL;
 
@@ -126,6 +129,9 @@ process.env.ABC;
 console.log(process.env.NODE_ENV);
 console.log(process.env.EXPO_PUBLIC_NODE_ENV);
 process.env.EXPO_PUBLIC_FOO;
+process.env['EXPO_PUBLIC_FOO'];
+process.env?.EXPO_PUBLIC_FOO;
+process.env?.['EXPO_PUBLIC_FOO'];
 
 env.EXPO_PUBLIC_URL;
 

--- a/packages/babel-preset-expo/src/inline-env-vars.ts
+++ b/packages/babel-preset-expo/src/inline-env-vars.ts
@@ -1,4 +1,4 @@
-import type { ConfigAPI, NodePath, PluginObj, types as t } from '@babel/core';
+import type { ConfigAPI, NodePath, PluginObj, PluginPass, types as t } from '@babel/core';
 
 import { createAddNamedImportOnce, getIsProd } from './common';
 
@@ -8,8 +8,63 @@ export function expoInlineEnvVars(api: ConfigAPI & typeof import('@babel/core'))
   const { types: t } = api;
   const isProduction = api.caller(getIsProd);
 
-  function isFirstInAssign(path: NodePath<t.MemberExpression>) {
+  function isProcessEnv(path: NodePath<t.MemberExpression | t.OptionalMemberExpression>) {
+    const { object } = path.node;
+    if (
+      !t.isMemberExpression(object) ||
+      !t.isIdentifier(object.object) ||
+      object.object.name !== 'process'
+    ) {
+      return false;
+    }
+    const { property } = object;
+    if (t.isIdentifier(property)) {
+      return property.name === 'env';
+    } else if (t.isStringLiteral(property)) {
+      return property.value === 'env';
+    } else {
+      return false;
+    }
+  }
+
+  function toMemberProperty(
+    path: NodePath<t.MemberExpression | t.OptionalMemberExpression>
+  ): string | undefined {
+    const { property } = path.node;
+    if (t.isStringLiteral(property)) {
+      return property.value;
+    } else if (t.isIdentifier(property)) {
+      return property.name;
+    } else {
+      return undefined;
+    }
+  }
+
+  /** If the `path.node` being assigned to (`left = right`) */
+  function isAssignment(path: NodePath<t.MemberExpression | t.OptionalMemberExpression>) {
     return t.isAssignmentExpression(path.parent) && path.parent.left === path.node;
+  }
+
+  function memberExpressionVisitor(
+    path: NodePath<t.MemberExpression | t.OptionalMemberExpression>,
+    state: PluginPass
+  ) {
+    if (!isProcessEnv(path) || isAssignment(path)) return;
+    const key = toMemberProperty(path);
+    if (key != null && key.startsWith('EXPO_PUBLIC_')) {
+      debug(
+        `${isProduction ? 'Inlining' : 'Referencing'} environment variable in %s: %s`,
+        state.filename,
+        key
+      );
+
+      publicEnvVars.add(key);
+      if (isProduction) {
+        path.replaceWith(t.valueToNode(process.env[key]));
+      } else {
+        path.replaceWith(t.memberExpression(addEnvImport(), t.identifier(key)));
+      }
+    }
   }
 
   let addEnvImport: () => t.Identifier;
@@ -26,31 +81,8 @@ export function expoInlineEnvVars(api: ConfigAPI & typeof import('@babel/core'))
       };
     },
     visitor: {
-      MemberExpression(path, state) {
-        const filename = state.filename;
-        if (path.get('object').matchesPattern('process.env')) {
-          const key = path.toComputedKey();
-          if (
-            t.isStringLiteral(key) &&
-            !isFirstInAssign(path) &&
-            key.value.startsWith('EXPO_PUBLIC_')
-          ) {
-            const envVar = key.value;
-            debug(
-              `${isProduction ? 'Inlining' : 'Referencing'} environment variable in %s: %s`,
-              filename,
-              envVar
-            );
-
-            publicEnvVars.add(envVar);
-            if (isProduction) {
-              path.replaceWith(t.valueToNode(process.env[envVar]));
-            } else {
-              path.replaceWith(t.memberExpression(addEnvImport(), t.identifier(envVar)));
-            }
-          }
-        }
-      },
+      OptionalMemberExpression: memberExpressionVisitor,
+      MemberExpression: memberExpressionVisitor,
     },
     post(file) {
       assertExpoMetadata(file.metadata);


### PR DESCRIPTION
# Why

Resolves #42296 (See comment: https://github.com/expo/expo/issues/42296#issuecomment-3769760783)
Resolves #41334

I believe this has come up across a few issues, although it'll be hard to find all of them that are related.

It's pretty intuitive to write `process.env?.EXPO_PUBLIC_*` and it's not intuitive for that not to be supported. The inline plugin doesn't yet have an `OptionalMemberExpression` visitor and nothing blocks us in the Babel plugin from supporting this.

# How

- Refactor to remove `matchesPattern` for local `isProcessEnv` check
- Refactor to remove `toComputedKey` for simple `toMemberProperty` helper
- Reuse `MemberExpression` visitor as `memberExpressionVisitor` for `OptionalMemberExpression`

# Test Plan

- Tests updated to reflect new cases

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
