### PR TITLE
fix(cli): Listen only on `localhost` when `--localhost` is passed

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Listen only on `localhost` when `--localhost` is passed ([#42760](https://github.com/expo/expo/pull/42760) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 55.0.5 — 2026-02-03

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -1202,6 +1202,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
     this.instanceMetroOptions = instanceMetroOptions;
 
     const parsedOptions = {
+      host: options.location.hostType === 'localhost' ? 'localhost' : undefined,
       port: options.port,
       maxWorkers: options.maxWorkers,
       resetCache: options.resetDevServer,

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -216,10 +216,14 @@ export async function loadMetroConfigAsync(
   };
 }
 
+interface InstantiateMetroConfigOptions extends LoadMetroConfigOptions {
+  host?: string;
+}
+
 /** The most generic possible setup for Metro bundler. */
 export async function instantiateMetroAsync(
   metroBundler: MetroBundlerDevServer,
-  options: LoadMetroConfigOptions,
+  options: InstantiateMetroConfigOptions,
   {
     isExporting,
     exp = getConfig(metroBundler.projectRoot, {
@@ -302,6 +306,7 @@ export async function instantiateMetroAsync(
     metroBundler,
     metroConfig,
     {
+      host: options.host,
       websocketEndpoints,
       watch: !isExporting && isWatchEnabled(),
     },

--- a/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
@@ -190,8 +190,11 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
     const compiler = webpack(config);
 
     const server = new WebpackDevServer(compiler, config.devServer);
+    const host =
+      env.WEB_HOST ?? (options.location.hostType === 'localhost' ? 'localhost' : undefined);
+
     // Launch WebpackDevServer.
-    server.listen(port, env.WEB_HOST, function (this: http.Server, error) {
+    server.listen(port, host, function (this: http.Server, error) {
       if (error) {
         Log.error(error.message);
       }


### PR DESCRIPTION
# Why

Resolves #40465

This has probably been missing for a few years, but the likely cause is that when `instantiateMetroAsync` was split out, it didn't quite accept the `Yargs` type from Metro. The recent refactor makes this a little clearer now, and the `host` doesn't end up on the config, which is likely why it was left out. Since the `location` building is hard to track (and defers a lot of work) this wasn't obvious but `runServer` never receives an explicit `host`.

When `--localhost` is set, `hostType: 'localhost` is instantiated for the `location` and this should then alter the `host` passed to the dev server to `localhost` too, to limit `listen` to `localhost`.

# How

- Add missing `host` option to `instantiateMetroAsync`'s options
- Add `host: 'localhost` to `parsedOptions` when `hostType === 'localhost'`
- Update Webpack equivalent for clarity (deprecated code, but should mirror this anyway)

# Test Plan

- Start with `expo start --localhost` and verify either that requests cannot be made from LAN or that `listen` receives `host: 'localhost'`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)