### PR TITLE
fix(cli): Search `~/Android/Sdk` as well for Android SDK location on Linux

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Add `~/Android/Sdk` to detected Android SDK locations on Linux ([#42761](https://github.com/expo/expo/pull/42761) by [@kitten](https://github.com/kitten))
+
 ## 55.0.5 — 2026-02-03
 
 ### 🛠 Breaking changes

--- a/packages/@expo/cli/src/start/platforms/android/AndroidSdk.ts
+++ b/packages/@expo/cli/src/start/platforms/android/AndroidSdk.ts
@@ -8,18 +8,23 @@ import path from 'path';
  * @see https://developer.android.com/studio/run/emulator-commandline#filedir
  * @see https://developer.android.com/studio/intro/studio-config#optimize-studio-windows
  */
-const ANDROID_DEFAULT_LOCATION: Readonly<Partial<Record<NodeJS.Platform, string>>> = {
+const ANDROID_DEFAULT_LOCATION = {
   darwin: path.join(os.homedir(), 'Library', 'Android', 'sdk'),
-  linux: path.join(os.homedir(), 'Android', 'sdk'),
+  linux: [path.join(os.homedir(), 'Android', 'Sdk'), path.join(os.homedir(), 'Android', 'sdk')],
   win32: path.join(os.homedir(), 'AppData', 'Local', 'Android', 'Sdk'),
 };
+
+const isAndroidDefaultLocationKey = (
+  platform: string
+): platform is keyof typeof ANDROID_DEFAULT_LOCATION =>
+  ANDROID_DEFAULT_LOCATION[platform as keyof typeof ANDROID_DEFAULT_LOCATION] != null;
 
 /**
  * Resolve and validate the root folder where the Android SDK has been installed.
  * This checks both `ANDROID_HOME`, `ANDROID_SDK_ROOT`, and the default path for the current platform.
  * @see https://developer.android.com/studio/command-line/variables
  */
-export function assertSdkRoot() {
+export function assertSdkRoot(): string | null {
   if (process.env.ANDROID_HOME) {
     assert(
       fs.existsSync(process.env.ANDROID_HOME),
@@ -36,14 +41,17 @@ export function assertSdkRoot() {
     return process.env.ANDROID_SDK_ROOT;
   }
 
-  const defaultLocation = ANDROID_DEFAULT_LOCATION[process.platform];
-  if (defaultLocation) {
-    assert(
-      fs.existsSync(defaultLocation),
-      `Failed to resolve the Android SDK path. Default install location not found: ${defaultLocation}. Use ANDROID_HOME to set the Android SDK location.`
-    );
-    return defaultLocation;
+  const platform = process.platform;
+  if (!isAndroidDefaultLocationKey(platform)) {
+    return null;
   }
 
-  return null;
+  const defaultLocation = ANDROID_DEFAULT_LOCATION[platform];
+  const locations = !Array.isArray(defaultLocation) ? [defaultLocation] : defaultLocation;
+  const resolvedLocation = locations.find((location) => fs.existsSync(location));
+  assert(
+    !!resolvedLocation,
+    `Failed to resolve the Android SDK path. Default install location not found: ${locations[0]}. Use ANDROID_HOME to set the Android SDK location.`
+  );
+  return resolvedLocation;
 }

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidSdk-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidSdk-test.ts
@@ -66,6 +66,13 @@ describe(assertSdkRoot, () => {
   });
 
   it('returns default location for Linux', () => {
+    const target = path.join(os.homedir(), 'Android', 'Sdk');
+    vol.fromJSON({ [path.join(target, 'file')]: 'file' });
+    setPlatform('linux');
+    expect(assertSdkRoot()).toBe(target);
+  });
+
+  it('returns alternative default location for Linux', () => {
     const target = path.join(os.homedir(), 'Android', 'sdk');
     vol.fromJSON({ [path.join(target, 'file')]: 'file' });
     setPlatform('linux');


### PR DESCRIPTION
# Why

Resolves #34548
Replaces #34712

We'd like to check `~/Android/Sdk` for the Android SDK location on Linux. This was previously typo'd since on macOS the `sdk` folder is lower-cased. To avoid breaking changes, we'll check both paths.

# How

- Check both `~/Android/Sdk` and `~/Android/sdk` on Linux

# Test Plan

- Unit tests updated

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)