### PR TITLE
chore(cli): Bump to `fetch-nodeshim@^0.4.3`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Replace tar dependency and `multipart/mixed` logic with `multitars` package ([#42472](https://github.com/expo/expo/pull/42472) by [@kitten](https://github.com/kitten))
 - Improve global resolution for `ExternalModule` resolution ([#42513](https://github.com/expo/expo/pull/42513) by [@kitten](https://github.com/kitten))
 - Replace `undici` dependency with `fetch-nodeshim` and Node built-ins ([#42720](https://github.com/expo/expo/pull/42720) by [@kitten](https://github.com/kitten))
+- Bump to `fetch-nodeshim@^0.4.3` ([#42765](https://github.com/expo/expo/pull/42765) by [@kitten](https://github.com/kitten))
 
 ## 55.0.4 — 2026-01-27
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -73,7 +73,7 @@
     "dnssd-advertise": "^1.1.1",
     "env-editor": "^0.4.1",
     "expo-server": "^55.0.2",
-    "fetch-nodeshim": "^0.4.2",
+    "fetch-nodeshim": "^0.4.3",
     "getenv": "^2.0.0",
     "glob": "^13.0.0",
     "lan-network": "^0.1.6",

--- a/packages/@expo/cli/src/utils/npm.ts
+++ b/packages/@expo/cli/src/utils/npm.ts
@@ -10,15 +10,8 @@ import { Readable } from 'stream';
 
 import { CommandError } from './errors';
 import { extractStream } from './tar';
-import { createCachedFetch } from '../api/rest/client';
 
 const debug = require('debug')('expo:utils:npm') as typeof console.log;
-
-const cachedFetch = createCachedFetch({
-  cacheDirectory: 'template-cache',
-  // Time to live. How long (in ms) responses remain cached before being automatically ejected. If undefined, responses are never automatically ejected from the cache.
-  // ttl: 1000,
-});
 
 export function sanitizeNpmPackageName(name: string): string {
   // https://github.com/npm/validate-npm-package-name/#naming-rules
@@ -146,7 +139,7 @@ export async function extractNpmTarballFromUrlAsync(
   output: string,
   props: ExtractProps
 ): Promise<string> {
-  const response = await cachedFetch(url);
+  const response = await fetch(url);
   if (!response.ok || !response.body) {
     throw new Error(`Unexpected response: ${response.statusText}. From url: ${url}`);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8499,10 +8499,10 @@ fdir@^6.5.0:
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
-fetch-nodeshim@^0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/fetch-nodeshim/-/fetch-nodeshim-0.4.2.tgz#611c175a3a367d17c720ebc123affa20ab070b55"
-  integrity sha512-n/XTOGZJerO6Ly9SHEWi2AVWoK6j+FoPw8Zcis68BKS2t1PxQ9kOuUrg2MjKt68NOI6l9gNAyPJ7h+rIqxOMzQ==
+fetch-nodeshim@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/fetch-nodeshim/-/fetch-nodeshim-0.4.3.tgz#46e5e42bea67b5b2f6f364b1e0d6750e489a11f5"
+  integrity sha512-zDg18QLrRKYbtRjqKMwwGsAmPG6Lnm4MODrV6IIkY0ihxTampOHacOJlVjJo7gYYK7WRVnpaayaPidP5er+rRw==
 
 fetch-retry@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
# Why

This is a follow-up to #42720

`fetch-nodeshim` was originally written for `@expo/ws-tunnel` and with these constraints in mind, didn't properly handle all edge-cases, since some assumptions could be made. When reviewing some of its features, some missing cases stood out that were addressed over on its repository (see PRs individually if any of them seem more relevant for a review)

- `NO_PROXY` handling had a few typos
- Consecutive `Set-Cookie` values weren't appended (which is something we ran into with `expo-server` too)
- Explicit `ETIMEDOUT` wasn't thrown (some fetch implementations don't time out, but `fetch-nodeshim` has a more aggressive 5s time out for the pre-headers phase, since it's mainly used in scripts/CLIs/servers)
- The `requestOptions.agent` wasn't being updated after a redirect
- Invalid `Location` headers on `redirect: 'follow'` didn't throw an error (Fetch API compliance issue)
- Depending on the timing of `Response.body` streams or when duplex streaming was used (Simultaneous `Request.body` and `Response.body` streams), the errors wouldn't propagate to all streams, See: https://github.com/kitten/fetch-nodeshim/pull/16/changes#diff-eeed782a266dc1fc529c811c9b7104828cfc608f349a191cab030dba2b5bc5f5

# How

- Bump to `fetch-nodeshim@^0.4.3`

# Test Plan

- E2E tests cover this

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
