### PR TITLE
fix(cli): Support `--variant debugOptimized` for active architecture filtering

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix loader URL resolution for nested `/index` paths ([#42629](https://github.com/expo/expo/pull/42629) by [@hassankhan](https://github.com/hassankhan))
 - [web] Ensure `<Head>` component re-renders when focus changes ([#42681](https://github.com/expo/expo/pull/42681) by [@hassankhan](https://github.com/hassankhan))
 - Mark `expo-router` as optional peer to prevent auto-installation ([#42728](https://github.com/expo/expo/pull/42728) by [@kitten](https://github.com/kitten))
+- [android] Support `debugOptimized` build variant for active architecture filtering ([#42766](https://github.com/expo/expo/pull/42766) by [@janicduplessis](https://github.com/janicduplessis))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/run/android/__tests__/resolveGradlePropsAsync-test.ts
+++ b/packages/@expo/cli/src/run/android/__tests__/resolveGradlePropsAsync-test.ts
@@ -76,10 +76,13 @@ describe(resolveGradlePropsAsync, () => {
   });
 
   it('returns with highly custom variant "firstSecondThird"', async () => {
+    // See: https://android.googlesource.com/platform/tools/base/+/e3b89c93d5e8238d6163f4e606d4ae9c4d229ee4/build-system/gradle-core/src/main/java/com/android/build/gradle/internal/variant/VariantPathHelper.kt?autodive=0%2F%2F%2F%2F%2F#137
+    // See: https://github.com/zawn/android-gradle-plugin/blob/c5d0ab91fac5a4acbe1845d3743b5ea0f896983d/builder/src/com/android/builder/core/VariantConfiguration.java#L402-L409
+    // The flavor should only be one directory, rather than multiple
     expect(
       await resolveGradlePropsAsync('/', { variant: 'firstSecondThird', allArch: true }, testDevice)
     ).toEqual({
-      apkVariantDirectory: '/android/app/build/outputs/apk/first/second/third',
+      apkVariantDirectory: '/android/app/build/outputs/apk/firstSecond/third',
       appName: 'app',
       buildType: 'third',
       flavors: ['first', 'second'],

--- a/packages/@expo/cli/src/run/android/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/run/android/__tests__/resolveOptions-test.ts
@@ -64,7 +64,7 @@ describe(resolveOptionsAsync, () => {
         appId: 'dev.expo.test',
       })
     ).toEqual({
-      apkVariantDirectory: '/android/app/build/outputs/apk/first/second/third',
+      apkVariantDirectory: '/android/app/build/outputs/apk/firstSecond/third',
       appName: 'app',
       buildCache: true,
       buildType: 'third',

--- a/packages/@expo/cli/src/run/android/resolveGradlePropsAsync.ts
+++ b/packages/@expo/cli/src/run/android/resolveGradlePropsAsync.ts
@@ -37,30 +37,34 @@ export async function resolveGradlePropsAsync(
 
   const apkDirectory = path.join(projectRoot, 'android', appName, 'build', 'outputs', 'apk');
 
-  // buildDeveloperTrust -> buildtype: trust, flavors: build, developer
+  // buildDeveloperTrust -> buildtype: trust, flavors: buildDeveloper
   // developmentDebug -> buildType: debug, flavors: development
   // productionRelease -> buildType: release, flavors: production
   // previewDebugOptimized -> buildType: debugOptimized, flavors: preview
-  // This won't work for non-standard flavor names like "myFlavor" would be treated as "my", "flavor".
-  let parts = variant.split(/(?=[A-Z])/).map((v) => v.toLowerCase());
+  const parts = variant.split(/(?=[A-Z])/);
 
-  // Special case: merge 'debug' and 'optimized' into 'debugOptimized'
-  if (parts.length >= 2 && parts[parts.length - 1] === 'optimized' && parts[parts.length - 2] === 'debug') {
-    parts = [...parts.slice(0, -2), 'debugOptimized'];
+  // Special case: merge 'Optimized' suffix with preceding part, e.g. into 'debugOptimized'
+  let buildType = parts.pop() ?? 'debug';
+  if (parts.length > 0 && buildType === 'Optimized') {
+    buildType = parts.pop()!.toLowerCase() + buildType;
+  } else {
+    buildType = buildType.toLowerCase();
   }
 
-  const flavors = parts.slice(0, -1);
-  const buildType = parts[parts.length - 1] ?? 'debug';
-
-  const apkVariantDirectory = path.join(apkDirectory, ...flavors, buildType);
-  const architectures = await getConnectedDeviceABIS(buildType, device, options.allArch);
+  let apkVariantDirectory: string;
+  if (parts.length > 0) {
+    const flavorPath = parts[0].toLowerCase() + parts.slice(1).join('');
+    apkVariantDirectory = path.join(apkDirectory, flavorPath, buildType);
+  } else {
+    apkVariantDirectory = path.join(apkDirectory, buildType);
+  }
 
   return {
     appName,
     buildType,
-    flavors,
+    flavors: parts.map((v) => v.toLowerCase()),
     apkVariantDirectory,
-    architectures,
+    architectures: await getConnectedDeviceABIS(buildType, device, options.allArch),
   };
 }
 


### PR DESCRIPTION
## Summary

This adds support for debug build type `debugOptimized`.

## Problem

When using build variants like `debugOptimized`, the CLI was building for all architectures instead of just the connected device's architecture.

The variant parsing logic was splitting `previewDebugOptimized` into `['preview', 'debug', 'optimized']` and treating `'optimized'` as the buildType, which failed the `buildType === 'debug'` check used for architecture filtering.

## Solution

This change:
- Detects when `'debug'` and `'optimized'` appear consecutively in the parsed variant parts
- Merges them into a single `'debugOptimized'` buildType
- Updates the architecture filtering check to support both `'debug'` and `'debugOptimized'` build types

## Test Plan

Tested locally with `npx expo run:android --variant debugOptimized` and confirmed that:
1. The variant is correctly parsed with buildType `'debugOptimized'`
2. Active architecture filtering is applied
3. Build only compiles for the connected device's architecture
