### PR TITLE
[android][brownfield] strip com.facebook.react:hermes-android

### DIFF
--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] strip com.facebook.react:hermes-android in [#42769](https://github.com/expo/expo/pull/42769) by [@pmleczek](https://github.com/pmleczek)
+
 ### 💡 Others
 
 - [test] Added E2E tests and improvements for CLI in [#42120](https://github.com/expo/expo/pull/42120) by [@pmleczek](https://github.com/pmleczek)

--- a/packages/expo-brownfield/gradle-plugins/publish/src/main/kotlin/expo/modules/plugin/publishing.kt
+++ b/packages/expo-brownfield/gradle-plugins/publish/src/main/kotlin/expo/modules/plugin/publishing.kt
@@ -103,7 +103,7 @@ internal fun createModuleRelatedTasks(project: Project, rnVersion: String?, herm
  * Create and register a task to remove react-native dependency from the module.json file for
  * specific publishing variant.
  *
- * com.facebook.react:react-native and com.facebook.react:hermes android are deprecated
+ * com.facebook.react:react-native and com.facebook.react:hermes-android are deprecated
  * and have to be stripped similarly to what React Native Gradle plugin does.
  *
  * @param project The project to remove react-native dependency from.

--- a/packages/expo-brownfield/gradle-plugins/publish/src/main/kotlin/expo/modules/plugin/publishing.kt
+++ b/packages/expo-brownfield/gradle-plugins/publish/src/main/kotlin/expo/modules/plugin/publishing.kt
@@ -103,8 +103,8 @@ internal fun createModuleRelatedTasks(project: Project, rnVersion: String?, herm
  * Create and register a task to remove react-native dependency from the module.json file for
  * specific publishing variant.
  *
- * com.facebook.react:react-native is deprecated and has to be stripped similarly to what React
- * Native Gradle plugin does.
+ * com.facebook.react:react-native and com.facebook.react:hermes android are deprecated
+ * and have to be stripped similarly to what React Native Gradle plugin does.
  *
  * @param project The project to remove react-native dependency from.
  * @param variant The variant name.
@@ -124,6 +124,9 @@ internal fun createRemoveReactNativeDependencyModuleTask(project: Project, varia
         moduleJson?.dependencyLists()?.forEach { dependencies ->
           dependencies.removeAll {
             it["group"] == "com.facebook.react" && it["module"] == "react-native"
+          }
+          dependencies.removeAll {
+            it["group"] == "com.facebook.react" && it["module"] == "hermes-android"
           }
         }
 


### PR DESCRIPTION
# Why

Some dependencies (e.g. RN Worklets) use the deprecated `com.facebook.react:hermes-android` dependency, which in greenfield setup is stripped by RNGP. In brownfield it results in the following error in the native (consuming) app:

```sh
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:dataBindingMergeDependencyArtifactsDebug'.
> Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
   > Could not find com.facebook.react:hermes-android:.
     Required by:
         project :app > host.exp.exponent:brownfield:1.0.0 > expo-app:com.swmansion.worklets:0.7.2
```

# How

We already strip deprecated `com.facebook.react:react-native` so we similarly need to remove the old hermes 

# Test Plan

- Verified that brownfield can be succesfully compiled
- Verified that it can be used in both Debug and Release variants and build doesn't end with the error mentioned above

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
