### PR TITLE
[docs] add sdk 54 to 55 native tabs migration guide

### DIFF
--- a/docs/pages/router/advanced/native-tabs.mdx
+++ b/docs/pages/router/advanced/native-tabs.mdx
@@ -974,6 +974,12 @@ export default function HomeScreen() {
 }
 ```
 
+## Migrating native tabs from SDK 54 to 55
+
+SDK 55 changes how you access tab bar item components. Instead of importing `Icon`, `Label`, and `Badge` separately, use the compound component API: `NativeTabs.Trigger.Icon`, `NativeTabs.Trigger.Label`, and `NativeTabs.Trigger.Badge`. For Android icons, the `md` prop is the new recommended way to use Material Symbols.
+
+<DiffBlock source="/static/diffs/router/native-tabs/sdk-54-to-55-migration.diff" />
+
 ## Migrating from JavaScript tabs
 
 Native tabs are not designed to be a drop-in replacement for [JavaScript tabs](/router/advanced/tabs/). The native tabs are constrained to the native platform behavior, whereas the JavaScript tabs can be customized more freely. If you aren't interested in the native platform behavior, you can continue using the JavaScript tabs.

--- a/docs/public/static/diffs/router/native-tabs/sdk-54-to-55-migration.diff
+++ b/docs/public/static/diffs/router/native-tabs/sdk-54-to-55-migration.diff
@@ -1,0 +1,25 @@
+diff --git a/app/_layout.tsx b/app/_layout.tsx
+index 0000000..1111111 100644
+--- a/app/_layout.tsx
++++ b/app/_layout.tsx
+@@ -1,14 +1,10 @@
+-import MIcons from '@expo/vector-icons/MaterialIcons';
+-import { NativeTabs, Icon, Label, Badge, VectorIcon } from 'expo-router/unstable-native-tabs';
++import { NativeTabs } from 'expo-router/unstable-native-tabs';
+
+ export default function TabLayout() {
+   return (
+     <NativeTabs>
+       <NativeTabs.Trigger name="index">
+-        <Label>Home</Label>
++        <NativeTabs.Trigger.Label>Home</NativeTabs.Trigger.Label>
+-        <Icon
+-          sf="house.fill"
+-          androidSrc={<VectorIcon family={MIcons} name="home" />}
+-        />
++        <NativeTabs.Trigger.Icon sf="house.fill" md="home" />
+-        <Badge>9+</Badge>
++        <NativeTabs.Trigger.Badge>9+</NativeTabs.Trigger.Badge>
+       </NativeTabs.Trigger>
+     </NativeTabs>
+   );


### PR DESCRIPTION
# Why

<img width="1105" height="703" alt="image" src="https://github.com/user-attachments/assets/77186bb4-1dce-4157-b5b5-2488a0832c54" />

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
