### PR TITLE
[video][android] Fix players not getting released during reload

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix only one player getting released when reloading with multiple players present. ([#42780](https://github.com/expo/expo/pull/42780) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 ## 55.0.5 — 2026-02-08

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
@@ -373,6 +373,7 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
     GlobalScope.launch(Dispatchers.Main) {
       firstFrameEventGenerator.release()
       player.removeListener(playerListener)
+      player.removeAnalyticsListener(analyticsListener)
       player.release()
     }
     uncommittedSource = null


### PR DESCRIPTION
# Why

When reloading the `sharedObjectDidDeallocate` is correctly called on the `VideoPlayer` instance, but the actual `ExoPlayer.release` sometimes won't be called, especially when multiple players are present. 
This is because the release calls are queued on `appContext.mainQueue`, which gets cancelled during the reload.

# How

- Move the release process onto `GlobalScope.launch(Dispatchers.Main)` which won't get cancelled during a reload.
Since firstFrameEventGenerator `release` also needs to be run on the main queue during deinit, remove the internal main queue usage and mark it with a @MainThread annotation. 

Also did a few quick changes that don't fix anything, but make the code a bit safer
- Clear all listeners when releasing
- In `FirstFrameEventGenerator` set onFirstFrameRendered callback to null, in case it holds a reference to the player.
- Clear the `intervalUpdateClock`

# Test Plan

Tested in BareExpo on Android.
