### PR TITLE
[core][Android] Introduce return type optimization

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -194,7 +194,7 @@ jsi::Value MethodMetadata::callSync(
   jni::JniLocalScope scope(env, (int) count);
 
   auto result = this->callJNISync(env, rt, thisValue, args, count);
-  return convert(env, rt, result);
+  return convert(env, rt, this->info.returnType, result);
 }
 
 jsi::Function MethodMetadata::toAsyncFunction(

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
@@ -5,6 +5,7 @@
 #include "types/CppType.h"
 #include "types/ExpectedType.h"
 #include "types/AnyType.h"
+#include "types/ReturnType.h"
 
 #include <jsi/jsi.h>
 #include <fbjni/fbjni.h>
@@ -48,6 +49,10 @@ public:
      * Representation of expected argument types.
      */
     std::vector<std::unique_ptr<AnyType>> argTypes;
+    /**
+     * Representation of expected return type.
+     */
+    ReturnType returnType = ReturnType::UNKNOWN;
   };
 
   Info info;

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.cpp
@@ -3,6 +3,7 @@
 #include "JSDecoratorsBridgingObject.h"
 
 #include "JSClassesDecorator.h"
+#include "../types/ReturnType.h"
 
 namespace expo {
 
@@ -36,13 +37,21 @@ void JSDecoratorsBridgingObject::registerSyncFunction(
   jboolean takesOwner,
   jboolean enumerable,
   jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
+  jint cppReturnType,
   jni::alias_ref<JNIFunctionBody::javaobject> body
 ) {
   if (!functionDecorator) {
     functionDecorator = std::make_unique<JSFunctionsDecorator>();
   }
 
-  functionDecorator->registerSyncFunction(name, takesOwner, enumerable, expectedArgTypes, body);
+  functionDecorator->registerSyncFunction(
+    name,
+    takesOwner,
+    enumerable,
+    expectedArgTypes,
+    (ReturnType)cppReturnType,
+    body
+  );
 }
 
 void JSDecoratorsBridgingObject::registerAsyncFunction(
@@ -94,7 +103,8 @@ void JSDecoratorsBridgingObject::registerConstant(
   constantsDecorator->registerConstant(name, getter);
 }
 
-void JSDecoratorsBridgingObject::registerConstants(jni::alias_ref<react::NativeMap::javaobject> constants) {
+void JSDecoratorsBridgingObject::registerConstants(
+  jni::alias_ref<react::NativeMap::javaobject> constants) {
   if (!constantsDecorator) {
     constantsDecorator = std::make_unique<JSConstantsDecorator>();
   }

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.h
@@ -51,6 +51,7 @@ public:
     jboolean takesOwner,
     jboolean enumerable,
     jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
+    jint cppReturnType,
     jni::alias_ref<JNIFunctionBody::javaobject> body
   );
 

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSFunctionsDecorator.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSFunctionsDecorator.cpp
@@ -30,6 +30,7 @@ void JSFunctionsDecorator::registerFunction(
   bool enumerable,
   bool isAsync,
   std::vector<std::unique_ptr<AnyType>> &&argTypes,
+  ReturnType returnType,
   jni::global_ref<jobject> body
 ) {
   MethodMetadata::Info info{
@@ -51,6 +52,7 @@ void JSFunctionsDecorator::registerSyncFunction(
   jboolean takesOwner,
   jboolean enumerable,
   jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
+  ReturnType returnType,
   jni::alias_ref<JNIFunctionBody::javaobject> body
 ) {
   registerFunction(
@@ -61,6 +63,7 @@ void JSFunctionsDecorator::registerSyncFunction(
     enumerable,
     /*isAsync=*/false,
     mapConverters(expectedArgTypes),
+    returnType,
     jni::make_global(body)
   );
 }
@@ -80,6 +83,7 @@ void JSFunctionsDecorator::registerAsyncFunction(
     enumerable,
     /*isAsync=*/true,
     mapConverters(expectedArgTypes),
+    ReturnType::UNKNOWN,
     jni::make_global(body)
   );
 }

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSFunctionsDecorator.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSFunctionsDecorator.h
@@ -12,6 +12,7 @@
 #include "../MethodMetadata.h"
 #include "../JNIFunctionBody.h"
 #include "../types/ExpectedType.h"
+#include "../types/ReturnType.h"
 
 namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;
@@ -26,6 +27,7 @@ public:
     jboolean takesOwner,
     jboolean enumerable,
     jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
+    ReturnType returnType,
     jni::alias_ref<JNIFunctionBody::javaobject> body
   );
 
@@ -56,6 +58,7 @@ private:
     bool enumerable,
     bool isAsync,
     std::vector<std::unique_ptr<AnyType>> &&argTypes,
+    ReturnType returnType,
     jni::global_ref<jobject> body
   );
 };

--- a/packages/expo-modules-core/android/src/main/cpp/types/CppType.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/CppType.h
@@ -7,7 +7,7 @@ namespace expo {
  * A cpp version of the `expo.modules.kotlin.jni.CppType` enum.
  * Used to determine which representation of the js value should be sent to the Kotlin.
  */
-enum CppType {
+enum class CppType {
   NONE = 0,
   DOUBLE = 1 << 0,
   INT = 1 << 1,
@@ -35,4 +35,5 @@ enum CppType {
   NATIVE_ARRAY_BUFFER = 1 << 23,
   SERIALIZABLE = 1 << 24,
 };
+
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.cpp
@@ -90,6 +90,67 @@ jsi::Value convert(
   return jsi::Value::undefined();
 }
 
+jsi::Value convert(
+  JNIEnv *env,
+  jsi::Runtime &rt,
+  ReturnType returnType,
+  const jni::local_ref<jobject> &value
+) {
+#define CAST_AND_RETURN(type) \
+    return convertToJS(env, rt, *((jni::local_ref<type>*)((void*)&value)));
+#define COMMA ,
+
+  switch (returnType) {
+    case ReturnType::UNKNOWN:
+      return convert(env, rt, value);
+    case ReturnType::DOUBLE:
+      CAST_AND_RETURN(jni::JDouble)
+    case ReturnType::INT:
+      CAST_AND_RETURN(jni::JInteger)
+    case ReturnType::LONG:
+      CAST_AND_RETURN(jni::JLong)
+    case ReturnType::STRING:
+      CAST_AND_RETURN(jni::JString)
+    case ReturnType::BOOLEAN:
+      CAST_AND_RETURN(jni::JBoolean)
+    case ReturnType::FLOAT:
+      CAST_AND_RETURN(jni::JFloat)
+    case ReturnType::WRITEABLE_ARRAY:
+      CAST_AND_RETURN(react::WritableNativeArray::javaobject)
+    case ReturnType::WRITEABLE_MAP:
+      CAST_AND_RETURN(react::WritableNativeMap::javaobject)
+    case ReturnType::JS_MODULE:
+      CAST_AND_RETURN(JavaScriptModuleObject::javaobject)
+    case ReturnType::SHARED_OBJECT:
+      CAST_AND_RETURN(JSharedObject::javaobject)
+    case ReturnType::JS_TYPED_ARRAY:
+      CAST_AND_RETURN(JavaScriptTypedArray::javaobject)
+    case ReturnType::JS_ARRAY_BUFFER:
+      CAST_AND_RETURN(JavaScriptArrayBuffer::javaobject)
+    case ReturnType::NATIVE_ARRAY_BUFFER:
+      CAST_AND_RETURN(NativeArrayBuffer::javaobject)
+    case ReturnType::MAP:
+      CAST_AND_RETURN(jni::JMap<jstring COMMA jobject>)
+    case ReturnType::COLLECTION:
+      CAST_AND_RETURN(jni::JCollection<jobject>)
+    case ReturnType::DOUBLE_ARRAY:
+      CAST_AND_RETURN(jni::JArrayDouble)
+    case ReturnType::INT_ARRAY:
+      CAST_AND_RETURN(jni::JArrayInt)
+    case ReturnType::LONG_ARRAY:
+      CAST_AND_RETURN(jni::JArrayLong)
+    case ReturnType::FLOAT_ARRAY:
+      CAST_AND_RETURN(jni::JArrayFloat)
+    case ReturnType::BOOLEAN_ARRAY:
+      CAST_AND_RETURN(jni::JArrayBoolean )
+  }
+
+#undef COMMA
+#undef CAST_AND_RETURN
+
+  assert("Unhandled ReturnType in JNIToJSIConverter::convert" && false);
+}
+
 std::optional<jsi::Value> decorateValueForDynamicExtension(jsi::Runtime &rt, const jsi::Value &value) {
   if (value.isString()) {
     std::string string = value.getString(rt).utf8(rt);

--- a/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.h
@@ -12,6 +12,7 @@
 #include "../concepts/jni_deref.h"
 #include "../concepts/jni.h"
 #include "../concepts/jsi.h"
+#include "ReturnType.h"
 
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
@@ -33,6 +34,13 @@ namespace expo {
 jsi::Value convert(
   JNIEnv *env,
   jsi::Runtime &rt,
+  const jni::local_ref<jobject> &value
+);
+
+jsi::Value convert(
+  JNIEnv *env,
+  jsi::Runtime &rt,
+  ReturnType returnType,
   const jni::local_ref<jobject> &value
 );
 

--- a/packages/expo-modules-core/android/src/main/cpp/types/ReturnType.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/ReturnType.h
@@ -1,0 +1,33 @@
+// Copyright © 2026-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+namespace expo {
+/**
+ * A cpp version of the `expo.modules.kotlin.jni.ReturnType` enum.
+ */
+enum class ReturnType {
+  UNKNOWN = 0,
+  DOUBLE = 1 << 0,
+  INT = 1 << 1,
+  LONG = 1 << 2,
+  STRING = 1 << 3,
+  BOOLEAN = 1 << 4,
+  FLOAT = 1 << 5,
+  WRITEABLE_ARRAY = 1 << 6,
+  WRITEABLE_MAP = 1 << 7,
+  JS_MODULE = 1 << 8,
+  SHARED_OBJECT = 1 << 9,
+  JS_TYPED_ARRAY = 1 << 10,
+  JS_ARRAY_BUFFER = 1 << 11,
+  NATIVE_ARRAY_BUFFER = 1 << 12,
+  MAP = 1 << 13,
+  COLLECTION = 1 << 14,
+  DOUBLE_ARRAY = 1 << 15,
+  INT_ARRAY = 1 << 16,
+  LONG_ARRAY = 1 << 17,
+  FLOAT_ARRAY = 1 << 18,
+  BOOLEAN_ARRAY = 1 << 19,
+};
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SyncFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SyncFunctionComponent.kt
@@ -35,6 +35,7 @@ class SyncFunctionComponent(
       takesOwner,
       isEnumerable,
       getCppRequiredTypes().toTypedArray(),
+      returnType.cppType.value,
       getJNIFunctionBody(moduleName, appContext)
     )
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/ReturnType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/ReturnType.kt
@@ -4,6 +4,7 @@ private var nextValue = 0
 
 private fun nextValue(): Int = (1 shl nextValue).also { nextValue++ }
 
+// Keep this in sync with  C++ enum in `ReturnType.h`.
 enum class ReturnType(val value: Int = nextValue()) {
   UNKNOWN(0),
   DOUBLE,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/ReturnType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/ReturnType.kt
@@ -1,0 +1,29 @@
+package expo.modules.kotlin.jni
+
+private var nextValue = 0
+
+private fun nextValue(): Int = (1 shl nextValue).also { nextValue++ }
+
+enum class ReturnType(val value: Int = nextValue()) {
+  UNKNOWN(0),
+  DOUBLE,
+  INT,
+  LONG,
+  STRING,
+  BOOLEAN,
+  FLOAT,
+  WRITEABLE_ARRAY,
+  WRITEABLE_MAP,
+  JS_MODULE,
+  SHARED_OBJECT,
+  JS_TYPED_ARRAY,
+  JS_ARRAY_BUFFER,
+  NATIVE_ARRAY_BUFFER,
+  MAP,
+  COLLECTION,
+  DOUBLE_ARRAY,
+  INT_ARRAY,
+  LONG_ARRAY,
+  FLOAT_ARRAY,
+  BOOLEAN_ARRAY
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/decorators/JSDecoratorsBridgingObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/decorators/JSDecoratorsBridgingObject.kt
@@ -44,6 +44,7 @@ class JSDecoratorsBridgingObject(jniDeallocator: JNIDeallocator) : Destructible 
     takesOwner: Boolean,
     enumerable: Boolean,
     desiredTypes: Array<ExpectedType>,
+    cppReturnType: Int,
     body: JNIFunctionBody
   )
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ExperimentalJSTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ExperimentalJSTypeConverter.kt
@@ -1,0 +1,237 @@
+package expo.modules.kotlin.types
+
+import android.net.Uri
+import android.os.Bundle
+import expo.modules.kotlin.jni.ReturnType
+import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.records.formatters.FormattedRecord
+import expo.modules.kotlin.typedarray.RawTypedArrayHolder
+import expo.modules.kotlin.types.folly.FollyDynamicExtensionConverter
+import java.io.File
+import java.net.URI
+import java.net.URL
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+
+interface ExperimentalJSTypeConverter<T> {
+  fun convertToJS(value: Any?): Any?
+  val returnType: ReturnType
+
+  class PassThroughConverter : ExperimentalJSTypeConverter<Any> {
+    override fun convertToJS(value: Any?): Any? {
+      return value
+    }
+
+    override val returnType: ReturnType
+      get() = ReturnType.UNKNOWN
+  }
+
+  class BundleConverter : ExperimentalJSTypeConverter<Bundle> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<Bundle?>(value)
+      return value?.toJSValue(JSTypeConverter.DefaultContainerProvider)
+    }
+
+    override val returnType: ReturnType
+      get() = ReturnType.WRITEABLE_MAP
+  }
+
+  class ArrayConverter : ExperimentalJSTypeConverter<Array<*>> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<Array<*>?>(value)
+      return value?.toJSValue(JSTypeConverter.DefaultContainerProvider)
+    }
+
+    override val returnType: ReturnType
+      get() = ReturnType.WRITEABLE_ARRAY
+  }
+
+  class IntArrayConverter : ExperimentalJSTypeConverter<IntArray> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<IntArray?>(value)
+      return value?.toJSValue(JSTypeConverter.DefaultContainerProvider)
+    }
+
+    override val returnType: ReturnType
+      get() = ReturnType.INT_ARRAY
+  }
+
+  class FloatArrayConverter : ExperimentalJSTypeConverter<FloatArray> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<FloatArray?>(value)
+      return value?.toJSValue(JSTypeConverter.DefaultContainerProvider)
+    }
+
+    override val returnType: ReturnType
+      get() = ReturnType.FLOAT_ARRAY
+  }
+
+  class DoubleArrayConverter : ExperimentalJSTypeConverter<DoubleArray> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<DoubleArray?>(value)
+      return value?.toJSValue(JSTypeConverter.DefaultContainerProvider)
+    }
+
+    override val returnType: ReturnType
+      get() = ReturnType.DOUBLE_ARRAY
+  }
+
+  class BooleanArrayConverter : ExperimentalJSTypeConverter<BooleanArray> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<BooleanArray?>(value)
+      return value?.toJSValue(JSTypeConverter.DefaultContainerProvider)
+    }
+
+    override val returnType: ReturnType
+      get() = ReturnType.BOOLEAN_ARRAY
+  }
+
+  class ByteArrayConverter : ExperimentalJSTypeConverter<ByteArray> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<ByteArray?>(value)
+      return value?.let { FollyDynamicExtensionConverter.put(it) }
+    }
+
+    override val returnType: ReturnType
+      get() = ReturnType.STRING
+  }
+
+  class MapConverter : ExperimentalJSTypeConverter<Map<*, *>> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<Map<*, *>?>(value)
+      return value?.toJSValueExperimental()
+    }
+
+    override val returnType: ReturnType
+      get() = ReturnType.MAP
+  }
+
+  class EnumConverter : ExperimentalJSTypeConverter<Enum<*>> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<Enum<*>?>(value)
+      return value?.toJSValue()
+    }
+
+    override val returnType: ReturnType
+      get() = ReturnType.UNKNOWN // TODO(@lukmccall): Define proper ReturnType for Enums
+  }
+
+  class RecordConverter : ExperimentalJSTypeConverter<Record> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<Record?>(value)
+      return value?.toJSValueExperimental()
+    }
+
+    override val returnType: ReturnType
+      get() = ReturnType.MAP
+  }
+
+  class URIConverter : ExperimentalJSTypeConverter<URI> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<URI?>(value)
+      return value?.toJSValue()
+    }
+
+    override val returnType: ReturnType
+      get() = ReturnType.STRING
+  }
+
+  class URLConverter : ExperimentalJSTypeConverter<URL> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<URL?>(value)
+      return value?.toJSValue()
+    }
+
+    override val returnType: ReturnType
+      get() = ReturnType.STRING
+  }
+
+  class AndroidUriConverter : ExperimentalJSTypeConverter<Uri> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<Uri?>(value)
+      return value?.toJSValue()
+    }
+
+    override val returnType: ReturnType
+      get() = ReturnType.STRING
+  }
+
+  class FileConverter : ExperimentalJSTypeConverter<File> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<File?>(value)
+      return value?.toJSValue()
+    }
+
+    override val returnType: ReturnType
+      get() = ReturnType.STRING
+  }
+
+  class PairConverter : ExperimentalJSTypeConverter<Pair<*, *>> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<Pair<*, *>?>(value)
+      return value?.toJSValue(JSTypeConverter.DefaultContainerProvider)
+    }
+
+    override val returnType: ReturnType
+      get() = ReturnType.WRITEABLE_ARRAY
+  }
+
+  class LongConverter : ExperimentalJSTypeConverter<Long> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<Long?>(value)
+      return value?.toDouble()
+    }
+
+    override val returnType: ReturnType
+      get() = ReturnType.LONG
+  }
+
+  class DurationConverter : ExperimentalJSTypeConverter<Duration> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<Duration?>(value)
+      return value?.toDouble(DurationUnit.SECONDS)
+    }
+
+    override val returnType: ReturnType
+      get() = ReturnType.DOUBLE
+  }
+
+  class RawTypedArrayHolderConverter : ExperimentalJSTypeConverter<RawTypedArrayHolder> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<RawTypedArrayHolder?>(value)
+      return value?.rawArray
+    }
+
+    override val returnType: ReturnType
+      get() = ReturnType.JS_TYPED_ARRAY
+  }
+
+  class CollectionConverter : ExperimentalJSTypeConverter<Collection<*>> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<Collection<*>?>(value)
+      return value?.toJSValueExperimental()
+    }
+
+    override val returnType: ReturnType
+      get() = ReturnType.COLLECTION
+  }
+
+  class AnyConverter : ExperimentalJSTypeConverter<Any> {
+    override fun convertToJS(value: Any?): Any? {
+      return JSTypeConverter.convertToJSValue(value, useExperimentalConverter = true)
+    }
+
+    override val returnType: ReturnType
+      get() = ReturnType.UNKNOWN
+  }
+
+  class FormattedRecordConverter : ExperimentalJSTypeConverter<FormattedRecord<*>> {
+    override fun convertToJS(value: Any?): Any? {
+      enforceType<FormattedRecord<*>?>(value)
+      return value?.toJSValueExperimental()
+    }
+
+    override val returnType: ReturnType
+      get() = ReturnType.MAP
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ReturnType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ReturnType.kt
@@ -2,10 +2,8 @@ package expo.modules.kotlin.types
 
 import android.os.Bundle
 import expo.modules.kotlin.records.formatters.FormattedRecord
-import expo.modules.kotlin.types.folly.FollyDynamicExtensionConverter
 import kotlin.reflect.KClass
 import kotlin.time.Duration
-import kotlin.time.DurationUnit
 
 object ReturnTypeProvider {
   val types = mutableMapOf<KClass<*>, ReturnType>()
@@ -19,162 +17,6 @@ inline fun <reified T> ReturnTypeProvider.get(): ReturnType {
 
 inline fun <reified T> toReturnType(): ReturnType {
   return ReturnTypeProvider.get<T>()
-}
-
-interface ExperimentalJSTypeConverter<T> {
-  fun convertToJS(value: Any?): Any?
-
-  class PassThroughConverter : ExperimentalJSTypeConverter<Any> {
-    override fun convertToJS(value: Any?): Any? {
-      return value
-    }
-  }
-
-  class BundleConverter : ExperimentalJSTypeConverter<Bundle> {
-    override fun convertToJS(value: Any?): Any? {
-      enforceType<Bundle?>(value)
-      return value?.toJSValue(JSTypeConverter.DefaultContainerProvider)
-    }
-  }
-
-  class ArrayConverter : ExperimentalJSTypeConverter<Array<*>> {
-    override fun convertToJS(value: Any?): Any? {
-      enforceType<Array<*>?>(value)
-      return value?.toJSValue(JSTypeConverter.DefaultContainerProvider)
-    }
-  }
-
-  class IntArrayConverter : ExperimentalJSTypeConverter<IntArray> {
-    override fun convertToJS(value: Any?): Any? {
-      enforceType<IntArray?>(value)
-      return value?.toJSValue(JSTypeConverter.DefaultContainerProvider)
-    }
-  }
-
-  class FloatArrayConverter : ExperimentalJSTypeConverter<FloatArray> {
-    override fun convertToJS(value: Any?): Any? {
-      enforceType<FloatArray?>(value)
-      return value?.toJSValue(JSTypeConverter.DefaultContainerProvider)
-    }
-  }
-
-  class DoubleArrayConverter : ExperimentalJSTypeConverter<DoubleArray> {
-    override fun convertToJS(value: Any?): Any? {
-      enforceType<DoubleArray?>(value)
-      return value?.toJSValue(JSTypeConverter.DefaultContainerProvider)
-    }
-  }
-
-  class BooleanArrayConverter : ExperimentalJSTypeConverter<BooleanArray> {
-    override fun convertToJS(value: Any?): Any? {
-      enforceType<BooleanArray?>(value)
-      return value?.toJSValue(JSTypeConverter.DefaultContainerProvider)
-    }
-  }
-
-  class ByteArrayConverter : ExperimentalJSTypeConverter<ByteArray> {
-    override fun convertToJS(value: Any?): Any? {
-      enforceType<ByteArray?>(value)
-      return value?.let { FollyDynamicExtensionConverter.put(it) }
-    }
-  }
-
-  class MapConverter : ExperimentalJSTypeConverter<Map<*, *>> {
-    override fun convertToJS(value: Any?): Any? {
-      enforceType<Map<*, *>?>(value)
-      return value?.toJSValueExperimental()
-    }
-  }
-
-  class EnumConverter : ExperimentalJSTypeConverter<Enum<*>> {
-    override fun convertToJS(value: Any?): Any? {
-      enforceType<Enum<*>?>(value)
-      return value?.toJSValue()
-    }
-  }
-
-  class RecordConverter : ExperimentalJSTypeConverter<expo.modules.kotlin.records.Record> {
-    override fun convertToJS(value: Any?): Any? {
-      enforceType<expo.modules.kotlin.records.Record?>(value)
-      return value?.toJSValueExperimental()
-    }
-  }
-
-  class URIConverter : ExperimentalJSTypeConverter<java.net.URI> {
-    override fun convertToJS(value: Any?): Any? {
-      enforceType<java.net.URI?>(value)
-      return value?.toJSValue()
-    }
-  }
-
-  class URLConverter : ExperimentalJSTypeConverter<java.net.URL> {
-    override fun convertToJS(value: Any?): Any? {
-      enforceType<java.net.URL?>(value)
-      return value?.toJSValue()
-    }
-  }
-
-  class AndroidUriConverter : ExperimentalJSTypeConverter<android.net.Uri> {
-    override fun convertToJS(value: Any?): Any? {
-      enforceType<android.net.Uri?>(value)
-      return value?.toJSValue()
-    }
-  }
-
-  class FileConverter : ExperimentalJSTypeConverter<java.io.File> {
-    override fun convertToJS(value: Any?): Any? {
-      enforceType<java.io.File?>(value)
-      return value?.toJSValue()
-    }
-  }
-
-  class PairConverter : ExperimentalJSTypeConverter<Pair<*, *>> {
-    override fun convertToJS(value: Any?): Any? {
-      enforceType<Pair<*, *>?>(value)
-      return value?.toJSValue(JSTypeConverter.DefaultContainerProvider)
-    }
-  }
-
-  class LongConverter : ExperimentalJSTypeConverter<Long> {
-    override fun convertToJS(value: Any?): Any? {
-      enforceType<Long?>(value)
-      return value?.toDouble()
-    }
-  }
-
-  class DurationConverter : ExperimentalJSTypeConverter<Duration> {
-    override fun convertToJS(value: Any?): Any? {
-      enforceType<Duration?>(value)
-      return value?.toDouble(DurationUnit.SECONDS)
-    }
-  }
-
-  class RawTypedArrayHolderConverter : ExperimentalJSTypeConverter<expo.modules.kotlin.typedarray.RawTypedArrayHolder> {
-    override fun convertToJS(value: Any?): Any? {
-      enforceType<expo.modules.kotlin.typedarray.RawTypedArrayHolder?>(value)
-      return value?.rawArray
-    }
-  }
-
-  class CollectionConverter : ExperimentalJSTypeConverter<Collection<*>> {
-    override fun convertToJS(value: Any?): Any? {
-      enforceType<Collection<*>?>(value)
-      return value?.toJSValueExperimental()
-    }
-  }
-
-  class AnyConverter : ExperimentalJSTypeConverter<Any> {
-    override fun convertToJS(value: Any?): Any? {
-      return JSTypeConverter.convertToJSValue(value, useExperimentalConverter = true)
-    }
-  }
-
-  class FormattedRecordConverter : ExperimentalJSTypeConverter<FormattedRecord<*>> {
-    override fun convertToJS(value: Any?): Any? {
-      enforceType<FormattedRecord<*>?>(value)
-      return value?.toJSValueExperimental()
-    }
-  }
 }
 
 class ReturnType(
@@ -215,6 +57,9 @@ class ReturnType(
   fun convertToJS(value: Any?): Any? {
     return converter.convertToJS(value)
   }
+
+  val cppType: expo.modules.kotlin.jni.ReturnType
+    get() = converter.returnType
 
   internal inline fun <reified T> inheritFrom(): Boolean {
     val jClass = klass.java


### PR DESCRIPTION
# Why

Introduces return type optimization to improve the performance of sync functions.

# How

- Passed information about the return type to the C++
- Instead of dynamically checking the type of the value during conversion, we're assuming the type based on the `ReturnType`

This optimization made sync functions up to 30% faster. This value depends on the given type. 

# Test Plan

- NCL ✅ 
- unit tests ✅ 