### PR TITLE
[docs] Add Color API documentation for expo-router

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -284,6 +284,7 @@ export const general = [
     makeGroup('Reference', [
       makePage('router/error-handling.mdx'),
       makePage('router/reference/url-parameters.mdx'),
+      makePage('router/reference/color.mdx'),
       makePage('router/reference/sitemap.mdx'),
       makePage('router/reference/redirects.mdx'),
       makePage('router/reference/link-preview.mdx'),

--- a/docs/pages/router/reference/color.mdx
+++ b/docs/pages/router/reference/color.mdx
@@ -1,0 +1,166 @@
+---
+title: Color
+description: Access platform-specific colors with type safety in Expo Router.
+---
+
+The `Color` API provides type-safe access to platform-specific colors on iOS and Android. It wraps React Native's `PlatformColor` with full TypeScript support, enabling autocomplete and compile-time type checking for system colors.
+
+## Usage
+
+```tsx
+import { Color } from 'expo-router';
+```
+
+The `Color` object has two platform-specific namespaces:
+
+- `Color.ios.*` - iOS system colors from UIKit
+- `Color.android.*` - Android colors including base colors, attributes, and Material Design 3 colors
+
+## iOS colors
+
+Access iOS system colors through `Color.ios.*`. These map directly to UIKit's [standard colors](https://developer.apple.com/documentation/uikit/standard-colors) and [UI element colors](https://developer.apple.com/documentation/uikit/ui-element-colors).
+
+```tsx
+import { Color } from 'expo-router';
+import { View, Text } from 'react-native';
+
+function MyComponent() {
+  return (
+    <View style={{ backgroundColor: Color.ios.systemBackground }}>
+      <Text style={{ color: Color.ios.label }}>Hello, World!</Text>
+    </View>
+  );
+}
+```
+
+iOS colors automatically adapt to the system appearance (light/dark mode) and accessibility settings.
+
+## Android colors
+
+Android provides four categories of colors through the `Color.android` namespace.
+
+### Base colors
+
+Access Android system colors through `Color.android.*`. These map to `@android:color/` resources.
+
+```tsx
+import { Color } from 'expo-router';
+
+// Basic colors
+Color.android.black;
+Color.android.white;
+Color.android.transparent;
+
+// Background colors
+Color.android.background_dark;
+Color.android.background_light;
+```
+
+See the [Android R.color documentation](https://developer.android.com/reference/android/R.color) for the full list of available colors.
+
+### Attribute colors
+
+Access Android theme attributes through `Color.android.attr.*`. These resolve colors from the current theme using `?attr/` syntax.
+
+```tsx
+import { Color } from 'expo-router';
+
+// Theme colors
+Color.android.attr.colorPrimary;
+Color.android.attr.colorSecondary;
+Color.android.attr.colorAccent;
+Color.android.attr.colorBackground;
+```
+
+See the [Android R.attr documentation](https://developer.android.com/reference/android/R.attr) for more information.
+
+### Material Design 3 static colors
+
+Access Material Design 3 static colors through `Color.android.material.*`. These use the standard Material 3 Light/Dark theme colors.
+
+```tsx
+import { Color } from 'expo-router';
+
+// Primary colors
+Color.android.material.primary;
+Color.android.material.onPrimary;
+Color.android.material.primaryContainer;
+Color.android.material.onPrimaryContainer;
+
+// Surface colors
+Color.android.material.surface;
+Color.android.material.onSurface;
+```
+
+See the [Material Design 3 color roles documentation](https://m3.material.io/styles/color/roles) for more information about each color role.
+
+### Material Design 3 dynamic colors
+
+Access Material Design 3 dynamic colors through `Color.android.dynamic.*`. Dynamic colors adapt to the user's wallpaper using Android's [Dynamic Color feature](https://m3.material.io/styles/color/dynamic/user-generated-source), available on Android 12+ (API 31+).
+
+```tsx
+import { Color } from 'expo-router';
+
+// Dynamic colors adapt to user's wallpaper
+Color.android.dynamic.primary;
+Color.android.dynamic.onPrimary;
+Color.android.dynamic.surface;
+Color.android.dynamic.onSurface;
+```
+
+The available colors are the same as [Material 3 static colors](#material-design-3-static-colors).
+
+### Responding to theme changes on Android
+
+Android Material colors (both static and dynamic) respond to the system's light/dark mode. To ensure your component re-renders when the theme changes, use the `useColorScheme()` hook from React Native.
+
+```tsx
+import { Color } from 'expo-router';
+import { View, Text, useColorScheme } from 'react-native';
+
+function MyComponent() {
+  // Triggers re-render when system theme changes
+  useColorScheme();
+
+  return (
+    <View style={{ backgroundColor: Color.android.dynamic.surface }}>
+      <Text style={{ color: Color.android.dynamic.onSurface }}>Hello, World!</Text>
+    </View>
+  );
+}
+```
+
+Without using `useColorScheme()`, the colors may not update when the user switches between light and dark mode.
+
+## Cross-platform usage
+
+The `Color` API is platform-specific. Use `useMemo` to select the appropriate color for each platform:
+
+```tsx
+import { Platform, View, Text } from 'react-native';
+import { Color } from 'expo-router';
+
+function MyComponent() {
+  const backgroundColor = Platform.select({
+    ios: Color.ios.systemBackground,
+    android: Color.android.dynamic.surface,
+    default: '#000000',
+  });
+
+  const textColor = Platform.select({
+    ios: Color.ios.label,
+    android: Color.android.dynamic.onSurface,
+    default: '#FFFFFF',
+  });
+
+  return (
+    <View style={{ backgroundColor }}>
+      <Text style={{ color: textColor }}>Hello, World!</Text>
+    </View>
+  );
+}
+```
+
+## API reference
+
+For the full list of available types and colors, see the [Color API reference](/versions/latest/sdk/router/#color).


### PR DESCRIPTION
# Why

https://github.com/user-attachments/assets/56c44b9b-b0e9-443b-b649-58a691c85789

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
