### PR TITLE
[audio][android] Fix memory leaks when refreshing the app

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix memory leaks when refreshing the app. ([#42785](https://github.com/expo/expo/pull/42785) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 ## 55.0.3 — 2026-01-27

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
@@ -18,7 +18,9 @@ import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.sharedobjects.SharedRef
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
@@ -314,9 +316,12 @@ class AudioPlayer(
     }
   }
 
+  @OptIn(DelicateCoroutinesApi::class)
   override fun sharedObjectDidRelease() {
     super.sharedObjectDidRelease()
-    appContext?.mainQueue?.launch {
+    // Run on global scope (not appContext.mainQueue) so that reloading doesn't cancel the release process
+    // https://github.com/expo/expo/blob/cdf592a7fea56fc01b0149e9b2e5dbd294bcdc4c/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt#L277-L279
+    GlobalScope.launch(Dispatchers.Main) {
       if (isActiveForLockScreen) {
         AudioControlsService.clearSession()
       }


### PR DESCRIPTION
# Why

Same as in https://github.com/expo/expo/pull/42780 - running code in `appContext.mainQueue.launch{}` inside `sharedObjectDidRelease` will fail to release the ExoPlayers (usually except for the first one or two) due to the queue getting cancelled during the reload.

# How

Use `GlobalDispatch(Dispatchers.Main)` instead

# Test Plan

Tested in BareExpo on a Pixel 8
