### PR TITLE
[docs] Fix missing icon in Store data

### DIFF
--- a/docs/pages/develop/user-interface/store-data.mdx
+++ b/docs/pages/develop/user-interface/store-data.mdx
@@ -3,6 +3,8 @@ title: Store data
 description: Learn about different libraries available to store data in your Expo project.
 ---
 
+import { Globe01Icon } from '@expo/styleguide-icons/outline/Globe01Icon';
+
 import { BoxLink } from '~/ui/components/BoxLink';
 
 Storing data can be essential to the features implemented in your mobile app. There are different ways to save data in your Expo project depending on the type of data you want to store and the security requirements of your app. This page lists a variety of libraries to help you decide which solution is best for your project.
@@ -48,7 +50,7 @@ Storing data can be essential to the features implemented in your mobile app. Th
   title="Async Storage documentation"
   description="For more information on how to install and use Async Storage, see its documentation."
   href="https://react-native-async-storage.github.io/async-storage/docs/usage"
-  imageUrl="https://react-native-async-storage.github.io/async-storage/img/logo.svg"
+  Icon={Globe01Icon}
 />
 
 ## Other libraries


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
<img width="860" height="279" alt="CleanShot 2026-02-02 at 23 06 52" src="https://github.com/user-attachments/assets/5054d35b-3666-4199-93e3-7cb93ca9dc42" />

This is why we should use the standard external link icon for third-party sites/docs because we don't control when those assets go 404 or change.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix missing icon in Store data by replacing it with `Globe01Icon` from `@expo/styleguide-icons`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
<img width="853" height="268" alt="CleanShot 2026-02-02 at 23 09 30" src="https://github.com/user-attachments/assets/1f16c9be-a9cc-4e64-90d6-8c8c1c339a33" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
