### PR TITLE
[docs] Update Top-level src directory for SDK 55

### DIFF
--- a/docs/pages/router/reference/src-directory.mdx
+++ b/docs/pages/router/reference/src-directory.mdx
@@ -7,7 +7,7 @@ import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-Projects created with the [default template](/get-started/create-a-project/) already include a top-level **src** directory that contains the **app**, **components**, **constants**, and **hooks** directories. No extra configuration is needed.
+Projects created with the [default template](/get-started/create-a-project/) on SDK 55 and later already include a top-level **src** directory that contains the **app**, **components**, **constants**, and **hooks** directories. No extra configuration is needed.
 
 If you are using a [custom template](/more/create-expo/#--template) or an existing project that doesn't include a **src** directory, follow the steps below to set it up.
 

--- a/docs/pages/router/reference/src-directory.mdx
+++ b/docs/pages/router/reference/src-directory.mdx
@@ -7,7 +7,9 @@ import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-As your project grows, it can be helpful to move all the directories containing application code into a single **src** directory. Expo Router supports this out of the box.
+Projects created with the [default template](/get-started/create-a-project/) already include a top-level **src** directory that contains the **app**, **components**, **constants**, and **hooks** directories. No extra configuration is needed.
+
+If you are using a [custom template](/more/create-expo/#--template) or an existing project that doesn't include a **src** directory, follow the steps below to set it up.
 
 ## Using a top-level src directory
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

- Updates the Top-level src directory guide to reflect that SDK 55's default template already includes the `src/` directory structure out of the box
- The previous intro implied users need to manually set up the `src/` directory. With SDK 55, this is only necessary for  custom templates or existing projects

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

http://localhost:3002/router/reference/src-directory/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify that SDK 55+ default templates include a pre-configured src directory structure with app, components, constants, and hooks. Added setup instructions for projects using custom templates or existing projects without a src directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->