### PR TITLE
[docs] Minor updates in Vale rules

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -295,3 +295,4 @@ exceptions:
   - Starting a Live Activity
   - Updating a Live Activity
   - Hiding the Tab bar
+  - Integrated vs Isolated

--- a/docs/.vale/writing-styles/expo-docs/PlatformsOrder.yml
+++ b/docs/.vale/writing-styles/expo-docs/PlatformsOrder.yml
@@ -1,7 +1,7 @@
 extends: existence
 message: "When referencing multiple platforms, use the order: 'Android, iOS, and web'."
 link: 'https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#referencing-android-ios-and-web'
-level: warning
+level: error
 scope: raw
 ignorecase: true
 tokens:


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

<img width="503" height="139" alt="CleanShot 2026-02-03 at 00 10 57" src="https://github.com/user-attachments/assets/f2dac6c2-2892-468e-9cfb-84e5b8617cc6" />

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add "Integrated vs Isolated" to the HeadingCase Vale exceptions list
- Update from warning to error for PlatformOrder (sometimes this gets ignored in the original PR and then we have to create follow up PRs to fix it)

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
