### PR TITLE
[docs] Update guides add src/ prefix and kebab-case file names for SDK 55

### DIFF
--- a/docs/pages/guides/keyboard-handling.mdx
+++ b/docs/pages/guides/keyboard-handling.mdx
@@ -32,7 +32,7 @@ The `KeyboardAvoidingView` is a component that automatically adjusts a view's he
 
 Android and iOS interact with the `behavior` property differently. On iOS, `padding` is usually what works best, and for Android, just having the `KeyboardAvoidingView` prevents covering the input. This is why the following example uses `undefined` for Android. Playing around with the `behavior` is a good practice since a different option could work best for your app.
 
-```tsx HomeScreen.tsx
+```tsx home-screen.tsx
 import { KeyboardAvoidingView, TextInput } from 'react-native';
 
 export default function HomeScreen() {
@@ -60,7 +60,7 @@ After adding this property, restart the development server and reload your app t
 
 It's also possible to hide the bottom tab when the keyboard opens using [`tabBarHideOnKeyboard`](https://reactnavigation.org/docs/bottom-tab-navigator/#tabbarhideonkeyboard). It is an option with the Bottom Tab Navigator. If set to `true`, it will hide the bar when the keyboard opens.
 
-```tsx app/_layout.tsx
+```tsx src/app/_layout.tsx
 import { Tabs } from 'expo-router';
 
 export default function TabLayout() {
@@ -83,7 +83,7 @@ To listen for keyboard events, use the `Keyboard.addListener` method. This metho
 
 The following example illustrates a use case for adding a keyboard listener. The state variable `isKeyboardVisible` is toggled each time the keyboard shows or hides. Based on this variable, a button allows the user to dismiss the keyboard only if the keyboard is active. Also, notice that the button uses the `Keyboard.dismiss` method.
 
-```tsx HomeScreen.tsx
+```tsx home-screen.tsx
 import { useEffect, useState } from 'react';
 import { Keyboard, View, Button, TextInput } from 'react-native';
 
@@ -137,7 +137,7 @@ Start by installing the Keyboard Controller library in your Expo project:
 
 To finalize the setup, add the `KeyboardProvider` to your app.
 
-```tsx app/_layout.tsx
+```tsx src/app/_layout.tsx
 import { Stack } from 'expo-router';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 
@@ -161,7 +161,7 @@ As a more powerful alternative, you can use the [`KeyboardAwareScrollView`](http
 
 For screens with multiple inputs, the Keyboard Controller library also provides a `KeyboardToolbar` component to use alongside `KeyboardAwareScrollView`. Together, these components handle input navigation and prevent the keyboard from covering the screen without custom configuration:
 
-```tsx FormScreen.tsx
+```tsx form-screen.tsx
 import { TextInput, View, StyleSheet } from 'react-native';
 import { KeyboardAwareScrollView, KeyboardToolbar } from 'react-native-keyboard-controller';
 
@@ -218,7 +218,7 @@ For a more advanced and customizable approach, you can use [`useKeyboardHandler`
 
 Using the `useKeyboardHandler` hook, you can create a custom hook to access the height of the keyboard at each frame. It uses `useSharedValue` from reanimated to return the height, as shown below.
 
-```tsx ChatScreen.tsx
+```tsx chat-screen.tsx
 import { useKeyboardHandler } from 'react-native-keyboard-controller';
 import Animated, { useAnimatedStyle, useSharedValue } from 'react-native-reanimated';
 
@@ -242,7 +242,7 @@ You can use the `useGradualAnimation` hook to animate a view and give it a smoot
 
 The `fakeView` animated style is used in an animated view after the `TextInput`. This view's height will animate based on the keyboard's height at each frame, which effectively pushes the content above the keyboard with a smooth animation. It also decreases its height to zero when the keyboard is dismissed.
 
-```tsx ChatScreen.tsx
+```tsx chat-screen.tsx
 import { StyleSheet, Platform, FlatList, View, StatusBar, TextInput } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue } from 'react-native-reanimated';
 import { useKeyboardHandler } from 'react-native-keyboard-controller';

--- a/docs/pages/guides/localization.mdx
+++ b/docs/pages/guides/localization.mdx
@@ -331,7 +331,7 @@ However, the default unset value of `textDirection` property signifies the actua
 
 It's best to define this style in your custom reusable `<Text>` component that you can then import everywhere you need to render text strings.
 
-```tsx MobileText.tsx
+```tsx mobile-text.tsx
 import { Text as RNText, TextProps as RNTextProps } from 'react-native';
 
 const MobileText = (props: RNTextProps) => {
@@ -344,7 +344,7 @@ export default MobileText;
 
 For each text tag, you need to add the `lang` property with the current locale identifier. It's best to define this style in a custom reusable component.
 
-```tsx WebText.tsx
+```tsx web-text.tsx
 import { getLocales } from 'expo-localization';
 
 const deviceLanguage = getLocales()[0].languageCode;

--- a/docs/pages/guides/progressive-web-apps.mdx
+++ b/docs/pages/guides/progressive-web-apps.mdx
@@ -103,9 +103,9 @@ Then add the manifest to the `<head>` tag:
 
 <Tab label="static & server">
 
-If you're using static or server rendering, the HTML entry can be dynamically created in **app/+html.tsx**. Here we'll link the manifest by adding a `<link>` tag to the `<head>` component:
+If you're using static or server rendering, the HTML entry can be dynamically created in **src/app/+html.tsx**. Here we'll link the manifest by adding a `<link>` tag to the `<head>` component:
 
-```tsx app/+html.tsx
+```tsx src/app/+html.tsx
 import { ScrollViewStyleReset } from 'expo-router/html';
 import type { PropsWithChildren } from 'react';
 
@@ -205,7 +205,7 @@ Then create the service worker registration script in the `<head>` tag:
 
 Next, create a root HTML file for the app and add the service worker registration script:
 
-```tsx app/+html.tsx
+```tsx src/app/+html.tsx
 import { ScrollViewStyleReset } from 'expo-router/html';
 import type { PropsWithChildren } from 'react';
 

--- a/docs/pages/guides/using-logrocket.mdx
+++ b/docs/pages/guides/using-logrocket.mdx
@@ -33,9 +33,9 @@ Then, in your [app config](/workflow/configuration/), include the LogRocket conf
 }
 ```
 
-Finally, initialize LogRocket in your app in a top-level file, like **app/\_layout.tsx**:
+Finally, initialize LogRocket in your app in a top-level file, like **src/app/\_layout.tsx**:
 
-```tsx app/_layout.tsx
+```tsx src/app/_layout.tsx
 import { useEffect } from 'react';
 import * as Updates from 'expo-updates';
 import LogRocket from '@logrocket/react-native';

--- a/docs/pages/guides/using-resend.mdx
+++ b/docs/pages/guides/using-resend.mdx
@@ -64,9 +64,9 @@ To enable using API Routes in your Expo project, you need to set the web.output 
 }
 ```
 
-Then, [create an API route](/router/web/api-routes/#create-an-api-route) to handle email submissions. Inside the **app** directory, create a new file called **api/audience+api.ts**. The `+api.ts` extension is used by Expo Router to identify the file as an API Route. To test the integration, you can add the minimal code below to send an email to a recipient using Resend SDK:
+Then, [create an API route](/router/web/api-routes/#create-an-api-route) to handle email submissions. Inside the **src/app** directory, create a new file called **api/audience+api.ts**. The `+api.ts` extension is used by Expo Router to identify the file as an API Route. To test the integration, you can add the minimal code below to send an email to a recipient using Resend SDK:
 
-```tsx app/api/audience+api.ts
+```tsx src/app/api/audience+api.ts
 import { Resend } from 'resend';
 
 const resend = new Resend(process.env.RESEND_API_KEY);
@@ -116,9 +116,9 @@ Note that only variables prefixed with `EXPO_PUBLIC_` can be used in the fronten
 
 ## Add a form to your Expo project
 
-The following example code shows a simple form to collect email addresses from app users. In a real-world scenario, you would want to add validation and error handling to the form. For example, the following code is added to the **app/index.tsx** file:
+The following example code shows a simple form to collect email addresses from app users. In a real-world scenario, you would want to add validation and error handling to the form. For example, the following code is added to the **src/app/index.tsx** file:
 
-```tsx app/index.tsx
+```tsx src/app/index.tsx
 import { useRef, useState } from 'react';
 import { Alert, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 
@@ -227,7 +227,7 @@ The `eas deploy --prod` command will:
 - Automatically create an EAS project if you haven't already
 - Prompt you to choose the preview URL for your project. Ensure that this URL is the same as the value of `EXPO_PUBLIC_BASE_URL` in your **.env.local** file. This will make the API route accessible from your Expo app while deployed in production
 
-> **Note:** Before deployment, you need to use the `EXPO_PUBLIC_BASE_URL` as your hosted domain in your form screen (**app/index.tsx**).
+> **Note:** Before deployment, you need to use the `EXPO_PUBLIC_BASE_URL` as your hosted domain in your form screen (**src/app/index.tsx**).
 
 </Step>
 

--- a/docs/pages/guides/using-vexo.mdx
+++ b/docs/pages/guides/using-vexo.mdx
@@ -44,9 +44,9 @@ With a two-line integration, Vexo starts collecting data automatically, giving y
      }}
    />
 
-4. Initialize Vexo: Add the following code in your app's entry file (for example, **index.js**, **App.js**, or **app/\_layout.tsx** if using Expo Router):
+4. Initialize Vexo: Add the following code in your app's entry file (for example, **index.js**, **App.js**, or **src/app/\_layout.tsx** if using Expo Router):
 
-   ```tsx app/_layout.tsx
+   ```tsx src/app/_layout.tsx
    import { vexo } from 'vexo-analytics';
 
    // You may want to wrap this with `if (!__DEV__) { ... }` to only run Vexo in production.

--- a/docs/pages/linking/ios-universal-links.mdx
+++ b/docs/pages/linking/ios-universal-links.mdx
@@ -180,9 +180,9 @@ If you're having trouble setting up the banner, run the following command to aut
 
 ### Add the meta tag to your statically rendered website
 
-If you're building a [statically rendered website with Expo Router](/router/web/static-rendering), then add the HTML tag to the `<head>` component in your [**app/+html.js** file](/router/web/static-rendering#root-html).
+If you're building a [statically rendered website with Expo Router](/router/web/static-rendering), then add the HTML tag to the `<head>` component in your [**src/app/+html.js** file](/router/web/static-rendering#root-html).
 
-```tsx app/+html.tsx
+```tsx src/app/+html.tsx
 import { type PropsWithChildren } from 'react';
 
 export default function Root({ children }: PropsWithChildren) {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

- Updates file path references across guides and linking docs to reflect the SDK 55 default project structure where app/,
  components/, constants/, and hooks/ directories live inside src/
- Renames PascalCase file name references to kebab-case (e.g., HomeScreen.tsx → home-screen.tsx, MobileText.tsx →
  mobile-text.tsx)
- Changes applied to 7 docs: using-logrocket, keyboard-handling, progressive-web-apps, using-resend, using-vexo,
  localization, and ios-universal-links


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Verify all updated code block annotations render correctly on the docs site locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples and file path references across multiple guides including keyboard handling, localization, progressive web apps, LogRocket integration, Resend integration, Vexo integration, and iOS universal links to reflect the current project structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->