### PR TITLE
[dev-launcher][ios] Respond to screen orientation changes

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 - [Android] Fix sometimes two dev menus would open. ([#42567](https://github.com/expo/expo/pull/42567) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Fix color of placeholder text in URL input. ([#42677](https://github.com/expo/expo/pull/42677) by [@alanjhughes](https://github.com/alanjhughes))
-- [ios] Dev launcher should respond to screen rotations. ([#42799](https://github.com/expo/expo/pull/42799) by [@douglowder](https://github.com/douglowder))
+- [iOS] Dev launcher should respond to screen rotations. ([#42799](https://github.com/expo/expo/pull/42799) by [@douglowder](https://github.com/douglowder))
 
 ## 55.0.4 — 2026-01-27
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - [Android] Fix sometimes two dev menus would open. ([#42567](https://github.com/expo/expo/pull/42567) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Fix color of placeholder text in URL input. ([#42677](https://github.com/expo/expo/pull/42677) by [@alanjhughes](https://github.com/alanjhughes))
+- [ios] Dev launcher should respond to screen rotations. ([#42799](https://github.com/expo/expo/pull/42799) by [@douglowder](https://github.com/douglowder))
 
 ## 55.0.4 — 2026-01-27
 

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -4,20 +4,20 @@ import ExpoModulesCore
 import EXUpdatesInterface
 import React
 
-public class DevLauncherWrapperView: UIView {
+private class DevLauncherWrapperView: UIView {
   weak var devLauncherViewController: UIViewController?
   private var devLauncherConstraints: [NSLayoutConstraint] = []
 
   #if os(iOS)
   @objc
-  public func orientationDidChange() {
+  func orientationDidChange() {
     if let controller = devLauncherViewController {
       setDevLauncherViewControllerConstraints(controller)
     }
   }
   #endif
 
-  public func setDevLauncherViewControllerConstraints(_ viewController: UIViewController) {
+  func setDevLauncherViewControllerConstraints(_ viewController: UIViewController) {
     viewController.view.translatesAutoresizingMaskIntoConstraints = false
     if !devLauncherConstraints.isEmpty {
       NSLayoutConstraint.deactivate(devLauncherConstraints)
@@ -32,7 +32,7 @@ public class DevLauncherWrapperView: UIView {
   }
 
 #if !os(macOS)
-  public override func didMoveToWindow() {
+  override func didMoveToWindow() {
     super.didMoveToWindow()
     #if os(iOS)
     if window != nil {
@@ -57,7 +57,7 @@ public class DevLauncherWrapperView: UIView {
     }
   }
 
-  public override func willMove(toWindow newWindow: UIWindow?) {
+  override func willMove(toWindow newWindow: UIWindow?) {
     super.willMove(toWindow: newWindow)
     if newWindow == nil {
       devLauncherViewController?.willMove(toParent: nil)


### PR DESCRIPTION
# Why

Testing an SDK 55 app showed that in development mode, the app was not laying out correctly in response to screen orientation changes on iPad.

Fixes #42459 .

# How

An update was needed to `DevLauncherWrapperView` to detect orientation changes and update constraints.

# Test Plan

- CI should pass
- Tested these changes in an SDK 55 app on iPad simulator



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * iOS dev launcher now properly responds to device screen rotations.
  * Layout refreshes on orientation change so UI elements reposition correctly.
  * Dev launcher view consistently fills the full viewport after rotation, preventing layout clipping or gaps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->