### PR TITLE
[docs] Fix AI Widget incorrectly showing fallback for on-page questions

### DIFF
--- a/docs/ui/components/AskPageAI/AskPageAIChatMessages.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChatMessages.tsx
@@ -85,10 +85,11 @@ export function AskPageAIChatMessages({
         const trimmedLower = trimmedAnswer?.toLowerCase() ?? '';
         const fallbackLower = fallbackResponse.toLowerCase();
         const hasSources = Array.isArray(qa.sources) && qa.sources.length > 0;
+        const normalizedBasePath = basePath.replace(/\/+$/, '');
         const isOffPageAnswer =
           contextScope === 'page' &&
           hasSources &&
-          qa.sources!.some(source => !source.source_url.includes(basePath));
+          qa.sources!.every(source => !source.source_url.includes(normalizedBasePath));
         const sourcesForDisplay = isOffPageAnswer ? [] : (qa.sources ?? []);
         const isFallbackAnswer =
           trimmedLower.includes(fallbackLower) ||


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

 The AI Assistant widget discards valid answers from Kapa and shows "Ican only answer questions about the current {page} documentation" with a "Search Expo docs" button, even when the question is clearly about the current page. This happens because the `isOffPageAnswer` check compares Kapa's source URLs against `basePath` using `String.includes()`, but basePath has a trailing slash (e.g., /versions/latest/sdk/apple-authentication/) while Kapa's source URLs don't (e.g., https://docs.expo.dev/versions/latest/sdk/apple-authentication). The mismatch causes the comparison to fail, so the widget replaces good answers with the fallback message.

Here's an example of a failed case:

<img width="1206" height="1116" alt="CleanShot 2026-02-03 at 03 25 00@2x" src="https://github.com/user-attachments/assets/abbe36c3-6dc6-4ea0-92dd-add3b910273a" />


# How

<!--
How did you build this feature or fix this bug and why?
-->

- Strip the trailing slash from `basePath` before comparing it against source URLs, so the `includes()` check matches regardless of trailing slash differences.
- Change `.some()` to ~.every()~ in the off-page check so answers are only treated as off-page when none of the sources match the current page, not when a single supplementary source happens to point elsewhere.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="4098" height="2382" alt="CleanShot 2026-02-03 at 03 52 26@2x" src="https://github.com/user-attachments/assets/a33df7f0-97c0-4b95-b0a7-af4b6a908f21" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved off-page source detection logic to be more accurate and consistent when evaluating content source locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->