### PR TITLE
[docs] fix Link.AppleZoom.Target to Link.AppleZoomTarget in zoom transition docs

### DIFF
--- a/docs/pages/router/advanced/zoom-transition.mdx
+++ b/docs/pages/router/advanced/zoom-transition.mdx
@@ -17,7 +17,7 @@ Zoom transitions provide a fluid animation effect when navigating between screen
 
 ## Get started
 
-To implement zoom transitions, you need to use the `Link.AppleZoom` component to mark the source element and optionally `Link.AppleZoom.Target` to specify the target alignment on the destination screen.
+To implement zoom transitions, you need to use the `Link.AppleZoom` component to mark the source element and optionally `Link.AppleZoomTarget` to specify the target alignment on the destination screen.
 
 ### Basic example
 
@@ -76,21 +76,21 @@ The `Link.AppleZoom` component wraps the element you want to zoom from. It is us
 
 ### Customizing alignment
 
-You can specify the alignment of the zoomed element on the destination screen by using `Link.AppleZoom.Target` element.
+You can specify the alignment of the zoomed element on the destination screen by using `Link.AppleZoomTarget` element.
 
 ```tsx app/image.tsx
 export default function ImageScreen() {
   return (
     <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <Link.AppleZoom.Target>
+      <Link.AppleZoomTarget>
         <Image source={{ uri: 'https://example.com/image-1.jpg' }} style={{ width: '100%' }} />
-      </Link.AppleZoom.Target>
+      </Link.AppleZoomTarget>
     </View>
   );
 }
 ```
 
-If you need more control over the alignment rectangle, you can pass an `alignmentRect` prop to `Link.AppleZoom`. However, this is normally not necessary if you use `Link.AppleZoom.Target`.
+If you need more control over the alignment rectangle, you can pass an `alignmentRect` prop to `Link.AppleZoom`. However, this is normally not necessary if you use `Link.AppleZoomTarget`.
 
 > **info** The `alignmentRect` prop internally relies on [`alignmentRectProvider`](https://developer.apple.com/documentation/uikit/uiviewcontroller/transition/zoomoptions/alignmentrectprovider) API.
 
@@ -311,7 +311,7 @@ We recommend avoiding the use of zoom transitions when navigating between screen
 
 <Collapsible summary="Single child requirement">
 
-Both `Link.AppleZoom` and `Link.AppleZoom.Target` only accept a single child component. If you attempt to pass multiple children, a warning will be logged and the component will not render properly.
+Both `Link.AppleZoom` and `Link.AppleZoomTarget` only accept a single child component. If you attempt to pass multiple children, a warning will be logged and the component will not render properly.
 
 **Incorrect:**
 


### PR DESCRIPTION
The documentation incorrectly referenced `Link.AppleZoom.Target` in several places, but the correct API is `Link.AppleZoomTarget` (a direct static property on Link, not a nested property under AppleZoom).

Fixed 5 occurrences throughout the zoom-transition.mdx documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API reference naming in zoom transition documentation to reflect current component naming conventions. All usage examples and guidance have been updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->