### PR TITLE
[expo-router] Fix typed routes generation missing Link.AppleZoom/AppleZoomTarget

### DIFF
--- a/packages/@expo/router-server/src/typed-routes/__tests__/default-types.tsd.ts
+++ b/packages/@expo/router-server/src/typed-routes/__tests__/default-types.tsd.ts
@@ -6,6 +6,7 @@ import {
   useLocalSearchParams,
   useSegments,
   UnknownOutputParams,
+  Link,
 } from './fixtures/default';
 
 // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -264,5 +265,28 @@ describe('set params', () => {
   });
   it('works without a generic', () => {
     expectType<void>(router.setParams({ hello: 'world' }));
+  });
+});
+describe('Link static properties', () => {
+  it('has AppleZoom property', () => {
+    expectType<typeof Link.AppleZoom>(Link.AppleZoom);
+  });
+  it('has AppleZoomTarget property', () => {
+    expectType<typeof Link.AppleZoomTarget>(Link.AppleZoomTarget);
+  });
+  it('has resolveHref property', () => {
+    expectType<typeof Link.resolveHref>(Link.resolveHref);
+  });
+  it('has Menu property', () => {
+    expectType<typeof Link.Menu>(Link.Menu);
+  });
+  it('has Trigger property', () => {
+    expectType<typeof Link.Trigger>(Link.Trigger);
+  });
+  it('has Preview property', () => {
+    expectType<typeof Link.Preview>(Link.Preview);
+  });
+  it('has MenuAction property', () => {
+    expectType<typeof Link.MenuAction>(Link.MenuAction);
   });
 });

--- a/packages/@expo/router-server/src/typed-routes/__tests__/fixtures/default.d.ts
+++ b/packages/@expo/router-server/src/typed-routes/__tests__/fixtures/default.d.ts
@@ -3,6 +3,9 @@ import * as Router from 'expo-router';
 
 export * from 'expo-router';
 
+// Re-export Link with proper static property types
+export declare const Link: Router.LinkComponent;
+
 declare module 'expo-router' {
   export namespace ExpoRouter {
     export interface __routes<T extends string | object = string> {

--- a/packages/@expo/router-server/src/typed-routes/__tests__/fixtures/partialGroups.d.ts
+++ b/packages/@expo/router-server/src/typed-routes/__tests__/fixtures/partialGroups.d.ts
@@ -3,6 +3,9 @@ import * as Router from 'expo-router';
 
 export * from 'expo-router';
 
+// Re-export Link with proper static property types
+export declare const Link: Router.LinkComponent;
+
 declare module 'expo-router' {
   export namespace ExpoRouter {
     export interface __routes<T extends string | object = string> {

--- a/packages/@expo/router-server/src/typed-routes/__tests__/type-generation.node.ts
+++ b/packages/@expo/router-server/src/typed-routes/__tests__/type-generation.node.ts
@@ -232,6 +232,9 @@ import * as Router from 'expo-router';
 
 export * from 'expo-router';
 
+// Re-export Link with proper static property types
+export declare const Link: Router.LinkComponent;
+
 declare module 'expo-router' {
   export namespace ExpoRouter {
     export interface __routes<T extends string | object = string> {

--- a/packages/@expo/router-server/src/typed-routes/generate.ts
+++ b/packages/@expo/router-server/src/typed-routes/generate.ts
@@ -120,6 +120,9 @@ import * as Router from 'expo-router';
 
 export * from 'expo-router';
 
+// Re-export Link with proper static property types
+export declare const Link: Router.LinkComponent;
+
 declare module 'expo-router' {
   export namespace ExpoRouter {
     export interface __routes<T extends string | object = string> {


### PR DESCRIPTION
@claude says:

> When typed routes are enabled, the generated router.d.ts file was missing proper type declarations for Link.AppleZoom and Link.AppleZoomTarget static properties. This caused TypeScript to report "Property 'AppleZoom' does not exist on type 'typeof Link'" errors.
>
> The fix adds an explicit re-export of the Link component with proper LinkComponent type in the generated declaration file:
>
>  export declare const Link: Router.LinkComponent;
>
> This ensures TypeScript correctly infers all static properties (AppleZoom, AppleZoomTarget, Menu, Preview, Trigger, MenuAction, resolveHref) when importing Link from the typed routes module.
>
> Fixes #42594

Feel free to disregard, I just saw this question in our Slack and thought I'd let Claude attempt to handle it. The solution / tests look reasonable to me, but I do not have any context all on this part of our codebase.