### PR TITLE
chore(router,router-server): Fix restrictive internal dependency ranges

### DIFF
--- a/packages/@expo/log-box/package.json
+++ b/packages/@expo/log-box/package.json
@@ -19,7 +19,7 @@
     "export:web": "expo export -p web --no-minify"
   },
   "dependencies": {
-    "@expo/dom-webview": "55.0.2",
+    "@expo/dom-webview": "^55.0.2",
     "anser": "^1.4.9",
     "stacktrace-parser": "^0.1.10"
   },

--- a/packages/@expo/router-server/CHANGELOG.md
+++ b/packages/@expo/router-server/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Open up `expo-font` dependency range in `@expo/router-server` ([#42808](https://github.com/expo/expo/pull/42808) by [@kitten](https://github.com/kitten))
+
 ## 55.0.4 — 2026-02-03
 
 ### 🐛 Bug fixes

--- a/packages/@expo/router-server/package.json
+++ b/packages/@expo/router-server/package.json
@@ -39,7 +39,7 @@
     "react-dom": "*",
     "expo": "*",
     "expo-constants": "^55.0.3",
-    "expo-font": "~55.0.3",
+    "expo-font": "^55.0.3",
     "expo-router": "*",
     "expo-server": "^55.0.3",
     "react-server-dom-webpack": "~19.0.1 || ~19.1.2 || ~19.2.1"

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `expo-image` dependency range in `expo-router` ([#42808](https://github.com/expo/expo/pull/42808) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 55.0.0-preview.5 — 2026-02-03

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -142,7 +142,7 @@
     "client-only": "^0.0.1",
     "debug": "^4.3.4",
     "escape-string-regexp": "^4.0.0",
-    "expo-image": "55.0.3",
+    "expo-image": "^55.0.3",
     "expo-server": "^55.0.3",
     "expo-symbols": "^55.0.3",
     "fast-deep-equal": "^3.1.3",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -101,7 +101,7 @@
     "whatwg-url-minimum": "^0.1.1"
   },
   "devDependencies": {
-    "@expo/dom-webview": "55.0.2",
+    "@expo/dom-webview": "^55.0.2",
     "@expo/metro-runtime": "^55.0.4",
     "@types/node": "^22.14.0",
     "@types/react": "~19.2.0",


### PR DESCRIPTION
# Why

The main issue that's present is that `expo-router -> expo-image` was pinned, but `expo-router` shouldn't excessively restrict this.

# How

See commits

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency version ranges for @expo/dom-webview, expo-font, and expo-image to allow compatible minor and patch updates across packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->