### PR TITLE
[docs] Update examples in guides to use `src/` for SDK 55

### DIFF
--- a/docs/pages/eas-update/trace-update-id-expo-dashboard.mdx
+++ b/docs/pages/eas-update/trace-update-id-expo-dashboard.mdx
@@ -13,7 +13,7 @@ To avoid this issue, you can use the `Updates.isEmbeddedLaunch` property to dete
 
 Here's an example of how you can display whether the update is embedded or downloaded:
 
-```tsx UpdateStatus.tsx
+```tsx update-status.tsx
 import * as Updates from 'expo-updates';
 import { Text } from 'react-native';
 

--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -101,7 +101,7 @@ Import the **global.css** file in your **src/app/\_layout.tsx** (if using Expo R
 <CodeBlocksTable tabs={['src/app/_layout.tsx', 'index.js']}>
 
 ```tsx
-import '../global.css';
+import '../../global.css';
 ```
 
 ```tsx
@@ -174,7 +174,7 @@ Import your CSS file in your **src/app/\_layout.tsx** (if using Expo Router) or 
 
 ```tsx
 // If using Expo Router, import your CSS file in the src/app/_layout.tsx file
-import '../global.css';
+import '../../global.css';
 ```
 
 ```tsx
@@ -242,7 +242,7 @@ Alternatively, you can use [DOM components](/guides/dom-components) to render yo
 'use dom';
 
 // Remember to import the global.css file in each DOM component.
-import '../global.css';
+import '../../global.css';
 
 export default function Page() {
   return (

--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -66,7 +66,7 @@ Add paths to all of your template files inside **tailwind.config.js**.
 module.exports = {
   content: [
     // Ensure this points to your source code
-    './app/**/*.{js,tsx,ts,jsx}',
+    './src/app/**/*.{js,tsx,ts,jsx}',
     // If you use a `src` directory, add: './src/**/*.{js,tsx,ts,jsx}'
     // Do the same with `components`, `hooks`, `styles`, or any other top-level directories
   ],
@@ -96,9 +96,9 @@ Create a **global.css** file in the root of your project and directives for each
 
 <Step label="4">
 
-Import the **global.css** file in your **app/\_layout.tsx** (if using Expo Router) or **index.js** file:
+Import the **global.css** file in your **src/app/\_layout.tsx** (if using Expo Router) or **index.js** file:
 
-<CodeBlocksTable tabs={['app/_layout.tsx', 'index.js']}>
+<CodeBlocksTable tabs={['src/app/_layout.tsx', 'index.js']}>
 
 ```tsx
 import '../global.css';
@@ -168,12 +168,12 @@ You can choose any name for this file. Using **global.css** is common practice.
 
 <Step label="4">
 
-Import your CSS file in your **app/\_layout.tsx** (if using Expo Router) or **index.js** file:
+Import your CSS file in your **src/app/\_layout.tsx** (if using Expo Router) or **index.js** file:
 
-<CodeBlocksTable tabs={['app/_layout.tsx', 'index.js']}>
+<CodeBlocksTable tabs={['src/app/_layout.tsx', 'index.js']}>
 
 ```tsx
-// If using Expo Router, import your CSS file in the app/_layout.tsx file
+// If using Expo Router, import your CSS file in the src/app/_layout.tsx file
 import '../global.css';
 ```
 
@@ -205,7 +205,7 @@ You now start your project and use Tailwind CSS classes in your components.
 You can use Tailwind with React DOM elements as-is:
 
 {/* prettier-ignore */}
-```tsx app/index.tsx
+```tsx src/app/index.tsx
 export default function Index() {
   return (
     <div className="bg-slate-100 rounded-xl">
@@ -217,7 +217,7 @@ export default function Index() {
 
 You can use the `{ $$css: true }` syntax to use Tailwind with React Native web elements:
 
-```tsx app/index.tsx
+```tsx src/app/index.tsx
 import { View, Text } from 'react-native';
 
 export default function Index() {
@@ -238,7 +238,7 @@ Tailwind does not support Android and iOS platforms. You can use a compatibility
 Alternatively, you can use [DOM components](/guides/dom-components) to render your Tailwind web code in a `WebView` on native.
 
 {/* prettier-ignore */}
-```tsx app/index.tsx
+```tsx src/app/index.tsx
 'use dom';
 
 // Remember to import the global.css file in each DOM component.

--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -42,7 +42,7 @@ Running the above command will run the `lint` script from **package.json**.
   cmd={[
     '# Example output for npx expo lint command',
     '',
-    '/app/components/HelloWave.tsx',
+    '/src/components/hello-wave.tsx',
     '  22:6 warning React Hook useEffect has a missing dependency: "rotateAnimation".',
     '       Either include it or remove the dependency array react-hooks/exhaustive-deps',
     '',
@@ -52,7 +52,7 @@ Running the above command will run the `lint` script from **package.json**.
 
 ### Environment configuration
 
-ESLint is generally configured for a single environment. However, the source code is written in JavaScript in an Expo app that runs in multiple different environments. For example, the **app.config.js**, **metro.config.js**, **babel.config.js**, and **app/+html.tsx** files are run in a Node.js environment. It means they have access to the global `__dirname` variable and can use Node.js modules such as `path`. Standard Expo project files like **app/index.js** can be run in Hermes, Node.js, or the web browser.
+ESLint is generally configured for a single environment. However, the source code is written in JavaScript in an Expo app that runs in multiple different environments. For example, the **app.config.js**, **metro.config.js**, **babel.config.js**, and **src/app/+html.tsx** files are run in a Node.js environment. It means they have access to the global `__dirname` variable and can use Node.js modules such as `path`. Standard Expo project files like **src/app/index.js** can be run in Hermes, Node.js, or the web browser.
 
 The approach to configure environment-specific globals differs between Flat config and legacy config:
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/expo/pull/42796

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Updates file path references across guides and linking docs to reflect the SDK 55 default project structure where app/,
components/, constants/, and hooks/ directories live inside `src/`.
- Applies to tailwind.mdx, using-eslint.mdx, and trace-update-id-expo-dashboard.mdx.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Verify all updated code block annotations render correctly on the docs site locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated guides and example code paths to reflect the `src/` directory layout (Tailwind and ESLint guides, sample imports and paths).
  * Corrected file naming and import references in code samples and documentation snippets.
  * Fixed a code block annotation to match updated filename casing in a dashboard guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->