### PR TITLE
[docs] Update examples in Expo Modules API to use src/ for SDK 55

### DIFF
--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -61,9 +61,9 @@ Then, if your project doesn't have native projects generated (**android** and **
 
 ### Use the local module
 
-Import the local module in your application, for example in **App.js** or **App.tsx** or **app/(tabs)/index.tsx**:
+Import the local module in your application, for example in **App.js** or **App.tsx** or **src/app/(tabs)/index.tsx**:
 
-```tsx app/(tabs)/index.tsx
+```tsx src/app/(tabs)/index.tsx
 /* @hide ...*/ /* @end */
 import MyModule from '@/modules/my-module';
 

--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -61,9 +61,9 @@ Then, if your project doesn't have native projects generated (**android** and **
 
 ### Use the local module
 
-Import the local module in your application, for example in **App.js** or **App.tsx** or **src/app/(tabs)/index.tsx**:
+Import the local module in your application, for example in **App.js** or **App.tsx** or **src/app/index.tsx**:
 
-```tsx src/app/(tabs)/index.tsx
+```tsx src/app/index.tsx
 /* @hide ...*/ /* @end */
 import MyModule from '@/modules/my-module';
 

--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -379,7 +379,7 @@ public class ExpoRadialChartModule: Module {
 
 You can update the app inside the **app** directory to test the module. Use the `ExpoRadialChartView` component to render a pie chart with three slices:
 
-```tsx app/(tabs)/index.tsx
+```tsx src/app/(tabs)/index.tsx
 import { ExpoRadialChartView } from '@/modules/expo-radial-chart';
 import { StyleSheet } from 'react-native';
 

--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -377,9 +377,9 @@ public class ExpoRadialChartModule: Module {
 
 ## Write an example app to use the module
 
-You can update the app inside the **app** directory to test the module. Use the `ExpoRadialChartView` component to render a pie chart with three slices:
+You can update the app inside the **src/app** directory to test the module. Use the `ExpoRadialChartView` component to render a pie chart with three slices:
 
-```tsx src/app/(tabs)/index.tsx
+```tsx src/app/index.tsx
 import { ExpoRadialChartView } from '@/modules/expo-radial-chart';
 import { StyleSheet } from 'react-native';
 

--- a/docs/pages/modules/use-standalone-expo-module-in-your-project.mdx
+++ b/docs/pages/modules/use-standalone-expo-module-in-your-project.mdx
@@ -83,7 +83,7 @@ Compile and run the app with the following command:
 
 You can now use the module in your app. To test it, edit the **app/(tabs)/index.tsx** file in your app and render the text message from the `expo-settings` module:
 
-```tsx app/(tabs)/index.tsx
+```tsx src/app/(tabs)/index.tsx
 import React from 'react';
 import { Text, View } from 'react-native';
 import * as Settings from 'expo-settings';
@@ -176,9 +176,9 @@ To test the published module in a new project, create a new app and install the 
   cmd={['$ npx create-expo-app my-app', '$ cd my-app', '$ npx expo install expo-settings']}
 />
 
-You can now use the module in your app! To test it, edit **app/(tabs)/index.tsx** and render the text message from **expo-settings**.
+You can now use the module in your app! To test it, edit **src/app/(tabs)/index.tsx** and render the text message from **expo-settings**.
 
-```tsx app/(tabs)/index.tsx
+```tsx src/app/(tabs)/index.tsx
 import React from 'react';
 import * as Settings from 'expo-settings';
 import { Text, View } from 'react-native';

--- a/docs/pages/modules/use-standalone-expo-module-in-your-project.mdx
+++ b/docs/pages/modules/use-standalone-expo-module-in-your-project.mdx
@@ -81,9 +81,9 @@ Compile and run the app with the following command:
   ]}
 />
 
-You can now use the module in your app. To test it, edit the **app/(tabs)/index.tsx** file in your app and render the text message from the `expo-settings` module:
+You can now use the module in your app. To test it, edit the **src/app/index.tsx** file in your app and render the text message from the `expo-settings` module:
 
-```tsx src/app/(tabs)/index.tsx
+```tsx src/app/index.tsx
 import React from 'react';
 import { Text, View } from 'react-native';
 import * as Settings from 'expo-settings';
@@ -176,9 +176,9 @@ To test the published module in a new project, create a new app and install the 
   cmd={['$ npx create-expo-app my-app', '$ cd my-app', '$ npx expo install expo-settings']}
 />
 
-You can now use the module in your app! To test it, edit **src/app/(tabs)/index.tsx** and render the text message from **expo-settings**.
+You can now use the module in your app! To test it, edit **src/app/index.tsx** and render the text message from **expo-settings**.
 
-```tsx src/app/(tabs)/index.tsx
+```tsx src/app/index.tsx
 import React from 'react';
 import * as Settings from 'expo-settings';
 import { Text, View } from 'react-native';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/expo/pull/42796

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Updates file path references across guides and linking docs to reflect the SDK 55 default project structure where app/,
components/, constants/, and hooks/ directories live inside src/.
- Applies to Expo Modules API section only

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Verify all updated code block annotations render correctly on the docs site locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples across multiple module guides to reflect the correct source directory paths, ensuring accurate import references in implementation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->