### PR TITLE
[expo] Update `react-native-screens` to `4.22.0`

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2924,7 +2924,7 @@ PODS:
     - ReactNativeDependencies
     - RNWorklets
     - Yoga
-  - RNScreens (4.20.0):
+  - RNScreens (4.22.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2946,9 +2946,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNScreens/common (= 4.20.0)
+    - RNScreens/common (= 4.22.0)
     - Yoga
-  - RNScreens/common (4.20.0):
+  - RNScreens/common (4.22.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3950,7 +3950,7 @@ SPEC CHECKSUMS:
   RNDateTimePicker: 5e0666de98f1edfac67ee7dde6be8a5415e487a0
   RNGestureHandler: 8e4a9372425d4caa9e3da5072a8dda7a54ed1097
   RNReanimated: 61462806110686a6f5d7c45c6f910cf73cd57dd9
-  RNScreens: dea74a9106daf3cbed39de1f5ce7ff4f96c5c722
+  RNScreens: ab386e79e49d0e4d95ed265d0ec7497c3b5bebfb
   RNSVG: 81c64c70e69ce2a1180a2f7355cada5f8aee001c
   RNWorklets: 87faff8e75d34d1240c75189e490e92901dd3544
   SDWebImage: f29024626962457f3470184232766516dee8dfea

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -75,7 +75,7 @@
     "react-native-pager-view": "6.9.1",
     "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "5.6.2",
-    "react-native-screens": "4.20.0",
+    "react-native-screens": "4.22.0",
     "react-native-svg": "15.15.1",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.16.0",

--- a/apps/brownfield-tester/expo-app/package.json
+++ b/apps/brownfield-tester/expo-app/package.json
@@ -35,7 +35,7 @@
     "react-native-worklets": "0.7.2",
     "react-native-reanimated": "~4.2.1",
     "react-native-safe-area-context": "~5.6.2",
-    "react-native-screens": "~4.20.0",
+    "react-native-screens": "~4.22.0",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3704,7 +3704,7 @@ PODS:
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNScreens (4.20.0):
+  - RNScreens (4.22.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3731,10 +3731,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.20.0)
+    - RNScreens/common (= 4.22.0)
     - SocketRocket
     - Yoga
-  - RNScreens/common (4.20.0):
+  - RNScreens/common (4.22.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -4823,7 +4823,7 @@ SPEC CHECKSUMS:
   RNDateTimePicker: e9e210197c267461f70f3f47bec705401ff72077
   RNGestureHandler: 77eecab5fd636666ca73a55bb61e2f1a685b7e84
   RNReanimated: 31da8d5f1605f5367e2392748ba9f4ba6eaf1178
-  RNScreens: b2a5c76af24a02a2fd71bfce42780fdd9c79cc6d
+  RNScreens: 47e9d9885f14d188d96c00c3db90d56e481539ef
   RNSVG: 55fc5dc0eaa36a875ffb7d05c0f2cd5b2cbfc342
   RNWorklets: 8e934a6b6d5a2710b9250e63a18a2d2f8b875a18
   SDWebImage: f29024626962457f3470184232766516dee8dfea

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -77,7 +77,7 @@
     "react-native-paper": "^5.12.5",
     "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "5.6.2",
-    "react-native-screens": "4.20.0",
+    "react-native-screens": "4.22.0",
     "react-native-svg": "15.15.1",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.16.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -152,7 +152,7 @@
     "react-native-worklets": "0.7.2",
     "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "5.6.2",
-    "react-native-screens": "4.20.0",
+    "react-native-screens": "4.22.0",
     "react-native-svg": "15.15.1",
     "react-native-view-shot": "4.0.3",
     "react-native-web": "~0.21.0",

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -36,7 +36,7 @@
     "react": "19.2.0",
     "react-native": "0.83.1",
     "react-native-safe-area-context": "5.6.2",
-    "react-native-screens": "4.20.0"
+    "react-native-screens": "4.22.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -71,7 +71,7 @@
     "react": "19.2.0",
     "react-native": "0.83.1",
     "react-native-safe-area-context": "5.6.2",
-    "react-native-screens": "4.20.0",
+    "react-native-screens": "4.22.0",
     "react-native-webview": "13.16.0"
   },
   "devDependencies": {

--- a/packages/@expo/cli/e2e/fixtures/with-monorepo/apps/app-a/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-monorepo/apps/app-a/package.json
@@ -13,7 +13,7 @@
     "react-dom": "19.2.0",
     "react-native": "0.83.1",
     "react-native-safe-area-context": "~5.6.2",
-    "react-native-screens": "~4.20.0",
+    "react-native-screens": "~4.22.0",
     "react-native-web": "~0.21.0"
   }
 }

--- a/packages/@expo/cli/e2e/fixtures/with-monorepo/apps/app-b/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-monorepo/apps/app-b/package.json
@@ -13,7 +13,7 @@
     "react-dom": "19.2.0",
     "react-native": "0.83.1",
     "react-native-safe-area-context": "~5.6.2",
-    "react-native-screens": "~4.20.0",
+    "react-native-screens": "~4.22.0",
     "react-native-web": "~0.21.0"
   }
 }

--- a/packages/@expo/cli/e2e/fixtures/with-router-typed-routes/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-router-typed-routes/package.json
@@ -13,7 +13,7 @@
     "react-dom": "19.2.0",
     "react-native": "0.83.1",
     "react-native-safe-area-context": "~5.6.2",
-    "react-native-screens": "~4.20.0",
+    "react-native-screens": "~4.22.0",
     "react-native-web": "~0.21.0"
   }
 }

--- a/packages/@expo/cli/e2e/fixtures/with-router/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-router/package.json
@@ -12,7 +12,7 @@
     "react-dom": "19.2.0",
     "react-native": "0.83.1",
     "react-native-safe-area-context": "~5.6.2",
-    "react-native-screens": "~4.20.0",
+    "react-native-screens": "~4.22.0",
     "react-native-web": "~0.21.0"
   }
 }

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -104,7 +104,7 @@
   "react-native-pager-view": "8.0.0",
   "react-native-worklets": "0.7.2",
   "react-native-reanimated": "~4.2.1",
-  "react-native-screens": "~4.20.0",
+  "react-native-screens": "~4.22.0",
   "react-native-safe-area-context": "~5.6.2",
   "react-native-svg": "15.15.1",
   "react-native-view-shot": "4.0.3",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -36,7 +36,7 @@
     "react-native-worklets": "0.7.2",
     "react-native-reanimated": "~4.2.1",
     "react-native-safe-area-context": "~5.6.2",
-    "react-native-screens": "~4.20.0",
+    "react-native-screens": "~4.22.0",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -27,7 +27,7 @@
     "react-native-worklets": "0.7.2",
     "react-native-reanimated": "~4.2.1",
     "react-native-safe-area-context": "~5.6.2",
-    "react-native-screens": "~4.20.0",
+    "react-native-screens": "~4.22.0",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13418,10 +13418,10 @@ react-native-screens@4.11.1-nightly-20250611-8b82e081e:
     react-native-is-edge-to-edge "^1.1.7"
     warn-once "^0.1.0"
 
-react-native-screens@4.20.0, react-native-screens@~4.20.0:
-  version "4.20.0"
-  resolved "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.20.0.tgz#16fc363a23f51495a15166982aadae58b0115947"
-  integrity sha512-wg3ILSd8yHM2YMsWqDjr1+Rxj1qn9CrzZ8qAqDXYd+jf6p3GIMwi+NugFUbRBRZMXs3MNEXCS1vAkvc2ZwpaAA==
+react-native-screens@4.22.0, react-native-screens@~4.22.0:
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.22.0.tgz#2e904bdb6227a355a78065f165f4e882315cb641"
+  integrity sha512-f1AtzxmgZlKeoioWzdNdQ/4SuqZ/w370KCBnA666pN8UZ33X4PkVJ/9v9y2y5sj0cXKEcgeN3Br9lmeDRQ735A==
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"


### PR DESCRIPTION
# Why

Updates `react-native-screens` to `4.22.0` to fix https://exponent-internal.slack.com/archives/C02T514E4RK/p1770061552337079?thread_ts=1770052320.422059&cid=C02T514E4RK

# Test Plan

- Bare expo and Expo Go on Android ✅ 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated react-native-screens to version 4.22.0 across apps, templates, and bundled modules to align dependency versions project-wide. No functional or public API changes expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->