### PR TITLE
refactor(cli): Replace QR code output with manual output with optional sextant-block mode

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 - Add `~/Android/Sdk` to detected Android SDK locations on Linux ([#42761](https://github.com/expo/expo/pull/42761) by [@kitten](https://github.com/kitten))
 - Bump to `fetch-nodeshim@^0.4.4` ([#42831](https://github.com/expo/expo/pull/42831) by [@kitten](https://github.com/kitten))
+- Add more compact QR code rendering for terminals that support it, unless `COLOR=0` is set or TTY is non-interactive ([#42834](https://github.com/expo/expo/pull/42834) by [@kitten](https://github.com/kitten))
 
 ## 55.0.5 — 2026-02-03
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -86,7 +86,6 @@
     "pretty-format": "^29.7.0",
     "progress": "^2.0.3",
     "prompts": "^2.3.2",
-    "qrcode-terminal": "0.11.0",
     "require-from-string": "^2.0.2",
     "resolve-from": "^5.0.0",
     "semver": "^7.6.0",

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -96,6 +96,7 @@
     "stacktrace-parser": "^0.1.10",
     "structured-headers": "^0.4.1",
     "terminal-link": "^2.1.1",
+    "toqr": "^0.1.0",
     "wrap-ansi": "^7.0.0",
     "ws": "^8.12.1",
     "zod": "^3.25.76"

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -95,7 +95,7 @@
     "stacktrace-parser": "^0.1.10",
     "structured-headers": "^0.4.1",
     "terminal-link": "^2.1.1",
-    "toqr": "^0.1.0",
+    "toqr": "^0.1.1",
     "wrap-ansi": "^7.0.0",
     "ws": "^8.12.1",
     "zod": "^3.25.76"

--- a/packages/@expo/cli/src/start/interface/commandsTable.ts
+++ b/packages/@expo/cli/src/start/interface/commandsTable.ts
@@ -1,6 +1,5 @@
 import { ExpoConfig } from '@expo/config';
 import chalk from 'chalk';
-import qrcode from 'qrcode-terminal';
 import wrapAnsi from 'wrap-ansi';
 
 import * as Log from '../../log';
@@ -21,11 +20,6 @@ export type StartOptions = {
 export const printHelp = (): void => {
   logCommandsTable([{ key: '?', msg: 'show all commands' }]);
 };
-
-/** Print the world famous 'Expo QR Code'. */
-export function printQRCode(url: string) {
-  qrcode.generate(url, { small: true }, (code) => Log.log(code));
-}
 
 export const getTerminalColumns = () => process.stdout.columns || 80;
 export const printItem = (text: string): string =>

--- a/packages/@expo/cli/src/start/interface/interactiveActions.ts
+++ b/packages/@expo/cli/src/start/interface/interactiveActions.ts
@@ -1,12 +1,12 @@
 import chalk from 'chalk';
 
-import { BLT, printHelp, printItem, printQRCode, printUsage, StartOptions } from './commandsTable';
+import { BLT, printHelp, printItem, printUsage, StartOptions } from './commandsTable';
 import { createDevToolsMenuItems } from './createDevToolsMenuItems';
 import * as Log from '../../log';
 import { env } from '../../utils/env';
 import { learnMore } from '../../utils/link';
-import { openBrowserAsync } from '../../utils/open';
 import { ExpoChoice, selectAsync } from '../../utils/prompts';
+import { printQRCode } from '../../utils/qr';
 import { DevServerManager } from '../server/DevServerManager';
 import {
   openJsInspector,

--- a/packages/@expo/cli/src/utils/qr.ts
+++ b/packages/@expo/cli/src/utils/qr.ts
@@ -1,0 +1,46 @@
+import { toQR } from 'toqr';
+
+import * as Log from '../log';
+
+/** Print the world famous 'Expo QR Code'. */
+export function printQRCode(url: string) {
+  const qr = toQR(url);
+  const output = createHalfblockOutput(qr);
+  Log.log(output + '\n');
+}
+
+/** ANSI QR code output by using half-blocks (2x1-sized unicode blocks) */
+function createHalfblockOutput(data: Uint8Array): string {
+  const extent = Math.sqrt(data.byteLength) | 0;
+  const CHAR_00 = '\u2588';
+  const CHAR_10 = '\u2584';
+  const CHAR_01 = '\u2580';
+  const CHAR_11 = ' ';
+  let output = '';
+  output += CHAR_10.repeat(extent + 2);
+  for (let row = 0; row < extent; row += 2) {
+    output += '\n' + CHAR_00;
+    for (let col = 0; col < extent; col++) {
+      const value = (data[row * extent + col] << 1) | data[(row + 1) * extent + col];
+      switch (value) {
+        case 0b00:
+          output += CHAR_00;
+          break;
+        case 0b01:
+          output += CHAR_01;
+          break;
+        case 0b10:
+          output += CHAR_10;
+          break;
+        case 0b11:
+          output += CHAR_11;
+          break;
+      }
+    }
+    output += CHAR_00;
+  }
+  if (extent % 2 === 0) {
+    output += '\n' + CHAR_01.repeat(extent + 2);
+  }
+  return output;
+}

--- a/packages/@expo/cli/src/utils/qr.ts
+++ b/packages/@expo/cli/src/utils/qr.ts
@@ -20,7 +20,10 @@ function supportsSextants() {
   }
   const isWindowsTerminal = process.platform === 'win32' && !!process.env.WT_SESSION?.length;
   const isGhostty = process.env.TERM_PROGRAM === 'ghostty';
-  return isWindowsTerminal || isGhostty;
+  const isWezterm = process.env.TERM_PROGRAM === 'WezTerm';
+  const isKitty = !!process.env.KITTY_WINDOW_ID?.length;
+  const isAlacritty = !!process.env.ALACRITTY_WINDOW_ID?.length;
+  return isWindowsTerminal || isGhostty || isWezterm || isKitty || isAlacritty;
 }
 
 /** ANSI QR code output by using half-blocks (1x2-sized unicode blocks) */

--- a/packages/@expo/cli/ts-declarations/qrcode-terminal/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/qrcode-terminal/index.d.ts
@@ -1,3 +1,0 @@
-declare module 'qrcode-terminal' {
-  export function generate(url: string, opts: { small: boolean }, cb: (code: string) => void): void;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13086,11 +13086,6 @@ pvutils@^1.1.3:
   resolved "https://registry.yarnpkg.com/pvutils/-/pvutils-1.1.3.tgz#f35fc1d27e7cd3dfbd39c0826d173e806a03f5a3"
   integrity sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==
 
-qrcode-terminal@0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/qrcode-terminal/-/qrcode-terminal-0.11.0.tgz#ffc6c28a2fc0bfb47052b47e23f4f446a5fbdb9e"
-  integrity sha1-/8bCii/Av7RwUrR+I/T0RqX7254=
-
 qs@6.13.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.13.0.tgz#6ca3bd58439f7e245655798997787b0d88a51906"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15309,10 +15309,10 @@ toidentifier@1.0.1, toidentifier@~1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
-toqr@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/toqr/-/toqr-0.1.0.tgz#c5b0342daa8dbe41108fca4563a83bd8dc013747"
-  integrity sha512-4CGF27PDWEKi0a/DRqwfyb2QPIYz8txynqlIRtbrSiT06KnC1kdmhcc/5MWARLRZ37RelwssnBkhsM1OsV07Kg==
+toqr@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/toqr/-/toqr-0.1.1.tgz#fb987ea706be36affc89336ca26543a16062725a"
+  integrity sha512-FWAPzCIHZHnrE/5/w9MPk0kK25hSQSH2IKhYh9PyjS3SG/+IEMvlwIHbhz+oF7xl54I+ueZlVnMjyzdSwLmAwA==
 
 tough-cookie@^4.1.2:
   version "4.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15314,6 +15314,11 @@ toidentifier@1.0.1, toidentifier@~1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
+toqr@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/toqr/-/toqr-0.1.0.tgz#c5b0342daa8dbe41108fca4563a83bd8dc013747"
+  integrity sha512-4CGF27PDWEKi0a/DRqwfyb2QPIYz8txynqlIRtbrSiT06KnC1kdmhcc/5MWARLRZ37RelwssnBkhsM1OsV07Kg==
+
 tough-cookie@^4.1.2:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf"


### PR DESCRIPTION
# Why

> [!NOTE]
> This replaces `qrcode-terminal` with `toqr` combined with our own printing code.

Resolves #42216

This replaces `qrcode-terminal`, since it hasn't been updated in a while, and to reduce the amount of older dependencies we're pulling in that might not have their supply-chain secured or use provenance releases. This also gives us an opportunity to refresh the QR code outputs.

For now, the added output is a small feature that uses sextant unicode block characters when certain terminal apps are used. These glyphs provide a 3x2 grid, rather than the 2x1 grid that we used to use via `qrcode-terminal`'s "small" output mode.

This is activated when we're detecting either:
- Windows Terminal (note: not the raw powershell or commandline programs)
- Alacritty
- Kitty
- Wezterm
- Ghostty

I've manually verified these terminals, and all of them seem to replace these glyphs with the appropriate box-drawing characters, regardless of the font used. The same doesn't apply to some other common terminals unfortunately, for example iTerm and macOS Terminal. We can currently only activate this output for vetted and tested terminal apps.

<table><tr>
<td><strong>Half-blocks</strong></td>
<td><strong>Sextants</strong></td>
</tr><tr>
<td><img width="790" height="337" alt="Screenshot 2026-02-03 at 15 43 20" src="https://github.com/user-attachments/assets/4d1f0ad0-b702-46a7-b907-2d90e829ea0d" /></td>
<td><img width="788" height="264" alt="Screenshot 2026-02-03 at 15 43 10" src="https://github.com/user-attachments/assets/067cc99c-d711-4284-977f-4cbf4424a4c3" /></td>
</tr></table>

The `toqr` encoding is using the exact same mode and logic as `qrcode-terminal`'s vendored QR encoding logic. **We shouldn't see any different QR code outputs.** This was tested manually against various different URLs.

The replacement code should be about 10x faster. Depending on the size of the QR code, `qrcode-terminal` could take 1-5ms while the new code consistently prints in <1ms in my testing on my machine. That makes the startup a little less computationally heavy.

### Notes

**Tested terminals that don't support sextent box drawing:**
- macOS Terminal.app
- iTerm 2
- VSCode Terminal
- Zed Terminal
- term.js
- Warp

Technically, we have two more options for graphics: the iTerm image protocol, and Kitty's graphics protocol. That only would really give us iTerm 2 support out of the above list. However, iTerm 2 creates a "security prompt" when trying to use the iTerm image protocol, which is annoying. When using the Kitty protocol with iTerm 2, the line wrapping is bugged and it overall doesn't behave very well.

# How

- Drop `qrcode-terminal` and replace with `toqr`
- Add manual output logic for half-blocks, matching `qrcode-terminal`
- Add output logic for sextants, activated if TTY is interactive, we're not on CI, and a supported terminal is detected

# Test Plan

- Manually run `expo start`; The QR code should scan without issue

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)