### PR TITLE
feat(cli): Reformat QR and usage guide messages

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### 💡 Others
 
 - Bump to `dnssd-advertise@^1.1.3` ([#42928](https://github.com/expo/expo/pull/42928) by [@kitten](https://github.com/kitten))
+- Add more compact QR code rendering for terminals that support it, unless `COLOR=0` is set or TTY is non-interactive ([#42834](https://github.com/expo/expo/pull/42834) by [@kitten](https://github.com/kitten))
+- Collapse usage guide on `expo start` if space is insufficient ([#42835](https://github.com/expo/expo/pull/42835) by [@kitten](https://gthub.com/kitten))
 
 ## 55.0.7 — 2026-02-08
 
@@ -36,7 +38,6 @@
 
 - Add `~/Android/Sdk` to detected Android SDK locations on Linux ([#42761](https://github.com/expo/expo/pull/42761) by [@kitten](https://github.com/kitten))
 - Bump to `fetch-nodeshim@^0.4.4` ([#42831](https://github.com/expo/expo/pull/42831) by [@kitten](https://github.com/kitten))
-- Add more compact QR code rendering for terminals that support it, unless `COLOR=0` is set or TTY is non-interactive ([#42834](https://github.com/expo/expo/pull/42834) by [@kitten](https://github.com/kitten))
 
 ## 55.0.5 — 2026-02-03
 

--- a/packages/@expo/cli/src/start/interface/commandsTable.ts
+++ b/packages/@expo/cli/src/start/interface/commandsTable.ts
@@ -45,10 +45,17 @@ export function printUsage(
   const switchMsg = `switch to ${options.devClient === false ? 'development build' : 'Expo Go'}`;
   const target = options.devClient === false ? `Expo Go` : 'development build';
 
-  Log.log();
-  Log.log(printItem(chalk`Using {cyan ${target}}`));
+  const printPrefix = ({ short }: { short: boolean }) => {
+    Log.log();
+    let message = chalk`Using {cyan ${target}}`;
+    if (!short) {
+      message += chalk` {dim │ Press {bold s} to ${switchMsg}}`;
+    }
+    Log.log(printItem(message));
+  };
 
   if (verbose) {
+    printPrefix({ short: true });
     return logCommandsTable([
       { key: 's', msg: switchMsg },
       {},
@@ -86,7 +93,10 @@ export function printUsage(
   // If we're not in verbose mode, we check if we have enough space. If we don't, we don't print
   // the full usage guide and rely on the `printHelp()` message being shown instead
   if ((rows || Infinity) - RESERVED_ROWS > table.lines) {
+    printPrefix({ short: true });
     table.print();
+  } else {
+    printPrefix({ short: false });
   }
 }
 

--- a/packages/@expo/cli/src/start/interface/commandsTable.ts
+++ b/packages/@expo/cli/src/start/interface/commandsTable.ts
@@ -55,7 +55,7 @@ export function printUsage(
     Log.log();
     let message = chalk`Using {cyan ${target}}`;
     if (!short) {
-      message += chalk` {dim │ Press {bold s} to ${switchMsg}}`;
+      message += chalk` {dim (Press {bold s} to ${switchMsg})}`;
     }
     Log.log(printItem(message));
   };

--- a/packages/@expo/cli/src/start/interface/commandsTable.ts
+++ b/packages/@expo/cli/src/start/interface/commandsTable.ts
@@ -27,8 +27,14 @@ export const printHelp = (): void => {
 };
 
 export const getTerminalColumns = () => process.stdout.columns || 80;
-export const printItem = (text: string): string =>
-  `${BLT} ` + wrapAnsi(text, getTerminalColumns()).trimStart();
+
+export const printItem = (text: string, opts?: { dim: boolean }): string => {
+  let output = `${BLT} ` + wrapAnsi(text, getTerminalColumns()).trimStart();
+  if (opts?.dim) {
+    output = chalk`{dim ${output}}`;
+  }
+  return output;
+};
 
 export function printUsage(
   options: Pick<StartOptions, 'devClient' | 'isWebSocketsEnabled' | 'platforms'>,

--- a/packages/@expo/cli/src/start/interface/interactiveActions.ts
+++ b/packages/@expo/cli/src/start/interface/interactiveActions.ts
@@ -54,7 +54,7 @@ export class DevServerManagerActions {
 
         let qrMessage = '';
         if (!options.devClient) {
-          qrMessage = `Scan the QR code to open in ${chalk`{bold Expo Go}`}.`;
+          qrMessage = `Scan the QR code above to open in ${chalk`{bold Expo Go}`}.`;
         } else {
           qrMessage = chalk`Scan the QR code above to open in a {bold development build}.`;
           qrMessage += ` (${learnMore('https://expo.fyi/start')})`;

--- a/packages/@expo/cli/src/start/interface/interactiveActions.ts
+++ b/packages/@expo/cli/src/start/interface/interactiveActions.ts
@@ -62,8 +62,6 @@ export class DevServerManagerActions {
         rows--;
         Log.log(printItem(qrMessage, { dim: true }));
 
-        // NOTE(@kitten): These currently always print the same hostname, which makes the URLs
-        // similar enough for us not having to print "Metro waiting on..." again. At most, the
         if (interstitialPageUrl) {
           rows--;
           Log.log(

--- a/packages/@expo/cli/src/start/interface/interactiveActions.ts
+++ b/packages/@expo/cli/src/start/interface/interactiveActions.ts
@@ -60,7 +60,7 @@ export class DevServerManagerActions {
           qrMessage += ` (${learnMore('https://expo.fyi/start')})`;
         }
         rows--;
-        Log.log(chalk`{dim ${printItem(qrMessage)}}`);
+        Log.log(printItem(qrMessage, { dim: true }));
 
         // NOTE(@kitten): These currently always print the same hostname, which makes the URLs
         // similar enough for us not having to print "Metro waiting on..." again. At most, the

--- a/packages/@expo/cli/src/start/interface/interactiveActions.ts
+++ b/packages/@expo/cli/src/start/interface/interactiveActions.ts
@@ -40,41 +40,41 @@ export class DevServerManagerActions {
         const nativeRuntimeUrl = devServer.getNativeRuntimeUrl()!;
         const interstitialPageUrl = devServer.getRedirectUrl();
 
-        const qr = printQRCode(interstitialPageUrl ?? nativeRuntimeUrl);
-        rows -= qr.lines;
-        qr.print();
-
-        if (interstitialPageUrl) {
-          Log.log(
-            printItem(
-              chalk`Choose an app to open your project at {underline ${interstitialPageUrl}}`
-            )
-          );
-          rows--;
-        }
-
+        // Print the URL to stdout for tests
         if (env.__EXPO_E2E_TEST) {
-          // Print the URL to stdout for tests
           console.info(
             `[__EXPO_E2E_TEST:server] ${JSON.stringify({ url: devServer.getDevServerUrl() })}`
           );
           rows--;
         }
 
-        Log.log(printItem(chalk`Metro waiting on {underline ${nativeRuntimeUrl}}`));
-        if (options.devClient === false) {
-          // TODO: if development build, change this message!
-          Log.log(printItem('Scan the QR code above to open the project in Expo Go.'));
-          rows--;
+        const qr = printQRCode(interstitialPageUrl ?? nativeRuntimeUrl);
+        rows -= qr.lines;
+        qr.print();
+
+        let qrMessage = '';
+        if (!options.devClient) {
+          qrMessage = `Scan the QR code to open in ${chalk`{bold Expo Go}`}.`;
         } else {
+          qrMessage = chalk`Scan the QR code above to open in a {bold development build}.`;
+          qrMessage += ` (${learnMore('https://expo.fyi/start')})`;
+        }
+        rows--;
+        Log.log(chalk`{dim ${printItem(qrMessage)}}`);
+
+        // NOTE(@kitten): These currently always print the same hostname, which makes the URLs
+        // similar enough for us not having to print "Metro waiting on..." again. At most, the
+        if (interstitialPageUrl) {
+          rows--;
           Log.log(
             printItem(
-              'Scan the QR code above to open the project in a development build. ' +
-                learnMore('https://expo.fyi/start')
+              chalk`Choose an app to open your project at {underline ${interstitialPageUrl}}`
             )
           );
-          rows--;
         }
+
+        rows--;
+        Log.log(printItem(chalk`Metro: {underline ${nativeRuntimeUrl}}`));
       } catch (error) {
         console.log('err', error);
         // @ts-ignore: If there is no development build scheme, then skip the QR code.
@@ -82,7 +82,7 @@ export class DevServerManagerActions {
           throw error;
         } else {
           const serverUrl = devServer.getDevServerUrl();
-          Log.log(printItem(chalk`Metro waiting on {underline ${serverUrl}}`));
+          Log.log(printItem(chalk`Metro: {underline ${serverUrl}}`));
           Log.log(printItem(`Linking is disabled because the client scheme cannot be resolved.`));
           rows -= 2;
         }
@@ -93,9 +93,8 @@ export class DevServerManagerActions {
       const webDevServer = this.devServerManager.getWebDevServer();
       const webUrl = webDevServer?.getDevServerUrl({ hostType: 'localhost' });
       if (webUrl) {
-        Log.log();
-        Log.log(printItem(chalk`Web is waiting on {underline ${webUrl}}`));
-        rows -= 2;
+        Log.log(printItem(chalk`Web: {underline ${webUrl}}`));
+        rows--;
       }
     }
 

--- a/packages/@expo/cli/src/start/server/DevServerManager.ts
+++ b/packages/@expo/cli/src/start/server/DevServerManager.ts
@@ -149,7 +149,8 @@ export class DevServerManager {
   /** Switch between Expo Go and Expo Dev Clients. */
   async toggleRuntimeMode(isUsingDevClient: boolean = !this.options.devClient): Promise<boolean> {
     const nextMode = isUsingDevClient ? '--dev-client' : '--go';
-    Log.log(printItem(chalk`Switching to {bold ${nextMode}}`));
+    Log.log(printItem(`Switching to ${chalk`{bold ${nextMode}}`}`, { dim: true }));
+    Log.log();
 
     const nextScheme = await resolveSchemeAsync(this.projectRoot, {
       devClient: isUsingDevClient,

--- a/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
@@ -223,7 +223,7 @@ export class MetroTerminalReporter extends TerminalReporter {
 
   _logInitializing(port: number, hasReducedPerformance: boolean): void {
     // Don't print a giant logo...
-    this.terminal.log(chalk.dim('Starting Metro Bundler'));
+    this.terminal.log(chalk.dim('Starting Metro Bundler') + '\n');
   }
 
   shouldFilterClientLog(event: { type: 'client_log'; data: unknown[] }): boolean {

--- a/packages/@expo/cli/src/utils/qr.ts
+++ b/packages/@expo/cli/src/utils/qr.ts
@@ -4,11 +4,21 @@ import { toQR } from 'toqr';
 import { env } from './env';
 import * as Log from '../log';
 
+export interface QROutput {
+  lines: number;
+  print(): void;
+}
+
 /** Print the world famous 'Expo QR Code'. */
-export function printQRCode(url: string) {
+export function printQRCode(url: string): QROutput {
   const qr = toQR(url);
   const output = supportsSextants() ? createSextantOutput(qr) : createHalfblockOutput(qr);
-  Log.log(output);
+  return {
+    lines: output.split('\n').length,
+    print() {
+      Log.log(output);
+    },
+  };
 }
 
 /** On specific terminals we can print a smaller QR code */


### PR DESCRIPTION
# Why

Branched off of #42834
Supersedes #42416

When we're in a very small terminal window, we might push the QR code off the visible screen area when printing the usage guide. Generally, I like the QR code above the information output a lot, since, for me at least, I'm looking at the messages that were printed bottom to top. That makes the QR code being on top look a little nicer and less jarring.

But when the terminal window is too small, we shouldn't print a large usage guide to avoid pushing the code off the screen. We can check `process.stdout.rows` (if it's set) and the QR code length to truncat the commands table, if we run out of space on startup.

This should be fine, since we'll still tell users to press `?` to bring up all commands, and generally, people will remember what they need anyway.

<img width="839" height="496" alt="image" src="https://github.com/user-attachments/assets/8269785c-3742-4de7-8e7f-cc92716464b7" />

We only cut off the key commands, but don't try to not output any of the other logs, since those are generally crucial to keep.

# How

- Keep track of qr code printing lengths
- Pass remaining available rows

**Some other formatting updates:**
- Move "Press s to switch..." next to "Using ..." message when we've run out of space
- Reformat Metro/Web links to say "Metro: [URL]" and "Web: [URL]"
- Move up QR message, shorten it, and recolor in dim
- Add newline after "Starting Metro Bundler" to separate output
- Add newline after "Switching to [X]" output and recolor in dim

# Test Plan

- Resize a terminal window to cut-off the QR code after `expo start`
  - When re-running `expo start`, it should omit the commands help section
  - Check that `?` still prints the full help section
  - Check that `c` re-prints the QR code message

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
