### PR TITLE
[docs] Add `@default` annotation support to `APISectionTypes`

### DIFF
--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -171,6 +171,12 @@ const renderType = (
   const defaultValue = parseCommentContent(
     defaultTag ? getCommentContent(defaultTag.content) : undefined
   );
+  const defaultValueElement = defaultValue ? (
+    <CALLOUT className="flex items-start gap-1">
+      <span className={STYLES_SECONDARY}>Default:</span>
+      <CODE className="!text-[90%]">{defaultValue}</CODE>
+    </CALLOUT>
+  ) : undefined;
 
   if (declaration) {
     // Object Types
@@ -182,7 +188,7 @@ const renderType = (
           name={`${name}${signature ? `(${signature.parameters ? listParams(signature.parameters) : ''})` : ''}`}
           comment={comment}
         />
-        <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={renderDefaultValue(defaultValue)} />
+        <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={defaultValueElement} />
         {declaration.children && renderTypeDeclarationTable(declaration, sdkVersion)}
         {signature ? (
           <div key={`type-definition-signature-${signature.name}`}>
@@ -215,7 +221,7 @@ const renderType = (
       <div key={`type-tuple-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
         <APIBoxHeader name={name} comment={comment} />
-        <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={renderDefaultValue(defaultValue)} />
+        <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={defaultValueElement} />
         <CALLOUT className={mergeClasses(STYLES_SECONDARY, VERTICAL_SPACING)}>
           Tuple: <CODE>{resolveTypeName(resolvedType, sdkVersion)}</CODE>
         </CALLOUT>
@@ -236,7 +242,7 @@ const renderType = (
         <div key={`prop-type-definition-${name}`} className={STYLES_APIBOX}>
           <APISectionDeprecationNote comment={comment} sticky />
           <APIBoxHeader name={name} comment={comment} />
-          <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={renderDefaultValue(defaultValue)} />
+          <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={defaultValueElement} />
           {resolvedType.type === 'intersection' || resolvedType.type === 'union' ? (
             <CALLOUT className={mergeClasses(STYLES_SECONDARY, VERTICAL_SPACING, ELEMENT_SPACING)}>
               Type:{' '}
@@ -286,7 +292,7 @@ const renderType = (
             <span className={STYLES_SECONDARY}>Literal Type: </span>
             {acceptedLiteralTypes ?? 'multiple types'}
           </CALLOUT>
-          <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={renderDefaultValue(defaultValue)} />
+          <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={defaultValueElement} />
           <CALLOUT className={mergeClasses(STYLES_SECONDARY, VERTICAL_SPACING, ELEMENT_SPACING)}>
             {shouldCollapseLiteralTypes ? (
               <>{COLLAPSED_LITERAL_MESSAGE}</>
@@ -319,7 +325,7 @@ const renderType = (
           <span className={STYLES_SECONDARY}>Type: </span>
           <APIDataType typeDefinition={resolvedType} sdkVersion={sdkVersion} />
         </CALLOUT>
-        <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={renderDefaultValue(defaultValue)} />
+        <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={defaultValueElement} />
       </div>
     );
   } else if (resolvedType.type === 'intrinsic') {
@@ -327,7 +333,7 @@ const renderType = (
       <div key={`generic-type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
         <APIBoxHeader name={name} comment={comment} />
-        <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={renderDefaultValue(defaultValue)} />
+        <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={defaultValueElement} />
         <CALLOUT className={mergeClasses(VERTICAL_SPACING, ELEMENT_SPACING)}>
           <span className={STYLES_SECONDARY}>Type: </span>
           <CODE>{resolvedType.name}</CODE>
@@ -339,7 +345,7 @@ const renderType = (
       <div key={`conditional-type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
         <APIBoxHeader name={`${name}<${resolvedType.checkType.name}>`} comment={comment} />
-        <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={renderDefaultValue(defaultValue)} />
+        <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={defaultValueElement} />
         <CALLOUT className={mergeClasses(VERTICAL_SPACING, 'mb-1')}>
           <span className={STYLES_SECONDARY}>Generic: </span>
           <CODE>
@@ -381,7 +387,7 @@ const renderType = (
       <div key={`conditional-type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
         <APIBoxHeader name={name} comment={comment} />
-        <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={renderDefaultValue(defaultValue)} />
+        <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={defaultValueElement} />
         <CALLOUT className={VERTICAL_SPACING}>
           String union of <CODE>{resolveTypeName(possibleData[0], sdkVersion)}</CODE> values.
         </CALLOUT>

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -188,7 +188,11 @@ const renderType = (
           name={`${name}${signature ? `(${signature.parameters ? listParams(signature.parameters) : ''})` : ''}`}
           comment={comment}
         />
-        <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={defaultValueElement} />
+        <APICommentTextBlock
+          comment={comment}
+          includePlatforms={false}
+          afterContent={defaultValueElement}
+        />
         {declaration.children && renderTypeDeclarationTable(declaration, sdkVersion)}
         {signature ? (
           <div key={`type-definition-signature-${signature.name}`}>
@@ -221,7 +225,11 @@ const renderType = (
       <div key={`type-tuple-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
         <APIBoxHeader name={name} comment={comment} />
-        <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={defaultValueElement} />
+        <APICommentTextBlock
+          comment={comment}
+          includePlatforms={false}
+          afterContent={defaultValueElement}
+        />
         <CALLOUT className={mergeClasses(STYLES_SECONDARY, VERTICAL_SPACING)}>
           Tuple: <CODE>{resolveTypeName(resolvedType, sdkVersion)}</CODE>
         </CALLOUT>
@@ -242,7 +250,11 @@ const renderType = (
         <div key={`prop-type-definition-${name}`} className={STYLES_APIBOX}>
           <APISectionDeprecationNote comment={comment} sticky />
           <APIBoxHeader name={name} comment={comment} />
-          <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={defaultValueElement} />
+          <APICommentTextBlock
+            comment={comment}
+            includePlatforms={false}
+            afterContent={defaultValueElement}
+          />
           {resolvedType.type === 'intersection' || resolvedType.type === 'union' ? (
             <CALLOUT className={mergeClasses(STYLES_SECONDARY, VERTICAL_SPACING, ELEMENT_SPACING)}>
               Type:{' '}
@@ -292,7 +304,11 @@ const renderType = (
             <span className={STYLES_SECONDARY}>Literal Type: </span>
             {acceptedLiteralTypes ?? 'multiple types'}
           </CALLOUT>
-          <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={defaultValueElement} />
+          <APICommentTextBlock
+            comment={comment}
+            includePlatforms={false}
+            afterContent={defaultValueElement}
+          />
           <CALLOUT className={mergeClasses(STYLES_SECONDARY, VERTICAL_SPACING, ELEMENT_SPACING)}>
             {shouldCollapseLiteralTypes ? (
               <>{COLLAPSED_LITERAL_MESSAGE}</>
@@ -325,7 +341,11 @@ const renderType = (
           <span className={STYLES_SECONDARY}>Type: </span>
           <APIDataType typeDefinition={resolvedType} sdkVersion={sdkVersion} />
         </CALLOUT>
-        <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={defaultValueElement} />
+        <APICommentTextBlock
+          comment={comment}
+          includePlatforms={false}
+          afterContent={defaultValueElement}
+        />
       </div>
     );
   } else if (resolvedType.type === 'intrinsic') {
@@ -333,7 +353,11 @@ const renderType = (
       <div key={`generic-type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
         <APIBoxHeader name={name} comment={comment} />
-        <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={defaultValueElement} />
+        <APICommentTextBlock
+          comment={comment}
+          includePlatforms={false}
+          afterContent={defaultValueElement}
+        />
         <CALLOUT className={mergeClasses(VERTICAL_SPACING, ELEMENT_SPACING)}>
           <span className={STYLES_SECONDARY}>Type: </span>
           <CODE>{resolvedType.name}</CODE>
@@ -345,7 +369,11 @@ const renderType = (
       <div key={`conditional-type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
         <APIBoxHeader name={`${name}<${resolvedType.checkType.name}>`} comment={comment} />
-        <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={defaultValueElement} />
+        <APICommentTextBlock
+          comment={comment}
+          includePlatforms={false}
+          afterContent={defaultValueElement}
+        />
         <CALLOUT className={mergeClasses(VERTICAL_SPACING, 'mb-1')}>
           <span className={STYLES_SECONDARY}>Generic: </span>
           <CODE>
@@ -387,7 +415,11 @@ const renderType = (
       <div key={`conditional-type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
         <APIBoxHeader name={name} comment={comment} />
-        <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={defaultValueElement} />
+        <APICommentTextBlock
+          comment={comment}
+          includePlatforms={false}
+          afterContent={defaultValueElement}
+        />
         <CALLOUT className={VERTICAL_SPACING}>
           String union of <CODE>{resolveTypeName(possibleData[0], sdkVersion)}</CODE> values.
         </CALLOUT>

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -167,6 +167,10 @@ const renderType = (
 ) => {
   const resolvedType = type ?? ({} as TypeDefinitionData);
   const declaration = resolvedType.declaration ?? (children ? { children } : undefined);
+  const defaultTag = getTagData('default', comment);
+  const defaultValue = parseCommentContent(
+    defaultTag ? getCommentContent(defaultTag.content) : undefined
+  );
 
   if (declaration) {
     // Object Types
@@ -178,7 +182,7 @@ const renderType = (
           name={`${name}${signature ? `(${signature.parameters ? listParams(signature.parameters) : ''})` : ''}`}
           comment={comment}
         />
-        <APICommentTextBlock comment={comment} includePlatforms={false} />
+        <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={renderDefaultValue(defaultValue)} />
         {declaration.children && renderTypeDeclarationTable(declaration, sdkVersion)}
         {signature ? (
           <div key={`type-definition-signature-${signature.name}`}>
@@ -211,7 +215,7 @@ const renderType = (
       <div key={`type-tuple-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
         <APIBoxHeader name={name} comment={comment} />
-        <APICommentTextBlock comment={comment} includePlatforms={false} />
+        <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={renderDefaultValue(defaultValue)} />
         <CALLOUT className={mergeClasses(STYLES_SECONDARY, VERTICAL_SPACING)}>
           Tuple: <CODE>{resolveTypeName(resolvedType, sdkVersion)}</CODE>
         </CALLOUT>
@@ -232,7 +236,7 @@ const renderType = (
         <div key={`prop-type-definition-${name}`} className={STYLES_APIBOX}>
           <APISectionDeprecationNote comment={comment} sticky />
           <APIBoxHeader name={name} comment={comment} />
-          <APICommentTextBlock comment={comment} includePlatforms={false} />
+          <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={renderDefaultValue(defaultValue)} />
           {resolvedType.type === 'intersection' || resolvedType.type === 'union' ? (
             <CALLOUT className={mergeClasses(STYLES_SECONDARY, VERTICAL_SPACING, ELEMENT_SPACING)}>
               Type:{' '}
@@ -282,7 +286,7 @@ const renderType = (
             <span className={STYLES_SECONDARY}>Literal Type: </span>
             {acceptedLiteralTypes ?? 'multiple types'}
           </CALLOUT>
-          <APICommentTextBlock comment={comment} includePlatforms={false} />
+          <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={renderDefaultValue(defaultValue)} />
           <CALLOUT className={mergeClasses(STYLES_SECONDARY, VERTICAL_SPACING, ELEMENT_SPACING)}>
             {shouldCollapseLiteralTypes ? (
               <>{COLLAPSED_LITERAL_MESSAGE}</>
@@ -315,7 +319,7 @@ const renderType = (
           <span className={STYLES_SECONDARY}>Type: </span>
           <APIDataType typeDefinition={resolvedType} sdkVersion={sdkVersion} />
         </CALLOUT>
-        <APICommentTextBlock comment={comment} includePlatforms={false} />
+        <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={renderDefaultValue(defaultValue)} />
       </div>
     );
   } else if (resolvedType.type === 'intrinsic') {
@@ -323,7 +327,7 @@ const renderType = (
       <div key={`generic-type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
         <APIBoxHeader name={name} comment={comment} />
-        <APICommentTextBlock comment={comment} includePlatforms={false} />
+        <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={renderDefaultValue(defaultValue)} />
         <CALLOUT className={mergeClasses(VERTICAL_SPACING, ELEMENT_SPACING)}>
           <span className={STYLES_SECONDARY}>Type: </span>
           <CODE>{resolvedType.name}</CODE>
@@ -335,7 +339,7 @@ const renderType = (
       <div key={`conditional-type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
         <APIBoxHeader name={`${name}<${resolvedType.checkType.name}>`} comment={comment} />
-        <APICommentTextBlock comment={comment} includePlatforms={false} />
+        <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={renderDefaultValue(defaultValue)} />
         <CALLOUT className={mergeClasses(VERTICAL_SPACING, 'mb-1')}>
           <span className={STYLES_SECONDARY}>Generic: </span>
           <CODE>
@@ -377,7 +381,7 @@ const renderType = (
       <div key={`conditional-type-definition-${name}`} className={STYLES_APIBOX}>
         <APISectionDeprecationNote comment={comment} sticky />
         <APIBoxHeader name={name} comment={comment} />
-        <APICommentTextBlock comment={comment} includePlatforms={false} />
+        <APICommentTextBlock comment={comment} includePlatforms={false} afterContent={renderDefaultValue(defaultValue)} />
         <CALLOUT className={VERTICAL_SPACING}>
           String union of <CODE>{resolveTypeName(possibleData[0], sdkVersion)}</CODE> values.
         </CALLOUT>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

While working https://github.com/expo/expo/pull/42837, I noticed that `@default` annotation support is missing from `APISectionTypes`.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add `@default` annoation support to `APISectionTypes` so `type` definitions (like this one here: https://github.com/expo/expo/pull/42837/files#diff-e86ea9facbc9f7d941e6c946c6f030df211e5abadfeab12263efc4b7cd9fdadcR518) can display default values.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2364" height="866" alt="CleanShot 2026-02-03 at 23 36 21@2x" src="https://github.com/user-attachments/assets/35925bc0-055a-42bf-bcce-4dbf98dfa6af" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  - API documentation now displays default values for type definitions and properties with labeled callouts for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->