### PR TITLE
[docs] Fix capitalization of Posthog to PostHog

### DIFF
--- a/docs/pages/guides/using-feature-flags.mdx
+++ b/docs/pages/guides/using-feature-flags.mdx
@@ -14,7 +14,7 @@ A feature flag (also known as a _feature gate_) is a mechanism that enables and 
 
 The following libraries provide robust support for feature flag functionality and out-of-the-box compatibility with Expo apps using [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/) and [config plugins](/config-plugins/introduction/) for seamless integration in your app.
 
-### Posthog
+### PostHog
 
 [PostHog](https://posthog.com/) is an open-source product analytics platform that provides comprehensive feature flagging capabilities alongside analytics, session recordings, and A/B testing. It supports real-time feature toggles with user segmentation and the ability to roll back features instantly, making it an excellent choice for teams that want analytics and feature management in a single platform. It includes built-in A/B testing and multivariate testing functionality, allowing you to run experiments directly through feature flags while collecting detailed analytics on feature adoption and performance metrics. The service also supports bootstrap flags to eliminate loading states and improve user experience.
 


### PR DESCRIPTION
Corrected the capitalization of 'Posthog' to 'PostHog' for consistency and correctness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the capitalization of PostHog in the Feature flag services section of the guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->