### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -50,17 +50,17 @@ jobs:
         api-level: [36]
     steps:
       - name: ⬢ Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
       - name: 👀 Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
       - name: 🧹 Cleanup GitHub Linux runner disk space
         uses: ./.github/actions/cleanup-linux-disk-space
       - name: 🔨 Use JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -86,7 +86,7 @@ jobs:
           script: expotools android-native-unit-tests --type instrumented
       - name: 💾 Save test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-results
           path: packages/**/build/outputs/androidTest-results/**/*

--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -35,17 +35,17 @@ jobs:
       GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx3072m -XX:MaxMetaspaceSize=1024m
     steps:
       - name: ⬢ Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
       - name: 👀 Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
       - name: 🧹 Cleanup GitHub Linux runner disk space
         uses: ./.github/actions/cleanup-linux-disk-space
       - name: 🔨 Use JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -71,7 +71,7 @@ jobs:
         run: expotools native-unit-tests --platform android
       - name: 💾 Save test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-results
           path: packages/**/build/test-results/**/*xml

--- a/.github/workflows/bare-diffs.yml
+++ b/.github/workflows/bare-diffs.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: ⬢ Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
       - name: ♻️ Restore caches
@@ -37,7 +37,7 @@ jobs:
           author_name: Check for Changes in Bare Diffs
       - name: 💾 Store artifacts of diff failures
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: template-bare-minimum-bare-diff-failure
           path: docs/public/static/diffs/template-bare-minimum/raw

--- a/.github/workflows/check-issues-nightly.yml
+++ b/.github/workflows/check-issues-nightly.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: ♻️ Restore caches

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -60,7 +60,7 @@ jobs:
         shard: [1, 2, 3, 4]
     steps:
       - name: 🏗️ Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 
@@ -72,7 +72,7 @@ jobs:
           bun-version: latest
 
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 100
       - name: ⬇️ Fetch commits from base branch
@@ -84,7 +84,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
         shell: bash
       - name: ♻️ Restore Yarn Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
@@ -124,7 +124,7 @@ jobs:
       EXPO_E2E_TEMP_DIR: D:\_temp\expo-e2e
     steps:
       - name: 🏗️ Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 
@@ -143,7 +143,7 @@ jobs:
           git config --global core.eol lf
 
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 100
       - name: ⬇️ Fetch commits from base branch
@@ -155,7 +155,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
         shell: bash
       - name: ♻️ Restore Yarn Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
@@ -185,7 +185,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: 🏗️ Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 
@@ -197,7 +197,7 @@ jobs:
           bun-version: latest
 
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 100
       - name: ⬇️ Fetch commits from base branch
@@ -208,7 +208,7 @@ jobs:
         id: yarn-cache
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: ♻️ Restore Yarn Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
@@ -229,7 +229,7 @@ jobs:
         run: |
           echo "version=$(npm info @playwright/test version)" >> $GITHUB_OUTPUT
       - name: 🎭 Cache Playwright browser binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: playwright-browser-cache
         with:
           path: ~/.cache/ms-playwright
@@ -244,7 +244,7 @@ jobs:
         run: yarn test:playwright
 
       - name: 🗄️ Upload playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: playwright-report
@@ -270,7 +270,7 @@ jobs:
       EXPO_E2E_TEMP_DIR: D:\_temp\expo-e2e
     steps:
       - name: 🏗️ Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 
@@ -289,7 +289,7 @@ jobs:
           git config --global core.eol lf
 
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 100
       - name: ⬇️ Fetch commits from base branch
@@ -301,7 +301,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
         shell: bash
       - name: ♻️ Restore Yarn Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
@@ -328,7 +328,7 @@ jobs:
           echo "version=$(npm info @playwright/test version)" >> $GITHUB_OUTPUT
           echo "dir=$(echo $PLAYWRIGHT_BROWSERS_PATH)" >> $GITHUB_OUTPUT
       - name: 🎭 Cache Playwright browser binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: playwright-browser-cache
         with:
           path: ${{ steps.playwright-info.outputs.dir }}
@@ -343,7 +343,7 @@ jobs:
         run: yarn test:playwright --shard ${{ matrix.shard }}/${{ strategy.job-total }}
 
       - name: 🗄️ Upload playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -18,9 +18,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: ⬢ Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
       - name: ➕ Add `bin` to GITHUB_PATH

--- a/.github/workflows/commentator.yml
+++ b/.github/workflows/commentator.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: ♻️ Restore caches

--- a/.github/workflows/create-expo-app.yml
+++ b/.github/workflows/create-expo-app.yml
@@ -28,23 +28,23 @@ jobs:
         node: [20, 22]
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 100
       - name: ⬇️ Fetch commits from base branch
         run: git fetch origin ${{ github.event.before || github.base_ref || 'main' }}:${{ github.event.before || github.base_ref || 'main' }} --depth 100
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
       - name: 🏗️ Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 9.x
       - name: 🏗️ Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
           # TODO(cedric): swap `latest` back once the issue is resolved
           bun-version: latest
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
       - name: ♻️ Restore caches

--- a/.github/workflows/development-client-e2e.yml
+++ b/.github/workflows/development-client-e2e.yml
@@ -24,7 +24,7 @@ jobs:
         api-level: [36]
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🍺 Install required tools
@@ -60,7 +60,7 @@ jobs:
         working-directory: packages/expo-dev-client
       - name: 💾 Store artifacts of build failures
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: expo-dev-client-e2e-artifacts
           path: packages/expo-dev-client/artifacts

--- a/.github/workflows/development-client-latest-e2e.yml
+++ b/.github/workflows/development-client-latest-e2e.yml
@@ -17,7 +17,7 @@ jobs:
         api-level: [36]
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🍺 Install required tools
@@ -33,7 +33,7 @@ jobs:
       - name: 💎 Install cocoapods
         run: sudo gem install cocoapods
       - name: 🔨 Use JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '11'
@@ -58,7 +58,7 @@ jobs:
         working-directory: packages/expo-dev-client
       - name: 💾 Store artifacts of build failures
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: expo-dev-client-latest-e2e-artifacts
           path: packages/expo-dev-client/artifacts

--- a/.github/workflows/development-client.yml
+++ b/.github/workflows/development-client.yml
@@ -26,7 +26,7 @@ jobs:
         ndk-version: [21.4.7075529]
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: ♻️ Restore caches
@@ -83,7 +83,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: ♻️ Restore caches

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: ⬢ Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
       - name: ♻️ Restore caches

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 30000
       - name: ⬢ Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
       - name: ♻️ Restore caches

--- a/.github/workflows/expotools.yml
+++ b/.github/workflows/expotools.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/.github/workflows/fingerprint.yml
+++ b/.github/workflows/fingerprint.yml
@@ -30,11 +30,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 100
       - name: ⬢ Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
       - name: 🚀 Setup Bun
@@ -127,7 +127,7 @@ jobs:
             node ../expo/packages/@expo/fingerprint/bin/cli.js fingerprint:generate > ../expo/fingerprint-${{ matrix.os }}.json
           }
       - name: 📤 Upload fingerprint
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: fingerprint-${{ matrix.os }}
           path: fingerprint-${{ matrix.os }}.json
@@ -137,17 +137,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Download fingerprint (macos)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: fingerprint-macos-latest
 
       - name: 📥 Download fingerprint (ubuntu)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: fingerprint-ubuntu-latest
 
       - name: 📥 Download fingerprint (windows)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: fingerprint-windows-latest
 

--- a/.github/workflows/ios-static-frameworks.yml
+++ b/.github/workflows/ios-static-frameworks.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
       - name: 🔨 Switch to Xcode 26.2

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -41,7 +41,7 @@ jobs:
     timeout-minutes: 75
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
       - name: 🔨 Switch to Xcode 26.2

--- a/.github/workflows/issue-closed.yml
+++ b/.github/workflows/issue-closed.yml
@@ -10,7 +10,7 @@ jobs:
     if: contains(github.event.issue.labels.*.name, 'Issue accepted')
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: ♻️ Restore caches

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -19,7 +19,7 @@ jobs:
           text: 'This issue should be triaged ASAP: ${{ github.event.issue.html_url }}'
           author_name: ${{ github.event.issue.user.login }}
           fields: repo
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         if: ${{ contains( env.TRUSTED_USERS, github.event.issue.user.login ) }}
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: ♻️ Restore caches

--- a/.github/workflows/issue-stale.yml
+++ b/.github/workflows/issue-stale.yml
@@ -8,7 +8,7 @@ jobs:
   close-issues:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v10
         with:
           ascending: false
           operations-per-run: 300

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: "${{ contains(github.event.label.name, 'incomplete issue: missing or invalid repro') }}"
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: "${{ contains(github.event.label.name, 'incomplete issue: missing info') }}"
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -86,7 +86,7 @@ jobs:
     if: github.event.label.name == 'issue accepted'
     steps:
       - name: Comment on issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -99,7 +99,7 @@ jobs:
               However, we can’t promise any sort of timeline for resolution. We prioritize issues based on severity, breadth of impact, and alignment with our roadmap. If you’d like to help move it more quickly, you can continue to investigate it more deeply and/or you can open a pull request that fixes the cause.
             `})
       - name: Remove "Needs Review" label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             try {
@@ -115,7 +115,7 @@ jobs:
               }
             }
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: ♻️ Restore caches
@@ -134,7 +134,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: "${{ contains(github.event.label.name, 'invalid issue: question') }}"
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -162,7 +162,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: "${{ contains(github.event.label.name, 'invalid issue: feature request') }}"
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -185,7 +185,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: "${{ contains(github.event.label.name, 'invalid issue: third-party library') }}"
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -212,7 +212,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: "${{ contains(github.event.label.name, 'invalid issue: react-native-core') }}"
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -234,7 +234,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: "${{ github.event.label.name == 'Comments on closed issue' }}"
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -256,7 +256,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: "${{ github.event.label.name == 'invalid issue: EAS Build troubleshooting' }}"
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -278,7 +278,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: "${{ github.event.label.name == 'Version bump PR' }}"
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -17,7 +17,7 @@ jobs:
   action:
     runs-on: ubuntu-24.04
     steps:
-      - uses: dessant/lock-threads@v5
+      - uses: dessant/lock-threads@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-inactive-days: '180'

--- a/.github/workflows/native-component-list.yml
+++ b/.github/workflows/native-component-list.yml
@@ -27,11 +27,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
       - name: ⬢ Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
       - name: ♻️ Restore caches

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -37,14 +37,14 @@ jobs:
       actions: write
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 100
       - name: ⬇️ Fetch commits from base branch
         run: git fetch origin main:main --depth 100
         if: github.event_name == 'pull_request'
       - name: ⬢ Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
       - name: ♻️ Restore caches
@@ -74,7 +74,7 @@ jobs:
           echo "isPreviousFingerprintEmpty=${{ steps.fingerprint.outputs.previous-fingerprint == '' }}"
 
       - name: 🏷️ Labeling PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         if: ${{ github.event_name == 'pull_request' && steps.fingerprint.outputs.previous-fingerprint != '' && steps.fingerprint.outputs.fingerprint-diff == '[]' }}
         with:
           script: |
@@ -97,7 +97,7 @@ jobs:
               labels: ['bot: fingerprint compatible']
             })
       - name: 🏷️ Labeling PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         if: ${{ github.event_name == 'pull_request' && steps.fingerprint.outputs.previous-fingerprint != '' && steps.fingerprint.outputs.fingerprint-diff != '[]' }}
         with:
           script: |
@@ -121,7 +121,7 @@ jobs:
             })
 
       - name: 🔍 Find old comment if it exists
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@v4
         if: ${{ github.event_name == 'pull_request' }}
         id: old_comment
         with:
@@ -130,7 +130,7 @@ jobs:
           body-includes: <!-- pr-labeler comment -->
       - name: 💬 Add comment with fingerprint
         if: ${{ github.event_name == 'pull_request' && steps.fingerprint.outputs.previous-fingerprint != '' && steps.fingerprint.outputs.fingerprint-diff != '[]' && steps.old_comment.outputs.comment-id == '' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -157,7 +157,7 @@ jobs:
             });
       - name: 💬 Update comment with fingerprint
         if: ${{ github.event_name == 'pull_request' && steps.fingerprint.outputs.previous-fingerprint != '' && steps.fingerprint.outputs.fingerprint-diff != '[]' && steps.old_comment.outputs.comment-id != '' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -185,7 +185,7 @@ jobs:
             });
       - name: 💬 Delete comment with fingerprint
         if: ${{ github.event_name == 'pull_request' && steps.fingerprint.outputs.previous-fingerprint != '' && steps.fingerprint.outputs.fingerprint-diff == '[]' && steps.old_comment.outputs.comment-id != '' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/publish-canaries.yml
+++ b/.github/workflows/publish-canaries.yml
@@ -19,14 +19,14 @@ jobs:
       NODE_AUTH_TOKEN: ${{ secrets.EXPO_BOT_NPM_TOKEN }}
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: ⬢ Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
       - name: 🔨 Use JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/sdk-cutoff.yml
+++ b/.github/workflows/sdk-cutoff.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Cut release branch
         run: |
           git checkout -b sdk-${{ github.event.inputs.sdkVersion }}

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 100
       - uses: dorny/paths-filter@v3
@@ -45,7 +45,7 @@ jobs:
       - name: ⬇️ Fetch commits from base branch
         run: git fetch origin ${{ github.base_ref || github.event.before || 'main' }}:${{ github.base_ref || github.event.before || 'main' }} --depth 100
         if: github.event_name == 'pull_request'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
       - name: 🏗️ Setup Bun
@@ -87,10 +87,10 @@ jobs:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 100
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
       - name: 🏗️ Setup Bun

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: 🚚 Rename .gitignore
         run: mv ./templates/expo-template-default/gitignore ./templates/expo-template-default/.gitignore
       - name: 🚀 Push changes to the template repository

--- a/.github/workflows/test-react-native-nightly.yml
+++ b/.github/workflows/test-react-native-nightly.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: 🔨 Switch to Xcode 26.2
         run: sudo xcode-select --switch /Applications/Xcode_26.2.app
       - name: 🍺 Install required tools
@@ -75,7 +75,7 @@ jobs:
           NODE_ENV: production
           CONFIGURATION: ${{ matrix.build-type == 'release' && 'Release' || 'Debug' }}
       - name: 📸 Upload builds
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ github.event_name == 'workflow_dispatch' && matrix.build-type == 'release' }} # Only archive release builds
         with:
           name: ios-builds-arch-${{ matrix.build-type }}
@@ -99,7 +99,7 @@ jobs:
       GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx4096m -XX:MaxMetaspaceSize=4096m"
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: 🧹 Cleanup GitHub Linux runner disk space
         uses: ./.github/actions/cleanup-linux-disk-space
       - name: 🚀 Setup Bun
@@ -107,7 +107,7 @@ jobs:
         with:
           bun-version: latest
       - name: 🔨 Use JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -136,7 +136,7 @@ jobs:
           NODE_ENV: production
           VARIANT: ${{ matrix.build-type == 'release' && 'Release' || 'Debug' }}
       - name: 📸 Upload builds
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ github.event_name == 'workflow_dispatch' && matrix.build-type == 'release' }} # Only archive release builds
         with:
           name: android-builds-${{ matrix.build-type }}

--- a/.github/workflows/test-suite-brownfield.yml
+++ b/.github/workflows/test-suite-brownfield.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
       - name: 🔨 Switch to Xcode 26.2
@@ -81,7 +81,7 @@ jobs:
           NODE_ENV: production
           CONFIGURATION: ${{ matrix.build-type == 'release' && 'Release' || 'Debug' }}
       - name: 📸 Upload builds
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ github.event_name == 'workflow_dispatch' && matrix.build-type == 'release' }} # Only archive release builds
         with:
           name: ios-builds-${{ matrix.build-type }}
@@ -114,7 +114,7 @@ jobs:
         with:
           bun-version: latest
       - name: 🔨 Use JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -138,7 +138,7 @@ jobs:
           NODE_ENV: production
           VARIANT: ${{ matrix.build-type == 'release' && 'Release' || 'Debug' }}
       - name: 📸 Upload builds
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ github.event_name == 'workflow_dispatch' && matrix.build-type == 'release' }} # Only archive release builds
         with:
           name: android-builds-${{ matrix.build-type }}

--- a/.github/workflows/test-suite-lint.yml
+++ b/.github/workflows/test-suite-lint.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
       - name: ⬢ Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
       - name: ♻️ Restore caches

--- a/.github/workflows/test-suite-macos.yml
+++ b/.github/workflows/test-suite-macos.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
       - name: 🔨 Switch to Xcode 26.2
@@ -99,7 +99,7 @@ jobs:
           EXPO_DEBUG: 1
           NODE_ENV: production
       - name: 📸 Upload builds
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: bare-expo-macos-builds
           path: apps/bare-expo/macos/build/BareExpo.app

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -35,7 +35,7 @@ jobs:
       should_run_android: ${{ steps.changes.outputs.should_run_android }}
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: 🧐 Detect platform change
         id: changes
         uses: ./.github/actions/detect-platform-change
@@ -66,7 +66,7 @@ jobs:
       actions: write
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -152,7 +152,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: true
       - name: 🏗️ Setup Bun
@@ -166,7 +166,7 @@ jobs:
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🌠 Download builds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: bare-expo-ios-builds
           path: apps/bare-expo/ios/build/BareExpo.app
@@ -214,7 +214,7 @@ jobs:
           mv ~/.maestro ~/maestroArtifacts
       - name: 📸 Store testing artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         id: upload-artifacts
         with:
           name: bare-expo-artifacts-ios
@@ -254,7 +254,7 @@ jobs:
       GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx4096m -XX:MaxMetaspaceSize=4096m"
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: 🧹 Cleanup GitHub Linux runner disk space
         uses: ./.github/actions/cleanup-linux-disk-space
       - name: 🏗️ Setup Bun
@@ -264,7 +264,7 @@ jobs:
           # TODO(cedric): swap `latest` back once the issue is resolved
           bun-version: latest
       - name: 🔨 Use JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -337,7 +337,7 @@ jobs:
         api-level: [36]
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: 🧹 Cleanup GitHub Linux runner disk space
         uses: ./.github/actions/cleanup-linux-disk-space
       - name: 🏗️ Setup Bun
@@ -347,7 +347,7 @@ jobs:
           # TODO(cedric): swap `latest` back once the issue is resolved
           bun-version: latest
       - name: 🌠 Download builds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: bare-expo-android-builds
           path: apps/bare-expo/android/app/build/outputs/apk/release
@@ -387,7 +387,7 @@ jobs:
       - name: 📸 Store testing artifacts
         if: always()
         id: upload-artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: bare-expo-artifacts-android
           path: |

--- a/.github/workflows/validate-npm-owners.yml
+++ b/.github/workflows/validate-npm-owners.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: ♻️ Restore caches


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/create-expo-app.yml`
- Updated `actions/setup-java` from `v4` to `v5` in `.github/workflows/test-react-native-nightly.yml`
- Updated `actions/github-script` from `v7` to `v8` in `.github/workflows/issue-opened.yml`
- Updated `dessant/lock-threads` from `v5` to `v6` in `.github/workflows/lock.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/android-instrumentation-tests.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/android-instrumentation-tests.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/fingerprint.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/ios-unit-tests.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/issue-triage.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/native-component-list.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/issue-closed.yml`
- Updated `actions/setup-java` from `v4` to `v5` in `.github/workflows/test-suite.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/pr-labeler.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/development-client-latest-e2e.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/cli.yml`
- Updated `actions/github-script` from `v7` to `v8` in `.github/workflows/docs-pr.yml`
- Updated `actions/setup-java` from `v4` to `v5` in `.github/workflows/android-unit-tests.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/check-issues-nightly.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/cli.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/docs.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/development-client-e2e.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/fingerprint.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/ios-static-frameworks.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/bare-diffs.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/development-client.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/test-react-native-nightly.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/issue-opened.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/android-instrumentation-tests.yml`
- Updated `actions/download-artifact` from `v4` to `v7` in `.github/workflows/fingerprint.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/code-review.yml`
- Updated `actions/cache` from `v4` to `v5` in `.github/workflows/cli.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/code-review.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/sdk-cutoff.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/expotools.yml`
- Updated `oven-sh/setup-bun` from `v1` to `v2` in `.github/workflows/create-expo-app.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/development-client-latest-e2e.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/docs-pr.yml`
- Updated `actions/setup-java` from `v4` to `v5` in `.github/workflows/development-client-latest-e2e.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/test-suite-lint.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/cli.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/sdk.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/android-unit-tests.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/fingerprint.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/test-suite-lint.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/commentator.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/test-suite.yml`
- Updated `actions/setup-java` from `v4` to `v5` in `.github/workflows/android-instrumentation-tests.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/docs.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/test-suite-brownfield.yml`
- Updated `actions/setup-java` from `v4` to `v5` in `.github/workflows/publish-canaries.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/test-suite-macos.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/test-suite-brownfield.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/pr-labeler.yml`
- Updated `peter-evans/find-comment` from `v3` to `v4` in `.github/workflows/docs-pr.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/validate-npm-owners.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/test-suite.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/android-unit-tests.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/sdk.yml`
- Updated `actions/github-script` from `v7` to `v8` in `.github/workflows/issue-triage.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/bare-diffs.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/publish-canaries.yml`
- Updated `pnpm/action-setup` from `v3` to `v4` in `.github/workflows/create-expo-app.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/docs-pr.yml`
- Updated `actions/download-artifact` from `v4` to `v7` in `.github/workflows/test-suite.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/sync-template.yml`
- Updated `peter-evans/find-comment` from `v3` to `v4` in `.github/workflows/pr-labeler.yml`
- Updated `actions/setup-java` from `v4` to `v5` in `.github/workflows/test-suite-brownfield.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/test-suite-macos.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/publish-canaries.yml`
- Updated `actions/stale` from `v4` to `v10` in `.github/workflows/issue-stale.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/android-unit-tests.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/development-client-e2e.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/bare-diffs.yml`
- Updated `actions/github-script` from `v7` to `v8` in `.github/workflows/pr-labeler.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/test-react-native-nightly.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/native-component-list.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/create-expo-app.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions and workflow tools to newer versions across all continuous integration and deployment pipelines. Changes include checkout actions, Node.js and Java setup tools, artifact upload and download utilities, caching mechanisms, GitHub scripting features, stale issue handling, thread locking, repository synchronization, npm package owner validation, and related build tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->