### PR TITLE
[docs] Update common-navigation-patterns guide in Expo Router for SDK 55

### DIFF
--- a/docs/pages/router/basics/common-navigation-patterns.mdx
+++ b/docs/pages/router/basics/common-navigation-patterns.mdx
@@ -21,19 +21,19 @@ Consider the following navigation tree:
 
 <FileTree
   files={[
-    ['app/(tabs)/\_layout.tsx'],
-    ['app/(tabs)/index.tsx', 'single page tab'],
-    ['app/(tabs)/feed/_layout.tsx', 'tab with a stack inside'],
-    ['app/(tabs)/feed/index.tsx'],
-    ['app/(tabs)/feed/[postId].tsx'],
-    ['app/(tabs)/settings.tsx', 'single page tab'],
+    ['src/app/(tabs)/\_layout.tsx'],
+    ['src/app/(tabs)/index.tsx', 'single page tab'],
+    ['src/app/(tabs)/feed/\_layout.tsx', 'tab with a stack inside'],
+    ['src/app/(tabs)/feed/index.tsx'],
+    ['src/app/(tabs)/feed/[postId].tsx'],
+    ['src/app/(tabs)/settings.tsx', 'single page tab'],
   ]}
 />
 
-In the **app/(tabs)/\_layout.tsx** file, return a `Tabs` component:
+In the **src/app/(tabs)/\_layout.tsx** file, return a `Tabs` component:
 
 {/* prettier-ignore */}
-```tsx app/(tabs)/_layout.tsx
+```tsx src/app/(tabs)/_layout.tsx
 import { Tabs } from 'expo-router';
 
 export default function TabLayout() {
@@ -49,9 +49,9 @@ export default function TabLayout() {
 }
 ```
 
-In the **app/(tabs)/feed/\_layout.tsx** file, return a `Stack` component:
+In the **src/app/(tabs)/feed/\_layout.tsx** file, return a `Stack` component:
 
-```tsx app/(tabs)/feed/_layout.tsx
+```tsx src/app/(tabs)/feed/_layout.tsx
 import { Stack } from 'expo-router';
 
 /* @info Setting <CODE>initialRouteName</CODE> ensures that direct links deep into the stack still push the index route onto the stack first. */
@@ -65,11 +65,11 @@ export default function FeedLayout() {
 }
 ```
 
-Now, within the **app/(tabs)/feed** directory, you can have `Link` components that point to different posts (for example, `/feed/123`). Those links will push the `feed/[postId]` route onto the stack, leaving the tab navigator visible.
+Now, within the **src/app/(tabs)/feed** directory, you can have `Link` components that point to different posts (for example, `/feed/123`). Those links will push the `feed/[postId]` route onto the stack, leaving the tab navigator visible.
 
 You can also navigate from any other tab to a post in the feed tab with the same URL. Use `withAnchor` in conjunction with `initialRouteName` to ensure that the `feed/index` route is always the first screen in the stack:
 
-```tsx app/(tabs)/feed/index.tsx
+```tsx src/app/(tabs)/feed/index.tsx
 <Link href="/feed/123" withAnchor>
   Go to post
 </Link>
@@ -84,23 +84,42 @@ You can also nest tabs inside of an outer stack navigator. That is often more us
   Icon={BookOpen02Icon}
 />
 
+## Different tabs per platform: platform-specific tabs
+
+When building a cross-platform app, you may want to use [native tabs](/router/advanced/native-tabs/) on Android and iOS for a platform-native look and feel, while using [custom tabs](/router/advanced/custom-tabs/) on web for full control over styling. You can achieve this using [platform-specific file extensions](/router/advanced/platform-specific-modules/).
+
+<FileTree
+  files={[
+    ['src/app/\_layout.tsx', 'imports AppTabs'],
+    ['src/app/index.tsx'],
+    ['src/app/feed.tsx'],
+    ['src/app/profile.tsx'],
+    ['src/components/app-tabs.native.tsx', 'AppTabs (native tabs) for Android and iOS'],
+    ['src/components/app-tabs.tsx', 'AppTabs (custom tabs) for web'],
+  ]}
+/>
+
+The root layout renders an `AppTabs` component. Expo's module resolution automatically picks **app-tabs.native.tsx** on Android and iOS, and **app-tabs.tsx** on web, allowing each platform to use a tab implementation suited to its conventions.
+
+For a complete example of this pattern with code, see [Platform-specific tabs](/router/basics/layout/#platform-specific-tabs) in the Layout guide.
+
 ## One screen, two tabs: sharing routes
 
 Route groups can be used to share a single screen between two different tabs. Consider a navigation tree that has a Feed tab and a Search tab, and they both share pages for viewing a user profile:
 
 <FileTree
   files={[
-    ['app/(tabs)/\_layout.tsx'],
-    ['app/(tabs)/(feed)/index.tsx', 'default route'],
-    ['app/(tabs)/(search)/search.tsx'],
-    ['app/(tabs)/(feed,search)/_layout.tsx', 'layout shared between the two tabs'],
-    ['app/(tabs)/(feed,search)/users/[username].tsx', 'shared user profile page'],
+    ['src/app/(tabs)/\_layout.tsx'],
+    ['src/app/(tabs)/(feed)/index.tsx', 'default route'],
+    ['src/app/(tabs)/(search)/search.tsx'],
+    ['src/app/(tabs)/(feed,search)/\_layout.tsx', 'layout shared between the two tabs'],
+    ['src/app/(tabs)/(feed,search)/users/[username].tsx', 'shared user profile page'],
   ]}
 />
 
-Each of the tabs is put in a group so you can define a third directory that shares routes between two groups (**app/(tabs)/(feed,search)/**). Even with the extra layer, **app/(tabs)/(feed)/index.tsx** is still the nearest index, so it will be the default route.
+Each of the tabs is put in a group so you can define a third directory that shares routes between two groups (**src/app/(tabs)/(feed,search)/**). Even with the extra layer, **src/app/(tabs)/(feed)/index.tsx** is still the nearest index, so it will be the default route.
 
-```tsx app/(tabs)/_layout.tsx
+```tsx src/app/(tabs)/_layout.tsx
 import { Tabs } from 'expo-router';
 
 export default function TabLayout() {
@@ -115,7 +134,7 @@ export default function TabLayout() {
 
 Both the `(feed)` and `(search)` route groups contain stacks, so they can also share a single layout:
 
-```tsx app/(tabs)/(feed,search)/_layout.tsx
+```tsx src/app/(tabs)/(feed,search)/_layout.tsx
 import { Stack } from 'expo-router';
 
 export default function SharedLayout() {
@@ -144,24 +163,24 @@ For example, consider the following navigation tree in which you have a bottom t
 
 <FileTree
   files={[
-    ['app/_layout.tsx', 'Root layout'],
-    ['app/(tabs)/_layout.tsx'],
+    ['src/app/\_layout.tsx', 'Root layout'],
+    ['src/app/(tabs)/\_layout.tsx'],
     [
-      'app/(tabs)/index.tsx',
+      'src/app/(tabs)/index.tsx',
       <span>
         Protected <Lock01Icon className="mb-1 inline" />
       </span>,
     ],
     [
-      'app/(tabs)/settings.tsx',
+      'src/app/(tabs)/settings.tsx',
       <span>
         Protected <Lock01Icon className="mb-1 inline" />
       </span>,
     ],
-    ['app/sign-in.tsx'],
-    ['app/create-account.tsx'],
+    ['src/app/sign-in.tsx'],
+    ['src/app/create-account.tsx'],
     [
-      'app/modal.tsx',
+      'src/app/modal.tsx',
       <span>
         Protected <Lock01Icon className="mb-1 inline" />
       </span>,
@@ -169,9 +188,9 @@ For example, consider the following navigation tree in which you have a bottom t
   ]}
 />
 
-When your app is first launched, the router will try to open the root index, **app/(tabs)/index.tsx**. If you wrap this screen in a `Stack.Protected` with the `guard={false}`, the screen will become inaccessible and the next available screen will be opened instead. In this example, the `sign-in` screen will be opened, since it is the next available route.
+When your app is first launched, the router will try to open the root index, **src/app/(tabs)/index.tsx**. If you wrap this screen in a `Stack.Protected` with the `guard={false}`, the screen will become inaccessible and the next available screen will be opened instead. In this example, the `sign-in` screen will be opened, since it is the next available route.
 
-```tsx app/_layout.tsx
+```tsx src/app/_layout.tsx
 import { Stack } from 'expo-router';
 import { useAuthState } from '@/utils/authState';
 
@@ -200,7 +219,7 @@ Another benefit of protected routes is that they are checked even if you deep li
 
 Protected routes can also be used to conditionally show bottom tabs. In this example, the `vip` tab will only be shown to authenticated users who are VIP members:
 
-```tsx app/(tabs)/_layout.tsx
+```tsx src/app/(tabs)/_layout.tsx
 import { Stack } from 'expo-router';
 import { useAuthState } from '@/utils/authState';
 
@@ -234,7 +253,7 @@ Separating your navigation states into distinct routes is meant to serve you and
 
 Thinking back to authentication, the protected route setup works great if the user should simply not be able to visit certain pages without logging in. But what about when unauthenticated users can browse an app in read-only mode? In that case, you might want to show a login modal over the app, rather than redirecting the user to a login page:
 
-```tsx app/(logged-in)/_layout.tsx
+```tsx src/app/(logged-in)/_layout.tsx
 import { Modal } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Stack } from 'expo-router';

--- a/docs/pages/router/basics/common-navigation-patterns.mdx
+++ b/docs/pages/router/basics/common-navigation-patterns.mdx
@@ -94,12 +94,12 @@ When building a cross-platform app, you may want to use [native tabs](/router/ad
     ['src/app/index.tsx'],
     ['src/app/feed.tsx'],
     ['src/app/profile.tsx'],
-    ['src/components/app-tabs.tsx', 'AppTabs (native tabs) for Android and iOS'],
-    ['src/components/app-tabs.web.tsx', 'AppTabs (custom tabs) for web'],
+    ['src/components/app-tabs.native.tsx', 'AppTabs (native tabs) for Android and iOS'],
+    ['src/components/app-tabs.tsx', 'AppTabs (custom tabs) for web'],
   ]}
 />
 
-The root layout renders an `AppTabs` component. Expo's module resolution automatically picks **app-tabs.tsx** on Android and iOS, and **app-tabs.web.tsx** on web, allowing each platform to use a tab implementation suited to its conventions.
+The root layout renders an `AppTabs` component. Expo's module resolution automatically picks **app-tabs.native.tsx** on Android and iOS, and **app-tabs.tsx** on web, allowing each platform to use a tab implementation suited to its conventions.
 
 For a complete example of this pattern with code, see [Platform-specific tabs](/router/basics/layout/#platform-specific-tabs) in the Layout guide.
 

--- a/docs/pages/router/basics/common-navigation-patterns.mdx
+++ b/docs/pages/router/basics/common-navigation-patterns.mdx
@@ -94,12 +94,12 @@ When building a cross-platform app, you may want to use [native tabs](/router/ad
     ['src/app/index.tsx'],
     ['src/app/feed.tsx'],
     ['src/app/profile.tsx'],
-    ['src/components/app-tabs.native.tsx', 'AppTabs (native tabs) for Android and iOS'],
-    ['src/components/app-tabs.tsx', 'AppTabs (custom tabs) for web'],
+    ['src/components/app-tabs.tsx', 'AppTabs (native tabs) for Android and iOS'],
+    ['src/components/app-tabs.web.tsx', 'AppTabs (custom tabs) for web'],
   ]}
 />
 
-The root layout renders an `AppTabs` component. Expo's module resolution automatically picks **app-tabs.native.tsx** on Android and iOS, and **app-tabs.tsx** on web, allowing each platform to use a tab implementation suited to its conventions.
+The root layout renders an `AppTabs` component. Expo's module resolution automatically picks **app-tabs.tsx** on Android and iOS, and **app-tabs.web.tsx** on web, allowing each platform to use a tab implementation suited to its conventions.
 
 For a complete example of this pattern with code, see [Platform-specific tabs](/router/basics/layout/#platform-specific-tabs) in the Layout guide.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Update common-navigation-patterns guide in Expo Router for SDK 55

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update file path references from app/ to src/app/ throughout the common navigation patterns page
- Add a new "Different tabs per platform" section documenting the pattern of using native tabs on Android/iOS and custom tabs on web via platform-specific file extensions

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Visit: http://localhost:3002/router/basics/common-navigation-patterns/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
