### PR TITLE
[doctor] Add Xcode 26.0.0 requirement for SDK 55

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Add Xcode 26.0.0 requirement for SDK 55 ([#42852](https://github.com/expo/expo/pull/42852) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 1.18.4 — 2026-02-03
 
 ### 🐛 Bug fixes

--- a/packages/expo-doctor/src/checks/NativeToolingVersionCheck.ts
+++ b/packages/expo-doctor/src/checks/NativeToolingVersionCheck.ts
@@ -39,6 +39,7 @@ async function checkMinimumXcodeVersionAsync(
   // Table of SDK version compatibility with Xcode versions
   const compatibilityTable: Record<string, string> = {
     '51': '<=16.2.0',
+    '55': '>=26.0.0',
   };
 
   const majorSdkVersion = semver.major(sdkVersion).toString();

--- a/packages/expo-doctor/src/checks/__tests__/NativeToolingVersionCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/NativeToolingVersionCheck.test.ts
@@ -184,4 +184,32 @@ describe('runAsync', () => {
     const result = await check.runAsync(additionalProjectProps);
     expect(result.isSuccessful).toBeTruthy();
   });
+
+  test('returns error if sdk version >= 55.0.0 and xcode version < 26', async () => {
+    jest.mocked(getXcodeVersionAsync).mockResolvedValueOnce({ xcodeVersion: '25.0.0' });
+
+    const check = new NativeToolingVersionCheck();
+    const result = await check.runAsync({
+      ...additionalProjectProps,
+      exp: {
+        ...additionalProjectProps.exp,
+        sdkVersion: '55.0.0',
+      },
+    });
+    expect(result.isSuccessful).toBeFalsy();
+  });
+
+  test('returns success if sdk version >= 55.0.0 and xcode version >= 26', async () => {
+    jest.mocked(getXcodeVersionAsync).mockResolvedValueOnce({ xcodeVersion: '26.0.0' });
+
+    const check = new NativeToolingVersionCheck();
+    const result = await check.runAsync({
+      ...additionalProjectProps,
+      exp: {
+        ...additionalProjectProps.exp,
+        sdkVersion: '55.0.0',
+      },
+    });
+    expect(result.isSuccessful).toBeTruthy();
+  });
 });


### PR DESCRIPTION
# Why

SDK 55 uses isolate protocol conformance for `HostingView` and this feature was only implemented Swift 6.2, which is bundled with Xcode >= 26.0

# How

Add sdk 55 entry to doctor's compatibility table

# Test Plan

Run expo-doctor locally and added new unit tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
