### PR TITLE
fix(log-box): fix SPA styles for logbox

### DIFF
--- a/packages/@expo/log-box/.npmignore
+++ b/packages/@expo/log-box/.npmignore
@@ -21,3 +21,4 @@ __rsc_tests__
 
 # This flag file trigger on-demand bundling during native builds in the Expo monorepo
 /.bundle-on-demand
+/CLAUDE.md

--- a/packages/@expo/log-box/CHANGELOG.md
+++ b/packages/@expo/log-box/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Migrate away from react-native-web to fix styles in SPA output.
+
 ### 💡 Others
 
 ## 55.0.5 — 2026-02-03

--- a/packages/@expo/log-box/CHANGELOG.md
+++ b/packages/@expo/log-box/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Migrate away from react-native-web to fix styles in SPA output.
+- Migrate away from react-native-web to fix styles in SPA output. ([#42853](https://github.com/expo/expo/pull/42853) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/log-box/CLAUDE.md
+++ b/packages/@expo/log-box/CLAUDE.md
@@ -1,0 +1,175 @@
+# @expo/log-box
+
+A universal error overlay for Expo apps that displays runtime errors, warnings, and build errors with symbolicated stack traces.
+
+## Package Structure
+
+```
+src/
+├── Data/                    # State management and data parsing
+│   ├── LogBoxData.tsx       # Central state store (observer pattern)
+│   ├── LogBoxLog.ts         # Log object + React context
+│   ├── parseLogBoxLog.ts    # Error parsing and categorization
+│   └── Types.ts             # TypeScript definitions
+├── overlay/                 # Full-screen error inspector
+│   ├── Overlay.tsx          # Main inspector component
+│   ├── Header.tsx           # Top bar with controls
+│   ├── StackTraceList.tsx   # Animated stack trace display
+│   ├── CodeFrame.tsx        # Code snippet with syntax highlighting
+│   ├── Message.tsx          # Error message rendering
+│   ├── AnsiHighlight.tsx    # ANSI terminal color parsing
+│   └── *.module.css         # CSS modules for each component
+├── toast/                   # Minimal error notification
+│   ├── ErrorToast.tsx       # Bottom-left toast
+│   └── ErrorToast.module.css
+├── utils/                   # Shared utilities
+│   ├── renderInShadowRoot.ts    # Shadow DOM isolation
+│   ├── devServerEndpoints.ts    # Dev server communication
+│   └── parseErrorStack.ts       # Stack trace parsing
+├── LogBox.ts                # Main API (install, middleware)
+├── index.tsx                # Web entry point
+├── index.native.tsx         # Native entry point (no-op)
+├── logbox-dom-polyfill.tsx  # DOM wrapper component
+├── logbox-rn-polyfill.tsx   # React Native Modal wrapper
+└── logbox-web-polyfill.tsx  # Static build error display
+```
+
+## How It Works
+
+### 1. Installation & Entry Points
+
+**Web (`src/index.tsx`):**
+- Auto-installs in development mode when `EXPO_OS === 'web'`
+- Renders ErrorToast into a Shadow DOM to isolate styles
+- `LogBox.install()` patches `console.error` to capture errors
+
+**Native (`src/index.native.tsx`):**
+- No-op - native platforms use React Native's built-in LogBox
+- The `logbox-rn-polyfill.tsx` provides native Modal presentation when needed
+
+### 2. Error Capture Flow
+
+```
+console.error() called
+    ↓
+LogBox middleware intercepts (LogBox.ts)
+    ↓
+parseLogBoxLog() parses into structured data
+    ↓
+LogBoxData.addLog() stores in Set<LogBoxLog>
+    ↓
+Observers notified → UI re-renders
+    ↓
+Symbolication requested from dev server
+    ↓
+Stack traces resolved → UI updates with source locations
+```
+
+### 3. Data Layer
+
+**LogBoxData.tsx** - Central state store using observer pattern:
+- `logs: Set<LogBoxLog>` - All captured logs
+- `selectedLogIndex` - Currently viewed log in overlay
+- `isDisabled` - Whether LogBox is suppressed
+- Implements rollup: duplicate errors increment count instead of adding new entries
+
+**LogBoxLog** - Individual log object:
+```typescript
+{
+  level: 'error' | 'fatal' | 'syntax' | 'static',
+  message: { content: string, substitutions: [] },
+  category: string,           // Used for deduplication
+  stack: MetroStackFrame[],   // JS call stack
+  componentStack: MetroStackFrame[],  // React component tree
+  codeFrame: { content, fileName, location },
+  symbolicated: { stack, component }  // Resolved source maps
+}
+```
+
+### 4. UI Components
+
+**ErrorToast** - Minimal notification:
+- Shows error count badge and truncated message
+- Click to open full overlay
+- Dismiss button clears errors
+
+**Overlay** - Full inspector:
+- Header with navigation (prev/next error), reload, minimize
+- Error message with syntax highlighting
+- CodeFrame showing source code context
+- StackTraceList with collapsible frames
+- "Open in editor" functionality
+
+### 5. Symbolication
+
+Stack traces start as raw JS locations and get resolved to source code:
+
+1. Raw stack captured from error
+2. Request sent to dev server `/symbolicate` endpoint
+3. Server uses source maps to resolve original locations
+4. UI updates with file names, line numbers, code preview
+5. Results cached to avoid duplicate requests
+
+States: `PENDING` → `COMPLETE` or `FAILED`
+
+### 6. Shadow DOM Isolation
+
+Web builds render into Shadow DOM (`renderInShadowRoot.ts`):
+- Prevents LogBox styles from affecting the app
+- Prevents app styles from affecting LogBox
+- Copies only necessary stylesheets into shadow root
+
+## Build Process
+
+```bash
+yarn build:lib     # TypeScript → build/ (types + JS)
+yarn build:bundle  # Metro bundle → dist/ExpoLogBox.bundle/
+yarn build         # Both
+```
+
+**Output:**
+- `build/` - TypeScript compilation output
+- `dist/ExpoLogBox.bundle/` - Bundled web assets (HTML + JS + CSS)
+
+## CSS Architecture
+
+All styles use CSS Modules (`.module.css`) with CSS custom properties:
+
+```css
+--expo-log-color-background: #111113
+--expo-log-color-border: #313538
+--expo-log-color-label: #edeef0
+--expo-log-color-danger: rgb(220, 103, 99)
+--expo-log-font-family: system-ui, -apple-system, ...
+--expo-log-font-mono: SFMono-Regular, Menlo, ...
+```
+
+## Key Files for Common Tasks
+
+| Task | Files |
+|------|-------|
+| Change error parsing | `Data/parseLogBoxLog.ts` |
+| Modify toast appearance | `toast/ErrorToast.tsx`, `ErrorToast.module.css` |
+| Update overlay UI | `overlay/Overlay.tsx`, `Overlay.module.css` |
+| Change stack trace display | `overlay/StackTraceList.tsx` |
+| Modify code frame | `overlay/CodeFrame.tsx` |
+| Update state management | `Data/LogBoxData.tsx` |
+| Change dev server endpoints | `utils/devServerEndpoints.ts` |
+
+## Platform Differences
+
+| Feature | Web | Native |
+|---------|-----|--------|
+| Entry point | `index.tsx` | `index.native.tsx` (no-op) |
+| Rendering | Shadow DOM | React Native Modal |
+| Styling | CSS Modules | React Native StyleSheet |
+| Error capture | Patched console | RN's built-in LogBox |
+
+## Recent Migration (RN → DOM)
+
+The following files were migrated from React Native components to plain React DOM:
+- `AnsiHighlight.tsx` - `View`/`Text` → `div`/`span`
+- `CodeFrame.tsx` - `ScrollView` → `div` with overflow
+- `StackTraceList.tsx` - `Pressable` → `button` with CSS hover
+- `LogBoxInspectorSourceMapStatus.tsx` - `Animated` → CSS animations, images → inline SVGs
+- `ErrorToast.tsx` - `Pressable`/`Text`/`View` → `div`/`span`/`button`

--- a/packages/@expo/log-box/src/overlay/AnsiHighlight.module.css
+++ b/packages/@expo/log-box/src/overlay/AnsiHighlight.module.css
@@ -1,0 +1,8 @@
+.line {
+  display: flex;
+  flex-direction: row;
+}
+
+.text {
+  white-space: pre;
+}

--- a/packages/@expo/log-box/src/overlay/AnsiHighlight.tsx
+++ b/packages/@expo/log-box/src/overlay/AnsiHighlight.tsx
@@ -7,8 +7,6 @@
  */
 import Anser from 'anser';
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
-import type { StyleProp, TextStyle } from 'react-native';
 
 // Afterglow theme from https://iterm2colorschemes.com/
 const COLORS: Record<string, string> = {
@@ -35,11 +33,11 @@ export class Ansi extends React.Component<
   {
     // TODO: Does undefined make sense here?
     text: string | undefined;
-    style: StyleProp<TextStyle>;
+    style: React.CSSProperties;
   },
   { hasError: boolean }
 > {
-  constructor(props: { text: string; style: StyleProp<TextStyle> }) {
+  constructor(props: { text: string; style: React.CSSProperties }) {
     super(props);
     this.state = { hasError: false };
   }
@@ -54,16 +52,16 @@ export class Ansi extends React.Component<
 
   render() {
     if (this.state.hasError) {
-      return <Text style={this.props.style}>Error rendering ANSI text.</Text>;
+      return <span style={{ ...this.props.style, whiteSpace: 'pre' }}>Error rendering ANSI text.</span>;
     }
     return <AnsiUnsafe text={this.props.text || ''} style={this.props.style} />;
   }
 }
 
-export function AnsiUnsafe({ text, style }: { text: string; style: StyleProp<TextStyle> }) {
+export function AnsiUnsafe({ text, style }: { text: string; style: React.CSSProperties }) {
   // TMP
   if (!text) {
-    return <Text style={style}>Text not provided to Ansi component.</Text>;
+    return <span style={{ ...style, whiteSpace: 'pre' }}>Text not provided to Ansi component.</span>;
   }
 
   let commonWhitespaceLength = Infinity;
@@ -101,9 +99,9 @@ export function AnsiUnsafe({ text, style }: { text: string; style: StyleProp<Tex
   return (
     <>
       {parsedLines.map((items, i) => (
-        <View style={styles.line} key={i}>
+        <div style={{ display: 'flex', flexDirection: 'row' }} key={i}>
           {items.map((bundle, key) => {
-            const textStyle =
+            const textStyle: React.CSSProperties =
               bundle.fg && COLORS[bundle.fg]
                 ? {
                     backgroundColor: bundle.bg && COLORS[bundle.bg],
@@ -113,19 +111,13 @@ export function AnsiUnsafe({ text, style }: { text: string; style: StyleProp<Tex
                     backgroundColor: bundle.bg && COLORS[bundle.bg],
                   };
             return (
-              <Text style={[style, textStyle]} key={key}>
+              <span style={{ ...style, ...textStyle, whiteSpace: 'pre' }} key={key}>
                 {getText(bundle.content, key)}
-              </Text>
+              </span>
             );
           })}
-        </View>
+        </div>
       ))}
     </>
   );
 }
-
-const styles = StyleSheet.create({
-  line: {
-    flexDirection: 'row',
-  },
-});

--- a/packages/@expo/log-box/src/overlay/AnsiHighlight.tsx
+++ b/packages/@expo/log-box/src/overlay/AnsiHighlight.tsx
@@ -8,6 +8,8 @@
 import Anser from 'anser';
 import React from 'react';
 
+import styles from './AnsiHighlight.module.css';
+
 // Afterglow theme from https://iterm2colorschemes.com/
 const COLORS: Record<string, string> = {
   'ansi-black': 'rgb(27, 27, 27)',
@@ -52,7 +54,11 @@ export class Ansi extends React.Component<
 
   render() {
     if (this.state.hasError) {
-      return <span style={{ ...this.props.style, whiteSpace: 'pre' }}>Error rendering ANSI text.</span>;
+      return (
+        <span className={styles.text} style={this.props.style}>
+          Error rendering ANSI text.
+        </span>
+      );
     }
     return <AnsiUnsafe text={this.props.text || ''} style={this.props.style} />;
   }
@@ -61,7 +67,11 @@ export class Ansi extends React.Component<
 export function AnsiUnsafe({ text, style }: { text: string; style: React.CSSProperties }) {
   // TMP
   if (!text) {
-    return <span style={{ ...style, whiteSpace: 'pre' }}>Text not provided to Ansi component.</span>;
+    return (
+      <span className={styles.text} style={style}>
+        Text not provided to Ansi component.
+      </span>
+    );
   }
 
   let commonWhitespaceLength = Infinity;
@@ -99,7 +109,7 @@ export function AnsiUnsafe({ text, style }: { text: string; style: React.CSSProp
   return (
     <>
       {parsedLines.map((items, i) => (
-        <div style={{ display: 'flex', flexDirection: 'row' }} key={i}>
+        <div className={styles.line} key={i}>
           {items.map((bundle, key) => {
             const textStyle: React.CSSProperties =
               bundle.fg && COLORS[bundle.fg]
@@ -111,7 +121,7 @@ export function AnsiUnsafe({ text, style }: { text: string; style: React.CSSProp
                     backgroundColor: bundle.bg && COLORS[bundle.bg],
                   };
             return (
-              <span style={{ ...style, ...textStyle, whiteSpace: 'pre' }} key={key}>
+              <span className={styles.text} style={{ ...style, ...textStyle }} key={key}>
                 {getText(bundle.content, key)}
               </span>
             );

--- a/packages/@expo/log-box/src/overlay/CodeFrame.tsx
+++ b/packages/@expo/log-box/src/overlay/CodeFrame.tsx
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 import React, { useEffect } from 'react';
-import { ScrollView } from 'react-native';
 
 import { Ansi } from './AnsiHighlight';
 import styles from './CodeFrame.module.css';
@@ -174,9 +173,10 @@ function CodeFrame({
           display: 'flex',
           flexDirection: 'column',
         }}>
-        <ScrollView
-          horizontal
-          contentContainerStyle={{
+        <div
+          style={{
+            overflowX: 'auto',
+            display: 'flex',
             flexDirection: 'column',
           }}>
           {content && (
@@ -185,14 +185,13 @@ function CodeFrame({
                 flexDirection: 'column',
                 color: 'var(--expo-log-color-label)',
                 fontSize: 12,
-                includeFontPadding: false,
-                lineHeight: 20,
+                lineHeight: '20px',
                 fontFamily: 'var(--expo-log-font-mono)',
               }}
               text={content}
             />
           )}
-        </ScrollView>
+        </div>
       </div>
     </div>
   );

--- a/packages/@expo/log-box/src/overlay/LogBoxInspectorSourceMapStatus.module.css
+++ b/packages/@expo/log-box/src/overlay/LogBoxInspectorSourceMapStatus.module.css
@@ -1,0 +1,45 @@
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.spinner {
+  animation: spin 2s linear infinite;
+}
+
+.root {
+  display: flex;
+  align-items: center;
+  border-radius: 12px;
+  flex-direction: row;
+  height: 24px;
+  padding: 0 8px;
+  cursor: pointer;
+  background-color: transparent;
+  border: none;
+}
+
+@media (hover: hover) {
+  .root:hover {
+    background-color: rgba(51, 51, 51, 1);
+  }
+}
+
+.root:active {
+  background-color: rgba(51, 51, 51, 0.6);
+}
+
+.image {
+  height: 14px;
+  width: 16px;
+  margin-right: 4px;
+}
+
+.text {
+  font-size: 12px;
+  line-height: 16px;
+}

--- a/packages/@expo/log-box/src/overlay/LogBoxInspectorSourceMapStatus.tsx
+++ b/packages/@expo/log-box/src/overlay/LogBoxInspectorSourceMapStatus.tsx
@@ -8,185 +8,86 @@
 
 'use client';
 
-import React, { useEffect, useState } from 'react';
-import { Animated, Easing, StyleSheet, Text } from 'react-native';
-import {
-  GestureResponderEvent,
-  type Insets,
-  Platform,
-  Pressable,
-  View,
-  ViewStyle,
-} from 'react-native';
+import React from 'react';
 
-function getBackgroundColor(opacity?: number): string {
-  return `rgba(51, 51, 51, ${opacity == null ? 1 : opacity})`;
-}
+import styles from './LogBoxInspectorSourceMapStatus.module.css';
 
-function getTextColor(opacity?: number): string {
-  return `rgba(255, 255, 255, ${opacity == null ? 1 : opacity})`;
-}
-
-function LogBoxButton(props: {
-  backgroundColor: {
-    default: string;
-    pressed: string;
-  };
-  children?: any;
-  hitSlop?: Insets;
-  onPress?: ((event: GestureResponderEvent) => void) | null;
-  style?: ViewStyle;
-}) {
-  const [pressed, setPressed] = useState(false);
-
-  let backgroundColor = props.backgroundColor;
-  if (!backgroundColor) {
-    backgroundColor = {
-      default: getBackgroundColor(0.95),
-      pressed: getBackgroundColor(0.6),
-    };
-  }
-
-  const content = (
-    <View
-      style={[
-        {
-          backgroundColor: pressed ? backgroundColor.pressed : backgroundColor.default,
-          ...Platform.select({
-            web: {
-              cursor: 'pointer',
-            },
-          }),
-        },
-        props.style,
-      ]}>
-      {props.children}
-    </View>
+function AlertTriangleIcon({ color, className }: { color: string; className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round">
+      <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+      <line x1="12" y1="9" x2="12" y2="13" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
   );
+}
 
-  return props.onPress == null ? (
-    content
-  ) : (
-    <Pressable
-      hitSlop={props.hitSlop}
-      onPress={props.onPress}
-      onPressIn={() => setPressed(true)}
-      onPressOut={() => setPressed(false)}>
-      {content}
-    </Pressable>
+function LoaderIcon({ color, className }: { color: string; className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round">
+      <line x1="12" y1="2" x2="12" y2="6" />
+      <line x1="12" y1="18" x2="12" y2="22" />
+      <line x1="4.93" y1="4.93" x2="7.76" y2="7.76" />
+      <line x1="16.24" y1="16.24" x2="19.07" y2="19.07" />
+      <line x1="2" y1="12" x2="6" y2="12" />
+      <line x1="18" y1="12" x2="22" y2="12" />
+      <line x1="4.93" y1="19.07" x2="7.76" y2="16.24" />
+      <line x1="16.24" y1="7.76" x2="19.07" y2="4.93" />
+    </svg>
   );
 }
 
 export function LogBoxInspectorSourceMapStatus(props: {
-  onPress?: ((event: GestureResponderEvent) => void) | null;
+  onPress?: (() => void) | null;
   status: 'COMPLETE' | 'FAILED' | 'NONE' | 'PENDING';
 }) {
-  const [state, setState] = useState<{
-    animation: null | Animated.CompositeAnimation;
-    rotate: null | Animated.AnimatedInterpolation<string>;
-  }>({
-    animation: null,
-    rotate: null,
-  });
-
-  useEffect(() => {
-    if (props.status === 'PENDING') {
-      if (state.animation == null) {
-        const animated = new Animated.Value(0);
-        const animation = Animated.loop(
-          Animated.timing(animated, {
-            duration: 2000,
-            easing: Easing.linear,
-            toValue: 1,
-            useNativeDriver: true,
-          }),
-          {
-            iterations: -1,
-          }
-        );
-        setState({
-          animation,
-          rotate: animated.interpolate({
-            inputRange: [0, 1],
-            outputRange: ['0deg', '360deg'],
-          }),
-        });
-        animation.start();
-      }
-    } else {
-      if (state.animation != null) {
-        state.animation.stop();
-        setState({
-          animation: null,
-          rotate: null,
-        });
-      }
-    }
-
-    return () => {
-      if (state.animation != null) {
-        state.animation.stop();
-      }
-    };
-  }, [props.status, state.animation]);
-
-  let image;
+  let icon;
   let color;
   switch (props.status) {
     case 'FAILED':
-      image = require('@expo/log-box/assets/alert-triangle.png');
       color = `rgba(243, 83, 105, 1)`;
+      icon = <AlertTriangleIcon color={color} className={styles.image} />;
       break;
     case 'PENDING':
-      image = require('@expo/log-box/assets/loader.png');
       color = `rgba(250, 186, 48, 1)`;
+      icon = <LoaderIcon color={color} className={`${styles.image} ${styles.spinner}`} />;
       break;
   }
 
-  if (props.status === 'COMPLETE' || image == null) {
+  if (props.status === 'COMPLETE' || icon == null) {
     return null;
   }
 
+  const content = (
+    <>
+      {icon}
+      <span className={styles.text} style={{ color }}>
+        Source Map
+      </span>
+    </>
+  );
+
+  if (props.onPress == null) {
+    return <div className={styles.root}>{content}</div>;
+  }
+
   return (
-    <LogBoxButton
-      backgroundColor={{
-        default: 'transparent',
-        pressed: getBackgroundColor(1),
-      }}
-      hitSlop={{ bottom: 8, left: 8, right: 8, top: 8 }}
-      onPress={props.onPress}
-      style={styles.root}>
-      <Animated.Image
-        source={image}
-        tintColor={color ?? getTextColor(0.4)}
-        style={[
-          styles.image,
-          state.rotate == null || props.status !== 'PENDING'
-            ? null
-            : { transform: [{ rotate: state.rotate }] },
-        ]}
-      />
-      <Text style={[styles.text, { color }]}>Source Map</Text>
-    </LogBoxButton>
+    <button className={styles.root} onClick={props.onPress}>
+      {content}
+    </button>
   );
 }
-
-const styles = StyleSheet.create({
-  root: {
-    alignItems: 'center',
-    borderRadius: 12,
-    flexDirection: 'row',
-    height: 24,
-    paddingHorizontal: 8,
-  },
-  image: {
-    height: 14,
-    width: 16,
-    marginEnd: 4,
-  },
-  text: {
-    fontSize: 12,
-    includeFontPadding: false,
-    lineHeight: 16,
-  },
-});

--- a/packages/@expo/log-box/src/overlay/Message.tsx
+++ b/packages/@expo/log-box/src/overlay/Message.tsx
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 import React from 'react';
-import type { StyleProp, TextStyle } from 'react-native';
 
 import type { Message } from '../Data/Types';
 
@@ -14,10 +13,10 @@ export function LogBoxMessage(props: { message: Message; maxLength?: number }): 
   const { content, substitutions }: Message = props.message;
 
   const maxLength = props.maxLength != null ? props.maxLength : Infinity;
-  const substitutionStyle: StyleProp<TextStyle> = { opacity: 0.6 };
+  const substitutionStyle: React.CSSProperties = { opacity: 0.6 };
   const elements: React.ReactElement[] = [];
   let length = 0;
-  const createUnderLength = (key: string | '-1', message: string, style?: StyleProp<TextStyle>) => {
+  const createUnderLength = (key: string | '-1', message: string, style?: React.CSSProperties) => {
     let cleanMessage = message;
 
     if (props.maxLength != null) {
@@ -26,10 +25,7 @@ export function LogBoxMessage(props: { message: Message; maxLength?: number }): 
 
     if (length < maxLength) {
       elements.push(
-        <span
-          key={key}
-          //@ts-expect-error
-          style={style}>
+        <span key={key} style={style}>
           {cleanMessage}
         </span>
       );

--- a/packages/@expo/log-box/src/overlay/StackTraceList.module.css
+++ b/packages/@expo/log-box/src/overlay/StackTraceList.module.css
@@ -1,3 +1,51 @@
+.root {
+  margin-top: 5px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 4px;
+  justify-content: space-between;
+}
+
+.headerLeft {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.headerIcon {
+  width: 1rem;
+  height: 1rem;
+  color: var(--expo-log-color-label);
+}
+
+.headerTitle {
+  font-family: var(--expo-log-font-family);
+  color: var(--expo-log-color-label);
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.badge {
+  background-color: rgba(234.6, 234.6, 244.8, 0.1);
+  font-family: var(--expo-log-font-family);
+  color: var(--expo-log-color-label);
+  border-radius: 50px;
+  font-size: 12px;
+  aspect-ratio: 1/1;
+  display: flex;
+  width: 22px;
+  height: 22px;
+  justify-content: center;
+  align-items: center;
+}
+
 .collapseButton {
   background: transparent;
   border: none;
@@ -26,7 +74,12 @@
 
 .collapseTitle {
   display: none;
+  font-family: var(--expo-log-font-family);
+  font-size: 14px;
+  user-select: none;
+  color: rgba(234.6, 234.6, 244.8, 0.6);
 }
+
 /* xs */
 @media screen and (min-width: 320px) {
   .collapseTitle {
@@ -34,20 +87,48 @@
   }
 }
 
+.transition {
+  overflow: hidden;
+  transition: height 0.3s ease, opacity 0.3s ease;
+}
+
+.warningBox {
+  background-color: var(--expo-log-secondary-system-background);
+  border: 1px solid var(--expo-log-color-border);
+  padding: 10px 15px;
+  border-radius: 5px;
+}
+
+.warningText {
+  font-family: var(--expo-log-font-family);
+  color: var(--expo-log-color-label);
+  opacity: 0.7;
+  font-size: 13px;
+  font-weight: 400;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
 .stackFrame {
   display: flex;
   flex-direction: column;
   flex: 1;
-  
   padding: 6px 12px;
   border-radius: 8px;
   transition: background-color 0.3s;
   outline-color: transparent;
   background-color: transparent;
-  opacity: var(--expo-log-opacity);
   color: var(--expo-log-color-label);
   cursor: pointer;
 
+  /* collapsed frames */
+  &[data-collapsed] {
+    opacity: 0.4;
+  }
 
   /* aria-disabled */
   &[aria-disabled='true'] {

--- a/packages/@expo/log-box/src/overlay/StackTraceList.module.css
+++ b/packages/@expo/log-box/src/overlay/StackTraceList.module.css
@@ -1,3 +1,29 @@
+.collapseButton {
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.collapseContent {
+  padding: 6px;
+  border-radius: 8px;
+  transition: background-color 0.3s;
+  outline-color: transparent;
+  color: rgba(234.6, 234.6, 244.8, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 2px;
+  user-select: none;
+}
+
+@media (hover: hover) {
+  .collapseButton:hover .collapseContent {
+    background-color: rgba(234.6, 234.6, 244.8, 0.1);
+  }
+}
+
 .collapseTitle {
   display: none;
 }

--- a/packages/@expo/log-box/src/overlay/StackTraceList.tsx
+++ b/packages/@expo/log-box/src/overlay/StackTraceList.tsx
@@ -80,12 +80,7 @@ function Transition({
   }, [status, onExitComplete]);
 
   return (
-    <div
-      ref={ref}
-      style={{
-        overflow: 'hidden',
-        transition: 'height 0.3s ease, opacity 0.3s ease',
-      }}>
+    <div ref={ref} className={styles.transition}>
       {children}
     </div>
   );
@@ -247,60 +242,19 @@ export function StackTraceList({
   });
 
   return (
-    <div style={{ marginTop: 5, display: 'flex', flexDirection: 'column', gap: 6 }}>
+    <div className={styles.root}>
       {/* Header */}
-      <div
-        ref={ref}
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          marginBottom: 4,
-          justifyContent: 'space-between',
-        }}>
-        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+      <div ref={ref} className={styles.header}>
+        <div className={styles.headerLeft}>
           {type === 'component' ? (
-            <ReactIcon
-              stroke="unset"
-              style={{
-                width: '1rem',
-                height: '1rem',
-                color: 'var(--expo-log-color-label)',
-              }}
-            />
+            <ReactIcon stroke="unset" className={styles.headerIcon} />
           ) : (
-            <JavaScriptIcon
-              style={{
-                width: '1rem',
-                height: '1rem',
-                color: 'var(--expo-log-color-label)',
-              }}
-            />
+            <JavaScriptIcon className={styles.headerIcon} />
           )}
-          <h3
-            style={{
-              fontFamily: 'var(--expo-log-font-family)',
-              color: 'var(--expo-log-color-label)',
-              fontSize: 18,
-              fontWeight: '600',
-              margin: 0,
-            }}>
+          <h3 className={styles.headerTitle}>
             {type === 'component' ? 'Component Stack' : 'Call Stack'}
           </h3>
-          <span
-            data-text
-            style={{
-              backgroundColor: 'rgba(234.6, 234.6, 244.8, 0.1)',
-              fontFamily: 'var(--expo-log-font-family)',
-              color: 'var(--expo-log-color-label)',
-              borderRadius: 50,
-              fontSize: 12,
-              aspectRatio: '1/1',
-              display: 'flex',
-              width: 22,
-              height: 22,
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}>
+          <span data-text className={styles.badge}>
             {stackCount}
           </span>
 
@@ -310,20 +264,9 @@ export function StackTraceList({
           />
         </div>
 
-        <button
-          className={styles.collapseButton}
-          onClick={() => setCollapsed(!collapsed)}>
-          <div
-            title={collapseTitle.full}
-            className={styles.collapseContent}>
-            <span
-              className={styles.collapseTitle}
-              style={{
-                fontFamily: 'var(--expo-log-font-family)',
-                fontSize: 14,
-                userSelect: 'none',
-                color: 'rgba(234.6, 234.6, 244.8, 0.6)',
-              }}>
+        <button className={styles.collapseButton} onClick={() => setCollapsed(!collapsed)}>
+          <div title={collapseTitle.full} className={styles.collapseContent}>
+            <span className={styles.collapseTitle}>
               {containerWidth > 440 ? collapseTitle.full : collapseTitle.short}
             </span>
 
@@ -336,8 +279,7 @@ export function StackTraceList({
               stroke="currentColor"
               strokeWidth="2"
               strokeLinecap="round"
-              strokeLinejoin="round"
-              className="md-hidden">
+              strokeLinejoin="round">
               {collapsed ? (
                 <>
                   <path d="m7 15 5 5 5-5" />
@@ -356,21 +298,8 @@ export function StackTraceList({
 
       {/* Body */}
       {symbolicationStatus !== 'COMPLETE' && (
-        <div
-          style={{
-            backgroundColor: `var(--expo-log-secondary-system-background)`,
-            border: `1px solid var(--expo-log-color-border)`,
-            padding: `10px 15px`,
-            borderRadius: 5,
-          }}>
-          <span
-            style={{
-              fontFamily: 'var(--expo-log-font-family)',
-              color: 'var(--expo-log-color-label)',
-              opacity: 0.7,
-              fontSize: 13,
-              fontWeight: '400',
-            }}>
+        <div className={styles.warningBox}>
+          <span className={styles.warningText}>
             This call stack is not symbolicated. Some features are unavailable such as viewing the
             function name or tapping to open files.
           </span>
@@ -378,7 +307,7 @@ export function StackTraceList({
       )}
 
       {/* List */}
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <div className={styles.list}>
         <List
           initialDelay={initialDelay}
           items={stackTraceItems}
@@ -406,9 +335,7 @@ function StackTraceItem({
       aria-disabled={!isLaunchable ? true : undefined}
       onClick={onPress}
       className={styles.stackFrame}
-      style={{
-        opacity: frame.collapse === true ? 0.4 : 1,
-      }}>
+      data-collapsed={frame.collapse === true ? '' : undefined}>
       <code className={styles.stackFrameTitle}>{frame.methodName}</code>
       <code className={styles.stackFrameFile}>{fileName}</code>
     </div>

--- a/packages/@expo/log-box/src/overlay/StackTraceList.tsx
+++ b/packages/@expo/log-box/src/overlay/StackTraceList.tsx
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 import React, { useState, type SVGProps } from 'react';
-import { Pressable } from 'react-native';
 
 import { LogBoxInspectorSourceMapStatus } from './LogBoxInspectorSourceMapStatus';
 import styles from './StackTraceList.module.css';
@@ -311,64 +310,48 @@ export function StackTraceList({
           />
         </div>
 
-        <Pressable onPress={() => setCollapsed(!collapsed)}>
-          {({
-            //@ts-expect-error fix rn-web typings
-            hovered,
-          }) => (
-            <div
-              title={collapseTitle.full}
+        <button
+          className={styles.collapseButton}
+          onClick={() => setCollapsed(!collapsed)}>
+          <div
+            title={collapseTitle.full}
+            className={styles.collapseContent}>
+            <span
+              className={styles.collapseTitle}
               style={{
-                padding: 6,
-                borderRadius: 8,
-                transition: 'background-color 0.3s',
-                outlineColor: 'transparent',
-                backgroundColor: hovered ? 'rgba(234.6, 234.6, 244.8, 0.1)' : undefined,
-                color: 'rgba(234.6, 234.6, 244.8, 0.6)',
-                display: 'flex',
-                justifyContent: 'center',
-                alignItems: 'center',
-                gap: 2,
+                fontFamily: 'var(--expo-log-font-family)',
+                fontSize: 14,
                 userSelect: 'none',
-                cursor: 'pointer',
+                color: 'rgba(234.6, 234.6, 244.8, 0.6)',
               }}>
-              <span
-                className={styles.collapseTitle}
-                style={{
-                  fontFamily: 'var(--expo-log-font-family)',
-                  fontSize: 14,
-                  userSelect: 'none',
-                  color: 'rgba(234.6, 234.6, 244.8, 0.6)',
-                }}>
-                {containerWidth > 440 ? collapseTitle.full : collapseTitle.short}
-              </span>
+              {containerWidth > 440 ? collapseTitle.full : collapseTitle.short}
+            </span>
 
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="18"
-                height="18"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="md-hidden">
-                {collapsed ? (
-                  <>
-                    <path d="m7 15 5 5 5-5" />
-                    <path d="m7 9 5-5 5 5" />
-                  </>
-                ) : (
-                  <>
-                    <path d="m7 20 5-5 5 5" />
-                    <path d="m7 4 5 5 5-5" />
-                  </>
-                )}
-              </svg>
-            </div>
-          )}
-        </Pressable>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="md-hidden">
+              {collapsed ? (
+                <>
+                  <path d="m7 15 5 5 5-5" />
+                  <path d="m7 9 5-5 5 5" />
+                </>
+              ) : (
+                <>
+                  <path d="m7 20 5-5 5 5" />
+                  <path d="m7 4 5 5 5-5" />
+                </>
+              )}
+            </svg>
+          </div>
+        </button>
       </div>
 
       {/* Body */}

--- a/packages/@expo/log-box/src/toast/ErrorToast.module.css
+++ b/packages/@expo/log-box/src/toast/ErrorToast.module.css
@@ -1,0 +1,29 @@
+.dismissButton {
+  background: transparent;
+  border: none;
+  padding: 12px 10px;
+  margin: -12px -10px;
+  margin-left: calc(5px - 10px);
+  cursor: pointer;
+}
+
+.dismissContent {
+  background-color: rgba(255, 255, 255, 0.1);
+  height: 20px;
+  width: 20px;
+  border-radius: 25px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.2s;
+}
+
+@media (hover: hover) {
+  .dismissButton:hover .dismissContent {
+    opacity: 0.8;
+  }
+}
+
+.dismissButton:active .dismissContent {
+  opacity: 0.5;
+}

--- a/packages/@expo/log-box/src/toast/ErrorToast.module.css
+++ b/packages/@expo/log-box/src/toast/ErrorToast.module.css
@@ -1,3 +1,68 @@
+.container {
+  bottom: calc(6px + env(safe-area-inset-bottom, 0px));
+  left: 10px;
+  right: 10px;
+  max-width: 320px;
+  position: fixed;
+  display: flex;
+}
+
+.toast {
+  background-color: #632e2c;
+  height: 48px;
+  justify-content: center;
+  margin-bottom: 4px;
+  display: flex;
+  border-radius: 6px;
+  transition: background-color 0.2s;
+  border: 1px solid var(--expo-log-color-danger);
+  cursor: pointer;
+  overflow: hidden;
+  flex: 1;
+  padding: 0 10px;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+
+@media (hover: hover) {
+  .toast:hover {
+    background-color: #924340;
+  }
+}
+
+.message {
+  user-select: none;
+  padding-left: 8px;
+  color: var(--expo-log-color-label);
+  flex: 1;
+  font-size: 14px;
+  line-height: 22px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}
+
+.count {
+  min-width: 30px;
+  height: 30px;
+  border-radius: 6px;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+  background: var(--expo-log-color-danger);
+}
+
+.countText {
+  color: var(--expo-log-color-label);
+  font-size: 14px;
+  line-height: 18px;
+  text-align: center;
+  font-weight: 600;
+  text-shadow: 0px 0px 3px rgba(51, 51, 51, 0.8);
+}
+
 .dismissButton {
   background: transparent;
   border: none;
@@ -26,4 +91,10 @@
 
 .dismissButton:active .dismissContent {
   opacity: 0.5;
+}
+
+.dismissIcon {
+  width: 12px;
+  height: 12px;
+  color: white;
 }

--- a/packages/@expo/log-box/src/toast/ErrorToast.module.css
+++ b/packages/@expo/log-box/src/toast/ErrorToast.module.css
@@ -23,6 +23,7 @@
   flex-direction: row;
   align-items: center;
   gap: 8px;
+  font-family: var(--expo-log-font-family);
 }
 
 @media (hover: hover) {
@@ -35,6 +36,7 @@
   user-select: none;
   padding-left: 8px;
   color: var(--expo-log-color-label);
+  font-family: var(--expo-log-font-family);
   flex: 1;
   font-size: 14px;
   line-height: 22px;
@@ -56,6 +58,7 @@
 
 .countText {
   color: var(--expo-log-color-label);
+  font-family: var(--expo-log-font-family);
   font-size: 14px;
   line-height: 18px;
   text-align: center;

--- a/packages/@expo/log-box/src/toast/ErrorToast.tsx
+++ b/packages/@expo/log-box/src/toast/ErrorToast.tsx
@@ -81,7 +81,7 @@ function ErrorToast(props: {
   useSymbolicatedLog(log);
 
   return (
-    <button className={styles.toast} onClick={props.onPressOpen}>
+    <div className={styles.toast} onClick={props.onPressOpen} role="button" tabIndex={0}>
       <Count count={totalLogCount} />
 
       <span className={styles.message}>
@@ -89,7 +89,7 @@ function ErrorToast(props: {
       </span>
 
       <Dismiss onPress={props.onPressDismiss} />
-    </button>
+    </div>
   );
 }
 
@@ -103,7 +103,12 @@ function Count({ count }: { count: number }) {
 
 function Dismiss({ onPress }: { onPress: () => void }) {
   return (
-    <button className={styles.dismissButton} onClick={onPress}>
+    <button
+      className={styles.dismissButton}
+      onClick={(e) => {
+        e.stopPropagation();
+        onPress();
+      }}>
       <div className={styles.dismissContent}>
         <svg
           className={styles.dismissIcon}

--- a/packages/@expo/log-box/src/toast/ErrorToast.tsx
+++ b/packages/@expo/log-box/src/toast/ErrorToast.tsx
@@ -6,8 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 import React, { useEffect, useCallback, useMemo } from 'react';
-import { Pressable, Text, View } from 'react-native';
 
+import styles from './ErrorToast.module.css';
 import * as LogBoxData from '../Data/LogBoxData';
 import { LogBoxLog, useLogs } from '../Data/LogBoxLog';
 import { LogBoxMessage } from '../overlay/Message';
@@ -119,18 +119,21 @@ function ErrorToast(props: {
       <button data-expo-log-toast onClick={props.onPressOpen}>
         <Count count={totalLogCount} />
 
-        <Text
-          numberOfLines={1}
+        <span
           style={{
             userSelect: 'none',
             paddingLeft: 8,
             color: 'var(--expo-log-color-label)',
             flex: 1,
             fontSize: 14,
-            lineHeight: 22,
+            lineHeight: '22px',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            display: 'block',
           }}>
           {log.message && <LogBoxMessage maxLength={40} message={log.message} />}
-        </Text>
+        </span>
 
         <Dismiss onPress={props.onPressDismiss} />
       </button>
@@ -150,73 +153,43 @@ function Count({ count }: { count: number }) {
         display: 'flex',
         background: 'var(--expo-log-color-danger)',
       }}>
-      <Text
+      <span
         style={{
           color: 'var(--expo-log-color-label)',
           fontSize: 14,
-          lineHeight: 18,
+          lineHeight: '18px',
           textAlign: 'center',
           fontWeight: '600',
-          // @ts-ignore
           textShadow: `0px 0px 3px rgba(51, 51, 51, 0.8)`,
         }}>
         {count <= 1 ? '!' : count}
-      </Text>
+      </span>
     </div>
   );
 }
 
 function Dismiss({ onPress }: { onPress: () => void }) {
   return (
-    <Pressable
-      style={{
-        marginLeft: 5,
-      }}
-      hitSlop={{
-        top: 12,
-        right: 10,
-        bottom: 12,
-        left: 10,
-      }}
-      onPress={onPress}>
-      {({
-        /** @ts-expect-error: react-native types are broken. */
-        hovered,
-        pressed,
-      }) => (
-        <View
-          style={[
-            {
-              backgroundColor: 'rgba(255,255,255,0.1)',
-              height: 20,
-              width: 20,
-              borderRadius: 25,
-              alignItems: 'center',
-              justifyContent: 'center',
-            },
-            hovered && { opacity: 0.8 },
-            pressed && { opacity: 0.5 },
-          ]}>
-          <svg
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            style={{
-              width: 12,
-              height: 12,
-              color: 'white',
-              // color: 'var(--expo-log-color-danger)',
-            }}>
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              d="M17 7L7 17M7 7L17 17"
-            />
-          </svg>
-        </View>
-      )}
-    </Pressable>
+    <button className={styles.dismissButton} onClick={onPress}>
+      <div className={styles.dismissContent}>
+        <svg
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          style={{
+            width: 12,
+            height: 12,
+            color: 'white',
+          }}>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            d="M17 7L7 17M7 7L17 17"
+          />
+        </svg>
+      </div>
+    </button>
   );
 }
 

--- a/packages/@expo/log-box/src/toast/ErrorToast.tsx
+++ b/packages/@expo/log-box/src/toast/ErrorToast.tsx
@@ -110,11 +110,7 @@ function Dismiss({ onPress }: { onPress: () => void }) {
         onPress();
       }}>
       <div className={styles.dismissContent}>
-        <svg
-          className={styles.dismissIcon}
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor">
+        <svg className={styles.dismissIcon} fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path
             strokeLinecap="round"
             strokeLinejoin="round"

--- a/packages/@expo/log-box/src/toast/ErrorToast.tsx
+++ b/packages/@expo/log-box/src/toast/ErrorToast.tsx
@@ -47,15 +47,7 @@ function ErrorToastStack({ logs }: { logs: LogBoxLog[] }) {
   );
 
   return (
-    <div
-      style={{
-        bottom: 'calc(6px + env(safe-area-inset-bottom, 0px))',
-        left: 10,
-        right: 10,
-        maxWidth: 320,
-        position: 'fixed',
-        display: 'flex',
-      }}>
+    <div className={styles.container}>
       {errors.length > 0 && (
         <ErrorToast
           log={errors[errors.length - 1]}
@@ -89,81 +81,22 @@ function ErrorToast(props: {
   useSymbolicatedLog(log);
 
   return (
-    <>
-      <style>
-        {`
-[data-expo-log-toast] {
-  background-color: #632e2c;
-  height: 48px;
-  justify-content: center;
-  margin-bottom: 4px;
-  display: flex;
-  border-radius: 6px;
-  transition: background-color 0.2s;
-  border: 1px solid var(--expo-log-color-danger);
-  /* border: 1px solid var(--expo-log-color-border); */
-  cursor: pointer;
-  overflow: hidden;
-  flex: 1;
-  padding: 0 10px;
-  flex-direction: row;
-  align-items: center;
-  gap: 8px;
-}
+    <button className={styles.toast} onClick={props.onPressOpen}>
+      <Count count={totalLogCount} />
 
-[data-expo-log-toast]:hover {
-  background-color: #924340;
-}
-`}
-      </style>
-      <button data-expo-log-toast onClick={props.onPressOpen}>
-        <Count count={totalLogCount} />
+      <span className={styles.message}>
+        {log.message && <LogBoxMessage maxLength={40} message={log.message} />}
+      </span>
 
-        <span
-          style={{
-            userSelect: 'none',
-            paddingLeft: 8,
-            color: 'var(--expo-log-color-label)',
-            flex: 1,
-            fontSize: 14,
-            lineHeight: '22px',
-            whiteSpace: 'nowrap',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            display: 'block',
-          }}>
-          {log.message && <LogBoxMessage maxLength={40} message={log.message} />}
-        </span>
-
-        <Dismiss onPress={props.onPressDismiss} />
-      </button>
-    </>
+      <Dismiss onPress={props.onPressDismiss} />
+    </button>
   );
 }
 
 function Count({ count }: { count: number }) {
   return (
-    <div
-      style={{
-        minWidth: 30,
-        height: 30,
-        borderRadius: 6,
-        justifyContent: 'center',
-        alignItems: 'center',
-        display: 'flex',
-        background: 'var(--expo-log-color-danger)',
-      }}>
-      <span
-        style={{
-          color: 'var(--expo-log-color-label)',
-          fontSize: 14,
-          lineHeight: '18px',
-          textAlign: 'center',
-          fontWeight: '600',
-          textShadow: `0px 0px 3px rgba(51, 51, 51, 0.8)`,
-        }}>
-        {count <= 1 ? '!' : count}
-      </span>
+    <div className={styles.count}>
+      <span className={styles.countText}>{count <= 1 ? '!' : count}</span>
     </div>
   );
 }
@@ -173,14 +106,10 @@ function Dismiss({ onPress }: { onPress: () => void }) {
     <button className={styles.dismissButton} onClick={onPress}>
       <div className={styles.dismissContent}>
         <svg
+          className={styles.dismissIcon}
           fill="none"
           viewBox="0 0 24 24"
-          stroke="currentColor"
-          style={{
-            width: 12,
-            height: 12,
-            color: 'white',
-          }}>
+          stroke="currentColor">
           <path
             strokeLinecap="round"
             strokeLinejoin="round"


### PR DESCRIPTION
# Why

- In SPA mode we don't have a system to safely populate the react-native-web styles from the `StyleSheet.create()` function.
- Migrating to standard react-dom since this code is always meant to run in a webview or browser anyways.

# Test Plan

- Run the router-e2e test and observe limited style differences.