### PR TITLE
[cli] delete old expo go artifacts to save disk space

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- delete old expo go artifacts to save disk space ([#42860](https://github.com/expo/expo/pull/42860) by [@vonovak](https://github.com/vonovak))
+
 ## 55.0.6 — 2026-02-03
 
 ### 🐛 Bug fixes


### PR DESCRIPTION
# Why

Add a cache cleanup mechanism for Expo Go downloads to prevent accumulation of old versions in the cache directory.
This cleaned up 7.2 GB of space for me.

# How

- added `cleanupOldExpoGoCacheEntriesAsync` that removes cached Expo Go apps (.apk / .app) that are older than 6 months (configurable) from the cache directory. This function is called when downloading a new version of Expo Go.
- if for some reason people run projects across SDK versions, 6 months should give leeway so that expo go download for SDK `X` doesn't delete the download for `X - 1`. But even if it does, it'd simply be re-downloaded if needed. 

# Test Plan

- Added a unit test
- tested removal locally. Repeated runs don't re-download.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)