### PR TITLE
[docs] improve docs for native tabs, zoom transition and stack toolbar

### DIFF
--- a/docs/pages/router/advanced/native-tabs.mdx
+++ b/docs/pages/router/advanced/native-tabs.mdx
@@ -976,15 +976,15 @@ export default function HomeScreen() {
 
 ### Custom web layout
 
-Native tabs render platform-specific tab bars on iOS and Android, but there is no standard system tab bar on web. On web, native tabs fall back to a basic implementation, loosely based on iPad design. You can use headless tabs from `expo-router/ui` to provide a custom web layout while keeping native tabs on mobile. There are two ways to set this up.
+Native tabs render platform-specific tab bars on Android and iOS, but there is no standard system tab bar on web. On web, native tabs fall back to a basic implementation, loosely based on iPad design. You can use headless tabs from `expo-router/ui` to provide a custom web layout while keeping native tabs on mobile. There are two ways to set this up.
 
 #### Platform-specific layout files
 
-Use a `_layout.web.tsx` file alongside your `_layout.tsx`. The web file completely replaces the layout on web, so each platform can have an entirely different layout.
+Use a **\_layout.web.tsx** file alongside your **\_layout.tsx**. The web file completely replaces the layout on web, so each platform can have an entirely different layout.
 
 <FileTree
   files={[
-    'app/_layout.tsx — native tabs for iOS and Android',
+    'app/_layout.tsx — native tabs for Android and iOS',
     'app/_layout.web.tsx — headless tabs for web',
   ]}
 />
@@ -1024,12 +1024,12 @@ const styles = StyleSheet.create({
 
 #### Shared component with platform extensions
 
-Extract the tab UI into a component with platform-specific extensions. A single `_layout.tsx` handles shared logic (providers, wrappers, analytics) and imports the tab component, which resolves to the correct platform file.
+Extract the tab UI into a component with platform-specific extensions. A single **\_layout.tsx** handles shared logic (providers, wrappers, analytics) and imports the tab component, which resolves to the correct platform file.
 
 <FileTree
   files={[
     'app/_layout.tsx — shared layout, imports AppTabs',
-    'components/app-tabs.tsx — native tabs for iOS and Android',
+    'components/app-tabs.tsx — native tabs for Android and iOS',
     'components/app-tabs.web.tsx — headless tabs for web',
   ]}
 />

--- a/docs/pages/router/advanced/native-tabs.mdx
+++ b/docs/pages/router/advanced/native-tabs.mdx
@@ -974,6 +974,144 @@ export default function HomeScreen() {
 }
 ```
 
+### Custom web layout
+
+Native tabs render platform-specific tab bars on iOS and Android, but there is no standard system tab bar on web. On web, native tabs fall back to a basic implementation, loosely based on iPad design. You can use headless tabs from `expo-router/ui` to provide a custom web layout while keeping native tabs on mobile. There are two ways to set this up.
+
+#### Platform-specific layout files
+
+Use a `_layout.web.tsx` file alongside your `_layout.tsx`. The web file completely replaces the layout on web, so each platform can have an entirely different layout.
+
+<FileTree
+  files={[
+    'app/_layout.tsx — native tabs for iOS and Android',
+    'app/_layout.web.tsx — headless tabs for web',
+  ]}
+/>
+
+```tsx app/_layout.web.tsx
+import { Tabs, TabList, TabTrigger, TabSlot } from 'expo-router/ui';
+import { StyleSheet } from 'react-native';
+
+export default function WebLayout() {
+  return (
+    <Tabs>
+      <TabSlot />
+      <TabList style={styles.tabList}>
+        <TabTrigger name="index" href="/" style={styles.tab}>
+          Home
+        </TabTrigger>
+        <TabTrigger name="settings" href="/settings" style={styles.tab}>
+          Settings
+        </TabTrigger>
+      </TabList>
+    </Tabs>
+  );
+}
+
+const styles = StyleSheet.create({
+  tabList: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    gap: 16,
+    padding: 16,
+  },
+  tab: {
+    padding: 8,
+  },
+});
+```
+
+#### Shared component with platform extensions
+
+Extract the tab UI into a component with platform-specific extensions. A single `_layout.tsx` handles shared logic (providers, wrappers, analytics) and imports the tab component, which resolves to the correct platform file.
+
+<FileTree
+  files={[
+    'app/_layout.tsx — shared layout, imports AppTabs',
+    'components/app-tabs.tsx — native tabs for iOS and Android',
+    'components/app-tabs.web.tsx — headless tabs for web',
+  ]}
+/>
+
+```tsx app/_layout.tsx
+import AppTabs from '@/components/app-tabs';
+
+export default function Layout() {
+  return (
+    <ThemeProvider>
+      <AppTabs />
+    </ThemeProvider>
+  );
+}
+```
+
+```tsx components/app-tabs.tsx
+import { NativeTabs } from 'expo-router/unstable-native-tabs';
+
+export default function AppTabs() {
+  return (
+    <NativeTabs>
+      <NativeTabs.Trigger name="index">
+        <NativeTabs.Trigger.Label>Home</NativeTabs.Trigger.Label>
+        <NativeTabs.Trigger.Icon sf="house.fill" md="home" />
+      </NativeTabs.Trigger>
+      <NativeTabs.Trigger name="settings">
+        <NativeTabs.Trigger.Icon sf="gear" md="settings" />
+        <NativeTabs.Trigger.Label>Settings</NativeTabs.Trigger.Label>
+      </NativeTabs.Trigger>
+    </NativeTabs>
+  );
+}
+```
+
+```tsx components/app-tabs.web.tsx
+import { Tabs, TabList, TabTrigger, TabSlot } from 'expo-router/ui';
+import { StyleSheet } from 'react-native';
+
+export default function AppTabs() {
+  return (
+    <Tabs>
+      <TabSlot />
+      <TabList style={styles.tabList}>
+        <TabTrigger name="index" href="/" style={styles.tab}>
+          Home
+        </TabTrigger>
+        <TabTrigger name="settings" href="/settings" style={styles.tab}>
+          Settings
+        </TabTrigger>
+      </TabList>
+    </Tabs>
+  );
+}
+
+const styles = StyleSheet.create({
+  tabList: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    gap: 16,
+    padding: 16,
+  },
+  tab: {
+    padding: 8,
+  },
+});
+```
+
+<BoxLink
+  title="Custom tabs"
+  href="/router/advanced/custom-tabs/"
+  description="Learn more about customizing headless tabs from expo-router/ui."
+  Icon={BookOpen02Icon}
+/>
+
+<BoxLink
+  title="Platform-specific extensions"
+  href="/router/advanced/platform-specific-modules/"
+  description="Learn how platform-specific file extensions like .web.tsx work in Expo Router."
+  Icon={BookOpen02Icon}
+/>
+
 ## Migrating native tabs from SDK 54 to 55
 
 SDK 55 changes how you access tab bar item components. Instead of importing `Icon`, `Label`, and `Badge` separately, use the compound component API: `NativeTabs.Trigger.Icon`, `NativeTabs.Trigger.Label`, and `NativeTabs.Trigger.Badge`. For Android icons, the `md` prop is the new recommended way to use Material Symbols.
@@ -1104,6 +1242,54 @@ export default function HomeScreen() {
     <View collapsable={false} style={{ flex: 1 }}>
       <ScrollView>{/* Screen content */}</ScrollView>
     </View>
+  );
+}
+```
+
+</Collapsible>
+
+<Collapsible summary="Liquid glass header buttons flicker in dark mode on iOS 26">
+
+Header buttons with liquid glass styling may flicker or flash their background when switching tabs in dark mode on iOS 26. This happens because React Navigation's default theme doesn't match the system dark mode, causing visual artifacts in the liquid glass rendering.
+
+The fix is the same as for the white background flash issue: wrap your layout with `<ThemeProvider>` from `@react-navigation/native` using the appropriate theme.
+
+**For apps supporting both light and dark modes:**
+
+```tsx app/_layout.tsx
+import { ThemeProvider, DarkTheme, DefaultTheme } from '@react-navigation/native';
+import { NativeTabs } from 'expo-router/unstable-native-tabs';
+import { useColorScheme } from 'react-native';
+
+export default function TabLayout() {
+  const colorScheme = useColorScheme();
+
+  return (
+    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+      <NativeTabs>
+        <NativeTabs.Trigger name="index">
+          <NativeTabs.Trigger.Label>Home</NativeTabs.Trigger.Label>
+        </NativeTabs.Trigger>
+        <NativeTabs.Trigger name="settings">
+          <NativeTabs.Trigger.Label>Settings</NativeTabs.Trigger.Label>
+        </NativeTabs.Trigger>
+      </NativeTabs>
+    </ThemeProvider>
+  );
+}
+```
+
+**For dark-mode-only apps:**
+
+```tsx app/_layout.tsx
+import { ThemeProvider, DarkTheme } from '@react-navigation/native';
+import { NativeTabs } from 'expo-router/unstable-native-tabs';
+
+export default function TabLayout() {
+  return (
+    <ThemeProvider value={DarkTheme}>
+      <NativeTabs>{/* tabs */}</NativeTabs>
+    </ThemeProvider>
   );
 }
 ```

--- a/docs/pages/router/advanced/stack-toolbar.mdx
+++ b/docs/pages/router/advanced/stack-toolbar.mdx
@@ -305,6 +305,104 @@ export default function DocumentScreen() {
 }
 ```
 
+## Common problems
+
+<Collapsible summary="Liquid glass toolbar buttons flicker in dark mode on iOS 26">
+
+Toolbar buttons with liquid glass styling may flicker or flash their background when navigating between screens in dark mode on iOS 26. This happens because React Navigation's default theme doesn't match the system dark mode, causing visual artifacts in the liquid glass rendering.
+
+To fix this, wrap your root layout with `ThemeProvider` from `@react-navigation/native` using the appropriate theme:
+
+```tsx app/_layout.tsx
+import { ThemeProvider, DarkTheme, DefaultTheme } from '@react-navigation/native';
+import { Stack } from 'expo-router';
+import { useColorScheme } from 'react-native';
+
+export default function RootLayout() {
+  const colorScheme = useColorScheme();
+
+  return (
+    /* @info Wrap your layout with ThemeProvider to fix liquid glass flickering */
+    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+      /* @end */
+      <Stack />
+    </ThemeProvider>
+  );
+}
+```
+
+</Collapsible>
+
+<Collapsible summary="White background flashes when navigating between screens">
+
+A white flash between screen transitions usually means the navigation stack is using a light background while your app uses a dark theme. This is especially noticeable when screens contain toolbar items, as the flash contrasts with the toolbar styling.
+
+To fix this, wrap your root layout with React Navigation's `ThemeProvider` and pass the appropriate theme:
+
+```tsx app/_layout.tsx
+import { ThemeProvider, DarkTheme, DefaultTheme } from '@react-navigation/native';
+import { Stack } from 'expo-router';
+import { useColorScheme } from 'react-native';
+
+export default function RootLayout() {
+  const colorScheme = useColorScheme();
+
+  return (
+    /* @info Wrap your layout with ThemeProvider to set backgrounds for all screens */
+    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+      /* @end */
+      <Stack />
+    </ThemeProvider>
+  );
+}
+```
+
+</Collapsible>
+
+<Collapsible summary="Large title does not collapse when scrolling">
+
+When using `headerLargeTitle: true` (or `<Stack.Screen.Title large>`) alongside `Stack.Toolbar`, the large title may not collapse on scroll. This happens when the scrollable view is not the direct first child of the screen component.
+
+To fix this, ensure `ScrollView` or `FlatList` is the first child rendered by your screen component. If you need a wrapper, set `collapsable={false}` on it:
+
+```tsx app/index.tsx
+import { Stack } from 'expo-router';
+import { ScrollView, View, Text } from 'react-native';
+
+/* @info Correct: ScrollView is the direct first child */
+export default function Home() {
+  return (
+    <ScrollView>
+      <Stack.Screen.Title large>Home</Stack.Screen.Title>
+      <Text>Content here</Text>
+    </ScrollView>
+  );
+}
+/* @end */
+```
+
+If you need to wrap the `ScrollView`, set `collapsable={false}` on the wrapper:
+
+```tsx app/index.tsx
+import { Stack } from 'expo-router';
+import { ScrollView, View, Text } from 'react-native';
+
+export default function Home() {
+  return (
+    /* @info Set collapsable={false} on any wrapper around ScrollView */
+    <View collapsable={false}>
+      /* @end */
+      <ScrollView>
+        <Stack.Screen.Title large>Home</Stack.Screen.Title>
+        <Text>Content here</Text>
+      </ScrollView>
+    </View>
+  );
+}
+```
+
+</Collapsible>
+
 ## Known limitations
 
 <Collapsible summary="iOS only">

--- a/docs/pages/router/advanced/stack-toolbar.mdx
+++ b/docs/pages/router/advanced/stack-toolbar.mdx
@@ -311,7 +311,7 @@ export default function DocumentScreen() {
 
 Toolbar buttons with liquid glass styling may flicker or flash their background when navigating between screens in dark mode on iOS 26. This happens because React Navigation's default theme doesn't match the system dark mode, causing visual artifacts in the liquid glass rendering.
 
-To fix this, wrap your root layout with `ThemeProvider` from `@react-navigation/native` using the appropriate theme:
+To fix this, wrap your root layout with `<ThemeProvider>` from `@react-navigation/native` using the appropriate theme:
 
 ```tsx app/_layout.tsx
 import { ThemeProvider, DarkTheme, DefaultTheme } from '@react-navigation/native';
@@ -337,7 +337,7 @@ export default function RootLayout() {
 
 A white flash between screen transitions usually means the navigation stack is using a light background while your app uses a dark theme. This is especially noticeable when screens contain toolbar items, as the flash contrasts with the toolbar styling.
 
-To fix this, wrap your root layout with React Navigation's `ThemeProvider` and pass the appropriate theme:
+To fix this, wrap your root layout with React Navigation's `<ThemeProvider>` and pass the appropriate theme:
 
 ```tsx app/_layout.tsx
 import { ThemeProvider, DarkTheme, DefaultTheme } from '@react-navigation/native';

--- a/docs/pages/router/advanced/zoom-transition.mdx
+++ b/docs/pages/router/advanced/zoom-transition.mdx
@@ -353,37 +353,3 @@ If you attempt to use Link with zoom transition to a screen that is not part of 
 The zoom transition feature requires iOS 18 or later. While the components will render on older versions, the zoom animation will not be applied.
 
 </Collapsible>
-
-<Collapsible summary="Using zoom transition with ScrollView">
-
-When using zoom transitions on screens with a `ScrollView`, the swipe-to-dismiss gesture may conflict with scrolling. To prevent accidental dismissal while scrolling, use the `usePreventZoomTransitionDismissal` hook with `unstable_dismissalBoundsRect`:
-
-```tsx app/image.tsx
-import { Link, usePreventZoomTransitionDismissal } from 'expo-router';
-import { useState } from 'react';
-import { ScrollView } from 'react-native';
-
-export default function Screen() {
-  const [shouldPrevent, setShouldPrevent] = useState(false);
-  usePreventZoomTransitionDismissal(
-    shouldPrevent
-      ? undefined
-      : {
-          unstable_dismissalBoundsRect: { minX: 0, minY: 0 },
-        }
-  );
-  return (
-    <ScrollView
-      style={{ flex: 1 }}
-      onScroll={event => {
-        setShouldPrevent(event.nativeEvent.contentOffset.y > 1);
-      }}>
-      {/* Content */}
-    </ScrollView>
-  );
-}
-```
-
-This approach disables the swipe-to-dismiss gesture when the scroll position is at the top, allowing users to scroll down without accidentally triggering the dismissal animation. Once scrolled, the gesture is re-enabled.
-
-</Collapsible>


### PR DESCRIPTION
# Why

On Slack and discord people asked questions about problems which can be easily documented.

# How

1. Add common problems to Stack toolbar
2. Document header buttons flickering in native tabs
3. Remove outdated ScrollView section from zoom transition
4. Custom web tabs guidelines were missing from native tabs docs

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
