### PR TITLE
fix(docs) added links to supported audio formats

### DIFF
--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -19,7 +19,7 @@ import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
 `expo-audio` is a cross-platform audio library for accessing the native audio capabilities of the device.
 
-The [iOS audio and video format documentation](https://developer.apple.com/documentation/coreaudiotypes/audio-format-identifiers) lists supported media formats for Apple devices. The [Android media format support documentation](https://developer.android.com/media/media3/exoplayer/supported-formats) covers formats supported when using Expo Player on Android.
+The [Android media format support documentation](https://developer.android.com/media/media3/exoplayer/supported-formats) covers formats supported when using Expo Player on Android. The [iOS audio and video format documentation](https://developer.apple.com/documentation/coreaudiotypes/audio-format-identifiers) lists supported media formats for Apple devices.
 
 Note that audio automatically stops if headphones/bluetooth audio devices are disconnected.
 

--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -19,7 +19,7 @@ import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
 `expo-audio` is a cross-platform audio library for accessing the native audio capabilities of the device.
 
-The [iOS audio and video format documentation](https://developer.apple.com/documentation/coreaudiotypes/audio-format-identifiers) lists supported media formats for Apple devices. The [Android media format support documentation](https://developer.android.com/guide/topics/media/media-formats) covers formats supported when using Expo Player on Android.
+The [iOS audio and video format documentation](https://developer.apple.com/documentation/coreaudiotypes/audio-format-identifiers) lists supported media formats for Apple devices. The [Android media format support documentation](https://developer.android.com/media/media3/exoplayer/supported-formats) covers formats supported when using Expo Player on Android.
 
 Note that audio automatically stops if headphones/bluetooth audio devices are disconnected.
 

--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -19,6 +19,8 @@ import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
 `expo-audio` is a cross-platform audio library for accessing the native audio capabilities of the device.
 
+The [iOS audio and video format documentation](https://developer.apple.com/documentation/coreaudiotypes/audio-format-identifiers) lists supported media formats for Apple devices. The [Android media format support documentation](https://developer.android.com/guide/topics/media/media-formats) covers formats supported when using Expo Player on Android.
+
 Note that audio automatically stops if headphones/bluetooth audio devices are disconnected.
 
 ## Installation

--- a/docs/pages/versions/v54.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/audio.mdx
@@ -15,7 +15,7 @@ import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
 `expo-audio` is a cross-platform audio library for accessing the native audio capabilities of the device.
 
-The [iOS audio and video format documentation](https://developer.apple.com/documentation/coreaudiotypes/audio-format-identifiers) lists supported media formats for Apple devices. The [Android media format support documentation](https://developer.android.com/media/media3/exoplayer/supported-formats) covers formats supported when using Expo Player on Android.
+The [Android media format support documentation](https://developer.android.com/media/media3/exoplayer/supported-formats) covers formats supported when using Expo Player on Android. The [iOS audio and video format documentation](https://developer.apple.com/documentation/coreaudiotypes/audio-format-identifiers) lists supported media formats for Apple devices.
 
 Note that audio automatically stops if headphones/bluetooth audio devices are disconnected.
 

--- a/docs/pages/versions/v54.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/audio.mdx
@@ -15,7 +15,7 @@ import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
 `expo-audio` is a cross-platform audio library for accessing the native audio capabilities of the device.
 
-The [iOS audio and video format documentation](https://developer.apple.com/documentation/coreaudiotypes/audio-format-identifiers) lists supported media formats for Apple devices. The [Android media format support documentation](https://developer.android.com/guide/topics/media/media-formats) covers formats supported when using Expo Player on Android.
+The [iOS audio and video format documentation](https://developer.apple.com/documentation/coreaudiotypes/audio-format-identifiers) lists supported media formats for Apple devices. The [Android media format support documentation](https://developer.android.com/media/media3/exoplayer/supported-formats) covers formats supported when using Expo Player on Android.
 
 Note that audio automatically stops if headphones/bluetooth audio devices are disconnected.
 

--- a/docs/pages/versions/v54.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/audio.mdx
@@ -15,6 +15,8 @@ import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
 `expo-audio` is a cross-platform audio library for accessing the native audio capabilities of the device.
 
+The [iOS audio and video format documentation](https://developer.apple.com/documentation/coreaudiotypes/audio-format-identifiers) lists supported media formats for Apple devices. The [Android media format support documentation](https://developer.android.com/guide/topics/media/media-formats) covers formats supported when using Expo Player on Android.
+
 Note that audio automatically stops if headphones/bluetooth audio devices are disconnected.
 
 ## Installation

--- a/docs/pages/versions/v55.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/audio.mdx
@@ -19,7 +19,7 @@ import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
 `expo-audio` is a cross-platform audio library for accessing the native audio capabilities of the device.
 
-The [iOS audio and video format documentation](https://developer.apple.com/documentation/coreaudiotypes/audio-format-identifiers) lists supported media formats for Apple devices. The [Android media format support documentation](https://developer.android.com/media/media3/exoplayer/supported-formats) covers formats supported when using Expo Player on Android.
+The [Android media format support documentation](https://developer.android.com/media/media3/exoplayer/supported-formats) covers formats supported when using Expo Player on Android. The [iOS audio and video format documentation](https://developer.apple.com/documentation/coreaudiotypes/audio-format-identifiers) lists supported media formats for Apple devices.
 
 Note that audio automatically stops if headphones/bluetooth audio devices are disconnected.
 

--- a/docs/pages/versions/v55.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/audio.mdx
@@ -19,7 +19,7 @@ import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
 `expo-audio` is a cross-platform audio library for accessing the native audio capabilities of the device.
 
-The [iOS audio and video format documentation](https://developer.apple.com/documentation/coreaudiotypes/audio-format-identifiers) lists supported media formats for Apple devices. The [Android media format support documentation](https://developer.android.com/guide/topics/media/media-formats) covers formats supported when using Expo Player on Android.
+The [iOS audio and video format documentation](https://developer.apple.com/documentation/coreaudiotypes/audio-format-identifiers) lists supported media formats for Apple devices. The [Android media format support documentation](https://developer.android.com/media/media3/exoplayer/supported-formats) covers formats supported when using Expo Player on Android.
 
 Note that audio automatically stops if headphones/bluetooth audio devices are disconnected.
 

--- a/docs/pages/versions/v55.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/audio.mdx
@@ -19,6 +19,8 @@ import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
 `expo-audio` is a cross-platform audio library for accessing the native audio capabilities of the device.
 
+The [iOS audio and video format documentation](https://developer.apple.com/documentation/coreaudiotypes/audio-format-identifiers) lists supported media formats for Apple devices. The [Android media format support documentation](https://developer.android.com/guide/topics/media/media-formats) covers formats supported when using Expo Player on Android.
+
 Note that audio automatically stops if headphones/bluetooth audio devices are disconnected.
 
 ## Installation


### PR DESCRIPTION
# Why

Expo-AV had a section about supported audio format that was not carried over to expo-audio.

This issues points it out: #42804

This commit fixes this by adding it to SDK-54, 55 and unversioned.

Closes #42804

# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
