### PR TITLE
[dev-launcher] improvements to error handling 

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- fixes to error handling ([#42873](https://github.com/expo/expo/pull/42873) by [@vonovak](https://github.com/vonovak))
+
 ### 💡 Others
 
 ## 55.0.5 — 2026-02-03

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -38,9 +38,10 @@
 #define VERSION @ STRINGIZE2(EX_DEV_LAUNCHER_VERSION)
 #endif
 
+static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
+
 @interface EXDevLauncherController ()
 
-@property (nonatomic, weak) UIWindow *window;
 @property (nonatomic, weak) ExpoDevLauncherReactDelegateHandler * delegate;
 @property (nonatomic, strong) NSDictionary *launchOptions;
 @property (nonatomic, strong) NSURL *sourceUrl;
@@ -159,9 +160,18 @@
 }
 
 
-- (EXDevLauncherErrorManager *)errorManage
+- (UIWindow *)currentWindow
 {
-  return _errorManager;
+#if !TARGET_OS_OSX
+  for (UIWindow *window in UIApplication.sharedApplication.windows) {
+    if (window.isKeyWindow) {
+      return window;
+    }
+  }
+  return nil;
+#else
+  return NSApplication.sharedApplication.keyWindow;
+#endif
 }
 
 - (void)start:(id<EXDevLauncherControllerDelegate>)delegate launchOptions:(NSDictionary * _Nullable)launchOptions
@@ -198,8 +208,7 @@
   if (_lastOpenedAppUrl != nil && shouldTryToLaunchLastOpenedBundle && [launchOptions objectForKey:@"UIApplicationLaunchOptionsURLKey"] == nil) {
     // When launch to the last opened url, the previous url could be unreachable because of LAN IP changed.
     // We use a shorter timeout to prevent black screen when loading for an unreachable server.
-    NSTimeInterval requestTimeout = 10.0;
-    [self loadApp:_lastOpenedAppUrl withProjectUrl:nil withTimeout:requestTimeout onSuccess:nil onError:navigateToLauncher];
+    [self loadApp:_lastOpenedAppUrl withProjectUrl:nil withTimeout:EXDevLauncherDefaultRequestTimeout onSuccess:nil onError:navigateToLauncher];
     return;
   }
   [self navigateToLauncher];
@@ -293,7 +302,7 @@
 {
   [self loadApp:url
  withProjectUrl:projectUrl
-    withTimeout:NSURLSessionConfiguration.defaultSessionConfiguration.timeoutIntervalForRequest
+    withTimeout:EXDevLauncherDefaultRequestTimeout
       onSuccess:onSuccess
         onError:onError];
 }
@@ -411,18 +420,20 @@
     } error:onError];
   };
 
+  __block BOOL shouldRetry = YES;
   [manifestParser isManifestURLWithCompletion:onIsManifestURL onError:^(NSError * _Nonnull error) {
     // Try to retry if the network connection was rejected because of the lack of the lan network permission.
-    static BOOL shouldRetry = true;
     NSString *host = expoUrl.host;
 
     if (shouldRetry && ([host hasPrefix:@"192.168."] || [host hasPrefix:@"172."] || [host hasPrefix:@"10."])) {
-      shouldRetry = false;
+      shouldRetry = NO;
       [manifestParser isManifestURLWithCompletion:onIsManifestURL onError:onError];
       return;
     }
 
-    onError(error);
+    if (onError) {
+      onError(error);
+    }
   }];
 }
 
@@ -447,6 +458,8 @@
     }
     __typeof(self) self = weakSelf;
 
+    UIWindow *window = self.currentWindow;
+
     self.sourceUrl = bundleUrl;
 
 #if RCT_DEV
@@ -466,7 +479,7 @@
     // So we swap `currentTraitCollection` with one from the root view controller.
     // Note that the root view controller will have the correct value of `userInterfaceStyle`.
     if (userInterfaceStyle != UIUserInterfaceStyleUnspecified) {
-      UITraitCollection.currentTraitCollection = [self.window.rootViewController.traitCollection copy];
+      UITraitCollection.currentTraitCollection = [window.rootViewController.traitCollection copy];
     }
 #endif
 
@@ -476,9 +489,9 @@
 
     if (backgroundColor) {
 #if !TARGET_OS_OSX
-      self.window.rootViewController.view.backgroundColor = backgroundColor;
+      window.rootViewController.view.backgroundColor = backgroundColor;
 #endif
-      self.window.backgroundColor = backgroundColor;
+      window.backgroundColor = backgroundColor;
     }
   });
 }
@@ -502,7 +515,7 @@
 - (void)onAppContentDidAppear
 {
   dispatch_async(dispatch_get_main_queue(), ^{
-    NSArray<UIView *> *views = [[[self->_window rootViewController] view] subviews];
+    NSArray<UIView *> *views = [self.currentWindow.rootViewController.view subviews];
     for (UIView *view in views) {
       if ([NSStringFromClass([view class]) containsString:@"SplashScreen"]) {
         [view removeFromSuperview];

--- a/packages/expo-dev-launcher/ios/Errors/EXDevLauncherErrorManager.swift
+++ b/packages/expo-dev-launcher/ios/Errors/EXDevLauncherErrorManager.swift
@@ -47,16 +47,19 @@ public class EXDevLauncherErrorManager: NSObject {
 
       let errorView = ErrorView(
         error: error,
-        onReload: {
-          self?.dismissCurrentErrorView()
-          guard let appUrl = self?.controller?.appManifestURLWithFallback() else {
+        onReload: { [weak self] in
+          guard let self else { return }
+          self.dismissCurrentErrorView()
+          guard let appUrl = self.controller?.appManifestURLWithFallback() else {
+            self.controller?.navigateToLauncher()
             return
           }
-          self?.controller?.loadApp(appUrl, onSuccess: nil, onError: nil)
+          self.controller?.loadApp(appUrl, onSuccess: nil, onError: nil)
         },
-        onGoHome: {
-          self?.dismissCurrentErrorView()
-          self?.controller?.navigateToLauncher()
+        onGoHome: { [weak self] in
+          guard let self else { return }
+          self.dismissCurrentErrorView()
+          self.controller?.navigateToLauncher()
         }
       )
 

--- a/packages/expo-dev-launcher/ios/Errors/EXDevLauncherRedBox.m
+++ b/packages/expo-dev-launcher/ios/Errors/EXDevLauncherRedBox.m
@@ -141,11 +141,6 @@
     return;
   }
 
-  // hide method was removed from the RCTLogBox interface in RN 0.64
-  if ([self.logBox respondsToSelector:@selector(hide)]) {
-    [self.logBox performSelector:@selector(hide)];
-  }
-
   dispatch_async(dispatch_get_main_queue(), ^{
     EXDevLauncherAppError *appError = [[EXDevLauncherAppError alloc] initWithMessage:[self stripAnsi:message] stack:stack];
     [[EXDevLauncherController sharedInstance].errorManager showError:appError];

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
@@ -108,11 +108,11 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response);
     [request setValue:self.installationID forHTTPHeaderField:@"Expo-Dev-Client-ID"];
   }
   NSURLSessionDataTask *dataTask = [self.session dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
-    if (error) {
+    if (!error) {
+      completionHandler(data, response);
+    } else if (onError) {
       onError(error);
-      return;
     }
-    completionHandler(data, response);
   }];
   [dataTask resume];
 }

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
@@ -87,6 +87,9 @@ struct DevServersView: View {
             .font(.system(size: 14))
             #endif
           Spacer()
+          if viewModel.isLoadingServer && viewModel.devServers.isEmpty {
+            ProgressView()
+          }
         }
       }
 


### PR DESCRIPTION
# Why

This PR improves  error handling of the Dev Launcher on iOS by fixing issues related to window management, unrecognized selector, attempting to call nil callbacks (closures) and network request timeout.

# How

- Replaced direct window property (it was never set) with a `currentWindow` method that finds the key window
- Added a constant for default request timeout (10 seconds) and used it consistently
- Improved error handling in the manifest parser to handle nil callbacks
- Added a loading indicator when no serves are available yet and user enters url manually
- Fixed an issue where the error handler could be called with a nil callback
- Made the retry flag for manifest URL checking instance-specific rather than static (seemed odd)

# Test Plan

Tested the Dev Launcher on iOS by:
1. Opening the launcher with no servers configured and entering manual url
2. with no metro running, connecting with invalid deep link `xcrun simctl openurl booted "exp+bare-expo://expo-development-client/?url=http://localhost:8081"` -> leads to ErrorView. Starting metro and tapping "Reload" button correctly reloads.
3. Testing error scenarios with unreachable servers

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)