### PR TITLE
[docs] Update docs inside Expo Router Advanced for SDK 55

### DIFF
--- a/docs/pages/router/advanced/apple-handoff.mdx
+++ b/docs/pages/router/advanced/apple-handoff.mdx
@@ -105,7 +105,7 @@ In development, you must start the website **before installing the app on your d
 
 In any route that you want to support handoff, use the `Head` component from `expo-router/head`:
 
-```tsx app/index.tsx
+```tsx src/app/index.tsx
 import Head from 'expo-router/head';
 import { Text } from 'react-native';
 
@@ -135,7 +135,7 @@ The `expo-router/head` component supports the following meta tags:
 You may want to switch the values between platforms, for that you can use **Platform.select**:
 
 {/* prettier-ignore */}
-```tsx app/index.tsx
+```tsx src/app/index.tsx
 import Head from 'expo-router/head';
 
 export default function App() {

--- a/docs/pages/router/advanced/custom-tabs.mdx
+++ b/docs/pages/router/advanced/custom-tabs.mdx
@@ -44,7 +44,7 @@ There are four components offered by `expo-router/ui` to create custom tab layou
 
 A bare minimum structure of a custom tab layout would consist of a `TabList` (containing `TabTrigger` components for each tab) and a`TabSlot`, all within the `Tabs` component, as shown here:
 
-```tsx app/(tabs)/_layout.tsx|collapseHeight=440
+```tsx src/app/(tabs)/_layout.tsx|collapseHeight=440
 import { Tabs, TabList, TabTrigger, TabSlot } from 'expo-router/ui';
 import { Text } from 'react-native';
 
@@ -105,7 +105,7 @@ A `TabTrigger` can link to a deeply nested route. `<TabTrigger name="route" href
 
 The `TabSlot` component renders the current route. `TabSlot` can be nested inside other components within `Tabs` but cannot be within the `TabList`.
 
-```tsx app/_layout.tsx
+```tsx src/app/_layout.tsx
 <Tabs>
   <TabList>
     <TabTrigger name="home" href="/">
@@ -217,7 +217,7 @@ The `TabList` is both the configuration and default appearance of the `Tabs`, bu
 
 `TabTrigger` will forward an `isFocused` prop, so you can create a separate tab button component that reacts to focused status.
 
-```tsx TabButton.tsx
+```tsx tab-button.tsx
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import { TabTriggerSlotProps } from 'expo-router/ui';
 import { ComponentProps, Ref } from 'react';

--- a/docs/pages/router/advanced/native-intent.mdx
+++ b/docs/pages/router/advanced/native-intent.mdx
@@ -24,13 +24,13 @@ Expo Router will always evaluate a URL with the assumption that the URL targets 
 
 In such scenarios, the URL needs to be rewritten to correctly target a route.
 
-To facilitate this, create a special file called **+native-intent.tsx** at the top level of your project's **app** directory. This file exports a special [`redirectSystemPath`](/versions/latest/sdk/router/#nativeintent) method designed to handle URL/path processing. When invoked, it receives an `options` object with two attributes: `path` and `initial`.
+To facilitate this, create a special file called **+native-intent.tsx** at the top level of your project's **src/app** directory. This file exports a special [`redirectSystemPath`](/versions/latest/sdk/router/#nativeintent) method designed to handle URL/path processing. When invoked, it receives an `options` object with two attributes: `path` and `initial`.
 
-<FileTree files={['app/+native-intent.tsx']} />
+<FileTree files={['src/app/+native-intent.tsx']} />
 
 Here's an example the applies practices on how `redirectSystemPath` is used inside **+native-intent.tsx** file. Following this example, you can ensure the stability and reliability of your app's URL processing functionality and mitigate the risk of unexpected errors and crashes.
 
-```ts app/+native-intent.tsx
+```ts src/app/+native-intent.tsx
 import ThirdPartyService from 'third-party-sdk';
 
 export function redirectSystemPath({ path, initial }) {
@@ -74,7 +74,7 @@ While your app is open, you can react to URL changes within your `_layout` files
 - **global**: Add the logic to your root `_layout` file
 - **localized**: Add a `_layout` file to an existing directory (or create a new [group directory](/router/basics/notation/#parentheses))
 
-```tsx app/_layout.tsx
+```tsx src/app/_layout.tsx
 import { Slot, Redirect } from 'expo-router';
 
 export default function RootLayout() {
@@ -99,7 +99,7 @@ In native apps, an alternative way to rewrite a URL is to handle it within the [
 
 Below is a basic example of how to send navigation events to an external service, such as an analytics or logging service. Consult with your provider for specific instructions.
 
-```tsx app/_layout.tsx
+```tsx src/app/_layout.tsx
 import ThirdPartyService from 'third-party-sdk';
 import { Slot, usePathname } from 'expo-router';
 

--- a/docs/pages/router/advanced/platform-specific-modules.mdx
+++ b/docs/pages/router/advanced/platform-specific-modules.mdx
@@ -13,19 +13,19 @@ While building your app, you may want to show specific content based on the curr
 
 There are two ways to use platform-specific extensions:
 
-### Within app directory
+### Within src/app directory
 
-Metro bundler's platform-specific extensions (for example, **.android.tsx**, **.ios.tsx**, **.native.tsx**, or **.web.tsx**) are supported in the **app** directory only if a **non-platform version** also exists. This ensures that routes are universal across platforms for deep linking.
+Metro bundler's platform-specific extensions (for example, **.android.tsx**, **.ios.tsx**, **.native.tsx**, or **.web.tsx**) are supported in the **src/app** directory only if a **non-platform version** also exists. This ensures that routes are universal across platforms for deep linking.
 
 Consider the following project structure:
 
 <FileTree
   files={[
-    'app/_layout.tsx',
-    'app/_layout.web.tsx',
-    'app/index.tsx',
-    'app/about.tsx',
-    'app/about.web.tsx',
+    'src/app/_layout.tsx',
+    'src/app/_layout.web.tsx',
+    'src/app/index.tsx',
+    'src/app/about.tsx',
+    'src/app/about.web.tsx',
   ]}
 />
 
@@ -35,34 +35,34 @@ In the above file structure:
 - **index.tsx** file is used as the home page for all platforms.
 - **about.web.tsx** file is used as the about page for the web, and the **about.tsx** file is used on all other platforms.
 
-### Outside app directory
+### Outside src/app directory
 
-You can create platform-specific files with extensions (for example, **.android.tsx**, **.ios.tsx**, **.native.tsx**, or **.web.tsx**) outside the **app** directory and use them from within the **app** directory.
+You can create platform-specific files with extensions (for example, **.android.tsx**, **.ios.tsx**, **.native.tsx**, or **.web.tsx**) outside the **src/app** directory and use them from within the **src/app** directory.
 
 Consider the following project structure:
 
 <FileTree
   files={[
-    'app/_layout.tsx',
-    'app/index.tsx',
-    'app/about.tsx',
-    'components/about.tsx',
-    'components/about.ios.tsx',
-    'components/about.web.tsx',
+    'src/app/_layout.tsx',
+    'src/app/index.tsx',
+    'src/app/about.tsx',
+    'src/components/about.tsx',
+    'src/components/about.ios.tsx',
+    'src/components/about.web.tsx',
   ]}
 />
 
-In the above file structure, the designs require you to build different `about` screens for each platform. In that case, you can create a component for each platform in the **components** directory using platform extensions. When imported, Metro will ensure the correct component version is used based on the current platform. You can then re-export the component as a screen in the **app** directory.
+In the above file structure, the designs require you to build different `about` screens for each platform. In that case, you can create a component for each platform in the **src/components** directory using platform extensions. When imported, Metro will ensure the correct component version is used based on the current platform. You can then re-export the component as a screen in the **src/app** directory.
 
-```tsx app/about.tsx
-export { default } from '../components/about';
+```tsx src/app/about.tsx
+export { default } from '@/components/about';
 ```
 
 ## Platform module
 
 You can use the [`Platform`](https://reactnative.dev/docs/platform-specific-code#platform-module) module from React Native to detect the current platform and render the appropriate content based on the result. For example, you can render a `Tabs` layout on native and a custom layout on the web.
 
-```tsx app/_layout.tsx
+```tsx src/app/_layout.tsx
 import { Platform } from 'react-native';
 import { Link, Slot, Tabs } from 'expo-router';
 

--- a/docs/pages/router/advanced/router-settings.mdx
+++ b/docs/pages/router/advanced/router-settings.mdx
@@ -14,9 +14,9 @@ import { FileTree } from '~/ui/components/FileTree';
 
 When deep linking to a route, you may want to provide a user with a "back" button. The `initialRouteName` sets the default screen of the stack and should match a valid filename (without the extension).
 
-<FileTree files={['app/_layout.tsx', 'app/index.tsx', 'app/other.tsx']} />
+<FileTree files={['src/app/_layout.tsx', 'src/app/index.tsx', 'src/app/other.tsx']} />
 
-```tsx app/_layout.tsx
+```tsx src/app/_layout.tsx
 import { Stack } from 'expo-router';
 
 export const unstable_settings = {

--- a/docs/pages/router/advanced/stack-toolbar.mdx
+++ b/docs/pages/router/advanced/stack-toolbar.mdx
@@ -13,7 +13,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 
 Use [`Stack.Toolbar.Button`](/versions/unversioned/sdk/router/#stacktoolbarbutton) within `Stack.Toolbar` with `placement="right"` or `placement="left"` to add buttons to the navigation header. This is useful for actions like favoriting, sharing, or editing content.
 
-```tsx app/notes/[id].tsx
+```tsx src/app/notes/[id].tsx
 import { useState } from 'react';
 import { Stack } from 'expo-router';
 import { View, Text, Alert } from 'react-native';
@@ -106,7 +106,7 @@ export default function Page() {
 
 For screens with multiple actions, use [`Stack.Toolbar.Menu`](/versions/unversioned/sdk/router/#stacktoolbarmenu) to group them into a dropdown menu:
 
-```tsx app/mail/[id].tsx
+```tsx src/app/mail/[id].tsx
 import { useState } from 'react';
 import { Stack } from 'expo-router';
 import { Alert } from 'react-native';
@@ -199,7 +199,7 @@ export default function EmailScreen() {
 
 iOS apps commonly have a bottom toolbar for primary actions. To add one, use `Stack.Toolbar` without a placement prop (it defaults to `"bottom"`):
 
-```tsx app/photos/index.tsx
+```tsx src/app/photos/index.tsx
 import { Stack } from 'expo-router';
 import { Alert } from 'react-native';
 
@@ -228,7 +228,7 @@ export default function PhotosScreen() {
 
 In header toolbars, you can add badges to indicate counts or status. Use [`Stack.Toolbar.Icon`](/versions/unversioned/sdk/router/#stacktoolbaricon), [`Stack.Toolbar.Label`](/versions/unversioned/sdk/router/#stacktoolbarlabel), and [`Stack.Toolbar.Badge`](/versions/unversioned/sdk/router/#stacktoolbarbadge) to compose the button content:
 
-```tsx app/inbox.tsx
+```tsx src/app/inbox.tsx
 import { Stack } from 'expo-router';
 
 export default function InboxScreen() {
@@ -255,7 +255,7 @@ export default function InboxScreen() {
 
 When you need something beyond buttons and menus, use [`Stack.Toolbar.View`](/versions/unversioned/sdk/router/#stacktoolbarview) to embed any React Native component:
 
-```tsx app/search.tsx
+```tsx src/app/search.tsx
 import { Stack } from 'expo-router';
 import { Pressable, Alert } from 'react-native';
 import { SymbolView } from 'expo-symbols';
@@ -284,7 +284,7 @@ export default function SearchScreen() {
 
 Use the `hidden` prop to toggle toolbar items based on state:
 
-```tsx app/document.tsx
+```tsx src/app/document.tsx
 import { useState } from 'react';
 import { Stack } from 'expo-router';
 
@@ -313,7 +313,7 @@ Toolbar buttons with liquid glass styling may flicker or flash their background 
 
 To fix this, wrap your root layout with `<ThemeProvider>` from `@react-navigation/native` using the appropriate theme:
 
-```tsx app/_layout.tsx
+```tsx src/app/_layout.tsx
 import { ThemeProvider, DarkTheme, DefaultTheme } from '@react-navigation/native';
 import { Stack } from 'expo-router';
 import { useColorScheme } from 'react-native';
@@ -339,7 +339,7 @@ A white flash between screen transitions usually means the navigation stack is u
 
 To fix this, wrap your root layout with React Navigation's `<ThemeProvider>` and pass the appropriate theme:
 
-```tsx app/_layout.tsx
+```tsx src/app/_layout.tsx
 import { ThemeProvider, DarkTheme, DefaultTheme } from '@react-navigation/native';
 import { Stack } from 'expo-router';
 import { useColorScheme } from 'react-native';
@@ -365,7 +365,7 @@ When using `headerLargeTitle: true` (or `<Stack.Screen.Title large>`) alongside 
 
 To fix this, ensure `ScrollView` or `FlatList` is the first child rendered by your screen component. If you need a wrapper, set `collapsable={false}` on it:
 
-```tsx app/index.tsx
+```tsx src/app/index.tsx
 import { Stack } from 'expo-router';
 import { ScrollView, View, Text } from 'react-native';
 
@@ -383,7 +383,7 @@ export default function Home() {
 
 If you need to wrap the `ScrollView`, set `collapsable={false}` on the wrapper:
 
-```tsx app/index.tsx
+```tsx src/app/index.tsx
 import { Stack } from 'expo-router';
 import { ScrollView, View, Text } from 'react-native';
 

--- a/docs/pages/router/advanced/zoom-transition.mdx
+++ b/docs/pages/router/advanced/zoom-transition.mdx
@@ -23,7 +23,7 @@ To implement zoom transitions, you need to use the `Link.AppleZoom` component to
 
 To activate zoom transition for a link, wrap the source (`Image`) element with `Link.AppleZoom` in your screen:
 
-```tsx app/index.tsx
+```tsx src/app/index.tsx
 import { View, Text, StyleSheet, Pressable } from 'react-native';
 import { Link } from 'expo-router';
 import { Image } from 'expo-image';
@@ -48,7 +48,7 @@ export default function HomeScreen() {
 
 In the destination screen, define the `Image` component:
 
-```tsx app/image.tsx
+```tsx src/app/image.tsx
 import { View, Text, StyleSheet } from 'react-native';
 import { Image } from 'expo-image';
 
@@ -78,7 +78,7 @@ The `Link.AppleZoom` component wraps the element you want to zoom from. It is us
 
 You can specify the alignment of the zoomed element on the destination screen by using `Link.AppleZoomTarget` element.
 
-```tsx app/image.tsx
+```tsx src/app/image.tsx
 export default function ImageScreen() {
   return (
     <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
@@ -102,9 +102,9 @@ If you need more control over the alignment rectangle, you can pass an `alignmen
 
 ## Complete example
 
-Here's a more complex example showing a gallery grid with zoom transitions to detail views. The source screen component (**app/index.tsx**) uses `Link.AppleZoom` to wrap an `Image` component:
+Here's a more complex example showing a gallery grid with zoom transitions to detail views. The source screen component (**src/app/index.tsx**) uses `Link.AppleZoom` to wrap an `Image` component:
 
-```tsx app/index.tsx
+```tsx src/app/index.tsx
 import { Image } from 'expo-image';
 import { Link } from 'expo-router';
 import { useState } from 'react';
@@ -177,7 +177,7 @@ const styles = StyleSheet.create({
 
 In the destination screen, the `Link.AppleZoomTarget` is used to specify the alignment of the zoomed element:
 
-```tsx app/image/[id].tsx
+```tsx src/app/image/[id].tsx
 import { Image } from 'expo-image';
 import { Link, useLocalSearchParams } from 'expo-router';
 import { useMemo } from 'react';
@@ -239,7 +239,7 @@ The [`usePreventZoomTransitionDismissal`](/versions/unversioned/sdk/router/#usep
 
 Call the hook without any options to completely disable the swipe-to-dismiss gesture:
 
-```tsx app/detail.tsx
+```tsx src/app/detail.tsx
 import { usePreventZoomTransitionDismissal } from 'expo-router';
 
 export default function DetailScreen() {
@@ -253,7 +253,7 @@ export default function DetailScreen() {
 
 Use the `unstable_dismissalBoundsRect` option to define a rectangle where dismissal gestures are allowed. This is useful for image viewers where you want dismissal only from the image area:
 
-```tsx app/image.tsx
+```tsx src/app/image.tsx
 import { usePreventZoomTransitionDismissal } from 'expo-router';
 import { View, StyleSheet } from 'react-native';
 import { Image } from 'expo-image';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Update docs inside Expo Router Advanced for SDK 55.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update file path references from app/ to src/app/ throughout the common navigation patterns page
- Replace relative imports (../, ../../) with @/ path alias in code examples

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Start here: http://localhost:3002/router/advanced/platform-specific-modules/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
