### PR TITLE
fix(expo-file-system): Fix bundle directory listing on Android

### DIFF
--- a/apps/test-suite/tests/FileSystem.ts
+++ b/apps/test-suite/tests/FileSystem.ts
@@ -213,6 +213,94 @@ export async function test({ describe, expect, it, ...t }) {
       }
     });
 
+    if (Platform.OS === 'android') {
+      describe('Android bundle directory listing (issue #41367)', () => {
+        it('returns correct names for files in bundle directory', () => {
+          const dir = new Directory(Paths.bundle);
+          const items = dir.list();
+
+          // All items should have non-empty names
+          for (const item of items) {
+            expect(item.name).not.toBe('');
+            expect(item.name).not.toBeNull();
+            expect(item.name).not.toBeUndefined();
+          }
+        });
+
+        it('returns non-null sizes for files in bundle directory', () => {
+          const dir = new Directory(Paths.bundle);
+          const items = dir.list();
+
+          // Find actual files (not directories)
+          const files = items.filter((item) => item instanceof File);
+
+          // Files should have non-null sizes
+          for (const file of files) {
+            expect((file as File).size).not.toBeNull();
+            expect((file as File).size).toBeGreaterThan(0);
+          }
+        });
+
+        it('can list subdirectories without permission errors', () => {
+          const dir = new Directory(Paths.bundle);
+          const items = dir.list();
+
+          // Find directories
+          const directories = items.filter((item) => item instanceof Directory);
+
+          // Should be able to list each subdirectory without throwing
+          for (const subdir of directories) {
+            expect(() => {
+              (subdir as Directory).list();
+            }).not.toThrow();
+          }
+        });
+
+        it('can recursively list nested bundle directories', () => {
+          const dir = new Directory(Paths.bundle);
+
+          // Recursive function to test listing
+          const testRecursiveList = (directory: Directory, depth: number) => {
+            if (depth > 3) return; // Limit depth to avoid infinite loops
+
+            const items = directory.list();
+            for (const item of items) {
+              // Every item should have a valid name
+              expect(item.name).toBeTruthy();
+
+              if (item instanceof Directory) {
+                // Subdirectories should be listable
+                expect(() => testRecursiveList(item, depth + 1)).not.toThrow();
+              } else if (item instanceof File) {
+                // Files should have size accessible (may be 0 for empty files, but not null)
+                expect(item.size).not.toBeNull();
+              }
+            }
+          };
+
+          expect(() => testRecursiveList(dir, 0)).not.toThrow();
+        });
+
+        it('maintains correct asset:// URIs for nested items', () => {
+          const dir = new Directory(Paths.bundle);
+          const items = dir.list();
+
+          for (const item of items) {
+            // All items in bundle should have asset:// URIs
+            expect(item.uri.startsWith('asset://')).toBe(true);
+
+            if (item instanceof Directory) {
+              const subItems = item.list();
+              for (const subItem of subItems) {
+                // Nested items should also have asset:// URIs
+                expect(subItem.uri.startsWith('asset://')).toBe(true);
+              }
+            }
+          }
+        });
+      });
+    }
+
     describe('Works with %, # and space characters in names', () => {
       it('Works with spaces as filename', () => {
         const outputFile = new File(testDirectory, 'my new file.txt');

--- a/apps/test-suite/tests/FileSystem.ts
+++ b/apps/test-suite/tests/FileSystem.ts
@@ -214,7 +214,7 @@ export async function test({ describe, expect, it, ...t }) {
     });
 
     if (Platform.OS === 'android') {
-      describe('Android bundle directory listing (issue #41367)', () => {
+      describe('Android bundle directory listing', () => {
         it('returns correct names for files in bundle directory', () => {
           const dir = new Directory(Paths.bundle);
           const items = dir.list();

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix bundle directory listing returning incorrect names, URIs and trailing slashes for files. ([#42882](https://github.com/expo/expo/pull/42882) by [@aleqsio](https://github.com/aleqsio))
+
 ### 💡 Others
 
 ## 55.0.4 — 2026-02-03

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemDirectory.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemDirectory.kt
@@ -93,9 +93,14 @@ class FileSystemDirectory(uri: Uri) : FileSystemPath(uri) {
     validatePermission(Permission.READ)
     return file.listFilesAsUnified().map {
       val uriString = it.uri.toString()
+      val isDir = it.isDirectory()
       mapOf(
-        "isDirectory" to it.isDirectory(),
-        "uri" to if (uriString.endsWith("/")) uriString else "$uriString/"
+        "isDirectory" to isDir,
+        "uri" to if (isDir) {
+          if (uriString.endsWith("/")) uriString else "$uriString/"
+        } else {
+          uriString
+        }
       )
     }
   }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/AssetFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/AssetFile.kt
@@ -50,7 +50,7 @@ class AssetFile(private val context: Context, override val uri: Uri) : UnifiedFi
       }
 
       val parentPath = currentPath.substringBeforeLast('/')
-      val parentUri = "asset://$parentPath".toUri()
+      val parentUri = "asset:///$parentPath".toUri()
 
       return AssetFile(context, parentUri)
     }
@@ -71,7 +71,7 @@ class AssetFile(private val context: Context, override val uri: Uri) : UnifiedFi
     val list = context.assets.list(path)
     return list?.map { name ->
       val childPath = if (path.isEmpty()) name else "$path/$name"
-      AssetFile(context, "asset://$childPath".toUri()) as UnifiedFileInterface
+      AssetFile(context, "asset:///$childPath".toUri()) as UnifiedFileInterface
     } ?: emptyList()
   }
 
@@ -134,8 +134,8 @@ class AssetFile(private val context: Context, override val uri: Uri) : UnifiedFi
     if (isDirectory()) {
       val assets = context.assets.list(path)
       assets?.forEach { assetName ->
-        val childUri = "$uri/$assetName".replace("//", "/").toUri()
-        val childFile = AssetFile(context, childUri)
+        val childPath = if (path.isEmpty()) assetName else "$path/$assetName"
+        val childFile = AssetFile(context, "asset:///$childPath".toUri())
         yieldAll(childFile.walkTopDown())
       }
     }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/AssetFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/AssetFile.kt
@@ -69,7 +69,10 @@ class AssetFile(private val context: Context, override val uri: Uri) : UnifiedFi
 
   override fun listFilesAsUnified(): List<UnifiedFileInterface> {
     val list = context.assets.list(path)
-    return list?.map { name -> AssetFile(context, File(path, name).toUri()) as UnifiedFileInterface } ?: emptyList()
+    return list?.map { name ->
+      val childPath = if (path.isEmpty()) name else "$path/$name"
+      AssetFile(context, "asset://$childPath".toUri()) as UnifiedFileInterface
+    } ?: emptyList()
   }
 
   override val type: String?


### PR DESCRIPTION
## Summary

Fixed incorrect URI construction in `AssetFile.listFilesAsUnified()` that was creating `file://` URIs instead of `asset://` URIs for child items. This resolves three bugs reported in issue #41367:
- Empty `directory.name` values when listing bundle directory
- `item.size` returning `null` for files in bundle directory
- "Missing 'READ' permission" errors when listing subdirectories

## Test plan

Added comprehensive Android-specific tests covering:
- Directory names are properly returned and non-empty
- File sizes are accessible and greater than zero
- Subdirectories can be listed without permission errors
- Deep recursive traversal of nested bundle directories works
- All items maintain correct `asset://` URI scheme

🤖 Generated with [Claude Code](https://claude.com/claude-code)