### PR TITLE
[docs] Update docs in Expo Router Reference and Migration sections for SDK 55

### DIFF
--- a/docs/pages/router/error-handling.mdx
+++ b/docs/pages/router/error-handling.mdx
@@ -17,7 +17,7 @@ This guide specifies how to handle unmatched routes and errors in your app when 
 
 Native apps don't have a server so there are technically no 404s. However, if you're implementing a router universally, then it makes sense to handle missing routes. This is done automatically for each app, but you can also customize it.
 
-```tsx app/+not-found.tsx
+```tsx src/app/+not-found.tsx
 import { Unmatched } from 'expo-router';
 export default Unmatched;
 ```
@@ -46,7 +46,7 @@ Expo Router enables fine-tuned error handling to enable a more opinionated data-
 You can export a nested [`ErrorBoundary`](/versions/latest/sdk/router/#errorboundary) component from any route to intercept and format component-level errors using [React Error Boundaries](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary):
 
 {/* prettier-ignore */}
-```tsx app/home.tsx
+```tsx src/app/home.tsx
 import { View, Text } from 'react-native';
 import { type ErrorBoundaryProps } from 'expo-router';
 

--- a/docs/pages/router/migrate/from-expo-webpack.mdx
+++ b/docs/pages/router/migrate/from-expo-webpack.mdx
@@ -59,7 +59,7 @@ In `@expo/webpack-config` all routes shared a single HTML file. This file was ba
 
 In Expo Router, there are two different rendering patterns:
 
-- **Recommended**: `web.output: "static"` which outputs a new HTML file for each route in the app. This approach lets you [dynamically generate the entire HTML template using the **app/+html.js** file](/router/web/static-rendering#root-html).
+- **Recommended**: `web.output: "static"` which outputs a new HTML file for each route in the app. This approach lets you [dynamically generate the entire HTML template using the **src/app/+html.tsx** file](/router/web/static-rendering#root-html).
 - **Not recommended**: `web.output: "single"` which outputs a single-page application. This approach lets you use `public/index.html` as the template HTML file.
 
 ## Static resources
@@ -176,7 +176,7 @@ For example, here's a possible flow for setting up Workbox. Create a new project
 
 Next, create a root HTML file for the app and add the service worker registration script:
 
-```tsx app/+html.tsx
+```tsx src/app/+html.tsx
 import { ScrollViewStyleReset } from 'expo-router/html';
 import type { PropsWithChildren } from 'react';
 
@@ -283,7 +283,7 @@ Unlike `@expo/webpack-config`, Expo Router does not automatically attempt to gen
 
 You can link this in your HTML file using the `link` tag:
 
-```tsx app/+html.tsx
+```tsx src/app/+html.tsx
 import { ScrollViewStyleReset } from 'expo-router/html';
 import type { PropsWithChildren } from 'react';
 

--- a/docs/pages/router/migrate/from-react-navigation.mdx
+++ b/docs/pages/router/migrate/from-react-navigation.mdx
@@ -70,7 +70,35 @@ Expo Router **does not** add `react-native-gesture-handler` (as of v3), so you'l
 
 ### Copy screens to the app directory
 
-Create an **app** directory in a root **src** directory.
+Create an **app** directory inside a root **src** directory. Expo Router automatically detects the **src/app** directory as the root of your routes.
+
+Ensure your **tsconfig.json** has the `@` path alias configured to point to `src`:
+
+```json tsconfig.json
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "paths": {
+      "@/*": ["./src/*"],
+      "@/assets/*": ["./assets/*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"]
+}
+```
+
+Also ensure your **app.json** has the `expo-router` plugin configured:
+
+```json app.json
+{
+  "expo": {
+    /* @hide ... */
+    /* @end */
+    "plugins": ["expo-router"]
+  }
+}
+```
 
 Layout the structure of your app by creating files according to the [application of Expo Router rules](/router/basics/core-concepts/#the-rules-of-expo-router-applied). Kebab-case and lowercase letters are considered best practice for route filenames.
 

--- a/docs/pages/router/migrate/from-react-navigation.mdx
+++ b/docs/pages/router/migrate/from-react-navigation.mdx
@@ -70,7 +70,7 @@ Expo Router **does not** add `react-native-gesture-handler` (as of v3), so you'l
 
 ### Copy screens to the app directory
 
-Create an **app** directory at the root of your repo, or in a root **src** directory.
+Create an **app** directory in a root **src** directory.
 
 Layout the structure of your app by creating files according to the [application of Expo Router rules](/router/basics/core-concepts/#the-rules-of-expo-router-applied). Kebab-case and lowercase letters are considered best practice for route filenames.
 
@@ -127,16 +127,16 @@ function App() {
 
 <FileTree
   files={[
-    'app/_layout.js',
-    'app/(home)/_layout.js',
-    'app/(home)/index.js',
-    'app/(home)/feed.js',
-    'app/profile.js',
-    'app/settings.js',
+    'src/app/_layout.tsx',
+    'src/app/(home)/_layout.tsx',
+    'src/app/(home)/index.tsx',
+    'src/app/(home)/feed.tsx',
+    'src/app/profile.tsx',
+    'src/app/settings.tsx',
   ]}
 />
 
-```jsx app/_layout.js
+```tsx src/app/_layout.tsx
 import { Stack } from 'expo-router';
 
 export default function RootLayout() {
@@ -157,7 +157,7 @@ export default function RootLayout() {
 
 The tab navigator will be moved to a subdirectory.
 
-```jsx app/(home)/_layout.js
+```tsx src/app/(home)/_layout.tsx
 import { Tabs } from 'expo-router';
 
 export default function HomeLayout() {
@@ -307,7 +307,7 @@ The [`fallback`](https://reactnavigation.org/docs/navigation-container/#fallback
 
 In React Navigation, you set the theme for the entire app using the [`<NavigationContainer />`](https://reactnavigation.org/docs/navigation-container/#theme) component. Expo Router manages the root container for you, so instead you should set the theme using the `ThemeProvider` directly.
 
-```tsx app/_layout.tsx
+```tsx src/app/_layout.tsx
 import { ThemeProvider, DarkTheme, DefaultTheme, useTheme } from '@react-navigation/native';
 import { Slot } from 'expo-router';
 
@@ -434,7 +434,7 @@ You can use the [`reset`](https://reactnavigation.org/docs/navigation-actions/#r
 In the below example, the `navigation` prop is accessible from the `useNavigation` hook and the `CommonActions.reset` action from `@react-navigation/native`. The object specified in the `reset` action replaces the existing navigation state with the new one.
 
 {/* prettier-ignore */}
-```jsx app/screen.js
+```tsx src/app/screen.tsx
 import { useNavigation } from 'expo-router'
 import { CommonActions } from '@react-navigation/native'
 
@@ -466,7 +466,7 @@ Expo Router can automatically generate [statically typed routes](/router/referen
 
 React Navigation navigators `<Stack>`, `<Drawer>`, and `<Tabs>` use a shared appearance provider. In React Navigation, you set the theme for the entire app using the `<NavigationContainer />` component. Expo Router manages the root container so that you can set the theme using the `ThemeProvider` directly.
 
-```tsx app/_layout.tsx
+```tsx src/app/_layout.tsx
 /* @info Import theme APIs from React Navigation directly. */
 import { ThemeProvider, DarkTheme, DefaultTheme, useTheme } from '@react-navigation/native';
 /* @end */

--- a/docs/pages/router/migrate/from-react-navigation.mdx
+++ b/docs/pages/router/migrate/from-react-navigation.mdx
@@ -72,7 +72,7 @@ Expo Router **does not** add `react-native-gesture-handler` (as of v3), so you'l
 
 Create an **app** directory inside a root **src** directory. Expo Router automatically detects the **src/app** directory as the root of your routes.
 
-Ensure your **tsconfig.json** has the `@` path alias configured to point to `src`:
+Ensure your **tsconfig.json** and **app.json** are properly configured
 
 ```json tsconfig.json
 {

--- a/docs/pages/router/reference/screen-tracking.mdx
+++ b/docs/pages/router/reference/screen-tracking.mdx
@@ -11,9 +11,9 @@ Unlike React Navigation, Expo Router always has access to a URL. This means scre
 1. Create a higher-order component that observes the currently selected URL
 2. Track the URL in your analytics provider
 
-<FileTree files={['app/_layout.tsx']} />
+<FileTree files={['src/app/_layout.tsx']} />
 
-```tsx app/_layout.tsx
+```tsx src/app/_layout.tsx
 import { useEffect } from 'react';
 import { usePathname, useGlobalSearchParams, Slot } from 'expo-router';
 

--- a/docs/pages/router/reference/troubleshooting.mdx
+++ b/docs/pages/router/reference/troubleshooting.mdx
@@ -63,7 +63,7 @@ This can happen when using a custom version of `@expo/metro-config` that does no
 
 If you set up a modal or another screen that is expected to have a back button, then you'll need to add [`unstable_settings`](/router/advanced/router-settings/) to the route's layout to ensure the initial route is configured. Initial routes are somewhat unique to mobile apps and fit awkwardly in the system &mdash; improvements pending.
 
-```tsx app/_layout.tsx
+```tsx src/app/_layout.tsx
 export const unstable_settings = {
   initialRouteName: 'index',
 };

--- a/docs/pages/router/reference/typed-routes.mdx
+++ b/docs/pages/router/reference/typed-routes.mdx
@@ -81,12 +81,12 @@ You can leverage the `useSegments()` hooks from `expo-router` to create complex 
 
 <FileTree
   files={[
-    'app/(feed)/_layout.tsx',
-    'app/(feed)/feed.tsx',
-    'app/(feed)/search.tsx',
-    'app/(feed)/profile.tsx',
-    'app/(search)/profile.tsx',
-    'components/button.tsx',
+    'src/app/(feed)/_layout.tsx',
+    'src/app/(feed)/feed.tsx',
+    'src/app/(feed)/search.tsx',
+    'src/app/(feed)/profile.tsx',
+    'src/app/(search)/profile.tsx',
+    'src/components/button.tsx',
   ]}
 />
 
@@ -105,7 +105,7 @@ export function Button() {
 }
 ```
 
-Now, you can leverage `<Button />` from both **app/(feed)/feed.tsx** and **app/(search)/search.tsx** to push `./profile` while preserving the current tab.
+Now, you can leverage `<Button />` from both **src/app/(feed)/feed.tsx** and **src/app/(search)/search.tsx** to push `./profile` while preserving the current tab.
 
 If you require the segments for a specific use, you can pass the full route to `useSegments`:
 
@@ -147,7 +147,7 @@ function Page() {
 
 For strongly typed route parameters, you can pass a full href to the `useLocalSearchParams` and `useGlobalSearchParams` hooks. For example:
 
-```tsx app/search.tsx
+```tsx src/app/search.tsx
 import { Text } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 
@@ -172,7 +172,7 @@ export default function Page() {
 
 Most query parameters will not be represented in the file system and therefore cannot be typed automatically. You can type query parameters manually by passing a generic to the `useLocalSearchParams` and `useGlobalSearchParams` hooks. For example:
 
-```tsx app/search.tsx
+```tsx src/app/search.tsx
 import { Text } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 
@@ -187,7 +187,7 @@ export default function Page() {
 
 If you need a combination of route and query parameters, pass the route as the first generic and then the query parameters:
 
-```tsx app/search.tsx
+```tsx src/app/search.tsx
 import { Text } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 

--- a/docs/pages/router/reference/url-parameters.mdx
+++ b/docs/pages/router/reference/url-parameters.mdx
@@ -29,13 +29,13 @@ Both hooks are typed and accessed the same way. However, the only difference is 
 
 The example below demonstrates the difference between `useLocalSearchParams` and `useGlobalSearchParams`. It uses the following **app** directory structure:
 
-<FileTree files={['app/_layout.tsx', 'app/index.tsx', 'app/[user].tsx']} />
+<FileTree files={['src/app/_layout.tsx', 'src/app/index.tsx', 'src/app/[user].tsx']} />
 
 <Step label="1">
 
     The Root Layout is a stack navigator:
 
-    ```tsx app/_layout.tsx
+    ```tsx src/app/_layout.tsx
     import { Stack } from 'expo-router';
 
     export default function Layout() {
@@ -47,9 +47,9 @@ The example below demonstrates the difference between `useLocalSearchParams` and
 
 <Step label="2">
 
-    The initial route redirects to the dynamic route **app/[user].tsx**, with **user=evanbacon**:
+    The initial route redirects to the dynamic route **src/app/[user].tsx**, with **user=evanbacon**:
 
-    ```tsx app/index.tsx
+    ```tsx src/app/index.tsx
     import { Redirect } from 'expo-router';
 
     export default function Route() {
@@ -61,9 +61,9 @@ The example below demonstrates the difference between `useLocalSearchParams` and
 
 <Step label="3">
 
-    The dynamic route **app/[user]** prints out the global and local URL parameters (route parameters, in this case). It also allows for pushing new instances of the same route with different **route parameters**:
+    The dynamic route **src/app/[user]** prints out the global and local URL parameters (route parameters, in this case). It also allows for pushing new instances of the same route with different **route parameters**:
 
-    ```tsx app/[user].tsx
+    ```tsx src/app/[user].tsx
     import { Text, View } from 'react-native';
     import { useLocalSearchParams, useGlobalSearchParams, Link } from 'expo-router';
 
@@ -132,7 +132,7 @@ Pressing "Visit james" has a similar effect:
 
 Both the `useLocalSearchParams` and `useGlobalSearchParams` can be statically typed using a generic. The following is an example for the `user` route parameter:
 
-```tsx app/[user].tsx
+```tsx src/app/[user].tsx
 import { Text } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 
@@ -148,7 +148,7 @@ export default function Route() {
 
 Any search parameters (for example, `?query=...`) can be typed optionally:
 
-```tsx app/[user].tsx
+```tsx src/app/[user].tsx
 const { user, query } = useLocalSearchParams<{ user: string; query?: string }>();
 
 // Given the URL: `/evanbacon?query=hello`
@@ -157,7 +157,7 @@ const { user, query } = useLocalSearchParams<{ user: string; query?: string }>()
 
 When used with the rest syntax (`...`), route parameters are returned as a string array:
 
-```tsx app/[...everything].tsx
+```tsx src/app/[...everything].tsx
 import { Text } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 
@@ -179,7 +179,7 @@ export default function Route() {
 Any search parameters will continue to be returned as individual strings:
 
 {/* prettier-ignore */}
-```tsx app/[...everything].tsx
+```tsx src/app/[...everything].tsx
 import { Text } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 
@@ -208,7 +208,7 @@ URL parameters can be updated using the **router.setParams** function from the i
 
 The following example uses a `<TextInput>` to update the search parameter **q**:
 
-```tsx app/search.tsx
+```tsx src/app/search.tsx
 import { useLocalSearchParams, router } from 'expo-router';
 import { useState } from 'react';
 import { TextInput, View } from 'react-native';
@@ -243,7 +243,7 @@ export default function Page() {
 
 Here is an example using an `onPress` event to update the route parameter **user**:
 
-```tsx app/[user].tsx
+```tsx src/app/[user].tsx
 import { useLocalSearchParams, router } from 'expo-router';
 import { Text } from 'react-native';
 
@@ -265,9 +265,9 @@ Route parameters are used to match a route, while search parameters are used to 
 
 <FileTree
   files={[
-    'app/index.tsx',
+    'src/app/index.tsx',
     [
-      'app/[user].tsx',
+      'src/app/[user].tsx',
       <>
         <code>user</code> is a <b>route parameter</b>
       </>,
@@ -275,9 +275,9 @@ Route parameters are used to match a route, while search parameters are used to 
   ]}
 />
 
-When the `app/[user]` route is matched, the `user` parameter is passed to the component and never a nullish value. Both search and route parameters can be used together and are accessible with the `useLocalSearchParams` and `useGlobalSearchParams` hooks:
+When the `src/app/[user]` route is matched, the `user` parameter is passed to the component and never a nullish value. Both search and route parameters can be used together and are accessible with the `useLocalSearchParams` and `useGlobalSearchParams` hooks:
 
-```tsx app/[user].tsx
+```tsx src/app/[user].tsx
 import { useLocalSearchParams } from 'expo-router';
 
 export default function User() {
@@ -300,7 +300,7 @@ export default function User() {
 
 Whenever a route parameter is changed, the component will re-mount.
 
-```tsx app/[user].tsx
+```tsx src/app/[user].tsx
 import { Text } from 'react-native';
 import { router, useLocalSearchParams, Link } from 'expo-router';
 
@@ -324,7 +324,7 @@ TODO: REMOVE COMMENT WHEN https://github.com/expo/expo/pull/30268 IS PUBLISHED
 
 URL parameters that are present multiple times will be grouped together as an array.
 
-```tsx app/hash.tsx
+```tsx src/app/hash.tsx
 import { router, useLocalSearchParams } from 'expo-router';
 
 export default function Route() {
@@ -341,7 +341,7 @@ export default function Route() {
 The URL [hash](https://developer.mozilla.org/en-US/docs/Web/API/URL/hash) is a string that follows the `#` symbol in a URL. It is commonly used on websites to link to a specific section of a page, but it can also be used to store data. Expo Router treats the hash as a special search parameter using the name `#`. It can be accessed and modified using the same hooks and APIs from [search parameters](#local-versus-global-search-parameters).
 
 {/* prettier-ignore */}
-```tsx app/hash.tsx
+```tsx src/app/hash.tsx
 import { Text } from 'react-native';
 import { router, useLocalSearchParams, Link } from 'expo-router';
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Update docs in Expo Router Reference and Migration sections for SDK 55.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update file path references from app/ to src/app/ throughout the common navigation patterns page.
- Updated the migration guide to include the tsconfig.json path alias configuration (@/* to ./src/*) and the app.json
  expo-router plugin setup, matching the SDK 55 conventions.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Start here: http://localhost:3002/router/error-handling/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
