### PR TITLE
[file-system][android] Fix copy/move support for SAF/content URIs

### DIFF
--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -10,6 +10,7 @@ on:
       - fastlane/**
       # - packages/**/android/**
       - packages/expo-eas-client/android/**
+      - packages/expo-file-system/android/**
       - packages/expo-json-utils/android/**
       - packages/expo-manifests/android/**
       - packages/expo-notifications/android/**
@@ -28,6 +29,7 @@ on:
       - fastlane/**
       # - packages/**/android/**
       - packages/expo-eas-client/android/**
+      - packages/expo-file-system/android/**
       - packages/expo-json-utils/android/**
       - packages/expo-manifests/android/**
       - packages/expo-notifications/android/**

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix copy/move support for SAF and content provider URIs.
+
 ### 💡 Others
 
 ## 55.0.9 — 2026-02-25

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix copy/move support for SAF and content provider URIs.
+- [Android] Fix copy/move support for SAF and content provider URIs. ([#42887](https://github.com/expo/expo/pull/42887) by [@barthap](https://github.com/barthap))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/android/build.gradle
+++ b/packages/expo-file-system/android/build.gradle
@@ -11,6 +11,10 @@ android {
   defaultConfig {
     versionCode 30
     versionName "55.0.9"
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+  }
+  testOptions {
+    unitTests.includeAndroidResources = true
   }
 }
 
@@ -22,4 +26,8 @@ dependencies {
   api 'com.squareup.okio:okio:2.9.0'
   api "androidx.legacy:legacy-support-v4:1.0.0"
   api "androidx.documentfile:documentfile:1.1.0"
+
+  if (project.findProject(':expo-modules-test-core')) {
+    androidTestImplementation project(':expo-modules-test-core')
+  }
 }

--- a/packages/expo-file-system/android/src/androidTest/AndroidManifest.xml
+++ b/packages/expo-file-system/android/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
+    <application>
+        <provider
+            android:name="expo.modules.filesystem.TestStorageProvider"
+            android:authorities="expo.modules.filesystem.test.documents"
+            android:enabled="true"
+            android:exported="true"
+            android:permission="android.permission.MANAGE_DOCUMENTS"
+            android:grantUriPermissions="true">
+            <intent-filter>
+                <action android:name="android.content.action.DOCUMENTS_PROVIDER" />
+            </intent-filter>
+        </provider>
+    </application>
+
+</manifest>

--- a/packages/expo-file-system/android/src/androidTest/java/expo/modules/filesystem/CopyMoveOperationsTest.kt
+++ b/packages/expo-file-system/android/src/androidTest/java/expo/modules/filesystem/CopyMoveOperationsTest.kt
@@ -1,0 +1,532 @@
+package expo.modules.filesystem
+
+import android.net.Uri
+import android.provider.DocumentsContract
+import androidx.documentfile.provider.DocumentFile
+import androidx.test.platform.app.InstrumentationRegistry
+import expo.modules.filesystem.fsops.DestinationSpec
+import expo.modules.filesystem.unifiedfile.JavaFile
+import expo.modules.filesystem.unifiedfile.SAFDocumentFile
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Comprehensive tests for copy/move operations across different file backends.
+ * Tests cover:
+ * - Copy operations (local, SAF, cross-backend)
+ * - Move operations (local, SAF, cross-backend)
+ * - Error handling and edge cases
+ * - Unix cp/mv behavior semantics
+ */
+class CopyMoveOperationsTest {
+
+  private val context = InstrumentationRegistry.getInstrumentation().targetContext
+  private val resolver = context.contentResolver
+
+  // ============================================================================
+  // TEST HELPERS
+  // ============================================================================
+
+  private fun getLocalTestDir() = File(context.cacheDir, "test_${System.currentTimeMillis()}").apply {
+    deleteRecursively()
+    mkdirs()
+  }
+
+  private fun getSAFRootDir(): DocumentFile {
+    val safRootUri = DocumentsContract.buildTreeDocumentUri(
+      TestStorageProvider.AUTHORITY,
+      TestStorageProvider.ROOT_DOC_ID
+    )
+    return DocumentFile.fromTreeUri(context, safRootUri)!!.apply {
+      listFiles().forEach { it.delete() }
+    }
+  }
+
+  private fun File.toUri(): Uri = Uri.parse(this.toURI().toString())
+
+  // ============================================================================
+  // COPY OPERATIONS: LOCAL → LOCAL
+  // ============================================================================
+
+  @Test
+  fun testCopyLocalFile_ToLocalFile() {
+    val localTestDir = getLocalTestDir()
+
+    val srcFile = File(localTestDir, "source.txt").apply { writeText("test content") }
+    val dstFile = File(localTestDir, "dest.txt")
+
+    val source = JavaFile(srcFile.toUri())
+    val dest = JavaFile(dstFile.toUri())
+
+    source.copyTo(DestinationSpec(path = dest, overwrite = false, isDirectory = false))
+
+    assertTrue("Source should still exist after copy", srcFile.exists())
+    assertTrue("Destination should exist", dstFile.exists())
+    assertEquals("test content", dstFile.readText())
+  }
+
+  @Test
+  fun testCopyLocalFile_ToLocalDirectory() {
+    val localTestDir = getLocalTestDir()
+
+    val srcFile = File(localTestDir, "source.txt").apply { writeText("test content") }
+    val dstDir = File(localTestDir, "destDir").apply { mkdirs() }
+
+    val source = JavaFile(srcFile.toUri())
+    val dest = JavaFile(dstDir.toUri())
+
+    source.copyTo(DestinationSpec(path = dest, overwrite = false, isDirectory = true))
+
+    val copiedFile = File(dstDir, "source.txt")
+    assertTrue("File should be created inside destination directory", copiedFile.exists())
+    assertEquals("test content", copiedFile.readText())
+  }
+
+  @Test
+  fun testCopyLocalDirectory_ToLocalDirectory() {
+    val localTestDir = getLocalTestDir()
+
+    val srcDir = File(localTestDir, "srcDir").apply { mkdirs() }
+    File(srcDir, "file1.txt").writeText("content1")
+    File(srcDir, "file2.txt").writeText("content2")
+
+    val dstDir = File(localTestDir, "dstDir").apply { mkdirs() }
+
+    val source = JavaFile(srcDir.toUri())
+    val dest = JavaFile(dstDir.toUri())
+
+    source.copyTo(DestinationSpec(path = dest, overwrite = false, isDirectory = true))
+
+    val copiedDir = File(dstDir, "srcDir")
+    assertTrue(copiedDir.exists() && copiedDir.isDirectory)
+    assertTrue(File(copiedDir, "file1.txt").exists())
+    assertTrue(File(copiedDir, "file2.txt").exists())
+    assertEquals("content1", File(copiedDir, "file1.txt").readText())
+  }
+
+  // ============================================================================
+  // COPY OPERATIONS: SAF → SAF
+  // ============================================================================
+
+  @Test
+  fun testCopySAFFile_ToSAFFile() {
+    val safRootDir = getSAFRootDir()
+
+    val srcDoc = safRootDir.createFile("text/plain", "source.txt")
+    assertNotNull("Failed to create source file", srcDoc)
+    resolver.openOutputStream(srcDoc!!.uri)?.use { it.write("saf content".toByteArray()) }
+
+    // For SAF, we need to create the destination file to get a URI
+    // Then copy with overwrite=true to write the content
+    val dstDoc = safRootDir.createFile("text/plain", "dest.txt")
+    assertNotNull("Failed to create destination file", dstDoc)
+
+    val source = SAFDocumentFile(context, srcDoc.uri)
+    val dest = SAFDocumentFile(context, dstDoc!!.uri)
+
+    source.copyTo(DestinationSpec(path = dest, overwrite = true, isDirectory = false))
+
+    val content = resolver.openInputStream(dstDoc.uri)?.bufferedReader()?.readText()
+    assertEquals("saf content", content)
+  }
+
+  @Test
+  fun testCopySAFFile_ToSAFDirectory() {
+    val safRootDir = getSAFRootDir()
+
+    val srcDoc = safRootDir.createFile("text/plain", "source.txt")!!
+    resolver.openOutputStream(srcDoc.uri)?.use { it.write("saf content".toByteArray()) }
+
+    val dstDir = safRootDir.createDirectory("targetDir")!!
+
+    val source = SAFDocumentFile(context, srcDoc.uri)
+    val dest = SAFDocumentFile(context, dstDir.uri)
+
+    source.copyTo(DestinationSpec(path = dest, overwrite = false, isDirectory = true))
+
+    val copiedFile = dstDir.findFile("source.txt")
+    assertNotNull("File should be created inside destination directory", copiedFile)
+    val content = resolver.openInputStream(copiedFile!!.uri)?.bufferedReader()?.readText()
+    assertEquals("saf content", content)
+  }
+
+  @Test
+  fun testCopySAFDirectory_ToSAFDirectory() {
+    val safRootDir = getSAFRootDir()
+
+    val srcDir = safRootDir.createDirectory("srcDir")!!
+    val file1 = srcDir.createFile("text/plain", "file1.txt")!!
+    resolver.openOutputStream(file1.uri)?.use { it.write("content1".toByteArray()) }
+
+    val dstDir = safRootDir.createDirectory("dstDir")!!
+
+    val source = SAFDocumentFile(context, srcDir.uri)
+    val dest = SAFDocumentFile(context, dstDir.uri)
+
+    source.copyTo(DestinationSpec(path = dest, overwrite = false, isDirectory = true))
+
+    val copiedDir = dstDir.findFile("srcDir")
+    assertNotNull("Directory should be created inside destination", copiedDir)
+    assertTrue(copiedDir!!.isDirectory)
+
+    val copiedFile = copiedDir.findFile("file1.txt")
+    assertNotNull(copiedFile)
+    val content = resolver.openInputStream(copiedFile!!.uri)?.bufferedReader()?.readText()
+    assertEquals("content1", content)
+  }
+
+  // ============================================================================
+  // COPY OPERATIONS: CROSS-BACKEND (SAF → LOCAL)
+  // ============================================================================
+
+  @Test
+  fun testCopySAFFile_ToLocalFile() {
+    val safRootDir = getSAFRootDir()
+    val localTestDir = getLocalTestDir()
+
+    val srcDoc = safRootDir.createFile("text/plain", "source.txt")!!
+    resolver.openOutputStream(srcDoc.uri)?.use { it.write("saf to local".toByteArray()) }
+
+    val dstFile = File(localTestDir, "dest.txt")
+
+    val source = SAFDocumentFile(context, srcDoc.uri)
+    val dest = JavaFile(dstFile.toUri())
+
+    source.copyTo(DestinationSpec(path = dest, overwrite = false, isDirectory = false))
+
+    assertTrue(dstFile.exists())
+    assertEquals("saf to local", dstFile.readText())
+  }
+
+  @Test
+  fun testCopySAFFile_ToLocalDirectory() {
+    val safRootDir = getSAFRootDir()
+    val localTestDir = getLocalTestDir()
+
+    val srcDoc = safRootDir.createFile("text/plain", "source.txt")!!
+    resolver.openOutputStream(srcDoc.uri)?.use { it.write("saf content".toByteArray()) }
+
+    val dstDir = File(localTestDir, "destDir").apply { mkdirs() }
+
+    val source = SAFDocumentFile(context, srcDoc.uri)
+    val dest = JavaFile(dstDir.toUri())
+
+    source.copyTo(DestinationSpec(path = dest, overwrite = false, isDirectory = true))
+
+    val copiedFile = File(dstDir, "source.txt")
+    assertTrue(copiedFile.exists())
+    assertEquals("saf content", copiedFile.readText())
+  }
+
+  // ============================================================================
+  // COPY OPERATIONS: CROSS-BACKEND (LOCAL → SAF)
+  // ============================================================================
+
+  @Test
+  fun testCopyLocalFile_ToSAFDirectory() {
+    val safRootDir = getSAFRootDir()
+    val localTestDir = getLocalTestDir()
+
+    val srcFile = File(localTestDir, "source.txt").apply { writeText("local content") }
+    val dstDir = safRootDir.createDirectory("targetDir")!!
+
+    val source = JavaFile(srcFile.toUri())
+    val dest = SAFDocumentFile(context, dstDir.uri)
+
+    source.copyTo(DestinationSpec(path = dest, overwrite = false, isDirectory = true))
+
+    val copiedFile = dstDir.findFile("source.txt")
+    assertNotNull(copiedFile)
+    val content = resolver.openInputStream(copiedFile!!.uri)?.bufferedReader()?.readText()
+    assertEquals("local content", content)
+  }
+
+  @Test
+  fun testCopyLocalDirectory_ToSAFDirectory() {
+    val safRootDir = getSAFRootDir()
+    val localTestDir = getLocalTestDir()
+
+    val srcDir = File(localTestDir, "srcDir").apply { mkdirs() }
+    File(srcDir, "nested.txt").writeText("nested content")
+
+    val dstDir = safRootDir.createDirectory("dstDir")!!
+
+    val source = JavaFile(srcDir.toUri())
+    val dest = SAFDocumentFile(context, dstDir.uri)
+
+    source.copyTo(DestinationSpec(path = dest, overwrite = false, isDirectory = true))
+
+    val copiedDir = dstDir.findFile("srcDir")
+    assertNotNull(copiedDir)
+    assertTrue(copiedDir!!.isDirectory)
+
+    val copiedFile = copiedDir.findFile("nested.txt")
+    assertNotNull(copiedFile)
+    val content = resolver.openInputStream(copiedFile!!.uri)?.bufferedReader()?.readText()
+    assertEquals("nested content", content)
+  }
+
+  // ============================================================================
+  // MOVE OPERATIONS: LOCAL → LOCAL
+  // ============================================================================
+
+  @Test
+  fun testMoveLocalFile_ToLocalFile() {
+    val localTestDir = getLocalTestDir()
+
+    val srcFile = File(localTestDir, "source.txt").apply { writeText("move content") }
+    val dstFile = File(localTestDir, "dest.txt")
+
+    val source = JavaFile(srcFile.toUri())
+    val dest = JavaFile(dstFile.toUri())
+
+    val resultUri = source.moveTo(DestinationSpec(path = dest, overwrite = false, isDirectory = false))
+
+    assertFalse("Source should not exist after move", srcFile.exists())
+    assertTrue("Destination should exist", dstFile.exists())
+    assertEquals("move content", dstFile.readText())
+    assertEquals(dstFile.toUri(), resultUri)
+  }
+
+  @Test
+  fun testMoveLocalFile_ToLocalDirectory() {
+    val localTestDir = getLocalTestDir()
+
+    val srcFile = File(localTestDir, "source.txt").apply { writeText("move content") }
+    val dstDir = File(localTestDir, "destDir").apply { mkdirs() }
+
+    val source = JavaFile(srcFile.toUri())
+    val dest = JavaFile(dstDir.toUri())
+
+    source.moveTo(DestinationSpec(path = dest, overwrite = false, isDirectory = true))
+
+    assertFalse("Source should not exist after move", srcFile.exists())
+    val movedFile = File(dstDir, "source.txt")
+    assertTrue(movedFile.exists())
+    assertEquals("move content", movedFile.readText())
+  }
+
+  // ============================================================================
+  // MOVE OPERATIONS: CROSS-BACKEND (SAF ↔ LOCAL)
+  // ============================================================================
+
+  @Test
+  fun testMoveSAFFile_ToLocalDirectory() {
+    val safRootDir = getSAFRootDir()
+    val localTestDir = getLocalTestDir()
+
+    val srcDoc = safRootDir.createFile("text/plain", "source.txt")!!
+    resolver.openOutputStream(srcDoc.uri)?.use { it.write("saf to local move".toByteArray()) }
+
+    val dstDir = File(localTestDir, "destDir").apply { mkdirs() }
+
+    val source = SAFDocumentFile(context, srcDoc.uri)
+    val dest = JavaFile(dstDir.toUri())
+
+    source.moveTo(DestinationSpec(path = dest, overwrite = false, isDirectory = true))
+
+    val movedFile = File(dstDir, "source.txt")
+    assertTrue("Destination file should exist at ${movedFile.absolutePath}", movedFile.exists())
+    assertEquals("saf to local move", movedFile.readText())
+
+    // Check if source was deleted by looking in the parent directory
+    val sourceStillExists = safRootDir.findFile("source.txt") != null
+    assertFalse("Source file should not exist after move", sourceStillExists)
+  }
+
+  @Test
+  fun testMoveLocalFile_ToSAFDirectory() {
+    val safRootDir = getSAFRootDir()
+    val localTestDir = getLocalTestDir()
+
+    val srcFile = File(localTestDir, "source.txt").apply { writeText("local to saf move") }
+    val dstDir = safRootDir.createDirectory("targetDir")!!
+
+    val source = JavaFile(srcFile.toUri())
+    val dest = SAFDocumentFile(context, dstDir.uri)
+
+    source.moveTo(DestinationSpec(path = dest, overwrite = false, isDirectory = true))
+
+    assertFalse("Source should not exist after move", srcFile.exists())
+    val movedFile = dstDir.findFile("source.txt")
+    assertNotNull(movedFile)
+    val content = resolver.openInputStream(movedFile!!.uri)?.bufferedReader()?.readText()
+    assertEquals("local to saf move", content)
+  }
+
+  // ============================================================================
+  // ERROR HANDLING: OVERWRITE BEHAVIOR
+  // ============================================================================
+
+  @Test
+  fun testCopy_ThrowsWhenDestinationExists_AndOverwriteIsFalse() {
+    val localTestDir = getLocalTestDir()
+
+    val srcFile = File(localTestDir, "source.txt").apply { writeText("source") }
+    val dstFile = File(localTestDir, "dest.txt").apply { writeText("existing") }
+
+    val source = JavaFile(srcFile.toUri())
+    val dest = JavaFile(dstFile.toUri())
+
+    val result = runCatching {
+      source.copyTo(DestinationSpec(path = dest, overwrite = false, isDirectory = false))
+    }
+
+    assertTrue(result.isFailure)
+    assertTrue(result.exceptionOrNull()!! is DestinationAlreadyExistsException)
+    assertEquals("existing", dstFile.readText())
+  }
+
+  @Test
+  fun testCopy_OverwritesDestination_WhenOverwriteIsTrue() {
+    val localTestDir = getLocalTestDir()
+
+    val srcFile = File(localTestDir, "source.txt").apply { writeText("new content") }
+    val dstFile = File(localTestDir, "dest.txt").apply { writeText("old content") }
+
+    val source = JavaFile(srcFile.toUri())
+    val dest = JavaFile(dstFile.toUri())
+
+    source.copyTo(DestinationSpec(path = dest, overwrite = true, isDirectory = false))
+
+    assertEquals("new content", dstFile.readText())
+  }
+
+  @Test
+  fun testMove_ThrowsWhenDestinationExists_AndOverwriteIsFalse() {
+    val localTestDir = getLocalTestDir()
+
+    val srcFile = File(localTestDir, "source.txt").apply { writeText("source") }
+    val dstFile = File(localTestDir, "dest.txt").apply { writeText("existing") }
+
+    val source = JavaFile(srcFile.toUri())
+    val dest = JavaFile(dstFile.toUri())
+
+    val result = runCatching {
+      source.moveTo(DestinationSpec(path = dest, overwrite = false, isDirectory = false))
+    }
+
+    assertTrue(result.isFailure)
+    assertTrue(result.exceptionOrNull()!! is DestinationAlreadyExistsException)
+    assertTrue(srcFile.exists())
+  }
+
+  @Test
+  fun testMove_OverwritesDestination_WhenOverwriteIsTrue() {
+    val localTestDir = getLocalTestDir()
+
+    val srcFile = File(localTestDir, "source.txt").apply { writeText("new content") }
+    val dstFile = File(localTestDir, "dest.txt").apply { writeText("old content") }
+
+    val source = JavaFile(srcFile.toUri())
+    val dest = JavaFile(dstFile.toUri())
+
+    source.moveTo(DestinationSpec(path = dest, overwrite = true, isDirectory = false))
+
+    assertTrue(dstFile.exists())
+    assertEquals("new content", dstFile.readText())
+  }
+
+  // ============================================================================
+  // ERROR HANDLING: INVALID OPERATIONS
+  // ============================================================================
+
+  @Test
+  fun testCopy_ThrowsWhenCopyingDirectoryToFile() {
+    val localTestDir = getLocalTestDir()
+
+    val srcDir = File(localTestDir, "srcDir").apply { mkdirs() }
+    val dstFile = File(localTestDir, "dest.txt").apply { writeText("file") }
+
+    val source = JavaFile(srcDir.toUri())
+    val dest = JavaFile(dstFile.toUri())
+
+    val result = runCatching {
+      source.copyTo(DestinationSpec(path = dest, overwrite = false, isDirectory = false))
+    }
+
+    assertTrue("Expected exception when copying directory to file", result.isFailure)
+    assertTrue(result.exceptionOrNull()!! is CopyOrMoveDirectoryToFileException)
+  }
+
+  @Test
+  fun testCopy_ThrowsWhenDestinationParentDoesNotExist() {
+    val localTestDir = getLocalTestDir()
+
+    val srcFile = File(localTestDir, "source.txt").apply { writeText("content") }
+    val dstFile = File(localTestDir, "nonexistent/dest.txt")
+
+    val source = JavaFile(srcFile.toUri())
+    val dest = JavaFile(dstFile.toUri())
+
+    val result = runCatching {
+      source.copyTo(DestinationSpec(path = dest, overwrite = false, isDirectory = false))
+    }
+
+    assertTrue("Expected exception for nonexistent directory", result.isFailure)
+    assertTrue(result.exceptionOrNull()!! is DestinationDoesNotExistException)
+  }
+
+  @Test
+  fun testCopy_FileToNonexistentDirectory_Throws() {
+    val localTestDir = getLocalTestDir()
+
+    val srcFile = File(localTestDir, "source.txt").apply { writeText("content") }
+    val dstDir = File(localTestDir, "nonexistent")
+
+    val source = JavaFile(srcFile.toUri())
+    val dest = JavaFile(dstDir.toUri())
+
+    val result = runCatching {
+      source.copyTo(DestinationSpec(path = dest, overwrite = false, isDirectory = true))
+    }
+
+    assertTrue("Expected exception for nonexistent directory", result.isFailure)
+    assertTrue(result.exceptionOrNull()!! is DestinationDoesNotExistException)
+  }
+
+  // ============================================================================
+  // UNIX BEHAVIOR: CP/MV SEMANTICS
+  // ============================================================================
+
+  @Test
+  fun testCopyDirectory_ToExistingDirectory_CreatesChildDirectory() {
+    val localTestDir = getLocalTestDir()
+
+    val srcDir = File(localTestDir, "srcDir").apply { mkdirs() }
+    File(srcDir, "file.txt").writeText("content")
+
+    val dstDir = File(localTestDir, "destDir").apply { mkdirs() }
+
+    val source = JavaFile(srcDir.toUri())
+    val dest = JavaFile(dstDir.toUri())
+
+    source.copyTo(DestinationSpec(path = dest, overwrite = false, isDirectory = true))
+
+    val copiedDir = File(dstDir, "srcDir")
+    assertTrue(copiedDir.exists() && copiedDir.isDirectory)
+    assertTrue(File(copiedDir, "file.txt").exists())
+  }
+
+  @Test
+  fun testCopyDirectory_ToNonexistentDirectory_RenamesIfParentExists() {
+    val localTestDir = getLocalTestDir()
+
+    val srcDir = File(localTestDir, "srcDir").apply { mkdirs() }
+    File(srcDir, "file.txt").writeText("content")
+
+    val dstDir = File(localTestDir, "newName") // Doesn't exist
+
+    val source = JavaFile(srcDir.toUri())
+    val dest = JavaFile(dstDir.toUri())
+
+    source.copyTo(DestinationSpec(path = dest, overwrite = false, isDirectory = true))
+
+    assertTrue(dstDir.exists() && dstDir.isDirectory)
+    assertTrue(File(dstDir, "file.txt").exists())
+  }
+}

--- a/packages/expo-file-system/android/src/androidTest/java/expo/modules/filesystem/CopyMoveOperationsTest.kt
+++ b/packages/expo-file-system/android/src/androidTest/java/expo/modules/filesystem/CopyMoveOperationsTest.kt
@@ -27,10 +27,6 @@ class CopyMoveOperationsTest {
   private val context = InstrumentationRegistry.getInstrumentation().targetContext
   private val resolver = context.contentResolver
 
-  // ============================================================================
-  // TEST HELPERS
-  // ============================================================================
-
   private fun getLocalTestDir() = File(context.cacheDir, "test_${System.currentTimeMillis()}").apply {
     deleteRecursively()
     mkdirs()
@@ -47,10 +43,6 @@ class CopyMoveOperationsTest {
   }
 
   private fun File.toUri(): Uri = Uri.parse(this.toURI().toString())
-
-  // ============================================================================
-  // COPY OPERATIONS: LOCAL → LOCAL
-  // ============================================================================
 
   @Test
   fun testCopyLocalFile_ToLocalFile() {
@@ -107,10 +99,6 @@ class CopyMoveOperationsTest {
     assertTrue(File(copiedDir, "file2.txt").exists())
     assertEquals("content1", File(copiedDir, "file1.txt").readText())
   }
-
-  // ============================================================================
-  // COPY OPERATIONS: SAF → SAF
-  // ============================================================================
 
   @Test
   fun testCopySAFFile_ToSAFFile() {
@@ -179,10 +167,6 @@ class CopyMoveOperationsTest {
     assertEquals("content1", content)
   }
 
-  // ============================================================================
-  // COPY OPERATIONS: CROSS-BACKEND (SAF → LOCAL)
-  // ============================================================================
-
   @Test
   fun testCopySAFFile_ToLocalFile() {
     val safRootDir = getSAFRootDir()
@@ -221,10 +205,6 @@ class CopyMoveOperationsTest {
     assertTrue(copiedFile.exists())
     assertEquals("saf content", copiedFile.readText())
   }
-
-  // ============================================================================
-  // COPY OPERATIONS: CROSS-BACKEND (LOCAL → SAF)
-  // ============================================================================
 
   @Test
   fun testCopyLocalFile_ToSAFDirectory() {
@@ -270,10 +250,6 @@ class CopyMoveOperationsTest {
     assertEquals("nested content", content)
   }
 
-  // ============================================================================
-  // MOVE OPERATIONS: LOCAL → LOCAL
-  // ============================================================================
-
   @Test
   fun testMoveLocalFile_ToLocalFile() {
     val localTestDir = getLocalTestDir()
@@ -309,10 +285,6 @@ class CopyMoveOperationsTest {
     assertTrue(movedFile.exists())
     assertEquals("move content", movedFile.readText())
   }
-
-  // ============================================================================
-  // MOVE OPERATIONS: CROSS-BACKEND (SAF ↔ LOCAL)
-  // ============================================================================
 
   @Test
   fun testMoveSAFFile_ToLocalDirectory() {
@@ -357,10 +329,6 @@ class CopyMoveOperationsTest {
     val content = resolver.openInputStream(movedFile!!.uri)?.bufferedReader()?.readText()
     assertEquals("local to saf move", content)
   }
-
-  // ============================================================================
-  // ERROR HANDLING: OVERWRITE BEHAVIOR
-  // ============================================================================
 
   @Test
   fun testCopy_ThrowsWhenDestinationExists_AndOverwriteIsFalse() {
@@ -431,10 +399,6 @@ class CopyMoveOperationsTest {
     assertEquals("new content", dstFile.readText())
   }
 
-  // ============================================================================
-  // ERROR HANDLING: INVALID OPERATIONS
-  // ============================================================================
-
   @Test
   fun testCopy_ThrowsWhenCopyingDirectoryToFile() {
     val localTestDir = getLocalTestDir()
@@ -488,10 +452,6 @@ class CopyMoveOperationsTest {
     assertTrue("Expected exception for nonexistent directory", result.isFailure)
     assertTrue(result.exceptionOrNull()!! is DestinationDoesNotExistException)
   }
-
-  // ============================================================================
-  // UNIX BEHAVIOR: CP/MV SEMANTICS
-  // ============================================================================
 
   @Test
   fun testCopyDirectory_ToExistingDirectory_CreatesChildDirectory() {

--- a/packages/expo-file-system/android/src/androidTest/java/expo/modules/filesystem/TestStorageProvider.kt
+++ b/packages/expo-file-system/android/src/androidTest/java/expo/modules/filesystem/TestStorageProvider.kt
@@ -196,7 +196,6 @@ class TestStorageProvider : DocumentsProvider() {
   }
 
   override fun isChildDocument(parentDocumentId: String, documentId: String): Boolean {
-    // This is crucial for tree URI validation
     if (parentDocumentId == ROOT_DOC_ID) {
       // Everything except root is a child of root
       return documentId != ROOT_DOC_ID
@@ -212,12 +211,11 @@ class TestStorageProvider : DocumentsProvider() {
     }
   }
 
-  // Helper methods to map between document IDs and actual files
   private fun getFileForDocId(id: String): File {
     return when (id) {
       ROOT_DOC_ID -> baseDir
       else -> {
-        // Document IDs are just relative paths from baseDir
+        // Document IDs are relative paths from baseDir
         File(baseDir, id)
       }
     }

--- a/packages/expo-file-system/android/src/androidTest/java/expo/modules/filesystem/TestStorageProvider.kt
+++ b/packages/expo-file-system/android/src/androidTest/java/expo/modules/filesystem/TestStorageProvider.kt
@@ -1,0 +1,232 @@
+package expo.modules.filesystem
+
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.os.CancellationSignal
+import android.os.ParcelFileDescriptor
+import android.provider.DocumentsContract.Document
+import android.provider.DocumentsContract.Root
+import android.provider.DocumentsProvider
+import java.io.File
+
+/**
+ * Mock DocumentsProvider for testing SAF operations without requiring user interaction.
+ * This provider uses the app's internal cache directory as its backing storage.
+ */
+class TestStorageProvider : DocumentsProvider() {
+  companion object {
+    const val AUTHORITY = "expo.modules.filesystem.test.documents"
+    const val ROOT_ID = "test_root"
+    const val ROOT_DOC_ID = "root_doc"
+  }
+
+  private lateinit var baseDir: File
+
+  override fun onCreate(): Boolean {
+    val cacheDir = context?.cacheDir ?: return false
+    baseDir = File(cacheDir, "test_saf_root").apply {
+      if (exists()) {
+        deleteRecursively()
+      }
+      mkdirs()
+    }
+    android.util.Log.d("TestStorageProvider", "Initialized with baseDir: ${baseDir.absolutePath}, exists: ${baseDir.exists()}")
+    return baseDir.exists() && baseDir.isDirectory
+  }
+
+  override fun queryRoots(projection: Array<out String>?): Cursor {
+    val cols = projection ?: arrayOf(
+      Root.COLUMN_ROOT_ID,
+      Root.COLUMN_FLAGS,
+      Root.COLUMN_TITLE,
+      Root.COLUMN_DOCUMENT_ID,
+      Root.COLUMN_ICON
+    )
+
+    return MatrixCursor(cols).apply {
+      newRow().apply {
+        add(Root.COLUMN_ROOT_ID, ROOT_ID)
+        add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_CREATE or Root.FLAG_SUPPORTS_IS_CHILD)
+        add(Root.COLUMN_TITLE, "Test SAF Storage")
+        add(Root.COLUMN_DOCUMENT_ID, ROOT_DOC_ID)
+        add(Root.COLUMN_ICON, android.R.drawable.ic_menu_manage)
+      }
+    }
+  }
+
+  override fun queryDocument(documentId: String, projection: Array<out String>?): Cursor {
+    val cols = projection ?: arrayOf(
+      Document.COLUMN_DOCUMENT_ID,
+      Document.COLUMN_MIME_TYPE,
+      Document.COLUMN_DISPLAY_NAME,
+      Document.COLUMN_FLAGS,
+      Document.COLUMN_SIZE,
+      Document.COLUMN_LAST_MODIFIED
+    )
+
+    val file = getFileForDocId(documentId)
+    return MatrixCursor(cols).apply {
+      newRow().apply {
+        add(Document.COLUMN_DOCUMENT_ID, documentId)
+        add(Document.COLUMN_DISPLAY_NAME, file.name)
+        add(
+          Document.COLUMN_MIME_TYPE,
+          if (file.isDirectory) Document.MIME_TYPE_DIR else "application/octet-stream"
+        )
+        add(
+          Document.COLUMN_FLAGS,
+          Document.FLAG_SUPPORTS_WRITE or
+            Document.FLAG_SUPPORTS_DELETE or
+            Document.FLAG_SUPPORTS_MOVE or
+            Document.FLAG_SUPPORTS_RENAME
+        )
+        add(Document.COLUMN_SIZE, if (file.isFile) file.length() else 0)
+        add(Document.COLUMN_LAST_MODIFIED, file.lastModified())
+      }
+    }
+  }
+
+  override fun queryChildDocuments(
+    parentDocumentId: String,
+    projection: Array<out String>?,
+    sortOrder: String?
+  ): Cursor {
+    val cols = projection ?: arrayOf(
+      Document.COLUMN_DOCUMENT_ID,
+      Document.COLUMN_MIME_TYPE,
+      Document.COLUMN_DISPLAY_NAME,
+      Document.COLUMN_FLAGS,
+      Document.COLUMN_SIZE
+    )
+
+    val parent = getFileForDocId(parentDocumentId)
+    return MatrixCursor(cols).apply {
+      parent.listFiles()?.forEach { file ->
+        newRow().apply {
+          add(Document.COLUMN_DOCUMENT_ID, getDocIdForFile(file))
+          add(Document.COLUMN_DISPLAY_NAME, file.name)
+          add(
+            Document.COLUMN_MIME_TYPE,
+            if (file.isDirectory) Document.MIME_TYPE_DIR else "text/plain"
+          )
+          add(
+            Document.COLUMN_FLAGS,
+            Document.FLAG_SUPPORTS_WRITE or Document.FLAG_SUPPORTS_DELETE
+          )
+          add(Document.COLUMN_SIZE, if (file.isFile) file.length() else 0)
+        }
+      }
+    }
+  }
+
+  override fun openDocument(
+    documentId: String,
+    mode: String,
+    signal: CancellationSignal?
+  ): ParcelFileDescriptor {
+    val file = getFileForDocId(documentId)
+    val accessMode = ParcelFileDescriptor.parseMode(mode)
+    return ParcelFileDescriptor.open(file, accessMode)
+  }
+
+  override fun createDocument(
+    parentDocumentId: String,
+    mimeType: String,
+    displayName: String
+  ): String? {
+    android.util.Log.d("TestStorageProvider", "createDocument: parent=$parentDocumentId, mime=$mimeType, name=$displayName")
+
+    val parent = getFileForDocId(parentDocumentId)
+    android.util.Log.d("TestStorageProvider", "Parent file: ${parent.absolutePath}, exists=${parent.exists()}, isDir=${parent.isDirectory}")
+
+    if (!parent.exists() || !parent.isDirectory) {
+      android.util.Log.e("TestStorageProvider", "Parent doesn't exist or is not a directory")
+      return null
+    }
+
+    val file = File(parent, displayName)
+
+    val success = if (mimeType == Document.MIME_TYPE_DIR) {
+      file.mkdir()
+    } else {
+      file.createNewFile()
+    }
+
+    if (!success) {
+      android.util.Log.e("TestStorageProvider", "Failed to create file: ${file.absolutePath}")
+      return null
+    }
+
+    val docId = getDocIdForFile(file)
+    android.util.Log.d("TestStorageProvider", "Created document: $docId at ${file.absolutePath}")
+    return docId
+  }
+
+  override fun deleteDocument(documentId: String) {
+    val file = getFileForDocId(documentId)
+    file.deleteRecursively()
+  }
+
+  override fun renameDocument(documentId: String, displayName: String): String? {
+    val file = getFileForDocId(documentId)
+    if (!file.exists()) return null
+
+    val parent = file.parentFile ?: return null
+    val newFile = File(parent, displayName)
+
+    if (!file.renameTo(newFile)) return null
+    return getDocIdForFile(newFile)
+  }
+
+  override fun moveDocument(
+    sourceDocumentId: String,
+    sourceParentDocumentId: String,
+    targetParentDocumentId: String
+  ): String? {
+    val sourceFile = getFileForDocId(sourceDocumentId)
+    if (!sourceFile.exists()) return null
+
+    val targetParent = getFileForDocId(targetParentDocumentId)
+    if (!targetParent.exists() || !targetParent.isDirectory) return null
+
+    val targetFile = File(targetParent, sourceFile.name)
+
+    if (!sourceFile.renameTo(targetFile)) return null
+    return getDocIdForFile(targetFile)
+  }
+
+  override fun isChildDocument(parentDocumentId: String, documentId: String): Boolean {
+    // This is crucial for tree URI validation
+    if (parentDocumentId == ROOT_DOC_ID) {
+      // Everything except root is a child of root
+      return documentId != ROOT_DOC_ID
+    }
+
+    // Check if documentId represents a child of parentDocumentId
+    return try {
+      val parent = getFileForDocId(parentDocumentId)
+      val child = getFileForDocId(documentId)
+      child.canonicalPath.startsWith(parent.canonicalPath + File.separator)
+    } catch (e: Exception) {
+      false
+    }
+  }
+
+  // Helper methods to map between document IDs and actual files
+  private fun getFileForDocId(id: String): File {
+    return when (id) {
+      ROOT_DOC_ID -> baseDir
+      else -> {
+        // Document IDs are just relative paths from baseDir
+        File(baseDir, id)
+      }
+    }
+  }
+
+  private fun getDocIdForFile(file: File): String {
+    if (file == baseDir) return ROOT_DOC_ID
+
+    // Document ID is the relative path from baseDir
+    return file.relativeTo(baseDir).path
+  }
+}

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemExceptions.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemExceptions.kt
@@ -56,3 +56,13 @@ internal class DestinationAlreadyExistsException :
   CodedException(
     "Destination already exists"
   )
+
+internal class UnableToCopyException(reason: String) :
+  CodedException(
+    "Unable to copy file or directory: $reason"
+  )
+
+internal class UnableToMoveException(reason: String) :
+  CodedException(
+    "Unable to move file or directory: $reason"
+  )

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemPath.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemPath.kt
@@ -29,7 +29,6 @@ val Uri.isAssetUri
     return scheme == "asset"
   }
 
-// TODO: Is this correct?
 fun Uri.isSAFUri(context: Context): Boolean =
   isContentUri && (
     DocumentsContract.isDocumentUri(context, this) || DocumentsContract.isTreeUri(this)

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemPath.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemPath.kt
@@ -1,9 +1,13 @@
 package expo.modules.filesystem
 
+import android.content.Context
 import android.net.Uri
 import android.os.Build
+import android.provider.DocumentsContract
 import androidx.core.net.toUri
 import expo.modules.filesystem.unifiedfile.AssetFile
+import expo.modules.filesystem.unifiedfile.ContentProviderFile
+import expo.modules.filesystem.fsops.DestinationSpec
 import expo.modules.filesystem.unifiedfile.JavaFile
 import expo.modules.filesystem.unifiedfile.SAFDocumentFile
 import expo.modules.filesystem.unifiedfile.UnifiedFileInterface
@@ -25,6 +29,12 @@ val Uri.isAssetUri
     return scheme == "asset"
   }
 
+// TODO: Is this correct?
+fun Uri.isSAFUri(context: Context): Boolean =
+  isContentUri && (
+    DocumentsContract.isDocumentUri(context, this) || DocumentsContract.isTreeUri(this)
+    )
+
 fun slashifyFilePath(path: String?): String? {
   return if (path == null) {
     null
@@ -44,16 +54,17 @@ abstract class FileSystemPath(var uri: Uri) : SharedObject() {
       if (currentAdapter?.uri == uri) {
         return currentAdapter
       }
-      val newAdapter = if (uri.isContentUri) {
-        SAFDocumentFile(appContext?.reactContext ?: throw Exception("No context"), uri)
-      } else if (uri.isAssetUri) {
-        AssetFile(appContext?.reactContext ?: throw Exception("No context"), uri)
-      } else {
-        JavaFile(uri)
+
+      val context = appContext?.reactContext ?: throw Exceptions.ReactContextLost()
+      val newAdapter = when {
+        uri.isSAFUri(context) -> SAFDocumentFile(context, uri)
+        uri.isContentUri -> ContentProviderFile(context, uri)
+        uri.isAssetUri -> AssetFile(context, uri)
+        else -> JavaFile(uri)
       }
-      fileAdapter = newAdapter
-      return newAdapter
+      return newAdapter.also { fileAdapter = it }
     }
+
   val javaFile: File
     get() =
       if (uri.isContentUri) {
@@ -141,7 +152,7 @@ abstract class FileSystemPath(var uri: Uri) : SharedObject() {
     validatePermission(FilePermissionService.Permission.READ)
     to.validatePermission(FilePermissionService.Permission.WRITE)
 
-    javaFile.copyRecursively(getMoveOrCopyPath(to))
+    file.copyTo(to.asCopyOrMoveDestination())
   }
 
   fun move(to: FileSystemPath) {
@@ -150,15 +161,11 @@ abstract class FileSystemPath(var uri: Uri) : SharedObject() {
     validatePermission(FilePermissionService.Permission.WRITE)
     to.validatePermission(FilePermissionService.Permission.WRITE)
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      val destination = getMoveOrCopyPath(to)
-      javaFile.toPath().moveTo(destination.toPath())
-      uri = destination.toUri()
-    } else {
-      javaFile.copyTo(getMoveOrCopyPath(to))
-      javaFile.delete()
-      uri = getMoveOrCopyPath(to).toUri()
-    }
+    // moveTo returns the URI of where the file was actually moved to
+    val finalUri = file.moveTo(to.asCopyOrMoveDestination())
+
+    // Update URI to reflect the new location
+    uri = finalUri
   }
 
   fun rename(newName: String) {
@@ -186,3 +193,9 @@ abstract class FileSystemPath(var uri: Uri) : SharedObject() {
       return file.creationTime
     }
 }
+
+fun FileSystemPath.asCopyOrMoveDestination(overwrite: Boolean = false) = DestinationSpec(
+  path = file,
+  overwrite = overwrite,
+  isDirectory = this is FileSystemDirectory
+)

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemPath.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemPath.kt
@@ -32,7 +32,7 @@ val Uri.isAssetUri
 fun Uri.isSAFUri(context: Context): Boolean =
   isContentUri && (
     DocumentsContract.isDocumentUri(context, this) || DocumentsContract.isTreeUri(this)
-    )
+  )
 
 fun slashifyFilePath(path: String?): String? {
   return if (path == null) {

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemPath.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemPath.kt
@@ -32,7 +32,7 @@ val Uri.isAssetUri
 fun Uri.isSAFUri(context: Context): Boolean =
   isContentUri && (
     DocumentsContract.isDocumentUri(context, this) || DocumentsContract.isTreeUri(this)
-  )
+    )
 
 fun slashifyFilePath(path: String?): String? {
   return if (path == null) {

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/CopyMoveStrategy.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/CopyMoveStrategy.kt
@@ -1,0 +1,186 @@
+package expo.modules.filesystem.fsops
+
+import android.content.Context
+import android.net.Uri
+import android.provider.DocumentsContract
+import androidx.core.net.toUri
+import expo.modules.filesystem.CopyOrMoveDirectoryToFileException
+import expo.modules.filesystem.DestinationAlreadyExistsException
+import expo.modules.filesystem.DestinationDoesNotExistException
+import expo.modules.filesystem.UnableToMoveException
+import expo.modules.filesystem.unifiedfile.AssetFile
+import expo.modules.filesystem.unifiedfile.ContentProviderFile
+import expo.modules.filesystem.unifiedfile.JavaFile
+import expo.modules.filesystem.unifiedfile.SAFDocumentFile
+import expo.modules.filesystem.unifiedfile.UnifiedFileInterface
+import expo.modules.kotlin.exception.Exceptions
+import java.io.File
+
+/**
+ * Strategy pattern for copy/move operations specific to each file backend type.
+ *
+ * Each file type (LocalFile, SAF, ContentProvider, Asset) has its own strategy
+ * that knows how to:
+ * - Prepare itself as a destination (validation, path resolution, overwrite handling)
+ * - Execute copy/move operations from itself as a source
+ * - Optimize operations based on source/destination type combinations
+ */
+sealed class CopyMoveStrategy(
+  protected open val file: UnifiedFileInterface
+) {
+
+  open fun copyTo(spec: DestinationSpec) {
+    spec.resolve(file).receiveFrom(file)
+  }
+
+  open fun moveTo(spec: DestinationSpec): Uri {
+    val resolved = spec.resolve(file)
+    return tryNativeMove(resolved) ?: run {
+      resolved.receiveFrom(file).also {
+        if (!file.deleteRecursively()) {
+          throw UnableToMoveException("Failed to delete source after move")
+        }
+      }
+    }
+  }
+
+  /**
+   * Attempts a native (atomic) move for the given resolved destination.
+   * Returns the resulting URI if native move succeeded, or null to fall back to copy+delete.
+   */
+  protected open fun tryNativeMove(resolved: DestinationSink): Uri? = null
+
+  internal abstract fun prepareAsDestination(source: UnifiedFileInterface, spec: DestinationSpec): DestinationSink
+
+  // / Implementations
+
+  class LocalFile(override val file: JavaFile) : CopyMoveStrategy(file) {
+    override fun prepareAsDestination(source: UnifiedFileInterface, spec: DestinationSpec): DestinationSink {
+      val sourceIsDir = source.isDirectory()
+      val fileName = source.fileName
+        ?: throw IllegalArgumentException("Source has no file name")
+
+      val target: JavaFile = when {
+        // Directory → File: error
+        sourceIsDir && !spec.isDirectory -> throw CopyOrMoveDirectoryToFileException()
+        // Directory → Directory
+        sourceIsDir && spec.isDirectory -> {
+          if (file.exists()) {
+            JavaFile(File(file, fileName).toUri())
+          } else {
+            if (file.parentFile?.exists() != true) throw DestinationDoesNotExistException()
+            file
+          }
+        }
+        // File → Directory
+        !sourceIsDir && spec.isDirectory -> {
+          if (!file.exists()) throw DestinationDoesNotExistException()
+          JavaFile(File(file, fileName).toUri())
+        }
+        // File → File
+        else -> {
+          if (file.parentFile?.exists() != true) throw DestinationDoesNotExistException()
+          file
+        }
+      }
+
+      target.takeIf { it.exists() }?.let {
+        if (!spec.overwrite) throw DestinationAlreadyExistsException()
+        it.deleteRecursively()
+      }
+
+      return DestinationSink.LocalFile(spec, target)
+    }
+
+    override fun tryNativeMove(resolved: DestinationSink): Uri? {
+      if (resolved is DestinationSink.LocalFile) {
+        if (file.renameTo(resolved.target)) return resolved.target.uri
+      }
+      return null
+    }
+  }
+
+  class SAF(
+    override val file: SAFDocumentFile,
+    private val context: Context
+  ) : CopyMoveStrategy(file) {
+    override fun prepareAsDestination(source: UnifiedFileInterface, spec: DestinationSpec): DestinationSink {
+      val sourceFileName = source.fileName
+        ?: throw Exceptions.IllegalArgument("Source ${source.uri} has no file name")
+
+      // → SAF File (not a directory spec)
+      if (!spec.isDirectory) {
+        if (file.exists() && !spec.overwrite) throw DestinationAlreadyExistsException()
+        if (file.exists() && spec.overwrite) file.deleteRecursively()
+        return DestinationSink.SAF(spec, file, isContainer = false)
+      }
+
+      // → SAF Directory that doesn't exist
+      if (!file.exists()) {
+        if (source.isDirectory()) {
+          if (file.parentFile?.exists() != true) throw DestinationDoesNotExistException()
+          return DestinationSink.SAF(spec, file, isContainer = false)
+        } else {
+          throw DestinationDoesNotExistException()
+        }
+      }
+
+      // → Existing SAF Directory: check child
+      file.findFile(sourceFileName)?.let { existingChild ->
+        if (!spec.overwrite) {
+          throw DestinationAlreadyExistsException()
+        }
+        existingChild.deleteRecursively()
+      }
+
+      return DestinationSink.SAF(spec, file, isContainer = true)
+    }
+
+    /**
+     * Attempts to use native SAF move operation.
+     * Only works if both documents are in the same tree.
+     *
+     * @return the URI of the moved document if successful, null if not supported/failed
+     */
+    override fun tryNativeMove(resolved: DestinationSink): Uri? {
+      if (resolved !is DestinationSink.SAF) {
+        return null
+      }
+
+      val destination = resolved.target
+      val sourceParent = file.documentFile?.parentFile?.uri ?: return null
+      val destParent = destination.documentFile?.parentFile?.uri ?: return null
+
+      return runCatching {
+        DocumentsContract.moveDocument(
+          context.contentResolver,
+          file.uri,
+          sourceParent,
+          destParent
+        )
+      }.getOrNull()
+    }
+  }
+
+  class ContentProvider(override val file: ContentProviderFile) : CopyMoveStrategy(file) {
+    override fun prepareAsDestination(source: UnifiedFileInterface, spec: DestinationSpec): DestinationSink {
+      if (file.exists() && !spec.overwrite) throw DestinationAlreadyExistsException()
+      return DestinationSink.ContentResource(spec)
+    }
+
+    override fun moveTo(spec: DestinationSpec): Uri {
+      throw UnableToMoveException("Content provider file cannot be moved (provider-dependent)")
+    }
+  }
+
+  class Asset(override val file: AssetFile) : CopyMoveStrategy(file) {
+    override fun prepareAsDestination(source: UnifiedFileInterface, spec: DestinationSpec): DestinationSink {
+      if (file.exists() && !spec.overwrite) throw DestinationAlreadyExistsException()
+      return DestinationSink.Asset(spec)
+    }
+
+    override fun moveTo(spec: DestinationSpec): Uri {
+      throw UnableToMoveException("Assets cannot be moved (provider-dependent)")
+    }
+  }
+}

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/CopyMoveStrategy.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/CopyMoveStrategy.kt
@@ -52,7 +52,7 @@ sealed class CopyMoveStrategy(
 
   internal abstract fun prepareAsDestination(source: UnifiedFileInterface, spec: DestinationSpec): DestinationSink
 
-  // / Implementations
+  // Implementations
 
   class LocalFile(override val file: JavaFile) : CopyMoveStrategy(file) {
     override fun prepareAsDestination(source: UnifiedFileInterface, spec: DestinationSpec): DestinationSink {
@@ -110,8 +110,10 @@ sealed class CopyMoveStrategy(
 
       // → SAF File (not a directory spec)
       if (!spec.isDirectory) {
-        if (file.exists() && !spec.overwrite) throw DestinationAlreadyExistsException()
-        if (file.exists() && spec.overwrite) file.deleteRecursively()
+        if (file.exists()) {
+          if (!spec.overwrite) throw DestinationAlreadyExistsException()
+          file.deleteRecursively()
+        }
         return DestinationSink.SAF(spec, file, isContainer = false)
       }
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/DestinationSink.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/DestinationSink.kt
@@ -1,0 +1,83 @@
+package expo.modules.filesystem.fsops
+
+import android.net.Uri
+import expo.modules.filesystem.UnableToCopyException
+import expo.modules.filesystem.unifiedfile.JavaFile
+import expo.modules.filesystem.unifiedfile.SAFDocumentFile
+import expo.modules.filesystem.unifiedfile.UnifiedFileInterface
+import expo.modules.kotlin.exception.Exceptions
+
+/**
+ * A validated, ready-to-write destination for copy/move operations.
+ * The destination has been:
+ * - Path-resolved (e.g., child path created if copying into directory)
+ * - Validated (overwrite checked, parent existence verified)
+ * - Cleaned up (existing file deleted if overwrite=true)
+ *
+ * Think of this as a "sink" that's ready to receive data from a source.
+ */
+sealed class DestinationSink(val spec: DestinationSpec) {
+  /**
+   * Receives data from the given source and writes it to this destination.
+   * Each subclass knows how to receive data appropriate to its backend.
+   *
+   * @param source The source file/directory to copy from
+   * @return The URI of the resulting copied file/directory
+   */
+  abstract fun receiveFrom(source: UnifiedFileInterface): Uri
+
+  class LocalFile(spec: DestinationSpec, val target: JavaFile) : DestinationSink(spec) {
+    override fun receiveFrom(source: UnifiedFileInterface): Uri {
+      when {
+        source is JavaFile -> source.copyRecursively(target, overwrite = spec.overwrite)
+        source.isDirectory() -> {
+          target.mkdir()
+          copyDirectoryViaStream(source, target)
+        }
+        else -> copyFileViaStream(source, target)
+      }
+      return target.uri
+    }
+  }
+
+  class SAF(spec: DestinationSpec, val target: SAFDocumentFile, val isContainer: Boolean = false) : DestinationSink(spec) {
+    override fun receiveFrom(source: UnifiedFileInterface): Uri {
+      if (source.isDirectory()) {
+        val actualDest = if (isContainer) {
+          val dirName = source.fileName
+            ?: throw Exceptions.IllegalStateException("Source has no directory name")
+          target.createDirectory(dirName)
+            ?: throw Exceptions.IllegalStateException("Failed to create directory: $dirName")
+        } else {
+          target
+        }
+        copyDirectoryViaStream(source, actualDest)
+        return actualDest.uri
+      } else {
+        val actualDest = if (isContainer) {
+          val fileName = source.fileName
+            ?: throw Exceptions.IllegalStateException("Source has no file name")
+          val mimeType = source.type ?: "*/*"
+          target.createFile(mimeType, fileName)
+            ?: throw Exceptions.IllegalStateException("Failed to create file: $fileName")
+        } else {
+          target
+        }
+        copyFileViaStream(source, actualDest)
+        return actualDest.uri
+      }
+    }
+  }
+
+  class ContentResource(spec: DestinationSpec) : DestinationSink(spec) {
+    override fun receiveFrom(source: UnifiedFileInterface): Uri {
+      throw UnableToCopyException("Cannot copy to read-only destination")
+    }
+  }
+
+  class Asset(spec: DestinationSpec) : DestinationSink(spec) {
+    override fun receiveFrom(source: UnifiedFileInterface): Uri {
+      throw UnableToCopyException("Cannot copy to read-only destination")
+    }
+  }
+}

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/DestinationSpec.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/DestinationSpec.kt
@@ -1,0 +1,30 @@
+package expo.modules.filesystem.fsops
+
+import expo.modules.filesystem.unifiedfile.UnifiedFileInterface
+import expo.modules.filesystem.DestinationAlreadyExistsException
+import expo.modules.filesystem.DestinationDoesNotExistException
+import expo.modules.filesystem.CopyOrMoveDirectoryToFileException
+
+/**
+ * Encapsulates destination parameters for copy/move operations.
+ * Represents what the user specified as the copy/move target.
+ */
+data class DestinationSpec(
+  val path: UnifiedFileInterface,
+  val overwrite: Boolean = false,
+  val isDirectory: Boolean = false
+) {
+  /**
+   * Resolves and validates the destination for a copy/move operation.
+   * Delegates to the destination path's own [CopyMoveStrategy.prepareAsDestination].
+   *
+   * @param source The source file/directory
+   * @return Validated and prepared destination
+   * @throws DestinationAlreadyExistsException if destination exists and overwrite is false
+   * @throws DestinationDoesNotExistException if parent doesn't exist
+   * @throws CopyOrMoveDirectoryToFileException if copying directory to file
+   */
+  internal fun resolve(source: UnifiedFileInterface): DestinationSink {
+    return this.path.copyMoveStrategy.prepareAsDestination(source, this)
+  }
+}

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
@@ -1,0 +1,55 @@
+package expo.modules.filesystem.fsops
+
+import expo.modules.filesystem.unifiedfile.UnifiedFileInterface
+import expo.modules.kotlin.exception.Exceptions
+
+/**
+ * Copy file contents via streams.
+ *
+ * @param source Source file (must be a file, not directory)
+ * @param dest DestinationSpec file (must be a file or not exist)
+ * @throws IllegalArgumentException if source is not a file
+ */
+internal fun copyFileViaStream(
+  source: UnifiedFileInterface,
+  dest: UnifiedFileInterface
+) {
+  require(source.isFile()) { "Source must be a file" }
+
+  source.inputStream().use { input ->
+    dest.outputStream().use { output ->
+      input.copyTo(output)
+    }
+  }
+}
+
+/**
+ * Copy directory recursively via streams.
+ *
+ * @param source Source directory (must be a directory)
+ * @param dest DestinationSpec directory (must be a directory)
+ * @throws Exceptions.IllegalArgument if source or dest is not a directory
+ * @throws Exceptions.IllegalStateException if child creation fails
+ */
+internal fun copyDirectoryViaStream(
+  source: UnifiedFileInterface,
+  dest: UnifiedFileInterface
+) {
+  require(source.isDirectory()) { "Source must be directory" }
+  require(dest.isDirectory()) { "Dest must be directory" }
+
+  source.listFilesAsUnified().forEach { child ->
+    val childName = child.fileName
+      ?: throw Exceptions.IllegalArgument("Child has no file name")
+
+    if (child.isDirectory()) {
+      val childDest = dest.createDirectory(childName)
+        ?: throw Exceptions.IllegalStateException("Failed to create directory: $childName")
+      copyDirectoryViaStream(child, childDest)
+    } else {
+      val childDest = dest.createFile(child.type ?: "*/*", childName)
+        ?: throw Exceptions.IllegalStateException("Failed to create file: $childName")
+      copyFileViaStream(child, childDest)
+    }
+  }
+}

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/AssetFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/AssetFile.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import android.webkit.MimeTypeMap
 import androidx.core.net.toUri
+import expo.modules.filesystem.fsops.CopyMoveStrategy
 import expo.modules.kotlin.AppContext
 import java.io.File
 import java.io.FileOutputStream
@@ -140,4 +141,6 @@ class AssetFile(private val context: Context, override val uri: Uri) : UnifiedFi
       }
     }
   }
+
+  override val copyMoveStrategy: CopyMoveStrategy = CopyMoveStrategy.Asset(this)
 }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/ContentProviderFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/ContentProviderFile.kt
@@ -1,0 +1,127 @@
+package expo.modules.filesystem.unifiedfile
+
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import android.webkit.MimeTypeMap
+import expo.modules.filesystem.fsops.CopyMoveStrategy
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.exception.Exceptions
+import java.io.InputStream
+import java.io.OutputStream
+
+/**
+ * Implementation of UnifiedFileInterface for generic content:// URIs
+ * that are NOT Storage Access Framework (SAF) URIs.
+ *
+ * Examples: MediaStore URIs, custom content provider URIs, share intent URIs.
+ *
+ * This implementation:
+ * - Uses ContentResolver directly (no DocumentFile)
+ * - Supports basic stream operations (read/write)
+ * - Does NOT support directory operations (create, list, delete)
+ * - May or may not support random access (openChannel) depending on the provider
+ */
+class ContentProviderFile(
+  private val context: Context,
+  override val uri: Uri
+) : UnifiedFileInterface {
+
+  override fun exists(): Boolean = runCatching {
+    context.contentResolver.openInputStream(uri)?.use { true }
+  }.getOrNull() ?: false
+
+  override fun isFile(): Boolean = exists()
+
+  override fun isDirectory(): Boolean = false
+
+  override val parentFile: UnifiedFileInterface? = null
+
+  override fun createFile(mimeType: String, displayName: String): UnifiedFileInterface? {
+    throw UnsupportedOperationException("Cannot create files in generic content provider: $uri")
+  }
+
+  override fun createDirectory(displayName: String): UnifiedFileInterface? {
+    throw UnsupportedOperationException("Cannot create directories in generic content provider: $uri")
+  }
+
+  override fun delete(): Boolean {
+    throw UnsupportedOperationException("Cannot delete from generic content provider: $uri")
+  }
+
+  override fun deleteRecursively(): Boolean {
+    throw UnsupportedOperationException("Cannot delete from generic content provider: $uri")
+  }
+
+  override fun listFilesAsUnified(): List<UnifiedFileInterface> = emptyList()
+
+  override val type: String?
+    get() {
+      context.contentResolver.getType(uri)?.let { mimeType ->
+        return mimeType
+      }
+
+      val extension = MimeTypeMap.getFileExtensionFromUrl(uri.toString())
+      return extension.takeUnless { it.isNullOrEmpty() }?.let { ext ->
+        MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext.lowercase())
+      }
+    }
+
+  override fun lastModified(): Long? {
+    return queryColumn(OpenableColumns.SIZE)?.toLongOrNull()
+  }
+
+  override val creationTime: Long? = null
+
+  override val fileName: String?
+    get() = queryColumn(OpenableColumns.DISPLAY_NAME) ?: uri.lastPathSegment
+
+  override fun getContentUri(appContext: AppContext): Uri = uri
+
+  override fun outputStream(append: Boolean): OutputStream {
+    return context.contentResolver.openOutputStream(uri)
+      ?: throw Exceptions.IllegalStateException("Unable to open output stream for URI: $uri")
+  }
+
+  override fun inputStream(): InputStream {
+    return context.contentResolver.openInputStream(uri)
+      ?: throw Exceptions.IllegalStateException("Unable to open input stream for URI: $uri")
+  }
+
+  override fun length(): Long {
+    queryColumn(OpenableColumns.SIZE)?.toLongOrNull()?.let { size ->
+      return size
+    }
+
+    return runCatching {
+      inputStream().use { stream ->
+        var total = 0L
+        val buffer = ByteArray(8192)
+        var read: Int
+        while (stream.read(buffer).also { read = it } != -1) {
+          total += read
+        }
+        total
+      }
+    }.getOrNull() ?: 0L
+  }
+
+  override fun walkTopDown(): Sequence<UnifiedFileInterface> = sequenceOf(this)
+
+  override val copyMoveStrategy: CopyMoveStrategy = CopyMoveStrategy.ContentProvider(this)
+
+  /**
+   * Helper to query a column from the ContentResolver.
+   */
+  private fun queryColumn(column: String): String? {
+    return runCatching {
+      context.contentResolver.query(uri, arrayOf(column), null, null, null)?.use { cursor ->
+        cursor.takeIf { it.moveToFirst() }?.let { cursor ->
+          cursor.getColumnIndex(column).takeIf { it >= 0 }?.let { index ->
+            cursor.getString(index)
+          }
+        }
+      }
+    }.getOrNull()
+  }
+}

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/ContentProviderFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/ContentProviderFile.kt
@@ -37,21 +37,17 @@ class ContentProviderFile(
 
   override val parentFile: UnifiedFileInterface? = null
 
-  override fun createFile(mimeType: String, displayName: String): UnifiedFileInterface? {
+  override fun createFile(mimeType: String, displayName: String): UnifiedFileInterface =
     throw UnsupportedOperationException("Cannot create files in generic content provider: $uri")
-  }
 
-  override fun createDirectory(displayName: String): UnifiedFileInterface? {
+  override fun createDirectory(displayName: String): UnifiedFileInterface =
     throw UnsupportedOperationException("Cannot create directories in generic content provider: $uri")
-  }
 
-  override fun delete(): Boolean {
+  override fun delete(): Boolean =
     throw UnsupportedOperationException("Cannot delete from generic content provider: $uri")
-  }
 
-  override fun deleteRecursively(): Boolean {
+  override fun deleteRecursively(): Boolean =
     throw UnsupportedOperationException("Cannot delete from generic content provider: $uri")
-  }
 
   override fun listFilesAsUnified(): List<UnifiedFileInterface> = emptyList()
 
@@ -67,9 +63,7 @@ class ContentProviderFile(
       }
     }
 
-  override fun lastModified(): Long? {
-    return queryColumn(OpenableColumns.SIZE)?.toLongOrNull()
-  }
+  override fun lastModified(): Long? = null
 
   override val creationTime: Long? = null
 
@@ -115,13 +109,16 @@ class ContentProviderFile(
    */
   private fun queryColumn(column: String): String? {
     return runCatching {
-      context.contentResolver.query(uri, arrayOf(column), null, null, null)?.use { cursor ->
-        cursor.takeIf { it.moveToFirst() }?.let { cursor ->
-          cursor.getColumnIndex(column).takeIf { it >= 0 }?.let { index ->
-            cursor.getString(index)
+      context
+        .contentResolver
+        .query(uri, arrayOf(column), null, null, null)
+        ?.use { cursor ->
+          cursor.takeIf { it.moveToFirst() }?.let { cursor ->
+            cursor.getColumnIndex(column).takeIf { it >= 0 }?.let { index ->
+              cursor.getString(index)
+            }
           }
         }
-      }
     }.getOrNull()
   }
 }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/JavaFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/JavaFile.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import android.webkit.MimeTypeMap
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
+import expo.modules.filesystem.fsops.CopyMoveStrategy
 import expo.modules.kotlin.AppContext
 import java.io.File
 import java.io.FileInputStream
@@ -22,13 +23,13 @@ class JavaFile(override val uri: Uri) : UnifiedFileInterface, File(URI.create(ur
     get() = super<File>.parentFile?.toUri()?.let { JavaFile(it) }
 
   override fun createFile(mimeType: String, displayName: String): UnifiedFileInterface? {
-    val childFile = File(super<File>.parentFile, displayName)
+    val childFile = File(this, displayName)
     childFile.createNewFile()
     return JavaFile(childFile.toUri())
   }
 
   override fun createDirectory(displayName: String): UnifiedFileInterface? {
-    val childFile = File(super<File>.parentFile, displayName)
+    val childFile = File(this, displayName)
     childFile.mkdir()
     return JavaFile(childFile.toUri())
   }
@@ -79,4 +80,6 @@ class JavaFile(override val uri: Uri) : UnifiedFileInterface, File(URI.create(ur
   override fun walkTopDown(): Sequence<JavaFile> {
     return walk(direction = FileWalkDirection.TOP_DOWN).map { JavaFile(it.toUri()) }
   }
+
+  override val copyMoveStrategy: CopyMoveStrategy = CopyMoveStrategy.LocalFile(this)
 }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/SAFDocumentFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/SAFDocumentFile.kt
@@ -95,12 +95,6 @@ class SAFDocumentFile(private val context: Context, override val uri: Uri) : Uni
     return SAFDocumentFile(context, child.uri)
   }
 
-  /**
-   * Internal property exposing the DocumentFile for use within the package
-   */
-  internal val document: DocumentFile?
-    get() = documentFile
-
   override fun walkTopDown(): Sequence<SAFDocumentFile> {
     return sequence {
       yield(this@SAFDocumentFile)

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/UnifiedFileInterface.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/UnifiedFileInterface.kt
@@ -1,6 +1,8 @@
 package expo.modules.filesystem.unifiedfile
 
 import android.net.Uri
+import expo.modules.filesystem.fsops.DestinationSpec
+import expo.modules.filesystem.fsops.CopyMoveStrategy
 import expo.modules.kotlin.AppContext
 
 interface UnifiedFileInterface {
@@ -23,4 +25,8 @@ interface UnifiedFileInterface {
   fun inputStream(): java.io.InputStream
   fun length(): Long
   fun walkTopDown(): Sequence<UnifiedFileInterface>
+
+  val copyMoveStrategy: CopyMoveStrategy
+  fun copyTo(dest: DestinationSpec) = copyMoveStrategy.copyTo(dest)
+  fun moveTo(dest: DestinationSpec): Uri = copyMoveStrategy.moveTo(dest)
 }


### PR DESCRIPTION
# Why

Legacy FileSystem supported copying from SAF and other `content://` URIs. This is very limited or missing in the new file system - it relies heavily on `javaFile` which is usually not available for content URIs.

# How

- Added non-SAF `ContentProviderFile` implementation of `UnifiedFileInterface` to let FileSystem support some subset of common operations
- Created a delegate to the unified interface that handles copying and moving between JavaFile, SAF, Asset and ContentProviderFile
  - handled edge cases and optimizations (assets stay read-only; JavaFiles are atomically copied using native Java File APIs)
  - to avoid spaghetti of nested if-else, came up with kinda over-engineered solution with two sealed classes:
    -  `CopyMoveStrategy` to handle each file type that can be copied and prepare destination config
    -  `DestinationSink` to handle creating the destination file and writing to it
- Introduced a `overwrite` boolean that can be easily exposed to the JS API in a later PR (legacy filesystem was always overwriting, new does not do it).

# Test Plan

- New Test Suite tests
- Added instrumentation tests

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
