### PR TITLE
[image-picker][ios] Improve MIME type resolution

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [iOS] Improved MIME type resolution.
+- [iOS] Improved MIME type resolution. ([#42889](https://github.com/expo/expo/pull/42889) by [@barthap](https://github.com/barthap))
 
 ## 55.0.4 — 2026-02-03
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [iOS] Improved MIME type resolution.
+
 ## 55.0.4 — 2026-02-03
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-image-picker/ios/MediaHandler.swift
+++ b/packages/expo-image-picker/ios/MediaHandler.swift
@@ -297,7 +297,7 @@ internal struct MediaHandler {
 
   private func getMimeType(from asset: PHAsset?, fileExtension: String) -> String? {
     let utType: UTType? = if #available(iOS 26.0, *) {
-      asset?.contentType
+      asset?.contentType ?? UTType(filenameExtension: fileExtension)
     } else {
       UTType(filenameExtension: fileExtension)
     }

--- a/packages/expo-image-picker/ios/MediaHandler.swift
+++ b/packages/expo-image-picker/ios/MediaHandler.swift
@@ -245,7 +245,7 @@ internal struct MediaHandler {
       for: videoResource, toFile: pairedVideoUrl, options: nil)
 
     let fileSize = getFileSize(from: photoUrl)
-    let mimeType = getMimeType(from: photoUrl.pathExtension)
+    let mimeType = getMimeType(from: photoResource, fileExtension: photoUrl.pathExtension)
     let base64 = options.base64 ? imageData.base64EncodedString() : nil
     let exif = options.exif ? ImageUtils.readExifFrom(data: imageData) : nil
 
@@ -275,7 +275,7 @@ internal struct MediaHandler {
       throw FailedToReadVideoSizeException()
     }
     let duration = VideoUtils.readDurationFrom(url: fileUrl)
-    let mimeType = getMimeType(from: fileUrl.pathExtension)
+    let mimeType = getMimeType(from: videoResource, fileExtension: fileUrl.pathExtension)
     let fileSize = getFileSize(from: fileUrl)
 
     return AssetInfo(
@@ -293,6 +293,24 @@ internal struct MediaHandler {
 
   private func getMimeType(from pathExtension: String) -> String? {
     return UTType(filenameExtension: pathExtension)?.preferredMIMEType
+  }
+
+  private func getMimeType(from asset: PHAsset?, fileExtension: String) -> String? {
+    let utType: UTType? = if #available(iOS 26.0, *) {
+      asset?.contentType
+    } else {
+      UTType(filenameExtension: fileExtension)
+    }
+    return utType?.preferredMIMEType
+  }
+
+  private func getMimeType(from resource: PHAssetResource, fileExtension: String) -> String? {
+    let utType: UTType? = if #available(iOS 26.0, *) {
+      resource.contentType
+    } else {
+      UTType(resource.uniformTypeIdentifier) ?? UTType(filenameExtension: fileExtension)
+    }
+    return utType?.preferredMIMEType
   }
 
   // MARK: - Video
@@ -319,7 +337,7 @@ internal struct MediaHandler {
           options: resourceOptions
         )
 
-        let mimeType = getMimeType(from: destinationUrl.pathExtension)
+        let mimeType = getMimeType(from: resource, fileExtension: destinationUrl.pathExtension)
         return try buildVideoResult(
           for: destinationUrl,
           withName: originalFilename,
@@ -353,7 +371,7 @@ internal struct MediaHandler {
     let videoUrlToReadDurationFrom = self.options.allowsEditing ? pickedUrl : targetUrl
 
     let asset = mediaInfo[.phAsset] as? PHAsset
-    let mimeType = getMimeType(from: targetUrl.pathExtension)
+    let mimeType = getMimeType(from: asset, fileExtension: targetUrl.pathExtension)
     let fileName = asset?.value(forKey: "filename") as? String
     let fileSize = getFileSize(from: targetUrl)
 
@@ -397,8 +415,7 @@ internal struct MediaHandler {
 
           try await PHAssetResourceManager.default().writeData(for: resource, toFile: destinationUrl, options: resourceOptions)
 
-          // Build and return the result using the helper.
-          let mimeType = getMimeType(from: destinationUrl.pathExtension)
+          let mimeType = getMimeType(from: resource, fileExtension: destinationUrl.pathExtension)
           return try buildVideoResult(
             for: destinationUrl,
             withName: originalFilename,


### PR DESCRIPTION
# Why

Fixes part mentioned in <https://github.com/expo/expo/issues/42739#issuecomment-3828573995>:

> - The issue is that the ImagePicker does not resolve MIME types correctly
>   - It defaults to getting it from file extension, so .mov -> video/quicktime. This is not perfect and can be improved

# How

Best-effort to resolve content type from `PHAsset` / `PHAssetResource` using iOS 26+ [`PHAssetResource.contenType`](https://developer.apple.com/documentation/photos/phassetresource/contenttype), with fallback to the existing file-extension-based resolution.

# Test Plan

NCL, operations described in the aforementioned comment

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
