### PR TITLE
patch(cli): Bump to `fetch-nodeshim@^0.4.5`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - delete old expo go artifacts to save disk space ([#42860](https://github.com/expo/expo/pull/42860) by [@vonovak](https://github.com/vonovak))
+- Bump to `fetch-nodeshim@^0.4.5` ([#42896](https://github.com/expo/expo/pull/42896) by [@kitten](https://github.com/kitten))
 
 ## 55.0.6 — 2026-02-03
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -73,7 +73,7 @@
     "dnssd-advertise": "^1.1.1",
     "env-editor": "^0.4.1",
     "expo-server": "^55.0.3",
-    "fetch-nodeshim": "^0.4.4",
+    "fetch-nodeshim": "^0.4.5",
     "getenv": "^2.0.0",
     "glob": "^13.0.0",
     "lan-network": "^0.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8481,10 +8481,10 @@ fdir@^6.5.0:
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
-fetch-nodeshim@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/fetch-nodeshim/-/fetch-nodeshim-0.4.4.tgz#ad2e396ae0700dce1eda8e3915d67ad9a2cdb8a8"
-  integrity sha512-LyNa+cxfzsMvf4NyGw4DZpHJlLif9BodSkrjtFCgB2+5zM1iRI6+EcZVOIDeuggNiK4ieff9abWOeDCQQLDWyA==
+fetch-nodeshim@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/fetch-nodeshim/-/fetch-nodeshim-0.4.5.tgz#618d643ee1f77040d7dde718147717fd0cbb29a8"
+  integrity sha512-n6dRDiC+/TlluvZxGDBnyNYqPftkDFjJIvXluekSSGildXSXvMWXXo+1/yK363BOZlOI2Q+PitrcLcF5CSolEA==
 
 fetch-retry@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
# Why

This is a combination of our API being strict with `Content-Type` and the body being passed specifically where a default `Content-Type` is available for it (as string, `text/plain`). Both wasn't true at the same time in testing before.

In such cases, `fetch-nodeshim` would disregard the already set `Content-Type`, unlike its `Accept` default, and not send it, and instead send the default, `text/plain` value.

See: https://github.com/kitten/fetch-nodeshim/commit/03e455761403e1295bc2c1494da7833c55a73890

# How

- Bump to `fetch-nodeshim@^0.4.5`

# Test Plan

- Run `expo login` on `main` after installing

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
