### PR TITLE
fix(build) fixed failing building from source + use_frameworks

### DIFF
--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed missing dependencies when building from source
+
 ### 💡 Others
 
 ## 55.0.4 — 2026-02-03

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed missing dependencies when building from source
+- [iOS] Fixed missing dependencies when building from source ([#42901](https://github.com/expo/expo/pull/42901) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-gl/ExpoGL.podspec
+++ b/packages/expo-gl/ExpoGL.podspec
@@ -33,7 +33,10 @@ Pod::Spec.new do |s|
       '"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers"',
     ].compact)
   end
-  pod_target_xcconfig['HEADER_SEARCH_PATHS'] = header_search_paths.join(' ')
+
+  if !header_search_paths.empty?
+    pod_target_xcconfig['HEADER_SEARCH_PATHS'] = '$(inherited) ' + header_search_paths.join(' ')
+  end
   s.pod_target_xcconfig = pod_target_xcconfig
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')

--- a/packages/expo-gl/ExpoGL.podspec
+++ b/packages/expo-gl/ExpoGL.podspec
@@ -21,9 +21,20 @@ Pod::Spec.new do |s|
   s.dependency 'ReactCommon/turbomodule/core'
 
   s.compiler_flags = '-x objective-c++ -std=c++20'
-  s.pod_target_xcconfig = {
+  pod_target_xcconfig = {
     'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) GLES_SILENCE_DEPRECATION=1'
   }
+
+  header_search_paths = []
+  if ENV['USE_FRAMEWORKS']
+    header_search_paths.concat([
+      # Transient dependencies
+      '"${PODS_CONFIGURATION_BUILD_DIR}/React-runtimescheduler/React_runtimescheduler.framework/Headers"',
+      '"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers"',
+    ].compact)
+  end
+  pod_target_xcconfig['HEADER_SEARCH_PATHS'] = header_search_paths.join(' ')
+  s.pod_target_xcconfig = pod_target_xcconfig
 
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "ios/**/*.h"

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed missing dependencies when building from source
+
 ### 💡 Others
 
 ## 55.0.7 — 2026-02-03

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed missing dependencies when building from source
+- [iOS] Fixed missing dependencies when building from source ([#42901](https://github.com/expo/expo/pull/42901) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ExpoModulesJSI.podspec
+++ b/packages/expo-modules-core/ExpoModulesJSI.podspec
@@ -30,6 +30,7 @@ Pod::Spec.new do |s|
       '"${PODS_CONFIGURATION_BUILD_DIR}/React-jsinspectorcdp/jsinspector_moderncdp.framework/Headers"',
       # Transitive dependencies of React-runtimescheduler
       '"${PODS_CONFIGURATION_BUILD_DIR}/React-runtimescheduler/React_runtimescheduler.framework/Headers"',
+      '"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers"',
       '"${PODS_CONFIGURATION_BUILD_DIR}/React-performancetimeline/React_performancetimeline.framework/Headers"',
       '"${PODS_CONFIGURATION_BUILD_DIR}/React-rendererconsistency/React_rendererconsistency.framework/Headers"',
       '"${PODS_CONFIGURATION_BUILD_DIR}/React-timing/React_timing.framework/Headers"',
@@ -55,6 +56,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'React-Core'
   s.dependency 'ReactCommon'
+  s.dependency 'React-runtimescheduler'
 
   s.source_files = ['ios/JSI/**/*.{h,m,mm,swift,cpp}', 'common/cpp/JSI/**/*.{h,cpp}']
   s.exclude_files = ['ios/JSI/Tests']

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed missing dependency on RCTFabric in ExpoUI podspec.
+- [iOS] Fixed missing dependency on RCTFabric in ExpoUI podspec. ([#42901](https://github.com/expo/expo/pull/42901) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed missing dependency on RCTFabric in ExpoUI podspec.
+
 ### 💡 Others
 
 ## 55.0.0-preview.4 — 2026-02-03

--- a/packages/expo-ui/ios/ExpoUI.podspec
+++ b/packages/expo-ui/ios/ExpoUI.podspec
@@ -19,6 +19,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
+  s.dependency 'React-RCTFabric'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {


### PR DESCRIPTION
# Why

CI "Test iOS Static Frameworks" are failing. It is using buildFromSource: true and useFramework: true. https://github.com/expo/expo/actions/runs/21553554799/job/62342466034

This combination causes some headers not to be found and the CI job to fail.

# How

Fixed the missing search paths.

# Test Plan

1. Build with source + use_framworks ✅
2. Build with source ✅
3. Build with prebuilds + use_frameworks ✅
4. Build with prebuilds ✅

Build without source isn't a problem since header paths are included in React-Core framework.

Make sure: "Test iOS Static Frameworks" is green ✅
https://github.com/expo/expo/actions/runs/21711769847/job/62616962422

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
