### PR TITLE
[updates][Android] Remove usage of `enableBridgelessArchitecture`

### DIFF
--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/errorrecovery/ErrorRecoveryTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/errorrecovery/ErrorRecoveryTest.kt
@@ -16,12 +16,12 @@ class ErrorRecoveryTest {
   private var mockDelegate: ErrorRecoveryDelegate = mockk()
   private val context = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
   private val updatesLogger = UpdatesLogger(context.filesDir)
-  private var errorRecovery: ErrorRecovery = ErrorRecovery(updatesLogger, enableBridgelessArchitecture = true)
+  private var errorRecovery: ErrorRecovery = ErrorRecovery(updatesLogger)
 
   @Before
   fun setup() {
     mockDelegate = mockk(relaxed = true)
-    errorRecovery = ErrorRecovery(updatesLogger, enableBridgelessArchitecture = true)
+    errorRecovery = ErrorRecovery(updatesLogger)
     errorRecovery.initialize(mockDelegate)
     errorRecovery.handler = spyk(ErrorRecoveryHandler(errorRecovery.handlerThread.looper, mockDelegate, UpdatesLogger(context.filesDir)))
     // make handler run synchronously

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecovery.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecovery.kt
@@ -27,8 +27,7 @@ import java.lang.ref.WeakReference
  * and so there is no more need to trigger the error recovery pipeline.
  */
 class ErrorRecovery(
-  private val logger: UpdatesLogger,
-  private val enableBridgelessArchitecture: Boolean = true
+  private val logger: UpdatesLogger
 ) {
   internal val handlerThread = HandlerThread("expo-updates-error-recovery")
   internal lateinit var handler: Handler
@@ -98,11 +97,7 @@ class ErrorRecovery(
   }
 
   private fun registerErrorHandler(devSupportManager: DevSupportManager) {
-    if (enableBridgelessArchitecture) {
-      registerErrorHandlerImplBridgeless()
-    } else {
-      registerErrorHandlerImplBridge(devSupportManager)
-    }
+    registerErrorHandlerImplBridgeless()
   }
 
   private fun registerErrorHandlerImplBridgeless() {
@@ -128,11 +123,7 @@ class ErrorRecovery(
   }
 
   private fun unregisterErrorHandler() {
-    if (enableBridgelessArchitecture) {
-      unregisterErrorHandlerImplBridgeless()
-    } else {
-      unregisterErrorHandlerImplBridge()
-    }
+    unregisterErrorHandlerImplBridgeless()
   }
 
   private fun unregisterErrorHandlerImplBridgeless() {
@@ -159,9 +150,5 @@ class ErrorRecovery(
     // quitSafely will wait for processing messages to finish but cancel all messages scheduled for
     // a future time, so delay for a few more seconds in case there are any scheduled messages
     handler.postDelayed({ handlerThread.quitSafely() }, 10000)
-  }
-
-  companion object {
-    private val TAG = ErrorRecovery::class.java.simpleName
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RestartReactAppExtensions.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RestartReactAppExtensions.kt
@@ -3,7 +3,6 @@ package expo.modules.updates.procedures
 import android.app.Activity
 import com.facebook.react.ReactApplication
 import com.facebook.react.common.LifecycleState
-import expo.modules.rncompatibility.ReactNativeFeatureFlags
 
 /**
  * An extension for [ReactApplication] to restart the app
@@ -12,15 +11,10 @@ import expo.modules.rncompatibility.ReactNativeFeatureFlags
  * @param reason The restart reason. Only used on bridgeless mode.
  */
 internal fun ReactApplication.restart(activity: Activity?, reason: String) {
-  if (ReactNativeFeatureFlags.enableBridgelessArchitecture) {
-    val reactHost = this.reactHost
-    check(reactHost != null)
-    if (reactHost.lifecycleState != LifecycleState.RESUMED && activity != null) {
-      reactHost.onHostResume(activity)
-    }
-    reactHost.reload(reason)
-    return
+  val reactHost = this.reactHost
+  check(reactHost != null)
+  if (reactHost.lifecycleState != LifecycleState.RESUMED && activity != null) {
+    reactHost.onHostResume(activity)
   }
-
-  reactNativeHost.reactInstanceManager.recreateReactContextInBackground()
+  reactHost.reload(reason)
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
@@ -2,7 +2,6 @@ package expo.modules.updates.procedures
 
 import android.content.Context
 import com.facebook.react.devsupport.interfaces.DevSupportManager
-import expo.modules.rncompatibility.ReactNativeFeatureFlags
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.DatabaseHolder
 import expo.modules.updates.db.entity.AssetEntity
@@ -66,7 +65,7 @@ class StartupProcedure(
 
   var emergencyLaunchException: Exception? = null
     private set
-  private val errorRecovery = ErrorRecovery(logger, ReactNativeFeatureFlags.enableBridgelessArchitecture)
+  private val errorRecovery = ErrorRecovery(logger)
   private var remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
 
   private val loaderTask = LoaderTask(


### PR DESCRIPTION
# Why

Removes usage of `enableBridgelessArchitecture` as we no longer support legacy architecture. 

# Test Plan

- Bare Expo built successfully - not sure how I should test it 🤔 Hopefully, our CI is enough.