### PR TITLE
[core][Android] Stop using deprecated `hostingRuntimeContext`

### DIFF
--- a/packages/@expo/dom-webview/android/src/main/java/expo/modules/webview/DomWebView.kt
+++ b/packages/@expo/dom-webview/android/src/main/java/expo/modules/webview/DomWebView.kt
@@ -163,7 +163,7 @@ internal class DomWebView(context: Context, appContext: AppContext) : ExpoView(c
           .replace("\"%%WEBVIEW_ID%%\"", webViewId.toString())
           .replace("\"%%SOURCE%%\"", source)
         try {
-          val result = appContext.hostingRuntimeContext.eval(wrappedSource)
+          val result = appContext.runtime.eval(wrappedSource)
           continuation.resume(result.getString())
         } catch (e: Exception) {
           continuation.resumeWithException(e)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
@@ -16,7 +16,7 @@ abstract class Module : AppContextProvider {
   internal var _appContextHolder: WeakReference<AppContext> = WeakReference(null)
 
   val runtime: Runtime
-    get() = requireNotNull(_appContextHolder.get()?.hostingRuntimeContext) { "The module wasn't created! You can't access the hosting runtime." }
+    get() = requireNotNull(_appContextHolder.get()?.runtime) { "The module wasn't created! You can't access the hosting runtime." }
 
   @Deprecated(
     message = "Use 'runtime' property instead.",

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
@@ -12,7 +12,7 @@ import kotlin.reflect.KClass
 
 @DoNotStrip
 open class SharedObject(runtime: Runtime? = null) {
-  constructor(appContext: AppContext) : this(appContext.hostingRuntimeContext)
+  constructor(appContext: AppContext) : this(appContext.runtime)
 
   /**
    * An identifier of the native shared object that maps to the JavaScript object.

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectTypeConverter.kt
@@ -26,7 +26,7 @@ class SharedObjectTypeConverter<T : SharedObject>(
     )
 
     val appContext = context.toStrongReference()
-    val result = id.toNativeObject(appContext.hostingRuntimeContext)
+    val result = id.toNativeObject(appContext.runtime)
     return result as T
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedRef.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedRef.kt
@@ -14,7 +14,7 @@ open class SharedRef<RefType>(
   val ref: RefType,
   runtime: Runtime? = null
 ) : SharedObject(runtime) {
-  constructor(ref: RefType, appContext: AppContext) : this(ref, appContext.hostingRuntimeContext)
+  constructor(ref: RefType, appContext: AppContext) : this(ref, appContext.runtime)
 
   /**
    * A type of the native reference. It can be used to distinguish between different SharedRefs in the JavaScript.


### PR DESCRIPTION
# Why

Stops using deprecated `AppContext.hostingRuntimeContext` 

# How

Replaced `AppContext.hostingRuntimeContext` with `AppContext.runtime`

# Test Plan

- bare expo ✅ 