### PR TITLE
refactor(cli): Add internal headless env flag

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -13,6 +13,7 @@
 - delete old expo go artifacts to save disk space ([#42860](https://github.com/expo/expo/pull/42860) by [@vonovak](https://github.com/vonovak))
 - Bump to `fetch-nodeshim@^0.4.5` ([#42896](https://github.com/expo/expo/pull/42896) by [@kitten](https://github.com/kitten))
 - Enable `experiments.autolinkingModuleResolution` by default for workspaces/monorepos ([#40606](https://github.com/expo/expo/pull/40606) by [@kitten](https://github.com/kitten))
+- Add flag to preconfigure other flags for headless environment ([#42909](https://github.com/expo/expo/pull/42909) by [@kitten](https://github.com/kitten))
 
 ## 55.0.6 — 2026-02-03
 

--- a/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
@@ -2,7 +2,7 @@ import type { NextHandleFunction } from 'connect';
 import { WebSocketServer } from 'ws';
 
 import { createHandlersFactory } from './createHandlersFactory';
-import { env } from '../../../../utils/env';
+import { env, envIsHeadless } from '../../../../utils/env';
 import { isLocalSocket, isMatchingOrigin } from '../../../../utils/net';
 import { TerminalReporter } from '../TerminalReporter';
 import { NETWORK_RESPONSE_STORAGE } from './messageHandlers/NetworkResponse';
@@ -47,6 +47,10 @@ export function createDebugMiddleware({
       // Only enable opening the browser version of React Native DevTools when debugging.
       // This is useful when debugging the React Native DevTools by going to `/open-debugger` in the browser.
       enableOpenDebuggerRedirect: env.EXPO_DEBUG,
+      // The standalone fusebox shell (@react-native/debugger-shell) starts installing almost
+      // immediately in the background when the dev middleware is created, which we don't
+      // always want to happen
+      enableStandaloneFuseboxShell: !envIsHeadless(),
     },
   });
 

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -67,7 +67,7 @@ class Env {
   }
   /** Disable auto web setup */
   get EXPO_NO_WEB_SETUP() {
-    return boolish('EXPO_NO_WEB_SETUP', false);
+    return boolish('EXPO_NO_WEB_SETUP', envIsHeadless());
   }
   /** Disable auto TypeScript setup */
   get EXPO_NO_TYPESCRIPT_SETUP() {
@@ -254,14 +254,12 @@ class Env {
 
   /** Disable the React Native Directory compatibility check for new architecture when installing packages */
   get EXPO_NO_NEW_ARCH_COMPAT_CHECK(): boolean {
-    return boolish('EXPO_NO_NEW_ARCH_COMPAT_CHECK', false);
+    return boolish('EXPO_NO_NEW_ARCH_COMPAT_CHECK', envIsHeadless());
   }
 
   /** Disable the dependency validation when installing other dependencies and starting the project */
   get EXPO_NO_DEPENDENCY_VALIDATION(): boolean {
-    // Default to disabling when running in a web container (stackblitz, bolt, etc).
-    const isWebContainer = process.versions.webcontainer != null;
-    return boolish('EXPO_NO_DEPENDENCY_VALIDATION', isWebContainer);
+    return boolish('EXPO_NO_DEPENDENCY_VALIDATION', envIsHeadless());
   }
 
   /** Force Expo CLI to run in webcontainer mode, this has impact on which URL Expo is using by default */
@@ -301,6 +299,11 @@ class Env {
   get EXPO_UNSTABLE_BONJOUR(): boolean {
     return boolish('EXPO_UNSTABLE_BONJOUR', false);
   }
+
+  /** @internal Configure other environment variables for headless operations */
+  get EXPO_UNSTABLE_HEADLESS() {
+    return boolish('EXPO_UNSTABLE_HEADLESS', envIsWebcontainer());
+  }
 }
 
 export const env = new Env();
@@ -311,4 +314,8 @@ export function envIsWebcontainer() {
     env.EXPO_FORCE_WEBCONTAINER_ENV ||
     (process.env.SHELL === '/bin/jsh' && !!process.versions.webcontainer)
   );
+}
+
+export function envIsHeadless() {
+  return env.EXPO_UNSTABLE_HEADLESS;
 }


### PR DESCRIPTION
# Why

This is for cases where an environment we're running in is somewhere in between a user's machine and a CI runner, i.e. we're neither offline, nor on a user's device, nor in CI. In that case, we want to make some particular assumptions without disabling all online functionality. We can for example assume that install checks are redundant, but shouldn't stop communicating with EAS.

# How

- Add `envIsHeadless` utility, default to webcontainers
- Preconfigure dependencies checks to stop on headless
- Disable standalone fusebox to be disabled on headless envs

# Test Plan

- Verify that setting the variable turns off install check tasks
- Verify that setting the variable turns off standalone fusebox

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
