### PR TITLE
feat(cli): Shrink QR code by leaving search params unencoded

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Retrieve default route's IP address concurrently ([#42923](https://github.com/expo/expo/pull/42923) by [@kitten](https://github.com/kitten))
 - Replace `require-from-string` with `@expo/require-utils` ([#42884](https://github.com/expo/expo/pull/42884) by [@kitten](https://github.com/kitten))
 - Refactor env loading and reloading to unified logic and don't overwrite original system values ([#43038](https://github.com/expo/expo/pull/43038) by [@kitten](https://github.com/kitten))
+- Only encode the QR code's URL params partially to save on size ([#42911](https://github.com/expo/expo/pull/42911) by [@kitten](https://github.com/kitten))
 
 ## 55.0.7 — 2026-02-08
 


### PR DESCRIPTION
# Why

> [!WARNING]
> This requires more testing and research to determine whether it's safe to do by default

Branched off of #42834

The QR code for development clients currently is quite large as it contains a lot of strings that don't have to be as long as they are. For example: `exp+notification-tester://expo-development-client/?url=http%3A%2F%2F10.0.0.112%3A8088`

In this string, the main components are:
- the protocol part (we can't change this)
- the hostname (changing this would require all dev clients to update)
- the url search param (replacing this would require all dev clients to update)
- the search params themselves

The entire URL is generated with a simple `new URL()` call. As such, the search parameters are URI-percentage-encoded. However, the [URL spec](https://url.spec.whatwg.org/) is tolerant of this part of the URL **not** being encoded. It only specifies that:
- [query parts start with `?` and end with EOF or `'#'`](https://url.spec.whatwg.org/#path-state)
- [query parts are ASCII strings](https://url.spec.whatwg.org/#url-representation)
- [must parse as `application/x-www-form-urlencoded`](https://url.spec.whatwg.org/#concept-urlencoded-parser)

Therefore, we don't have to let the `url` query parameter be encoded.

# How

When creating a QR code, we can parse the URL passed to it and manually stringify the `URLSearchParams`. We'll only encode it (with `encodeURIComponent`), if the value contains any special characters. Otherwise, we leave it unencoded. We can also strip off `hash` values and normalize `'/'` pathnames to `''`.

In all cases for dev-client URLs, this will result in a slightly smaller QR code, e.g. `exp+notification-tester://expo-development-client?url=http://10.0.0.112:8088/`

<img width="300" alt="Screenshot 2026-02-05 at 16 40 12" src="https://github.com/user-attachments/assets/07fae684-3533-44c2-b6df-7c141fe2b32e" />

# Test Plan

- [x] Test opening QR code with the camera app on iOS
- [ ] Test opening QR code with a dev client on Android
- [ ] Test opening QR code with **various** camera apps on Android

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
