### PR TITLE
[brownfield][cli] treat configuration all and maven local as the defaults

### DIFF
--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] fix dev menu in isolated brownfield ([#42637](https://github.com/expo/expo/pull/42637) by [@pmleczek](https://github.com/pmleczek))
+- [cli] handle build:android called with no args ([#42914](https://github.com/expo/expo/pull/42914) by [@pmleczek](https://github.com/pmleczek))
 
 ### 💡 Others
 

--- a/packages/expo-brownfield/cli/build/commands/android/build.js
+++ b/packages/expo-brownfield/cli/build/commands/android/build.js
@@ -3,6 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+const chalk_1 = __importDefault(require("chalk"));
 const path_1 = __importDefault(require("path"));
 const constants_1 = require("../../constants");
 const utils_1 = require("../../utils");
@@ -30,11 +31,17 @@ const action = async () => {
     if (config.tasks.length > 0) {
         tasks = config.tasks;
     }
-    else {
+    else if (config.repositories.length > 0) {
         for (const repository of config.repositories) {
             const task = constructTask(config.buildType, repository);
             tasks.push(task);
         }
+    }
+    else {
+        console.warn(chalk_1.default.yellow('⚠  No tasks or repositories specified'));
+        console.warn(chalk_1.default.yellow('Defaulting to repository: MavenLocal and configuration: All'));
+        console.warn(chalk_1.default.yellow('This repository might not be available in your configuration\n'));
+        tasks.push('publishBrownfieldAllPublicationToMavenLocal');
     }
     for (const task of tasks) {
         if (!config.dryRun) {

--- a/packages/expo-brownfield/cli/build/commands/android/build.js
+++ b/packages/expo-brownfield/cli/build/commands/android/build.js
@@ -3,7 +3,6 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-const chalk_1 = __importDefault(require("chalk"));
 const path_1 = __importDefault(require("path"));
 const constants_1 = require("../../constants");
 const utils_1 = require("../../utils");
@@ -38,10 +37,7 @@ const action = async () => {
         }
     }
     else {
-        console.warn(chalk_1.default.yellow('⚠  No tasks or repositories specified'));
-        console.warn(chalk_1.default.yellow('Defaulting to repository: MavenLocal and configuration: All'));
-        console.warn(chalk_1.default.yellow('This repository might not be available in your configuration\n'));
-        tasks.push('publishBrownfieldAllPublicationToMavenLocal');
+        constants_1.Errors.missingTasksOrRepositories();
     }
     for (const task of tasks) {
         if (!config.dryRun) {

--- a/packages/expo-brownfield/cli/build/constants/errors.d.ts
+++ b/packages/expo-brownfield/cli/build/constants/errors.d.ts
@@ -3,6 +3,7 @@ export declare const Errors: {
     readonly additionalCommand: (command: string) => never;
     readonly generic: (error: unknown) => never;
     readonly inference: (valueName: string) => never;
+    readonly missingTasksOrRepositories: () => never;
     readonly parseArgs: () => never;
     readonly unknownCommand: () => never;
     readonly unknownOption: (argError: ArgError) => never;

--- a/packages/expo-brownfield/cli/build/constants/errors.js
+++ b/packages/expo-brownfield/cli/build/constants/errors.js
@@ -29,6 +29,13 @@ const inferenceError = (valueName) => {
     return process.exit(1);
 };
 /**
+ * Prints the error message for missing tasks or repositories.
+ */
+const missingTasksOrRepositoriesError = () => {
+    console.error('Error: At least one task or repository must be specified');
+    return process.exit(1);
+};
+/**
  * Prints the error message for failed argument parsing.
  */
 const parseArgsError = () => {
@@ -57,6 +64,7 @@ exports.Errors = {
     additionalCommand: additionalCommandError,
     generic: genericError,
     inference: inferenceError,
+    missingTasksOrRepositories: missingTasksOrRepositoriesError,
     parseArgs: parseArgsError,
     unknownCommand: unknownCommandError,
     unknownOption: unkownOptionError,

--- a/packages/expo-brownfield/cli/src/commands/android/build.ts
+++ b/packages/expo-brownfield/cli/src/commands/android/build.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import path from 'path';
 
 import { Args, Errors, Help } from '../../constants';
@@ -41,11 +42,16 @@ const action = async () => {
   let tasks = [];
   if (config.tasks.length > 0) {
     tasks = config.tasks;
-  } else {
+  } else if (config.repositories.length > 0) {
     for (const repository of config.repositories) {
       const task = constructTask(config.buildType, repository);
       tasks.push(task);
     }
+  } else {
+    console.warn(chalk.yellow('⚠  No tasks or repositories specified'));
+    console.warn(chalk.yellow('Defaulting to repository: MavenLocal and configuration: All'));
+    console.warn(chalk.yellow('This repository might not be available in your configuration\n'));
+    tasks.push('publishBrownfieldAllPublicationToMavenLocal');
   }
 
   for (const task of tasks) {

--- a/packages/expo-brownfield/cli/src/commands/android/build.ts
+++ b/packages/expo-brownfield/cli/src/commands/android/build.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk';
 import path from 'path';
 
 import { Args, Errors, Help } from '../../constants';
@@ -48,10 +47,7 @@ const action = async () => {
       tasks.push(task);
     }
   } else {
-    console.warn(chalk.yellow('⚠  No tasks or repositories specified'));
-    console.warn(chalk.yellow('Defaulting to repository: MavenLocal and configuration: All'));
-    console.warn(chalk.yellow('This repository might not be available in your configuration\n'));
-    tasks.push('publishBrownfieldAllPublicationToMavenLocal');
+    Errors.missingTasksOrRepositories();
   }
 
   for (const task of tasks) {

--- a/packages/expo-brownfield/cli/src/constants/errors.ts
+++ b/packages/expo-brownfield/cli/src/constants/errors.ts
@@ -30,6 +30,14 @@ const inferenceError = (valueName: string) => {
 };
 
 /**
+ * Prints the error message for missing tasks or repositories.
+ */
+const missingTasksOrRepositoriesError = () => {
+  console.error('Error: At least one task or repository must be specified');
+  return process.exit(1);
+};
+
+/**
  * Prints the error message for failed argument parsing.
  */
 const parseArgsError = () => {
@@ -61,6 +69,7 @@ export const Errors = {
   additionalCommand: additionalCommandError,
   generic: genericError,
   inference: inferenceError,
+  missingTasksOrRepositories: missingTasksOrRepositoriesError,
   parseArgs: parseArgsError,
   unknownCommand: unknownCommandError,
   unknownOption: unkownOptionError,

--- a/packages/expo-brownfield/e2e/cli/__tests__/build-android.test.ts
+++ b/packages/expo-brownfield/e2e/cli/__tests__/build-android.test.ts
@@ -305,5 +305,17 @@ describe('build:android command', () => {
         ],
       });
     });
+
+    /**
+     * Command: npx expo-brownfield build:android
+     * Expected behavior: The CLI should print an error message and exit
+     */
+    it('should print an error message and exit if no tasks or repositories are specified', async () => {
+      await buildAndroidTest({
+        directory: TEMP_DIR_PREBUILD,
+        successExit: false,
+        stderr: [ERROR.MISSING_TASKS_OR_REPOSITORIES()],
+      });
+    });
   });
 });

--- a/packages/expo-brownfield/e2e/utils/output.ts
+++ b/packages/expo-brownfield/e2e/utils/output.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
  * Help messages
  */
 export const HELP_MESSAGE = {
-  GENERAL_HEADER: `Usage: expo-brownfield <command> [<options>]`
+  GENERAL_HEADER: `Usage: expo-brownfield <command> [<options>]`,
 };
 
 /**
@@ -90,6 +90,7 @@ export const ERROR = {
   ) => `Error: Command ${command} doesn't support additional commands
 For all available options please use the help command:
 npx expo-brownfield ${command} --help`,
+  MISSING_TASKS_OR_REPOSITORIES: () => `Error: At least one task or repository must be specified`,
   UNKNOWN_COMMAND: () => `Error: unknown command
 Supported commands: build:android, build:ios, tasks:android`,
   UNKNOWN_OPTION: (option: string) => `Error: unknown or unexpected option: ${option}`,


### PR DESCRIPTION
# Why

It has been reported that the CLI silently does nothing if `build:android` is called without passing any repo and any task - https://github.com/expo/expo/issues/42655.

# How

Since it's not guaranteed that maven local, to which we might want to default will be configured (if user uses some other repos) we can throw an error:

```sh
> npx expo-brownfield build:android

Build configuration:
- Verbose: false
- Build type: All
- Brownfield library: brownfield
- Repositories: []
- Tasks: []

Error: At least one task or repository must be specified
```

# Test Plan

- Validated the new error handling manually
- Updated and ensured that E2E tests for the CLI pass

# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
