### PR TITLE
refactor(cli): Get default route IP address concurrently

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Collapse usage guide on `expo start` if space is insufficient ([#42835](https://github.com/expo/expo/pull/42835) by [@kitten](https://gthub.com/kitten))
 - Drop obsolete `rawBody` parsing from Metro middleware stack ([#43074](https://github.com/expo/expo/pull/43074) by [@kitten](https://github.com/kitten))
 - Add minimum Node.js version check and warning to CLI startup ([#43076](https://github.com/expo/expo/pull/43076) by [@kitten](https://github.com/kitten))
+- Retrieve default route's IP address concurrently ([#42923](https://github.com/expo/expo/pull/42923) by [@kitten](https://github.com/kitten))
 
 ## 55.0.7 — 2026-02-08
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -76,7 +76,7 @@
     "fetch-nodeshim": "^0.4.6",
     "getenv": "^2.0.0",
     "glob": "^13.0.0",
-    "lan-network": "^0.1.6",
+    "lan-network": "^0.2.0",
     "minimatch": "^9.0.0",
     "multitars": "^0.2.3",
     "node-forge": "^1.3.3",

--- a/packages/@expo/cli/src/run/android/__tests__/runAndroidAsync-test.ts
+++ b/packages/@expo/cli/src/run/android/__tests__/runAndroidAsync-test.ts
@@ -27,6 +27,7 @@ jest.mock('../../../utils/env', () => ({
   env: {
     CI: false,
   },
+  envIsHeadless: () => false,
 }));
 
 jest.mock('../../startBundler', () => ({

--- a/packages/@expo/cli/src/run/ios/__tests__/runIosAsync-test.ts
+++ b/packages/@expo/cli/src/run/ios/__tests__/runIosAsync-test.ts
@@ -30,6 +30,7 @@ jest.mock('../../../utils/env', () => ({
   env: {
     CI: false,
   },
+  envIsHeadless: () => false,
 }));
 
 jest.mock('../../startBundler', () => ({

--- a/packages/@expo/cli/src/start/server/DevServerManager.ts
+++ b/packages/@expo/cli/src/start/server/DevServerManager.ts
@@ -161,6 +161,7 @@ export class DevServerManager {
     this.options.devClient = isUsingDevClient;
     for (const devServer of this.devServers) {
       devServer.isDevClient = isUsingDevClient;
+      // TODO(@kitten): Clean up mode switching better
       const urlCreator = devServer.getUrlCreator();
       urlCreator.defaults ??= {};
       urlCreator.defaults.scheme = nextScheme;

--- a/packages/@expo/cli/src/start/server/UrlCreator.ts
+++ b/packages/@expo/cli/src/start/server/UrlCreator.ts
@@ -20,10 +20,16 @@ interface UrlComponents {
   hostname: string;
   protocol: string;
 }
+
+interface BundlerInfo {
+  port: number;
+  getTunnelUrl?(): string | null;
+}
+
 export class UrlCreator {
   constructor(
     public defaults: CreateURLOptions | undefined,
-    private bundlerInfo: { port: number; getTunnelUrl?: () => string | null }
+    private bundlerInfo: BundlerInfo
   ) {}
 
   /**

--- a/packages/@expo/cli/src/start/server/UrlCreator.ts
+++ b/packages/@expo/cli/src/start/server/UrlCreator.ts
@@ -95,6 +95,10 @@ export class UrlCreator {
     return url;
   }
 
+  public getDefaultRouteAddress(): string {
+    return this.gatewayInfo.address;
+  }
+
   /** Get the URL components from the Ngrok server URL. */
   private getTunnelUrlComponents(options: Pick<CreateURLOptions, 'scheme'>): UrlComponents | null {
     const tunnelUrl = this.bundlerInfo.getTunnelUrl?.();

--- a/packages/@expo/cli/src/start/server/__tests__/BundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/BundlerDevServer-test.ts
@@ -338,7 +338,7 @@ describe('getExpoGoUrl', () => {
       '/',
       getPlatformBundlers('/', { web: { bundler: 'metro' } })
     );
-    expect(() => server['getExpoGoUrl']()).toThrow('Dev server instance not found');
+    expect(() => server['getExpoGoUrl']()).toThrow('Dev server is uninitialized');
   });
 
   it(`gets the native Expo Go URL`, async () => {
@@ -399,7 +399,7 @@ describe('getManifestMiddlewareAsync', () => {
   );
   it(`asserts server is not running`, async () => {
     await expect(server['getManifestMiddlewareAsync']()).rejects.toThrow(
-      /Dev server instance not found/
+      /Dev server is uninitialized/
     );
   });
 });

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -1162,7 +1162,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
     options: BundlerStartOptions
   ): Promise<DevServerInstance> {
     options.port = await this.resolvePortAsync(options);
-    this.urlCreator = this.getUrlCreator(options);
+    await this.initUrlCreator(options);
 
     const config = getConfig(this.projectRoot, { skipSDKVersionRequirement: true });
     const { exp } = config;

--- a/packages/@expo/cli/src/start/server/metro/createServerComponentsMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/createServerComponentsMiddleware.ts
@@ -18,7 +18,7 @@ import type { ExportAssetMap } from '../../../export/saveAssets';
 import { stripAnsi } from '../../../utils/ansi';
 import { toPosixPath } from '../../../utils/filePath';
 import { memoize } from '../../../utils/fn';
-import { getIpAddress } from '../../../utils/ip';
+import { getIpAddressAsync } from '../../../utils/ip';
 import { streamToStringAsync } from '../../../utils/stream';
 import {
   createBundleUrlSearchParams,
@@ -78,7 +78,7 @@ export function createServerComponentsMiddleware(
     renderRsc: async (args) => {
       // In development we should add simulated versions of common production headers.
       if (args.headers['x-real-ip'] == null) {
-        args.headers['x-real-ip'] = getIpAddress();
+        args.headers['x-real-ip'] = await getIpAddressAsync();
       }
       if (args.headers['x-forwarded-for'] == null) {
         args.headers['x-forwarded-for'] = args.headers['x-real-ip'];

--- a/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
@@ -17,7 +17,6 @@ import { ensureEnvironmentSupportsTLSAsync } from './tls';
 import * as Log from '../../../log';
 import { env } from '../../../utils/env';
 import { CommandError } from '../../../utils/errors';
-import { getIpAddress } from '../../../utils/ip';
 import { setNodeEnv } from '../../../utils/nodeEnv';
 import { choosePortAsync } from '../../../utils/port';
 import { createProgressBar } from '../../../utils/progress';
@@ -163,7 +162,7 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
 
     const { resetDevServer, https, port, mode } = options;
 
-    await this.initUrlCreator({
+    const urlCreator = await this.initUrlCreator({
       port,
       location: {
         scheme: https ? 'https' : 'http',
@@ -211,13 +210,14 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
       });
     };
 
-    const _host = getIpAddress();
+    const _host = urlCreator.getDefaultRouteAddress();
     const protocol = https ? 'https' : 'http';
 
     return {
       // Server instance
       server,
       // URL Info
+      // TODO(@kitten): Why is this not using the URL creator?
       location: {
         url: `${protocol}://${_host}:${port}`,
         port,

--- a/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
@@ -160,9 +160,10 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
     options.port = await this.getAvailablePortAsync({
       defaultPort: options.port,
     });
+
     const { resetDevServer, https, port, mode } = options;
 
-    this.urlCreator = this.getUrlCreator({
+    await this.initUrlCreator({
       port,
       location: {
         scheme: https ? 'https' : 'http',

--- a/packages/@expo/cli/src/utils/ip.ts
+++ b/packages/@expo/cli/src/utils/ip.ts
@@ -7,15 +7,6 @@ export interface GatewayInfo {
   internal: boolean;
 }
 
-export function getIpAddress(): string {
-  try {
-    const lan = lanNetworkSync();
-    return lan.address;
-  } catch {
-    return '127.0.0.1';
-  }
-}
-
 export function getGateway(): GatewayInfo {
   try {
     return lanNetworkSync();

--- a/packages/@expo/cli/src/utils/ip.ts
+++ b/packages/@expo/cli/src/utils/ip.ts
@@ -1,5 +1,13 @@
 import { lanNetworkSync, lanNetwork } from 'lan-network';
 
+import { envIsHeadless } from './env';
+
+// NOTE(@kitten): In headless mode, there's no point in trying to run DHCP, since
+// we assume we're online and probing is going to be enough
+const options = {
+  noDhcp: envIsHeadless(),
+};
+
 export interface GatewayInfo {
   iname: string | null;
   address: string;
@@ -9,7 +17,7 @@ export interface GatewayInfo {
 
 export function getGateway(): GatewayInfo {
   try {
-    return lanNetworkSync();
+    return lanNetworkSync(options);
   } catch {
     return {
       iname: null,
@@ -22,7 +30,7 @@ export function getGateway(): GatewayInfo {
 
 export async function getGatewayAsync(): Promise<GatewayInfo> {
   try {
-    return await lanNetwork();
+    return await lanNetwork(options);
   } catch {
     return {
       iname: null,

--- a/packages/@expo/cli/src/utils/ip.ts
+++ b/packages/@expo/cli/src/utils/ip.ts
@@ -1,8 +1,17 @@
-import { lanNetworkSync } from 'lan-network';
+import { lanNetworkSync, lanNetwork } from 'lan-network';
 
 export function getIpAddress(): string {
   try {
     const lan = lanNetworkSync();
+    return lan.address;
+  } catch {
+    return '127.0.0.1';
+  }
+}
+
+export async function getIpAddressAsync(): Promise<string> {
+  try {
+    const lan = await lanNetwork();
     return lan.address;
   } catch {
     return '127.0.0.1';

--- a/packages/@expo/cli/src/utils/ip.ts
+++ b/packages/@expo/cli/src/utils/ip.ts
@@ -1,5 +1,12 @@
 import { lanNetworkSync, lanNetwork } from 'lan-network';
 
+export interface GatewayInfo {
+  iname: string | null;
+  address: string;
+  gateway: string | null;
+  internal: boolean;
+}
+
 export function getIpAddress(): string {
   try {
     const lan = lanNetworkSync();
@@ -9,11 +16,32 @@ export function getIpAddress(): string {
   }
 }
 
-export async function getIpAddressAsync(): Promise<string> {
+export function getGateway(): GatewayInfo {
   try {
-    const lan = await lanNetwork();
-    return lan.address;
+    return lanNetworkSync();
   } catch {
-    return '127.0.0.1';
+    return {
+      iname: null,
+      address: '127.0.0.1',
+      gateway: null,
+      internal: true,
+    };
   }
+}
+
+export async function getGatewayAsync(): Promise<GatewayInfo> {
+  try {
+    return await lanNetwork();
+  } catch {
+    return {
+      iname: null,
+      address: '127.0.0.1',
+      gateway: null,
+      internal: true,
+    };
+  }
+}
+
+export async function getIpAddressAsync(): Promise<string> {
+  return (await getGatewayAsync()).address;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10906,10 +10906,10 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-lan-network@^0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/lan-network/-/lan-network-0.1.6.tgz#098375edbb996bb6ca0cc597eff03ce45f1a2787"
-  integrity sha512-0qPYjNoD89v+bfhkIqFBYGBAof1xhxLqjX8bkNN1kQdP81UHpZw5TDXgEjwB+X2iCFGQmzF8TRmvg4vQcykyDA==
+lan-network@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/lan-network/-/lan-network-0.2.0.tgz#2d0858ef8f909dff62f17e868bb31786def30a64"
+  integrity sha512-EZgbsXMrGS+oK+Ta12mCjzBFse+SIewGdwrSTr5g+MSymnjpox2x05ceI20PQejJOFvOgzcXrfDk/SdY7dSCtw==
 
 lazy-cache@^1.0.3:
   version "1.0.4"


### PR DESCRIPTION
# Why

There's two tasks in the CLI startup phase that block the main thread: getting the IP address of the default route, and `@expo/config`'s `getConfig` (partially). Both have synchronous operations. The former has a `spawnSync` that was only needed because we didn't build this to be asynchronous. This holds up CLI startup by blocking.

Instead, we should initialize the `UrlCreator` asynchronously (and leave some assertions around to validate that it's safe to do so), and not block the main thread.

# How

- Add separate `ip.ts` utilities that are async
- Add `UrlCreator.init` async initializer
- Refactor `UrlCreator` to get gateway info from its own state
- Add `initUrlCreator` and run it in headless and implementation starts
- Disable `lan-network`'s DHCP strategy for headless mode

There's still a remaining gap of delay in the startup phase, which we can probably close more easily now:

<img width="550" height="289" alt="image" src="https://github.com/user-attachments/assets/0724cf50-f9d1-4d09-afdd-abd0c50d2602" />


# Test Plan

- Try various `expo start` operations and ensure assertions don't trigger

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
