### PR TITLE
[docs] Add preview to release statuses

### DIFF
--- a/docs/pages/more/release-statuses.mdx
+++ b/docs/pages/more/release-statuses.mdx
@@ -1,6 +1,6 @@
 ---
 title: Release statuses
-description: Learn about alpha, beta, and stable release statuses and how they affect feature stability when using Expo SDK and Expo Application Services (EAS).
+description: Learn about alpha, preview, beta, and stable release statuses and how they affect feature stability when using Expo SDK and Expo Application Services (EAS).
 ---
 
 Expo uses different release statuses to indicate the stability and readiness of its tools and services. Understanding these statuses can help you make informed decisions about which features and versions to use in your projects.
@@ -17,6 +17,19 @@ Alpha features are available for early testing but may have significant limitati
 - Not recommended for production apps
 
 Alpha features are opportunities to influence the future of Expo. We encourage you to test these features in development environments and [provide feedback](https://expo.dev/contact) to help us refine them before they reach a wider audience.
+
+## Preview
+
+Preview features provide an early look at a slice of new functionality. Unlike alpha features, preview features are designed with minimal overhead and limited scope, but they are not yet feature-complete.
+
+**What to expect:**
+
+- A focused slice of functionality, not the full feature set
+- Designed with minimal overhead, but not yet fully validated for all production scenarios
+- APIs may evolve as the feature is built out further
+- Can be used in production with thorough testing, though functionality is limited
+
+The purpose of a preview is to share new functionality early and gather feedback about a specific slice before building it out further. Your input directly helps shape the direction of the feature. [Share your feedback](https://expo.dev/contact) to help us prioritize what to build next.
 
 ## Beta
 

--- a/docs/pages/more/release-statuses.mdx
+++ b/docs/pages/more/release-statuses.mdx
@@ -20,7 +20,7 @@ Alpha features are opportunities to influence the future of Expo. We encourage y
 
 ## Preview
 
-Preview features provide an early look at a slice of new functionality. Unlike alpha features, preview features are designed with minimal overhead and limited scope, but they are not yet feature-complete.
+Preview features provide an early look at a slice of new functionality. Unlike alpha releases, preview features are designed with minimal overhead and limited scope, but they are not yet feature-complete.
 
 **What to expect:**
 


### PR DESCRIPTION
# Why

We're missing a release status to communicate out intent in some new upcoming features.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Add a `preview` release status and an explanation of what it means.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Review the copy.

<img width="976" height="421" alt="Screenshot 2026-02-06 at 10 29 57" src="https://github.com/user-attachments/assets/f81ce5f4-8c80-46e5-a353-65a80bb774ad" />


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
