### PR TITLE
[ios][camera] Various config consistency improvements

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed a number of configuration issues and error inconsistencies.
+- [iOS] Fixed a number of configuration issues and error inconsistencies. ([#42926](https://github.com/expo/expo/pull/42926) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed a number of configuration issues and error inconsistencies.
+
 ### 💡 Others
 
 ## 55.0.3 — 2026-01-27

--- a/packages/expo-camera/ios/CameraViewModule.swift
+++ b/packages/expo-camera/ios/CameraViewModule.swift
@@ -343,8 +343,6 @@ public final class CameraViewModule: Module, ScannerResultHandler {
           scannerContext = ScannerContext(delegate: delegate)
           launchScanner(with: options)
         }
-      } else {
-        throw CameraScannerUnavailableException()
       }
     }
 

--- a/packages/expo-camera/ios/Common/CameraExceptions.swift
+++ b/packages/expo-camera/ios/Common/CameraExceptions.swift
@@ -8,7 +8,7 @@ internal final class CameraUnmountedException: Exception {
 
 internal final class CameraNotReadyException: Exception {
   override var reason: String {
-    "Camera unmounted during taking photo process"
+    "Camera is not ready yet"
   }
 }
 
@@ -57,5 +57,11 @@ internal final class CameraInvalidPhotoData: Exception {
 internal final class CameraToggleRecordingException: Exception {
   override var reason: String {
     "`toggleRecording()` is only supported on iOS 18.0 or later"
+  }
+}
+
+internal final class CameraScannerUnavailableException: Exception {
+  override var reason: String {
+    "Modern barcode scanner is not available on this device"
   }
 }

--- a/packages/expo-camera/ios/Current/CameraSessionManager.swift
+++ b/packages/expo-camera/ios/Current/CameraSessionManager.swift
@@ -355,7 +355,7 @@ class CameraSessionManager: NSObject, DeviceDiscoveryDelegate {
       delegate.onMountError(["message": "Camera could not be started - \(error.localizedDescription)"])
     }
   }
-  
+
   func deviceDiscovery(_ discovery: DeviceDiscovery, didUpdateDevices devices: [AVCaptureDevice]) {
     DispatchQueue.main.async { [weak self] in
       self?.delegate?.emitAvailableLenses()

--- a/packages/expo-camera/ios/Current/MetaDataDelegate.swift
+++ b/packages/expo-camera/ios/Current/MetaDataDelegate.swift
@@ -8,6 +8,7 @@ class MetaDataDelegate: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCapt
   private var zxingBarcodeReaders: [AVMetadataObject.ObjectType: ZXReader]
   private var zxingEnabled = true
   private var zxingFPSProcessed = 6.0
+  private var lastFrameTimeStamp = 0.0
   private let responseHandler: BarcodeScanningResponseHandler
 
   init(
@@ -56,13 +57,9 @@ class MetaDataDelegate: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCapt
 
     let kMinMargin = 1.0 / zxingFPSProcessed
     let presentTimeStamp = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+    let curFrameTimeStamp = Double(presentTimeStamp.value) / Double(presentTimeStamp.timescale)
 
-    var curFrameTimeStamp = 0.0
-    var lastFrameTimeStamp = 0.0
-
-    curFrameTimeStamp = Double(presentTimeStamp.value) / Double(presentTimeStamp.timescale)
-
-    if curFrameTimeStamp - lastFrameTimeStamp > Double(kMinMargin) {
+    if curFrameTimeStamp - lastFrameTimeStamp > kMinMargin {
       lastFrameTimeStamp = curFrameTimeStamp
 
       if let videoFrame = CMSampleBufferGetImageBuffer(sampleBuffer),


### PR DESCRIPTION
# Why
Makes a number of small improvements and consistency improvments.

# How
- Fix incorrect error message from a copy/paste mistake
- Fixes possible `beginConfiguration` calls not having matching `commitConfiguration` due to early returns
- Defaults to `builtInWideAngleCamera` which is the standard default instead of selecting the OS preferred camera.
- Added kvo to device discovery
- Added a `withSessionConfiguration` argument to some methods so configuration calls can be skipped if they are not needed 

# Test Plan
Bare expo

