### PR TITLE
fix(cli/e2e): Fix playwright cache key and hmr test

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -227,7 +227,7 @@ jobs:
         id: playwright-info
         shell: bash
         run: |
-          echo "version=$(npm info @playwright/test version)" >> $GITHUB_OUTPUT
+          echo version="$(yarn --silent playwright --version)" >> $GITHUB_OUTPUT
       - name: 🎭 Cache Playwright browser binaries
         uses: actions/cache@v4
         id: playwright-browser-cache
@@ -235,7 +235,7 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.playwright-info.outputs.version }}
       - name: 🎭 Install Playwright Browsers
-        run: bun playwright install --with-deps chromium
+        run: yarn playwright install --with-deps chromium
         working-directory: packages/@expo/cli
         if: steps.playwright-browser-cache.outputs.cache-hit != 'true'
 
@@ -325,8 +325,8 @@ jobs:
         id: playwright-info
         shell: bash
         run: |
-          echo "version=$(npm info @playwright/test version)" >> $GITHUB_OUTPUT
-          echo "dir=$(echo $PLAYWRIGHT_BROWSERS_PATH)" >> $GITHUB_OUTPUT
+          echo version="$(yarn --silent playwright --version)" >> $GITHUB_OUTPUT
+          echo dir="$(echo $PLAYWRIGHT_BROWSERS_PATH)" >> $GITHUB_OUTPUT
       - name: 🎭 Cache Playwright browser binaries
         uses: actions/cache@v4
         id: playwright-browser-cache
@@ -334,7 +334,7 @@ jobs:
           path: ${{ steps.playwright-info.outputs.dir }}
           key: ${{ runner.os }}-playwright-${{ steps.playwright-info.outputs.version }}
       - name: 🎭 Install Playwright Browsers
-        run: bun playwright install --with-deps chromium
+        run: yarn playwright install --with-deps chromium
         working-directory: packages/@expo/cli
         if: steps.playwright-browser-cache.outputs.cache-hit != 'true'
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bump to `dnssd-advertise@^1.1.3` ([#42928](https://github.com/expo/expo/pull/42928) by [@kitten](https://github.com/kitten))
+
 ## 55.0.7 — 2026-02-08
 
 ### 🎉 New features

--- a/packages/@expo/cli/e2e/playwright/dev/hmr-env-vars.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/hmr-env-vars.test.ts
@@ -81,7 +81,7 @@ test.describe('router-e2e with spaces', () => {
     await expect(page.locator('[data-testid="env-var-inline"]')).toHaveText('inlined');
 
     // Ensure the initial hash is correct
-    await expect(page.locator('[data-testid="env-var"]')).toHaveText('ROUTE_VALUE');
+    await expect(page.locator('[data-testid="env-var"]')).toHaveText(/ROUTE_VALUE/);
     const envFile = path.join(projectRoot, '.env');
     // Use a changing value to prevent caching.
     const nextValue = 'ROUTE_VALUE_' + Date.now();
@@ -92,7 +92,7 @@ test.describe('router-e2e with spaces', () => {
         throw new Error(`Expected to find 'ROUTE_VALUE' in the file`);
       }
       console.log('Emulate writing to a file');
-      return contents.replace(/ROUTE_VALUE/g, nextValue);
+      return contents.replace(/ROUTE_VALUE(_\w+)?/g, nextValue);
     });
 
     await waitForFashRefresh();

--- a/packages/@expo/cli/e2e/playwright/dev/hmr-env-vars.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/hmr-env-vars.test.ts
@@ -39,6 +39,7 @@ test.describe('router-e2e with spaces', () => {
         // TODO(@hassankhan): remove @expo/router-server after publishing
         linkExpoPackagesDev: [
           '@expo/cli',
+          '@expo/env',
           '@expo/router-server',
           'babel-preset-expo',
           '@expo/metro-config',

--- a/packages/@expo/cli/e2e/utils/hmr.ts
+++ b/packages/@expo/cli/e2e/utils/hmr.ts
@@ -31,8 +31,8 @@ export async function openPageAndEagerlyLoadJS(
 
   // Ensure the sockets are registered
   const [hotSocket] = await Promise.all([
-    raceOrFail(hotSocketPromise, 500, 'HMR on client took too long to connect.'),
-    raceOrFail(messageSocketPromise, 500, 'Message socket on client took too long to connect.'),
+    raceOrFail(hotSocketPromise, 1_000, 'HMR on client took too long to connect.'),
+    raceOrFail(messageSocketPromise, 1_000, 'Message socket on client took too long to connect.'),
   ]);
 
   return {

--- a/packages/@expo/cli/e2e/utils/server.ts
+++ b/packages/@expo/cli/e2e/utils/server.ts
@@ -122,6 +122,8 @@ export function createBackgroundServer({
         stdio: ['ignore', 'pipe', 'pipe'],
         ...spawnOptions,
         env: {
+          // NOTE: Preconfigure flags to disable certain background-like activities
+          EXPO_UNSTABLE_HEADLESS: '1',
           ...env, // Pipe through all environment variables from the host by default
           ...spawnOptions.env,
         },

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -70,7 +70,7 @@
     "compression": "^1.7.4",
     "connect": "^3.7.0",
     "debug": "^4.3.4",
-    "dnssd-advertise": "^1.1.1",
+    "dnssd-advertise": "^1.1.3",
     "env-editor": "^0.4.1",
     "expo-server": "^55.0.3",
     "fetch-nodeshim": "^0.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7264,10 +7264,10 @@ dlv@^1.1.3:
   resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
 
-dnssd-advertise@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/dnssd-advertise/-/dnssd-advertise-1.1.1.tgz#5ed075133854c252b64eebeb784960c3994b0d3d"
-  integrity sha512-5lwwxSitFrESlnv0JQhmhFlBAD6I97ghwo/xfNio1SajbZgsqq3OQY4kELcJiK/j38fgJFbeIDotAjSGcI85eg==
+dnssd-advertise@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/dnssd-advertise/-/dnssd-advertise-1.1.3.tgz#bf130e5b22f2d76b2b6b33b201e93c68c75b3786"
+  integrity sha512-XENsHi3MBzWOCAXif3yZvU1Ah0l+nhJj1sjWL6TnOAYKvGiFhbTx32xHN7+wLMLUOCj7Nr0evADWG4R8JtqCDA==
 
 doctrine@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
# Why

Resolves #42969

- Should be based on current version
- Should use CLI not `@playwright/test`

# How

- Add missing linked package `@expo/env`
- Bump `dnssd-advertise` to latest

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
