### PR TITLE
chore(cli): Enable Bonjour by default

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Bump to `fetch-nodeshim@^0.4.5` ([#42896](https://github.com/expo/expo/pull/42896) by [@kitten](https://github.com/kitten))
 - Enable `experiments.autolinkingModuleResolution` by default for workspaces/monorepos ([#40606](https://github.com/expo/expo/pull/40606) by [@kitten](https://github.com/kitten))
 - Add flag to preconfigure other flags for headless environment ([#42909](https://github.com/expo/expo/pull/42909) by [@kitten](https://github.com/kitten))
+- (Beta) Enable Bonjour by default ([#42929](https://github.com/expo/expo/pull/42929) by [@kitten](https://github.com/kitten))
 
 ## 55.0.6 — 2026-02-03
 

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -297,7 +297,7 @@ class Env {
    * Enable Bonjour advertising of the Expo CLI on local networks
    */
   get EXPO_UNSTABLE_BONJOUR(): boolean {
-    return boolish('EXPO_UNSTABLE_BONJOUR', false);
+    return boolish('EXPO_UNSTABLE_BONJOUR', !envIsHeadless());
   }
 
   /** @internal Configure other environment variables for headless operations */


### PR DESCRIPTION
We're enabling Bonjour support, which is currently going to be supported by the iOS `expo-dev-client` for the SDK 55 beta period. We may disable this again, if it's not in a stable and widely supported state by the end of the beta.