### PR TITLE
[ci] Add skip cleanup if disk size is sufficient

### DIFF
--- a/.github/actions/cleanup-linux-disk-space/action.yml
+++ b/.github/actions/cleanup-linux-disk-space/action.yml
@@ -10,6 +10,14 @@ runs:
         echo 'Disk space before cleanup'
         df -aH
 
+        # There are two runners with different disk sizes used in CI. If the job is running on a large disk runner, skip the cleanup.
+        TOTAL_DISK_GB=$(df -BG / | tail -1 | awk '{print $2}' | sed 's/G//')
+        echo "Detected Disk Size: ${TOTAL_DISK_GB} GB"
+        if [ "$TOTAL_DISK_GB" -ge 100 ]; then
+          echo "Large disk size detected, skipping cleanup."
+          exit 0
+        fi
+
         # Regular package cleanup
         sudo apt-get remove -y --purge '^mysql-.*' '^mongodb-.*' '^mssql-.*' '^postgresql-.*' '^aspnetcore-*' '^dotnet-.*' '^php.*-.*' 'mono-complete' '^llvm-.*' 'powershell' 'google-chrome-*' 'microsoft-edge-*' 'firefox' 'nginx' 'apache2' 'ghc' '^ghc-*'
         sudo apt-get autoremove -y


### PR DESCRIPTION
# Why 

I found that there are 2 runners executing our tests. One has ~150GB and the other ~80GB. While it is necessary to remove unused packages on the latter, we can skip cleanup on the bigger one. This change saves ~2m. 

# How 

Added a bash script to the `cleanup-linux-disk-space` action.

# Test Plan 
Tested on a stacked PR.