### PR TITLE
[ci] Improve node_modules caching performance

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -11,6 +11,9 @@ inputs:
   yarn-docs:
     description: 'Restore yarn /docs cache'
     required: false
+  yarn-cache:
+    description: 'Restore yarn global cache'
+    required: false
   ios-pods:
     description: 'Restore /ios pods cache'
     required: false
@@ -94,6 +97,20 @@ runs:
           packages/@expo/*/node_modules
           react-native-lab/react-native/node_modules
         key: ${{ runner.os }}-workspace-modules-${{ hashFiles('yarn.lock') }}
+
+    - name: 🔎 Find Yarn Cache
+      if: inputs.yarn-cache == 'true'
+      id: yarn-cache
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: ♻️ Restore Yarn Cache
+      if: inputs.yarn-cache == 'true'
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.yarn-cache.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
 
     - name: ♻️ Restore /tools node modules and bins
       if: inputs.yarn-tools == 'true'

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -89,12 +89,10 @@ jobs:
         uses: ./.github/actions/expo-caches
         id: expo-caches
         with:
-          yarn-workspace: 'true'
-          yarn-tools: 'true'
+          yarn-cache: 'true'
           bare-expo-pods: 'true'
       - name: 🧶 Install node modules in root dir
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        run: yarn install --frozen-lockfile
+        run: yarn install --prefer-offline --frozen-lockfile
       - name: 🕵️ Debug CocoaPods lockfiles
         run: git diff Podfile.lock Pods/Manifest.lock
         working-directory: apps/bare-expo/ios
@@ -185,12 +183,11 @@ jobs:
         uses: ./.github/actions/expo-caches
         id: expo-caches
         with:
-          yarn-workspace: 'true'
+          yarn-cache: 'true'
       - name: 🧶 Install node modules in root dir
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        run: yarn install --frozen-lockfile
+        run: yarn install --prefer-offline --frozen-lockfile
       - name: 🧶 Install image comparison server node modules
-        run: yarn install --frozen-lockfile
+        run: yarn install --prefer-offline --frozen-lockfile
         working-directory: apps/bare-expo/e2e/image-comparison
       - name: Build Screen Inspector
         run: ./scripts/build.sh
@@ -275,14 +272,12 @@ jobs:
         id: expo-caches
         with:
           gradle: 'true'
-          yarn-workspace: 'true'
-          yarn-tools: 'true'
+          yarn-cache: 'true'
           react-native-gradle-downloads: 'true'
       - name: 🧶 Install workspace node modules
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        run: yarn install --frozen-lockfile
+        run: yarn install --prefer-offline --frozen-lockfile
       - name: 🧶 Install image comparison server node modules
-        run: yarn install --frozen-lockfile
+        run: yarn install --prefer-offline --frozen-lockfile
         working-directory: apps/bare-expo/e2e/image-comparison
       - name: 🧪 Test image comparison utilities
         run: bun test
@@ -359,12 +354,11 @@ jobs:
         uses: ./.github/actions/expo-caches
         id: expo-caches
         with:
-          yarn-workspace: 'true'
+          yarn-cache: 'true'
       - name: 🧶 Install node modules in root dir
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        run: yarn install --frozen-lockfile
+        run: yarn install --prefere-offline --frozen-lockfile
       - name: 🧶 Install image comparison server node modules
-        run: yarn install --frozen-lockfile
+        run: yarn install --prefer-offline --frozen-lockfile
         working-directory: apps/bare-expo/e2e/image-comparison
       - name: 🧪 Run e2e tests (bare-expo)
         uses: ./.github/actions/use-android-emulator


### PR DESCRIPTION
# Why
The problem with the current strategy of caching the entire `node_modules` directory is that it creates ~500MB of cache but still results in a full `node_modules` reinstall. This occurs due to the following reasons:

- There is an issue with the Node version in `.yarn-integrity` because different workflows sharing this cache use different Node versions. This mismatch causes a full reinstall.
- I also checked a scenario where the `.yarn-integrity` is identical to the one from `yarn install`. Even then, Yarn fails to detect `node_modules` as up-to-date. There must be another reason why this happens – I didn't find out why, but fixing it would save only another ~30s per build because running `yarn postinstall` would still be required.

So I changed the mechanism to cache the Yarn global cache (the same mechanism and the same cache are used in the CLI workflows), because it doesn't depend on `.yarn-integrity` and still speeds up the workflow.

Results:
- `yarn install` time reduced (on average): Android and iOS by ~30s–1m.
- Now the same cache is reusable between CLI and E2E workflows – saves ~2 minutes in the post-restore stage and ~500MB storage per `yarn.lock` change.
- No dependency on NPM download bandwidth if the cache is hit.

# How
Added restoring the global yarn cache to the `expo-caches` action.

# Test Plan
Tested on a stacked PR.