### PR TITLE
[babel-preset][widgets] Add babel plugin for new expo-widgets API

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add babel plugin for `expo-widgets`.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add babel plugin for `expo-widgets`.
+- Add babel plugin for `expo-widgets`. ([#42941](https://github.com/expo/expo/pull/42941) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -12,6 +12,7 @@ const restricted_react_api_plugin_1 = require("./restricted-react-api-plugin");
 const server_actions_plugin_1 = require("./server-actions-plugin");
 const server_data_loaders_plugin_1 = require("./server-data-loaders-plugin");
 const use_dom_directive_plugin_1 = require("./use-dom-directive-plugin");
+const widgets_plugin_1 = require("./widgets-plugin");
 function getOptions(options, platform) {
     const tag = platform === 'web' ? 'web' : 'native';
     return {
@@ -184,6 +185,11 @@ function babelPresetExpo(api, options = {}) {
     }
     // This plugin is fine to run whenever as the server-only imports were introduced as part of RSC and shouldn't be used in any client code.
     extraPlugins.push(environment_restricted_imports_1.environmentRestrictedImportsPlugin);
+    // Transform widget component JSX expressions to capture widget components for native-side evaluation.
+    // This enables the native side to re-evaluate widget components with updated props without re-sending the entire layout.
+    if ((0, common_1.hasModule)('expo-widgets')) {
+        extraPlugins.push(widgets_plugin_1.widgetsPlugin);
+    }
     if (platformOptions.enableReactFastRefresh ||
         (isFastRefreshEnabled && platformOptions.enableReactFastRefresh !== false)) {
         extraPlugins.push([

--- a/packages/babel-preset-expo/build/widgets-plugin.d.ts
+++ b/packages/babel-preset-expo/build/widgets-plugin.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright © 2026 650 Industries.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Babel plugin that transforms widget component JSX expressions.
+ */
+import type { ConfigAPI, NodePath, PluginObj, PluginPass, types as t } from '@babel/core';
+export declare function widgetsPlugin(api: ConfigAPI & typeof import('@babel/core')): PluginObj<PluginPass & {
+    widgetComponents?: Map<NodePath<t.Function>, {
+        propNames: Set<string>;
+        propsIdentifier?: string;
+    }>;
+}>;

--- a/packages/babel-preset-expo/build/widgets-plugin.js
+++ b/packages/babel-preset-expo/build/widgets-plugin.js
@@ -1,0 +1,107 @@
+"use strict";
+/**
+ * Copyright © 2026 650 Industries.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Babel plugin that transforms widget component JSX expressions.
+ */
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.widgetsPlugin = widgetsPlugin;
+const generator = __importStar(require("@babel/generator"));
+const WidgetizableFunction = 'FunctionDeclaration|FunctionExpression|ArrowFunctionExpression|ObjectMethod';
+function widgetsPlugin(api) {
+    const { types: t } = api;
+    return {
+        name: 'expo-widgets',
+        visitor: {
+            [WidgetizableFunction]: {
+                exit(path) {
+                    if (!t.isBlockStatement(path.node.body)) {
+                        return;
+                    }
+                    // Skip if no 'widget' directive
+                    if (!path.node.body.directives.some((directive) => t.isDirectiveLiteral(directive.value) && directive.value.value === 'widget')) {
+                        return;
+                    }
+                    // Remove the 'widget' directive to avoid runtime overhead
+                    path.traverse({
+                        DirectiveLiteral(nodePath) {
+                            if (nodePath.node.value === 'widget' && nodePath.getFunctionParent() === path) {
+                                nodePath.parentPath.remove();
+                            }
+                        },
+                    });
+                    const code = generateWidgetFunctionString(t, path.node);
+                    replaceWidgetFunction(t, path, code);
+                },
+            },
+        },
+    };
+}
+function generateWidgetFunctionString(t, node) {
+    const expression = t.functionExpression(null, node.params, node.body, node.generator, node.async);
+    return generator.generate(expression, { compact: false }).code;
+}
+function replaceWidgetFunction(t, path, code) {
+    const literal = buildTemplateLiteral(t, code);
+    if (path.isObjectMethod()) {
+        path.replaceWith(t.objectProperty(path.node.key, literal, path.node.computed));
+        return;
+    }
+    if (path.isFunctionDeclaration()) {
+        if (path.parentPath.isExportDefaultDeclaration()) {
+            path.parentPath.replaceWith(t.exportDefaultDeclaration(literal));
+            return;
+        }
+        if (path.node.id) {
+            path.replaceWith(t.variableDeclaration('var', [t.variableDeclarator(path.node.id, literal)]));
+        }
+        else {
+            path.replaceWith(literal);
+        }
+        return;
+    }
+    path.replaceWith(literal);
+}
+function buildTemplateLiteral(t, code) {
+    const raw = escapeTemplateLiteral(code);
+    return t.templateLiteral([t.templateElement({ raw, cooked: raw }, true)], []);
+}
+function escapeTemplateLiteral(value) {
+    return value.replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
+}

--- a/packages/babel-preset-expo/build/widgets-plugin.js
+++ b/packages/babel-preset-expo/build/widgets-plugin.js
@@ -53,7 +53,7 @@ function widgetsPlugin(api) {
                     if (!isWidgetFunction(path)) {
                         return;
                     }
-                    removeWidgetDirective(path);
+                    removeWidgetDirective(path.node.body);
                     const code = generateWidgetFunctionString(t, path.node);
                     const literal = buildTemplateLiteral(t, code);
                     if (path.parentPath.isExportDefaultDeclaration()) {
@@ -73,7 +73,8 @@ function widgetsPlugin(api) {
                     if (!isWidgetFunction(path)) {
                         return;
                     }
-                    removeWidgetDirective(path);
+                    // Check above will guarantee body is a BlockStatement
+                    removeWidgetDirective(path.node.body);
                     const code = generateWidgetFunctionString(t, path.node);
                     const literal = buildTemplateLiteral(t, code);
                     path.replaceWith(literal);
@@ -84,7 +85,7 @@ function widgetsPlugin(api) {
                     if (!isWidgetFunction(path)) {
                         return;
                     }
-                    removeWidgetDirective(path);
+                    removeWidgetDirective(path.node.body);
                     const code = generateWidgetFunctionString(t, path.node);
                     const literal = buildTemplateLiteral(t, code);
                     path.replaceWith(t.objectProperty(path.node.key, literal, path.node.computed));
@@ -98,8 +99,7 @@ function widgetsPlugin(api) {
         }
         return path.node.body.directives.some((directive) => t.isDirectiveLiteral(directive.value) && directive.value.value === 'widget');
     }
-    function removeWidgetDirective(path) {
-        const body = path.node.body;
+    function removeWidgetDirective(body) {
         const widgetDirectiveIndex = body.directives.findIndex((directive) => t.isDirectiveLiteral(directive.value) && directive.value.value === 'widget');
         if (widgetDirectiveIndex !== -1) {
             body.directives.splice(widgetDirectiveIndex, 1);

--- a/packages/babel-preset-expo/build/widgets-plugin.js
+++ b/packages/babel-preset-expo/build/widgets-plugin.js
@@ -108,7 +108,7 @@ function widgetsPlugin(api) {
 }
 function generateWidgetFunctionString(t, node) {
     const expression = t.functionExpression(null, node.params, node.body, node.generator, node.async);
-    return generator.generate(expression, { compact: false }).code;
+    return generator.generate(expression, { compact: true }).code;
 }
 function buildTemplateLiteral(t, code) {
     const raw = escapeTemplateLiteral(code);

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -43,13 +43,17 @@
   "peerDependencies": {
     "@babel/runtime": "^7.20.0",
     "react-refresh": ">=0.14.0 <1.0.0",
-    "expo": "*"
+    "expo": "*",
+    "expo-widgets": "^55.0.0"
   },
   "peerDependenciesMeta": {
     "@babel/runtime": {
       "optional": true
     },
     "expo": {
+      "optional": true
+    },
+    "expo-widgets": {
       "optional": true
     }
   },

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -58,6 +58,7 @@
     }
   },
   "dependencies": {
+    "@babel/generator": "^7.20.5",
     "@babel/helper-module-imports": "^7.25.9",
     "@babel/plugin-proposal-decorators": "^7.12.9",
     "@babel/plugin-syntax-export-default-from": "^7.24.7",

--- a/packages/babel-preset-expo/src/__tests__/widgets-plugin.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/widgets-plugin.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright © 2026 650 Industries.
+ */
+
+import * as babel from '@babel/core';
+
+import preset from '..';
+
+const ENABLED_CALLER = {
+  name: 'metro',
+  isDev: false,
+  isServer: false,
+  isReactServer: false,
+  platform: 'ios',
+  projectRoot: '/',
+};
+
+function getCaller(props: Record<string, string | boolean>): babel.TransformCaller {
+  return props as unknown as babel.TransformCaller;
+}
+
+const DEF_OPTIONS = {
+  filename: '/unknown',
+  babelrc: false,
+  presets: [preset],
+  sourceMaps: true,
+  configFile: false,
+  compact: false,
+  comments: true,
+  retainLines: false,
+  caller: getCaller({ ...ENABLED_CALLER }),
+};
+
+function transformTest(sourceCode: string) {
+  const options = { ...DEF_OPTIONS };
+
+  const results = babel.transform(sourceCode, options);
+  if (!results) throw new Error('Failed to transform code');
+
+  return {
+    code: results.code,
+  };
+}
+
+describe('widgets-plugin', () => {
+  describe('detection', () => {
+    it('does not transform non-widget components', () => {
+      const result = transformTest(`
+        function MyComponent({ name }) {
+          return <Text>My not 'widget' component</Text>;
+        }
+      `);
+
+      expect(result.code).toContain("'widget'");
+    });
+
+    it("removes 'widget' directive from widget components", () => {
+      const result = transformTest(`
+        function MyComponent({ name }) {
+          'widget';
+          return <Text>{name}</Text>;
+        }
+      `);
+
+      expect(result.code).not.toContain("'widget'");
+    });
+  });
+
+  describe('transform', () => {
+    it('stringifies widget function after JSX transform', () => {
+      const backtick = '`';
+      const result = transformTest(`
+        function MyComponent({ name }) {
+          'widget';
+          return <Text><Text>{name + \`sadaas\`}</Text></Text>;
+        }
+      `);
+
+      expect(result.code).toContain('var MyComponent = `function');
+      expect(result.code).toContain('jsx(');
+    });
+
+    it('handles fragments', () => {
+      const result = transformTest(`
+        function MyComponent({ name }) {
+          'widget';
+          return <Text><>{name}</></Text>;
+        }
+      `);
+
+      expect(result.code).toContain('var MyComponent = `function');
+      expect(result.code).toContain('jsx(_Fragment');
+    });
+  });
+});

--- a/packages/babel-preset-expo/src/__tests__/widgets-plugin.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/widgets-plugin.test.ts
@@ -80,6 +80,20 @@ describe('widgets-plugin', () => {
       expect(result.code).toContain('jsx(');
     });
 
+    it('stringifies widget arrow function after JSX transform', () => {
+      const backtick = '`';
+      const result = transformTest(`
+        const MyComponent = ({ name }) => {
+          'widget';
+          return <Text><Text>{name + \`sadaas\`}</Text></Text>;
+        }
+      `);
+
+      expect(result.code).not.toContain("'widget'");
+      expect(result.code).toContain('var MyComponent = `function');
+      expect(result.code).toContain('jsx(');
+    });
+
     it('handles fragments', () => {
       const result = transformTest(`
         function MyComponent({ name }) {

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -27,6 +27,7 @@ import { environmentRestrictedReactAPIsPlugin } from './restricted-react-api-plu
 import { reactServerActionsPlugin } from './server-actions-plugin';
 import { serverDataLoadersPlugin } from './server-data-loaders-plugin';
 import { expoUseDomDirectivePlugin } from './use-dom-directive-plugin';
+import { widgetsPlugin } from './widgets-plugin';
 
 type BabelPresetExpoPlatformOptions = {
   /** Disable or configure the `@babel/plugin-proposal-decorators` plugin. */
@@ -294,6 +295,12 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
 
   // This plugin is fine to run whenever as the server-only imports were introduced as part of RSC and shouldn't be used in any client code.
   extraPlugins.push(environmentRestrictedImportsPlugin);
+
+  // Transform widget component JSX expressions to capture widget components for native-side evaluation.
+  // This enables the native side to re-evaluate widget components with updated props without re-sending the entire layout.
+  if (hasModule('expo-widgets')) {
+    extraPlugins.push(widgetsPlugin);
+  }
 
   if (
     platformOptions.enableReactFastRefresh ||

--- a/packages/babel-preset-expo/src/widgets-plugin.ts
+++ b/packages/babel-preset-expo/src/widgets-plugin.ts
@@ -101,7 +101,7 @@ function generateWidgetFunctionString(
     node.generator,
     node.async
   );
-  return generator.generate(expression, { compact: false }).code;
+  return generator.generate(expression, { compact: true }).code;
 }
 
 function buildTemplateLiteral(t: typeof import('@babel/core').types, code: string) {

--- a/packages/babel-preset-expo/src/widgets-plugin.ts
+++ b/packages/babel-preset-expo/src/widgets-plugin.ts
@@ -1,0 +1,109 @@
+/**
+ * Copyright © 2026 650 Industries.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Babel plugin that transforms widget component JSX expressions.
+ */
+
+import type { ConfigAPI, NodePath, PluginObj, PluginPass, types as t } from '@babel/core';
+import * as generator from '@babel/generator';
+
+const WidgetizableFunction =
+  'FunctionDeclaration|FunctionExpression|ArrowFunctionExpression|ObjectMethod';
+
+export function widgetsPlugin(api: ConfigAPI & typeof import('@babel/core')): PluginObj<
+  PluginPass & {
+    widgetComponents?: Map<
+      NodePath<t.Function>,
+      { propNames: Set<string>; propsIdentifier?: string }
+    >;
+  }
+> {
+  const { types: t } = api;
+  return {
+    name: 'expo-widgets',
+    visitor: {
+      [WidgetizableFunction as 'FunctionDeclaration']: {
+        exit(path) {
+          if (!t.isBlockStatement(path.node.body)) {
+            return;
+          }
+          // Skip if no 'widget' directive
+          if (
+            !path.node.body.directives.some(
+              (directive) =>
+                t.isDirectiveLiteral(directive.value) && directive.value.value === 'widget'
+            )
+          ) {
+            return;
+          }
+          // Remove the 'widget' directive to avoid runtime overhead
+          path.traverse({
+            DirectiveLiteral(nodePath) {
+              if (nodePath.node.value === 'widget' && nodePath.getFunctionParent() === path) {
+                nodePath.parentPath.remove();
+              }
+            },
+          });
+
+          const code = generateWidgetFunctionString(t, path.node);
+          replaceWidgetFunction(t, path, code);
+        },
+      },
+    },
+  };
+}
+
+function generateWidgetFunctionString(
+  t: typeof import('@babel/core').types,
+  node: t.Function
+): string {
+  const expression = t.functionExpression(
+    null,
+    node.params as t.FunctionExpression['params'],
+    node.body as t.BlockStatement,
+    node.generator,
+    node.async
+  );
+  return generator.generate(expression, { compact: false }).code;
+}
+
+function replaceWidgetFunction(
+  t: typeof import('@babel/core').types,
+  path: NodePath<t.Function>,
+  code: string
+) {
+  const literal = buildTemplateLiteral(t, code);
+
+  if (path.isObjectMethod()) {
+    path.replaceWith(t.objectProperty(path.node.key, literal, path.node.computed));
+    return;
+  }
+
+  if (path.isFunctionDeclaration()) {
+    if (path.parentPath.isExportDefaultDeclaration()) {
+      path.parentPath.replaceWith(t.exportDefaultDeclaration(literal));
+      return;
+    }
+
+    if (path.node.id) {
+      path.replaceWith(t.variableDeclaration('var', [t.variableDeclarator(path.node.id, literal)]));
+    } else {
+      path.replaceWith(literal);
+    }
+    return;
+  }
+
+  path.replaceWith(literal);
+}
+
+function buildTemplateLiteral(t: typeof import('@babel/core').types, code: string) {
+  const raw = escapeTemplateLiteral(code);
+  return t.templateLiteral([t.templateElement({ raw, cooked: raw }, true)], []);
+}
+
+function escapeTemplateLiteral(value: string) {
+  return value.replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
+}

--- a/packages/babel-preset-expo/src/widgets-plugin.ts
+++ b/packages/babel-preset-expo/src/widgets-plugin.ts
@@ -27,7 +27,7 @@ export function widgetsPlugin(api: ConfigAPI & typeof import('@babel/core')): Pl
           if (!isWidgetFunction(path)) {
             return;
           }
-          removeWidgetDirective(path);
+          removeWidgetDirective(path.node.body);
           const code = generateWidgetFunctionString(t, path.node);
           const literal = buildTemplateLiteral(t, code);
 
@@ -50,7 +50,8 @@ export function widgetsPlugin(api: ConfigAPI & typeof import('@babel/core')): Pl
           if (!isWidgetFunction(path)) {
             return;
           }
-          removeWidgetDirective(path);
+          // Check above will guarantee body is a BlockStatement
+          removeWidgetDirective(path.node.body as t.BlockStatement);
           const code = generateWidgetFunctionString(t, path.node);
           const literal = buildTemplateLiteral(t, code);
           path.replaceWith(literal);
@@ -61,7 +62,7 @@ export function widgetsPlugin(api: ConfigAPI & typeof import('@babel/core')): Pl
           if (!isWidgetFunction(path)) {
             return;
           }
-          removeWidgetDirective(path);
+          removeWidgetDirective(path.node.body);
           const code = generateWidgetFunctionString(t, path.node);
           const literal = buildTemplateLiteral(t, code);
           path.replaceWith(t.objectProperty(path.node.key, literal, path.node.computed));
@@ -79,8 +80,7 @@ export function widgetsPlugin(api: ConfigAPI & typeof import('@babel/core')): Pl
     );
   }
 
-  function removeWidgetDirective(path: NodePath<t.Function>) {
-    const body = path.node.body as t.BlockStatement;
+  function removeWidgetDirective(body: t.BlockStatement) {
     const widgetDirectiveIndex = body.directives.findIndex(
       (directive) => t.isDirectiveLiteral(directive.value) && directive.value.value === 'widget'
     );


### PR DESCRIPTION
# Why

With new expo-widgets, widget components are evaluated in the JSC context in widget itself instead of the app.

# How

To get that function, we need to transform the component expression to string containing the component function. The plugin works similar to worklets plugin and changes code only when `'widget';` directive is present.

Widgets has to be "referentially free" functions (they can use only functions/components imported from `@expo/ui` so there is no need to collect the context.  

# Test Plan

Tests should pass.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
