### PR TITLE
[docs][linear-gradient] - Add a callout for `experimental_backgroundImage` property

### DIFF
--- a/docs/pages/versions/unversioned/sdk/linear-gradient.mdx
+++ b/docs/pages/versions/unversioned/sdk/linear-gradient.mdx
@@ -13,6 +13,8 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-linear-gradient` provides a native React view that transitions between multiple colors in a linear direction.
 
+> **info** React Native also provides `experimental_backgroundImage` (Android and iOS) and `backgroundImage` (Web) style properties on `View` component that support CSS gradient syntax such as [`linear-gradient()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/gradient/linear-gradient) and [`radial-gradient()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/gradient/radial-gradient). This can be an alternative for gradient backgrounds without adding an extra dependency. Since this is an experimental property, if you encounter any issues, please [report them to the React Native repository](https://github.com/facebook/react-native/issues).
+
 ## Installation
 
 <APIInstallSection />

--- a/docs/pages/versions/v55.0.0/sdk/linear-gradient.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/linear-gradient.mdx
@@ -13,6 +13,8 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-linear-gradient` provides a native React view that transitions between multiple colors in a linear direction.
 
+> **info** React Native also provides `experimental_backgroundImage` (Android and iOS) and `backgroundImage` (Web) style properties on `View` component that support CSS gradient syntax such as [`linear-gradient()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/gradient/linear-gradient) and [`radial-gradient()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/gradient/radial-gradient). This can be an alternative for gradient backgrounds without adding an extra dependency. Since this is an experimental property, if you encounter any issues, please [report them to the React Native repository](https://github.com/facebook/react-native/issues).
+
 ## Installation
 
 <APIInstallSection />


### PR DESCRIPTION
# Why

React native has a property `experimental_backgroundImage` that can be used to create linear and radial gradients. Calling it out in the docs will help us test the feature and catch if there any issues.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Tested docs locally

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
