### PR TITLE
[android][video] Avoid crash when FullscreenPlayerActivity init fails

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [iOS] Prevents blocking main thread when loading asset tracks for non-HSL tracks ([#42037](https://github.com/expo/expo/pull/42037) by [@santitopo](https://github.com/santitopo))
 - [Android] Fix crash due to `SimpleCache` directory lock conflicts. ([#42723](https://github.com/expo/expo/pull/42723) by [@santitopo](https://github.com/santitopo))
+- [Android] Avoid crash when FullscreenPlayerActivity init fails. ([#42943](https://github.com/expo/expo/pull/42943) by [@amyu](https://github.com/amyu))
 
 ### 💡 Others
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/FullscreenPlayerActivity.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/FullscreenPlayerActivity.kt
@@ -27,14 +27,14 @@ import expo.modules.video.managers.VideoManager
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 class FullscreenPlayerActivity : Activity() {
   private lateinit var mContentView: View
-  private lateinit var videoViewId: String
+  private var videoViewId: String? = null
   private var videoPlayer: VideoPlayer? = null
   private lateinit var playerView: PlayerView
   private lateinit var videoView: VideoView
   private var didFinish = false
   private var wasAutoPaused = false
   private lateinit var options: FullscreenOptions
-  private lateinit var orientationHelper: FullscreenActivityOrientationHelper
+  private var orientationHelper: FullscreenActivityOrientationHelper? = null
   private var captioningChangeListener: CaptioningManager.CaptioningChangeListener? = null
 
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -53,7 +53,8 @@ class FullscreenPlayerActivity : Activity() {
           ?: throw FullScreenOptionsNotFoundException()
       }
 
-      videoView = VideoManager.getVideoView(videoViewId)
+      videoView = videoViewId?.let { VideoManager.getVideoView(it) }
+        ?: throw FullScreenVideoViewNotFoundException()
 
       orientationHelper = FullscreenActivityOrientationHelper(
         this,
@@ -65,7 +66,7 @@ class FullscreenPlayerActivity : Activity() {
           requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
         }
       )
-      orientationHelper.startOrientationEventListener()
+      orientationHelper?.startOrientationEventListener()
     } catch (e: CodedException) {
       Log.e("ExpoVideo", "${e.message}", e)
       finish()
@@ -116,7 +117,7 @@ class FullscreenPlayerActivity : Activity() {
   override fun finish() {
     super.finish()
     didFinish = true
-    VideoManager.getVideoView(videoViewId).attachPlayer()
+    videoViewId?.let { VideoManager.getVideoView(it).attachPlayer() }
 
     // Disable the exit transition
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
@@ -128,7 +129,7 @@ class FullscreenPlayerActivity : Activity() {
   }
 
   override fun onResume() {
-    orientationHelper.startOrientationEventListener()
+    orientationHelper?.startOrientationEventListener()
     playerView.useController = true
     // Reconfigure subtitles when resuming (handles returning from settings)
     SubtitleUtils.configureSubtitleView(playerView, this)
@@ -143,7 +144,7 @@ class FullscreenPlayerActivity : Activity() {
         videoPlayer?.player?.pause()
       }
     }
-    orientationHelper.stopOrientationEventListener()
+    orientationHelper?.stopOrientationEventListener()
     super.onPause()
   }
 
@@ -159,7 +160,7 @@ class FullscreenPlayerActivity : Activity() {
 
     videoView.exitFullscreen()
     VideoManager.unregisterFullscreenPlayerActivity(hashCode().toString())
-    orientationHelper.stopOrientationEventListener()
+    orientationHelper?.stopOrientationEventListener()
   }
 
   private fun setupFullscreenButton() {
@@ -213,7 +214,7 @@ class FullscreenPlayerActivity : Activity() {
 
   override fun onConfigurationChanged(newConfig: Configuration) {
     super.onConfigurationChanged(newConfig)
-    orientationHelper.onConfigurationChanged(newConfig)
+    orientationHelper?.onConfigurationChanged(newConfig)
   }
 
   companion object {


### PR DESCRIPTION
This indicates that the error path inside `onCreate` calls `finish()` while `videoViewId` is still uninitialized.
Crash Log
```
Fatal Exception: java.lang.RuntimeException: Unable to start activity ComponentInfo{hoge/expo.modules.video.FullscreenPlayerActivity}: kotlin.UninitializedPropertyAccessException: lateinit property videoViewId has not been initialized
```

# How

- Made `videoViewId` nullable and guarded its use in `finish()` to avoid `UninitializedPropertyAccessException`.
- Made `orientationHelper` nullable and guarded lifecycle calls to avoid similar issues if initialization fails early.

# Test Plan

- passed CI

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
