### PR TITLE
[docs] Fix build bugs in sitemap, LLM generators, and config

### DIFF
--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -74,7 +74,7 @@ const nextConfig: NextConfig = {
   webpack: (config, { defaultLoaders }) => {
     // Add support for MDX with our custom loader
     config.module.rules.push({
-      test: /.mdx?$/,
+      test: /\.mdx?$/,
       use: [
         defaultLoaders.babel,
         {
@@ -135,7 +135,7 @@ const nextConfig: NextConfig = {
           }
         }
 
-        return { [page.page]: page };
+        return { [pathname]: page };
       })
     );
 

--- a/docs/pages/versions/unversioned/sdk/video-thumbnails.mdx
+++ b/docs/pages/versions/unversioned/sdk/video-thumbnails.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-> **warning** **Deprecated:** Video Thumbnails library has been deprecated in favor of [`generateThumbnailsAsync`](video.mdx/#generatethumbnailsasynctimes-options) from [`expo-video`](video.mdx). `expo-video-thumbnails` is not receiving patches and will be removed in SDK 56.
+> **warning** **Deprecated:** Video Thumbnails library has been deprecated in favor of [`generateThumbnailsAsync`](video.mdx#generatethumbnailsasynctimes-options) from [`expo-video`](video.mdx). `expo-video-thumbnails` is not receiving patches and will be removed in SDK 56.
 
 `expo-video-thumbnails` allows you to generate an image to serve as a thumbnail from a video file.
 

--- a/docs/pages/versions/v55.0.0/sdk/video-thumbnails.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/video-thumbnails.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-> **warning** **Deprecated:** Video Thumbnails library has been deprecated in favor of [`generateThumbnailsAsync`](video.mdx/#generatethumbnailsasynctimes-options) from [`expo-video`](video.mdx). `expo-video-thumbnails` is not receiving patches and will be removed in SDK 56.
+> **warning** **Deprecated:** Video Thumbnails library has been deprecated in favor of [`generateThumbnailsAsync`](video.mdx#generatethumbnailsasynctimes-options) from [`expo-video`](video.mdx). `expo-video-thumbnails` is not receiving patches and will be removed in SDK 56.
 
 `expo-video-thumbnails` allows you to generate an image to serve as a thumbnail from a video file.
 

--- a/docs/scripts/create-sitemap.js
+++ b/docs/scripts/create-sitemap.js
@@ -64,7 +64,7 @@ function pathWithStartingSlash(url) {
  *   - Index page is always moved to the top
  *   - Matches the order of prioritized paths using "startsWith" check
  */
-function pathSortedByPriority(a, b, priorities = []) {
+export function pathSortedByPriority(a, b, priorities = []) {
   if (a === '/') {
     return -1;
   }
@@ -74,8 +74,15 @@ function pathSortedByPriority(a, b, priorities = []) {
 
   const aPriority = priorities.findIndex(prio => a.startsWith(prio));
   const bPriority = priorities.findIndex(prio => b.startsWith(prio));
-  if (aPriority >= 0 || bPriority >= 0) {
+  if (aPriority >= 0 && bPriority >= 0) {
     return aPriority - bPriority;
+  }
+  // Sort priority items before non-priority items
+  if (aPriority >= 0) {
+    return -1;
+  }
+  if (bPriority >= 0) {
+    return 1;
   }
 
   return 0;

--- a/docs/scripts/create-sitemap.test.js
+++ b/docs/scripts/create-sitemap.test.js
@@ -1,0 +1,49 @@
+import { pathSortedByPriority } from './create-sitemap.js';
+
+const priorities = ['/get-started', '/guides', '/versions'];
+
+describe('pathSortedByPriority', () => {
+  test('index page sorts first', () => {
+    expect(pathSortedByPriority('/', '/guides/foo', priorities)).toBeLessThan(0);
+    expect(pathSortedByPriority('/guides/foo', '/', priorities)).toBeGreaterThan(0);
+  });
+
+  test('two priority items sort by their priority order', () => {
+    expect(pathSortedByPriority('/get-started/intro', '/guides/foo', priorities)).toBeLessThan(0);
+    expect(
+      pathSortedByPriority('/versions/latest', '/get-started/intro', priorities)
+    ).toBeGreaterThan(0);
+  });
+
+  test('two non-priority items are treated as equal', () => {
+    expect(pathSortedByPriority('/random/page', '/other/page', priorities)).toBe(0);
+  });
+
+  test('priority item sorts before non-priority item', () => {
+    expect(pathSortedByPriority('/guides/foo', '/random/page', priorities)).toBeLessThan(0);
+  });
+
+  test('non-priority item sorts after priority item', () => {
+    expect(pathSortedByPriority('/random/page', '/guides/foo', priorities)).toBeGreaterThan(0);
+  });
+
+  test('full sort produces correct order', () => {
+    const paths = [
+      '/random/page',
+      '/versions/latest',
+      '/',
+      '/guides/foo',
+      '/other/page',
+      '/get-started/intro',
+    ];
+    const sorted = paths.sort((a, b) => pathSortedByPriority(a, b, priorities));
+    expect(sorted).toEqual([
+      '/',
+      '/get-started/intro',
+      '/guides/foo',
+      '/versions/latest',
+      '/random/page',
+      '/other/page',
+    ]);
+  });
+});

--- a/docs/scripts/generate-llms/index.js
+++ b/docs/scripts/generate-llms/index.js
@@ -1,3 +1,5 @@
+import process from 'node:process';
+
 import { compileTalksFile } from './compileTalks.js';
 import { generateLlmsEasTxt } from './llms-eas-txt.js';
 import { generateLlmsFullTxt } from './llms-full-txt.js';
@@ -6,9 +8,17 @@ import { generateLlmsTxt } from './llms-txt.js';
 
 await compileTalksFile();
 
-Promise.allSettled([
-  await generateLlmsSdkTxt(),
-  await generateLlmsEasTxt(),
-  await generateLlmsFullTxt(),
-  await generateLlmsTxt(),
-]).catch(console.error);
+const results = await Promise.allSettled([
+  generateLlmsSdkTxt(),
+  generateLlmsEasTxt(),
+  generateLlmsFullTxt(),
+  generateLlmsTxt(),
+]);
+
+const failures = results.filter(result => result.status === 'rejected');
+for (const failure of failures) {
+  console.error(failure.reason);
+}
+if (failures.length > 0) {
+  process.exit(1);
+}

--- a/docs/scripts/generate-llms/llms-eas-txt.js
+++ b/docs/scripts/generate-llms/llms-eas-txt.js
@@ -90,6 +90,6 @@ export async function generateLlmsEasTxt() {
     console.log(` \x1b[1m\x1b[32m✓\x1b[0m Successfully generated ${OUTPUT_FILENAME_EAS_DOCS}`);
   } catch (error) {
     console.error('Error generating llms-eas.txt:', error);
-    process.exit(1);
+    throw error;
   }
 }

--- a/docs/scripts/generate-llms/llms-full-txt.js
+++ b/docs/scripts/generate-llms/llms-full-txt.js
@@ -98,6 +98,6 @@ export async function generateLlmsFullTxt() {
     console.log(` \x1b[1m\x1b[32m✓\x1b[0m Successfully generated ${OUTPUT_FILENAME_EXPO_DOCS}`);
   } catch (error) {
     console.error('Error generating llms-full.txt:', error);
-    process.exit(1);
+    throw error;
   }
 }

--- a/docs/scripts/generate-llms/llms-sdk.js
+++ b/docs/scripts/generate-llms/llms-sdk.js
@@ -108,6 +108,6 @@ export async function generateLlmsSdkTxt() {
     console.log(` \x1b[1m\x1b[32m✓\x1b[0m Successfully generated ${OUTPUT_FILENAME}`);
   } catch (error) {
     console.error('Error generating SDK documentation:', error);
-    process.exit(1);
+    throw error;
   }
 }

--- a/docs/scripts/generate-llms/llms-txt.js
+++ b/docs/scripts/generate-llms/llms-txt.js
@@ -74,9 +74,8 @@ export async function generateLlmsTxt() {
     );
 
     console.log(` \x1b[1m\x1b[32m✓\x1b[0m Successfully generated ${OUTPUT_FILENAME_LLMS_TXT}`);
-    process.exit(0);
   } catch (error) {
     console.error('Error generating llms.txt:', error);
-    process.exit(1);
+    throw error;
   }
 }


### PR DESCRIPTION
Why
===
Several bugs were found by running `yarn export` and auditing the build scripts. The sitemap sort was placing priority pages after non-priority pages, the LLM generators were running sequentially despite being wrapped in `Promise.allSettled`, and `next.config.ts` had a regex with an unescaped dot and an `exportPathMap` using the wrong key.

How
===
Fix `pathSortedByPriority` in `create-sitemap.js`: the comparator used `||` where it needed `&&`, causing `findIndex`'s `-1` sentinel to corrupt the subtraction when only one path matched a priority. Add explicit handling for mixed priority/non-priority comparisons and export the function for testing.

Fix `generate-llms/index.js`: remove `await` from inside the `Promise.allSettled` array so the four generators actually run concurrently instead of sequentially. Replace `process.exit(1)` in each generator's catch block with `throw` so a failure in one generator doesn't kill sibling tasks. Remove the erroneous `process.exit(0)` in `llms-txt.js` that killed the process on success. Move error aggregation and the single `process.exit(1)` to `index.js`.

Fix the MDX webpack loader regex from `/.mdx?$/` to `/\.mdx?$/` so the dot is matched literally. Fix `exportPathMap` to use `pathname` as the key instead of `page.page`.

Fix the `video-thumbnails.mdx` href from `video.mdx/#anchor` to `video.mdx#anchor` to eliminate the double-slash in the resolved URL.

Test Plan
===
`yarn export` succeeds with exit code 0 and zero "Invalid href" warnings. All four LLM files generate successfully. `pathSortedByPriority` has 6 unit tests covering index-first, priority ordering, mixed priority/non-priority, and full sort integration.
\