### PR TITLE
[docs] Use branch alias URL for PR preview comments

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -92,7 +92,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '📘 Your docs [preview website](${{ steps.deploy.outputs.deployment-url }}) is ready!'
+              body: '📘 Your docs [preview website](https://pr-${{ github.event.pull_request.number }}.expo-docs.pages.dev/) is ready!'
             });
       - name: 💬 Update comment with preview URL
         if: contains(github.event.pull_request.labels.*.name, 'preview') && steps.old_comment.outputs.comment-id != ''
@@ -105,5 +105,5 @@ jobs:
               comment_id: ${{ steps.old_comment.outputs.comment-id }},
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '📘 Your docs [preview website](${{ steps.deploy.outputs.deployment-url }}) is ready!'
+              body: '📘 Your docs [preview website](https://pr-${{ github.event.pull_request.number }}.expo-docs.pages.dev/) is ready!'
             });


### PR DESCRIPTION
Why
===
The Cloudflare wrangler action's `deployment-url` output returns a commit-hash-based URL like `https://1e9a9993.expo-docs.pages.dev/`. Since we deploy with `--branch=pr-<number>`, Cloudflare Pages creates a stable branch alias at `https://pr-<number>.expo-docs.pages.dev/` that is more recognizable and doesn't change across deploys.

How
===
Construct the preview URL from the PR number instead of using the wrangler action's `deployment-url` output.

Test Plan
===
Open a PR with the `preview` label and verify the comment links to `https://pr-<number>.expo-docs.pages.dev/`.
