### PR TITLE
fix(docs): preserve terminal install commands in markdown output

### DIFF
--- a/docs/scripts/generate-markdown-pages-utils.test.ts
+++ b/docs/scripts/generate-markdown-pages-utils.test.ts
@@ -156,10 +156,10 @@ describe('card links', () => {
 });
 
 describe('terminal snippet labels', () => {
-  it('removes labels using data-md="terminal"', () => {
+  it('removes snippet-header and converts code-block inside terminal', () => {
     const html = `<main>
       <div data-md="terminal">
-        <div class="flex min-h-[40px] justify-between">
+        <div data-md="snippet-header" class="flex min-h-[40px] justify-between">
           <span>Terminal</span>
         </div>
         <div data-md="code-block"><code>npx expo start</code></div>
@@ -168,6 +168,26 @@ describe('terminal snippet labels', () => {
     const md = convertHtmlToMarkdown(html);
     expect(md).toContain('```sh\nnpx expo start\n```');
     expect(md).not.toMatch(/^Terminal$/m);
+  });
+
+  it('preserves install command from Terminal with prompt prefix', () => {
+    const html = [
+      '<main>',
+      '<div data-md="terminal" class="terminal-snippet">',
+      '<div data-md="snippet-header"><span>Terminal</span></div>',
+      '<div data-md="code-block" class="bg-palette-black">',
+      '<div class="w-fit">',
+      '<code data-md="skip" class="select-none">- </code>',
+      '<code>npx expo install expo-camera</code>',
+      '</div>',
+      '</div>',
+      '</div>',
+      '</main>',
+    ].join('');
+    const md = convertHtmlToMarkdown(html);
+    expect(md).toContain('npx expo install expo-camera');
+    expect(md).not.toContain('Terminal');
+    expect(md).not.toContain('- ');
   });
 });
 

--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -198,21 +198,9 @@ export function cleanHtml($: CheerioAPI, main: Cheerio<AnyNode>): void {
     }
   });
 
-  // Remove snippet headers (file labels, "Example" labels above code blocks).
+  // Remove snippet headers (file labels, "Terminal" labels above code blocks).
   // data-md="snippet-header" is the stable marker (from SnippetHeader component).
   main.find('[data-md="snippet-header"]').remove();
-
-  // Remove terminal snippet labels ("Terminal", filename labels above code blocks).
-  // data-md="terminal" is the stable marker; .terminal-snippet is the fallback.
-  main.find('[data-md="terminal"], .terminal-snippet').each((_, el) => {
-    const $snippet = $(el);
-    // The label is in the first child div (the header bar), the code is in the rest
-    const header = $snippet.children().first();
-    const headerText = header.text().trim();
-    if (headerText) {
-      header.remove();
-    }
-  });
 
   // Remove orphaned step numbers: replace step containers with just the content.
   // data-md="step" is the stable marker; the fallback matches div.flex.gap-4 with


### PR DESCRIPTION
## Summary

- Fix missing install commands (e.g. `npx expo install expo-camera`) in the markdown output served via `Accept: text/markdown`
- The `[data-md="snippet-header"]` removal already deleted the Terminal header bar, so the subsequent terminal processing code was grabbing `.children().first()` on the headerless snippet — which was the **content div** containing the actual install command — and deleting it
- Remove the redundant terminal header removal code since `[data-md="snippet-header"]` handling already covers it

## Test plan

- [x] Added test: terminal with `data-md="snippet-header"` + `data-md="code-block"` preserves install command
- [x] Updated existing terminal test to use `data-md="snippet-header"` (matching real component output)
- [x] All 69 markdown conversion tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)