### PR TITLE
fix(docs): fix docs next build cache never matching

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -112,12 +112,13 @@ runs:
         path: docs/node_modules
         key: ${{ runner.os }}-docs-modules-${{ hashFiles('docs/yarn.lock') }}
     - name: ♻️ Restore Docs Next cache
-      if: inputs.yarn-docs == 'true' && steps.docs-modules-cache.outputs.cache-hit == 'true'
+      if: inputs.yarn-docs == 'true'
       uses: actions/cache@v4
       with:
         path: docs/.next/cache
-        key: ${{ runner.os }}-docs-next-${{ hashFiles('docs/yarn.lock') }}-${{ hashFiles('docs/**/*.ts', 'docs/**/*.tsx', 'docs/**/*.js', 'docs/**/*.jsx', 'docs/**/*.mdx', 'docs/**/*.md', 'docs/**/*.cjs') }}
-        restore-keys: ${{ runner.os }}-docs-next-${{ hashFiles('docs/yarn.lock') }}-
+        key: ${{ runner.os }}-docs-${{ hashFiles('docs/yarn.lock') }}-${{ hashFiles('docs/**/*.js', 'docs/**/*.jsx', 'docs/**/*.ts', 'docs/**/*.tsx') }}
+        restore-keys: |
+          ${{ runner.os }}-docs-${{ hashFiles('docs/yarn.lock') }}-
     - name: ♻️ Restore Docs ESLint cache
       if: inputs.yarn-docs == 'true'
       uses: actions/cache@v4


### PR DESCRIPTION
# Why

Faster

# How

1. Removed the node_modules gate — the cache step was only running when docs/node_modules was an exact cache hit. Since actions/cache saves in a post-job hook, skipping the step meant the cache was never saved either. Now it always runs.                                                                                                                                                                       
2. Dropped content files from the exact key — *.mdx, *.md, and *.cjs were in the hash, so every docs PR busted the exact key. Now the exact key only covers JS/TS source and deps. Content changes fall through to restore-keys, which restores the most recent cache and lets Next.js handle incremental recompilation.