### PR TITLE
feat(docs): prepend MDX frontmatter to generated markdown pages

### DIFF
--- a/docs/scripts/generate-markdown-pages-utils.test.ts
+++ b/docs/scripts/generate-markdown-pages-utils.test.ts
@@ -917,6 +917,16 @@ describe('extractFrontmatter', () => {
     fs.writeFileSync(path.join(tmpDir, 'minimal.mdx'), '---\ntitle: Minimal\n---\n\n# Minimal\n');
 
     fs.writeFileSync(
+      path.join(tmpDir, 'empty-values.mdx'),
+      '---\nmodificationDate: \ntitle: Camera\ndescription: A camera.\n---\n\n# Camera\n'
+    );
+
+    fs.writeFileSync(
+      path.join(tmpDir, 'only-empty.mdx'),
+      '---\nmodificationDate: \n---\n\n# Page\n'
+    );
+
+    fs.writeFileSync(
       path.join(tmpDir, 'no-frontmatter.mdx'),
       "import Foo from './Foo';\n\n# Hello\n"
     );
@@ -944,6 +954,19 @@ describe('extractFrontmatter', () => {
     expect(result).not.toBeNull();
     expect(result).toContain('title: Minimal');
     expect(result).not.toContain('# Minimal');
+  });
+
+  it('strips lines with empty values', () => {
+    const result = extractFrontmatter(path.join(tmpDir, 'empty-values.mdx'));
+    expect(result).not.toBeNull();
+    expect(result).toContain('title: Camera');
+    expect(result).toContain('description: A camera.');
+    expect(result).not.toContain('modificationDate');
+  });
+
+  it('returns null when all frontmatter fields are empty', () => {
+    const result = extractFrontmatter(path.join(tmpDir, 'only-empty.mdx'));
+    expect(result).toBeNull();
   });
 
   it('returns null when no frontmatter exists', () => {

--- a/docs/scripts/generate-markdown-pages-utils.test.ts
+++ b/docs/scripts/generate-markdown-pages-utils.test.ts
@@ -1,3 +1,8 @@
+import * as cheerio from 'cheerio';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
 import {
   checkMarkdownQuality,
   checkPage,
@@ -8,12 +13,6 @@ import {
   findMdxSource,
   stripCodeBlocks,
 } from './generate-markdown-pages-utils.ts';
-
-// eslint-disable-next-line import/order -- cheerio must be imported after the local module for jest ESM transforms
-import * as cheerio from 'cheerio';
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
 
 describe('cleanHtml', () => {
   it('removes buttons', () => {
@@ -871,11 +870,7 @@ describe('findMdxSource', () => {
   });
 
   it('finds direct .mdx file for route', () => {
-    const result = findMdxSource(
-      path.join(outDir, 'guides/routing/index.html'),
-      outDir,
-      pagesDir
-    );
+    const result = findMdxSource(path.join(outDir, 'guides/routing/index.html'), outDir, pagesDir);
     expect(result).toBe(path.join(pagesDir, 'guides/routing.mdx'));
   });
 
@@ -910,7 +905,7 @@ describe('extractFrontmatter', () => {
       [
         '---',
         'title: Camera',
-        "description: A camera component.",
+        'description: A camera component.',
         "platforms: ['android', 'ios']",
         '---',
         '',
@@ -919,10 +914,7 @@ describe('extractFrontmatter', () => {
       ].join('\n')
     );
 
-    fs.writeFileSync(
-      path.join(tmpDir, 'minimal.mdx'),
-      '---\ntitle: Minimal\n---\n\n# Minimal\n'
-    );
+    fs.writeFileSync(path.join(tmpDir, 'minimal.mdx'), '---\ntitle: Minimal\n---\n\n# Minimal\n');
 
     fs.writeFileSync(
       path.join(tmpDir, 'no-frontmatter.mdx'),

--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -6,6 +6,39 @@ import path from 'node:path';
 import TurndownService from 'turndown';
 import { gfm } from 'turndown-plugin-gfm';
 
+/**
+ * Find the MDX source file corresponding to an output HTML path.
+ * Returns the absolute path to the .mdx file, or null if not found.
+ *
+ * Mapping: out/a/b/c/index.html → pages/a/b/c.mdx or pages/a/b/c/index.mdx
+ */
+export function findMdxSource(htmlPath: string, outDir: string, pagesDir: string): string | null {
+  const rel = path.relative(outDir, path.dirname(htmlPath)); // e.g. "versions/v55.0.0/sdk/camera"
+  const candidates = [
+    path.join(pagesDir, rel + '.mdx'),
+    path.join(pagesDir, rel, 'index.mdx'),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract the raw YAML frontmatter block (including --- delimiters) from an MDX file.
+ * Returns the frontmatter string with trailing newline, or null if no frontmatter found.
+ */
+export function extractFrontmatter(mdxPath: string): string | null {
+  const content = fs.readFileSync(mdxPath, 'utf-8');
+  const match = content.match(/^---\n([\s\S]*?\n)---\n/);
+  if (!match) {
+    return null;
+  }
+  return match[0];
+}
+
 function createTurndownService(): TurndownService {
   const turndown = new TurndownService({
     headingStyle: 'atx',

--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -14,10 +14,7 @@ import { gfm } from 'turndown-plugin-gfm';
  */
 export function findMdxSource(htmlPath: string, outDir: string, pagesDir: string): string | null {
   const rel = path.relative(outDir, path.dirname(htmlPath)); // e.g. "versions/v55.0.0/sdk/camera"
-  const candidates = [
-    path.join(pagesDir, rel + '.mdx'),
-    path.join(pagesDir, rel, 'index.mdx'),
-  ];
+  const candidates = [path.join(pagesDir, rel + '.mdx'), path.join(pagesDir, rel, 'index.mdx')];
   for (const candidate of candidates) {
     if (fs.existsSync(candidate)) {
       return candidate;
@@ -32,7 +29,7 @@ export function findMdxSource(htmlPath: string, outDir: string, pagesDir: string
  */
 export function extractFrontmatter(mdxPath: string): string | null {
   const content = fs.readFileSync(mdxPath, 'utf-8');
-  const match = content.match(/^---\n([\s\S]*?\n)---\n/);
+  const match = content.match(/^---\n([\S\s]*?\n)---\n/);
   if (!match) {
     return null;
   }

--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -25,6 +25,8 @@ export function findMdxSource(htmlPath: string, outDir: string, pagesDir: string
 
 /**
  * Extract the raw YAML frontmatter block (including --- delimiters) from an MDX file.
+ * Strips lines with empty values (e.g. `modificationDate:` injected by append-dates.js
+ * with no value in shallow CI clones).
  * Returns the frontmatter string with trailing newline, or null if no frontmatter found.
  */
 export function extractFrontmatter(mdxPath: string): string | null {
@@ -33,7 +35,14 @@ export function extractFrontmatter(mdxPath: string): string | null {
   if (!match) {
     return null;
   }
-  return match[0];
+  const filtered = match[1]
+    .split('\n')
+    .filter(line => !/^\w+:\s*$/.test(line))
+    .join('\n');
+  if (!filtered.trim()) {
+    return null;
+  }
+  return '---\n' + filtered + '---\n';
 }
 
 function createTurndownService(): TurndownService {

--- a/docs/scripts/generate-markdown-pages.ts
+++ b/docs/scripts/generate-markdown-pages.ts
@@ -18,6 +18,7 @@ import { Worker } from 'node:worker_threads';
 import { findHtmlPages, findMarkdownPages } from './generate-markdown-pages-utils.ts';
 
 const OUT_DIR = path.join(process.cwd(), 'out');
+const PAGES_DIR = path.join(process.cwd(), 'pages');
 
 if (!fs.existsSync(OUT_DIR)) {
   console.error('out/ directory not found. Run `next build` first.');
@@ -60,7 +61,7 @@ const done = new Promise<void>((resolve, reject) => {
   for (let i = 0; i < numWorkers; i++) {
     const worker = new Worker(workerFile, {
       execArgv: ['--experimental-strip-types'],
-      workerData: { outDir: OUT_DIR },
+      workerData: { outDir: OUT_DIR, pagesDir: PAGES_DIR },
     });
 
     worker.on('message', (msg: { type: string; status: string; warnings?: string[] }) => {


### PR DESCRIPTION
## Summary

- Maps each output HTML path back to its MDX source file (`pages/{route}.mdx` or `pages/{route}/index.mdx`) and copies the raw YAML frontmatter block to the top of the generated markdown
- Pages without an MDX source (JS/TSX index pages, redirects) or without frontmatter are unaffected
- Adds 7 new tests covering `findMdxSource` and `extractFrontmatter`

## Test plan

- [x] All 76 tests pass (`node --experimental-vm-modules jest --testPathPattern generate-markdown-pages`)
- [x] Run full `yarn export` and verify frontmatter appears in generated `.md` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)