### PR TITLE
feat(docs): add end-to-end integration test for markdown conversion pipeline

### DIFF
--- a/docs/pages/internal/test-markdown-pipeline.mdx
+++ b/docs/pages/internal/test-markdown-pipeline.mdx
@@ -1,0 +1,90 @@
+---
+title: Markdown Pipeline Integration Test
+description: Internal test page for validating HTML→Markdown conversion.
+hideFromSearch: true
+---
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { Collapsible } from '~/ui/components/Collapsible';
+import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
+import { Tab, Tabs } from '~/ui/components/Tabs';
+
+# Markdown Pipeline Integration Test
+
+This page exists to validate the HTML-to-Markdown conversion pipeline.
+
+## Terminal Block
+
+<Terminal cmd={['$ npx expo-md-test@latest']} />
+
+## Tab Panels
+
+<Tabs>
+<Tab label="npm">
+
+```sh
+npm install md-test-npm-pkg
+```
+
+</Tab>
+<Tab label="yarn">
+
+```sh
+yarn add md-test-yarn-pkg
+```
+
+</Tab>
+</Tabs>
+
+## Collapsible Section
+
+<Collapsible summary="Expand for details">
+  This is md-test-collapsible-content that should survive conversion.
+</Collapsible>
+
+## Step-by-Step Guide
+
+<Step label="1">
+### md-test-step-one
+
+First step instructions.
+
+</Step>
+
+<Step label="2">
+### md-test-step-two
+
+Second step instructions.
+
+</Step>
+
+## Card Links
+
+<BoxLink title="md-test-boxlink-title" description="md-test-boxlink-desc" href="/test/boxlink" />
+
+## Code Blocks
+
+```typescript
+const mdTestCode: string = 'md-test-typed-code';
+```
+
+## Tables
+
+| Feature            | Description               |
+| ------------------ | ------------------------- |
+| md-test-table-cell | A table cell with content |
+
+## Callout
+
+> **Note:** This is md-test-callout-info for the integration test.
+
+## Links and Formatting
+
+Here is [md-test-link-text](/test/link) and **md-test-bold-text** in a paragraph.
+
+- md-test-unordered-item
+- Another list item
+
+1. md-test-ordered-item
+2. Another ordered item

--- a/docs/scripts/check-markdown-pages.ts
+++ b/docs/scripts/check-markdown-pages.ts
@@ -12,58 +12,160 @@
  * - Code block fences are balanced
  * - No empty files
  * - Minimum page count (content-loss detection)
+ *
+ * Integration test (pages/internal/test-markdown-pipeline.mdx):
+ * - If the dev server is running on localhost:3002, fetches the page and converts
+ *   HTML→Markdown live, then validates the output.
+ * - Otherwise, checks out/internal/test-markdown-pipeline/index.md if it exists.
+ * - Validates that key content survived conversion and no artifacts leaked through.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { checkPage, findHtmlPages, findMarkdownPages } from './generate-markdown-pages-utils.ts';
+import {
+  checkPage,
+  convertHtmlToMarkdown,
+  extractFrontmatter,
+  findHtmlPages,
+  findMarkdownPages,
+} from './generate-markdown-pages-utils.ts';
 
 const OUT_DIR = path.join(process.cwd(), 'out');
 
-if (!fs.existsSync(OUT_DIR)) {
-  console.error('out/ directory not found. Run `next build` first.');
-  process.exit(1);
-}
-
-const htmlFiles = findHtmlPages(OUT_DIR);
-const mdFiles = findMarkdownPages(OUT_DIR);
-
-if (mdFiles.length === 0) {
-  console.error('No markdown files found in out/. Did generate-markdown-pages run?');
-  process.exit(1);
-}
-
-// Every HTML page should have a corresponding markdown file.
-if (mdFiles.length !== htmlFiles.length) {
-  console.error(
-    `\n \x1b[1m\x1b[31m✗\x1b[0m Markdown/HTML count mismatch: ${mdFiles.length} markdown files for ${htmlFiles.length} HTML pages`
-  );
-  process.exit(1);
-}
-
 let failCount = 0;
 
-for (const mdPath of mdFiles) {
-  const markdown = fs.readFileSync(mdPath, 'utf-8');
-  const rel = path.relative(OUT_DIR, mdPath);
-  const htmlRel = rel.replace(/\.md$/, '.html');
-  const errors = checkPage(markdown, htmlRel);
+// --- Bulk quality gate (requires out/ from a full build) ---
+
+if (fs.existsSync(OUT_DIR)) {
+  const htmlFiles = findHtmlPages(OUT_DIR);
+  const mdFiles = findMarkdownPages(OUT_DIR);
+
+  if (mdFiles.length === 0) {
+    console.error('No markdown files found in out/. Did generate-markdown-pages run?');
+    process.exit(1);
+  }
+
+  if (mdFiles.length !== htmlFiles.length) {
+    console.error(
+      `\n \x1b[1m\x1b[31m✗\x1b[0m Markdown/HTML count mismatch: ${mdFiles.length} markdown files for ${htmlFiles.length} HTML pages`
+    );
+    process.exit(1);
+  }
+
+  for (const mdPath of mdFiles) {
+    const markdown = fs.readFileSync(mdPath, 'utf-8');
+    const rel = path.relative(OUT_DIR, mdPath);
+    const htmlRel = rel.replace(/\.md$/, '.html');
+    const errors = checkPage(markdown, htmlRel);
+    if (errors.length > 0) {
+      for (const error of errors) {
+        console.error(`  \x1b[31m✗\x1b[0m ${rel}: ${error}`);
+      }
+      failCount++;
+    }
+  }
+
+  if (failCount) {
+    console.error(
+      `\n \x1b[1m\x1b[31m✗\x1b[0m ${failCount} of ${mdFiles.length} markdown pages have quality issues`
+    );
+  } else {
+    console.warn(
+      ` \x1b[1m\x1b[32m✓\x1b[0m All ${mdFiles.length} markdown pages passed quality checks`
+    );
+  }
+}
+
+// --- Integration test for test-markdown-pipeline page ---
+
+const INTEGRATION_TEST_SLUG = 'internal/test-markdown-pipeline';
+const DEV_SERVER_URL = `http://localhost:3002/${INTEGRATION_TEST_SLUG}/`;
+
+async function getIntegrationTestMarkdownAsync(): Promise<string | null> {
+  // Try the dev server first
+  try {
+    const response = await fetch(DEV_SERVER_URL, {
+      signal: AbortSignal.timeout(3000),
+    });
+    if (response.ok) {
+      const html = await response.text();
+      const mdxPath = path.join(process.cwd(), 'pages', INTEGRATION_TEST_SLUG + '.mdx');
+      const frontmatter = fs.existsSync(mdxPath) ? extractFrontmatter(mdxPath) : null;
+      const markdown = convertHtmlToMarkdown(html);
+      return frontmatter ? frontmatter + '\n' + markdown : markdown;
+    }
+  } catch {
+    // Dev server not running or page not found — fall through
+  }
+
+  // Fall back to pre-built markdown in out/
+  const outPath = path.join(OUT_DIR, INTEGRATION_TEST_SLUG, 'index.md');
+  if (fs.existsSync(outPath)) {
+    return fs.readFileSync(outPath, 'utf-8');
+  }
+
+  return null;
+}
+
+const integrationMd = await getIntegrationTestMarkdownAsync();
+
+if (integrationMd === null) {
+  if (!fs.existsSync(OUT_DIR)) {
+    console.warn(
+      ' \x1b[33m⚠\x1b[0m No out/ directory and dev server not running — skipping all checks'
+    );
+  } else {
+    console.warn(' \x1b[33m⚠\x1b[0m Integration test page not found — skipping integration test');
+  }
+} else {
+  const errors: string[] = [];
+
+  // Positive: content must survive conversion
+  const mustContain: [string, string][] = [
+    ['terminal command', 'npx expo-md-test@latest'],
+    ['collapsible content', 'md-test-collapsible-content'],
+    ['step one', 'md-test-step-one'],
+    ['step two', 'md-test-step-two'],
+    ['boxlink title', 'md-test-boxlink-title'],
+    ['callout', 'md-test-callout-info'],
+    ['typed code', 'md-test-typed-code'],
+    ['table cell', 'md-test-table-cell'],
+    ['link text', 'md-test-link-text'],
+    ['bold text', 'md-test-bold-text'],
+    ['unordered list', 'md-test-unordered-item'],
+    ['ordered list', 'md-test-ordered-item'],
+    ['npm tab content', 'md-test-npm-pkg'],
+  ];
+  for (const [label, text] of mustContain) {
+    if (!integrationMd.includes(text)) {
+      errors.push(`Missing ${label}: "${text}"`);
+    }
+  }
+
+  // Negative: artifacts must not leak
+  if (integrationMd.includes('md-test-yarn-pkg')) {
+    errors.push('Non-default tab panel content leaked (yarn tab should be stripped)');
+  }
+  if (/^Terminal$/m.test(integrationMd)) {
+    errors.push('Snippet header "Terminal" label leaked as standalone text');
+  }
+
+  // Structural checks (reuse existing quality gate)
+  const pageErrors = checkPage(integrationMd, `${INTEGRATION_TEST_SLUG}/index.html`);
+  errors.push(...pageErrors);
+
   if (errors.length > 0) {
+    console.error('\n  Integration test page validation failed:');
     for (const error of errors) {
-      console.error(`  \x1b[31m✗\x1b[0m ${rel}: ${error}`);
+      console.error(`    \x1b[31m✗\x1b[0m ${error}`);
     }
     failCount++;
+  } else {
+    console.warn(' \x1b[1m\x1b[32m✓\x1b[0m Integration test page passed');
   }
 }
 
 if (failCount) {
-  console.error(
-    `\n \x1b[1m\x1b[31m✗\x1b[0m ${failCount} of ${mdFiles.length} markdown pages have quality issues`
-  );
   process.exit(1);
-} else {
-  console.warn(
-    ` \x1b[1m\x1b[32m✓\x1b[0m All ${mdFiles.length} markdown pages passed quality checks`
-  );
 }

--- a/docs/scripts/generate-markdown-pages-utils.test.ts
+++ b/docs/scripts/generate-markdown-pages-utils.test.ts
@@ -164,14 +164,12 @@ describe('cleanHtml', () => {
   });
 
   it('re-escapes unknown HTML elements in code as angle-bracket text', () => {
-    const html = [
-      '<main><p><code>',
-      'Promise<uint8array></uint8array>',
-      '</code></p></main>',
-    ].join('');
+    const html = ['<main><p><code>', 'Promise<uint8array></uint8array>', '</code></p></main>'].join(
+      ''
+    );
     const $ = cheerio.load(html);
     cleanHtml($, $('main'));
-    const result = $('code').html() || '';
+    const result = $('code').html() ?? '';
     expect(result).toContain('&lt;uint8array&gt;');
   });
 
@@ -183,7 +181,7 @@ describe('cleanHtml', () => {
     ].join('');
     const $ = cheerio.load(html);
     cleanHtml($, $('main'));
-    const result = $('code').html() || '';
+    const result = $('code').html() ?? '';
     expect(result).toContain('&lt;expo-sfv&gt;');
     expect(result).not.toContain('&amp;');
   });
@@ -1106,11 +1104,7 @@ describe('collapsed headings', () => {
 describe('generic type parameters', () => {
   it('preserves angle brackets around unknown elements in code', () => {
     // Simulates cheerio parsing <Uint8Array> as an HTML element
-    const html = [
-      '<main><p><code>',
-      'Promise&lt;Uint8Array&gt;',
-      '</code></p></main>',
-    ].join('');
+    const html = ['<main><p><code>', 'Promise&lt;Uint8Array&gt;', '</code></p></main>'].join('');
     const md = convertHtmlToMarkdown(html);
     expect(md).toMatch(/Promise.*Uint8Array/);
   });

--- a/docs/scripts/generate-markdown-pages-utils.test.ts
+++ b/docs/scripts/generate-markdown-pages-utils.test.ts
@@ -103,6 +103,90 @@ describe('cleanHtml', () => {
     expect(html).toContain('<code class="language-sh">');
     expect(html).toContain('npx expo start');
   });
+
+  it('removes <br> tags inside table cells', () => {
+    const html = [
+      '<main><table><tr>',
+      '<td>',
+      '<span>Only for: </span>',
+      '<div data-md="platform-badge"><svg/><span>iOS</span></div>',
+      '<br/>',
+      '<p>A string to set the permission message.</p>',
+      '</td>',
+      '</tr></table></main>',
+    ].join('');
+    const $ = cheerio.load(html);
+    cleanHtml($, $('main'));
+    expect($('td').find('br').length).toBe(0);
+  });
+
+  it('removes style tags', () => {
+    const html = '<main><style>.foo { color: red; }</style><p>content</p></main>';
+    const $ = cheerio.load(html);
+    cleanHtml($, $('main'));
+    expect($('main').html()).not.toContain('style');
+    expect($('main').html()).not.toContain('color');
+    expect($('main').text()).toContain('content');
+  });
+
+  it('keeps only first tab panel in @reach/tabs groups', () => {
+    const html = [
+      '<main>',
+      '<div data-reach-tabs="">',
+      '<div data-reach-tab-panels="">',
+      '<div data-reach-tab-panel="" role="tabpanel">',
+      '<pre><code class="language-sh">npm install expo</code></pre>',
+      '</div>',
+      '<div data-reach-tab-panel="" role="tabpanel">',
+      '<pre><code class="language-sh">yarn add expo</code></pre>',
+      '</div>',
+      '</div>',
+      '</div>',
+      '</main>',
+    ].join('');
+    const $ = cheerio.load(html);
+    cleanHtml($, $('main'));
+    expect($('main').text()).toContain('npm install expo');
+    expect($('main').text()).not.toContain('yarn add expo');
+  });
+
+  it('unwraps non-empty div/span inside headings', () => {
+    const html = [
+      '<main>',
+      '<h2><span class="wrapper"><span class="inner">Fix the error</span></span></h2>',
+      '</main>',
+    ].join('');
+    const $ = cheerio.load(html);
+    cleanHtml($, $('main'));
+    expect($('h2').text().trim()).toBe('Fix the error');
+    expect($('h2').find('div').length).toBe(0);
+    expect($('h2').find('span').length).toBe(0);
+  });
+
+  it('re-escapes unknown HTML elements in code as angle-bracket text', () => {
+    const html = [
+      '<main><p><code>',
+      'Promise<uint8array></uint8array>',
+      '</code></p></main>',
+    ].join('');
+    const $ = cheerio.load(html);
+    cleanHtml($, $('main'));
+    const result = $('code').html() || '';
+    expect(result).toContain('&lt;uint8array&gt;');
+  });
+
+  it('decodes double-encoded HTML entities in code blocks', () => {
+    const html = [
+      '<main><pre><code>',
+      'filters: &amp;lt;expo-sfv&amp;gt;',
+      '</code></pre></main>',
+    ].join('');
+    const $ = cheerio.load(html);
+    cleanHtml($, $('main'));
+    const result = $('code').html() || '';
+    expect(result).toContain('&lt;expo-sfv&gt;');
+    expect(result).not.toContain('&amp;');
+  });
 });
 
 describe('cleanMarkdown', () => {
@@ -310,6 +394,60 @@ describe('platform indicators', () => {
   });
 });
 
+describe('platform indicators in table cells', () => {
+  it('keeps "Only for: iOS" on same line as description in table cells', () => {
+    const html = [
+      '<main><table>',
+      '<thead><tr><th>Property</th><th>Default</th><th>Description</th></tr></thead>',
+      '<tbody><tr>',
+      '<td><code>contactsPermission</code></td>',
+      '<td><code>"Allow..."</code></td>',
+      '<td>',
+      '<span>Only for: </span>',
+      '<div data-md="platform-badge"><svg/><span>iOS</span></div>',
+      '<br/>',
+      '<p>A string to set the permission message.</p>',
+      '</td>',
+      '</tr></tbody>',
+      '</table></main>',
+    ].join('');
+    const md = convertHtmlToMarkdown(html);
+    // Should be a single table row, not split across lines
+    const lines = md.split('\n').filter(l => l.startsWith('|'));
+    const dataRow = lines.find(l => l.includes('contactsPermission'));
+    expect(dataRow).toBeDefined();
+    expect(dataRow).toContain('iOS');
+    expect(dataRow).toContain('permission message');
+  });
+});
+
+describe('tab panel deduplication', () => {
+  it('only includes first tab panel content in output', () => {
+    const html = [
+      '<main>',
+      '<h1>Installation</h1>',
+      '<div data-reach-tabs="">',
+      '<div data-reach-tab-panels="">',
+      '<div data-reach-tab-panel="" role="tabpanel">',
+      '<pre><code class="language-sh">npx expo install expo-camera</code></pre>',
+      '</div>',
+      '<div data-reach-tab-panel="" role="tabpanel">',
+      '<pre><code class="language-sh">yarn add expo-camera</code></pre>',
+      '</div>',
+      '<div data-reach-tab-panel="" role="tabpanel">',
+      '<pre><code class="language-sh">bun add expo-camera</code></pre>',
+      '</div>',
+      '</div>',
+      '</div>',
+      '</main>',
+    ].join('');
+    const md = convertHtmlToMarkdown(html);
+    expect(md).toContain('npx expo install expo-camera');
+    expect(md).not.toContain('yarn add expo-camera');
+    expect(md).not.toContain('bun add expo-camera');
+  });
+});
+
 describe('diff tables', () => {
   it('converts diff tables inside data-md="diff" wrapper', () => {
     const html = `<main>
@@ -334,6 +472,34 @@ describe('diff tables', () => {
     expect(md).toContain('```diff');
     expect(md).toContain('- removed');
     expect(md).toContain('+ added');
+  });
+
+  it('infers +/- markers from react-diff-view CSS classes', () => {
+    const html = [
+      '<main><div data-md="diff"><table class="diff">',
+      '<colgroup><col class="diff-gutter-col"/><col class="diff-gutter-col"/><col/></colgroup>',
+      '<tr class="diff-line">',
+      '<td class="diff-gutter diff-gutter-delete">1</td>',
+      '<td class="diff-gutter diff-gutter-delete"></td>',
+      '<td class="diff-code diff-code-delete">old line</td>',
+      '</tr>',
+      '<tr class="diff-line">',
+      '<td class="diff-gutter diff-gutter-insert"></td>',
+      '<td class="diff-gutter diff-gutter-insert">1</td>',
+      '<td class="diff-code diff-code-insert">new line</td>',
+      '</tr>',
+      '<tr class="diff-line">',
+      '<td class="diff-gutter diff-gutter-normal">2</td>',
+      '<td class="diff-gutter diff-gutter-normal">2</td>',
+      '<td class="diff-code diff-code-normal">unchanged</td>',
+      '</tr>',
+      '</table></div></main>',
+    ].join('');
+    const md = convertHtmlToMarkdown(html);
+    expect(md).toContain('```diff');
+    expect(md).toContain('- old line');
+    expect(md).toContain('+ new line');
+    expect(md).toMatch(/^\s+unchanged$/m);
   });
 });
 
@@ -910,6 +1076,75 @@ describe('code block language from data-md-lang', () => {
       '<main><pre data-md-lang="typescript"><code class="language-js">const x = 1;</code></pre></main>';
     const md = convertHtmlToMarkdown(html);
     expect(md).toContain('```typescript\nconst x = 1;\n```');
+  });
+});
+
+describe('collapsed headings', () => {
+  it('unwraps non-empty span wrappers inside headings', () => {
+    const html = [
+      '<main>',
+      '<h2><span class="text-wrapper"><span>Fix the TypeScript error</span></span></h2>',
+      '<p>Details here.</p>',
+      '</main>',
+    ].join('');
+    const md = convertHtmlToMarkdown(html);
+    expect(md).toContain('## Fix the TypeScript error');
+  });
+
+  it('unwraps non-empty div inside heading without losing text', () => {
+    const html = [
+      '<main>',
+      '<h3><div class="inline">Custom tabs</div></h3>',
+      '<p>Content.</p>',
+      '</main>',
+    ].join('');
+    const md = convertHtmlToMarkdown(html);
+    expect(md).toContain('### Custom tabs');
+  });
+});
+
+describe('generic type parameters', () => {
+  it('preserves angle brackets around unknown elements in code', () => {
+    // Simulates cheerio parsing <Uint8Array> as an HTML element
+    const html = [
+      '<main><p><code>',
+      'Promise&lt;Uint8Array&gt;',
+      '</code></p></main>',
+    ].join('');
+    const md = convertHtmlToMarkdown(html);
+    expect(md).toMatch(/Promise.*Uint8Array/);
+  });
+});
+
+describe('double-encoded HTML entities', () => {
+  it('decodes double-encoded entities in code blocks', () => {
+    const html = [
+      '<main><pre><code>',
+      'expo-manifest-filters: &amp;lt;expo-sfv&amp;gt;',
+      '</code></pre></main>',
+    ].join('');
+    const md = convertHtmlToMarkdown(html);
+    expect(md).toContain('<expo-sfv>');
+    expect(md).not.toContain('&amp;');
+    expect(md).not.toContain('&lt;');
+  });
+});
+
+describe('style tag removal', () => {
+  it('removes style tags and their CSS content', () => {
+    const html = [
+      '<main>',
+      '<style>.react-flow { display: flex; } .node { padding: 10px; }</style>',
+      '<h1>Config Plugins</h1>',
+      '<p>Content here.</p>',
+      '</main>',
+    ].join('');
+    const md = convertHtmlToMarkdown(html);
+    expect(md).toContain('# Config Plugins');
+    expect(md).toContain('Content here.');
+    expect(md).not.toContain('react-flow');
+    expect(md).not.toContain('display');
+    expect(md).not.toContain('padding');
   });
 });
 


### PR DESCRIPTION
## Summary

Adds an end-to-end integration test that validates the full HTML→Markdown conversion pipeline against a real rendered page, catching regressions when React components change their HTML structure or drop `data-md` attributes.

- **Test page** (`pages/internal/test-markdown-pipeline.mdx`): Exercises Terminal, Tabs, Collapsible, Step, BoxLink, code blocks, tables, callouts, links, bold, and lists with unique `md-test-*` assertion strings. Hidden from search and sidebar navigation.
- **Dual-mode validation** in `check-markdown-pages.ts`: Fetches from the dev server (`localhost:3002`) when running, or falls back to `out/` from a full build. Gracefully skips when neither source is available.

### Usage

```sh
# With dev server running (fast — no full build needed):
yarn dev &
yarn check-markdown-pages

# With full build (CI):
yarn export  # includes check-markdown-pages in pipeline
```

Stacked on #42962.

## Test plan

- [x] `yarn check-markdown-pages` passes with dev server running (no `out/`)
- [x] `yarn check-markdown-pages` passes with `out/` directory (no dev server)
- [x] Gracefully skips when neither source is available
- [x] Full `yarn export` builds the test page and validates it


🤖 Generated with [Claude Code](https://claude.com/claude-code)