### PR TITLE
fix(docs): serve .md files without worker, add 404 and worker/routing tests

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -42,6 +42,8 @@ jobs:
         run: yarn install --immutable
       - name: 🧪 Run Docs tests
         run: yarn test
+      - name: 🧪 Test Cloudflare worker and routes
+        run: yarn test:worker
       - name: 🚨 Lint Docs website code
         env:
           NODE_ENV: production

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,6 +58,9 @@ jobs:
       - name: 🧪 Run Docs tests
         working-directory: docs
         run: yarn test
+      - name: 🧪 Test Cloudflare worker and routes
+        working-directory: docs
+        run: yarn test:worker
       - name: 🚨 Lint Docs website code
         working-directory: docs
         env:

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -17,6 +17,7 @@ out
 
 # worker test temp dir
 .worker-test
+.wrangler
 
 # yarn berry
 .pnp.*

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -15,6 +15,9 @@ public/static/constants
 .swc
 out
 
+# worker test temp dir
+.worker-test
+
 # yarn berry
 .pnp.*
 .yarn/*

--- a/docs/eslint.config.mjs
+++ b/docs/eslint.config.mjs
@@ -72,6 +72,8 @@ export default defineConfig([
     '**/.cache',
     '**/.next/',
     '**/.swc/',
+    '**/.wrangler/',
+    '**/.worker-test/',
     '**/.yarn/',
     '**/.vale',
     '**/node_modules',

--- a/docs/package.json
+++ b/docs/package.json
@@ -132,7 +132,8 @@
     "typescript": "~5.8.3",
     "unist-builder": "^4.0.0",
     "unist-util-visit": "^5.0.0",
-    "user-agent-data-types": "^0.4.2"
+    "user-agent-data-types": "^0.4.2",
+    "wrangler": "^4.63.0"
   },
   "prettier": {
     "printWidth": 100,

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,6 +11,7 @@
     "export-preview": "yarn copy-latest && yarn generate-static-resources preview && yarn export-prep && NEXT_TELEMETRY_DISABLED=1 SENTRY_SUPPRESS_INSTRUMENTATION_FILE_WARNING=1 next build --webpack && yarn generate-markdown-pages && yarn check-markdown-pages && yarn generate-llms",
     "export-prep": "node ./scripts/export-prep.js",
     "export-server": "wrangler pages dev --port 8000",
+    "test:worker": "node --experimental-strip-types scripts/test-worker.ts",
     "lint": "node scripts/lint.js --max-warnings 0",
     "lint-links": "remark -u validate-links ./pages",
     "lint-prose": "yarn vale --glob='!pages/versions/latest/**' .",

--- a/docs/public/_routes.json
+++ b/docs/public/_routes.json
@@ -5,6 +5,7 @@
     "/_next/*",
     "/static/*",
     "/data/*",
+    "/*.md",
     "/*.txt",
     "/*.xml",
     "/*.ico",

--- a/docs/public/_worker.js
+++ b/docs/public/_worker.js
@@ -11,7 +11,8 @@ export default {
       url.pathname = mdPath;
       const mdResponse = await env.ASSETS.fetch(new Request(url, request));
 
-      if (mdResponse.ok) {
+      const contentType = mdResponse.headers.get("Content-Type") || "";
+      if (mdResponse.ok && contentType.includes("text/markdown")) {
         return new Response(mdResponse.body, {
           status: 200,
           headers: {
@@ -19,6 +20,8 @@ export default {
           },
         });
       }
+
+      return new Response("Not found\n", { status: 404 });
     }
 
     return env.ASSETS.fetch(request);

--- a/docs/scripts/test-worker.ts
+++ b/docs/scripts/test-worker.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { spawn, type ChildProcess } from 'node:child_process';
 import fs from 'node:fs';
 
@@ -39,7 +40,7 @@ function waitForReady(process: ChildProcess, timeoutMs = 30000): Promise<void> {
   });
 }
 
-async function cleanup(): Promise<void> {
+async function cleanupAsync(): Promise<void> {
   if (wranglerProcess) {
     wranglerProcess.kill();
     wranglerProcess = null;
@@ -80,7 +81,7 @@ function setupTestDirectory(): void {
   console.log('✓ Test directory created');
 }
 
-async function startWrangler(): Promise<void> {
+async function startWranglerAsync(): Promise<void> {
   console.log('\n--- Starting wrangler pages dev ---');
 
   wranglerProcess = spawn('wrangler', ['pages', 'dev', TEST_DIR, '--port', String(PORT)], {
@@ -93,7 +94,7 @@ async function startWrangler(): Promise<void> {
   console.log('✓ Wrangler started');
 }
 
-async function testHttpResponse(): Promise<void> {
+async function testHttpResponseAsync(): Promise<void> {
   console.log('\n--- Testing HTTP responses ---');
 
   const response = await fetch(BASE_URL);
@@ -103,7 +104,7 @@ async function testHttpResponse(): Promise<void> {
   console.log(`✓ Server responds with HTTP ${response.status}`);
 }
 
-async function testDirectMarkdownAccess(): Promise<void> {
+async function testDirectMarkdownAccessAsync(): Promise<void> {
   console.log('\n--- Testing direct .md file access (bypasses worker) ---');
 
   const response = await fetch(`${BASE_URL}/test-page/index.md`);
@@ -120,7 +121,7 @@ async function testDirectMarkdownAccess(): Promise<void> {
   console.log('✓ Direct .md file request serves content correctly');
 }
 
-async function testMarkdownContentNegotiation(): Promise<void> {
+async function testMarkdownContentNegotiationAsync(): Promise<void> {
   console.log('\n--- Testing markdown content negotiation ---');
 
   // Without Accept: text/markdown, should serve HTML
@@ -137,7 +138,7 @@ async function testMarkdownContentNegotiation(): Promise<void> {
     headers: { Accept: 'text/markdown' },
   });
 
-  const mdContentType = mdResponse.headers.get('content-type') || '';
+  const mdContentType = mdResponse.headers.get('content-type') ?? '';
   const mdBody = await mdResponse.text();
 
   if (!mdBody.includes('Test Markdown Content')) {
@@ -151,7 +152,7 @@ async function testMarkdownContentNegotiation(): Promise<void> {
   console.log('✓ Accept: text/markdown request returns correct Content-Type');
 }
 
-async function testMarkdownNotFound(): Promise<void> {
+async function testMarkdownNotFoundAsync(): Promise<void> {
   console.log('\n--- Testing markdown 404 responses ---');
 
   // Page with HTML but no .md should 404 when markdown is requested
@@ -175,24 +176,37 @@ async function testMarkdownNotFound(): Promise<void> {
   console.log('✓ Nonexistent page returns 404');
 }
 
-async function main(): Promise<void> {
+async function testHtmlNotFoundAsync(): Promise<void> {
+  console.log('\n--- Testing HTML 404 responses ---');
+
+  // Nonexistent page without Accept: text/markdown should not 500
+  const response = await fetch(`${BASE_URL}/nonexistent-page`);
+
+  if (response.status >= 500) {
+    throw new Error(`Server error for nonexistent page: HTTP ${response.status}`);
+  }
+  console.log(`✓ Nonexistent HTML page returns HTTP ${response.status} (not a server error)`);
+}
+
+async function mainAsync(): Promise<void> {
   console.log('=== Testing Cloudflare Pages Worker and Routes ===');
 
   try {
     setupTestDirectory();
-    await startWrangler();
-    await testHttpResponse();
-    await testDirectMarkdownAccess();
-    await testMarkdownContentNegotiation();
-    await testMarkdownNotFound();
+    await startWranglerAsync();
+    await testHttpResponseAsync();
+    await testDirectMarkdownAccessAsync();
+    await testMarkdownContentNegotiationAsync();
+    await testMarkdownNotFoundAsync();
+    await testHtmlNotFoundAsync();
 
     console.log('\n=== All tests passed! ===');
   } catch (error) {
     console.error('\n✗ Test failed:', error instanceof Error ? error.message : error);
     process.exitCode = 1;
   } finally {
-    await cleanup();
+    await cleanupAsync();
   }
 }
 
-main();
+void mainAsync();

--- a/docs/scripts/test-worker.ts
+++ b/docs/scripts/test-worker.ts
@@ -1,5 +1,5 @@
-import { spawn, type ChildProcess } from 'child_process';
-import { readFileSync, existsSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { spawn, type ChildProcess } from 'node:child_process';
+import fs from 'node:fs';
 
 const PORT = 8788;
 const BASE_URL = `http://localhost:${PORT}`;
@@ -44,8 +44,8 @@ async function cleanup(): Promise<void> {
     wranglerProcess.kill();
     wranglerProcess = null;
   }
-  if (existsSync(TEST_DIR)) {
-    rmSync(TEST_DIR, { recursive: true, force: true });
+  if (fs.existsSync(TEST_DIR)) {
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
   }
 }
 
@@ -53,12 +53,12 @@ function validateRoutesJson(): void {
   console.log('\n--- Validating _routes.json ---');
 
   const routesPath = 'public/_routes.json';
-  if (!existsSync(routesPath)) {
+  if (!fs.existsSync(routesPath)) {
     throw new Error('_routes.json does not exist');
   }
   console.log('✓ _routes.json exists');
 
-  const content = readFileSync(routesPath, 'utf8');
+  const content = fs.readFileSync(routesPath, 'utf8');
   const routes = JSON.parse(content);
   console.log('✓ _routes.json is valid JSON');
 
@@ -94,12 +94,12 @@ function validateWorkerJs(): void {
   console.log('\n--- Validating _worker.js ---');
 
   const workerPath = 'public/_worker.js';
-  if (!existsSync(workerPath)) {
+  if (!fs.existsSync(workerPath)) {
     throw new Error('_worker.js does not exist');
   }
   console.log('✓ _worker.js exists');
 
-  const content = readFileSync(workerPath, 'utf8');
+  const content = fs.readFileSync(workerPath, 'utf8');
 
   if (!content.includes('export default')) {
     throw new Error('_worker.js missing default export');
@@ -115,21 +115,21 @@ function validateWorkerJs(): void {
 function setupTestDirectory(): void {
   console.log('\n--- Setting up test directory ---');
 
-  mkdirSync(TEST_DIR, { recursive: true });
-  mkdirSync(`${TEST_DIR}/test-page`, { recursive: true });
+  fs.mkdirSync(TEST_DIR, { recursive: true });
+  fs.mkdirSync(`${TEST_DIR}/test-page`, { recursive: true });
 
   // Copy worker files
-  const routesContent = readFileSync('public/_routes.json', 'utf8');
-  const workerContent = readFileSync('public/_worker.js', 'utf8');
+  const routesContent = fs.readFileSync('public/_routes.json', 'utf8');
+  const workerContent = fs.readFileSync('public/_worker.js', 'utf8');
 
-  writeFileSync(`${TEST_DIR}/_routes.json`, routesContent);
-  writeFileSync(`${TEST_DIR}/_worker.js`, workerContent);
-  writeFileSync(`${TEST_DIR}/index.html`, '<html><body><h1>Test Page</h1></body></html>');
-  writeFileSync(
+  fs.writeFileSync(`${TEST_DIR}/_routes.json`, routesContent);
+  fs.writeFileSync(`${TEST_DIR}/_worker.js`, workerContent);
+  fs.writeFileSync(`${TEST_DIR}/index.html`, '<html><body><h1>Test Page</h1></body></html>');
+  fs.writeFileSync(
     `${TEST_DIR}/test-page/index.html`,
     '<html><body><h1>Test Page HTML</h1></body></html>'
   );
-  writeFileSync(
+  fs.writeFileSync(
     `${TEST_DIR}/test-page/index.md`,
     '# Test Markdown Content\n\nThis is test content.'
   );

--- a/docs/scripts/test-worker.ts
+++ b/docs/scripts/test-worker.ts
@@ -1,0 +1,227 @@
+import { spawn, type ChildProcess } from 'child_process';
+import { readFileSync, existsSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+
+const PORT = 8788;
+const BASE_URL = `http://localhost:${PORT}`;
+
+let wranglerProcess: ChildProcess | null = null;
+
+function waitForReady(process: ChildProcess, timeoutMs = 30000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let output = '';
+
+    const timeout = setTimeout(() => {
+      reject(new Error(`Wrangler did not start within ${timeoutMs / 1000}s\n${output}`));
+    }, timeoutMs);
+
+    const onData = (data: Buffer) => {
+      const chunk = data.toString();
+      output += chunk;
+
+      // Wrangler prints "Ready on http://localhost:PORT" when ready
+      if (chunk.includes('Ready on')) {
+        clearTimeout(timeout);
+        process.stdout?.off('data', onData);
+        process.stderr?.off('data', onData);
+        resolve();
+      }
+    };
+
+    process.stdout?.on('data', onData);
+    process.stderr?.on('data', onData);
+
+    process.on('exit', code => {
+      clearTimeout(timeout);
+      reject(new Error(`Wrangler exited with code ${code}\n${output}`));
+    });
+  });
+}
+
+async function cleanup(): Promise<void> {
+  if (wranglerProcess) {
+    wranglerProcess.kill();
+    wranglerProcess = null;
+  }
+  if (existsSync('out')) {
+    rmSync('out', { recursive: true, force: true });
+  }
+}
+
+function validateRoutesJson(): void {
+  console.log('\n--- Validating _routes.json ---');
+
+  const routesPath = 'public/_routes.json';
+  if (!existsSync(routesPath)) {
+    throw new Error('_routes.json does not exist');
+  }
+  console.log('✓ _routes.json exists');
+
+  const content = readFileSync(routesPath, 'utf8');
+  const routes = JSON.parse(content);
+  console.log('✓ _routes.json is valid JSON');
+
+  if (routes.version !== 1) {
+    throw new Error('_routes.json version must be 1');
+  }
+  if (!Array.isArray(routes.include)) {
+    throw new Error('_routes.json include must be an array');
+  }
+  if (!Array.isArray(routes.exclude)) {
+    throw new Error('_routes.json exclude must be an array');
+  }
+  console.log('✓ _routes.json has valid structure (version, include, exclude)');
+
+  // Validate that static asset extensions are excluded from the worker
+  const requiredExcludes = ['/*.md', '/*.txt', '/*.xml', '/*.json'];
+  for (const pattern of requiredExcludes) {
+    if (!routes.exclude.includes(pattern)) {
+      throw new Error(`_routes.json missing required exclude pattern: ${pattern}`);
+    }
+  }
+  console.log('✓ _routes.json excludes static asset patterns (md, txt, xml, json)');
+
+  // Ensure total rules stay within Cloudflare's limit of 100
+  const totalRules = routes.include.length + routes.exclude.length;
+  if (totalRules > 100) {
+    throw new Error(`_routes.json has ${totalRules} rules, exceeding Cloudflare's limit of 100`);
+  }
+  console.log(`✓ _routes.json has ${totalRules} rules (limit: 100)`);
+}
+
+function validateWorkerJs(): void {
+  console.log('\n--- Validating _worker.js ---');
+
+  const workerPath = 'public/_worker.js';
+  if (!existsSync(workerPath)) {
+    throw new Error('_worker.js does not exist');
+  }
+  console.log('✓ _worker.js exists');
+
+  const content = readFileSync(workerPath, 'utf8');
+
+  if (!content.includes('export default')) {
+    throw new Error('_worker.js missing default export');
+  }
+  console.log('✓ _worker.js has default export');
+
+  if (!content.includes('async fetch')) {
+    throw new Error('_worker.js missing fetch handler');
+  }
+  console.log('✓ _worker.js has fetch handler');
+}
+
+function setupTestDirectory(): void {
+  console.log('\n--- Setting up test directory ---');
+
+  mkdirSync('out', { recursive: true });
+  mkdirSync('out/test-page', { recursive: true });
+
+  // Copy worker files
+  const routesContent = readFileSync('public/_routes.json', 'utf8');
+  const workerContent = readFileSync('public/_worker.js', 'utf8');
+
+  writeFileSync('out/_routes.json', routesContent);
+  writeFileSync('out/_worker.js', workerContent);
+  writeFileSync('out/index.html', '<html><body><h1>Test Page</h1></body></html>');
+  writeFileSync(
+    'out/test-page/index.html',
+    '<html><body><h1>Test Page HTML</h1></body></html>'
+  );
+  writeFileSync('out/test-page/index.md', '# Test Markdown Content\n\nThis is test content.');
+
+  console.log('✓ Test directory created');
+}
+
+async function startWrangler(): Promise<void> {
+  console.log('\n--- Starting wrangler pages dev ---');
+
+  wranglerProcess = spawn('npx', ['wrangler', 'pages', 'dev', 'out', '--port', String(PORT)], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  // Wait for "Ready on" message in stdout/stderr
+  await waitForReady(wranglerProcess);
+
+  console.log('✓ Wrangler started');
+}
+
+async function testHttpResponse(): Promise<void> {
+  console.log('\n--- Testing HTTP responses ---');
+
+  const response = await fetch(BASE_URL);
+  if (!response.ok) {
+    throw new Error(`Server not responding: HTTP ${response.status}`);
+  }
+  console.log(`✓ Server responds with HTTP ${response.status}`);
+}
+
+async function testDirectMarkdownAccess(): Promise<void> {
+  console.log('\n--- Testing direct .md file access (bypasses worker) ---');
+
+  const response = await fetch(`${BASE_URL}/test-page/index.md`);
+
+  if (!response.ok) {
+    throw new Error(`Direct .md request failed: HTTP ${response.status}`);
+  }
+
+  const body = await response.text();
+
+  if (!body.includes('Test Markdown Content')) {
+    throw new Error('Direct .md request did not return markdown content');
+  }
+  console.log('✓ Direct .md file request serves content correctly');
+}
+
+async function testMarkdownContentNegotiation(): Promise<void> {
+  console.log('\n--- Testing markdown content negotiation ---');
+
+  // Without Accept: text/markdown, should serve HTML
+  const htmlResponse = await fetch(`${BASE_URL}/test-page`);
+  const htmlBody = await htmlResponse.text();
+
+  if (!htmlBody.includes('Test Page HTML')) {
+    throw new Error('Expected HTML content for normal request, got: ' + htmlBody.slice(0, 200));
+  }
+  console.log('✓ Normal request serves HTML');
+
+  // With Accept: text/markdown, should serve markdown
+  const mdResponse = await fetch(`${BASE_URL}/test-page`, {
+    headers: { Accept: 'text/markdown' },
+  });
+
+  const mdContentType = mdResponse.headers.get('content-type') || '';
+  const mdBody = await mdResponse.text();
+
+  if (!mdBody.includes('Test Markdown Content')) {
+    throw new Error('Worker did not serve markdown content');
+  }
+  console.log('✓ Accept: text/markdown request serves markdown content');
+
+  if (!mdContentType.includes('text/markdown')) {
+    throw new Error(`Expected Content-Type text/markdown, got: ${mdContentType}`);
+  }
+  console.log('✓ Accept: text/markdown request returns correct Content-Type');
+}
+
+async function main(): Promise<void> {
+  console.log('=== Testing Cloudflare Pages Worker and Routes ===');
+
+  try {
+    validateRoutesJson();
+    validateWorkerJs();
+    setupTestDirectory();
+    await startWrangler();
+    await testHttpResponse();
+    await testDirectMarkdownAccess();
+    await testMarkdownContentNegotiation();
+
+    console.log('\n=== All tests passed! ===');
+  } catch (error) {
+    console.error('\n✗ Test failed:', error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  } finally {
+    await cleanup();
+  }
+}
+
+main();

--- a/docs/scripts/test-worker.ts
+++ b/docs/scripts/test-worker.ts
@@ -4,6 +4,8 @@ import { readFileSync, existsSync, mkdirSync, writeFileSync, rmSync } from 'fs';
 const PORT = 8788;
 const BASE_URL = `http://localhost:${PORT}`;
 
+const TEST_DIR = '.worker-test';
+
 let wranglerProcess: ChildProcess | null = null;
 
 function waitForReady(process: ChildProcess, timeoutMs = 30000): Promise<void> {
@@ -42,8 +44,8 @@ async function cleanup(): Promise<void> {
     wranglerProcess.kill();
     wranglerProcess = null;
   }
-  if (existsSync('out')) {
-    rmSync('out', { recursive: true, force: true });
+  if (existsSync(TEST_DIR)) {
+    rmSync(TEST_DIR, { recursive: true, force: true });
   }
 }
 
@@ -113,21 +115,24 @@ function validateWorkerJs(): void {
 function setupTestDirectory(): void {
   console.log('\n--- Setting up test directory ---');
 
-  mkdirSync('out', { recursive: true });
-  mkdirSync('out/test-page', { recursive: true });
+  mkdirSync(TEST_DIR, { recursive: true });
+  mkdirSync(`${TEST_DIR}/test-page`, { recursive: true });
 
   // Copy worker files
   const routesContent = readFileSync('public/_routes.json', 'utf8');
   const workerContent = readFileSync('public/_worker.js', 'utf8');
 
-  writeFileSync('out/_routes.json', routesContent);
-  writeFileSync('out/_worker.js', workerContent);
-  writeFileSync('out/index.html', '<html><body><h1>Test Page</h1></body></html>');
+  writeFileSync(`${TEST_DIR}/_routes.json`, routesContent);
+  writeFileSync(`${TEST_DIR}/_worker.js`, workerContent);
+  writeFileSync(`${TEST_DIR}/index.html`, '<html><body><h1>Test Page</h1></body></html>');
   writeFileSync(
-    'out/test-page/index.html',
+    `${TEST_DIR}/test-page/index.html`,
     '<html><body><h1>Test Page HTML</h1></body></html>'
   );
-  writeFileSync('out/test-page/index.md', '# Test Markdown Content\n\nThis is test content.');
+  writeFileSync(
+    `${TEST_DIR}/test-page/index.md`,
+    '# Test Markdown Content\n\nThis is test content.'
+  );
 
   console.log('✓ Test directory created');
 }
@@ -135,7 +140,7 @@ function setupTestDirectory(): void {
 async function startWrangler(): Promise<void> {
   console.log('\n--- Starting wrangler pages dev ---');
 
-  wranglerProcess = spawn('npx', ['wrangler', 'pages', 'dev', 'out', '--port', String(PORT)], {
+  wranglerProcess = spawn('wrangler', ['pages', 'dev', TEST_DIR, '--port', String(PORT)], {
     stdio: ['ignore', 'pipe', 'pipe'],
   });
 

--- a/docs/scripts/test-worker.ts
+++ b/docs/scripts/test-worker.ts
@@ -49,74 +49,12 @@ async function cleanup(): Promise<void> {
   }
 }
 
-function validateRoutesJson(): void {
-  console.log('\n--- Validating _routes.json ---');
-
-  const routesPath = 'public/_routes.json';
-  if (!fs.existsSync(routesPath)) {
-    throw new Error('_routes.json does not exist');
-  }
-  console.log('✓ _routes.json exists');
-
-  const content = fs.readFileSync(routesPath, 'utf8');
-  const routes = JSON.parse(content);
-  console.log('✓ _routes.json is valid JSON');
-
-  if (routes.version !== 1) {
-    throw new Error('_routes.json version must be 1');
-  }
-  if (!Array.isArray(routes.include)) {
-    throw new Error('_routes.json include must be an array');
-  }
-  if (!Array.isArray(routes.exclude)) {
-    throw new Error('_routes.json exclude must be an array');
-  }
-  console.log('✓ _routes.json has valid structure (version, include, exclude)');
-
-  // Validate that static asset extensions are excluded from the worker
-  const requiredExcludes = ['/*.md', '/*.txt', '/*.xml', '/*.json'];
-  for (const pattern of requiredExcludes) {
-    if (!routes.exclude.includes(pattern)) {
-      throw new Error(`_routes.json missing required exclude pattern: ${pattern}`);
-    }
-  }
-  console.log('✓ _routes.json excludes static asset patterns (md, txt, xml, json)');
-
-  // Ensure total rules stay within Cloudflare's limit of 100
-  const totalRules = routes.include.length + routes.exclude.length;
-  if (totalRules > 100) {
-    throw new Error(`_routes.json has ${totalRules} rules, exceeding Cloudflare's limit of 100`);
-  }
-  console.log(`✓ _routes.json has ${totalRules} rules (limit: 100)`);
-}
-
-function validateWorkerJs(): void {
-  console.log('\n--- Validating _worker.js ---');
-
-  const workerPath = 'public/_worker.js';
-  if (!fs.existsSync(workerPath)) {
-    throw new Error('_worker.js does not exist');
-  }
-  console.log('✓ _worker.js exists');
-
-  const content = fs.readFileSync(workerPath, 'utf8');
-
-  if (!content.includes('export default')) {
-    throw new Error('_worker.js missing default export');
-  }
-  console.log('✓ _worker.js has default export');
-
-  if (!content.includes('async fetch')) {
-    throw new Error('_worker.js missing fetch handler');
-  }
-  console.log('✓ _worker.js has fetch handler');
-}
-
 function setupTestDirectory(): void {
   console.log('\n--- Setting up test directory ---');
 
   fs.mkdirSync(TEST_DIR, { recursive: true });
   fs.mkdirSync(`${TEST_DIR}/test-page`, { recursive: true });
+  fs.mkdirSync(`${TEST_DIR}/html-only-page`, { recursive: true });
 
   // Copy worker files
   const routesContent = fs.readFileSync('public/_routes.json', 'utf8');
@@ -132,6 +70,11 @@ function setupTestDirectory(): void {
   fs.writeFileSync(
     `${TEST_DIR}/test-page/index.md`,
     '# Test Markdown Content\n\nThis is test content.'
+  );
+  // Page with HTML but no .md — for fallback testing
+  fs.writeFileSync(
+    `${TEST_DIR}/html-only-page/index.html`,
+    '<html><body><h1>HTML Only Page</h1></body></html>'
   );
 
   console.log('✓ Test directory created');
@@ -208,17 +151,40 @@ async function testMarkdownContentNegotiation(): Promise<void> {
   console.log('✓ Accept: text/markdown request returns correct Content-Type');
 }
 
+async function testMarkdownNotFound(): Promise<void> {
+  console.log('\n--- Testing markdown 404 responses ---');
+
+  // Page with HTML but no .md should 404 when markdown is requested
+  const missingMd = await fetch(`${BASE_URL}/html-only-page`, {
+    headers: { Accept: 'text/markdown' },
+  });
+
+  if (missingMd.status !== 404) {
+    throw new Error(`Expected 404 for missing .md, got: HTTP ${missingMd.status}`);
+  }
+  console.log('✓ Missing .md file returns 404');
+
+  // Nonexistent page should also 404
+  const notFound = await fetch(`${BASE_URL}/nonexistent-page`, {
+    headers: { Accept: 'text/markdown' },
+  });
+
+  if (notFound.status !== 404) {
+    throw new Error(`Expected 404 for nonexistent page, got: HTTP ${notFound.status}`);
+  }
+  console.log('✓ Nonexistent page returns 404');
+}
+
 async function main(): Promise<void> {
   console.log('=== Testing Cloudflare Pages Worker and Routes ===');
 
   try {
-    validateRoutesJson();
-    validateWorkerJs();
     setupTestDirectory();
     await startWrangler();
     await testHttpResponse();
     await testDirectMarkdownAccess();
     await testMarkdownContentNegotiation();
+    await testMarkdownNotFound();
 
     console.log('\n=== All tests passed! ===');
   } catch (error) {

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -595,12 +595,258 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cloudflare/kv-asset-handler@npm:0.4.2":
+  version: 0.4.2
+  resolution: "@cloudflare/kv-asset-handler@npm:0.4.2"
+  checksum: 10c0/c8877851ce069b04d32d50a640c9c0faaab054970204f64a4111bac3dd85f177c001a0b57d32f7e65269e3896268b8f94605f31e4fa06253a6a5779587a63d17
+  languageName: node
+  linkType: hard
+
+"@cloudflare/unenv-preset@npm:2.12.0":
+  version: 2.12.0
+  resolution: "@cloudflare/unenv-preset@npm:2.12.0"
+  peerDependencies:
+    unenv: 2.0.0-rc.24
+    workerd: ^1.20260115.0
+  peerDependenciesMeta:
+    workerd:
+      optional: true
+  checksum: 10c0/0f4b1acc23229f7ff92782cffed5b49ab279f351457eef7adff5fa7ae4681ae793408c8c0ecec2daacc4436eab2b79b38ae9e7ec9aa06f4a96b50670ca524ad1
+  languageName: node
+  linkType: hard
+
+"@cloudflare/workerd-darwin-64@npm:1.20260205.0":
+  version: 1.20260205.0
+  resolution: "@cloudflare/workerd-darwin-64@npm:1.20260205.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@cloudflare/workerd-darwin-arm64@npm:1.20260205.0":
+  version: 1.20260205.0
+  resolution: "@cloudflare/workerd-darwin-arm64@npm:1.20260205.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@cloudflare/workerd-linux-64@npm:1.20260205.0":
+  version: 1.20260205.0
+  resolution: "@cloudflare/workerd-linux-64@npm:1.20260205.0"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@cloudflare/workerd-linux-arm64@npm:1.20260205.0":
+  version: 1.20260205.0
+  resolution: "@cloudflare/workerd-linux-arm64@npm:1.20260205.0"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@cloudflare/workerd-windows-64@npm:1.20260205.0":
+  version: 1.20260205.0
+  resolution: "@cloudflare/workerd-windows-64@npm:1.20260205.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@cspotcode/source-map-support@npm:0.8.1":
+  version: 0.8.1
+  resolution: "@cspotcode/source-map-support@npm:0.8.1"
+  dependencies:
+    "@jridgewell/trace-mapping": "npm:0.3.9"
+  checksum: 10c0/05c5368c13b662ee4c122c7bfbe5dc0b613416672a829f3e78bc49a357a197e0218d6e74e7c66cfcd04e15a179acab080bd3c69658c9fbefd0e1ccd950a07fc6
+  languageName: node
+  linkType: hard
+
 "@emnapi/runtime@npm:^1.7.0":
   version: 1.8.1
   resolution: "@emnapi/runtime@npm:1.8.1"
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/f4929d75e37aafb24da77d2f58816761fe3f826aad2e37fa6d4421dac9060cbd5098eea1ac3c9ecc4526b89deb58153852fa432f87021dc57863f2ff726d713f
+  languageName: node
+  linkType: hard
+
+"@esbuild/aix-ppc64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/aix-ppc64@npm:0.27.0"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/android-arm64@npm:0.27.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/android-arm@npm:0.27.0"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/android-x64@npm:0.27.0"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/darwin-arm64@npm:0.27.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/darwin-x64@npm:0.27.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/freebsd-arm64@npm:0.27.0"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/freebsd-x64@npm:0.27.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-arm64@npm:0.27.0"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-arm@npm:0.27.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-ia32@npm:0.27.0"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-loong64@npm:0.27.0"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-mips64el@npm:0.27.0"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-ppc64@npm:0.27.0"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-riscv64@npm:0.27.0"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-s390x@npm:0.27.0"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/linux-x64@npm:0.27.0"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/netbsd-arm64@npm:0.27.0"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/netbsd-x64@npm:0.27.0"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/openbsd-arm64@npm:0.27.0"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/openbsd-x64@npm:0.27.0"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openharmony-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/openharmony-arm64@npm:0.27.0"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/sunos-x64@npm:0.27.0"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/win32-arm64@npm:0.27.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-ia32@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/win32-ia32@npm:0.27.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@esbuild/win32-x64@npm:0.27.0"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -1441,17 +1687,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/resolve-uri@npm:^3.1.0":
+"@jridgewell/resolve-uri@npm:^3.0.3, @jridgewell/resolve-uri@npm:^3.1.0":
   version: 3.1.2
   resolution: "@jridgewell/resolve-uri@npm:3.1.2"
   checksum: 10c0/d502e6fb516b35032331406d4e962c21fe77cdf1cbdb49c6142bcbd9e30507094b18972778a6e27cbad756209cfe34b1a27729e6fa08a2eb92b33943f680cf1e
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.4.15, @jridgewell/sourcemap-codec@npm:^1.5.0":
+"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.4.15, @jridgewell/sourcemap-codec@npm:^1.5.0":
   version: 1.5.5
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
   checksum: 10c0/f9e538f302b63c0ebc06eecb1dd9918dd4289ed36147a0ddce35d6ea4d7ebbda243cda7b2213b6a5e1d8087a298d5cf630fb2bd39329cdecb82017023f6081a0
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:0.3.9":
+  version: 0.3.9
+  resolution: "@jridgewell/trace-mapping@npm:0.3.9"
+  dependencies:
+    "@jridgewell/resolve-uri": "npm:^3.0.3"
+    "@jridgewell/sourcemap-codec": "npm:^1.4.10"
+  checksum: 10c0/fa425b606d7c7ee5bfa6a31a7b050dd5814b4082f318e0e4190f991902181b4330f43f4805db1dd4f2433fd0ed9cc7a7b9c2683f1deeab1df1b0a98b1e24055b
   languageName: node
   linkType: hard
 
@@ -2296,6 +2552,33 @@ __metadata:
   version: 2.11.8
   resolution: "@popperjs/core@npm:2.11.8"
   checksum: 10c0/4681e682abc006d25eb380d0cf3efc7557043f53b6aea7a5057d0d1e7df849a00e281cd8ea79c902a35a414d7919621fc2ba293ecec05f413598e0b23d5a1e63
+  languageName: node
+  linkType: hard
+
+"@poppinss/colors@npm:^4.1.5":
+  version: 4.1.6
+  resolution: "@poppinss/colors@npm:4.1.6"
+  dependencies:
+    kleur: "npm:^4.1.5"
+  checksum: 10c0/5c2cec5393e33294465873002f4c570adf36b5405b9f06551485162a6fb422d01de90ac20cb00800be6ab2f0d93da26e67302e95691dff2e0aa339cf93e5bf7f
+  languageName: node
+  linkType: hard
+
+"@poppinss/dumper@npm:^0.6.4":
+  version: 0.6.5
+  resolution: "@poppinss/dumper@npm:0.6.5"
+  dependencies:
+    "@poppinss/colors": "npm:^4.1.5"
+    "@sindresorhus/is": "npm:^7.0.2"
+    supports-color: "npm:^10.0.0"
+  checksum: 10c0/7a0916fe4ce543cac1e61f09218e5c88b903ad0d853301b790686c772b7f5c595a04beccbf13172e0c77dc64b132b27ad438b888816fd7f6128c816290f9dc1f
+  languageName: node
+  linkType: hard
+
+"@poppinss/exception@npm:^1.2.2":
+  version: 1.2.3
+  resolution: "@poppinss/exception@npm:1.2.3"
+  checksum: 10c0/44e48400c9f2d33a4904bee99321b89239774bb9210049f1c55864725fd524ff55bc78a5a94a13d5edea93b84e13023c229c88ebba8c2dc717fb4b2205e42ac7
   languageName: node
   linkType: hard
 
@@ -3730,6 +4013,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sindresorhus/is@npm:^7.0.2":
+  version: 7.2.0
+  resolution: "@sindresorhus/is@npm:7.2.0"
+  checksum: 10c0/0040c17d7826414363f99f5d56077c200789d51e6dfe5542920bfb29ab3828ec0ebf2845e8bae796bee461debb646b5e4c0a623140131cf3143471e915b50b54
+  languageName: node
+  linkType: hard
+
 "@sinonjs/commons@npm:^3.0.0":
   version: 3.0.1
   resolution: "@sinonjs/commons@npm:3.0.1"
@@ -3745,6 +4035,13 @@ __metadata:
   dependencies:
     "@sinonjs/commons": "npm:^3.0.0"
   checksum: 10c0/2e2fb6cc57f227912814085b7b01fede050cd4746ea8d49a1e44d5a0e56a804663b0340ae2f11af7559ea9bf4d087a11f2f646197a660ea3cb04e19efc04aa63
+  languageName: node
+  linkType: hard
+
+"@speed-highlight/core@npm:^1.2.7":
+  version: 1.2.14
+  resolution: "@speed-highlight/core@npm:1.2.14"
+  checksum: 10c0/8391bbfa04e9ea1677119b463f9a1413024a83319d271f5eacbc64dcd6d05394f092b876a5e47612eb98b4b55c1abe6c1b16270462ad4ac0f21311a1736e540f
   languageName: node
   linkType: hard
 
@@ -5265,6 +5562,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"blake3-wasm@npm:2.1.5":
+  version: 2.1.5
+  resolution: "blake3-wasm@npm:2.1.5"
+  checksum: 10c0/5dc729d8e3a9d1d7ab016b36cdda264a327ada0239716df48435163e11d2bf6df25d6e421655a1f52649098ae49555268a654729b7d02768f77c571ab37ef814
+  languageName: node
+  linkType: hard
+
 "bluebird@npm:~3.4.1":
   version: 3.4.7
   resolution: "bluebird@npm:3.4.7"
@@ -5832,6 +6136,13 @@ __metadata:
   version: 2.0.0
   resolution: "convert-source-map@npm:2.0.0"
   checksum: 10c0/8f2f7a27a1a011cc6cc88cc4da2d7d0cfa5ee0369508baae3d98c260bb3ac520691464e5bbe4ae7cdf09860c1d69ecc6f70c63c6e7c7f7e3f18ec08484dc7d9b
+  languageName: node
+  linkType: hard
+
+"cookie@npm:^1.0.2":
+  version: 1.1.1
+  resolution: "cookie@npm:1.1.1"
+  checksum: 10c0/79c4ddc0fcad9c4f045f826f42edf54bcc921a29586a4558b0898277fa89fb47be95bc384c2253f493af7b29500c830da28341274527328f18eba9f58afa112c
   languageName: node
   linkType: hard
 
@@ -6520,6 +6831,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"error-stack-parser-es@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "error-stack-parser-es@npm:1.0.5"
+  checksum: 10c0/040665eb87a42fe068c0da501bc258f3d15d3a03963c0723d7a2741e251d400c9776a52d2803afdc5709def99554cdb5a5d99c203c7eaf4885d3fbc217e2e8f7
+  languageName: node
+  linkType: hard
+
 "es-abstract@npm:^1.17.5, es-abstract@npm:^1.23.2, es-abstract@npm:^1.23.3, es-abstract@npm:^1.23.5, es-abstract@npm:^1.23.6, es-abstract@npm:^1.23.9":
   version: 1.23.9
   resolution: "es-abstract@npm:1.23.9"
@@ -6750,6 +7068,95 @@ __metadata:
     esast-util-from-estree: "npm:^2.0.0"
     vfile-message: "npm:^4.0.0"
   checksum: 10c0/3a446fb0b0d7bcd7e0157aa44b3b692802a08c93edbea81cc0f7fe4437bfdfb4b72e4563fe63b4e36d390086b71185dba4ac921f4180cc6349985c263cc74421
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:0.27.0":
+  version: 0.27.0
+  resolution: "esbuild@npm:0.27.0"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.27.0"
+    "@esbuild/android-arm": "npm:0.27.0"
+    "@esbuild/android-arm64": "npm:0.27.0"
+    "@esbuild/android-x64": "npm:0.27.0"
+    "@esbuild/darwin-arm64": "npm:0.27.0"
+    "@esbuild/darwin-x64": "npm:0.27.0"
+    "@esbuild/freebsd-arm64": "npm:0.27.0"
+    "@esbuild/freebsd-x64": "npm:0.27.0"
+    "@esbuild/linux-arm": "npm:0.27.0"
+    "@esbuild/linux-arm64": "npm:0.27.0"
+    "@esbuild/linux-ia32": "npm:0.27.0"
+    "@esbuild/linux-loong64": "npm:0.27.0"
+    "@esbuild/linux-mips64el": "npm:0.27.0"
+    "@esbuild/linux-ppc64": "npm:0.27.0"
+    "@esbuild/linux-riscv64": "npm:0.27.0"
+    "@esbuild/linux-s390x": "npm:0.27.0"
+    "@esbuild/linux-x64": "npm:0.27.0"
+    "@esbuild/netbsd-arm64": "npm:0.27.0"
+    "@esbuild/netbsd-x64": "npm:0.27.0"
+    "@esbuild/openbsd-arm64": "npm:0.27.0"
+    "@esbuild/openbsd-x64": "npm:0.27.0"
+    "@esbuild/openharmony-arm64": "npm:0.27.0"
+    "@esbuild/sunos-x64": "npm:0.27.0"
+    "@esbuild/win32-arm64": "npm:0.27.0"
+    "@esbuild/win32-ia32": "npm:0.27.0"
+    "@esbuild/win32-x64": "npm:0.27.0"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10c0/a3a1deec285337b7dfe25cbb9aa8765d27a0192b610a8477a39bf5bd907a6bdb75e98898b61fb4337114cfadb13163bd95977db14e241373115f548e235b40a2
   languageName: node
   linkType: hard
 
@@ -7644,6 +8051,7 @@ __metadata:
     unist-builder: "npm:^4.0.0"
     unist-util-visit: "npm:^5.0.0"
     user-agent-data-types: "npm:^0.4.2"
+    wrangler: "npm:^4.63.0"
     yet-another-react-lightbox: "npm:^3.28.0"
   languageName: unknown
   linkType: soft
@@ -9901,7 +10309,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"kleur@npm:^4.0.3":
+"kleur@npm:^4.0.3, kleur@npm:^4.1.5":
   version: 4.1.5
   resolution: "kleur@npm:4.1.5"
   checksum: 10c0/e9de6cb49657b6fa70ba2d1448fd3d691a5c4370d8f7bbf1c2f64c24d461270f2117e1b0afe8cb3114f13bbd8e51de158c2a224953960331904e636a5e4c0f2a
@@ -10970,6 +11378,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"miniflare@npm:4.20260205.0":
+  version: 4.20260205.0
+  resolution: "miniflare@npm:4.20260205.0"
+  dependencies:
+    "@cspotcode/source-map-support": "npm:0.8.1"
+    sharp: "npm:^0.34.5"
+    undici: "npm:7.18.2"
+    workerd: "npm:1.20260205.0"
+    ws: "npm:8.18.0"
+    youch: "npm:4.1.0-beta.10"
+  bin:
+    miniflare: bootstrap.js
+  checksum: 10c0/ee929f424084fd3c737064446e8f9ddb827924351fc7982b2afd78ca958b482c8282ad5403b427bc15ccd6e557465b63bbd37ee3abf29b97ffe17afec0290517
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
@@ -11847,6 +12271,20 @@ __metadata:
     lru-cache: "npm:^10.2.0"
     minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
   checksum: 10c0/32a13711a2a505616ae1cc1b5076801e453e7aae6ac40ab55b388bb91b9d0547a52f5aaceff710ea400205f18691120d4431e520afbe4266b836fadede15872d
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:6.3.0":
+  version: 6.3.0
+  resolution: "path-to-regexp@npm:6.3.0"
+  checksum: 10c0/73b67f4638b41cde56254e6354e46ae3a2ebc08279583f6af3d96fe4664fc75788f74ed0d18ca44fa4a98491b69434f9eee73b97bb5314bd1b5adb700f5c18d6
+  languageName: node
+  linkType: hard
+
+"pathe@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "pathe@npm:2.0.3"
+  checksum: 10c0/c118dc5a8b5c4166011b2b70608762e260085180bb9e33e80a50dcdb1e78c010b1624f4280c492c92b05fc276715a4c357d1f9edc570f8f1b3d90b6839ebaca1
   languageName: node
   linkType: hard
 
@@ -13337,7 +13775,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sharp@npm:^0.34.4":
+"sharp@npm:^0.34.4, sharp@npm:^0.34.5":
   version: 0.34.5
   resolution: "sharp@npm:0.34.5"
   dependencies:
@@ -13955,6 +14393,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"supports-color@npm:^10.0.0":
+  version: 10.2.2
+  resolution: "supports-color@npm:10.2.2"
+  checksum: 10c0/fb28dd7e0cdf80afb3f2a41df5e068d60c8b4f97f7140de2eaed5b42e075d82a0e980b20a2c0efd2b6d73cfacb55555285d8cc719fa0472220715aefeaa1da7c
+  languageName: node
+  linkType: hard
+
 "supports-color@npm:^7.1.0":
   version: 7.2.0
   resolution: "supports-color@npm:7.2.0"
@@ -14475,10 +14920,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici@npm:7.18.2":
+  version: 7.18.2
+  resolution: "undici@npm:7.18.2"
+  checksum: 10c0/4ff0722799f5e06fde5d1e58d318b1d78ba9a477836ad3e7374e9ac30ca20d1ab3282952d341635bf69b8e74b5c1cf366e595b3a96810e0dbf74e622dad7b5f9
+  languageName: node
+  linkType: hard
+
 "undici@npm:^7.19.0":
   version: 7.21.0
   resolution: "undici@npm:7.21.0"
   checksum: 10c0/ec5d7524125ac9c392a8a67b84fe4f9301936ca6b2afd7be12e73ab98726e55761dc9624ac10361d2f346e6fdaf66043381a62f7d0b565facd61bbfda975a586
+  languageName: node
+  linkType: hard
+
+"unenv@npm:2.0.0-rc.24":
+  version: 2.0.0-rc.24
+  resolution: "unenv@npm:2.0.0-rc.24"
+  dependencies:
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/e8556b4287fcf647f23db790eea2782cc79f182370718680e3aba4753d5fb7177abf5d6df489c8f74f7e3ad6cd554b8623cc01caf3e6f2d5548e69178adb1691
   languageName: node
   linkType: hard
 
@@ -15258,6 +15719,60 @@ __metadata:
   languageName: node
   linkType: hard
 
+"workerd@npm:1.20260205.0":
+  version: 1.20260205.0
+  resolution: "workerd@npm:1.20260205.0"
+  dependencies:
+    "@cloudflare/workerd-darwin-64": "npm:1.20260205.0"
+    "@cloudflare/workerd-darwin-arm64": "npm:1.20260205.0"
+    "@cloudflare/workerd-linux-64": "npm:1.20260205.0"
+    "@cloudflare/workerd-linux-arm64": "npm:1.20260205.0"
+    "@cloudflare/workerd-windows-64": "npm:1.20260205.0"
+  dependenciesMeta:
+    "@cloudflare/workerd-darwin-64":
+      optional: true
+    "@cloudflare/workerd-darwin-arm64":
+      optional: true
+    "@cloudflare/workerd-linux-64":
+      optional: true
+    "@cloudflare/workerd-linux-arm64":
+      optional: true
+    "@cloudflare/workerd-windows-64":
+      optional: true
+  bin:
+    workerd: bin/workerd
+  checksum: 10c0/1685b81c08cb5465b4c4d39159cafb54e84c48e2c64b0d0689661903a6b48018ef41349c4f601236e26cfffe5ac23ec3caaa75d2053f78bdeb2601831ae7dfd3
+  languageName: node
+  linkType: hard
+
+"wrangler@npm:^4.63.0":
+  version: 4.63.0
+  resolution: "wrangler@npm:4.63.0"
+  dependencies:
+    "@cloudflare/kv-asset-handler": "npm:0.4.2"
+    "@cloudflare/unenv-preset": "npm:2.12.0"
+    blake3-wasm: "npm:2.1.5"
+    esbuild: "npm:0.27.0"
+    fsevents: "npm:~2.3.2"
+    miniflare: "npm:4.20260205.0"
+    path-to-regexp: "npm:6.3.0"
+    unenv: "npm:2.0.0-rc.24"
+    workerd: "npm:1.20260205.0"
+  peerDependencies:
+    "@cloudflare/workers-types": ^4.20260205.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@cloudflare/workers-types":
+      optional: true
+  bin:
+    wrangler: bin/wrangler.js
+    wrangler2: bin/wrangler.js
+  checksum: 10c0/d681df451e8e6e0caa6a12a704cec4db0bcf39f6b12a11dd2f262baae547b5b427ed2a526f7e7a00703a45b8295299f2bf67bfd9a78881f28449994c8e728e8a
+  languageName: node
+  linkType: hard
+
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0, wrap-ansi@npm:^7.0.0":
   version: 7.0.0
   resolution: "wrap-ansi@npm:7.0.0"
@@ -15297,7 +15812,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.11.0":
+"ws@npm:8.18.0, ws@npm:^8.11.0":
   version: 8.18.0
   resolution: "ws@npm:8.18.0"
   peerDependencies:
@@ -15413,6 +15928,29 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
+  languageName: node
+  linkType: hard
+
+"youch-core@npm:^0.3.3":
+  version: 0.3.3
+  resolution: "youch-core@npm:0.3.3"
+  dependencies:
+    "@poppinss/exception": "npm:^1.2.2"
+    error-stack-parser-es: "npm:^1.0.5"
+  checksum: 10c0/fe101a037a6cfaaa4e80e3d062ff33d4b087b65e3407e65220b453c9b2a66c87ea348a7da0239b61623d929d8fa0a9e139486eaa690ef5605bb49947a2fa82f6
+  languageName: node
+  linkType: hard
+
+"youch@npm:4.1.0-beta.10":
+  version: 4.1.0-beta.10
+  resolution: "youch@npm:4.1.0-beta.10"
+  dependencies:
+    "@poppinss/colors": "npm:^4.1.5"
+    "@poppinss/dumper": "npm:^0.6.4"
+    "@speed-highlight/core": "npm:^1.2.7"
+    cookie: "npm:^1.0.2"
+    youch-core: "npm:^0.3.3"
+  checksum: 10c0/588d65aa5837a46c8473cf57a9129115383f57aad5899915d37005950decfefc66bec85b8a1262dbefd623a122c279095074655889317311a554f9c2e290a5b3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Add `/*.md` to `_routes.json` exclude list so markdown files are served directly as static assets, bypassing the Cloudflare Pages worker
- Add `test-worker.ts` integration test that actually starts `wrangler` and verifies it behaves as expected
- Run `yarn test:worker` in both `docs.yml` and `docs-pr.yml` CI workflows
- Fix worker Content-Type check: Cloudflare's `env.ASSETS.fetch` returns 200 for all paths due to SPA fallback, so the worker now checks `Content-Type` (text/markdown vs text/html) to distinguish real `.md` files from the fallback. Returns a clean 404 when markdown is requested but no `.md` file exists — previously this served garbled HTML as markdown
- Add `wrangler` as a devDependency

## Test plan
- [x] `yarn test:worker` passes — validates routes config, starts wrangler, tests direct `.md` access and content negotiation
- [x] Try it out in a preview deployment

### 404 handling

```
curl -s https://pr-42975.expo-docs.pages.dev/dsfjdsjf -H 'accept: text/markdown'
Not found   
```

```
curl -s https://pr-42975.expo-docs.pages.dev/dsfjdsjf
<!DOCTYPE html><html lang="en"><head><meta charSet="utf-8" data-next-head=""/>
(etc..)
```