### PR TITLE
[docs] Update README.md for server side redirects

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -137,7 +137,7 @@ Open the doc file (`*.mdx`) that you are working on and you'll may see suggested
 
 We use two layers of redirects:
 
-- **Server-side redirects** generated during deployment process in `deploy.sh` for simple 1:1 path mappings and SEO-friendly behavior.
+- **Server-side redirects** defined in `public/_redirects` using the Cloudflare Pages redirect format (`source_path destination_path status_code`, one rule per line). These are 301 permanent redirects for simple 1:1 path mappings and SEO-friendly behavior.
 - **Client-side redirects** in `common/client-redirects.ts` that run on the 404 page for more complex rules (for example, stripping `.html`, version fallbacks) and to catch cases where server-side redirects do not apply (local/dev/preview or missed mappings).
 
 We currently do two client-side redirects, using meta tags with `http-equiv="refresh"`:

--- a/docs/common/client-redirects.ts
+++ b/docs/common/client-redirects.ts
@@ -135,7 +135,7 @@ function endsInNull(path: string) {
   return path.endsWith('/null');
 }
 
-// Simple remapping of renamed pages, similar to in deploy.sh but in some cases,
+// Simple remapping of renamed pages, similar to public/_redirects but in some cases,
 // for reasons I'm not totally clear on, those redirects do not work
 const RENAMED_PAGES: Record<string, string> = {
   // Redirects after creating Home pages and route


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Updated README.md and client-redirects.ts to replace stale references to the removed `deploy.sh` script with the current setup (`public/_redirects`).

# How

<!--
How did you build this feature or fix this bug and why?
-->

The docs infrastructure migrated to Cloudflare Pages, but a couple of references to the old `deploy.sh` script were left behind. This brings the documentation in line with the actual setup in `docs/README.md`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
