### PR TITLE
[docs] Update llms script generation file to copy output to out/ directory

### DIFF
--- a/docs/scripts/generate-llms/index.js
+++ b/docs/scripts/generate-llms/index.js
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import process from 'node:process';
 
 import { compileTalksFile } from './compileTalks.js';
@@ -5,6 +7,40 @@ import { generateLlmsEasTxt } from './llms-eas-txt.js';
 import { generateLlmsFullTxt } from './llms-full-txt.js';
 import { generateLlmsSdkTxt } from './llms-sdk.js';
 import { generateLlmsTxt } from './llms-txt.js';
+import {
+  OUTPUT_DIRECTORY_NAME,
+  OUTPUT_FILENAME_EAS_DOCS,
+  OUTPUT_FILENAME_EXPO_DOCS,
+  OUTPUT_FILENAME_LLMS_TXT,
+} from './utils.js';
+
+const GENERATED_LLMS_FILES = [
+  OUTPUT_FILENAME_LLMS_TXT,
+  OUTPUT_FILENAME_EXPO_DOCS,
+  OUTPUT_FILENAME_EAS_DOCS,
+  'llms-sdk.txt',
+];
+
+async function syncGeneratedLlmsToOut() {
+  const outDir = path.join(process.cwd(), 'out');
+
+  if (!fs.existsSync(outDir)) {
+    return;
+  }
+
+  await Promise.all(
+    GENERATED_LLMS_FILES.map(async filename => {
+      const sourcePath = path.join(process.cwd(), OUTPUT_DIRECTORY_NAME, filename);
+      const targetPath = path.join(outDir, filename);
+
+      if (!fs.existsSync(sourcePath)) {
+        return;
+      }
+
+      await fs.promises.copyFile(sourcePath, targetPath);
+    })
+  );
+}
 
 await compileTalksFile();
 
@@ -22,3 +58,5 @@ for (const failure of failures) {
 if (failures.length > 0) {
   process.exit(1);
 }
+
+await syncGeneratedLlmsToOut();


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->


The docs site deploys from `out/`, but generate-llms writes files to `public/` after `next build`. This means the generated `llms*.txt` files were not guaranteed to exist in `out/` for deployment.


https://github.com/user-attachments/assets/440ef7ee-d6ed-44e4-beb2-805364355665

# How

<!--
How did you build this feature or fix this bug and why?
-->

This fixes a production issue where `/llms.txt` could end up in the 404 fallback flow (and show the redirected behavior) instead of being served as a static file.
- Updated `scripts/generate-llms/index.js` to sync generated files into `out/`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Visit: https://pr-42988.expo-docs.pages.dev/llms.txt

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
