### PR TITLE
[ci] Fix: execute postinstall on cache hit

### DIFF
--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -226,7 +226,6 @@ jobs:
         with:
           yarn-workspace: 'true'
       - name: 🧶 Install node modules in root dir
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🤖 Run Android tests
         uses: ./.github/actions/use-android-emulator

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -93,7 +93,6 @@ jobs:
           yarn-tools: 'true'
           bare-expo-pods: 'true'
       - name: 🧶 Install node modules in root dir
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🕵️ Debug CocoaPods lockfiles
         run: git diff Podfile.lock Pods/Manifest.lock
@@ -187,7 +186,6 @@ jobs:
         with:
           yarn-workspace: 'true'
       - name: 🧶 Install node modules in root dir
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🧶 Install image comparison server node modules
         run: yarn install --frozen-lockfile
@@ -279,7 +277,6 @@ jobs:
           yarn-tools: 'true'
           react-native-gradle-downloads: 'true'
       - name: 🧶 Install workspace node modules
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🧶 Install image comparison server node modules
         run: yarn install --frozen-lockfile
@@ -361,7 +358,6 @@ jobs:
         with:
           yarn-workspace: 'true'
       - name: 🧶 Install node modules in root dir
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🧶 Install image comparison server node modules
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
# Why
If the node_modules cache is hit, yarn install is skipped. However, yarn install triggers `yarn postinstall`, which is mandatory as the files produced by this command are not in the cache.

# How
Remove the conditions which skip `yarn install`

# Test Plan
Github Actions 