### PR TITLE
[expo] Update `lottie-react-native` to `7.3.5`

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -674,7 +674,7 @@ PODS:
   - libwebp/webp (1.5.0):
     - libwebp/sharpyuv
   - lottie-ios (4.5.0)
-  - lottie-react-native (7.3.4):
+  - lottie-react-native (7.3.5):
     - hermes-engine
     - lottie-ios (= 4.5.0)
     - RCTRequired
@@ -3870,7 +3870,7 @@ SPEC CHECKSUMS:
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
-  lottie-react-native: 97a11537edc72d0763edab0c83e8cc8a0b9d8484
+  lottie-react-native: bb71dad3f6d44ff2f234d46b6d684a443623f728
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: 83e25bf349dd84f894b024f48033274512d6129b

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -64,7 +64,7 @@
     "expo-notifications": "~55.0.6",
     "expo-router": "~55.0.0-preview.7",
     "expo-splash-screen": "~55.0.5",
-    "lottie-react-native": "^7.3.4",
+    "lottie-react-native": "^7.3.5",
     "native-component-list": "*",
     "react": "19.2.0",
     "react-dom": "19.2.0",

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -63,7 +63,7 @@
     "expo-web-browser": "~55.0.5",
     "graphql": "^15.3.0",
     "immutable": "^4.0.0",
-    "lottie-react-native": "^7.3.4",
+    "lottie-react-native": "^7.3.5",
     "react": "19.2.0",
     "react-native": "0.83.1",
     "react-native-edge-to-edge": "1.6.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -135,7 +135,7 @@
     "gl-mat4": "^1.1.4",
     "hsv2rgb": "^1.1.0",
     "i18n-js": "^3.1.0",
-    "lottie-react-native": "^7.3.4",
+    "lottie-react-native": "^7.3.5",
     "moment": "^2.29.4",
     "path": "^0.12.7",
     "pixi.js": "^4.6.1",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -92,7 +92,7 @@
   "expo-video": "~55.0.5",
   "expo-web-browser": "~55.0.5",
   "jest-expo": "~55.0.6",
-  "lottie-react-native": "~7.3.4",
+  "lottie-react-native": "~7.3.5",
   "react": "19.2.0",
   "react-dom": "19.2.0",
   "react-native": "0.83.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11226,10 +11226,10 @@ loose-envify@^1.0.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-lottie-react-native@^7.3.4:
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/lottie-react-native/-/lottie-react-native-7.3.4.tgz#774bc028e2b93dd88cd87ab84ac51a1c3e015cad"
-  integrity sha512-XUh7eGFb7ID8JRdU6U4N4cYQeYmjtdQRvd8ZXJ6xrdSsn5gZD0c79ITOREPcwJg4YupBFHgyV1GXdAHQP+KYUQ==
+lottie-react-native@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/lottie-react-native/-/lottie-react-native-7.3.5.tgz#515c703e8a8845c54dbd54d489467c0c1f21d8bd"
+  integrity sha512-5VPrHGbEmpNxrcEfmxyFZBvDksMaZ6LhyQZL0S0VIDwMRVrhGwOZQZKVFSEFU5HxNuDjxm/vPSoEhlKKfbYKHw==
 
 lottie-web@^5.12.2:
   version "5.12.2"


### PR DESCRIPTION
# Why

Updates `lottie-react-native` to `7.3.5`

# Test Plan

- NCL in bare-expo on both iOS and Android 