### PR TITLE
[expo] Update `@react-native-community/slider` to `5.1.2`

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2290,7 +2290,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-slider (5.1.1):
+  - react-native-slider (5.1.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2302,7 +2302,7 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-slider/common (= 5.1.1)
+    - react-native-slider/common (= 5.1.2)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -2313,7 +2313,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-slider/common (5.1.1):
+  - react-native-slider/common (5.1.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3936,7 +3936,7 @@ SPEC CHECKSUMS:
   react-native-pager-view: e37989fc447aa4b5de6d0d2ffb0229e817329246
   react-native-safe-area-context: 53f796cb6c814661bbe99fbdfd0585d07b996cdd
   react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
-  react-native-slider: 7814a1258f438c043f370eb82110ef036793e95a
+  react-native-slider: a4bbed2fba298dbcd09225b5f4a1e9baf2d04268
   react-native-skia: 9f66ac6335a2fe03db06733fafb746435c097ca0
   react-native-view-shot: 26174e54ec6b4b7c5d70b86964b747919759adc1
   react-native-webview: a0107c12442bf2ac454d509f615daef00f34df47

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -46,7 +46,7 @@
     "@expo/styleguide-base": "^1.0.1",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/datetimepicker": "8.6.0",
-    "@react-native-community/slider": "5.1.1",
+    "@react-native-community/slider": "5.1.2",
     "@react-native-community/netinfo": "11.5.2",
     "@react-native-masked-view/masked-view": "0.3.2",
     "@react-native-picker/picker": "2.11.4",

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -29,7 +29,7 @@
     "@graphql-codegen/introspection": "^2.1.1",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/datetimepicker": "^8.6.0",
-    "@react-native-community/slider": "5.1.1",
+    "@react-native-community/slider": "5.1.2",
     "@react-native-community/netinfo": "11.5.2",
     "@react-native-masked-view/masked-view": "0.3.2",
     "@react-native-picker/picker": "2.11.4",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -43,7 +43,7 @@
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/datetimepicker": "8.6.0",
     "@expo/app-integrity": "~55.0.5",
-    "@react-native-community/slider": "5.1.1",
+    "@react-native-community/slider": "5.1.2",
     "@react-native-community/netinfo": "11.5.2",
     "@react-native-masked-view/masked-view": "0.3.2",
     "@react-native-picker/picker": "2.11.4",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -6,7 +6,7 @@
   "@react-native-async-storage/async-storage": "2.2.0",
   "@react-native-community/datetimepicker": "8.6.0",
   "@react-native-masked-view/masked-view": "0.3.2",
-  "@react-native-community/slider": "5.1.1",
+  "@react-native-community/slider": "5.1.2",
   "@react-native-community/netinfo": "11.5.2",
   "@react-native-community/viewpager": "5.0.11",
   "@react-native-picker/picker": "2.11.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3604,10 +3604,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-11.5.2.tgz#daf3bc1b5cf6e9fc6725600c9e95875b5e50e694"
   integrity sha512-/g0m65BtX9HU+bPiCH2517bOHpEIUsGrWFXDzi1a5nNKn5KujQgm04WhL7/OSXWKHyrT8VVtUoJA0XKRxueBpQ==
 
-"@react-native-community/slider@5.1.1":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-5.1.1.tgz#321c37da565b264fd8f96a4edcb55d3fe78f26aa"
-  integrity sha512-W98If/LnTaziU3/0h5+G1LvJaRhMc6iLQBte6UWa4WBIHDMaDPglNBIFKcCXc9Dxp83W+f+5Wv22Olq9M2HJYA==
+"@react-native-community/slider@5.1.2":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-5.1.2.tgz#b7255c27b52d74440bcf146a05dcf13c94e7d91c"
+  integrity sha512-UV/MjCyCtSjS5BQDrrGIMmCXm309xEG6XbR0Dj65kzTraJSVDxSjQS2uBUXgX+5SZUOCzCxzv3OufOZBdtQY4w==
 
 "@react-native-masked-view/masked-view@0.3.2":
   version "0.3.2"


### PR DESCRIPTION
# Why

Updates `@react-native-community/slider` to `5.1.2`

# Test Plan

- NCL in bare-expo on both iOS and Android 