### PR TITLE
[jest-expo][expo-file-system] Fix expo-file-system mock to support new File/Directory/Paths API

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix Jest mock to support new `File`/`Directory`/`Paths` API. ([#43005](https://github.com/expo/expo/pull/43005) by [@aleqsio](https://github.com/aleqsio))
+
 ### 💡 Others
 
 ## 55.0.4 — 2026-02-03

--- a/packages/expo-file-system/mocks/FileSystem.ts
+++ b/packages/expo-file-system/mocks/FileSystem.ts
@@ -10,6 +10,12 @@ export type TypedArray = any;
 
 export type CreateOptions = any;
 
+export const documentDirectory = 'file:///mock/document/';
+export const cacheDirectory = 'file:///mock/cache/';
+export const bundleDirectory = 'file:///mock/bundle/';
+export const totalDiskSpace = 1000000000;
+export const availableDiskSpace = 500000000;
+
 export function info(url: URL): any {}
 
 export async function downloadFileAsync(
@@ -18,7 +24,16 @@ export async function downloadFileAsync(
   options: DownloadOptions | undefined
 ): Promise<any> {}
 
+export async function pickDirectoryAsync(initialUri?: string): Promise<any> {}
+
+export async function pickFileAsync(initialUri?: string, mimeType?: string): Promise<any> {}
+
 export class FileSystemFile {
+  uri: string;
+  exists: boolean = false;
+  constructor(uri: string) {
+    this.uri = uri;
+  }
   validatePath(): any {}
   textSync(): any {}
   base64Sync(): any {}
@@ -30,6 +45,7 @@ export class FileSystemFile {
   create(options: CreateOptions | undefined): any {}
   copy(to: FileSystemPath): any {}
   move(to: FileSystemPath): any {}
+  rename(newName: string): any {}
   async text(): Promise<any> {}
   async base64(): Promise<any> {}
   async bytes(): Promise<any> {}
@@ -42,11 +58,19 @@ export class FileSystemFileHandle {
 }
 
 export class FileSystemDirectory {
+  uri: string;
+  exists: boolean = false;
+  constructor(uri: string) {
+    this.uri = uri;
+  }
   info(): any {}
   validatePath(): any {}
   delete(): any {}
   create(options: CreateOptions | undefined): any {}
   copy(to: FileSystemPath): any {}
   move(to: FileSystemPath): any {}
+  rename(newName: string): any {}
   listAsRecords(): any {}
+  createFile(name: string, mimeType: string | null): any {}
+  createDirectory(name: string): any {}
 }

--- a/packages/expo-file-system/src/__tests__/FileSystem-test.native.ts
+++ b/packages/expo-file-system/src/__tests__/FileSystem-test.native.ts
@@ -1,0 +1,94 @@
+import { File, Directory, Paths } from 'expo-file-system';
+
+describe('expo-file-system new API', () => {
+  it('exports File, Directory, and Paths classes', () => {
+    expect(File).toBeDefined();
+    expect(Directory).toBeDefined();
+    expect(Paths).toBeDefined();
+  });
+
+  it('Paths.document returns a Directory with a mock URI', () => {
+    const doc = Paths.document;
+    expect(doc).toBeDefined();
+    expect(doc.uri).toBe('file:///mock/document/');
+  });
+
+  it('Paths.cache returns a Directory with a mock URI', () => {
+    const cache = Paths.cache;
+    expect(cache).toBeDefined();
+    expect(cache.uri).toBe('file:///mock/cache/');
+  });
+
+  it('Paths.bundle returns a Directory with a mock URI', () => {
+    const bundle = Paths.bundle;
+    expect(bundle).toBeDefined();
+    expect(bundle.uri).toBe('file:///mock/bundle/');
+  });
+
+  it('Paths.totalDiskSpace and availableDiskSpace return numbers', () => {
+    expect(typeof Paths.totalDiskSpace).toBe('number');
+    expect(typeof Paths.availableDiskSpace).toBe('number');
+  });
+
+  it('can construct a File from Paths.cache', () => {
+    const file = new File(Paths.cache, 'test.txt');
+    expect(file).toBeDefined();
+    expect(file.uri).toContain('test.txt');
+    expect(file.uri).toContain('mock/cache');
+  });
+
+  it('can construct a Directory from Paths.document', () => {
+    const dir = new Directory(Paths.document, 'subdir');
+    expect(dir).toBeDefined();
+    expect(dir.uri).toContain('subdir');
+    expect(dir.uri).toContain('mock/document');
+  });
+
+  it('File has inherited methods from native mock', () => {
+    const file = new File(Paths.cache, 'test.txt');
+    expect(typeof file.delete).toBe('function');
+    expect(typeof file.create).toBe('function');
+    expect(typeof file.copy).toBe('function');
+    expect(typeof file.move).toBe('function');
+    expect(typeof file.text).toBe('function');
+    expect(typeof file.write).toBe('function');
+  });
+
+  it('Directory has inherited methods from native mock', () => {
+    const dir = new Directory(Paths.document, 'subdir');
+    expect(typeof dir.delete).toBe('function');
+    expect(typeof dir.create).toBe('function');
+    expect(typeof dir.copy).toBe('function');
+    expect(typeof dir.move).toBe('function');
+  });
+
+  it('File.parentDirectory returns a Directory', () => {
+    const file = new File(Paths.cache, 'subdir', 'test.txt');
+    const parent = file.parentDirectory;
+    expect(parent).toBeInstanceOf(Directory);
+    expect(parent.uri).toContain('subdir');
+  });
+
+  it('File.name and File.extension work', () => {
+    const file = new File(Paths.cache, 'test.txt');
+    expect(file.name).toBe('test.txt');
+    expect(file.extension).toBe('.txt');
+  });
+});
+
+describe('expo-file-system/legacy mock', () => {
+  it('legacy API functions are mocked', () => {
+    const legacy = require('expo-file-system/legacy');
+    expect(legacy.downloadAsync).toBeDefined();
+    expect(legacy.getInfoAsync).toBeDefined();
+    expect(legacy.readAsStringAsync).toBeDefined();
+    expect(legacy.deleteAsync).toBeDefined();
+    expect(typeof legacy.downloadAsync).toBe('function');
+  });
+
+  it('legacy mock functions return promises', async () => {
+    const legacy = require('expo-file-system/legacy');
+    const result = await legacy.downloadAsync();
+    expect(result).toEqual({ md5: 'md5', uri: 'uri' });
+  });
+});

--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `expo-file-system` mock to target `expo-file-system/legacy` instead of replacing the entire module, and preserve prototype chains for native module class mocks. ([#43005](https://github.com/expo/expo/pull/43005) by [@aleqsio](https://github.com/aleqsio))
+
 ### 💡 Others
 
 ## 55.0.6 — 2026-02-03


### PR DESCRIPTION
## Summary
- Retargets the `jest.mock('expo-file-system', ...)` in jest-expo's setup to `expo-file-system/legacy`, so the new class-based API (`File`, `Directory`, `Paths`) is no longer replaced by legacy function stubs
- Adds missing module constants (`documentDirectory`, `cacheDirectory`, `bundleDirectory`, `totalDiskSpace`, `availableDiskSpace`) and constructor support to the native module mock in `expo-file-system/mocks/FileSystem.ts`
- Fixes `requireMockModule` to not wrap classes with `jest.fn()`, which was destroying the prototype chain needed for `extends` (e.g. `File extends ExpoFileSystem.FileSystemFile`)
- Adds tests for the new API exercising `Paths`, `File`, and `Directory` construction and method availability in Jest

## Test plan
- [x] `yarn test` in `packages/jest-expo` — 23 suites, 93 tests pass
- [x] `yarn test` in `packages/expo-file-system` — 4 suites, 34 tests pass (including new + existing legacy tests)
- [x] Verify in a user project that `import { File, Directory, Paths } from 'expo-file-system'` works in Jest tests

Fixes https://github.com/expo/expo/issues/39922