### PR TITLE
feat(cli): Add initial event logging system

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -34,6 +34,7 @@ _This version does not introduce any user-facing changes._
 - Retrieve default route's IP address concurrently ([#42923](https://github.com/expo/expo/pull/42923) by [@kitten](https://github.com/kitten))
 - Replace `require-from-string` with `@expo/require-utils` ([#42884](https://github.com/expo/expo/pull/42884) by [@kitten](https://github.com/kitten))
 - Refactor env loading and reloading to unified logic and don't overwrite original system values ([#43038](https://github.com/expo/expo/pull/43038) by [@kitten](https://github.com/kitten))
+- Add initial event logging system ([#43013](https://github.com/expo/expo/pull/43013) by [@kitten](https://github.com/kitten))
 
 ## 55.0.7 — 2026-02-08
 

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -4,6 +4,8 @@ import chalk from 'chalk';
 import Debug from 'debug';
 import { boolish } from 'getenv';
 
+import { installEventLogger } from '../src/events';
+
 // Check Node.js version and issue a loud warning if it's too outdated
 // This is sent to stderr (console.error) so it doesn't interfere with programmatic commands
 const NODE_MIN = [20, 19, 4];
@@ -15,6 +17,9 @@ if (nodeVersion[0] < NODE_MIN[0] || (nodeVersion[0] === NODE_MIN[0] && nodeVersi
       + chalk.red`Go to: https://nodejs.org/en/download\n`
   );
 }
+
+// Setup event logger output
+installEventLogger();
 
 // Setup before requiring `debug`.
 if (boolish('EXPO_DEBUG', false)) {

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -6,6 +6,10 @@ import { boolish } from 'getenv';
 
 import { installEventLogger } from '../src/events';
 
+// Setup event logger output
+// NOTE: Done before any console output
+installEventLogger();
+
 // Check Node.js version and issue a loud warning if it's too outdated
 // This is sent to stderr (console.error) so it doesn't interfere with programmatic commands
 const NODE_MIN = [20, 19, 4];
@@ -17,9 +21,6 @@ if (nodeVersion[0] < NODE_MIN[0] || (nodeVersion[0] === NODE_MIN[0] && nodeVersi
       + chalk.red`Go to: https://nodejs.org/en/download\n`
   );
 }
-
-// Setup event logger output
-installEventLogger();
 
 // Setup before requiring `debug`.
 if (boolish('EXPO_DEBUG', false)) {

--- a/packages/@expo/cli/src/events/__tests__/stream-test.ts
+++ b/packages/@expo/cli/src/events/__tests__/stream-test.ts
@@ -1,0 +1,499 @@
+import fs from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { LogStream } from '../stream';
+
+jest.unmock('fs');
+
+let destFile: string;
+let destFD: number;
+
+beforeEach(() => {
+  destFile = path.resolve(tmpdir(), `logstream-${Math.random().toString(36).substring(7)}.log`);
+  destFD = fs.openSync(destFile, 'w', 0o666);
+});
+
+afterEach(async () => {
+  try {
+    fs.closeSync(destFD);
+  } catch {}
+  try {
+    fs.unlinkSync(destFile);
+  } catch {}
+});
+
+describe('basic write operations', () => {
+  it('writes before destroying a stream', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    expect(stream.write('hello world\n')).toBeTruthy();
+    stream.destroy();
+
+    await _close;
+    expect(await fs.promises.readFile(destFile, 'utf8')).toBe('hello world\n');
+  });
+
+  it('writes twice then ends a stream', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    expect(stream.write('line 1\n')).toBeTruthy();
+    expect(stream.write('line 2\n')).toBeTruthy();
+    stream.end();
+
+    await _close;
+    expect(await fs.promises.readFile(destFile, 'utf8')).toBe('line 1\nline 2\n');
+  });
+
+  it('performs partial writes atomically', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    expect(stream.write('line')).toBeTruthy();
+    expect(stream.write(' 1\n')).toBeTruthy();
+    stream.destroy();
+
+    await _close;
+    expect(await fs.promises.readFile(destFile, 'utf8')).toBe('line 1\n');
+  });
+
+  it('writes multiple lines in a single call', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    stream.write('line 1\nline 2\nline 3\n');
+    stream.end();
+
+    await _close;
+    expect(await fs.promises.readFile(destFile, 'utf8')).toBe('line 1\nline 2\nline 3\n');
+  });
+
+  it('handles empty writes', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    stream.write('');
+    stream.write('hello\n');
+    stream.write('');
+    stream.end();
+
+    await _close;
+    expect(await fs.promises.readFile(destFile, 'utf8')).toBe('hello\n');
+  });
+
+  it('writes with Uint8Array input', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    const data = new TextEncoder().encode('hello world\n');
+    stream.write(data);
+    stream.end();
+
+    await _close;
+    expect(await fs.promises.readFile(destFile, 'utf8')).toBe('hello world\n');
+  });
+});
+
+describe('partial line handling', () => {
+  it('accumulates multiple partial writes before newline', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    stream.write('a');
+    stream.write('b');
+    stream.write('c');
+    stream.write('\n');
+    stream.end();
+
+    await _close;
+    expect(await fs.promises.readFile(destFile, 'utf8')).toBe('abc\n');
+  });
+
+  it('handles interleaved complete and partial lines', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    stream.write('complete 1\npartial');
+    stream.write(' complete 2\n');
+    stream.end();
+
+    await _close;
+    expect(await fs.promises.readFile(destFile, 'utf8')).toBe('complete 1\npartial complete 2\n');
+  });
+
+  it('does not write incomplete lines on destroy', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    stream.write('complete\n');
+    stream.write('incomplete');
+    stream.destroy();
+
+    await _close;
+    expect(await fs.promises.readFile(destFile, 'utf8')).toBe('complete\n');
+  });
+
+  it('does not write incomplete lines on end', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    stream.write('complete\n');
+    stream.write('incomplete');
+    stream.end();
+
+    await _close;
+    expect(await fs.promises.readFile(destFile, 'utf8')).toBe('complete\n');
+  });
+});
+
+describe('flush behavior', () => {
+  it('flushes complete lines and calls callback', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    stream.write('line 1\n');
+
+    await new Promise<void>((resolve, reject) => {
+      stream.flush((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+
+    expect(await fs.promises.readFile(destFile, 'utf8')).toBe('line 1\n');
+
+    stream.end();
+    await _close;
+  });
+
+  it('preserves partial line data after flush', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    stream.write('partial');
+
+    await new Promise<void>((resolve, reject) => {
+      stream.flush((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+
+    stream.write(' complete\n');
+    stream.end();
+
+    await _close;
+    expect(await fs.promises.readFile(destFile, 'utf8')).toBe('partial complete\n');
+  });
+
+  it('preserves partial line when flushing with complete lines', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    stream.write('complete 1\n');
+    stream.write('partial');
+
+    await new Promise<void>((resolve, reject) => {
+      stream.flush((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+
+    expect(await fs.promises.readFile(destFile, 'utf8')).toBe('complete 1\n');
+
+    stream.write(' complete 2\n');
+    stream.end();
+
+    await _close;
+    expect(await fs.promises.readFile(destFile, 'utf8')).toBe('complete 1\npartial complete 2\n');
+  });
+
+  it('handles multiple flushes', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    stream.write('line 1\n');
+    await new Promise<void>((resolve) => stream.flush(() => resolve()));
+
+    stream.write('line 2\n');
+    await new Promise<void>((resolve) => stream.flush(() => resolve()));
+
+    stream.end();
+    await _close;
+
+    expect(await fs.promises.readFile(destFile, 'utf8')).toBe('line 1\nline 2\n');
+  });
+
+  it('flush on empty stream completes immediately', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    await new Promise<void>((resolve, reject) => {
+      stream.flush((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+
+    stream.end();
+    await _close;
+  });
+
+  it('flush on destroyed stream calls callback immediately', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    stream.destroy();
+    await _close;
+
+    let callbackCalled = false;
+    stream.flush(() => {
+      callbackCalled = true;
+    });
+
+    expect(callbackCalled).toBe(true);
+  });
+});
+
+describe('end behavior', () => {
+  it('end with data writes the data', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    stream.end('final line\n');
+
+    await _close;
+    expect(await fs.promises.readFile(destFile, 'utf8')).toBe('final line\n');
+  });
+
+  it('end with callback calls callback on close', async () => {
+    const stream = new LogStream(destFD);
+
+    await new Promise<void>((resolve) => {
+      stream.write('line\n');
+      stream.end(() => resolve());
+    });
+
+    expect(await fs.promises.readFile(destFile, 'utf8')).toBe('line\n');
+  });
+
+  it('end with data and callback', async () => {
+    const stream = new LogStream(destFD);
+
+    await new Promise<void>((resolve) => {
+      stream.end('line\n', resolve);
+    });
+
+    expect(await fs.promises.readFile(destFile, 'utf8')).toBe('line\n');
+  });
+
+  it('emits finish event on end', async () => {
+    const stream = new LogStream(destFD);
+    const _finish = new Promise((resolve) => stream.on('finish', resolve));
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    stream.write('line\n');
+    stream.end();
+
+    await _finish;
+    await _close;
+  });
+
+  it('multiple end calls are idempotent', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    stream.write('line\n');
+    stream.end();
+    stream.end();
+    stream.end();
+
+    await _close;
+    expect(await fs.promises.readFile(destFile, 'utf8')).toBe('line\n');
+  });
+});
+
+describe('file path support', () => {
+  it('opens and writes to file path', async () => {
+    const filePath = path.resolve(tmpdir(), `logstream-path-${Date.now()}.log`);
+    const stream = new LogStream(filePath);
+
+    const _ready = new Promise((resolve) => stream.on('ready', resolve));
+    await _ready;
+
+    expect(stream.file).toBe(filePath);
+    expect(stream.fd).toBeGreaterThan(0);
+
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+    stream.write('hello from path\n');
+    stream.end();
+
+    await _close;
+    expect(await fs.promises.readFile(filePath, 'utf8')).toBe('hello from path\n');
+
+    await fs.promises.unlink(filePath);
+  });
+
+  it('creates parent directories for file path', async () => {
+    const filePath = path.resolve(tmpdir(), `logstream-nested-${Date.now()}`, 'subdir', 'test.log');
+    const stream = new LogStream(filePath);
+
+    const _ready = new Promise((resolve) => stream.on('ready', resolve));
+    await _ready;
+
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+    stream.write('nested file\n');
+    stream.end();
+
+    await _close;
+    expect(await fs.promises.readFile(filePath, 'utf8')).toBe('nested file\n');
+
+    await fs.promises.rm(path.dirname(path.dirname(filePath)), { recursive: true });
+  });
+
+  it('queues writes before file is opened', async () => {
+    const filePath = path.resolve(tmpdir(), `logstream-queue-${Date.now()}.log`);
+    const stream = new LogStream(filePath);
+
+    stream.write('line 1\n');
+    stream.write('line 2\n');
+
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+    stream.end();
+
+    await _close;
+    expect(await fs.promises.readFile(filePath, 'utf8')).toBe('line 1\nline 2\n');
+
+    await fs.promises.unlink(filePath);
+  });
+});
+
+describe('stream properties', () => {
+  it('writable is true initially', () => {
+    const stream = new LogStream(destFD);
+    expect(stream.writable).toBe(true);
+  });
+
+  it('writable is false after end', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    stream.end();
+    expect(stream.writable).toBe(false);
+
+    await _close;
+  });
+
+  it('writable is false after destroy', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    stream.destroy();
+    expect(stream.writable).toBe(false);
+
+    await _close;
+  });
+
+  it('fd returns the file descriptor', () => {
+    const stream = new LogStream(destFD);
+    expect(stream.fd).toBe(destFD);
+  });
+
+  it('file returns null for fd-based stream', () => {
+    const stream = new LogStream(destFD);
+    expect(stream.file).toBeNull();
+  });
+});
+
+describe('events', () => {
+  it('emits ready event on next tick for fd', async () => {
+    const stream = new LogStream(destFD);
+    const _ready = new Promise((resolve) => stream.on('ready', resolve));
+    await _ready;
+  });
+
+  it('emits drain event when buffer is flushed', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    stream.write('line\n');
+
+    const _drain = new Promise((resolve) => stream.on('drain', resolve));
+    await _drain;
+
+    stream.end();
+    await _close;
+  });
+
+  it('emits write event with bytes written', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    const writes: number[] = [];
+    stream.on('write', (written) => writes.push(written));
+
+    stream.write('hello\n');
+    stream.end();
+
+    await _close;
+    expect(writes.length).toBeGreaterThan(0);
+    expect(writes.reduce((a, b) => a + b, 0)).toBe(6);
+  });
+
+  it('emits close event on destroy', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    stream.destroy();
+    await _close;
+  });
+});
+
+describe('write returns backpressure signal', () => {
+  it('returns true when under high water mark', () => {
+    const stream = new LogStream(destFD);
+    const result = stream.write('small\n');
+    expect(result).toBe(true);
+    stream.destroy();
+  });
+
+  it('returns false when over high water mark', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    const largeLine = 'x'.repeat(20000) + '\n';
+    const result = stream.write(largeLine);
+    expect(result).toBe(false);
+
+    stream.end();
+    await _close;
+  });
+});
+
+describe('destroyed stream behavior', () => {
+  it('write returns false on destroyed stream', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    stream.destroy();
+    await _close;
+
+    expect(stream.write('ignored\n')).toBe(false);
+  });
+});
+
+describe('Symbol.dispose', () => {
+  it('disposes the stream', async () => {
+    const stream = new LogStream(destFD);
+    const _close = new Promise((resolve) => stream.on('close', resolve));
+
+    stream.write('line\n');
+    stream[Symbol.dispose]();
+
+    await _close;
+    expect(await fs.promises.readFile(destFile, 'utf8')).toBe('line\n');
+  });
+});

--- a/packages/@expo/cli/src/events/builder.ts
+++ b/packages/@expo/cli/src/events/builder.ts
@@ -1,0 +1,76 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+
+type obj<T> = T extends { [key: string | number]: any } ? { [K in keyof T]: T[K] } : never;
+
+export type EmptyPayload = {
+  [key: string]: never;
+  key: never;
+};
+
+type AbstractPayload = Record<string, any> & {
+  key?: never;
+};
+
+export type Event<
+  Name extends string = string,
+  Payload extends AbstractPayload = EmptyPayload,
+> = obj<{ key: Name } & Payload>;
+
+export type EventShape<Name extends string, Payload = any> = Name & {
+  __payload: Payload;
+};
+
+type getEventPayloadOfShape<Shape> =
+  Shape extends EventShape<infer Name, infer Payload>
+    ? Payload extends AbstractPayload
+      ? { [K in Name]: Payload }
+      : never
+    : never;
+
+type getEventsOfShapesRec<Shapes, Out = {}> = Shapes extends readonly [infer Shape, ...infer Rest]
+  ? getEventsOfShapesRec<Rest, Out & getEventPayloadOfShape<Shape>>
+  : obj<Out>;
+
+type reduceEventLoggerEvents<EventLogger> =
+  EventLogger extends EventLoggerType<infer Category, infer Events>
+    ? Category extends string
+      ? {
+          [K in keyof Events]: K extends string
+            ? obj<{ key: `${Category}:${K}` } & Events[K]>
+            : never;
+        }[keyof Events]
+      : never
+    : never;
+
+type reduceEventLoggersRec<EventLoggers, Out = never> = EventLoggers extends readonly [
+  infer EventLogger,
+  ...infer Rest,
+]
+  ? reduceEventLoggersRec<Rest, Out | reduceEventLoggerEvents<EventLogger>>
+  : obj<Out>;
+
+interface EventLoggerType<Category, Events> {
+  category: Category;
+  __eventTypes?: () => Events;
+}
+
+export interface EventLogger<Category, Events> extends EventLoggerType<Category, Events> {
+  <EventName extends keyof Events>(event: EventName, data: Events[EventName]): void;
+}
+
+export interface EventBuilder {
+  event<const Name extends string, const Payload extends AbstractPayload>(): EventShape<
+    Name,
+    Payload
+  >;
+}
+
+export interface EventLoggerBuilder {
+  <const Category extends string, const Shapes extends readonly EventShape<string>[]>(
+    category: Category,
+    _fn: (builder: EventBuilder) => Shapes
+  ): EventLogger<Category, getEventsOfShapesRec<Shapes>>;
+}
+
+export type collectEventLoggers<EventLoggers extends [...EventLoggerType<any, any>[]]> =
+  reduceEventLoggersRec<EventLoggers>;

--- a/packages/@expo/cli/src/events/builder.ts
+++ b/packages/@expo/cli/src/events/builder.ts
@@ -4,11 +4,13 @@ type obj<T> = T extends { [key: string | number]: any } ? { [K in keyof T]: T[K]
 
 export type EmptyPayload = {
   [key: string]: never;
-  key: never;
+  _e: never;
+  _t: never;
 };
 
 type AbstractPayload = Record<string, any> & {
-  key?: never;
+  _e?: never;
+  _t?: never;
 };
 
 export type Event<

--- a/packages/@expo/cli/src/events/index.ts
+++ b/packages/@expo/cli/src/events/index.ts
@@ -81,7 +81,7 @@ export const shouldReduceLogs = () => !!logStream && env.EXPO_UNSTABLE_HEADLESS;
  * event('my_event', { myValue: 'test' });
  * ```
  *
- * This will log a `{ key: 'test:my_event', myValue: 'test' }` entry in the event log.
+ * This will log a `{ _e: 'test:my_event', _t: 0, myValue: 'test' }` entry in the event log.
  */
 export const events: EventLoggerBuilder = ((
   category: string,
@@ -89,8 +89,9 @@ export const events: EventLoggerBuilder = ((
 ) => {
   function log(event: string, data: any) {
     if (logStream) {
-      const key = `${category}:${String(event)}`;
-      const payload = JSON.stringify({ key, ...data });
+      const _e = `${category}:${String(event)}`;
+      const _t = Date.now();
+      const payload = JSON.stringify({ _e, _t, ...data });
       logStream._write(payload + '\n');
     }
   }

--- a/packages/@expo/cli/src/events/index.ts
+++ b/packages/@expo/cli/src/events/index.ts
@@ -46,7 +46,7 @@ export function installEventLogger(env = process.env.EVENT_LOG) {
 }
 
 /** Returns whether the event logger is active */
-export const shouldLogEvents = () => !!logStream;
+export const isEventLoggerActive = () => !!logStream?.writable;
 
 /** Whether logs shown in the terminal should be reduced.
  * @remarks

--- a/packages/@expo/cli/src/events/index.ts
+++ b/packages/@expo/cli/src/events/index.ts
@@ -40,9 +40,9 @@ function getInitMetadata(): InitMetadata {
 }
 
 /** Activates the event logger based on the input env var
- * @param env - The target to write the logs to; defaults to `$EVENT_LOG`
+ * @param env - The target to write the logs to; defaults to `$LOG_EVENTS`
  */
-export function installEventLogger(env = process.env.EVENT_LOG) {
+export function installEventLogger(env = process.env.LOG_EVENTS) {
   const eventLogDestination = parseLogTarget(env);
   if (eventLogDestination) {
     if (eventLogDestination === 1) {
@@ -70,7 +70,7 @@ export const isEventLoggerActive = () => !!logStream?.writable;
  */
 export const shouldReduceLogs = () => !!logStream && env.EXPO_UNSTABLE_HEADLESS;
 
-/** Used to create an event logger for structured JSONL logs activated with the `EVENT_LOG` environment variable.
+/** Used to create an event logger for structured JSONL logs activated with the `LOG_EVENTS` environment variable.
  *
  * @remarks
  * Structured logs are streamed to a JSONL output file or file descriptor, and are meant for automated tooling

--- a/packages/@expo/cli/src/events/index.ts
+++ b/packages/@expo/cli/src/events/index.ts
@@ -1,0 +1,68 @@
+import { Console } from 'node:console';
+import path from 'node:path';
+import { WriteStream } from 'node:tty';
+
+import { LogStream } from './stream';
+
+let logStream: LogStream | undefined;
+
+function parseLogTarget(env: string | undefined) {
+  let logDestination: string | number | undefined;
+  if (env) {
+    const fd = parseInt(env, 10);
+    if (fd > 0 && Number.isSafeInteger(fd)) {
+      logDestination = fd;
+    } else {
+      try {
+        const parsedPath = path.parse(env);
+        logDestination = path.format(parsedPath);
+      } catch {
+        logDestination = undefined;
+      }
+    }
+  }
+  return logDestination;
+}
+
+export function installEventLogger(env = process.env.EVENT_LOG) {
+  const eventLogDestination = parseLogTarget(env);
+  if (eventLogDestination) {
+    if (eventLogDestination === 1) {
+      const output = new WriteStream(2);
+      Object.defineProperty(process, 'stdout', { get: () => output });
+      globalThis.console = new Console(output, output);
+    } else if (eventLogDestination === 2) {
+      const output = new WriteStream(1);
+      Object.defineProperty(process, 'stderr', { get: () => output });
+      globalThis.console = new Console(output, output);
+    }
+    logStream = new LogStream(eventLogDestination);
+  }
+}
+
+type EmptyPayloads = {
+  [eventName: string]: never;
+};
+
+interface AbstractPayloads {
+  [eventName: string]: Record<string, any>;
+}
+
+export interface EventLogger<Payloads extends AbstractPayloads> {
+  <EventName extends keyof Payloads>(event: EventName, data: Payloads[EventName]): void;
+}
+
+export function events<const Payloads extends AbstractPayloads = EmptyPayloads>(
+  category: string
+): EventLogger<Payloads> {
+  return function log<EventName extends keyof Payloads>(
+    event: EventName,
+    data: Payloads[EventName]
+  ) {
+    if (logStream) {
+      const key = `${category}:${String(event)}`;
+      const payload = JSON.stringify({ key, ...data });
+      logStream._write(payload + '\n');
+    }
+  };
+}

--- a/packages/@expo/cli/src/events/index.ts
+++ b/packages/@expo/cli/src/events/index.ts
@@ -4,6 +4,7 @@ import { WriteStream } from 'node:tty';
 
 import type { EventBuilder, EventLoggerBuilder, EventShape } from './builder';
 import { LogStream } from './stream';
+import { env } from '../utils/env';
 
 let logStream: LogStream | undefined;
 
@@ -46,6 +47,14 @@ export function installEventLogger(env = process.env.EVENT_LOG) {
 
 /** Returns whether the event logger is active */
 export const shouldLogEvents = () => !!logStream;
+
+/** Whether logs shown in the terminal should be reduced.
+ * @remarks
+ * We indicate that we're in an automated tool (e.g. E2E tests) with `EXPO_UNSTABLE_HEADLESS`.
+ * If the event logger is activate and we're running in a headless tool, we should reduce
+ * interactive or noisy logs, in favour of the event logger.
+ */
+export const shouldReduceLogs = () => !!logStream && env.EXPO_UNSTABLE_HEADLESS;
 
 /** Used to create an event logger for structured JSONL logs activated with the `EVENT_LOG` environment variable.
  *

--- a/packages/@expo/cli/src/events/stream.ts
+++ b/packages/@expo/cli/src/events/stream.ts
@@ -1,0 +1,315 @@
+import { Buffer } from 'node:buffer';
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const BUSY_WRITE_TIMEOUT = 100;
+const HIGH_WATER_MARK = 16_387; /*16KB*/
+
+export class LogStream extends EventEmitter implements NodeJS.WritableStream {
+  #fd = -1;
+  #file: string | null = null;
+
+  #writing = false;
+  #ending = false;
+  #flushPending = false;
+  #destroyed = false;
+  #opening = false;
+
+  #output = '';
+  #len = 0;
+  #lines: string[] = [];
+  #partialLine = 0;
+
+  constructor(dest: string | number) {
+    super();
+    if (typeof dest === 'number') {
+      fs.fsyncSync(dest);
+      this.#fd = dest;
+      process.nextTick(() => this.emit('ready'));
+    } else if (typeof dest === 'string') {
+      this.#openFile(dest);
+    }
+  }
+
+  get file(): string | null {
+    return this.#file;
+  }
+
+  get fd(): number {
+    return this.#fd;
+  }
+
+  get writing(): boolean {
+    return this.#writing;
+  }
+
+  get writable(): boolean {
+    return !this.#destroyed && !this.#ending;
+  }
+
+  #release(error: NodeJS.ErrnoException | null, written: number) {
+    if (error) {
+      if (error.code === 'EAGAIN' || error.code === 'EBUSY') {
+        setTimeout(() => this.#writeLine(), BUSY_WRITE_TIMEOUT);
+      } else {
+        this.#writing = false;
+        this.emit('error', error);
+      }
+    } else {
+      this.emit('write', written);
+
+      const outputLength = Buffer.byteLength(this.#output);
+      if (outputLength > written) {
+        const output = Buffer.from(this.#output).subarray(written).toString();
+        this.#len -= this.#output.length - output.length;
+        this.#output = output;
+      } else {
+        this.#len -= this.#output.length;
+        this.#output = '';
+      }
+
+      if (this.#output || this.#lines.length > this.#partialLine) {
+        this.#writeLine();
+      } else if (this.#ending) {
+        this.#writing = false;
+        this.#close();
+      } else {
+        this.#writing = false;
+        this.emit('drain');
+      }
+    }
+  }
+
+  #openFile(file: string) {
+    this.#opening = true;
+    this.#writing = true;
+
+    const onOpened = (error: Error | null, fd?: number | null) => {
+      if (error) {
+        this.#writing = false;
+        this.#opening = false;
+        this.emit('error', error);
+      } else {
+        this.#fd = fd!;
+        this.#file = file;
+        this.#opening = false;
+        this.#writing = false;
+        this.emit('ready');
+        if (this.#destroyed) {
+          // do nothing when we're already closing the file
+        } else if (
+          (!this.writing && this.#lines.length > this.#partialLine) ||
+          this.#flushPending
+        ) {
+          this.#writeLine();
+        }
+      }
+    };
+
+    fs.mkdir(path.dirname(file), { recursive: true }, (err) => {
+      if (err) return onOpened(err);
+      fs.open(file, 'a', 0o666, onOpened);
+    });
+  }
+
+  #close() {
+    if (this.#fd === -1) {
+      this.once('ready', () => this.#close());
+      return;
+    }
+
+    this.#destroyed = true;
+    this.#partialLine = 0;
+    this.#lines.length = 0;
+
+    const onClose = (error?: NodeJS.ErrnoException | null) => {
+      if (error) {
+        this.emit('error', error);
+        this.emit('close', error);
+      } else {
+        if (this.#ending && !this.#writing) this.emit('finish');
+        this.emit('close');
+      }
+    };
+
+    fsFsync(this.#fd, (error) => {
+      if (!error && !isStdFd(this.#fd)) {
+        fs.close(this.#fd, onClose);
+      } else {
+        onClose(); // Error intentionally ignored, assume closed
+      }
+    });
+  }
+
+  #writeLine() {
+    this.#writing = true;
+    this.#output ||= this.#lines.length > this.#partialLine ? this.#lines.shift() || '' : '';
+    fs.write(this.#fd, this.#output, (err, written) => this.#release(err, written));
+  }
+
+  _end() {
+    if (!this.#destroyed && !this.#ending) {
+      this.#ending = true;
+      if (this.#opening) {
+        this.once('ready', () => this._end());
+      } else if (!this.#writing && this.#fd >= 0) {
+        if (this.#lines.length > this.#partialLine) {
+          this.#writeLine();
+        } else {
+          this.#close();
+        }
+      }
+    }
+    return this;
+  }
+
+  end(cb?: () => void): this;
+  end(data: string | Uint8Array, cb?: () => void): this;
+  end(str: string, encoding?: BufferEncoding, cb?: () => void): this;
+
+  end(
+    arg1?: Uint8Array | string | (() => void),
+    arg2?: BufferEncoding | (() => void),
+    arg3?: () => void
+  ) {
+    const maybeCb = arg3 || arg2 || arg1;
+    const input = typeof arg1 !== 'function' ? arg1 : undefined;
+    const encoding = typeof arg2 === 'string' ? arg2 : 'utf8';
+    const cb = typeof maybeCb === 'function' ? maybeCb : undefined;
+    if (typeof input === 'string') {
+      this.write(input, encoding);
+    } else if (input != null) {
+      this.write(input);
+    }
+    if (cb) this.once('close', cb);
+    return this._end();
+  }
+
+  destroy() {
+    if (!this.#destroyed) this.#close();
+  }
+
+  flush(cb?: (error?: Error | null) => void) {
+    if (this.#destroyed) {
+      cb?.();
+    } else {
+      const onDrain = () => {
+        if (!this.#destroyed) {
+          fsFsync(this.#fd, (error) => {
+            this.#flushPending = false;
+            if (error?.code === 'EBADF') {
+              cb?.(); // If fd is closed, ignore the error
+            } else {
+              cb?.(error);
+            }
+          });
+        } else {
+          this.#flushPending = false;
+          cb?.();
+        }
+        this.off('error', onError);
+      };
+
+      const onError = (err: Error) => {
+        this.#flushPending = false;
+        this.off('drain', onDrain);
+        cb?.(err);
+      };
+
+      this.#flushPending = true;
+      this.once('drain', onDrain);
+      this.once('error', onError);
+
+      if (!this.#writing) {
+        if (this.#lines.length > this.#partialLine || this.#output) {
+          // There are complete lines or remaining output to write
+          this.#writeLine();
+        } else {
+          // Nothing complete to write, emit drain immediately
+          process.nextTick(() => this.emit('drain'));
+        }
+      }
+    }
+  }
+
+  _write(data: string): boolean {
+    if (this.#destroyed) {
+      return false;
+    }
+
+    this.#len += data.length;
+
+    let startIdx = 0;
+    let endIdx = -1;
+    while ((endIdx = data.indexOf('\n', startIdx)) > -1) {
+      const line = data.slice(startIdx, endIdx + 1);
+      if (this.#partialLine > 0) {
+        this.#lines[this.#lines.length - 1] += line;
+      } else {
+        this.#lines.push(line);
+      }
+      this.#partialLine = 0;
+      startIdx = ++endIdx;
+    }
+
+    if (startIdx < data.length) {
+      const line = data.slice(startIdx);
+      if (this.#partialLine > 0) {
+        this.#lines[this.#lines.length - 1] += line;
+      } else {
+        this.#lines.push(data.slice(startIdx));
+      }
+      this.#partialLine = 1;
+    }
+
+    if (!this.#writing && this.#lines.length > this.#partialLine) {
+      this.#writeLine();
+    }
+
+    return this.#len < HIGH_WATER_MARK;
+  }
+
+  write(buffer: Uint8Array | string, cb?: (err?: Error | null) => void): boolean;
+  write(str: string, encoding?: BufferEncoding, cb?: (err?: Error | null) => void): boolean;
+
+  write(
+    input: Uint8Array | string,
+    arg2?: BufferEncoding | ((err?: Error | null) => void),
+    arg3?: (err?: Error | null) => void
+  ): boolean {
+    const maybeCb = arg3 || arg2;
+    const encoding = typeof arg2 === 'string' ? arg2 : 'utf8';
+    const data = typeof input === 'string' ? input : Buffer.from(input).toString(encoding);
+    const cb = typeof maybeCb === 'function' ? maybeCb : undefined;
+    try {
+      return this._write(data);
+    } finally {
+      cb?.();
+    }
+  }
+
+  [Symbol.dispose]() {
+    this.destroy();
+  }
+}
+
+const isStdFd = (fd: number) => {
+  switch (fd) {
+    case 1:
+    case 2:
+    case process.stdout.fd:
+    case process.stderr.fd:
+      return true;
+    default:
+      return false;
+  }
+};
+
+const fsFsync = (fd: number, cb: (error?: NodeJS.ErrnoException | null) => void) => {
+  try {
+    fs.fsync(fd, cb);
+  } catch (error: any) {
+    cb(error);
+  }
+};

--- a/packages/@expo/cli/src/events/types.ts
+++ b/packages/@expo/cli/src/events/types.ts
@@ -1,12 +1,9 @@
 import type { collectEventLoggers } from '../events/builder';
+import type { event as metroTerminalReporterEvent } from '../start/server/metro/MetroTerminalReporter';
 
 /** Collection of all event logger events
  * @privateRemarks
  * When creating a new logger with `events()`, import it here and
  * add it to add its types to this union type.
  */
-export type Events = collectEventLoggers<
-  [
-    // typeof startAsyncEvent,
-  ]
->;
+export type Events = collectEventLoggers<[typeof metroTerminalReporterEvent]>;

--- a/packages/@expo/cli/src/events/types.ts
+++ b/packages/@expo/cli/src/events/types.ts
@@ -1,0 +1,12 @@
+import type { collectEventLoggers } from '../events/builder';
+
+/** Collection of all event logger events
+ * @privateRemarks
+ * When creating a new logger with `events()`, import it here and
+ * add it to add its types to this union type.
+ */
+export type Events = collectEventLoggers<
+  [
+    // typeof startAsyncEvent,
+  ]
+>;

--- a/packages/@expo/cli/src/events/types.ts
+++ b/packages/@expo/cli/src/events/types.ts
@@ -1,3 +1,4 @@
+import type { rootEvent } from './index';
 import type { collectEventLoggers } from '../events/builder';
 import type { event as metroTerminalReporterEvent } from '../start/server/metro/MetroTerminalReporter';
 
@@ -6,4 +7,4 @@ import type { event as metroTerminalReporterEvent } from '../start/server/metro/
  * When creating a new logger with `events()`, import it here and
  * add it to add its types to this union type.
  */
-export type Events = collectEventLoggers<[typeof metroTerminalReporterEvent]>;
+export type Events = collectEventLoggers<[typeof rootEvent, typeof metroTerminalReporterEvent]>;

--- a/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
@@ -21,6 +21,7 @@ import {
 } from '../serverLogLikeMetro';
 import { attachImportStackToRootMessage, nearestImportStack } from './metroErrorInterface';
 import { events } from '../../../events';
+import { stripAnsi } from '../../../utils/ansi';
 
 type ClientLogLevel =
   | 'trace'
@@ -285,7 +286,7 @@ export class MetroTerminalReporter extends TerminalReporter {
       const message = maybeAppendCodeFrame(moduleResolutionError, error.message);
       event('bundling:failed', {
         id: this.#lastFailedBuildID ?? null,
-        message: error.message ?? null,
+        message: stripAnsi(message) ?? null,
         importStack: importStack ?? null,
         filename: error.filename ?? null,
         targetModuleName: this.#normalizePath(error.targetModuleName),
@@ -296,7 +297,7 @@ export class MetroTerminalReporter extends TerminalReporter {
     } else {
       event('bundling:failed', {
         id: this.#lastFailedBuildID ?? null,
-        message: error.message ?? null,
+        message: stripAnsi(error.message) ?? null,
         importStack: importStack ?? null,
         filename: error.filename ?? null,
         targetModuleName: error.targetModuleName ?? null,

--- a/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
@@ -92,7 +92,7 @@ export class MetroTerminalReporter extends TerminalReporter {
   #lastFailedBuildID: string | undefined;
 
   constructor(
-    public projectRoot: string,
+    public serverRoot: string,
     terminal: Terminal
   ) {
     super(terminal);
@@ -279,7 +279,7 @@ export class MetroTerminalReporter extends TerminalReporter {
 
   _logBundlingError(error: SnippetError): void {
     const importStack = nearestImportStack(error);
-    const moduleResolutionError = formatUsingNodeStandardLibraryError(this.projectRoot, error);
+    const moduleResolutionError = formatUsingNodeStandardLibraryError(this.serverRoot, error);
 
     if (moduleResolutionError) {
       const message = maybeAppendCodeFrame(moduleResolutionError, error.message);
@@ -345,7 +345,7 @@ export class MetroTerminalReporter extends TerminalReporter {
               typeof p.message === 'string'
             ) {
               return maybeSymbolicateAndFormatJSErrorStackLogAsync(
-                this.projectRoot,
+                this.serverRoot,
                 level,
                 p as any
               );
@@ -426,7 +426,7 @@ export class MetroTerminalReporter extends TerminalReporter {
 
   #normalizePath<T extends string | null>(dest: T | undefined): T | string {
     return dest != null && path.isAbsolute(dest)
-      ? path.relative(this.projectRoot, dest)
+      ? path.relative(this.serverRoot, dest)
       : ((dest || null) as T);
   }
 }
@@ -439,7 +439,7 @@ export class MetroTerminalReporter extends TerminalReporter {
  * @returns error message or null if not a module resolution error
  */
 export function formatUsingNodeStandardLibraryError(
-  projectRoot: string,
+  serverRoot: string,
   error: SnippetError
 ): string | null {
   if (!error.message) {
@@ -449,7 +449,7 @@ export function formatUsingNodeStandardLibraryError(
   if (!targetModuleName || !originModulePath) {
     return null;
   }
-  const relativePath = path.relative(projectRoot, originModulePath);
+  const relativePath = path.relative(serverRoot, originModulePath);
 
   const DOCS_PAGE_URL =
     'https://docs.expo.dev/workflow/using-libraries/#using-third-party-libraries';

--- a/packages/@expo/cli/src/start/server/metro/metroErrorInterface.ts
+++ b/packages/@expo/cli/src/start/server/metro/metroErrorInterface.ts
@@ -401,14 +401,13 @@ export function likelyContainsCodeFrame(message: string | undefined): boolean {
  * Walks thru the error cause chain and attaches the import stack to the root error message.
  * Removes the error stack for import and syntax errors.
  */
-export const attachImportStackToRootMessage = (err: unknown) => {
-  if (!(err instanceof Error)) return;
-
+export const attachImportStackToRootMessage = (
+  err: unknown,
+  importStack = nearestImportStack(err)
+) => {
   // Space out build failures.
-  const nearestImportStackValue = nearestImportStack(err);
-  if (nearestImportStackValue) {
-    err.message += '\n\n' + nearestImportStackValue;
-
+  if (err instanceof Error && importStack) {
+    err.message += '\n\n' + importStack;
     if (!isDebug) {
       // When not debugging remove the stack to avoid cluttering the output and confusing users,
       // the import stack is the guide to fixing the error.


### PR DESCRIPTION
# Why

Based on / Supersedes #42249

We should be able to log JSONL events and capture them for debugging. In theory, most places that receive/send events, or that have `debug` calls that are ultimately useful to be surfaced in non-terminal environments or when more output is needed should have event calls.

In the future, we may be able to add the `profiler` system to this as well, and be able to fork performance-relevant data (e.g. performance marks and profiler outputs) out of the event system.

As a proof of concept, this ports the `MetroTerminalReporter` events to the new system (with new requirements applied)

# How

**Base Requirements:**
- should be able to write to file descriptors (compatible with both unix sockets and files/streams), and to file paths
- shouldn't slow down the runtime of the CLI by much more than the cost to stringify JSONL events
- should be able to define types ahead of time and collect them in one place

Most events we want to capture can be captured rapidly (we shouldn't care too much about how many events we log), and we should keep pre-processing to a minimum to allow the event system to always be active without much overhead.

The stream that we're writing with is similar to `FastUtf8Stream` / `SonicBoom` and is non-blocking. Flushing is avoided to keep performance high.

- Implement non-blocking `LogStream`
- Add `installEventLogger` to entrypoint
  - protects stdout/stderr when logger is active on one of them)
- Add `events('category')` helper to create structured log events
- Add logger to `MetroTerminalReporter` to demonstrate usage
- Clean up calls in `MetroTerminalReporter` and pass sanitized data to event logger
- Add `shouldReduceLogs` helper and disable bundling progress when headless is active and event logger is used
- **Drive-by fix:** Rename `projectRoot` variable in `MetroTerminalReporter` to `serverRoot` to reflect its actual path

# Test Plan

Verify that metro events are logged:
- Run `LOG_EVENTS=events.log expo start` and check `events.log`
- Run `LOG_EVENTS=1 expo start` and check standard output

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
