### PR TITLE
[audio][2/2] - Rework foreground service handling - native Android changes

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -17,7 +17,7 @@
 ### 💡 Others
 
 - [Android] Improve event handling. ([#43121](https://github.com/expo/expo/pull/43121) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Rework native audio service handling.
+- [Android] Rework native audio service handling. ([#43015](https://github.com/expo/expo/pull/43015) by [@behenate](https://github.com/behenate))
 
 ## 55.0.5 — 2026-02-08
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### 💡 Others
 
 - [Android] Improve event handling. ([#43121](https://github.com/expo/expo/pull/43121) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Rework native audio service handling.
 
 ## 55.0.5 — 2026-02-08
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioExceptions.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioExceptions.kt
@@ -2,6 +2,15 @@ package expo.modules.audio
 
 import expo.modules.kotlin.exception.CodedException
 
+private const val defaultPlaybackServiceTip =
+  "Make sure that the expo-audio config plugin is properly configured with " +
+    "'enableBackgroundPlayback: true' to avoid issues with lock screen controls " +
+    "and background audio playback."
+
+private const val defaultRecordingServiceTip =
+  "Make sure that the expo-audio config plugin is properly configured with " +
+    "'enableBackgroundRecording: true' to avoid issues with background recording."
+
 internal class AudioPermissionsException :
   CodedException("RECORD_AUDIO permission has not been granted")
 
@@ -22,3 +31,23 @@ internal class AudioRecorderPrepareException(cause: Throwable) :
 
 internal class AudioRecorderAlreadyPreparedException :
   CodedException("AudioRecorder has already been prepared. Stop or release the current session before preparing again.")
+
+internal fun getPlaybackServiceErrorMessage(
+  message: String?,
+  tip: String = defaultPlaybackServiceTip
+): String {
+  return (message ?: "expo-audio playback service error") + ". $tip"
+}
+
+internal fun getRecordingServiceErrorMessage(
+  message: String?,
+  tip: String = defaultRecordingServiceTip
+): String {
+  return (message ?: "expo-audio recording service error") + ". $tip"
+}
+
+internal class AudioRecordingServiceException(message: String?, cause: Throwable? = null) :
+  CodedException(getRecordingServiceErrorMessage(message), cause)
+
+internal class AudioPlaybackServiceException(message: String?, cause: Throwable? = null) :
+  CodedException(getPlaybackServiceErrorMessage(message), cause)

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioExceptions.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioExceptions.kt
@@ -14,6 +14,12 @@ private const val defaultRecordingServiceTip =
 internal class AudioPermissionsException :
   CodedException("RECORD_AUDIO permission has not been granted")
 
+internal class NotificationPermissionsException :
+  CodedException(
+    "POST_NOTIFICATIONS permission has not been granted. This permission is required when using background recording (allowsBackgroundRecording: true). " +
+      "Request notification permissions using AudioModule.requestNotificationPermissionsAsync() before calling prepareRecording()."
+  )
+
 internal class GetAudioInputNotSupportedException :
   CodedException("Getting current audio input is not supported on devices running Android version lower than Android 9.0")
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
@@ -28,10 +28,10 @@ import androidx.media3.exoplayer.hls.HlsMediaSource
 import androidx.media3.exoplayer.smoothstreaming.SsMediaSource
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
-import expo.modules.audio.service.AudioControlsService
 import expo.modules.interfaces.permissions.Permissions
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.Exceptions
+import expo.modules.kotlin.functions.Coroutine
 import expo.modules.kotlin.functions.Queues
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
@@ -273,8 +273,6 @@ class AudioModule : Module() {
         recorders.values.forEach {
           it.stopRecording()
         }
-
-        AudioControlsService.clearSession()
       }
     }
 
@@ -498,7 +496,7 @@ class AudioModule : Module() {
         recorder.getCurrentTimeSeconds()
       }
 
-      AsyncFunction("prepareToRecordAsync") { recorder: AudioRecorder, options: RecordingOptions? ->
+      AsyncFunction("prepareToRecordAsync") Coroutine { recorder: AudioRecorder, options: RecordingOptions? ->
         checkRecordingPermission()
         recorder.prepareRecording(options)
       }

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
@@ -90,7 +90,7 @@ class AudioRecorder(
     if (useForegroundService && !hasNotificationPermissions()) {
       throw NotificationPermissionsException()
     }
-    
+
     val recordingOptions = options ?: this.options
     val mediaRecorder = createRecorder(recordingOptions)
     recorder = mediaRecorder

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
@@ -13,15 +13,19 @@ import android.os.Build
 import android.os.Bundle
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
-import expo.modules.audio.service.AudioRecordingService
+import expo.modules.audio.service.AudioRecordingServiceConnection
 import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.exception.CodedException
+import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.sharedobjects.SharedObject
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.io.File
 import java.io.IOException
+import java.lang.ref.WeakReference
 import java.util.UUID
+import kotlin.coroutines.Continuation
 import kotlin.math.log10
 
 private const val RECORDING_STATUS_UPDATE = "recordingStatusUpdate"
@@ -45,7 +49,14 @@ class AudioRecorder(
   var isPaused = false
   private var recordingTimerJob: Job? = null
   var useForegroundService = false
-  private var isRegisteredWithService = false
+  private var bindingContinuation: Continuation<Boolean>? = null
+
+  val serviceConnection = AudioRecordingServiceConnection(WeakReference(this), appContext)
+
+  private val _appContext: AppContext
+    get() {
+      return appContext ?: throw Exceptions.AppContextLost()
+    }
 
   private fun currentFileUrl(): String? =
     filePath?.let(::File)?.toUri()?.toString()
@@ -71,25 +82,36 @@ class AudioRecorder(
     }
   }
 
-  fun prepareRecording(options: RecordingOptions?) {
+  suspend fun prepareRecording(options: RecordingOptions?) {
     if (recorder != null || isPrepared || isRecording || isPaused) {
       throw AudioRecorderAlreadyPreparedException()
     }
     val recordingOptions = options ?: this.options
     val mediaRecorder = createRecorder(recordingOptions)
     recorder = mediaRecorder
+
     try {
+      if (useForegroundService) {
+        serviceConnection.bindWithService()
+      }
       mediaRecorder.prepare()
       isPrepared = true
-    } catch (cause: Exception) {
+    } catch (e: Exception) {
       mediaRecorder.release()
       recorder = null
       isPrepared = false
-      throw AudioRecorderPrepareException(cause)
+
+      throw e as? CodedException ?: AudioRecorderPrepareException(e)
     }
   }
 
   fun record() {
+    if (useForegroundService) {
+      serviceConnection.recordingServiceBinder?.service?.registerRecorder(this) ?: run {
+        throw AudioRecordingServiceException("The service connection is not bound, but `allowsBackgroundRecording` is set to `true`")
+      }
+    }
+
     if (isPaused) {
       recorder?.resume()
     } else {
@@ -98,11 +120,6 @@ class AudioRecorder(
     startTime = System.currentTimeMillis()
     isRecording = true
     isPaused = false
-
-    if (useForegroundService && !isRegisteredWithService) {
-      AudioRecordingService.startService(context, this)
-      isRegisteredWithService = true
-    }
   }
 
   fun recordWithOptions(atTimeSeconds: Double? = null, forDurationSeconds: Double? = null) {
@@ -147,9 +164,8 @@ class AudioRecorder(
     var stopFailed = false
     var stopError: String? = null
 
-    if (useForegroundService && isRegisteredWithService) {
-      AudioRecordingService.getInstance()?.unregisterRecorder(this)
-      isRegisteredWithService = false
+    if (useForegroundService) {
+      serviceConnection.recordingServiceBinder?.service?.unregisterRecorder(this)
     }
 
     try {
@@ -259,9 +275,16 @@ class AudioRecorder(
 
   override fun sharedObjectDidRelease() {
     super.sharedObjectDidRelease()
-    if (useForegroundService && isRegisteredWithService) {
-      AudioRecordingService.getInstance()?.unregisterRecorder(this)
-      isRegisteredWithService = false
+
+    // Mark recorder as released
+    serviceConnection.release()
+
+    if (useForegroundService) {
+      serviceConnection.recordingServiceBinder?.service?.unregisterRecorder(this)
+      // Unbind service connection
+      serviceConnection.unbind()
+      // Clean up service connection resources
+      serviceConnection.cleanup()
     }
     reset()
   }
@@ -319,9 +342,10 @@ class AudioRecorder(
       MEDIA_RECORDER_INFO_MAX_FILESIZE_REACHED -> {
         val url = currentFileUrl()
 
-        if (useForegroundService && isRegisteredWithService) {
-          AudioRecordingService.getInstance()?.unregisterRecorder(this)
-          isRegisteredWithService = false
+        if (useForegroundService) {
+          serviceConnection.recordingServiceBinder?.service?.unregisterRecorder(this)
+          // Unbind the service connection
+          serviceConnection.unbind()
         }
 
         try {

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
@@ -86,6 +86,11 @@ class AudioRecorder(
     if (recorder != null || isPrepared || isRecording || isPaused) {
       throw AudioRecorderAlreadyPreparedException()
     }
+
+    if (useForegroundService && !hasNotificationPermissions()) {
+      throw NotificationPermissionsException()
+    }
+    
     val recordingOptions = options ?: this.options
     val mediaRecorder = createRecorder(recordingOptions)
     recorder = mediaRecorder
@@ -413,6 +418,14 @@ class AudioRecorder(
 
   private fun hasRecordingPermissions() =
     ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED
+
+  private fun hasNotificationPermissions(): Boolean {
+    // POST_NOTIFICATIONS permission is only required on Android 13+ (API 33+)
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+      return true
+    }
+    return ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
+  }
 
   fun getAvailableInputs(audioManager: AudioManager) =
     audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS).mapNotNull { deviceInfo ->

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioUtils.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioUtils.kt
@@ -1,7 +1,10 @@
 package expo.modules.audio
 
+import android.content.Context
 import android.media.AudioDeviceInfo
 import android.os.Bundle
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.session.MediaSession
 import java.io.File
 import java.io.IOException
 
@@ -26,4 +29,10 @@ fun getMapFromDeviceInfo(deviceInfo: AudioDeviceInfo): Bundle {
   map.putString("type", type)
   map.putString("uid", deviceInfo.id.toString())
   return map
+}
+
+fun buildBasicMediaSession(context: Context, player: ExoPlayer): MediaSession {
+  return MediaSession.Builder(context, player)
+    .setId("ExpoAudioBasicMediaSession_${player.hashCode()}")
+    .build()
 }

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
@@ -26,7 +26,6 @@ import expo.modules.audio.AudioPlayer
 import expo.modules.audio.Metadata
 import expo.modules.audio.getPlaybackServiceErrorMessage
 import expo.modules.kotlin.AppContext
-import expo.modules.kotlin.exception.Exceptions
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioPlaybackServiceConnection.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioPlaybackServiceConnection.kt
@@ -1,0 +1,100 @@
+package expo.modules.audio.service
+
+import android.content.ComponentName
+import android.os.IBinder
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.session.MediaSessionService.SERVICE_INTERFACE
+import expo.modules.audio.AudioPlayer
+import expo.modules.audio.getPlaybackServiceErrorMessage
+import expo.modules.kotlin.AppContext
+import java.lang.ref.WeakReference
+
+class AudioPlaybackServiceBinder(val service: AudioControlsService) : android.os.Binder()
+
+@OptIn(UnstableApi::class)
+class AudioPlaybackServiceConnection(
+  val player: WeakReference<AudioPlayer>,
+  appContext: AppContext
+) : BaseServiceConnection<AudioPlaybackServiceBinder>(appContext) {
+  var playbackServiceBinder: AudioPlaybackServiceBinder? = null
+    private set
+
+  @Volatile
+  private var isReleased = false
+
+  fun release() {
+    isReleased = true
+  }
+
+  fun bindWithService() {
+    if (bindingState == ServiceBindingState.BOUND || bindingState == ServiceBindingState.BINDING || bindingState == ServiceBindingState.UNBINDING) {
+      return
+    }
+
+    if (bindingState == ServiceBindingState.UNBOUND || bindingState == ServiceBindingState.FAILED) {
+      val reactContext = appContext.reactContext ?: run {
+        onBindingFailed("Binding with the expo-audio playback service failed: React context lost")
+        return
+      }
+      val serviceStarted = startServiceAndBind(appContext, reactContext, this, AudioControlsService::class.java, SERVICE_INTERFACE)
+
+      if (!serviceStarted) {
+        onBindingFailed("Failed to start the expo-audio playback service.")
+        return
+      }
+
+      transitionToState(ServiceBindingState.BINDING)
+    }
+  }
+
+  override fun onServiceConnected(componentName: ComponentName, binder: IBinder) {
+    val player = player.get()
+    if (player == null || isReleased) {
+      transitionToState(ServiceBindingState.FAILED)
+      return
+    }
+
+    val serviceBinder: AudioPlaybackServiceBinder = binder as? AudioPlaybackServiceBinder ?: run {
+      onBindingFailed("Could not bind to the playback service - invalid binder type")
+      transitionToState(ServiceBindingState.FAILED)
+      return
+    }
+
+    transitionToState(ServiceBindingState.BOUND)
+
+    playbackServiceBinder = serviceBinder
+    serviceBinder.service.appContext = appContext
+
+    if (player.isActiveForLockScreen) {
+      serviceBinder.service.setPlayerOptions(player, player.metadata, player.lockScreenOptions)
+    }
+  }
+
+  override fun onServiceDisconnected(componentName: ComponentName) {
+    playbackServiceBinder?.service?.let { service ->
+      service.playbackListener?.let { listener ->
+        val player = player.get()
+        if (player != null && !isReleased) {
+          player.ref.removeListener(listener)
+        }
+      }
+      service.playbackListener = null
+    }
+
+    playbackServiceBinder = null
+    super.onServiceDisconnected(componentName)
+  }
+
+  override fun onServiceDied() {
+    super.onServiceDied()
+  }
+
+  override fun onServiceConnectedInternal(binder: AudioPlaybackServiceBinder) {
+    // NOOP
+  }
+
+  override fun getServiceErrorMessage(message: String): String {
+    return getPlaybackServiceErrorMessage(message)
+  }
+}

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioRecordingService.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioRecordingService.kt
@@ -29,11 +29,11 @@ class AudioRecordingService : Service() {
   @Volatile
   private var isRunningForeground = false
 
-  private lateinit var weakContext: WeakReference<AppContext>
-  var appContext: AppContext
-    get() = weakContext.get() ?: throw Exceptions.AppContextLost()
+  private var weakContext: WeakReference<AppContext>? = null
+  var appContext: AppContext?
+    get() = weakContext?.get()
     set(value) {
-      weakContext = WeakReference(value)
+      weakContext = value?.let { WeakReference(it) }
     }
 
   override fun onCreate() {
@@ -129,7 +129,7 @@ class AudioRecordingService : Service() {
       }
       isRunningForeground = true
     } catch (e: Exception) {
-      appContext.jsLogger?.error(
+      appContext?.jsLogger?.error(
         getRecordingServiceErrorMessage("Failed to start the expo-audio foreground service for background recording"),
         e
       )

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioRecordingService.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioRecordingService.kt
@@ -15,7 +15,6 @@ import androidx.core.app.NotificationCompat
 import expo.modules.audio.AudioRecorder
 import expo.modules.audio.getRecordingServiceErrorMessage
 import expo.modules.kotlin.AppContext
-import expo.modules.kotlin.exception.Exceptions
 import java.lang.ref.WeakReference
 
 private const val TAG = "AudioRecordingService"

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioRecordingServiceConnection.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioRecordingServiceConnection.kt
@@ -1,0 +1,135 @@
+package expo.modules.audio.service
+
+import android.content.ComponentName
+import android.os.IBinder
+import expo.modules.audio.AudioRecorder
+import expo.modules.audio.AudioRecordingServiceException
+import expo.modules.audio.getRecordingServiceErrorMessage
+import expo.modules.kotlin.AppContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.lang.ref.WeakReference
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+
+class AudioRecordingServiceBinder(val service: AudioRecordingService) : android.os.Binder()
+
+class AudioRecordingServiceConnection(
+  val recorder: WeakReference<AudioRecorder>,
+  appContext: AppContext
+) : BaseServiceConnection<AudioRecordingServiceBinder>(appContext) {
+  var recordingServiceBinder: AudioRecordingServiceBinder? = null
+    private set
+  private var bindingTimeoutJob: Job? = null
+
+  @Volatile
+  private var isRecorderReleased = false
+  private var bindingContinuation: Continuation<Unit>? = null
+
+  fun release() {
+    isRecorderReleased = true
+    cancelBindingTimeout()
+  }
+
+  fun startBindingTimeout(timeoutMs: Long = 5000) { // 5000ms is more or less the default Android system timeout for binding
+    bindingTimeoutJob?.cancel()
+    bindingTimeoutJob = CoroutineScope(Dispatchers.Default).launch {
+      delay(timeoutMs)
+      if (bindingState == ServiceBindingState.BINDING) {
+        bindingContinuation?.resumeWithException(AudioRecordingServiceException("The recording service connection has failed to connect with the recording service within ${timeoutMs}ms"))
+        unbind()
+      }
+    }
+  }
+
+  private fun cancelBindingTimeout() {
+    bindingTimeoutJob?.cancel()
+    bindingTimeoutJob = null
+  }
+
+  /**
+   * Binds with the recording service. If the service doesn't exist, it will create the service.
+   */
+  suspend fun bindWithService() {
+    if (bindingState == ServiceBindingState.BOUND) {
+      return
+    }
+
+    if (bindingState == ServiceBindingState.BINDING) {
+      throw AudioRecordingServiceException("Tried binding to the recording service while the previous attempt is still ongoing.")
+    }
+
+    if (bindingState == ServiceBindingState.UNBINDING) {
+      throw AudioRecordingServiceException("Tried binding to the recording service while the unbinding process is ongoing.")
+    }
+
+    suspendCoroutine { continuation ->
+      if (bindingState == ServiceBindingState.UNBOUND || bindingState == ServiceBindingState.FAILED) {
+        val reactContext = appContext.reactContext ?: run {
+          onBindingFailed("Binding with the expo-audio playback service failed: React context lost")
+          return@suspendCoroutine
+        }
+        val serviceRunning = startServiceAndBind(appContext, reactContext, this, AudioRecordingService::class.java, AudioRecordingService.ACTION_START_RECORDING)
+
+        if (!serviceRunning) {
+          continuation.resumeWithException(AudioRecordingServiceException("Failed to start the recording service"))
+          return@suspendCoroutine
+        }
+
+        transitionToState(ServiceBindingState.BINDING)
+        bindingContinuation = continuation
+      }
+    }
+  }
+
+  override fun onServiceConnected(componentName: ComponentName, binder: IBinder) {
+    cancelBindingTimeout()
+
+    val recorder = recorder.get()
+    if (recorder == null || isRecorderReleased) {
+      transitionToState(ServiceBindingState.FAILED)
+      bindingContinuation?.resumeWithException(AudioRecordingServiceException("The recorder has been deallocated"))
+      return
+    }
+
+    val serviceBinder: AudioRecordingServiceBinder = binder as? AudioRecordingServiceBinder ?: run {
+      bindingContinuation?.resumeWithException(AudioRecordingServiceException("Could not bind to the recording service - invalid binder type"))
+      transitionToState(ServiceBindingState.FAILED)
+      return
+    }
+    transitionToState(ServiceBindingState.BOUND)
+
+    bindingContinuation?.resume(Unit)
+    recordingServiceBinder = serviceBinder
+    serviceBinder.service.appContext = appContext
+  }
+
+  override fun onServiceDisconnected(componentName: ComponentName) {
+    cancelBindingTimeout()
+    recordingServiceBinder = null
+    super.onServiceDisconnected(componentName)
+  }
+
+  override fun onServiceDied() {
+    cancelBindingTimeout()
+    recordingServiceBinder = null
+    super.onServiceDied()
+  }
+
+  override fun onServiceConnectedInternal(binder: AudioRecordingServiceBinder) {
+    // Not used, handled in onServiceConnected above
+  }
+
+  override fun getServiceErrorMessage(message: String): String {
+    return getRecordingServiceErrorMessage(message)
+  }
+
+  fun cleanup() {
+    cancelBindingTimeout()
+  }
+}

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioRecordingServiceConnection.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioRecordingServiceConnection.kt
@@ -115,6 +115,24 @@ class AudioRecordingServiceConnection(
     super.onServiceDisconnected(componentName)
   }
 
+  override fun onBindingDied(name: ComponentName?) {
+    cancelBindingTimeout()
+    bindingContinuation?.resumeWithException(
+      AudioRecordingServiceException("Service binding died")
+    )
+    bindingContinuation = null
+    super.onBindingDied(name)
+  }
+
+  override fun onNullBinding(componentName: ComponentName) {
+    cancelBindingTimeout()
+    bindingContinuation?.resumeWithException(
+      AudioRecordingServiceException("Service returned null binding")
+    )
+    bindingContinuation = null
+    super.onNullBinding(componentName)
+  }
+
   override fun onServiceDied() {
     cancelBindingTimeout()
     recordingServiceBinder = null

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/service/BaseServiceConnection.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/service/BaseServiceConnection.kt
@@ -1,0 +1,141 @@
+package expo.modules.audio.service
+
+import android.app.Service
+import android.content.ComponentName
+import android.content.Context
+import android.content.Context.BIND_AUTO_CREATE
+import android.content.Context.BIND_INCLUDE_CAPABILITIES
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.Build
+import android.util.Log
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.exception.Exceptions
+import java.lang.ref.WeakReference
+
+enum class ServiceBindingState {
+  UNBOUND,
+  BINDING,
+  BOUND,
+  UNBINDING,
+  FAILED
+}
+
+abstract class BaseServiceConnection<T>(appContext: AppContext) : ServiceConnection {
+  @Volatile
+  private var _bindingState = ServiceBindingState.UNBOUND
+
+  /**
+   * Current binding state of the service connection.
+   * This property is thread-safe and can be read from any thread.
+   */
+  var bindingState: ServiceBindingState
+    get() = synchronized(this) {
+      _bindingState
+    }
+    set(value) = synchronized(this) {
+      _bindingState = value
+    }
+
+  val isConnected: Boolean
+    get() = bindingState == ServiceBindingState.BOUND
+
+  private val _appContext = WeakReference(appContext)
+  protected val appContext: AppContext
+    get() = _appContext.get() ?: throw Exceptions.AppContextLost()
+
+  protected abstract fun onServiceConnectedInternal(binder: T)
+  protected abstract fun getServiceErrorMessage(message: String): String
+
+  protected open fun onBindingFailed(message: String, reason: Throwable? = null) {
+    try {
+      appContext.jsLogger?.error(getServiceErrorMessage(message), reason)
+    } catch (e: Exception) {
+      Log.e(TAG, "Failed to log binding error: $message", e)
+    }
+  }
+
+  protected open fun onServiceDied() {
+    try {
+      appContext.jsLogger?.error(
+        getServiceErrorMessage("Service died unexpectedly")
+      )
+    } catch (e: Exception) {
+      Log.e(TAG, "Failed to log service death", e)
+    }
+  }
+
+  fun transitionToState(newState: ServiceBindingState) {
+    bindingState = newState
+  }
+
+  override fun onServiceDisconnected(componentName: ComponentName) {
+    bindingState = ServiceBindingState.UNBOUND
+
+    onServiceDied()
+  }
+
+  override fun onBindingDied(name: ComponentName?) {
+    bindingState = ServiceBindingState.UNBOUND
+
+    onServiceDied()
+    super.onBindingDied(name)
+  }
+
+  override fun onNullBinding(componentName: ComponentName) {
+    bindingState = ServiceBindingState.FAILED
+
+    val errorMessage = "Could not bind to the service. " +
+      "Check AndroidManifest.xml for proper service and permission declarations."
+    onBindingFailed(errorMessage)
+
+    super.onNullBinding(componentName)
+  }
+
+  fun unbind() {
+    val shouldUnbind =
+      bindingState == ServiceBindingState.BOUND || bindingState == ServiceBindingState.BINDING
+
+    if (shouldUnbind) {
+      bindingState = ServiceBindingState.UNBINDING
+      try {
+        appContext.reactContext?.unbindService(this)
+      } catch (e: IllegalArgumentException) {
+        // Service was never bound or already unbound - this is expected in some cases
+        Log.d(TAG, "Service was already unbound: ${e.message}")
+      } catch (e: Exception) {
+        appContext.jsLogger?.error("Unexpected error unbinding service: ${e.message}")
+      } finally {
+        bindingState = ServiceBindingState.UNBOUND
+      }
+    }
+  }
+
+  companion object {
+    private const val TAG = "BaseServiceConnection"
+
+    fun <T : Service> startServiceAndBind(
+      appContext: AppContext,
+      context: Context,
+      serviceConnection: ServiceConnection,
+      clazz: Class<T>,
+      action: String
+    ): Boolean {
+      appContext.reactContext?.apply {
+        val intent = Intent(context, clazz)
+        intent.action = action
+
+        startService(intent)
+
+        val flags = if (Build.VERSION.SDK_INT >= 29) {
+          BIND_AUTO_CREATE or BIND_INCLUDE_CAPABILITIES
+        } else {
+          BIND_AUTO_CREATE
+        }
+
+        return bindService(intent, serviceConnection, flags)
+      }
+      return false
+    }
+  }
+}


### PR DESCRIPTION
# Why

I wanted to add clear errors if the plugin is misconfigured due to changes introduced in :https://github.com/expo/expo/pull/43014 , but I've found it impossible to actually detect if the service has successfully started with the current singleton-based implementation for some reason.

# How

- Migrate to having a separate Recodring and playback services
- Use the pattern of having a single service and multiple service connections and bindings
- Add errors if the plugin is misconfigured
  - Try connecting to the service in the recording preparation, if connection fails throw an error
  - For the controls service, we don't have the luxury of having an async function to wait to connect to the service, so we start the playback and update the service once it connects. If it fails we use the jsLogger to send a visible non-fatal error to developers

# Test Plan

Tested in prebuilt NCL on Android

