### PR TITLE
[CI] Publish scheduled canaries from sdk-56 branch

### DIFF
--- a/.github/workflows/publish-canaries.yml
+++ b/.github/workflows/publish-canaries.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'schedule' && 'sdk-56' || github.ref }}
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
# Why

React native 0.84 will be out this week and we will support it through SDK 56 canaries. Given that we haven't officially released SDK 55 yet, we can't just merge the upgrade to main, so we should land it first in the SDK 56 branch and publish canaries from there for now.

# How

Update the publish scheduled workflow to publish canaries from the sdk-56 branch

# Test Plan

N / A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
