### PR TITLE
[docs] Add brownfield isolated approach guide

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -138,6 +138,7 @@ exceptions:
   - '.*macOS.*'
   - '.*manifest\.json.*'
   - '.*metro\.config\.js.*'
+  - '.*Maven.*'
   - '.*Netlify.*'
   - '.*Node\.js.*'
   - '.*Node Package Managers.*'

--- a/docs/common/client-redirects.ts
+++ b/docs/common/client-redirects.ts
@@ -525,7 +525,8 @@ const RENAMED_PAGES: Record<string, string> = {
   '/regulatory-compliance/privacy-shield/': '/regulatory-compliance/data-and-privacy-protection/',
 
   // After changing brownfield docs
-  '/brownfield/installing-expo-modules/': '/brownfield/get-started/',
+  '/brownfield/installing-expo-modules/': '/brownfield/overview/',
+  '/brownfield/get-started/': '/brownfield/isolated-approach/',
 
   // After removing Navigation section from Home and adding a Navigation page
   '/develop/file-based-routing/': '/develop/app-navigation/',

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -223,7 +223,8 @@ export const general = [
     ]),
     makeSection('Existing native apps', [
       makePage('brownfield/overview.mdx'),
-      makePage('brownfield/get-started.mdx'),
+      makePage('brownfield/isolated-approach.mdx'),
+      makePage('brownfield/integrated-approach.mdx'),
       makePage('brownfield/lifecycle-listeners.mdx'),
     ]),
     makeGroup(

--- a/docs/pages/brownfield/integrated-approach.mdx
+++ b/docs/pages/brownfield/integrated-approach.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to add Expo to an existing native (brownfield) app
-sidebar_title: Get started
+sidebar_title: Integrated approach
 description: A guide for adding Expo and React Native to existing native apps and adding a first view component.
 ---
 
@@ -15,7 +15,7 @@ React Native and Expo are flexible and can be adopted incrementally, one screen 
 
 This guide will walk you through the steps to add a React Native view into an existing native app. The approach covered here is what we call the "integrated" approach, because React Native and Expo are integrated in the same way that you would any other library.
 
-Another popular technique is what we call the "isolated" approach, where your Expo app is packaged as a library and treated as a black box by the main existing application. A guide for the isolated approach will be available shortly. Now, back to using the "integrated" approach in your existing native app.
+Another popular technique is what we call the "isolated" approach, where your Expo app is packaged as a library and treated as a black box by the main existing application. See the [isolated approach guide](/brownfield/isolated-approach/) for details. Now, back to using the "integrated" approach in your existing native app.
 
 ## Prerequisites
 

--- a/docs/pages/brownfield/integrated-approach.mdx
+++ b/docs/pages/brownfield/integrated-approach.mdx
@@ -1,7 +1,7 @@
 ---
-title: How to add Expo to an existing native (brownfield) app
+title: How to add Expo to a native app using the integrated approach
 sidebar_title: Integrated approach
-description: A guide for adding Expo and React Native to existing native apps and adding a first view component.
+description: A guide for adding Expo and React Native to existing native (brownfield) apps using the integrated approach.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/brownfield/integrated-approach.mdx
+++ b/docs/pages/brownfield/integrated-approach.mdx
@@ -15,7 +15,7 @@ React Native and Expo are flexible and can be adopted incrementally, one screen 
 
 This guide will walk you through the steps to add a React Native view into an existing native app. The approach covered here is what we call the "integrated" approach, because React Native and Expo are integrated in the same way that you would any other library.
 
-Another popular technique is what we call the "isolated" approach, where your Expo app is packaged as a library and treated as a black box by the main existing application. See the [isolated approach guide](/brownfield/isolated-approach/) for details. Now, back to using the "integrated" approach in your existing native app.
+> **info** Another popular technique is what we call the "isolated" approach, where your Expo app is packaged as a library and treated as a black box by the main existing application. See the [isolated approach guide](/brownfield/isolated-approach/) for details.
 
 ## Prerequisites
 

--- a/docs/pages/brownfield/isolated-approach.mdx
+++ b/docs/pages/brownfield/isolated-approach.mdx
@@ -4,12 +4,13 @@ sidebar_title: Isolated approach
 description: A guide for packaging your Expo app as a native library (XCFramework/AAR) and integrating it into an existing native app.
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
-import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
-import { BoxLink } from '~/ui/components/BoxLink';
 
 In the isolated approach, your React Native code is developed and maintained separately from your native project. You package it as a native library &mdash; an XCFramework for iOS or an AAR for Android &mdash; and integrate it into your native app like any other dependency.
 

--- a/docs/pages/brownfield/isolated-approach.mdx
+++ b/docs/pages/brownfield/isolated-approach.mdx
@@ -1,0 +1,387 @@
+---
+title: How to use the isolated brownfield approach with expo-brownfield
+sidebar_title: Isolated approach
+description: A guide for packaging your Expo app as a native library (XCFramework/AAR) and integrating it into an existing native app.
+---
+
+import { Collapsible } from '~/ui/components/Collapsible';
+import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
+import { Tabs, Tab } from '~/ui/components/Tabs';
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+import { BoxLink } from '~/ui/components/BoxLink';
+
+In the isolated approach, your React Native code is developed and maintained separately from your native project. You package it as a native library &mdash; an XCFramework for iOS or an AAR for Android &mdash; and integrate it into your native app like any other dependency.
+
+This approach is ideal when you have separate teams for native and React Native development, or when you want to minimize the impact of React Native on your existing native build process. Native developers don't need Node.js, Yarn, or any React Native build tooling &mdash; they just consume pre-built artifacts.
+
+For an alternative approach where React Native is integrated directly into your native project, see the [integrated approach guide](/brownfield/get-started/).
+
+## Prerequisites
+
+To integrate React Native into your existing application, you'll need to set up a JavaScript development environment. This includes installing Node.js to run Expo CLI and Yarn to manage the project's JavaScript dependencies.
+
+- [Node.js (LTS)](https://nodejs.org/en/): The runtime to execute JavaScript code and Expo CLI.
+- [Yarn](https://yarnpkg.com/): A package manager for installing and managing JavaScript dependencies.
+
+Learn more from the [Set up environment guide](/get-started/set-up-your-environment/).
+
+## Create an Expo project
+
+<Step label="1">
+
+Create a new Expo project. Unlike the [integrated approach](/brownfield/get-started/), this project does not need to live inside your native project &mdash; it can be in a separate repository or a monorepo.
+
+<Terminal cmd={['$ npx create-expo-app@latest my-rn-library']} />
+
+</Step>
+
+<Step label="2">
+### Install expo-brownfield
+
+<Terminal cmd={['$ cd my-rn-library', '$ npx expo install expo-brownfield']} />
+
+</Step>
+
+<Step label="3">
+### Add the config plugin
+
+Add `expo-brownfield` to the `plugins` array in your **app.json**:
+
+```json app.json
+{
+  "expo": {
+    "plugins": ["expo-brownfield"]
+  }
+}
+```
+
+This uses the default configuration, which is sufficient for most projects. The defaults are derived from your app config (for example, target names are based on your app's scheme or slug).
+But you can also pass options to customize the target names, bundle identifiers, and publishing configuration. Check the [API reference](/versions/latest/sdk/brownfield/) for details on all available options.
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-brownfield",
+        {
+          "ios": {
+            "targetName": "MyBrownfield",
+            "bundleIdentifier": "com.example.mybrownfield"
+          },
+          "android": {
+            "libraryName": "mybrownfield",
+            "group": "com.example",
+            "package": "com.example.mybrownfield",
+            "version": "1.0.0"
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+</Step>
+
+## Package your Expo project as library
+
+Use the expo-brownfield CLI to build your React Native code as native libraries (XCFramework for iOS and AAR for Android) and integrate them into your existing native app.
+
+<Terminal cmd={['$ npx expo-brownfield build:[android|ios]']} />
+
+<Tabs>
+<Tab label="iOS">
+
+Build the XCFramework artifacts:
+
+<Terminal cmd={['$ npx expo-brownfield build:ios']} />
+
+This compiles the framework target for both device and simulator architectures, packages them into XCFrameworks, and copies the Hermes engine framework. The output is placed in the **./artifacts** directory by default and contains:
+
+- **\{TargetName\}.xcframework** &mdash; your React Native library
+- **hermes.xcframework** &mdash; the Hermes JavaScript engine
+
+Check the [API reference](/versions/latest/sdk/brownfield/) for more build options, such as building only debug or release, specifying a custom output directory, and more.
+
+</Tab>
+<Tab label="Android">
+
+Build and publish the AAR to a Maven repository:
+
+<Terminal cmd={['$ npx expo-brownfield build:android']} />
+
+By default, this publishes to your local Maven repository (`~/.m2`). The artifact coordinates are determined by your config plugin settings (for example, `com.example:brownfield:1.0.0`).
+
+To see all available publishing tasks and repositories:
+
+<Terminal cmd={['$ npx expo-brownfield tasks:android']} />
+
+<Collapsible summary="Android build options">
+
+| Option         | Short    | Description                                                      |
+| -------------- | -------- | ---------------------------------------------------------------- |
+| `--all`        | `-a`     | Build both debug and release (default)                           |
+| `--release`    | `-r`     | Build in release configuration only                              |
+| `--debug`      | `-d`     | Build in debug configuration only                                |
+| `--library`    | `-l`     | Specify brownfield library name                                  |
+| `--repository` | `--repo` | Maven repository to publish to (can be specified multiple times) |
+| `--task`       | `-t`     | Gradle publish task to run (can be specified multiple times)     |
+| `--verbose`    |          | Include all logs from subprocesses                               |
+
+</Collapsible>
+
+<Collapsible summary="Publishing to a remote Maven repository">
+
+Configure remote Maven publishing in your **app.json** plugin options:
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-brownfield",
+        {
+          "android": {
+            "publishing": [
+              {
+                "type": "remotePrivate",
+                "url": { "variable": "MAVEN_URL" },
+                "username": { "variable": "MAVEN_USERNAME" },
+                "password": { "variable": "MAVEN_PASSWORD" }
+              }
+            ]
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+The `variable` fields reference environment variables, keeping credentials out of your source code.
+
+</Collapsible>
+
+</Tab>
+</Tabs>
+
+## Integrating into your native app
+
+This section is for the native developer consuming the pre-built artifacts. No Node.js, Yarn, or React Native tooling is required.
+
+<Tabs tabs={["iOS", "Android"]}>
+<Tab>
+
+<Step label="1">
+### Add XCFrameworks to your project
+
+Drag both XCFramework files (\{TargetName\}**.xcframework** and **hermes.xcframework**) into your Xcode project navigator. In the dialog that appears:
+
+- Check **Copy items if needed**
+- Add them to your app target
+
+Then, in your target's **General** tab under **Frameworks, Libraries, and Embedded Content**, ensure both frameworks are set to **Embed & Sign**.
+
+</Step>
+
+<Step label="2">
+### Initialize React Native
+
+Call `ReactNativeHostManager.shared.initialize()` early in your app's lifecycle. A good place is your `AppDelegate`:
+
+```swift AppDelegate.swift
+import UIKit
+import MyAppBrownfield // Replace with your target name
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+  func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+  ) -> Bool {
+    ReactNativeHostManager.shared.initialize()
+    return true
+  }
+}
+```
+
+</Step>
+
+<Step label="3">
+### Present a React Native view
+
+**UIKit:**
+
+```swift ViewController.swift
+import UIKit
+import MyAppBrownfield
+
+class ViewController: UIViewController {
+  @IBAction func openReactNative(_ sender: Any) {
+    let rnViewController = ReactNativeViewController(moduleName: "main")
+    navigationController?.pushViewController(rnViewController, animated: true)
+  }
+}
+```
+
+The `ReactNativeViewController` also accepts optional `initialProps` and `launchOptions` parameters:
+
+```swift
+let rnViewController = ReactNativeViewController(
+  moduleName: "main",
+  initialProps: ["userId": "123"],
+  launchOptions: [:]
+)
+```
+
+**SwiftUI:**
+
+```swift ContentView.swift
+import SwiftUI
+import MyAppBrownfield
+
+struct ContentView: View {
+  @State private var showReactNative = false
+
+  var body: some View {
+    Button("Open React Native") {
+      showReactNative = true
+    }
+    .fullScreenCover(isPresented: $showReactNative) {
+      ReactNativeView(moduleName: "main")
+    }
+  }
+}
+```
+
+</Step>
+
+</Tab>
+<Tab>
+
+<Step label="1">
+### Add the Maven dependency
+
+If the library was published to local Maven (the default), add `mavenLocal()` to your repository configuration:
+
+```kotlin settings.gradle.kts
+dependencyResolutionManagement {
+  repositories {
+    google()
+    mavenCentral()
+    mavenLocal()
+  }
+}
+```
+
+Then add the dependency in your app's **build.gradle.kts**. The group, artifact name, and version match your config plugin settings:
+
+```kotlin app/build.gradle.kts
+dependencies {
+  implementation("com.example:brownfield:1.0.0")
+}
+```
+
+</Step>
+
+<Step label="2">
+### Initialize React Native
+
+Call `ReactNativeHostManager.shared.initialize(this)` in your `Application` class:
+
+```kotlin MyApplication.kt
+import android.app.Application
+import com.example.brownfield.ReactNativeHostManager
+
+class MyApplication : Application() {
+  override fun onCreate() {
+    super.onCreate()
+    ReactNativeHostManager.shared.initialize(this)
+  }
+}
+```
+
+</Step>
+
+<Step label="3">
+### Show a React Native screen
+
+Create an activity that extends `BrownfieldActivity` and use the `showReactNativeFragment()` extension:
+
+```kotlin ExpoActivity.kt
+import android.os.Bundle
+import com.example.brownfield.BrownfieldActivity
+import com.example.brownfield.showReactNativeFragment
+
+class ExpoActivity : BrownfieldActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    showReactNativeFragment()
+  }
+}
+```
+
+Add the activity to your **AndroidManifest.xml** with a non-ActionBar theme:
+
+```xml AndroidManifest.xml
+<activity
+  android:name=".ExpoActivity"
+  android:theme="@style/Theme.AppCompat.Light.NoActionBar"
+  android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
+/>
+```
+
+Then launch it from anywhere in your app:
+
+```kotlin
+startActivity(Intent(this, ExpoActivity::class.java))
+```
+
+`BrownfieldActivity` extends `AppCompatActivity` and handles forwarding configuration changes to Expo modules. The `showReactNativeFragment()` extension also sets up native back button handling automatically.
+
+</Step>
+
+</Tab>
+</Tabs>
+
+### Generate native targets
+
+Run `npx expo prebuild` to generate the native projects with the brownfield library targets:
+
+<Terminal cmd={['$ npx expo prebuild']} />
+
+This generates:
+
+- **iOS**: A separate Xcode framework target containing `ReactNativeHostManager`, `ReactNativeViewController`, `ReactNativeView` (SwiftUI), `BrownfieldMessaging`, and `ReactNativeDelegate`.
+- **Android**: A separate library module containing `ReactNativeHostManager`, `BrownfieldActivity`, `ReactNativeFragment`, `ReactNativeViewFactory`, and `BrownfieldMessaging`.
+
+## Test your integration
+
+### Development (debug builds)
+
+Start the Metro bundler in your Expo project directory:
+
+<Terminal cmd={['$ npx expo start']} />
+
+Then build and run the native app from Xcode or Android Studio. When you navigate to the React Native screen, it will load from the Metro dev server with hot reloading support.
+
+### Production (release builds)
+
+In release builds, the JavaScript bundle is embedded in the artifact (XCFramework or AAR), so no Metro server is needed. Build the native app in Release configuration and verify the React Native screen loads correctly.
+
+## Next steps
+
+<BoxLink
+  title="Lifecycle listeners"
+  description="Configure application lifecycle listeners for deeper integration with Expo modules."
+  href="/brownfield/lifecycle-listeners/"
+  Icon={BookOpen02Icon}
+/>
+<BoxLink
+  title="expo-brownfield API reference"
+  description="Explore the full JavaScript API for communication, navigation, and more."
+  href="/versions/latest/sdk/brownfield/"
+  Icon={BookOpen02Icon}
+/>

--- a/docs/pages/brownfield/isolated-approach.mdx
+++ b/docs/pages/brownfield/isolated-approach.mdx
@@ -1,7 +1,7 @@
 ---
-title: How to use the isolated brownfield approach with expo-brownfield
+title: How to add Expo to a native app using the isolated approach
 sidebar_title: Isolated approach
-description: A guide for packaging your Expo app as a native library (XCFramework/AAR) and integrating it into an existing native app.
+description: A guide for adding Expo and React Native as a native library and integrating it into an existing (brownfield) native app using the isolated approach.
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
@@ -12,11 +12,11 @@ import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
-In the isolated approach, your React Native code is developed and maintained separately from your native project. You package it as a native library &mdash; an XCFramework for iOS or an AAR for Android &mdash; and integrate it into your native app like any other dependency.
+In the isolated approach, your React Native code is developed and maintained separately from your native project. You package it as a native library, using an XCFramework for iOS or an AAR for Android, and integrate it into your native app like any other dependency.
 
-This approach is ideal when you have separate teams for native and React Native development, or when you want to minimize the impact of React Native on your existing native build process. Native developers don't need Node.js, Yarn, or any React Native build tooling &mdash; they just consume pre-built artifacts.
+This approach is ideal when you want to minimize the impact of React Native on your existing native build process, or when you have separate teams for native and React Native development. Using this approach, native developers don't need Node.js, Yarn, or any React Native build tooling and they can just consume pre-built artifacts.
 
-For an alternative approach where React Native is integrated directly into your native project, see the [integrated approach guide](/brownfield/get-started/).
+For an alternative approach where React Native is integrated directly into your native project, see the [integrated approach guide](/brownfield/integrated-approach/).
 
 ## Prerequisites
 
@@ -27,27 +27,32 @@ To integrate React Native into your existing application, you'll need to set up 
 
 Learn more from the [Set up environment guide](/get-started/set-up-your-environment/).
 
-## Create an Expo project
+## Setup an Expo project
 
 <Step label="1">
 
-Create a new Expo project. Unlike the [integrated approach](/brownfield/get-started/), this project does not need to live inside your native project &mdash; it can be in a separate repository or a monorepo.
+### Create a new Expo project
 
-<Terminal cmd={['$ npx create-expo-app@latest my-rn-library']} />
+<Terminal cmd={['$ npx create-expo-app@latest my-project']} />
+
+This command creates a new directory named my-project that contains your new Expo project. While you can name the project anything, this guide uses my-project for consistency.
+This project does not need to live inside your existing native app and can be created in a separate repository or a monorepo. The new project includes an example TypeScript application to help you get started.
 
 </Step>
 
 <Step label="2">
 ### Install expo-brownfield
 
-<Terminal cmd={['$ cd my-rn-library', '$ npx expo install expo-brownfield']} />
+Navigate to your new Expo project and install the `expo-brownfield` package, which provides the tools to build your React Native code as native libraries and integrate them into your existing native app.
+
+<Terminal cmd={['$ npx expo install expo-brownfield']} />
 
 </Step>
 
 <Step label="3">
-### Add the config plugin
+### Adjust the config plugin (optional)
 
-Add `expo-brownfield` to the `plugins` array in your **app.json**:
+`expo-brownfield` should automatically add an entry to the `plugins` array in your **app.json**, using the default configuration, which is sufficient for most projects.
 
 ```json app.json
 {
@@ -57,8 +62,8 @@ Add `expo-brownfield` to the `plugins` array in your **app.json**:
 }
 ```
 
-This uses the default configuration, which is sufficient for most projects. The defaults are derived from your app config (for example, target names are based on your app's scheme or slug).
-But you can also pass options to customize the target names, bundle identifiers, and publishing configuration. Check the [API reference](/versions/latest/sdk/brownfield/) for details on all available options.
+The defaults are derived from your app config (for example, target names are based on your app's scheme or slug).
+But you can also pass options to customize the target names, bundle identifiers, and publishing configuration.
 
 ```json app.json
 {
@@ -84,96 +89,130 @@ But you can also pass options to customize the target names, bundle identifiers,
 }
 ```
 
+Check the [API reference](/versions/latest/sdk/brownfield/) for details on all available options.
+
 </Step>
 
-## Package your Expo project as library
+## Export your Expo project as a native library
 
-Use the expo-brownfield CLI to build your React Native code as native libraries (XCFramework for iOS and AAR for Android) and integrate them into your existing native app.
-
-<Terminal cmd={['$ npx expo-brownfield build:[android|ios]']} />
+Once you have your Expo project set up, use the `expo-brownfield` CLI to build your React Native code as XCFrameworks for iOS and AARs for Android.
 
 <Tabs>
-<Tab label="iOS">
-
-Build the XCFramework artifacts:
-
-<Terminal cmd={['$ npx expo-brownfield build:ios']} />
-
-This compiles the framework target for both device and simulator architectures, packages them into XCFrameworks, and copies the Hermes engine framework. The output is placed in the **./artifacts** directory by default and contains:
-
-- **\{TargetName\}.xcframework** &mdash; your React Native library
-- **hermes.xcframework** &mdash; the Hermes JavaScript engine
-
-Check the [API reference](/versions/latest/sdk/brownfield/) for more build options, such as building only debug or release, specifying a custom output directory, and more.
-
-</Tab>
 <Tab label="Android">
 
-Build and publish the AAR to a Maven repository:
+From your Expo project directory, run:
 
 <Terminal cmd={['$ npx expo-brownfield build:android']} />
 
-By default, this publishes to your local Maven repository (`~/.m2`). The artifact coordinates are determined by your config plugin settings (for example, `com.example:brownfield:1.0.0`).
+This will build the AAR and publish it to a Maven repository. By default, it publishes to your local Maven repository (`~/.m2`), but it can also be configured to publish to a remote repository.
+The produced artifact name will be determined by your config plugin settings, in this case `com.username.myproject:brownfield:1.0.0`.
 
-To see all available publishing tasks and repositories:
+Check the [API reference](/versions/latest/sdk/brownfield/) for more details on build options, such as building only debug or release, specifying a custom output directory, and more.
 
-<Terminal cmd={['$ npx expo-brownfield tasks:android']} />
+</Tab>
+<Tab label="iOS">
 
-<Collapsible summary="Android build options">
+From your Expo project directory, run:
 
-| Option         | Short    | Description                                                      |
-| -------------- | -------- | ---------------------------------------------------------------- |
-| `--all`        | `-a`     | Build both debug and release (default)                           |
-| `--release`    | `-r`     | Build in release configuration only                              |
-| `--debug`      | `-d`     | Build in debug configuration only                                |
-| `--library`    | `-l`     | Specify brownfield library name                                  |
-| `--repository` | `--repo` | Maven repository to publish to (can be specified multiple times) |
-| `--task`       | `-t`     | Gradle publish task to run (can be specified multiple times)     |
-| `--verbose`    |          | Include all logs from subprocesses                               |
+<Terminal cmd={['$ npx expo-brownfield build:ios']} />
 
-</Collapsible>
+This will build the XCFramework artifacts, compiling the framework target for both device and simulator architectures, package them into XCFrameworks, and copy the Hermes engine framework.
 
-<Collapsible summary="Publishing to a remote Maven repository">
+When the build process is completed, the output is placed in the **./artifacts** directory and contains:
 
-Configure remote Maven publishing in your **app.json** plugin options:
+- **\{TargetName\}.xcframework** - Your Expo project as a native library
+- **hermesvm.xcframework** - The Hermes JavaScript engine
 
-```json app.json
-{
-  "expo": {
-    "plugins": [
-      [
-        "expo-brownfield",
-        {
-          "android": {
-            "publishing": [
-              {
-                "type": "remotePrivate",
-                "url": { "variable": "MAVEN_URL" },
-                "username": { "variable": "MAVEN_USERNAME" },
-                "password": { "variable": "MAVEN_PASSWORD" }
-              }
-            ]
-          }
-        }
-      ]
-    ]
-  }
-}
-```
-
-The `variable` fields reference environment variables, keeping credentials out of your source code.
-
-</Collapsible>
+Check the [API reference](/versions/latest/sdk/brownfield/) for more details on build options, such as building only debug or release, specifying a custom output directory, and more.
 
 </Tab>
 </Tabs>
 
+<Collapsible summary="Debugging native targets">
+
+If you need to debug native code of the Expo project targets, you can run `npx expo prebuild` to generate the native projects with the brownfield library targets, inside the `./android` and `./ios` directories.
+
+<Terminal cmd={['$ npx expo prebuild']} />
+
+This generates:
+
+- **iOS**: A separate Xcode framework target containing `ReactNativeHostManager`, `ReactNativeViewController`, `ReactNativeView` (SwiftUI), `BrownfieldMessaging`, and `ReactNativeDelegate`.
+- **Android**: A separate library module containing `ReactNativeHostManager`, `BrownfieldActivity`, `ReactNativeFragment`, `ReactNativeViewFactory`, and `BrownfieldMessaging`.
+
+</Collapsible >
+
 ## Integrating into your native app
 
-This section is for the native developer consuming the pre-built artifacts. No Node.js, Yarn, or React Native tooling is required.
+With the artifacts built, you can now integrate them into your existing native app. The exact steps will depend on your project structure and build system, but the general process involves adding the pre-built artifacts as dependencies and initializing the React Native host.
 
-<Tabs tabs={["iOS", "Android"]}>
-<Tab>
+<Tabs>
+<Tab label="Android">
+
+<Step label="1">
+### Add the Maven dependency
+
+Start by adding the dependency to your app's **build.gradle.kts**. The group, artifact name, and version should match your config plugin settings:
+
+```kotlin app/build.gradle.kts
+dependencies {
+  implementation("com.username.myproject:brownfield:1.0.0")
+}
+```
+
+If the library was published to local Maven, make sure to add `mavenLocal()` to your repository configuration:
+
+```kotlin settings.gradle.kts
+dependencyResolutionManagement {
+  repositories {
+    google()
+    mavenCentral()
+    mavenLocal()
+  }
+}
+```
+
+</Step>
+
+<Step label="2">
+### Show a React Native screen
+
+Create an activity that extends `BrownfieldActivity` and use the `showReactNativeFragment()` extension:
+
+```kotlin ExpoActivity.kt
+import android.os.Bundle
+import com.example.brownfield.BrownfieldActivity
+import com.example.brownfield.showReactNativeFragment
+
+class ExpoActivity : BrownfieldActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    showReactNativeFragment()
+  }
+}
+```
+
+Add the activity to your **AndroidManifest.xml** with a non-ActionBar theme:
+
+```xml AndroidManifest.xml
+<activity
+  android:name=".ExpoActivity"
+  android:theme="@style/Theme.AppCompat.Light.NoActionBar"
+  android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
+/>
+```
+
+Then launch it from anywhere in your app:
+
+```kotlin
+startActivity(Intent(this, ExpoActivity::class.java))
+```
+
+`BrownfieldActivity` extends `AppCompatActivity` and handles forwarding configuration changes to Expo modules. The `showReactNativeFragment()` extension also sets up native back button handling automatically.
+
+</Step>
+
+</Tab>
+<Tab label="iOS">
 
 <Step label="1">
 ### Add XCFrameworks to your project
@@ -213,7 +252,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 <Step label="3">
 ### Present a React Native view
 
-**UIKit:**
+<Tabs>
+<Tab label="UIKit">
 
 ```swift ViewController.swift
 import UIKit
@@ -237,7 +277,8 @@ let rnViewController = ReactNativeViewController(
 )
 ```
 
-**SwiftUI:**
+</Tab>
+<Tab label="SwiftUI">
 
 ```swift ContentView.swift
 import SwiftUI
@@ -257,112 +298,21 @@ struct ContentView: View {
 }
 ```
 
-</Step>
-
 </Tab>
-<Tab>
-
-<Step label="1">
-### Add the Maven dependency
-
-If the library was published to local Maven (the default), add `mavenLocal()` to your repository configuration:
-
-```kotlin settings.gradle.kts
-dependencyResolutionManagement {
-  repositories {
-    google()
-    mavenCentral()
-    mavenLocal()
-  }
-}
-```
-
-Then add the dependency in your app's **build.gradle.kts**. The group, artifact name, and version match your config plugin settings:
-
-```kotlin app/build.gradle.kts
-dependencies {
-  implementation("com.example:brownfield:1.0.0")
-}
-```
-
-</Step>
-
-<Step label="2">
-### Initialize React Native
-
-Call `ReactNativeHostManager.shared.initialize(this)` in your `Application` class:
-
-```kotlin MyApplication.kt
-import android.app.Application
-import com.example.brownfield.ReactNativeHostManager
-
-class MyApplication : Application() {
-  override fun onCreate() {
-    super.onCreate()
-    ReactNativeHostManager.shared.initialize(this)
-  }
-}
-```
-
-</Step>
-
-<Step label="3">
-### Show a React Native screen
-
-Create an activity that extends `BrownfieldActivity` and use the `showReactNativeFragment()` extension:
-
-```kotlin ExpoActivity.kt
-import android.os.Bundle
-import com.example.brownfield.BrownfieldActivity
-import com.example.brownfield.showReactNativeFragment
-
-class ExpoActivity : BrownfieldActivity() {
-  override fun onCreate(savedInstanceState: Bundle?) {
-    super.onCreate(savedInstanceState)
-    showReactNativeFragment()
-  }
-}
-```
-
-Add the activity to your **AndroidManifest.xml** with a non-ActionBar theme:
-
-```xml AndroidManifest.xml
-<activity
-  android:name=".ExpoActivity"
-  android:theme="@style/Theme.AppCompat.Light.NoActionBar"
-  android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
-/>
-```
-
-Then launch it from anywhere in your app:
-
-```kotlin
-startActivity(Intent(this, ExpoActivity::class.java))
-```
-
-`BrownfieldActivity` extends `AppCompatActivity` and handles forwarding configuration changes to Expo modules. The `showReactNativeFragment()` extension also sets up native back button handling automatically.
+</Tabs>
 
 </Step>
 
 </Tab>
 </Tabs>
 
-### Generate native targets
-
-Run `npx expo prebuild` to generate the native projects with the brownfield library targets:
-
-<Terminal cmd={['$ npx expo prebuild']} />
-
-This generates:
-
-- **iOS**: A separate Xcode framework target containing `ReactNativeHostManager`, `ReactNativeViewController`, `ReactNativeView` (SwiftUI), `BrownfieldMessaging`, and `ReactNativeDelegate`.
-- **Android**: A separate library module containing `ReactNativeHostManager`, `BrownfieldActivity`, `ReactNativeFragment`, `ReactNativeViewFactory`, and `BrownfieldMessaging`.
-
 ## Test your integration
+
+You have completed all the basic steps to integrate React Native with your application. Now it's time to test it out! The exact process will depend on whether you're running a debug or release build.
 
 ### Development (debug builds)
 
-Start the Metro bundler in your Expo project directory:
+Now run the following command in the React Native directory to start the [Metro bundler](https://metrobundler.dev/)
 
 <Terminal cmd={['$ npx expo start']} />
 
@@ -370,7 +320,7 @@ Then build and run the native app from Xcode or Android Studio. When you navigat
 
 ### Production (release builds)
 
-In release builds, the JavaScript bundle is embedded in the artifact (XCFramework or AAR), so no Metro server is needed. Build the native app in Release configuration and verify the React Native screen loads correctly.
+In release builds, the JavaScript bundle is embedded in the artifact (XCFramework or AAR), so Metro server is not needed. Build the native app in Release configuration and verify the React Native screen loads correctly.
 
 ## Next steps
 

--- a/docs/pages/brownfield/isolated-approach.mdx
+++ b/docs/pages/brownfield/isolated-approach.mdx
@@ -12,11 +12,11 @@ import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
-In the isolated approach, your React Native code is developed and maintained separately from your native project. You package it as a native library, using an XCFramework for iOS or an AAR for Android, and integrate it into your native app like any other dependency.
+In the isolated approach, your React Native code is developed and maintained separately from your native project. You package it as a native library, using an AAR for Android or XCFramework for iOS, and integrate it into your native app like any other dependency.
 
-This approach is ideal when you want to minimize the impact of React Native on your existing native build process, or when you have separate teams for native and React Native development. Using this approach, native developers don't need Node.js, Yarn, or any React Native build tooling and they can just consume pre-built artifacts.
+This approach is ideal when you want to minimize the impact of React Native on your existing native build process, or when you have separate teams for native and React Native development. Using this approach, native developers don't need Node.js, Yarn, or any React Native build tooling, and they can just consume pre-built artifacts.
 
-For an alternative approach where React Native is integrated directly into your native project, see the [integrated approach guide](/brownfield/integrated-approach/).
+> **info** For an alternative approach where React Native is integrated directly into your native project, see the [integrated approach guide](/brownfield/integrated-approach/).
 
 ## Prerequisites
 
@@ -27,23 +27,25 @@ To integrate React Native into your existing application, you'll need to set up 
 
 Learn more from the [Set up environment guide](/get-started/set-up-your-environment/).
 
-## Setup an Expo project
+## Set up an Expo project
 
 <Step label="1">
 
 ### Create a new Expo project
 
+
+Run the following command to create a new directory named **my-project** that contains your new Expo project. While you can name the project anything, this guide uses **my-project** for consistency.
+
 <Terminal cmd={['$ npx create-expo-app@latest my-project']} />
 
-This command creates a new directory named my-project that contains your new Expo project. While you can name the project anything, this guide uses my-project for consistency.
-This project does not need to live inside your existing native app and can be created in a separate repository or a monorepo. The new project includes an example TypeScript application to help you get started.
+The **my-project** does not need to live inside your existing native app and can be created in a separate repository or a monorepo. The new project includes an example TypeScript application to help you get started.
 
 </Step>
 
 <Step label="2">
 ### Install expo-brownfield
 
-Navigate to your new Expo project and install the `expo-brownfield` package, which provides the tools to build your React Native code as native libraries and integrate them into your existing native app.
+Navigate to your new Expo project and install the `expo-brownfield` library, which provides the tools to build your React Native code as native libraries and integrate them into your existing native app.
 
 <Terminal cmd={['$ npx expo install expo-brownfield']} />
 
@@ -62,8 +64,7 @@ Navigate to your new Expo project and install the `expo-brownfield` package, whi
 }
 ```
 
-The defaults are derived from your app config (for example, target names are based on your app's scheme or slug).
-But you can also pass options to customize the target names, bundle identifiers, and publishing configuration.
+The defaults are derived from your app config (for example, target names are based on your app's scheme or slug). You can also pass options to customize the target names, bundle identifiers, and publishing configuration.
 
 ```json app.json
 {
@@ -89,13 +90,13 @@ But you can also pass options to customize the target names, bundle identifiers,
 }
 ```
 
-Check the [API reference](/versions/latest/sdk/brownfield/) for details on all available options.
+See the [`expo-brownfield` API reference](/versions/latest/sdk/brownfield/) for details on all available options.
 
 </Step>
 
 ## Export your Expo project as a native library
 
-Once you have your Expo project set up, use the `expo-brownfield` CLI to build your React Native code as XCFrameworks for iOS and AARs for Android.
+Once you have your Expo project set up, use the `expo-brownfield` CLI to build your React Native code as  AARs for Android and XCFrameworks for iOS.
 
 <Tabs>
 <Tab label="Android">
@@ -116,32 +117,32 @@ From your Expo project directory, run:
 
 <Terminal cmd={['$ npx expo-brownfield build:ios']} />
 
-This will build the XCFramework artifacts, compiling the framework target for both device and simulator architectures, package them into XCFrameworks, and copy the Hermes engine framework.
+This will build the XCFramework artifacts: compile the framework target for both device and simulator architectures, package them into XCFrameworks, and copy the Hermes engine framework.
 
 When the build process is completed, the output is placed in the **./artifacts** directory and contains:
 
 - **\{TargetName\}.xcframework** - Your Expo project as a native library
 - **hermesvm.xcframework** - The Hermes JavaScript engine
 
-Check the [API reference](/versions/latest/sdk/brownfield/) for more details on build options, such as building only debug or release, specifying a custom output directory, and more.
+See the [`expo-brownfield` API reference](/versions/latest/sdk/brownfield/) for more details on build options, such as building only debug or release, specifying a custom output directory, and more.
 
 </Tab>
 </Tabs>
 
 <Collapsible summary="Debugging native targets">
 
-If you need to debug native code of the Expo project targets, you can run `npx expo prebuild` to generate the native projects with the brownfield library targets, inside the `./android` and `./ios` directories.
+If you need to debug native code of the Expo project targets, you can run `npx expo prebuild` to generate the native projects with the brownfield library targets, inside the **android** and **ios`** directories.
 
 <Terminal cmd={['$ npx expo prebuild']} />
 
-This generates:
+The above command generates the following:
 
-- **iOS**: A separate Xcode framework target containing `ReactNativeHostManager`, `ReactNativeViewController`, `ReactNativeView` (SwiftUI), `BrownfieldMessaging`, and `ReactNativeDelegate`.
 - **Android**: A separate library module containing `ReactNativeHostManager`, `BrownfieldActivity`, `ReactNativeFragment`, `ReactNativeViewFactory`, and `BrownfieldMessaging`.
+- **iOS**: A separate Xcode framework target containing `ReactNativeHostManager`, `ReactNativeViewController`, `ReactNativeView` (SwiftUI), `BrownfieldMessaging`, and `ReactNativeDelegate`.
 
 </Collapsible >
 
-## Integrating into your native app
+## Integrate into your native app
 
 With the artifacts built, you can now integrate them into your existing native app. The exact steps will depend on your project structure and build system, but the general process involves adding the pre-built artifacts as dependencies and initializing the React Native host.
 
@@ -217,7 +218,7 @@ startActivity(Intent(this, ExpoActivity::class.java))
 <Step label="1">
 ### Add XCFrameworks to your project
 
-Drag both XCFramework files (\{TargetName\}**.xcframework** and **hermes.xcframework**) into your Xcode project navigator. In the dialog that appears:
+Drag both XCFramework files (\{TargetName\}**.xcframework** and **hermesvm.xcframework**) into your Xcode project navigator. In the dialog that appears:
 
 - Check **Copy items if needed**
 - Add them to your app target
@@ -312,7 +313,7 @@ struct ContentView: View {
 
 ## Test your integration
 
-You have completed all the basic steps to integrate React Native with your application. Now it's time to test it out! The exact process will depend on whether you're running a debug or release build.
+You have completed all the basic steps to integrate React Native with your application. Now it's time to test it out. The exact process will depend on whether you're running a debug or release build.
 
 ### Development (debug builds)
 
@@ -320,11 +321,11 @@ Now run the following command in the React Native directory to start the [Metro 
 
 <Terminal cmd={['$ npx expo start']} />
 
-Then build and run the native app from Xcode or Android Studio. When you navigate to the React Native screen, it will load from the Metro dev server with hot reloading support.
+Then, build and run the native app from Android Studio or Xcode. When you navigate to the React Native screen, it will load from the Metro dev server with hot reloading support.
 
 ### Production (release builds)
 
-In release builds, the JavaScript bundle is embedded in the artifact (XCFramework or AAR), so Metro server is not needed. Build the native app in Release configuration and verify the React Native screen loads correctly.
+In release builds, the JavaScript bundle is embedded in the artifact (AAR or XCFramework), so the Metro server is not needed. Build the native app in Release configuration and verify the React Native screen loads correctly.
 
 ## Next steps
 

--- a/docs/pages/brownfield/isolated-approach.mdx
+++ b/docs/pages/brownfield/isolated-approach.mdx
@@ -222,7 +222,11 @@ Drag both XCFramework files (\{TargetName\}**.xcframework** and **hermes.xcframe
 - Check **Copy items if needed**
 - Add them to your app target
 
+{/* vale off */}
+
 Then, in your target's **General** tab under **Frameworks, Libraries, and Embedded Content**, ensure both frameworks are set to **Embed & Sign**.
+
+{/* vale on */}
 
 </Step>
 

--- a/docs/pages/brownfield/isolated-approach.mdx
+++ b/docs/pages/brownfield/isolated-approach.mdx
@@ -33,7 +33,6 @@ Learn more from the [Set up environment guide](/get-started/set-up-your-environm
 
 ### Create a new Expo project
 
-
 Run the following command to create a new directory named **my-project** that contains your new Expo project. While you can name the project anything, this guide uses **my-project** for consistency.
 
 <Terminal cmd={['$ npx create-expo-app@latest my-project']} />
@@ -66,6 +65,7 @@ Navigate to your new Expo project and install the `expo-brownfield` library, whi
 
 The defaults are derived from your app config (for example, target names are based on your app's scheme or slug). You can also pass options to customize the target names, bundle identifiers, and publishing configuration.
 
+<Collapsible summary="Custom expo-brownfield configuration">
 ```json app.json
 {
   "expo": {
@@ -89,6 +89,7 @@ The defaults are derived from your app config (for example, target names are bas
   }
 }
 ```
+</Collapsible>
 
 See the [`expo-brownfield` API reference](/versions/latest/sdk/brownfield/) for details on all available options.
 
@@ -96,7 +97,7 @@ See the [`expo-brownfield` API reference](/versions/latest/sdk/brownfield/) for 
 
 ## Export your Expo project as a native library
 
-Once you have your Expo project set up, use the `expo-brownfield` CLI to build your React Native code as  AARs for Android and XCFrameworks for iOS.
+Once you have your Expo project set up, use the `expo-brownfield` CLI to build your React Native code as AARs for Android and XCFrameworks for iOS.
 
 <Tabs>
 <Tab label="Android">
@@ -150,7 +151,7 @@ With the artifacts built, you can now integrate them into your existing native a
 <Tab label="Android">
 
 <Step label="1">
-### Add the Maven dependency
+#### Add the Maven dependency
 
 Start by adding the dependency to your app's **build.gradle.kts**. The group, artifact name, and version should match your config plugin settings:
 
@@ -175,7 +176,7 @@ dependencyResolutionManagement {
 </Step>
 
 <Step label="2">
-### Show a React Native screen
+#### Show a React Native screen
 
 Create an activity that extends `BrownfieldActivity` and use the `showReactNativeFragment()` extension:
 
@@ -216,7 +217,7 @@ startActivity(Intent(this, ExpoActivity::class.java))
 <Tab label="iOS">
 
 <Step label="1">
-### Add XCFrameworks to your project
+#### Add XCFrameworks to your project
 
 Drag both XCFramework files (\{TargetName\}**.xcframework** and **hermesvm.xcframework**) into your Xcode project navigator. In the dialog that appears:
 
@@ -232,7 +233,7 @@ Then, in your target's **General** tab under **Frameworks, Libraries, and Embedd
 </Step>
 
 <Step label="2">
-### Initialize React Native
+#### Initialize React Native
 
 Call `ReactNativeHostManager.shared.initialize()` early in your app's lifecycle. A good place is your `AppDelegate`:
 
@@ -255,7 +256,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 </Step>
 
 <Step label="3">
-### Present a React Native view
+#### Present a React Native view
 
 <Tabs>
 <Tab label="UIKit">

--- a/docs/pages/brownfield/isolated-approach.mdx
+++ b/docs/pages/brownfield/isolated-approach.mdx
@@ -91,7 +91,7 @@ The defaults are derived from your app config (for example, target names are bas
 ```
 </Collapsible>
 
-See the [`expo-brownfield` API reference](/versions/latest/sdk/brownfield/) for details on all available options.
+See the [`expo-brownfield` API reference](/versions/v55.0.0/sdk/brownfield/) for details on all available options.
 
 </Step>
 
@@ -109,7 +109,7 @@ From your Expo project directory, run:
 This will build the AAR and publish it to a Maven repository. By default, it publishes to your local Maven repository (`~/.m2`), but it can also be configured to publish to a remote repository.
 The produced artifact name will be determined by your config plugin settings, in this case `com.username.myproject:brownfield:1.0.0`.
 
-Check the [API reference](/versions/latest/sdk/brownfield/) for more details on build options, such as building only debug or release, specifying a custom output directory, and more.
+See the [API reference](/versions/v55.0.0/sdk/brownfield/) for more details on build options, such as building only debug or release, specifying a custom output directory, and more.
 
 </Tab>
 <Tab label="iOS">
@@ -125,7 +125,7 @@ When the build process is completed, the output is placed in the **./artifacts**
 - **\{TargetName\}.xcframework** - Your Expo project as a native library
 - **hermesvm.xcframework** - The Hermes JavaScript engine
 
-See the [`expo-brownfield` API reference](/versions/latest/sdk/brownfield/) for more details on build options, such as building only debug or release, specifying a custom output directory, and more.
+See the [`expo-brownfield` API reference](/versions/v55.0.0/sdk/brownfield/) for more details on build options, such as building only debug or release, specifying a custom output directory, and more.
 
 </Tab>
 </Tabs>
@@ -339,6 +339,6 @@ In release builds, the JavaScript bundle is embedded in the artifact (AAR or XCF
 <BoxLink
   title="expo-brownfield API reference"
   description="Explore the full JavaScript API for communication, navigation, and more."
-  href="/versions/latest/sdk/brownfield/"
+  href="/versions/v55.0.0/sdk/brownfield/"
   Icon={BookOpen02Icon}
 />

--- a/docs/pages/brownfield/overview.mdx
+++ b/docs/pages/brownfield/overview.mdx
@@ -65,8 +65,14 @@ This separation simplifies the workflow for native developers, as they don't nee
 ## Next steps
 
 <BoxLink
-  title="How to add Expo to an existing native (brownfield) app"
-  description="Learn how to add Expo and React Native root view into existing native apps."
-  href="/brownfield/get-started/"
+  title="Isolated approach: Package Expo as a native library"
+  description="Build your React Native code as XCFramework/AAR artifacts and integrate them into any native app."
+  href="/brownfield/isolated-approach/"
+  Icon={BookOpen02Icon}
+/>
+<BoxLink
+  title="Integrated approach: Add Expo directly to your native project"
+  description="Configure your existing native project to use React Native and Expo directly."
+  href="/brownfield/integrated-approach/"
   Icon={BookOpen02Icon}
 />

--- a/docs/pages/brownfield/overview.mdx
+++ b/docs/pages/brownfield/overview.mdx
@@ -66,7 +66,7 @@ This separation simplifies the workflow for native developers, as they don't nee
 
 <BoxLink
   title="Isolated approach: Package Expo as a native library"
-  description="Build your React Native code as XCFramework/AAR artifacts and integrate them into any native app."
+  description="Build your React Native code as AAR/ XCFramework artifacts and integrate them into any native app."
   href="/brownfield/isolated-approach/"
   Icon={BookOpen02Icon}
 />

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -292,7 +292,8 @@
 /regulatory-compliance/privacy-shield /regulatory-compliance/data-and-privacy-protection 301
 
 # After changing brownfield docs
-/brownfield/installing-expo-modules /brownfield/get-started 301
+/brownfield/installing-expo-modules /brownfield/overview 301
+/brownfield/get-started /brownfield/isolated-approach 301
 
 # After removing Navigation section from Home and adding a Navigation page
 /develop/file-based-routing /develop/app-navigation 301


### PR DESCRIPTION
# Why

SDK 55 is about to be released and we should include a full guide explaining how to use the new brownfield isolated approach

# How

Add brownfield isolated approach guide

# Test Plan

N / A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
