### PR TITLE
[go][Android] Fix cannot access constructor of NetInfoModule

### DIFF
--- a/patches/@react-native-community+netinfo+11.5.2.patch
+++ b/patches/@react-native-community+netinfo+11.5.2.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@react-native-community/netinfo/android/src/newarch/com/reactnativecommunity/netinfo/NetInfoModule.java b/node_modules/@react-native-community/netinfo/android/src/newarch/com/reactnativecommunity/netinfo/NetInfoModule.java
+index 61e44c4..d2c8844 100644
+--- a/node_modules/@react-native-community/netinfo/android/src/newarch/com/reactnativecommunity/netinfo/NetInfoModule.java
++++ b/node_modules/@react-native-community/netinfo/android/src/newarch/com/reactnativecommunity/netinfo/NetInfoModule.java
+@@ -9,7 +9,7 @@ public class NetInfoModule extends NativeRNCNetInfoSpec {
+ 
+     private NetInfoModuleImpl implementation;
+ 
+-    NetInfoModule(ReactApplicationContext context) {
++    public NetInfoModule(ReactApplicationContext context) {
+         super(context);
+         implementation = new NetInfoModuleImpl(context);
+     }


### PR DESCRIPTION
# Why

Fixes: `e: file:///home/expo/workingdir/build/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt:129:27 Cannot access 'constructor(p0: ReactApplicationContext!): NetInfoModule': it is package-private in 'com/reactnativecommunity/netinfo/NetInfoModule'.`

# Test Plan

- Android Expo Go ✅ 