### PR TITLE
[ci] bump tests to use ios 26

### DIFF
--- a/apps/bare-expo/scripts/start-ios-e2e-test.js
+++ b/apps/bare-expo/scripts/start-ios-e2e-test.js
@@ -9,7 +9,7 @@ const path = require('path');
 const { createMaestroFlowAsync, ensureDirAsync, getStartMode, retryAsync } = require('./lib/e2e-common.js');
 
 const TARGET_DEVICE = 'iPhone 16 Pro';
-const TARGET_DEVICE_IOS_VERSION = 18;
+const TARGET_DEVICE_IOS_VERSION = 26;
 const APP_ID = 'dev.expo.Payments';
 const MAESTRO_GENERATED_FLOW = 'e2e/maestro-generated.yaml';
 const OUTPUT_APP_PATH = 'ios/build/BareExpo.app';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
