### PR TITLE
[ci] Fix: execute postinstall on cache hit for all workflows

### DIFF
--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -75,7 +75,6 @@ jobs:
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🧶 Install node modules in root dir
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 📱 Run instrumented unit tests
         timeout-minutes: 80

--- a/.github/workflows/create-expo-app.yml
+++ b/.github/workflows/create-expo-app.yml
@@ -53,7 +53,6 @@ jobs:
         with:
           yarn-workspace: 'true'
       - name: 🧶 Install node modules in root dir
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🛠 Build create-expo
         run: yarn prepare

--- a/.github/workflows/development-client.yml
+++ b/.github/workflows/development-client.yml
@@ -37,7 +37,6 @@ jobs:
           ndk: 'true'
           ndk-version: ${{ matrix.ndk-version }}
       - name: 🧶 Yarn install
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: Init new expo app
         working-directory: ../
@@ -92,7 +91,6 @@ jobs:
         with:
           yarn-workspace: 'true'
       - name: 🧶 Yarn install
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: Init new expo app
         working-directory: ../

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,6 @@ jobs:
           yarn-workspace: 'true'
           docs-api-data: 'true'
       - name: 🧶 Install workspace deps on cache miss
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --immutable
       - name: 🧶 Install tools deps on cache miss
         if: steps.expo-caches.outputs.yarn-tools-hit != 'true'

--- a/.github/workflows/fingerprint.yml
+++ b/.github/workflows/fingerprint.yml
@@ -50,7 +50,6 @@ jobs:
         with:
           yarn-workspace: 'true'
       - name: 🧶 Install node modules in root dir
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         # NOTE(cedric): yarn v1 on Windows has networking issues, we need to set `--network-timeout` to a higher value
         run: yarn install --frozen-lockfile --network-timeout 1000000
       - name: E2E Test @expo/fingerprint

--- a/.github/workflows/ios-static-frameworks.yml
+++ b/.github/workflows/ios-static-frameworks.yml
@@ -37,7 +37,6 @@ jobs:
           yarn-workspace: 'true'
           yarn-tools: 'true'
       - name: 🧶 Yarn install
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🍏 Build iOS Project
         working-directory: ./apps/bare-expo

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -68,7 +68,6 @@ jobs:
           yarn-tools: 'true'
           native-tests-pods: 'true'
       - name: 🧶 Yarn install
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🥥 Install CocoaPods in `apps/native-tests/ios`
         if: steps.expo-caches.outputs.bare-expo-pods-hit != 'true'

--- a/.github/workflows/native-component-list.yml
+++ b/.github/workflows/native-component-list.yml
@@ -41,7 +41,6 @@ jobs:
           yarn-workspace: 'true'
           yarn-tools: 'true'
       - name: 🧶 Install workspace node modules
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🛠 Compile NCL sources
         run: yarn tsc

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -53,7 +53,6 @@ jobs:
         with:
           yarn-workspace: 'true'
       - name: 🧶 Install node modules in root dir
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: Get the base commit
         id: base-commit

--- a/.github/workflows/publish-canaries.yml
+++ b/.github/workflows/publish-canaries.yml
@@ -37,7 +37,6 @@ jobs:
           yarn-workspace: 'true'
           yarn-tools: 'true'
       - name: 🧶 Install workspace node modules
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🧶 Install modules in tools dir
         if: steps.expo-caches.outputs.yarn-tools-hit != 'true'

--- a/.github/workflows/router.yml
+++ b/.github/workflows/router.yml
@@ -42,7 +42,6 @@ jobs:
           yarn-workspace: 'true'
           yarn-tools: 'true'
       - name: 🧶 Install workspace node modules
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🧪 Run types tests
         working-directory: packages/expo-router

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -59,17 +59,14 @@ jobs:
           yarn-workspace: 'true'
           yarn-tools: 'true'
       - name: 🧶 Install workspace node modules
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🧐 Check all packages
-        if:
-          github.event_name == 'schedule' ||
+        if: github.event_name == 'schedule' ||
           github.event.inputs.checkAll == 'check-all' ||
           steps.filter.outputs.module-scripts == 'true'
         run: node bin/expotools check-packages --all
       - name: 🧐 Check changed packages
-        if:
-          github.event_name != 'schedule' &&
+        if: github.event_name != 'schedule' &&
           github.event.inputs.checkAll != 'check-all' &&
           steps.filter.outputs.module-scripts != 'true'
         env:
@@ -104,7 +101,6 @@ jobs:
           yarn-workspace: 'true'
           yarn-tools: 'true'
       - name: 🧶 Install workspace node modules
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🧐 Check all packages
         run: node bin/expotools check-packages --all

--- a/.github/workflows/test-suite-brownfield-isolated.yml
+++ b/.github/workflows/test-suite-brownfield-isolated.yml
@@ -83,7 +83,6 @@ jobs:
           yarn-tools: 'true'
           react-native-gradle-downloads: 'true'
       - name: 🧶 Install workspace node modules
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🤖 Build and publish Android artifacts (apps/brownfield-tester/expo-app)
         run: |

--- a/.github/workflows/test-suite-brownfield.yml
+++ b/.github/workflows/test-suite-brownfield.yml
@@ -69,7 +69,6 @@ jobs:
           yarn-workspace: 'true'
           yarn-tools: 'true'
       - name: 🧶 Install node modules in root dir
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🍏 Build iOS Project
         working-directory: ./apps/brownfield-tester
@@ -127,7 +126,6 @@ jobs:
           yarn-tools: 'true'
           react-native-gradle-downloads: 'true'
       - name: 🧶 Install node modules in root dir
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🤖 Build Android project
         run: |

--- a/.github/workflows/test-suite-lint.yml
+++ b/.github/workflows/test-suite-lint.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           yarn-workspace: 'true'
       - name: 🧶 Install workspace node modules
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🚨 Lint test-suite files
         run: yarn lint --max-warnings 0

--- a/.github/workflows/test-suite-macos.yml
+++ b/.github/workflows/test-suite-macos.yml
@@ -73,7 +73,6 @@ jobs:
           yarn-tools: 'true'
           bare-expo-macos-pods: 'true'
       - name: 🧶 Install node modules in root dir
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🕵️ Debug CocoaPods lockfiles
         run: git diff Podfile.lock Pods/Manifest.lock

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -119,7 +119,6 @@ jobs:
         with:
           yarn-workspace: 'true'
       - name: 🧶 Install node modules in root dir
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🍏 Run iOS tests
         run: ./scripts/start-ios-e2e-test.ts --test
@@ -246,6 +245,7 @@ jobs:
       - name: 🔔 Notify on Slack
         uses: ./.github/actions/slack-notify
         if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main')
+        with:
           webhook: ${{ secrets.slack_webhook_android }}
           channel: '#expo-android'
           author_name: Test Suite Nightly (Android)


### PR DESCRIPTION
# Why
I saw that `iOS Unit Tests / build (push)` keeps failing. 
That's a follow-up to https://github.com/expo/expo/pull/42990
# How
same as here: https://github.com/expo/expo/pull/42990
lint 
# Test Plan
green CI 