### PR TITLE
[ui][iOS] Fix rendering `0` in SwiftUI Text

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix rendering `0` in SwiftUI Text.
+
 ### 💡 Others
 
 ## 55.0.0-preview.5 — 2026-02-08

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix rendering `0` in SwiftUI Text.
+- [iOS] Fix rendering `0` in SwiftUI Text. ([#43036](https://github.com/expo/expo/pull/43036) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-ui/src/swift-ui/Text/index.tsx
+++ b/packages/expo-ui/src/swift-ui/Text/index.tsx
@@ -30,7 +30,7 @@ const TextNativeView: React.ComponentType<NativeTextProps> = requireNativeView(
 export function Text(props: TextProps) {
   const { children, modifiers, ...restProps } = props;
 
-  if (!children) {
+  if (children === undefined || children === null) {
     return null;
   }
 


### PR DESCRIPTION
# Why

`<Text>{0}</Text>` returns `null` instead of native component.

# How

Changed `!children` to `children === undefined || children === null`

# Test Plan

Pass `0` as a children to Text component 

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
