### PR TITLE
refactor(cli): Refactor env file loading and refactor reloading to not overwrite system keys

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add minimum Node.js version check and warning to CLI startup ([#43076](https://github.com/expo/expo/pull/43076) by [@kitten](https://github.com/kitten))
 - Retrieve default route's IP address concurrently ([#42923](https://github.com/expo/expo/pull/42923) by [@kitten](https://github.com/kitten))
 - Replace `require-from-string` with `@expo/require-utils` ([#42884](https://github.com/expo/expo/pull/42884) by [@kitten](https://github.com/kitten))
+- Refactor env loading and reloading to unified logic and don't overwrite original system values ([#43038](https://github.com/expo/expo/pull/43038) by [@kitten](https://github.com/kitten))
 
 ## 55.0.7 — 2026-02-08
 

--- a/packages/@expo/cli/src/config/configAsync.ts
+++ b/packages/@expo/cli/src/config/configAsync.ts
@@ -4,7 +4,7 @@ import util from 'util';
 
 import * as Log from '../log';
 import { CommandError } from '../utils/errors';
-import { setNodeEnv } from '../utils/nodeEnv';
+import { setNodeEnv, loadEnvFiles } from '../utils/nodeEnv';
 import { profile } from '../utils/profile';
 
 type Options = {
@@ -45,7 +45,7 @@ export async function configAsync(projectRoot: string, options: Options) {
     console.error = function () {};
   }
   setNodeEnv('development');
-  require('@expo/env').load(projectRoot);
+  loadEnvFiles(projectRoot);
 
   if (options.type) {
     assert.match(options.type, /^(public|prebuild|introspect)$/);

--- a/packages/@expo/cli/src/customize/customizeAsync.ts
+++ b/packages/@expo/cli/src/customize/customizeAsync.ts
@@ -6,7 +6,7 @@ import { DestinationResolutionProps } from './templates';
 import { getRouterDirectoryModuleIdWithManifest } from '../start/server/metro/router';
 import { getPlatformBundlers } from '../start/server/platformBundlers';
 import { findUpProjectRootOrAssert } from '../utils/findUp';
-import { setNodeEnv } from '../utils/nodeEnv';
+import { setNodeEnv, loadEnvFiles } from '../utils/nodeEnv';
 
 export async function customizeAsync(files: string[], options: Options, extras: any[]) {
   setNodeEnv('development');
@@ -14,7 +14,7 @@ export async function customizeAsync(files: string[], options: Options, extras: 
   // This enables users to run `npx expo customize` from a subdirectory of the project.
   const projectRoot = findUpProjectRootOrAssert(process.cwd());
 
-  require('@expo/env').load(projectRoot);
+  loadEnvFiles(projectRoot);
 
   // Get the static path (defaults to 'web/')
   // Doesn't matter if expo is installed or which mode is used.

--- a/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
+++ b/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
@@ -26,7 +26,7 @@ import { getMetroDirectBundleOptionsForExpoConfig } from '../../start/server/mid
 import { stripAnsi } from '../../utils/ansi';
 import { copyAsync, removeAsync } from '../../utils/dir';
 import { env } from '../../utils/env';
-import { setNodeEnv } from '../../utils/nodeEnv';
+import { setNodeEnv, loadEnvFiles } from '../../utils/nodeEnv';
 import { exportDomComponentAsync } from '../exportDomComponents';
 import { isEnableHermesManaged } from '../exportHermes';
 import { persistMetroAssetsAsync } from '../persistMetroAssets';
@@ -68,7 +68,7 @@ export async function exportEmbedAsync(projectRoot: string, options: Options) {
   }
 
   setNodeEnv(options.dev ? 'development' : 'production');
-  require('@expo/env').load(projectRoot);
+  loadEnvFiles(projectRoot);
 
   // This is an optimized codepath that can occur during `npx expo run` and does not occur during builds from Xcode or Android Studio.
   // Here we reconcile a bundle pass that was run before the native build process. This order can fail faster and is show better errors since the logs won't be obscured by Xcode and Android Studio.

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -43,7 +43,7 @@ import { getBaseUrlFromExpoConfig } from '../start/server/middleware/metroOption
 import { createTemplateHtmlFromExpoConfigAsync } from '../start/server/webTemplate';
 import { env } from '../utils/env';
 import { CommandError } from '../utils/errors';
-import { setNodeEnv } from '../utils/nodeEnv';
+import { setNodeEnv, loadEnvFiles } from '../utils/nodeEnv';
 
 export async function exportAppAsync(
   projectRoot: string,
@@ -80,8 +80,7 @@ export async function exportAppAsync(
   const environment = dev ? 'development' : 'production';
   process.env.NODE_ENV = environment;
   setNodeEnv(environment);
-
-  require('@expo/env').load(projectRoot);
+  loadEnvFiles(projectRoot);
 
   const projectConfig = getConfig(projectRoot);
   const exp = await getPublicExpoManifestAsync(projectRoot, {

--- a/packages/@expo/cli/src/export/web/exportWebAsync.ts
+++ b/packages/@expo/cli/src/export/web/exportWebAsync.ts
@@ -7,14 +7,14 @@ import { WebSupportProjectPrerequisite } from '../../start/doctor/web/WebSupport
 import { getPlatformBundlers } from '../../start/server/platformBundlers';
 import { WebpackBundlerDevServer } from '../../start/server/webpack/WebpackBundlerDevServer';
 import { CommandError } from '../../utils/errors';
-import { setNodeEnv } from '../../utils/nodeEnv';
+import { setNodeEnv, loadEnvFiles } from '../../utils/nodeEnv';
 
 export async function exportWebAsync(projectRoot: string, options: Options) {
   // Ensure webpack is available
   await new WebSupportProjectPrerequisite(projectRoot).assertAsync();
 
   setNodeEnv(options.dev ? 'development' : 'production');
-  require('@expo/env').load(projectRoot);
+  loadEnvFiles(projectRoot);
 
   const { exp } = getConfig(projectRoot);
   const platformBundlers = getPlatformBundlers(projectRoot, exp);

--- a/packages/@expo/cli/src/install/installAsync.ts
+++ b/packages/@expo/cli/src/install/installAsync.ts
@@ -13,7 +13,7 @@ import { env } from '../utils/env';
 import { CommandError } from '../utils/errors';
 import { findUpProjectRootOrAssert } from '../utils/findUp';
 import { learnMore } from '../utils/link';
-import { setNodeEnv } from '../utils/nodeEnv';
+import { setNodeEnv, loadEnvFiles } from '../utils/nodeEnv';
 import { joinWithCommasAnd } from '../utils/strings';
 
 /**
@@ -34,7 +34,7 @@ export async function installAsync(
   // Locate the project root based on the process current working directory.
   // This enables users to run `npx expo install` from a subdirectory of the project.
   const projectRoot = options?.projectRoot ?? findUpProjectRootOrAssert(process.cwd());
-  require('@expo/env').load(projectRoot);
+  loadEnvFiles(projectRoot);
 
   // Resolve the package manager used by the project, or based on the provided arguments.
   const packageManager = PackageManager.createForProject(projectRoot, {

--- a/packages/@expo/cli/src/lint/lintAsync.ts
+++ b/packages/@expo/cli/src/lint/lintAsync.ts
@@ -7,7 +7,7 @@ import { ESLintProjectPrerequisite } from './ESlintPrerequisite';
 import type { Options } from './resolveOptions';
 import { CommandError } from '../utils/errors';
 import { findUpProjectRootOrAssert } from '../utils/findUp';
-import { setNodeEnv } from '../utils/nodeEnv';
+import { setNodeEnv, loadEnvFiles } from '../utils/nodeEnv';
 
 const debug = require('debug')('expo:lint');
 
@@ -22,7 +22,7 @@ export const lintAsync = async (
   // Locate the project root based on the process current working directory.
   // This enables users to run `npx expo install` from a subdirectory of the project.
   const projectRoot = options?.projectRoot ?? findUpProjectRootOrAssert(process.cwd());
-  require('@expo/env').load(projectRoot);
+  loadEnvFiles(projectRoot);
 
   // TODO: Perhaps we should assert that TypeScript is required.
 

--- a/packages/@expo/cli/src/prebuild/prebuildAsync.ts
+++ b/packages/@expo/cli/src/prebuild/prebuildAsync.ts
@@ -10,7 +10,7 @@ import { updateFromTemplateAsync } from './updateFromTemplate';
 import { installAsync } from '../install/installAsync';
 import { Log } from '../log';
 import { env } from '../utils/env';
-import { setNodeEnv } from '../utils/nodeEnv';
+import { setNodeEnv, loadEnvFiles } from '../utils/nodeEnv';
 import { clearNodeModulesAsync } from '../utils/nodeModules';
 import { logNewSection } from '../utils/ora';
 import { profile } from '../utils/profile';
@@ -63,7 +63,7 @@ export async function prebuildAsync(
   }
 ): Promise<PrebuildResults | null> {
   setNodeEnv('development');
-  require('@expo/env').load(projectRoot);
+  loadEnvFiles(projectRoot);
 
   const { platforms } = getConfig(projectRoot).exp;
   if (platforms?.length) {

--- a/packages/@expo/cli/src/run/android/runAndroidAsync.ts
+++ b/packages/@expo/cli/src/run/android/runAndroidAsync.ts
@@ -10,7 +10,7 @@ import type { AndroidOpenInCustomProps } from '../../start/platforms/android/And
 import { assembleAsync, installAsync } from '../../start/platforms/android/gradle';
 import { resolveBuildCache, uploadBuildCache } from '../../utils/build-cache-providers';
 import { CommandError } from '../../utils/errors';
-import { setNodeEnv } from '../../utils/nodeEnv';
+import { setNodeEnv, loadEnvFiles } from '../../utils/nodeEnv';
 import { ensurePortAvailabilityAsync } from '../../utils/port';
 import { getSchemesForAndroidAsync } from '../../utils/scheme';
 import { ensureNativeProjectAsync } from '../ensureNativeProject';
@@ -23,7 +23,7 @@ export async function runAndroidAsync(projectRoot: string, { install, ...options
   // NOTE: This is a guess, the developer can overwrite with `NODE_ENV`.
   const isProduction = options.variant?.toLowerCase().endsWith('release');
   setNodeEnv(isProduction ? 'production' : 'development');
-  require('@expo/env').load(projectRoot);
+  loadEnvFiles(projectRoot);
 
   await ensureNativeProjectAsync(projectRoot, { platform: 'android', install });
 

--- a/packages/@expo/cli/src/run/ios/runIosAsync.ts
+++ b/packages/@expo/cli/src/run/ios/runIosAsync.ts
@@ -15,7 +15,7 @@ import { getContainerPathAsync, simctlAsync } from '../../start/platforms/ios/si
 import { resolveBuildCache, uploadBuildCache } from '../../utils/build-cache-providers';
 import { maybePromptToSyncPodsAsync } from '../../utils/cocoapods';
 import { CommandError } from '../../utils/errors';
-import { setNodeEnv } from '../../utils/nodeEnv';
+import { setNodeEnv, loadEnvFiles } from '../../utils/nodeEnv';
 import { ensurePortAvailabilityAsync } from '../../utils/port';
 import { profile } from '../../utils/profile';
 import { getSchemesForIosAsync } from '../../utils/scheme';
@@ -27,7 +27,7 @@ const debug = require('debug')('expo:run:ios');
 
 export async function runIosAsync(projectRoot: string, options: Options) {
   setNodeEnv(options.configuration === 'Release' ? 'production' : 'development');
-  require('@expo/env').load(projectRoot);
+  loadEnvFiles(projectRoot);
 
   assertPlatform();
 

--- a/packages/@expo/cli/src/serve/serveAsync.ts
+++ b/packages/@expo/cli/src/serve/serveAsync.ts
@@ -9,7 +9,7 @@ import * as Log from '../log';
 import { directoryExistsAsync, fileExistsAsync } from '../utils/dir';
 import { CommandError } from '../utils/errors';
 import { findUpProjectRootOrAssert } from '../utils/findUp';
-import { setNodeEnv } from '../utils/nodeEnv';
+import { setNodeEnv, loadEnvFiles } from '../utils/nodeEnv';
 import { resolvePortAsync } from '../utils/port';
 
 type Options = {
@@ -24,7 +24,7 @@ export async function serveAsync(inputDir: string, options: Options) {
   const projectRoot = findUpProjectRootOrAssert(inputDir);
 
   setNodeEnv('production');
-  require('@expo/env').load(projectRoot);
+  loadEnvFiles(projectRoot);
 
   const port = await resolvePortAsync(projectRoot, {
     defaultPort: options.port,

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -6,7 +6,6 @@
  */
 import { ExpoConfig, getConfig } from '@expo/config';
 import { getMetroServerRoot } from '@expo/config/paths';
-import * as runtimeEnv from '@expo/env';
 import baseJSBundle from '@expo/metro/metro/DeltaBundler/Serializers/baseJSBundle';
 import {
   sourceMapGeneratorNonBlocking,
@@ -71,7 +70,7 @@ import { Log } from '../../../log';
 import { env } from '../../../utils/env';
 import { CommandError } from '../../../utils/errors';
 import { toPosixPath } from '../../../utils/filePath';
-import { reloadEnvFiles } from '../../../utils/nodeEnv';
+import { getEnvFiles, reloadEnvFiles } from '../../../utils/nodeEnv';
 import { getFreePortAsync } from '../../../utils/port';
 import { BundlerDevServer, BundlerStartOptions, DevServerInstance } from '../BundlerDevServer';
 import {
@@ -1139,16 +1138,12 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       return;
     }
 
-    const envFiles = runtimeEnv
-      .getEnvFiles({ mode: process.env.NODE_ENV })
-      .map((fileName) => path.join(this.projectRoot, fileName));
-
     observeFileChanges(
       {
         metro: this.metro,
         server: this.instance.server,
       },
-      envFiles,
+      getEnvFiles(this.projectRoot),
       () => {
         debug('Reloading environment variables...');
         // Force reload the environment variables.

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -71,6 +71,7 @@ import { Log } from '../../../log';
 import { env } from '../../../utils/env';
 import { CommandError } from '../../../utils/errors';
 import { toPosixPath } from '../../../utils/filePath';
+import { reloadEnvFiles } from '../../../utils/nodeEnv';
 import { getFreePortAsync } from '../../../utils/port';
 import { BundlerDevServer, BundlerStartOptions, DevServerInstance } from '../BundlerDevServer';
 import {
@@ -1139,7 +1140,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
     }
 
     const envFiles = runtimeEnv
-      .getFiles(process.env.NODE_ENV)
+      .getEnvFiles({ mode: process.env.NODE_ENV })
       .map((fileName) => path.join(this.projectRoot, fileName));
 
     observeFileChanges(
@@ -1151,7 +1152,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       () => {
         debug('Reloading environment variables...');
         // Force reload the environment variables.
-        runtimeEnv.load(this.projectRoot, { force: true });
+        reloadEnvFiles(this.projectRoot);
       }
     );
   }

--- a/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
@@ -17,7 +17,7 @@ import { ensureEnvironmentSupportsTLSAsync } from './tls';
 import * as Log from '../../../log';
 import { env } from '../../../utils/env';
 import { CommandError } from '../../../utils/errors';
-import { setNodeEnv } from '../../../utils/nodeEnv';
+import { setNodeEnv, loadEnvFiles } from '../../../utils/nodeEnv';
 import { choosePortAsync } from '../../../utils/port';
 import { createProgressBar } from '../../../utils/progress';
 import { ensureDotExpoProjectDirectoryInitialized } from '../../project/dotExpo';
@@ -259,8 +259,10 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
       mode: options.mode,
       https: options.https,
     };
+
     setNodeEnv(env.mode ?? 'development');
-    require('@expo/env').load(env.projectRoot);
+    loadEnvFiles(env.projectRoot);
+
     // Check if the project has a webpack.config.js in the root.
     const projectWebpackConfig = this.getProjectConfigFilePath();
     let config: WebpackConfiguration;

--- a/packages/@expo/cli/src/utils/nodeEnv.ts
+++ b/packages/@expo/cli/src/utils/nodeEnv.ts
@@ -1,4 +1,5 @@
 import * as env from '@expo/env';
+import path from 'node:path';
 
 type EnvOutput = Record<string, string | undefined>;
 
@@ -51,6 +52,12 @@ export function loadEnvFiles(projectRoot: string, options?: LoadEnvFilesOptions)
 
   env.logLoadedEnv(envInfo, params);
   return process.env;
+}
+
+export function getEnvFiles(projectRoot: string) {
+  return env
+    .getEnvFiles({ mode: process.env.NODE_ENV })
+    .map((fileName) => path.join(projectRoot, fileName));
 }
 
 export function reloadEnvFiles(projectRoot: string) {

--- a/packages/@expo/cli/src/utils/nodeEnv.ts
+++ b/packages/@expo/cli/src/utils/nodeEnv.ts
@@ -1,5 +1,7 @@
 import * as env from '@expo/env';
 
+type EnvOutput = Record<string, string | undefined>;
+
 // TODO(@kitten): We assign this here to run server-side code bundled by metro
 // It's not isolated into a worker thread yet
 declare namespace globalThis {
@@ -16,10 +18,49 @@ export function setNodeEnv(mode: 'development' | 'production') {
   globalThis.__DEV__ = process.env.NODE_ENV !== 'production';
 }
 
+interface LoadEnvFilesOptions {
+  force?: boolean;
+  silent?: boolean;
+  mode?: string;
+}
+
 /**
  * Load the dotenv files into the current `process.env` scope.
  * Note, this requires `NODE_ENV` being set through `setNodeEnv`.
  */
-export function loadEnvFiles(projectRoot: string, options?: Parameters<typeof env.load>[1]) {
-  return env.load(projectRoot, options);
+export function loadEnvFiles(projectRoot: string, options?: LoadEnvFilesOptions) {
+  const isEnabled = env.isEnabled();
+  if (isEnabled) {
+    const params = {
+      ...options,
+      force: !!options?.force,
+      silent: !!options?.silent,
+      mode: process.env.NODE_ENV,
+    };
+
+    const envInfo = env.parseProjectEnv(projectRoot, params);
+    const envOutput: EnvOutput = {};
+    const skipped: string[] = [];
+    for (const key in envInfo.env) {
+      if (typeof process.env[key] !== 'undefined') {
+        skipped.push(key);
+      } else {
+        process.env[key] = envInfo.env[key];
+        envOutput[key] = envInfo.env[key] ?? undefined;
+      }
+    }
+
+    if (!params.silent) {
+      env.logLoadedEnv(
+        {
+          ...envInfo,
+          result: 'loaded',
+          loaded: Object.keys(envOutput),
+        },
+        params
+      );
+    }
+  }
+
+  return process.env;
 }

--- a/packages/@expo/cli/src/utils/nodeEnv.ts
+++ b/packages/@expo/cli/src/utils/nodeEnv.ts
@@ -24,43 +24,60 @@ interface LoadEnvFilesOptions {
   mode?: string;
 }
 
+let prevEnvKeys: Set<string> | undefined;
+
 /**
  * Load the dotenv files into the current `process.env` scope.
  * Note, this requires `NODE_ENV` being set through `setNodeEnv`.
  */
 export function loadEnvFiles(projectRoot: string, options?: LoadEnvFilesOptions) {
-  const isEnabled = env.isEnabled();
-  if (isEnabled) {
-    const params = {
-      ...options,
-      force: !!options?.force,
-      silent: !!options?.silent,
-      mode: process.env.NODE_ENV,
-    };
+  const params = {
+    ...options,
+    force: !!options?.force,
+    silent: !!options?.silent,
+    mode: process.env.NODE_ENV,
+    systemEnv: process.env,
+  };
 
-    const envInfo = env.parseProjectEnv(projectRoot, params);
-    const envOutput: EnvOutput = {};
-    const skipped: string[] = [];
-    for (const key in envInfo.env) {
-      if (typeof process.env[key] !== 'undefined') {
-        skipped.push(key);
-      } else {
-        process.env[key] = envInfo.env[key];
-        envOutput[key] = envInfo.env[key] ?? undefined;
-      }
-    }
-
-    if (!params.silent) {
-      env.logLoadedEnv(
-        {
-          ...envInfo,
-          result: 'loaded',
-          loaded: Object.keys(envOutput),
-        },
-        params
-      );
+  const envInfo = env.loadProjectEnv(projectRoot, params);
+  const envOutput: EnvOutput = {};
+  if (envInfo.result === 'loaded') {
+    prevEnvKeys = new Set();
+    for (const key of envInfo.loaded) {
+      envOutput[key] = envInfo.env[key] ?? undefined;
+      prevEnvKeys.add(key);
     }
   }
 
+  env.logLoadedEnv(envInfo, params);
   return process.env;
+}
+
+export function reloadEnvFiles(projectRoot: string) {
+  const isEnabled = env.isEnabled();
+  if (isEnabled) {
+    const params = {
+      force: true,
+      silent: true,
+      mode: process.env.NODE_ENV,
+      systemEnv: process.env,
+    };
+
+    // We use a global tracker to allow overwrites of env vars we set ourselves
+    const envInfo = env.parseProjectEnv(projectRoot, params);
+    const envOutput: EnvOutput = {};
+    for (const key in envInfo.env) {
+      const value = envInfo.env[key];
+      if (process.env[key] !== value) {
+        if (
+          typeof process.env[key] === 'undefined' ||
+          ((!prevEnvKeys || prevEnvKeys.has(key)) && process.env[key] !== value)
+        ) {
+          (prevEnvKeys ||= new Set()).add(key);
+          process.env[key] = envInfo.env[key];
+          envOutput[key] = value ?? undefined;
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
# Why

Based on #43037

This refactors all old `require('@expo/env').load` calls to instead go through `src/utils/nodeEnv.ts` helpers, and updates said helpers to use the newer (undeprecated) `@expo/env` calls.

This also replaces the reloading logic for env files in `MetroBundlerDevServer`. The new logic keeps track of values we've set (which had to have kept track of `typeof process.env[key] === 'undefined'`) and does another `typeof process.env[key] === 'undefined'` check before setting them. Together with #43037 this should now consistently reload environment variables, update them, and not overwrite any values that were already set in the environment.

**Note:** This should be sufficient to affect `@expo/metro-config`'s serializer which should be updating this value, but I'd need to double-check that. CI tests generally cover this behaviour though.

# How

- Update all CLI commands to use `loadEnvFiles` from `nodeEnv.ts`
- Update implementation of `loadEnvFiles` to use newer helpers from `@expo/env`
- Keep track of set keys and add `reloadEnvFiles` helper to `nodeEnv.ts`
- Add `getEnvFiles` helper to `nodeEnv.ts`
- Update `MetroBundlerDevServer`

# Test Plan

- Existing E2E tests should cover this together with unit test changes in the base PR

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
