### PR TITLE
[template] fix keyframe animation on AnimatedSplashOverlay remount

### DIFF
--- a/templates/expo-template-default/src/components/animated-icon.tsx
+++ b/templates/expo-template-default/src/components/animated-icon.tsx
@@ -7,29 +7,29 @@ import { scheduleOnRN } from 'react-native-worklets';
 const INITIAL_SCALE_FACTOR = Dimensions.get('screen').height / 90;
 const DURATION = 600;
 
-const splashKeyframe = new Keyframe({
-  0: {
-    transform: [{ scale: INITIAL_SCALE_FACTOR }],
-    opacity: 1,
-  },
-  20: {
-    opacity: 1,
-  },
-  70: {
-    opacity: 0,
-    easing: Easing.elastic(0.7),
-  },
-  100: {
-    opacity: 0,
-    transform: [{ scale: 1 }],
-    easing: Easing.elastic(0.7),
-  },
-});
-
 export function AnimatedSplashOverlay() {
   const [visible, setVisible] = useState(true);
 
   if (!visible) return null;
+
+  const splashKeyframe = new Keyframe({
+    0: {
+      transform: [{ scale: INITIAL_SCALE_FACTOR }],
+      opacity: 1,
+    },
+    20: {
+      opacity: 1,
+    },
+    70: {
+      opacity: 0,
+      easing: Easing.elastic(0.7),
+    },
+    100: {
+      opacity: 0,
+      transform: [{ scale: 1 }],
+      easing: Easing.elastic(0.7),
+    },
+  });
 
   return (
     <Animated.View


### PR DESCRIPTION
# Why

Because the `Keyframe` was created in the global scope, the worklet assigned `setVisible` only once. Therefore when the `AnimatedSplashOverlay` was remounted, the "splash screen overlay" remained visible. 

Fixes: https://github.com/expo/expo/issues/42500

Full context - https://exponent-internal.slack.com/archives/CGHFEK33M/p1770717235914549

## Before

https://github.com/user-attachments/assets/40d12010-b7b4-4e67-b696-10419ee5e795

## After

https://github.com/user-attachments/assets/963eb889-f05d-4eab-b5c4-d7e9e00046a6

# How

Move the `Keyframe` creation to the component scope

# Test Plan

Manual testing

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
