### PR TITLE
[docs] fix prettier

### DIFF
--- a/docs/pages/build-reference/ios-capabilities.mdx
+++ b/docs/pages/build-reference/ios-capabilities.mdx
@@ -62,7 +62,7 @@ EAS Build will only enable capabilities that it has built-in support for, any un
 | <YesIcon /> | Increased Memory Limit                            | `com.apple.developer.kernel.increased-memory-limit`                                                              |
 | <YesIcon /> | Inter-App Audio                                   | `inter-app-audio`                                                                                                |
 | <YesIcon /> | Journaling Suggestions                            | `com.apple.developer.journal.allow`                                                                              |
-| <YesIcon /> | Low Latency HLS                                   | `com.apple.developer.low-latency-streaming`                                                                  |
+| <YesIcon /> | Low Latency HLS                                   | `com.apple.developer.low-latency-streaming`                                                                      |
 | <YesIcon /> | MDM Managed Associated Domains                    | `com.apple.developer.associated-domains.mdm-managed`                                                             |
 | <YesIcon /> | Managed App Installation UI                       | `com.apple.developer.managed-app-distribution.install-ui`                                                        |
 | <YesIcon /> | Maps                                              | `com.apple.developer.maps`                                                                                       |


### PR DESCRIPTION
# Why

Fixed the alignment of the "Low Latency HLS" capability entry in the iOS capabilities documentation table.

# How



# Test Plan



# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)