### PR TITLE
[docs] Handle edge cases in generate-markdown-script

### DIFF
--- a/docs/scripts/generate-markdown-pages-utils.test.ts
+++ b/docs/scripts/generate-markdown-pages-utils.test.ts
@@ -9,10 +9,100 @@ import {
   cleanHtml,
   cleanMarkdown,
   convertHtmlToMarkdown,
+  convertMdxInstructionToMarkdown,
   extractFrontmatter,
   findMdxSource,
   stripCodeBlocks,
 } from './generate-markdown-pages-utils.ts';
+
+describe('convertMdxInstructionToMarkdown', () => {
+  it('converts scene JSX components and inlines helper MDX', () => {
+    const mdx = `
+import Helper from './_helper.mdx';
+import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
+
+<BuildEnvironmentSwitch />
+
+## Set up root
+
+<Helper />
+
+<Step label="1">
+<Terminal cmd={['$ npm install -g eas-cli', '', '# comment', 'echo done']} />
+</Step>
+
+<div className="wrapper">
+  <QRCodeReact value="https://example.dev/download" size={228} />
+</div>
+
+Press <kbd>Y</kbd> when prompted.
+
+<ContentSpotlight alt="ignored" src="/image.png" />
+`;
+
+    const helperMdx = `
+import { Tabs, Tab } from '~/ui/components/Tabs';
+import { Collapsible } from '~/ui/components/Collapsible';
+
+<Tabs>
+  <Tab label="macOS">
+    <Collapsible summary="Troubleshooting">Helper details</Collapsible>
+  </Tab>
+  <Tab label="Windows">
+    Helper on Windows
+  </Tab>
+</Tabs>
+`;
+
+    const markdown = convertMdxInstructionToMarkdown(
+      mdx,
+      (importPath, fromPath) => {
+        if (importPath === './_helper.mdx' && fromPath === '/tmp/root.mdx') {
+          return { content: helperMdx, resolvedPath: '/tmp/_helper.mdx' };
+        }
+        return null;
+      },
+      { fromPath: '/tmp/root.mdx' }
+    );
+
+    expect(markdown).toContain('## Set up root');
+    expect(markdown).toContain('#### macOS');
+    expect(markdown).toContain('**Troubleshooting**');
+    expect(markdown).toContain('```sh\nnpm install -g eas-cli\necho done\n```');
+    expect(markdown).toContain('Download link: [https://example.dev/download]');
+    expect(markdown).toContain('Press <kbd>Y</kbd> when prompted.');
+    expect(markdown).not.toMatch(
+      /<BuildEnvironmentSwitch|<Terminal|<Step|<ContentSpotlight|import\s/
+    );
+    expect(markdown).not.toContain('# comment');
+  });
+
+  it('avoids recursive import loops', () => {
+    const files = new Map<string, string>([
+      ['/tmp/main.mdx', "import A from './A.mdx';\n\n<A />\n"],
+      ['/tmp/A.mdx', "import B from './B.mdx';\n\n## A heading\n\n<B />\n"],
+      ['/tmp/B.mdx', "import A from './A.mdx';\n\n## B heading\n\n<A />\n"],
+    ]);
+
+    const markdown = convertMdxInstructionToMarkdown(
+      files.get('/tmp/main.mdx')!,
+      (importPath, fromPath) => {
+        const parentDir = path.dirname(fromPath ?? '/tmp/main.mdx');
+        const resolvedPath = path.resolve(parentDir, importPath);
+        const content = files.get(resolvedPath);
+        if (!content) {
+          return null;
+        }
+        return { content, resolvedPath };
+      },
+      { fromPath: '/tmp/main.mdx' }
+    );
+
+    expect(markdown).toContain('## A heading\n\n## B heading');
+    expect(markdown).not.toMatch(/<A\s*\/>|<B\s*\/>/);
+  });
+});
 
 describe('cleanHtml', () => {
   it('removes buttons', () => {

--- a/docs/scripts/generate-markdown-pages-utils.test.ts
+++ b/docs/scripts/generate-markdown-pages-utils.test.ts
@@ -351,6 +351,59 @@ describe('terminal snippet labels', () => {
     expect(md).not.toContain('Terminal');
     expect(md).not.toContain('- ');
   });
+
+  it('converts tabbed terminal commands from data-md-commands in package manager order', () => {
+    const commands = {
+      bun: ['$ bun add expo'],
+      yarn: ['$ yarn add expo'],
+      npm: ['$ npm install expo', '# npm comment'],
+      pnpm: ['$ pnpm add expo'],
+    };
+    const $ = cheerio.load(`<main>
+      <div data-md="terminal">
+        <div data-md="snippet-header"><span>Terminal</span></div>
+        <div data-md="code-block"><code>npm install expo</code></div>
+      </div>
+    </main>`);
+    $('[data-md="terminal"]').attr('data-md-commands', JSON.stringify(commands));
+
+    const md = convertHtmlToMarkdown($.html());
+    const npmIndex = md.indexOf('# npm');
+    const yarnIndex = md.indexOf('# yarn');
+    const pnpmIndex = md.indexOf('# pnpm');
+    const bunIndex = md.indexOf('# bun');
+
+    expect(npmIndex).toBeGreaterThan(-1);
+    expect(yarnIndex).toBeGreaterThan(npmIndex);
+    expect(pnpmIndex).toBeGreaterThan(yarnIndex);
+    expect(bunIndex).toBeGreaterThan(pnpmIndex);
+    expect(md).toContain('npm install expo');
+    expect(md).toContain('yarn add expo');
+    expect(md).toContain('pnpm add expo');
+    expect(md).toContain('bun add expo');
+    expect(md).not.toContain('# npm comment');
+  });
+
+  it('skips empty/comment-only manager sections, ignores unknown keys, and preserves angle brackets', () => {
+    const commands = {
+      npm: ['# only comment', ''],
+      pnpm: ['$ pnpm add <package-name>'],
+      unknown: ['$ unknown add expo'],
+    };
+    const $ = cheerio.load(`<main>
+      <div data-md="terminal">
+        <div data-md="snippet-header"><span>Terminal</span></div>
+        <div data-md="code-block"><code>npm install expo</code></div>
+      </div>
+    </main>`);
+    $('[data-md="terminal"]').attr('data-md-commands', JSON.stringify(commands));
+
+    const md = convertHtmlToMarkdown($.html());
+
+    expect(md).toContain('```sh\n# pnpm\npnpm add <package-name>\n```');
+    expect(md).not.toContain('# npm');
+    expect(md).not.toContain('unknown add expo');
+  });
 });
 
 describe('step numbers', () => {

--- a/docs/scripts/generate-markdown-pages-utils.test.ts
+++ b/docs/scripts/generate-markdown-pages-utils.test.ts
@@ -1262,6 +1262,7 @@ describe('extractFrontmatter', () => {
       path.join(tmpDir, 'full.mdx'),
       [
         '---',
+        'modificationDate: July 08, 2025',
         'title: Camera',
         'description: A camera component.',
         "platforms: ['android', 'ios']",
@@ -1294,12 +1295,13 @@ describe('extractFrontmatter', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('extracts full frontmatter including delimiters', () => {
+  it('extracts only modificationDate including delimiters', () => {
     const result = extractFrontmatter(path.join(tmpDir, 'full.mdx'));
     expect(result).not.toBeNull();
-    expect(result).toContain('title: Camera');
-    expect(result).toContain('description: A camera component.');
-    expect(result).toContain('platforms:');
+    expect(result).toContain('modificationDate: July 08, 2025');
+    expect(result).not.toContain('title: Camera');
+    expect(result).not.toContain('description: A camera component.');
+    expect(result).not.toContain('platforms:');
     // Should include --- delimiters
     expect(result).toMatch(/^---\n/);
     expect(result).toMatch(/\n---\n$/);
@@ -1307,19 +1309,14 @@ describe('extractFrontmatter', () => {
     expect(result).not.toContain('import');
   });
 
-  it('extracts minimal frontmatter', () => {
+  it('returns null when frontmatter has no modificationDate', () => {
     const result = extractFrontmatter(path.join(tmpDir, 'minimal.mdx'));
-    expect(result).not.toBeNull();
-    expect(result).toContain('title: Minimal');
-    expect(result).not.toContain('# Minimal');
+    expect(result).toBeNull();
   });
 
-  it('strips lines with empty values', () => {
+  it('returns null when modificationDate is empty', () => {
     const result = extractFrontmatter(path.join(tmpDir, 'empty-values.mdx'));
-    expect(result).not.toBeNull();
-    expect(result).toContain('title: Camera');
-    expect(result).toContain('description: A camera.');
-    expect(result).not.toContain('modificationDate');
+    expect(result).toBeNull();
   });
 
   it('returns null when all frontmatter fields are empty', () => {

--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -115,6 +115,166 @@ export function findMarkdownPages(dir: string): string[] {
   return results;
 }
 
+export interface ResolvedMdxImport {
+  content: string;
+  resolvedPath?: string;
+}
+
+type ResolveImportedMdx = (importPath: string, fromPath: string | null) => ResolvedMdxImport | null;
+
+function decodeJsStringLiteral(value: string): string {
+  return value
+    .replace(/\\n/g, '\n')
+    .replace(/\\r/g, '\r')
+    .replace(/\\t/g, '\t')
+    .replace(/\\\\/g, '\\')
+    .replace(/\\'/g, "'")
+    .replace(/\\"/g, '"');
+}
+
+function extractTerminalCommands(arrayLiteral: string): string[] {
+  const commands: string[] = [];
+  const strRegex = /'((?:\\.|[^'\\])*)'|"((?:\\.|[^"\\])*)"/g;
+  let match: RegExpExecArray | null = null;
+
+  while ((match = strRegex.exec(arrayLiteral)) !== null) {
+    const raw = match[1] ?? match[2] ?? '';
+    const decoded = decodeJsStringLiteral(raw);
+    if (!decoded.trim()) {
+      continue;
+    }
+    commands.push(decoded);
+  }
+
+  return commands;
+}
+
+/**
+ * Convert raw MDX instruction content to markdown.
+ * Handles JSX patterns used by set-up-your-environment instruction scenes.
+ */
+export function convertMdxInstructionToMarkdown(
+  mdxContent: string,
+  resolveImportedMdx: ResolveImportedMdx,
+  options: { fromPath?: string | null; visitedPaths?: Set<string> } = {}
+): string {
+  let content = mdxContent;
+  const fromPath = options.fromPath ?? null;
+  const visitedPaths = options.visitedPaths ?? new Set<string>();
+
+  if (fromPath) {
+    visitedPaths.add(fromPath);
+  }
+
+  const importMap = new Map<string, string>();
+  const importRegex = /^import\s+(\w+)\s+from\s+["'](\.\.?\/[^"']+\.mdx)["']\s*;?\s*$/gm;
+  let importMatch: RegExpExecArray | null = null;
+
+  while ((importMatch = importRegex.exec(content)) !== null) {
+    const componentName = importMatch[1];
+    const importPath = importMatch[2];
+    const resolvedImport = resolveImportedMdx(importPath, fromPath);
+    if (!resolvedImport) {
+      continue;
+    }
+
+    if (resolvedImport.resolvedPath && visitedPaths.has(resolvedImport.resolvedPath)) {
+      continue;
+    }
+
+    const nestedVisited = new Set(visitedPaths);
+    if (resolvedImport.resolvedPath) {
+      nestedVisited.add(resolvedImport.resolvedPath);
+    }
+
+    const inlinedMarkdown = convertMdxInstructionToMarkdown(
+      resolvedImport.content,
+      resolveImportedMdx,
+      {
+        fromPath: resolvedImport.resolvedPath ?? null,
+        visitedPaths: nestedVisited,
+      }
+    );
+
+    importMap.set(componentName, inlinedMarkdown);
+  }
+
+  content = content.replace(/^import\s+.*$/gm, '');
+
+  for (const [name, resolved] of importMap) {
+    content = content.replace(new RegExp(`<${name}\\s*/>`, 'g'), `\n${resolved}\n`);
+    content = content.replace(
+      new RegExp(`<${name}[^>]*>[\\s\\S]*?</${name}>`, 'g'),
+      `\n${resolved}\n`
+    );
+  }
+
+  content = content.replace(/<BuildEnvironmentSwitch\s*\/>/g, '');
+  content = content.replace(/<BuildEnvironmentSwitch[^>]*>[\S\s]*?<\/BuildEnvironmentSwitch>/g, '');
+
+  content = content.replace(/<Terminal\b([\S\s]*?)\/>/g, (_match, attrs: string) => {
+    const cmdMatch = attrs.match(/cmd={([\S\s]*?)}\s*(?=\w+=|$)/);
+    if (!cmdMatch) {
+      return '';
+    }
+
+    const lines = extractTerminalCommands(cmdMatch[1])
+      .map(line => line.replace(/^\$\s*/, '').trimEnd())
+      .filter(line => line.length > 0 && !line.startsWith('#'));
+
+    if (lines.length === 0) {
+      return '';
+    }
+
+    return `\n\`\`\`sh\n${lines.join('\n')}\n\`\`\`\n`;
+  });
+
+  content = content.replace(/<Step\s+label=(?:"[^"]*"|'[^']*')\s*>/g, '');
+  content = content.replace(/<\/Step>/g, '');
+
+  content = content.replace(/<ContentSpotlight[\S\s]*?\/>/g, '');
+  content = content.replace(/<ContentSpotlight[\S\s]*?<\/ContentSpotlight>/g, '');
+
+  content = content.replace(/<\/?Tabs[^>]*>/g, '');
+  content = content.replace(
+    /<Tab\s+label=(?:"([^"]*)"|'([^']*)')\s*>/g,
+    (_match, doubleQuoted: string | undefined, singleQuoted: string | undefined) =>
+      `\n#### ${(doubleQuoted ?? singleQuoted ?? '').trim()}\n`
+  );
+  content = content.replace(/<\/Tab>/g, '');
+
+  content = content.replace(
+    /<Collapsible\s+summary=(?:"([^"]*)"|'([^']*)')\s*>/g,
+    (_match, doubleQuoted: string | undefined, singleQuoted: string | undefined) =>
+      `\n**${(doubleQuoted ?? singleQuoted ?? '').trim()}**\n`
+  );
+  content = content.replace(/<\/Collapsible>/g, '');
+
+  content = content.replace(
+    /<QRCodeReact[\S\s]*?value=(?:"([^"]*)"|'([^']*)')[\S\s]*?\/>/g,
+    (_match, doubleQuoted: string | undefined, singleQuoted: string | undefined) => {
+      const url = (doubleQuoted ?? singleQuoted ?? '').trim();
+      if (!url) {
+        return '';
+      }
+      return `Download link: [${url}](${url})`;
+    }
+  );
+
+  content = content.replace(/<div[^>]*>/g, '');
+  content = content.replace(/<\/div>/g, '');
+
+  content = content.replace(/<\/?[A-Z][^>]*>/g, '');
+  content = content.replace(/{\/\*[\S\s]*?\*\/}/g, '');
+
+  content = content.replace(/&gt;/g, '>').replace(/&lt;/g, '<').replace(/&amp;/g, '&');
+
+  content = content.replace(/\n{3,}/g, '\n\n');
+  content = cleanMarkdown(content);
+
+  return content.trim();
+}
+
 /**
  * Clean up the HTML before conversion: remove non-content elements,
  * normalize terminal blocks, and strip decorative artifacts.

--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -25,8 +25,7 @@ export function findMdxSource(htmlPath: string, outDir: string, pagesDir: string
 
 /**
  * Extract the raw YAML frontmatter block (including --- delimiters) from an MDX file.
- * Strips lines with empty values (e.g. `modificationDate:` injected by append-dates.js
- * with no value in shallow CI clones).
+ * Keeps only non-empty `modificationDate` and drops other frontmatter fields.
  * Returns the frontmatter string with trailing newline, or null if no frontmatter found.
  */
 export function extractFrontmatter(mdxPath: string): string | null {
@@ -37,12 +36,12 @@ export function extractFrontmatter(mdxPath: string): string | null {
   }
   const filtered = match[1]
     .split('\n')
-    .filter(line => !/^\w+:\s*$/.test(line))
+    .filter(line => /^modificationDate:\s+\S/.test(line))
     .join('\n');
   if (!filtered.trim()) {
     return null;
   }
-  return '---\n' + filtered + '---\n';
+  return '---\n' + filtered + '\n---\n';
 }
 
 function createTurndownService(): TurndownService {

--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -75,6 +75,8 @@ function createTurndownService(): TurndownService {
 }
 
 const turndown = createTurndownService();
+// Keep in sync with ui/components/Snippet/blocks/packageManagerStore.ts.
+const PACKAGE_MANAGER_MARKDOWN_ORDER = ['npm', 'yarn', 'pnpm', 'bun'] as const;
 
 /**
  * Recursively find all index.html files in a directory, skipping internal directories.
@@ -295,6 +297,51 @@ export function cleanHtml($: CheerioAPI, main: Cheerio<AnyNode>): void {
   // Remove snippet headers (file labels, "Terminal" labels above code blocks).
   // data-md="snippet-header" is the stable marker (from SnippetHeader component).
   main.find('[data-md="snippet-header"]').remove();
+
+  // Convert tabbed Terminal blocks (package manager variants) into a single shell block.
+  // data-md="terminal" is the stable marker; data-md-commands contains all manager commands.
+  main.find('[data-md="terminal"][data-md-commands]').each((_, el) => {
+    const $el = $(el);
+    const commandsJson = $el.attr('data-md-commands');
+    if (!commandsJson) {
+      return;
+    }
+
+    const commands = JSON.parse(commandsJson) as Record<string, unknown>;
+    const lines: string[] = [];
+
+    for (const manager of PACKAGE_MANAGER_MARKDOWN_ORDER) {
+      const rawCommands = commands[manager];
+      if (!Array.isArray(rawCommands) || rawCommands.length === 0) {
+        continue;
+      }
+
+      const managerLines = rawCommands
+        .filter((line): line is string => typeof line === 'string')
+        .map(line => line.replace(/^\$\s*/, '').trim())
+        // Preserve existing terminal behavior: drop source comment lines.
+        .filter(line => line.length > 0 && !line.startsWith('#'));
+
+      // Skip heading-only sections (for example, comment-only manager arrays).
+      if (managerLines.length === 0) {
+        continue;
+      }
+
+      if (lines.length > 0) {
+        lines.push('');
+      }
+      lines.push(`# ${manager}`);
+      lines.push(...managerLines);
+    }
+
+    if (lines.length > 0) {
+      const $pre = $('<pre></pre>');
+      const $code = $('<code class="language-sh"></code>');
+      $code.text(lines.join('\n'));
+      $pre.append($code);
+      $el.replaceWith($pre);
+    }
+  });
 
   // Remove orphaned step numbers: replace step containers with just the content.
   // data-md="step" is the stable marker; the fallback matches div.flex.gap-4 with

--- a/docs/scripts/generate-markdown-pages-worker.ts
+++ b/docs/scripts/generate-markdown-pages-worker.ts
@@ -10,13 +10,123 @@ import { parentPort, workerData } from 'node:worker_threads';
 
 import {
   checkMarkdownQuality,
+  convertMdxInstructionToMarkdown,
   convertHtmlToMarkdown,
   extractFrontmatter,
   findMdxSource,
+  type ResolvedMdxImport,
 } from './generate-markdown-pages-utils.ts';
+import { SCENE_PAGES } from './scene-page-manifest.ts';
 
 const outDir: string = workerData.outDir;
 const pagesDir: string = workerData.pagesDir;
+const SCENE_MODE_HEADING = '## How would you like to develop?';
+const NEXT_STEP_HEADING = '## Next step';
+
+function toPosixPath(filePath: string): string {
+  return filePath.split(path.sep).join('/');
+}
+
+function getFirstH2Heading(markdown: string): string | null {
+  const match = markdown.match(/^##\s+.+$/m);
+  return match ? match[0].trim() : null;
+}
+
+function shiftHeadingLevels(markdown: string, levelOffset: number): string {
+  const lines = markdown.split('\n');
+  let inFence = false;
+
+  return lines
+    .map(line => {
+      if (/^\s*```/.test(line)) {
+        inFence = !inFence;
+        return line;
+      }
+
+      if (inFence) {
+        return line;
+      }
+
+      const headingMatch = line.match(/^(\s*)(#{1,6})(\s+.*)$/);
+      if (!headingMatch) {
+        return line;
+      }
+
+      const indent = headingMatch[1];
+      const heading = headingMatch[2];
+      const suffix = headingMatch[3];
+      const nextLevel = Math.min(6, heading.length + levelOffset);
+      return `${indent}${'#'.repeat(nextLevel)}${suffix}`;
+    })
+    .join('\n');
+}
+
+function findSceneSectionStart(
+  markdown: string,
+  defaultHeading: string | null,
+  nextStepIdx: number
+): number {
+  if (defaultHeading) {
+    const withLeadingNewline = `\n${defaultHeading}`;
+    let byHeading = markdown.indexOf(withLeadingNewline);
+    if (byHeading === -1 && markdown.startsWith(defaultHeading)) {
+      byHeading = 0;
+    }
+    if (byHeading !== -1 && (nextStepIdx === -1 || byHeading < nextStepIdx)) {
+      return byHeading;
+    }
+  }
+
+  const modeHeadingIdx = markdown.indexOf(SCENE_MODE_HEADING);
+  if (modeHeadingIdx === -1) {
+    return -1;
+  }
+
+  const headingRegex = /\n##\s+.+/g;
+  headingRegex.lastIndex = modeHeadingIdx + SCENE_MODE_HEADING.length;
+  const sceneHeadingMatch = headingRegex.exec(markdown);
+  if (!sceneHeadingMatch) {
+    return -1;
+  }
+  if (nextStepIdx !== -1 && sceneHeadingMatch.index >= nextStepIdx) {
+    return -1;
+  }
+  return sceneHeadingMatch.index;
+}
+
+function injectSceneVariants(
+  baseMarkdown: string,
+  sceneSections: string[],
+  defaultHeading: string | null
+) {
+  if (sceneSections.length === 0) {
+    return baseMarkdown;
+  }
+
+  const nextStepNeedle = `\n${NEXT_STEP_HEADING}`;
+  const nextStepIdx = baseMarkdown.indexOf(nextStepNeedle);
+  const sceneStartIdx = findSceneSectionStart(baseMarkdown, defaultHeading, nextStepIdx);
+  const sceneBlock = sceneSections.join('\n\n---\n\n');
+
+  if (sceneStartIdx !== -1 && nextStepIdx !== -1 && sceneStartIdx < nextStepIdx) {
+    const before = baseMarkdown.slice(0, sceneStartIdx).trimEnd();
+    const after = baseMarkdown.slice(nextStepIdx).trimStart();
+    return `${before}\n\n${sceneBlock}\n\n${after}`;
+  }
+
+  if (sceneStartIdx !== -1 && nextStepIdx === -1) {
+    const before = baseMarkdown.slice(0, sceneStartIdx).trimEnd();
+    return `${before}\n\n${sceneBlock}\n`;
+  }
+
+  if (nextStepIdx !== -1) {
+    const before = baseMarkdown.slice(0, nextStepIdx).trimEnd();
+    const after = baseMarkdown.slice(nextStepIdx).trimStart();
+    return `${before}\n\n${sceneBlock}\n\n${after}`;
+  }
+
+  return `${baseMarkdown.trimEnd()}\n\n${sceneBlock}\n`;
+}
 
 parentPort!.on('message', (msg: { type: string; htmlPath?: string }) => {
   if (msg.type === 'done') {
@@ -25,8 +135,53 @@ parentPort!.on('message', (msg: { type: string; htmlPath?: string }) => {
 
   if (msg.type === 'task') {
     const htmlPath = msg.htmlPath!;
+    const relHtmlPath = toPosixPath(path.relative(outDir, htmlPath));
     const html = fs.readFileSync(htmlPath, 'utf-8');
     let markdown = convertHtmlToMarkdown(html);
+
+    const scenePage = SCENE_PAGES.find(page => page.htmlPath === relHtmlPath);
+    if (scenePage) {
+      const sceneSections: string[] = [];
+      let defaultVariantHeading: string | null = null;
+
+      for (const variant of scenePage.variants) {
+        const absoluteMdxPath = path.join(process.cwd(), variant.mdxPath);
+        if (!fs.existsSync(absoluteMdxPath)) {
+          continue;
+        }
+
+        const mdxContent = fs.readFileSync(absoluteMdxPath, 'utf-8');
+        const variantMarkdown = convertMdxInstructionToMarkdown(
+          mdxContent,
+          (importPath, fromPath): ResolvedMdxImport | null => {
+            const basePath = fromPath ? path.dirname(fromPath) : path.dirname(absoluteMdxPath);
+            const resolvedPath = path.resolve(basePath, importPath);
+            if (!resolvedPath.endsWith('.mdx') || !fs.existsSync(resolvedPath)) {
+              return null;
+            }
+            return {
+              content: fs.readFileSync(resolvedPath, 'utf-8'),
+              resolvedPath,
+            };
+          },
+          {
+            fromPath: absoluteMdxPath,
+            visitedPaths: new Set([absoluteMdxPath]),
+          }
+        ).trim();
+
+        if (!variantMarkdown) {
+          continue;
+        }
+
+        defaultVariantHeading ??= getFirstH2Heading(variantMarkdown);
+
+        const nestedMarkdown = shiftHeadingLevels(variantMarkdown, 1);
+        sceneSections.push(`## ${variant.heading}\n\n${nestedMarkdown}`);
+      }
+
+      markdown = injectSceneVariants(markdown, sceneSections, defaultVariantHeading);
+    }
 
     // Prepend frontmatter from the MDX source file if available
     const mdxPath = findMdxSource(htmlPath, outDir, pagesDir);
@@ -37,8 +192,7 @@ parentPort!.on('message', (msg: { type: string; htmlPath?: string }) => {
       }
     }
 
-    const rel = path.relative(outDir, htmlPath);
-    const warnings = checkMarkdownQuality(markdown, rel);
+    const warnings = checkMarkdownQuality(markdown, relHtmlPath);
 
     const mdPath = path.join(path.dirname(htmlPath), 'index.md');
     fs.writeFileSync(mdPath, markdown);
@@ -47,7 +201,7 @@ parentPort!.on('message', (msg: { type: string; htmlPath?: string }) => {
       type: 'result',
       htmlPath,
       status: 'generated',
-      warnings: warnings.length > 0 ? warnings.map(w => `${rel}: ${w}`) : undefined,
+      warnings: warnings.length > 0 ? warnings.map(w => `${relHtmlPath}: ${w}`) : undefined,
     });
   }
 });

--- a/docs/scripts/scene-page-manifest.ts
+++ b/docs/scripts/scene-page-manifest.ts
@@ -1,0 +1,72 @@
+/**
+ * Scene-based pages where query params control client-rendered content.
+ * The markdown pipeline uses this manifest to include every variant in one .md file.
+ */
+
+export interface SceneVariant {
+  heading: string;
+  mdxPath: string;
+}
+
+export interface ScenePage {
+  htmlPath: string;
+  variants: SceneVariant[];
+}
+
+const INSTRUCTIONS_DIR = 'scenes/get-started/set-up-your-environment/instructions';
+
+export const SCENE_PAGES: ScenePage[] = [
+  {
+    htmlPath: 'get-started/set-up-your-environment/index.html',
+    variants: [
+      {
+        heading: 'Android device with Expo Go',
+        mdxPath: `${INSTRUCTIONS_DIR}/androidPhysicalExpoGo.mdx`,
+      },
+      {
+        heading: 'Android device with a development build (EAS)',
+        mdxPath: `${INSTRUCTIONS_DIR}/androidPhysicalDevelopmentBuild.mdx`,
+      },
+      {
+        heading: 'Android device with a development build (local)',
+        mdxPath: `${INSTRUCTIONS_DIR}/androidPhysicalDevelopmentBuildLocal.mdx`,
+      },
+      {
+        heading: 'Android Emulator with Expo Go',
+        mdxPath: `${INSTRUCTIONS_DIR}/androidSimulatedExpoGo.mdx`,
+      },
+      {
+        heading: 'Android Emulator with a development build (EAS)',
+        mdxPath: `${INSTRUCTIONS_DIR}/androidSimulatedDevelopmentBuild.mdx`,
+      },
+      {
+        heading: 'Android Emulator with a development build (local)',
+        mdxPath: `${INSTRUCTIONS_DIR}/androidSimulatedDevelopmentBuildLocal.mdx`,
+      },
+      {
+        heading: 'iOS device with Expo Go',
+        mdxPath: `${INSTRUCTIONS_DIR}/iosPhysicalExpoGo.mdx`,
+      },
+      {
+        heading: 'iOS device with a development build (EAS)',
+        mdxPath: `${INSTRUCTIONS_DIR}/iosPhysicalDevelopmentBuild.mdx`,
+      },
+      {
+        heading: 'iOS device with a development build (local)',
+        mdxPath: `${INSTRUCTIONS_DIR}/iosPhysicalDevelopmentBuildLocal.mdx`,
+      },
+      {
+        heading: 'iOS Simulator with Expo Go',
+        mdxPath: `${INSTRUCTIONS_DIR}/iosSimulatedExpoGo.mdx`,
+      },
+      {
+        heading: 'iOS Simulator with a development build (EAS)',
+        mdxPath: `${INSTRUCTIONS_DIR}/iosSimulatedDevelopmentBuild.mdx`,
+      },
+      {
+        heading: 'iOS Simulator with a development build (local)',
+        mdxPath: `${INSTRUCTIONS_DIR}/iosSimulatedDevelopmentBuildLocal.mdx`,
+      },
+    ],
+  },
+];

--- a/docs/ui/components/Snippet/Terminal.test.tsx
+++ b/docs/ui/components/Snippet/Terminal.test.tsx
@@ -105,6 +105,25 @@ describe(Terminal, () => {
     expect(screen.getByRole<HTMLTextAreaElement>('textbox').value).toBe('yarn add expo');
   });
 
+  it('adds data-md-commands only for package-manager command maps', () => {
+    const { container } = render(
+      <>
+        <Terminal
+          cmd={{
+            npm: ['$ npm install expo'],
+            bun: ['$ bun add expo'],
+          }}
+        />
+        <Terminal cmd={['$ npx expo start']} />
+      </>
+    );
+
+    const terminals = container.querySelectorAll('[data-md="terminal"]');
+    expect(terminals.length).toBe(2);
+    expect(terminals[0].getAttribute('data-md-commands')).not.toBeNull();
+    expect(terminals[1].getAttribute('data-md-commands')).toBeNull();
+  });
+
   it('renders browser action when provided', async () => {
     const originalWindowOpen = window.open;
     const openMock = jest.fn();

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -89,7 +89,10 @@ export const Terminal = ({
   ) : null;
 
   return (
-    <Snippet data-md="terminal" className={mergeClasses('terminal-snippet [li_&]:mt-4', className)}>
+    <Snippet
+      data-md="terminal"
+      data-md-commands={packageManagers ? JSON.stringify(packageManagers) : undefined}
+      className={mergeClasses('terminal-snippet [li_&]:mt-4', className)}>
       <SnippetHeader
         alwaysDark
         title={title}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Improves the markdown generation pipeline so scene-based Set up your environment doc and tabbed terminal commands are captured correctly in generated .md files, and tightens frontmatter xtraction to keep only useful metadata (`modificationDate`).

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Added `scripts/scene-page-manifest.ts` to define scene-based pages and their variants from get-started/set-up-your-environment with all 12 platform/device/mode combinations.
- Updated extractFrontmatter() to retain only non-empty `modificationDate` in YAML frontmatter
-  Added `convertMdxInstructionToMarkdown()` in `scripts/generate-markdown-pages-utils.ts` to transform instruction MDX into markdown.
- Enhanced terminal markdown conversion to support package-manager command maps (npm,
    yarn, pnpm, bun) via `data-md-commands`.
- Added/updated tests in:
	- scripts/generate-markdown-pages-utils.test.ts
	- ui/components/Snippet/Terminal.test.tsx

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

To test scene-based Set up your environment markdown output, go to: https://pr-43044.expo-docs.pages.dev/get-started/set-up-your-environment/index.md

To test Terminal tabs markdown output, go to: https://pr-43044.expo-docs.pages.dev/more/create-expo/index.md and look for:

<img width="990" height="520" alt="CleanShot 2026-02-11 at 00 26 19@2x" src="https://github.com/user-attachments/assets/0996f84b-ecbd-4861-8d73-3f68af897e31" />


To test YAML frontmatter clearance and only `modificationDate` included, go to: https://pr-43044.expo-docs.pages.dev/more/create-expo/index.md and look for:

<img width="1192" height="238" alt="CleanShot 2026-02-11 at 00 26 36@2x" src="https://github.com/user-attachments/assets/9688e390-04bd-47c5-8855-d016250cd5b4" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
