### PR TITLE
[docs] Update Vale config

### DIFF
--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -19,3 +19,12 @@ CommentDelimiters = {/*, */}
 # Ignore code surrounded by backticks or plus sign, parameters defaults, URLs and so on.
 BlockIgnores = (?s)<Terminal.*?/>,
 TokenIgnores = (\x60[^\n\x60]+\x60), ([^\n]+=[^\n]*), (\+[^\n]+\+), (http[^\n]+\[), .github, .gitlab, vscode-, Signing & Capabilities, eas.json, eas-json, .yarn+, yarn: "# yarn", eas+, eas-cli, npx+, Build & deploy, OAuth & Permissions, Languages & Frameworks, typescript, Privacy & Security, Certificates, IDs & Profiles, application/javascript, Motion & Orientation Access, Show devices and ask me again, my-app,  Still having trouble?, "my app runs well locally by crashes immediately when I run a build", my-app, MY_CUSTOM_API_KEY, withMyApiKey, My App, com.my., myFunction, my app, my-plugin, my-module, 'Hello from my TypeScript function!', my-scheme, my-root, Change my environment variables, my custom plugin, my, cocoapods, javascript, Ink & Switch, macos-medium, macos-large,
+
+# Ignore internal test fixtures and generated output.
+[pages/internal/**]
+Vale = NO
+BasedOnStyles =
+
+[out/**]
+Vale = NO
+BasedOnStyles =

--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -28,3 +28,7 @@ BasedOnStyles =
 [out/**]
 Vale = NO
 BasedOnStyles =
+
+[pages/versions/latest/**]
+Vale = NO
+BasedOnStyles =

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
     "test:worker": "node --experimental-strip-types scripts/test-worker.ts",
     "lint": "node scripts/lint.js --max-warnings 0",
     "lint-links": "remark -u validate-links ./pages",
-    "lint-prose": "yarn vale --config='.vale.ini' --glob='!pages/versions/latest/**' .",
+    "lint-prose": "yarn vale --config='.vale.ini' --glob='*.{md,mdx}' .",
     "watch": "tsc --noEmit -w",
     "test": "yarn generate-static-resources && yarn node --experimental-strip-types --experimental-vm-modules \"$(yarn bin jest)\"",
     "remove-version": "node --unhandled-rejections=strict ./scripts/remove-version.js",

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
     "test:worker": "node --experimental-strip-types scripts/test-worker.ts",
     "lint": "node scripts/lint.js --max-warnings 0",
     "lint-links": "remark -u validate-links ./pages",
-    "lint-prose": "yarn vale --config='.vale.ini' --glob='*.{md,mdx}' .",
+    "lint-prose": "yarn vale --config='.vale.ini' --glob='!pages/versions/latest/**' .",
     "watch": "tsc --noEmit -w",
     "test": "yarn generate-static-resources && yarn node --experimental-strip-types --experimental-vm-modules \"$(yarn bin jest)\"",
     "remove-version": "node --unhandled-rejections=strict ./scripts/remove-version.js",

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
     "test:worker": "node --experimental-strip-types scripts/test-worker.ts",
     "lint": "node scripts/lint.js --max-warnings 0",
     "lint-links": "remark -u validate-links ./pages",
-    "lint-prose": "yarn vale --glob='!pages/versions/latest/**' .",
+    "lint-prose": "yarn vale --config='.vale.ini' --glob='*.{md,mdx}' .",
     "watch": "tsc --noEmit -w",
     "test": "yarn generate-static-resources && yarn node --experimental-strip-types --experimental-vm-modules \"$(yarn bin jest)\"",
     "remove-version": "node --unhandled-rejections=strict ./scripts/remove-version.js",


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Both on CI and locally, `yarn run lint-prose` is generating false positives for `internal/` test MDX doc and `.md` files included in `out/`.

<img width="824" height="521" alt="CleanShot 2026-02-11 at 00 32 35" src="https://github.com/user-attachments/assets/870adfee-0c0a-4715-b305-31f6dd9cd158" />

<img width="859" height="489" alt="CleanShot 2026-02-11 at 00 32 31" src="https://github.com/user-attachments/assets/30811f14-f5d0-46d6-9030-f7cd4e3f8b44" />

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update Vale config to exclude `pages/internal/` and `out/` directories. 
Update `lint-prose` script to always resepct configuration defined in `.vale.ini` file.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn run lint-prose` and there should be no warnings or errors from `pages/internal/` or `out/`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
