### PR TITLE
[docs] Exclude internal markdown pipeline test page from sitemap and SEO indexing

### DIFF
--- a/docs/common/routes.ts
+++ b/docs/common/routes.ts
@@ -19,6 +19,10 @@ export const isArchivePath = (path: string) => {
   return Utilities.pathStartsWith('archive', path);
 };
 
+export const isInternalPath = (path: string) => {
+  return Utilities.pathStartsWith('internal', path);
+};
+
 export const isVersionedPath = (path: string) => {
   return Utilities.pathStartsWith('versions', path);
 };

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -314,7 +314,9 @@ export default function DocumentationPage({
           title={title}
           description={description}
           canonicalUrl={
-            version !== 'unversioned' ? RoutesUtils.getCanonicalUrl(pathname) : undefined
+            version !== 'unversioned' && !RoutesUtils.isInternalPath(pathname)
+              ? RoutesUtils.getCanonicalUrl(pathname)
+              : undefined
           }>
           {hideFromSearch !== true && (
             <meta
@@ -324,7 +326,8 @@ export default function DocumentationPage({
           )}
           {(version === 'unversioned' ||
             RoutesUtils.isPreviewPath(pathname) ||
-            RoutesUtils.isArchivePath(pathname)) && <meta name="robots" content="noindex" />}
+            RoutesUtils.isArchivePath(pathname) ||
+            RoutesUtils.isInternalPath(pathname)) && <meta name="robots" content="noindex" />}
           {searchRank && <meta name="searchRank" content={String(searchRank)} />}
           {searchPosition && <meta name="searchPosition" content={String(searchPosition)} />}
         </DocumentationHead>

--- a/docs/next-env.d.ts
+++ b/docs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -154,7 +154,7 @@ const nextConfig: NextConfig = {
         ...VERSIONS.map(version => `versions/${version}`),
       ],
       // Some of our pages are "hidden" and should not be added to the sitemap
-      pathsHidden: [...navigation.previewDirectories, ...navigation.archiveDirectories],
+      pathsHidden: [...navigation.previewDirectories, ...navigation.archiveDirectories, 'internal'],
     });
     event(`Generated sitemap with ${sitemapEntries.length} entries`);
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, https://docs.expo.dev/internal/test-markdown-pipeline/ is included in the Sitemap and available for SEO indexing. Since this page is only used by the generated markdown script for testing, we should not provide a link to it publicly.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR prevents the internal markdown pipeline test page (`/internal/test-markdown-pipeline`) from being surfaced publicly by excluding all `/internal/*` routes from sitemap generation and marking internal docs pages as non-indexable in page metadata.

It adds an internal path helper, applies noindex and removes canonical tags for internal routes in `DocumentationPage`, and hides internal paths in `next.config.ts` sitemap generation.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn export`, and verify sitemap exclusion by opening `/out/sitemap.xml`. Then, search for `/internal/test-markdown-pipeline/` and it should not be there.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
