### PR TITLE
[docs] Fix small typos in tailwind and updates docs

### DIFF
--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -43,7 +43,7 @@ Configure Tailwind CSS in your Expo project according to the [Tailwind PostCSS d
 
 <Step label="1">
 
-Install `tailwindcss` and its required peer dependencies. Then, the run initialization command to create **tailwind.config.js** and **post.config.js** files in the root of your project.
+Install `tailwindcss` and its required peer dependencies. Then, run the initialization command to create **tailwind.config.js** and **post.config.js** files in the root of your project.
 
 <Terminal
   cmd={[

--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -193,7 +193,7 @@ This policy works for both projects with and without custom native code. It work
 
 #### Native configuration and overriding
 
-If your project does not use Continuous Native Generation, these configuration values may also be set in your app's native configuration files or overridden at during initialization in native code.
+If your project does not use Continuous Native Generation, these configuration values may also be set in your app's native configuration files or overridden during initialization in native code.
 
 <Collapsible summary="Native configuration instructions">
 

--- a/docs/pages/versions/v52.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/updates.mdx
@@ -191,7 +191,7 @@ This policy works for both projects with and without custom native code. It work
 
 #### Native configuration and overriding
 
-If your project does not use Continuous Native Generation, these configuration values may also be set in your app's native configuration files or overridden at during initialization in native code.
+If your project does not use Continuous Native Generation, these configuration values may also be set in your app's native configuration files or overridden during initialization in native code.
 
 <Collapsible summary="Native configuration instructions">
 

--- a/docs/pages/versions/v53.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/updates.mdx
@@ -192,7 +192,7 @@ This policy works for both projects with and without custom native code. It work
 
 #### Native configuration and overriding
 
-If your project does not use Continuous Native Generation, these configuration values may also be set in your app's native configuration files or overridden at during initialization in native code.
+If your project does not use Continuous Native Generation, these configuration values may also be set in your app's native configuration files or overridden during initialization in native code.
 
 <Collapsible summary="Native configuration instructions">
 

--- a/docs/pages/versions/v54.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/updates.mdx
@@ -192,7 +192,7 @@ This policy works for both projects with and without custom native code. It work
 
 #### Native configuration and overriding
 
-If your project does not use Continuous Native Generation, these configuration values may also be set in your app's native configuration files or overridden at during initialization in native code.
+If your project does not use Continuous Native Generation, these configuration values may also be set in your app's native configuration files or overridden during initialization in native code.
 
 <Collapsible summary="Native configuration instructions">
 

--- a/docs/pages/versions/v55.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/updates.mdx
@@ -193,7 +193,7 @@ This policy works for both projects with and without custom native code. It work
 
 #### Native configuration and overriding
 
-If your project does not use Continuous Native Generation, these configuration values may also be set in your app's native configuration files or overridden at during initialization in native code.
+If your project does not use Continuous Native Generation, these configuration values may also be set in your app's native configuration files or overridden during initialization in native code.
 
 <Collapsible summary="Native configuration instructions">
 


### PR DESCRIPTION
## Why

The tailwind guide has "the run" instead of "run the" and the `expo-updates` SDK reference has an extra "at" in "overridden at during initialization."

## How

Fix the transposed words in `tailwind.mdx` and remove the extra "at" in all versioned and unversioned copies of `updates.mdx`.

## Test Plan

Read the corrected sentences.