### PR TITLE
[ios][screen-orientation] - Restore orientationMask when app transition from background to foreground

### DIFF
--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] [New Architecture] Restore orientationMask after app transition from background to foreground ([]() by [@LongyuW](https://github.com/LongyuW))
+
 ### 💡 Others
 
 ## 8.1.7 — 2025-06-04

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] [New Architecture] Restore orientationMask after app transition from background to foreground ([]() by [@LongyuW](https://github.com/LongyuW))
+- [iOS] [New Architecture] Restore orientationMask after app transition from background to foreground ([#43052](https://github.com/expo/expo/pull/43052) by [@LongyuW](https://github.com/LongyuW))
 
 ### 💡 Others
 

--- a/packages/expo-screen-orientation/ios/ScreenOrientationModule.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationModule.swift
@@ -3,6 +3,7 @@ import ExpoModulesCore
 public class ScreenOrientationModule: Module, ScreenOrientationController {
   static let didUpdateDimensionsEvent = "expoDidUpdateDimensions"
   let screenOrientationRegistry = ScreenOrientationRegistry.shared
+  private var lastSetOrientationMask: UIInterfaceOrientationMask?
 
   public func definition() -> ModuleDefinition {
     Name("ExpoScreenOrientation")
@@ -19,7 +20,7 @@ public class ScreenOrientationModule: Module, ScreenOrientationController {
       guard orientationMask.isSupportedByDevice() else {
         throw UnsupportedOrientationLockException(orientationLock)
       }
-
+      self.lastSetOrientationMask = orientationMask
       screenOrientationRegistry.setMask(orientationMask, forController: self)
     }
 
@@ -40,7 +41,7 @@ public class ScreenOrientationModule: Module, ScreenOrientationController {
       guard allowedOrientationsMask.isSupportedByDevice() else {
         throw UnsupportedOrientationLockException(nil)
       }
-
+      self.lastSetOrientationMask = allowedOrientationsMask
       screenOrientationRegistry.setMask(allowedOrientationsMask, forController: self)
     }
 
@@ -83,6 +84,11 @@ public class ScreenOrientationModule: Module, ScreenOrientationController {
 
     OnAppEntersForeground {
       screenOrientationRegistry.registerController(self)
+
+      // Re-apply the last set orientation mask when the app comes to foreground
+      if let lastMask = self.lastSetOrientationMask {
+        screenOrientationRegistry.setMask(lastMask, forController: self)
+      }
     }
 
     OnAppEntersBackground {


### PR DESCRIPTION
Fix for **NEW ARCHITECTURE** only, restore the orientationMask after iOS app background/foreground transition.

Same change merged in expo/main branch. Need the same change for SDK 53.
Reference: https://github.com/expo/expo/pull/42536

# Why
- **Problem:** 
On the new architecture the ScreenOrientationController is explicitly unregistered when the app goes to background and re-registered on foreground. That lifecycle causes the controller to lose its transient orientation lock state (the lastSetOrientationMask) that was set by the previously visible screen, producing incorrect orientation after returning to foreground.

Also noticed a flicker issue happen on iOS 26 if any ts/js code changes tried to restore previous lock rule by checking app active status. 

For more details please see the last section ** Case Details** in this template.

- **Root cause:** 
The new-architecture controller instance is not persistent across background/foreground transitions, so any in-memory orientation mask previously applied is lost when the controller is unregistered.

- **Contrast with old architecture:** 
The old architecture kept the orientation controller (and its orientationMask) alive across background/foreground, so no re-application was necessary and the lock persisted.


Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This iOS native fix resolved new architecture react native iOS app issue. 
Haven't found an exiting issue related it, if needed, please let me know if I could open an issue for it. Thanks team!

# How

- **Fix:** Persist and re-apply the last orientation mask when the app re-enters foreground (re-register path). This ensures the previously applied lock is restored immediately after re-registration.

- **Result:** Prevents orientation flicker or unexpected rotations when returning from background and preserves the intended orientation lock behavior on the new architecture.

# Test Plan
Would like to generate test version for iOS app testing.

The solution was tested on iOS version 16, 18 and 26. It was working well.

**Steps to reproduce issue:**
1. New architecture react native iOS app with expo-screen-orientation library.
2. Set orientation config as default (unlock app).
3. Set the lockAsync as PORTRAIT_UP or LANDSCAPE_LEFT
4. Switch app from foreground -> background -> foreground 
(Note: do not fully close the iOS app)

**Expected:**
The app screen is keeping on the previous screen, and the orientation should keep previous lock rule: PORTRAIT_UP or LANDSCAPE_LEFT

**Actual:**
The app is as unlock.


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

----

### Case Details

1. I have an application (SDK 53 with new architecture upgraded) setup the screen lock rule as default (not lock)

2. I have some screens need to be locked as portrait or landscape.

3. When I'm on the portrait/landscape Locked screen, it can be locked as expected, however, when I move app to background and back to active on the same screen, in the ScreenOrientationAppDelegate.swift file, some flows happen for new architecture only:

a. OrientationClient with orientationMask which handle how to lock the screen worked as expected on my landscape screen A before I move app to background.

b. Then moved the app to Background when the screen A displayed -> it will result the OrientationClient unregistered. (As designed)

c. Moved the app to Active and the screen A kept display on app -> it will result Orientation re-registered. (As designed)

*Issue:*
When app backed to active, the screen A was unlocked unexpected, the previous orientationMask is missing after OrientationClient re-register. 

*Expected:*
The screen A should keep locked as landscape when app transition from background to active.

---
#### Clarify:

- Before the new architecture upgrade, the OrientationClient worked correctly because the old architecture did not un-register the OrientationClient when the app entered the background. As a result, its orientationMask persisted when the app transitioned from the background to the foreground. The lock rule keeps working for the screen when app transition from background to foreground.

- The current solution is only for the new architecture fix. The fix will work for the app transition between background - active, no influence for other app flows like fully close app and restart.

