### PR TITLE
fix(cli): Fix `getRunningProcess` causing process to hang

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Add missing `Content-Type: application/json` to internal `/symbolicate` call ([#43074](https://github.com/expo/expo/pull/43074) by [@kitten](https://github.com/kitten))
 - Key loader data by `contextKey` instead of URL pathname ([#43017](https://github.com/expo/expo/pull/43017) by [@hassankhan]
+- Fix port prompt causing process hangs on some systems when checking the conflicting process's info ([#43054](https://github.com/expo/expo/pull/43054) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/runServer-fork.ts
+++ b/packages/@expo/cli/src/start/server/metro/runServer-fork.ts
@@ -17,7 +17,6 @@ import type { WebSocketServer } from 'ws';
 
 import { MetroBundlerDevServer } from './MetroBundlerDevServer';
 import { Log } from '../../../log';
-import { getRunningProcess } from '../../../utils/getRunningProcess';
 import type { ConnectAppType } from '../middleware/server.types';
 
 export const runServer = async (
@@ -79,12 +78,15 @@ export const runServer = async (
     if ('code' in error && error.code === 'EADDRINUSE') {
       // If `Error: listen EADDRINUSE: address already in use :::8081` then print additional info
       // about the process before throwing.
-      const info = getRunningProcess(config.server.port);
-      if (info) {
-        Log.error(
-          `Port ${config.server.port} is busy running ${info.command} in: ${info.directory}`
-        );
-      }
+      const { getRunningProcess } =
+        require('../../../utils/getRunningProcess') as typeof import('../../../utils/getRunningProcess');
+      getRunningProcess(config.server.port).then((info) => {
+        if (info) {
+          Log.error(
+            `Port ${config.server.port} is busy running ${info.command} in: ${info.directory}`
+          );
+        }
+      });
     }
 
     if (onError) {

--- a/packages/@expo/cli/src/utils/__tests__/getRunningProcess-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/getRunningProcess-test.ts
@@ -1,19 +1,29 @@
-import { execFileSync, execSync } from 'child_process';
+import spawnAsync from '@expo/spawn-async';
 
-import { getDirectoryOfProcessById, getPID } from '../getRunningProcess';
+import { getDirectoryOfProcessById, getPID, getProcessCommand } from '../getRunningProcess';
+
+jest.mock('@expo/spawn-async');
 
 describe(getPID, () => {
-  it(`should return the pid value for a running port`, () => {
-    jest.mocked(execFileSync).mockImplementationOnce(() => '63828');
-    const pid = getPID(63828);
+  it(`should return the pid value for a running port`, async () => {
+    jest.mocked(spawnAsync).mockResolvedValueOnce({ stdout: ' 63828 ' } as any);
+    const pid = await getPID(8081);
     expect(pid).toBe(63828);
   });
 });
 
 describe(getDirectoryOfProcessById, () => {
-  it(`should return the directory of a pid`, () => {
-    jest.mocked(execSync).mockImplementationOnce(() => 'cwd');
-    const directory = getDirectoryOfProcessById(63828);
-    expect(directory).toBe('cwd');
+  it(`should return the directory of a pid`, async () => {
+    jest.mocked(spawnAsync).mockResolvedValueOnce({ stdout: '\nn/test/folder\n' } as any);
+    const directory = await getDirectoryOfProcessById(63828);
+    expect(directory).toBe('/test/folder');
+  });
+});
+
+describe(getProcessCommand, () => {
+  it(`should return the argv of a pid`, async () => {
+    jest.mocked(spawnAsync).mockResolvedValueOnce({ stdout: 'command arg' } as any);
+    const command = await getProcessCommand(63828, __dirname);
+    expect(command).toBe('command arg');
   });
 });

--- a/packages/@expo/cli/src/utils/getRunningProcess.ts
+++ b/packages/@expo/cli/src/utils/getRunningProcess.ts
@@ -64,7 +64,7 @@ export async function getDirectoryOfProcessById(pid: number): Promise<string | n
       .split('\n')
       .find((output) => output.startsWith('n'))
       ?.slice(1);
-    return processCWD && path.isAbsolute(processCWD) ? processCWD : null;
+    return processCWD && path.isAbsolute(processCWD) ? path.normalize(processCWD) : null;
   } catch {
     return null;
   }

--- a/packages/@expo/cli/src/utils/getRunningProcess.ts
+++ b/packages/@expo/cli/src/utils/getRunningProcess.ts
@@ -1,22 +1,20 @@
-import { execFileSync, execSync, ExecSyncOptionsWithStringEncoding } from 'child_process';
+import spawnAsync from '@expo/spawn-async';
 import * as path from 'path';
 
 const debug = require('debug')('expo:utils:getRunningProcess') as typeof console.log;
 
-const defaultOptions: ExecSyncOptionsWithStringEncoding = {
-  encoding: 'utf8',
-  stdio: ['pipe', 'pipe', 'ignore'],
-};
+/** Timeout applied to shell commands */
+const timeout = 350;
 
 /** Returns a pid value for a running port like `63828` or null if nothing is running on the given port. */
-export function getPID(port: number): number | null {
+export async function getPID(port: number): Promise<number | null> {
   try {
-    const results = execFileSync('lsof', [`-i:${port}`, '-P', '-t', '-sTCP:LISTEN'], defaultOptions)
-      .split('\n')[0]
-      .trim();
-    const pid = Number(results);
+    const { stdout } = await spawnAsync('lsof', [`-i:${port}`, '-P', '-t', '-sTCP:LISTEN'], {
+      timeout,
+    });
+    const pid = Number(stdout.split('\n', 1)[0].trim());
     debug(`pid: ${pid} for port: ${port}`);
-    return pid;
+    return Number.isSafeInteger(pid) ? pid : null;
   } catch (error: any) {
     debug(`No pid found for port: ${port}. Error: ${error}`);
     return null;
@@ -25,55 +23,78 @@ export function getPID(port: number): number | null {
 
 /** Get `package.json` `name` field for a given directory. Returns `null` if none exist. */
 function getPackageName(packageRoot: string): string | null {
-  const packageJson = path.join(packageRoot, 'package.json');
   try {
+    const packageJson = path.resolve(packageRoot, 'package.json');
     return require(packageJson).name || null;
-  } catch {
+  } catch (error) {
     return null;
   }
 }
 
 /** Returns a command like `node /Users/evanbacon/.../bin/expo start` or the package.json name. */
-function getProcessCommand(pid: number, procDirectory: string): string {
-  const name = getPackageName(procDirectory);
-
-  if (name) {
-    return name;
+async function getProcessCommand(pid: number, procDirectory: string): Promise<string | null> {
+  let name = getPackageName(procDirectory);
+  if (!name) {
+    // ps
+    // -o args=: Output argv without header
+    // -p [pid]: For process of PID
+    const { stdout } = await spawnAsync('ps', ['-o', 'args=', '-p', `${pid}`], {
+      timeout,
+    });
+    name = stdout.trim();
   }
-  return execSync(`ps -o command -p ${pid} | sed -n 2p`, defaultOptions).replace(/\n$/, '').trim();
+  return name || null;
 }
 
 /** Get directory for a given process ID. */
-export function getDirectoryOfProcessById(processId: number): string {
-  return execSync(
-    `lsof -p ${processId} | awk '$4=="cwd" {for (i=9; i<=NF; i++) printf "%s ", $i}'`,
-    defaultOptions
-  ).trim();
+export async function getDirectoryOfProcessById(pid: number): Promise<string | null> {
+  try {
+    // lsof
+    // -F n: ask for machine readable output
+    // -a: apply conditions as logical AND
+    // -d cwd: Filter by cwd fd
+    // -p [pid]: Filter by input process id
+    const { stdout } = await spawnAsync('lsof', ['-F', 'n', '-a', '-d', 'cwd', '-p', `${pid}`], {
+      timeout,
+    });
+    const processCWD = stdout
+      .split('\n')
+      .find((output) => output.startsWith('n'))
+      ?.slice(1);
+    return processCWD && path.isAbsolute(processCWD) ? processCWD : null;
+  } catch {
+    return null;
+  }
 }
 
-/** Get information about a running process given a port. Returns null if no process is running on the given port. */
-export function getRunningProcess(port: number): {
+interface RunningProcess {
   /** The PID value for the port. */
   pid: number;
   /** Get the directory for the running process. */
   directory: string;
   /** The command running the process like `node /Users/evanbacon/.../bin/expo start` or the `package.json` name like `my-app`. */
   command: string;
-} | null {
-  // 63828
-  const pid = getPID(port);
-  if (!pid) {
+}
+
+/** Get information about a running process given a port. Returns null if no process is running on the given port. */
+export async function getRunningProcess(port: number): Promise<RunningProcess | null> {
+  // Don't even try on Windows, since `lsof` and `ps` are not available there
+  if (process.platform === 'win32') {
     return null;
   }
 
-  try {
-    // /Users/evanbacon/Documents/GitHub/lab/myapp
-    const directory = getDirectoryOfProcessById(pid);
-    // /Users/evanbacon/Documents/GitHub/lab/myapp/package.json
-    const command = getProcessCommand(pid, directory);
-    // TODO: Have a better message for reusing another process.
-    return { pid, directory, command };
-  } catch {
+  const pid = await getPID(port);
+  if (!pid) {
     return null;
   }
+  try {
+    const directory = await getDirectoryOfProcessById(pid);
+    if (directory) {
+      const command = await getProcessCommand(pid, directory);
+      if (command) {
+        return { pid, directory, command };
+      }
+    }
+  } catch {}
+  return null;
 }

--- a/packages/@expo/cli/src/utils/getRunningProcess.ts
+++ b/packages/@expo/cli/src/utils/getRunningProcess.ts
@@ -32,7 +32,10 @@ function getPackageName(packageRoot: string): string | null {
 }
 
 /** Returns a command like `node /Users/evanbacon/.../bin/expo start` or the package.json name. */
-async function getProcessCommand(pid: number, procDirectory: string): Promise<string | null> {
+export async function getProcessCommand(
+  pid: number,
+  procDirectory: string
+): Promise<string | null> {
   let name = getPackageName(procDirectory);
   if (!name) {
     // ps

--- a/packages/@expo/cli/src/utils/port.ts
+++ b/packages/@expo/cli/src/utils/port.ts
@@ -51,8 +51,7 @@ function isRestrictedPort(port: number) {
 async function isBusyPortRunningSameProcessAsync(projectRoot: string, { port }: { port: number }) {
   const { getRunningProcess } =
     require('./getRunningProcess') as typeof import('./getRunningProcess');
-
-  const runningProcess = isRestrictedPort(port) ? null : getRunningProcess(port);
+  const runningProcess = isRestrictedPort(port) ? null : await getRunningProcess(port);
   if (runningProcess) {
     if (runningProcess.directory === projectRoot) {
       return true;
@@ -91,7 +90,7 @@ export async function choosePortAsync(
 
     const { getRunningProcess } =
       require('./getRunningProcess') as typeof import('./getRunningProcess');
-    const runningProcess = isRestricted ? null : getRunningProcess(defaultPort);
+    const runningProcess = isRestricted ? null : await getRunningProcess(defaultPort);
 
     if (runningProcess) {
       const pidTag = chalk.gray(`(pid ${runningProcess.pid})`);


### PR DESCRIPTION
# Why

This has annoyed me a few times. The commands that `getRunningProcess` runs can cause the CLI to hang. Since it's there to be useful in case of a conflicting process using the default port, this is a very unfortunate moment to hang.

This is seeminly caused by two causes:
- the specific commands and piped shell commands in this file may not resolve and exit
- the sync execution without a timeout is risky for the above reason

# How

- Switch the commands to cleaner equivalents so we don't need extra commands to parse their outputs and can remove the pipes
- Switch to `@expo/spawn-async` and add a low timeout

# Test Plan

- Unit tests updated, but they're quite mocked
- Run a second process of `expo start` to test the conflict

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
