### PR TITLE
[ci] documented issue-closed workflow failure without a Linear issue

### DIFF
--- a/.github/workflows/issue-closed.yml
+++ b/.github/workflows/issue-closed.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           yarn-tools: 'true'
       - name: 🔎 Close Linear issue
+        # accepted issues should have a corresponding Linear issue (from issue-triage.yml)
+        # if not, we don't want to fail the workflow
+        continue-on-error: true
         run: expotools close-linear-issue-from-github --issue "${{ github.event.issue.number }}"
         env:
           GITHUB_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}

--- a/tools/src/commands/ImportGithubIssueToLinear.ts
+++ b/tools/src/commands/ImportGithubIssueToLinear.ts
@@ -78,7 +78,7 @@ async function importIssueAsync(githubIssueNumber: number, importer?: string) {
     Linear.ENG_TEAM_ID
   );
 
-  Linear.createIssueAsync({
+  return Linear.createIssueAsync({
     title: issue.title,
     labelIds: [githubLabel.id, expoSDKLabel.id],
     stateId: backlogWorkflowState.id,


### PR DESCRIPTION
# Why

This PR prevents failures in `.github/workflows/issue-closed.yml` when a corresponding Linear issue cannot be found. 

This happens rarely as a consequence of failed `🔎 Import issue to Linear` in `.github/workflows/issue-triage.yml` but it happened in https://github.com/expo/expo/actions/runs/21864091751/job/63100557088

```
Error: S.match is not a function - s.match is not a function
There was an error running import-github-issue-to-linear command: S.match is not a function - s.match is not a function
```

it's not immediately clear how that error should be resolved, and re-running the action passed okay.

# How

- Added a comment to the "Close Linear issue" step in the GitHub workflow
- Updated the `importIssueAsync` function to return the result of `Linear.createIssueAsync` so that the result is awaited. That shouldn't make any difference for this problem though

# Test Plan

- green CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)