### PR TITLE
[docs] Remove unnecessary polyfills, reduce unused CSS, and fix accessibility issues

### DIFF
--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -4,6 +4,7 @@ import { LayoutAlt01Icon } from '@expo/styleguide-icons/outline/LayoutAlt01Icon'
 import { Server03Icon } from '@expo/styleguide-icons/outline/Server03Icon';
 import { useEffect, useRef, useState, type PropsWithChildren } from 'react';
 import tippy, { roundArrow } from 'tippy.js';
+import 'tippy.js/dist/tippy.css';
 
 import {
   cleanCopyValue,

--- a/docs/empty-polyfill.js
+++ b/docs/empty-polyfill.js
@@ -1,0 +1,3 @@
+// Intentionally empty. Next.js bundles polyfills for APIs like Array.prototype.at,
+// Object.hasOwn, etc. that are natively supported by all browsers we target.
+// This file replaces the built-in polyfill module via a webpack alias in next.config.ts.

--- a/docs/next-env.d.ts
+++ b/docs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -2,7 +2,6 @@ import { withSentryConfig } from '@sentry/nextjs';
 import type { NextConfig } from 'next';
 import { event, error } from 'next/dist/build/output/log.js';
 import { join } from 'node:path';
-import webpack from 'webpack';
 import { exit } from 'node:process';
 import rehypeSlug from 'rehype-slug';
 import remarkFrontmatter from 'remark-frontmatter';
@@ -11,6 +10,7 @@ import remarkMDX from 'remark-mdx';
 import remarkMdxDisableExplicitJsx from 'remark-mdx-disable-explicit-jsx';
 import remarkMDXFrontmatter from 'remark-mdx-frontmatter';
 import semver from 'semver';
+import webpack from 'webpack';
 
 import packageJson from '~/package.json';
 
@@ -79,7 +79,7 @@ const nextConfig: NextConfig = {
     if (!isServer) {
       config.plugins.push(
         new webpack.NormalModuleReplacementPlugin(
-          /[\\/]polyfill-module\.js$/,
+          /[/\\]polyfill-module\.js$/,
           join(__dirname, 'empty-polyfill.js')
         )
       );

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -2,6 +2,7 @@ import { withSentryConfig } from '@sentry/nextjs';
 import type { NextConfig } from 'next';
 import { event, error } from 'next/dist/build/output/log.js';
 import { join } from 'node:path';
+import webpack from 'webpack';
 import { exit } from 'node:process';
 import rehypeSlug from 'rehype-slug';
 import remarkFrontmatter from 'remark-frontmatter';
@@ -71,7 +72,19 @@ const nextConfig: NextConfig = {
   },
   output: 'export',
   poweredByHeader: false,
-  webpack: (config, { defaultLoaders }) => {
+  webpack: (config, { defaultLoaders, isServer }) => {
+    // Remove unnecessary built-in polyfills that Next.js injects unconditionally.
+    // All polyfilled APIs (Array.prototype.at, Object.hasOwn, etc.) are natively
+    // supported by our browserslist targets (Chrome 93+, Firefox 92+, Safari 15.4+).
+    if (!isServer) {
+      config.plugins.push(
+        new webpack.NormalModuleReplacementPlugin(
+          /[\\/]polyfill-module\.js$/,
+          join(__dirname, 'empty-polyfill.js')
+        )
+      );
+    }
+
     // Add support for MDX with our custom loader
     config.module.rules.push({
       test: /\.mdx?$/,

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -10,7 +10,6 @@ import remarkMDX from 'remark-mdx';
 import remarkMdxDisableExplicitJsx from 'remark-mdx-disable-explicit-jsx';
 import remarkMDXFrontmatter from 'remark-mdx-frontmatter';
 import semver from 'semver';
-import webpack from 'webpack';
 
 import packageJson from '~/package.json';
 
@@ -78,7 +77,7 @@ const nextConfig: NextConfig = {
     // supported by our browserslist targets (Chrome 93+, Firefox 92+, Safari 15.4+).
     if (!isServer) {
       config.plugins.push(
-        new webpack.NormalModuleReplacementPlugin(
+        new (require('webpack').NormalModuleReplacementPlugin)(
           /[/\\]polyfill-module\.js$/,
           join(__dirname, 'empty-polyfill.js')
         )

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -18,9 +18,6 @@ import * as Tooltip from '~/ui/components/Tooltip';
 import '~/styles/global.css';
 import '@expo/styleguide/dist/expo-theme.css';
 import '@expo/styleguide-search-ui/dist/expo-search-ui.css';
-import 'tippy.js/dist/tippy.css';
-import '@xyflow/react/dist/style.css';
-import 'yet-another-react-lightbox/styles.css';
 
 const isDev = process.env.NODE_ENV === 'development';
 const KAPA_INTEGRATION_ID = '2063233f-1e70-45e8-b1b5-a872c9887afc';

--- a/docs/ui/components/AppJSBanner/index.tsx
+++ b/docs/ui/components/AppJSBanner/index.tsx
@@ -64,6 +64,7 @@ export function AppJSBanner() {
         <Button
           size="xs"
           theme="tertiary"
+          aria-label="Dismiss banner"
           onClick={() => {
             setIsAppJSBannerVisible(false);
           }}

--- a/docs/ui/components/ConfigPluginHierarchy/index.tsx
+++ b/docs/ui/components/ConfigPluginHierarchy/index.tsx
@@ -8,6 +8,7 @@ import {
   MarkerType,
   BackgroundVariant,
 } from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
 import React from 'react';
 
 type ConfigPluginHierarchyProps = {

--- a/docs/ui/components/ContentSpotlight/LightboxImage.tsx
+++ b/docs/ui/components/ContentSpotlight/LightboxImage.tsx
@@ -1,5 +1,6 @@
 import { ImgHTMLAttributes, useState } from 'react';
 import { Lightbox } from 'yet-another-react-lightbox';
+import 'yet-another-react-lightbox/styles.css';
 import Zoom from 'yet-another-react-lightbox/plugins/zoom';
 
 type Props = ImgHTMLAttributes<HTMLImageElement> & {

--- a/docs/ui/components/Header/Header.tsx
+++ b/docs/ui/components/Header/Header.tsx
@@ -74,6 +74,7 @@ export const Header = ({
           <div className={mergeClasses('hidden', 'max-lg-gutters:flex')}>
             <Button
               theme="quaternary"
+              aria-label="Toggle navigation menu"
               className={mergeClasses(
                 'px-3',
                 'hocus:bg-element hocus:shadow-[none]',

--- a/docs/ui/components/Home/sections/QuickStart.tsx
+++ b/docs/ui/components/Home/sections/QuickStart.tsx
@@ -60,7 +60,7 @@ export function QuickStart() {
             Create a universal Android, iOS, and web app
           </h2>
           <HomeButton
-            className="border-palette-blue10 bg-palette-blue10 hocus:bg-palette-blue9 dark:text-palette-blue2"
+            className="border-palette-blue11 bg-palette-blue11 text-palette-white hocus:bg-palette-blue10 dark:text-palette-blue2"
             href="/tutorial/introduction/"
             rightSlot={<ArrowRightIcon className="icon-md" />}>
             Start Tutorial


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-19409

Lighthouse flags ~34.5 KiB of legacy JavaScript polyfills on every page of docs.expo.dev. Next.js unconditionally injects polyfills for APIs like `Array.prototype.at`, `Object.hasOwn`, and `URL.canParse` regardless of browserslist config. All of these are natively supported by every browser we target (Chrome 93+, Firefox 92+, Safari 15.4+).

Additionally, ~19 KiB of CSS was loaded globally but only used by specific components, and a few accessibility issues were flagged (missing button labels, insufficient color contrast).

The following is the final Lighthouse score on docs.expo.dev homepage:

<img width="2388" height="344" alt="CleanShot 2026-02-11 at 17 23 20@2x" src="https://github.com/user-attachments/assets/5cfd55f9-60dc-47d7-9b3a-6601369a262d" />

<img width="2398" height="2014" alt="CleanShot 2026-02-11 at 17 23 28@2x" src="https://github.com/user-attachments/assets/b5243f6d-8641-4dd3-8598-1690e3238586" />


# How

<!--
How did you build this feature or fix this bug and why?
-->

**Remove Next.js built-in polyfills (12.4 KiB JS saved)**

 Uses a webpack `NormalModuleReplacementPlugin` to replace Next.js's built-in `polyfill-module.js` with an empty file on client builds. Neither `browserslist` nor `resolve.alias` work for this because Next.js hardcodes a relative `require()` path that bypasses both. This is a known limitation ([vercel/next.js#86785](https://github.com/vercel/next.js/issues/86785)).

**Move component-specific CSS to component level (~3.2 KiB CSS saved)**

Three CSS imports were loaded globally in `_app.tsx` but only used by specific components:
- `@xyflow/react/dist/style.css` (18.5 KiB) -> `ConfigPluginHierarchy` (3 pages under `/config-plugins/`)
- `yet-another-react-lightbox/styles.css` (5.6 KiB) -> `LightboxImage`
- `tippy.js/dist/tippy.css` (1.4 KiB) -> `code.tsx`

**Fix accessibility issues**

- Added `aria-label` to icon-only buttons (hamburger menu, banner dismiss)
- Changed "Start Tutorial" button background from `palette-blue10` (3.59:1 contrast) to `palette-blue11` (4.78:1 contrast) to pass WCAG AA

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Run `yarn build` and it should succeed with no errors
- Homepage: `main` chunk no longer appears in Lighthouse "Legacy JavaScript" audit,  "Reduce unused CSS" audit shows reduced savings, and no Lighthouse accessibility warnings for button labels or contrast. 
  - Accessibility: "Start Tutorial" button looks correct in light and dark mode
  - All of this can be done via `rm -rf .next out && yarn build` and then run `npx serve out`. 
  - Then, open `localhost:3000` in an Incognito window (to ensure no third-party extensions are running). Go to the Lighthouse tab in the developer tool and analyze the page for Desktop.
- Pages with images: lightbox opens and displays correctly
-  Pages with code blocks: tippy tooltips render correctly
- General navigation, search, and interactive components work as expected

Lighthouse score after above improvements:

<img width="2408" height="482" alt="CleanShot 2026-02-11 at 17 20 22@2x" src="https://github.com/user-attachments/assets/2a9a73f2-4fe0-404e-8ddb-9dc1e241a08c" />

<img width="2402" height="998" alt="CleanShot 2026-02-11 at 17 20 32@2x" src="https://github.com/user-attachments/assets/d8ef1b0e-79ff-46e3-828c-c9aa4a907347" />

<img width="2390" height="1398" alt="CleanShot 2026-02-11 at 17 20 38@2x" src="https://github.com/user-attachments/assets/4e7040d9-a04c-43f5-8a5c-5d54c4901455" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
