### PR TITLE
[docs] Suppress ESLint concurrency warning in lint script

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
     "export-prep": "node ./scripts/export-prep.js",
     "export-server": "wrangler pages dev --port 8000",
     "test:worker": "node --experimental-strip-types scripts/test-worker.ts",
-    "lint": "node scripts/lint.js --max-warnings 0",
+    "lint": "NODE_OPTIONS='--no-warnings' node scripts/lint.js --max-warnings 0",
     "lint-links": "remark -u validate-links ./pages",
     "lint-prose": "yarn vale --glob='!pages/versions/latest/**' .",
     "watch": "tsc --noEmit -w",


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

 Running `yarn lint` prints this warning on every run:

<img width="1077" height="173" alt="CleanShot 2026-02-11 at 17 46 36" src="https://github.com/user-attachments/assets/46b0977f-bd80-449f-b4ec-57238db88f03" />

This is a known Node.js warning from ESLint v9+ and is purely informational. It does not affect linting correctnes or results. Suppressing it keeps the lint output clean and easy to read.


# How

<!--
How did you build this feature or fix this bug and why?
-->
- Suppress the `ESLintPoorConcurrencyWarning` noise from `yarn lint` output by adding `NODE_OPTIONS='--no warnings'` to the lint script.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn lint` and confirm no warning is printed.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
