### PR TITLE
[widgets][plugin] Fix duplicated warnings on start and prebuild

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix blank widget preview content ([#42857](https://github.com/expo/expo/pull/42857) by [@garygcchiu](https://github.com/garygcchiu))
-- Fix duplicated warnings on start and prebuild.
+- Fix duplicated warnings on start and prebuild. ([#43072](https://github.com/expo/expo/pull/43072) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### 🐛 Bug fixes
 
-- fix: blank widget preview content ([#42857](https://github.com/expo/expo/pull/42857) by [@garygcchiu](https://github.com/garygcchiu)
+- Fix blank widget preview content ([#42857](https://github.com/expo/expo/pull/42857) by [@garygcchiu](https://github.com/garygcchiu))
+- Fix duplicated warnings on start and prebuild.
 
 ### 💡 Others
 

--- a/packages/expo-widgets/package.json
+++ b/packages/expo-widgets/package.json
@@ -7,10 +7,11 @@
   "scripts": {
     "build": "expo-module build",
     "build:plugin": "expo-module build plugin",
+    "build:bundle": "tsc --build bundle",
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "expo-module test",
-    "prepare": "expo-module prepare",
+    "prepare": "node bundle/build/index.js && expo-module prepare",
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module"
   },
@@ -31,6 +32,8 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/widgets/",
   "dependencies": {
+    "@expo/config-plugins": "~55.0.4",
+    "@expo/config-types": "^55.0.4",
     "@expo/plist": "^0.5.2",
     "@expo/ui": "55.0.0-preview.5"
   },

--- a/packages/expo-widgets/plugin/build/index.js
+++ b/packages/expo-widgets/plugin/build/index.js
@@ -7,18 +7,26 @@ const config_plugins_1 = require("expo/config-plugins");
 const withAppGroupEntitlements_1 = __importDefault(require("./withAppGroupEntitlements"));
 const withAppInfoPlist_1 = __importDefault(require("./withAppInfoPlist"));
 const withEasConfig_1 = __importDefault(require("./withEasConfig"));
+const withIosWarning_1 = __importDefault(require("./withIosWarning"));
 const withPodsLinking_1 = __importDefault(require("./withPodsLinking"));
 const withPushNotifications_1 = __importDefault(require("./withPushNotifications"));
 const withWidgetSourceFiles_1 = __importDefault(require("./withWidgetSourceFiles"));
 const withTargetXcodeProject_1 = __importDefault(require("./xcode/withTargetXcodeProject"));
 const pkg = require('expo-widgets/package.json');
 const withWidgets = (config, props) => {
+    let plugins = [];
     const deploymentTarget = '16.2';
     const targetName = 'ExpoWidgetsTarget';
     let bundleIdentifier = props.bundleIdentifier;
     if (!bundleIdentifier) {
         bundleIdentifier = `${config.ios?.bundleIdentifier}.${targetName}`;
-        console.log(`No bundleIdentifier provided, fallback to: ${bundleIdentifier}`);
+        plugins.push([
+            withIosWarning_1.default,
+            {
+                property: 'bundleIdentifier',
+                warning: `Expo Widgets: No bundle identifier provided, using fallback: ${bundleIdentifier}.`,
+            },
+        ]);
     }
     let groupIdentifier = props.groupIdentifier;
     if (!groupIdentifier) {
@@ -26,7 +34,13 @@ const withWidgets = (config, props) => {
             throw new Error('iOS bundle identifier is required. Please set `ios.bundleIdentifier` in `app.json` or `app.config.js`');
         }
         groupIdentifier = `group.${config.ios.bundleIdentifier}`;
-        console.log(`No groupIdentifier provided, fallback to: ${groupIdentifier}`);
+        plugins.push([
+            withIosWarning_1.default,
+            {
+                property: 'groupIdentifier',
+                warning: `Expo Widgets: No group identifier provided, using fallback: ${groupIdentifier}.`,
+            },
+        ]);
     }
     const widgets = props.widgets ?? [];
     const enablePushNotifications = props.enablePushNotifications ?? false;
@@ -36,7 +50,8 @@ const withWidgets = (config, props) => {
         sharedFiles = [...sharedFiles, ...files];
     };
     const getFileUris = () => sharedFiles;
-    return (0, config_plugins_1.withPlugins)(config, [
+    plugins = [
+        ...plugins,
         [withEasConfig_1.default, { targetName, bundleIdentifier, groupIdentifier }],
         [withPodsLinking_1.default, { targetName }],
         [withWidgetSourceFiles_1.default, { targetName, widgets, groupIdentifier, onFilesGenerated: setFiles }],
@@ -53,6 +68,7 @@ const withWidgets = (config, props) => {
                 getFileUris,
             },
         ],
-    ]);
+    ];
+    return (0, config_plugins_1.withPlugins)(config, plugins);
 };
 exports.default = (0, config_plugins_1.createRunOncePlugin)(withWidgets, pkg.name, pkg.version);

--- a/packages/expo-widgets/plugin/build/withIosWarning.d.ts
+++ b/packages/expo-widgets/plugin/build/withIosWarning.d.ts
@@ -1,0 +1,7 @@
+import { ConfigPlugin } from '@expo/config-plugins';
+type WithIosWarningProps = {
+    property: string;
+    warning: string;
+};
+declare const withIosWarning: ConfigPlugin<WithIosWarningProps>;
+export default withIosWarning;

--- a/packages/expo-widgets/plugin/build/withIosWarning.js
+++ b/packages/expo-widgets/plugin/build/withIosWarning.js
@@ -1,0 +1,9 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const config_plugins_1 = require("@expo/config-plugins");
+// Hack to display the warning only once
+const withIosWarning = (config, { property, warning }) => (0, config_plugins_1.withInfoPlist)(config, (config) => {
+    config_plugins_1.WarningAggregator.addWarningIOS(property, warning);
+    return config;
+});
+exports.default = withIosWarning;

--- a/packages/expo-widgets/plugin/src/withIosWarning.ts
+++ b/packages/expo-widgets/plugin/src/withIosWarning.ts
@@ -1,0 +1,16 @@
+import { ConfigPlugin, WarningAggregator, withInfoPlist } from '@expo/config-plugins';
+import { ExpoConfig } from '@expo/config-types';
+
+type WithIosWarningProps = { property: string; warning: string };
+
+// Hack to display the warning only once
+const withIosWarning: ConfigPlugin<WithIosWarningProps> = (
+  config: ExpoConfig,
+  { property, warning }: WithIosWarningProps
+) =>
+  withInfoPlist(config, (config) => {
+    WarningAggregator.addWarningIOS(property, warning);
+    return config;
+  });
+
+export default withIosWarning;


### PR DESCRIPTION
# Why

Fix spam of `console.log` warnings on prebuild and remove them from start.

# How

Yoink `withIosWarning` from `expo-sharing` https://github.com/expo/expo/blob/49914479511b11af6f7bf57c17779bc744528025/packages/expo-sharing/plugin/src/ios/withIosWarning.ts

# Test Plan

Run `yarn expo prebuild -p ios` with expo-widgets installed. 

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
