### PR TITLE
fix(cli): Prevent terminal editors from being spawned and add more fallback logic

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add missing `Content-Type: application/json` to internal `/symbolicate` call ([#43074](https://github.com/expo/expo/pull/43074) by [@kitten](https://github.com/kitten))
 - Key loader data by `contextKey` instead of URL pathname ([#43017](https://github.com/expo/expo/pull/43017) by [@hassankhan]
 - Fix port prompt causing process hangs on some systems when checking the conflicting process's info ([#43054](https://github.com/expo/expo/pull/43054) by [@kitten](https://github.com/kitten))
+- Fix editor opening to not spawn terminal editors and have more fallbacks ([#43073](https://github.com/expo/expo/pull/43073) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/jest.setup.ts
+++ b/packages/@expo/cli/jest.setup.ts
@@ -8,7 +8,6 @@ jest.mock('child_process');
 jest.mock('fs');
 jest.mock('fs/promises');
 jest.mock('better-opn');
-jest.mock('env-editor');
 jest.mock('lan-network');
 jest.mock('ora');
 jest.mock('os');

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -72,7 +72,6 @@
     "connect": "^3.7.0",
     "debug": "^4.3.4",
     "dnssd-advertise": "^1.1.3",
-    "env-editor": "^0.4.1",
     "expo-server": "^55.0.3",
     "fetch-nodeshim": "^0.4.6",
     "getenv": "^2.0.0",

--- a/packages/@expo/cli/src/utils/__tests__/editor-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/editor-test.ts
@@ -1,51 +1,90 @@
 import spawnAsync from '@expo/spawn-async';
-import editors from 'env-editor';
+import { vol } from 'memfs';
 
-import { guessEditor, openInEditorAsync } from '../editor';
+import { guessEditor, openInEditorAsync, guessFallbackVisualEditor } from '../editor';
 
 jest.mock('../../log');
 
-const original_EXPO_EDITOR = process.env.EXPO_EDITOR;
-
-afterAll(() => {
-  process.env.EXPO_EDITOR = original_EXPO_EDITOR;
+beforeEach(() => {
+  vol.reset();
+  process.env.EXPO_EDITOR = undefined;
+  process.env.VISUAL = undefined;
+  process.env.EDITOR = undefined;
 });
 
-describe(guessEditor, () => {
-  beforeEach(() => {
-    delete process.env.EXPO_EDITOR;
-  });
-
+describe('guessEditor', () => {
   it(`uses EXPO_EDITOR as the highest priority setting if defined`, () => {
-    process.env.EXPO_EDITOR = 'bacon';
-    guessEditor();
-
-    expect(editors.getEditor).toHaveBeenCalledWith('bacon');
+    process.env.EXPO_EDITOR = 'atom';
+    expect(guessEditor()).toMatchObject({
+      id: 'atom',
+    });
   });
 
-  it(`defaults to vscode if the default editor cannot be guessed`, () => {
-    jest.mocked(editors.defaultEditor).mockImplementationOnce(() => {
-      throw new Error('Could not guess default editor');
+  it(`uses VISUAL as the next-highest priority setting if defined`, () => {
+    process.env.EXPO_EDITOR = undefined;
+    process.env.VISUAL = 'atom';
+    expect(guessEditor()).toMatchObject({
+      id: 'atom',
     });
-    guessEditor();
-    expect(editors.getEditor).toHaveBeenCalledWith('vscode');
+  });
+
+  it(`uses EDITOR as the lowest priority setting if defined`, () => {
+    process.env.EXPO_EDITOR = undefined;
+    process.env.VISUAL = undefined;
+    process.env.EDITOR = 'atom';
+    expect(guessEditor()).toMatchObject({
+      id: 'atom',
+    });
+  });
+
+  it(`returns null if no editor is applied`, () => {
+    process.env.EXPO_EDITOR = undefined;
+    process.env.VISUAL = undefined;
+    process.env.EDITOR = undefined;
+    expect(guessEditor()).toBe(null);
+  });
+
+  it(`returns null if editor is unknown`, () => {
+    process.env.EXPO_EDITOR = 'any';
+    expect(guessEditor()).toBe(null);
+  });
+});
+
+describe('guessFallbackVisualEditor', () => {
+  it(`tries to find a visual editor in PATH`, async () => {
+    vol.fromJSON(
+      {
+        '/bin/code': '',
+      },
+      '/'
+    );
+    process.env.PATH = '/bin';
+    expect(await guessFallbackVisualEditor()).toMatchObject({
+      id: 'vscode',
+    });
+  });
+
+  it(`otherwise returns null`, async () => {
+    process.env.PATH = '/bin';
+    expect(await guessFallbackVisualEditor()).toBe(null);
   });
 });
 
 describe(openInEditorAsync, () => {
-  it(`fails to open in a given editor that does not exist`, async () => {
-    jest.mocked(editors.defaultEditor).mockReturnValueOnce({
-      name: 'my-editor',
-      binary: 'my-editor-binary',
-      id: 'my-editor-id',
-    } as any);
+  it(`spawns the determined editor`, async () => {
+    process.env.EDITOR = 'code';
+
     jest.mocked(spawnAsync).mockImplementationOnce(() => {
       throw new Error('failed');
     });
 
-    await expect(openInEditorAsync('/foo/bar')).resolves.toBe(false);
+    await expect(openInEditorAsync('file')).resolves.toBe(false);
 
-    expect(spawnAsync).toHaveBeenCalledWith('my-editor-binary', ['/foo/bar']);
+    expect(spawnAsync).toHaveBeenCalledWith(
+      'code',
+      ['file'],
+      expect.objectContaining({ timeout: 1000 })
+    );
     expect(spawnAsync).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/@expo/cli/src/utils/__tests__/editor-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/editor-test.ts
@@ -82,7 +82,7 @@ describe(openInEditorAsync, () => {
 
     expect(spawnAsync).toHaveBeenCalledWith(
       'code',
-      ['file'],
+      ['-g', 'file'],
       expect.objectContaining({ timeout: 1000 })
     );
     expect(spawnAsync).toHaveBeenCalledTimes(1);

--- a/packages/@expo/cli/src/utils/editor.ts
+++ b/packages/@expo/cli/src/utils/editor.ts
@@ -76,13 +76,19 @@ export async function guessFallbackVisualEditor(): Promise<Editor | null> {
   if (_cachedVisualEditor !== undefined) {
     return _cachedVisualEditor;
   }
-  for (const editor of EDITORS) {
-    if (editor.isTerminalEditor) {
-      continue;
-    }
-    const target = await editorExists(editor);
+  // We search for editors at known `editor.paths`
+  for (const editor of VISUAL_EDITORS) {
+    const target = await editorExistsAtPaths(editor);
     if (target) {
       debug('Found visual editor fallback:', editor.name);
+      return (_cachedVisualEditor = { ...editor, binary: target });
+    }
+  }
+  // We search again for a visual editor against `editor.binary` in `$PATH`
+  for (const editor of VISUAL_EDITORS) {
+    const target = await editorExistsInPath(editor);
+    if (target) {
+      debug('Found visual editor fallback in $PATH:', editor.name);
       return (_cachedVisualEditor = { ...editor, binary: target });
     }
   }
@@ -164,7 +170,8 @@ function getEditorArguments(editor: Editor, path: string, lineNumber?: number): 
   }
 }
 
-async function editorExists(editor: Editor) {
+/** Attempt to resolve an editor against $PATH */
+async function editorExistsInPath(editor: Editor) {
   const binary = editor.binary;
   const paths = (process.env.PATH || process.env.Path || '')
     .split(path.delimiter)
@@ -175,6 +182,22 @@ async function editorExists(editor: Editor) {
       ? (process.env.PATHEXT || '.EXE;.CMD;.BAT;.COM').split(path.delimiter).filter(Boolean)
       : [''];
   const targets = paths.flatMap((dir) => exts.map((ext) => path.join(dir, `${binary}${ext}`)));
+  for (const target of targets) {
+    try {
+      const mode = process.platform === 'win32' ? fs.constants.F_OK : fs.constants.X_OK;
+      await fs.promises.access(target, mode);
+      return target;
+    } catch {
+      // ignore not found and continue
+    }
+  }
+  return null;
+}
+
+/** Attempt to resolve an editor against known `paths` */
+async function editorExistsAtPaths(editor: Editor) {
+  // We can skip the path if it's not for our platform (win32 vs posix paths)
+  const targets = editor.paths.filter((target) => target.includes(path.sep));
   for (const target of targets) {
     try {
       const mode = process.platform === 'win32' ? fs.constants.F_OK : fs.constants.X_OK;
@@ -222,7 +245,7 @@ const TERMINAL_EDITORS = [
   },
 ];
 
-const EDITORS = [
+const VISUAL_EDITORS = [
   {
     id: 'sublime',
     name: 'Sublime Text',
@@ -332,5 +355,6 @@ const EDITORS = [
     ],
     keywords: ['studio'],
   },
-  ...TERMINAL_EDITORS,
 ];
+
+const EDITORS = [...VISUAL_EDITORS, ...TERMINAL_EDITORS];

--- a/packages/@expo/cli/src/utils/editor.ts
+++ b/packages/@expo/cli/src/utils/editor.ts
@@ -1,4 +1,5 @@
 import spawnAsync from '@expo/spawn-async';
+import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 
@@ -9,6 +10,8 @@ const debug = require('debug')('expo:utils:editor') as typeof console.log;
 
 type Editor = (typeof EDITORS)[number];
 
+// See: https://github.com/sindresorhus/env-editor/blob/3f6aea10ff53910c877b1bf73a8e0c954a5fbf11/index.js
+// MIT License, Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
 function getEditor(input: string | undefined): Editor | null {
   if (!input) {
     return null;
@@ -67,9 +70,37 @@ export function guessEditor(): Editor | null {
   }
 }
 
+let _cachedVisualEditor: Editor | null | undefined;
+
+export async function guessFallbackVisualEditor(): Promise<Editor | null> {
+  if (_cachedVisualEditor !== undefined) {
+    return _cachedVisualEditor;
+  }
+  for (const editor of EDITORS) {
+    if (editor.isTerminalEditor) {
+      continue;
+    }
+    const target = await editorExists(editor);
+    if (target) {
+      debug('Found visual editor fallback:', editor.name);
+      return (_cachedVisualEditor = { ...editor, binary: target });
+    }
+  }
+  return (_cachedVisualEditor = null);
+}
+
 /** Open a file path in a given editor. */
 export async function openInEditorAsync(path: string, lineNumber?: number): Promise<boolean> {
-  const editor = guessEditor();
+  let editor = guessEditor();
+
+  // Try to find a fallback visual editor, but keep the found one if we can't find a fallback
+  if (editor?.isTerminalEditor) {
+    const fallback = await guessFallbackVisualEditor();
+    if (fallback) {
+      editor = fallback;
+    }
+  }
+
   if (editor && !editor.isTerminalEditor) {
     const fileReference = lineNumber ? `${path}:${lineNumber}` : path;
     debug(
@@ -132,6 +163,64 @@ function getEditorArguments(editor: Editor, path: string, lineNumber?: number): 
       return [path];
   }
 }
+
+async function editorExists(editor: Editor) {
+  const binary = editor.binary;
+  const paths = (process.env.PATH || process.env.Path || '')
+    .split(path.delimiter)
+    .map((target) => target.trim())
+    .filter((target) => !!target);
+  const exts =
+    process.platform === 'win32'
+      ? (process.env.PATHEXT || '.EXE;.CMD;.BAT;.COM').split(path.delimiter).filter(Boolean)
+      : [''];
+  const targets = paths.flatMap((dir) => exts.map((ext) => path.join(dir, `${binary}${ext}`)));
+  for (const target of targets) {
+    try {
+      const mode = process.platform === 'win32' ? fs.constants.F_OK : fs.constants.X_OK;
+      await fs.promises.access(target, mode);
+      return target;
+    } catch {
+      // ignore not found and continue
+    }
+  }
+  return null;
+}
+
+const TERMINAL_EDITORS = [
+  {
+    id: 'vim',
+    name: 'Vim',
+    binary: 'vim',
+    isTerminalEditor: true,
+    paths: [],
+    keywords: ['vi'],
+  },
+  {
+    id: 'neovim',
+    name: 'NeoVim',
+    binary: 'nvim',
+    isTerminalEditor: true,
+    paths: [],
+    keywords: ['vim'],
+  },
+  {
+    id: 'nano',
+    name: 'GNU nano',
+    binary: 'nano',
+    isTerminalEditor: true,
+    paths: [],
+    keywords: [],
+  },
+  {
+    id: 'emacs',
+    name: 'GNU Emacs',
+    binary: 'emacs',
+    isTerminalEditor: true,
+    paths: [],
+    keywords: [],
+  },
+];
 
 const EDITORS = [
   {
@@ -204,22 +293,6 @@ const EDITORS = [
     keywords: [],
   },
   {
-    id: 'vim',
-    name: 'Vim',
-    binary: 'vim',
-    isTerminalEditor: true,
-    paths: [],
-    keywords: ['vi'],
-  },
-  {
-    id: 'neovim',
-    name: 'NeoVim',
-    binary: 'nvim',
-    isTerminalEditor: true,
-    paths: [],
-    keywords: ['vim'],
-  },
-  {
     id: 'intellij',
     name: 'IntelliJ IDEA',
     binary: 'idea',
@@ -228,28 +301,23 @@ const EDITORS = [
     keywords: ['idea', 'java', 'jetbrains', 'ide'],
   },
   {
-    id: 'nano',
-    name: 'GNU nano',
-    binary: 'nano',
-    isTerminalEditor: true,
-    paths: [],
-    keywords: [],
-  },
-  {
-    id: 'emacs',
-    name: 'GNU Emacs',
-    binary: 'emacs',
-    isTerminalEditor: true,
-    paths: [],
-    keywords: [],
-  },
-  {
     id: 'emacsforosx',
     name: 'GNU Emacs for Mac OS X',
     binary: 'Emacs',
     isTerminalEditor: false,
     paths: ['/Applications/Emacs.app/Contents/MacOS/Emacs'],
     keywords: [],
+  },
+  {
+    id: 'xcode',
+    name: 'Xcode',
+    binary: 'xed',
+    isTerminalEditor: false,
+    paths: [
+      '/Applications/Xcode.app/Contents/MacOS/Xcode',
+      '/Applications/Xcode-beta.app/Contents/MacOS/Xcode',
+    ],
+    keywords: ['xed'],
   },
   {
     id: 'android-studio',
@@ -264,15 +332,5 @@ const EDITORS = [
     ],
     keywords: ['studio'],
   },
-  {
-    id: 'xcode',
-    name: 'Xcode',
-    binary: 'xed',
-    isTerminalEditor: false,
-    paths: [
-      '/Applications/Xcode.app/Contents/MacOS/Xcode',
-      '/Applications/Xcode-beta.app/Contents/MacOS/Xcode',
-    ],
-    keywords: ['xed'],
-  },
+  ...TERMINAL_EDITORS,
 ];

--- a/packages/@expo/cli/src/utils/editor.ts
+++ b/packages/@expo/cli/src/utils/editor.ts
@@ -174,32 +174,28 @@ export async function openInEditorAsync(path: string, lineNumber?: number): Prom
 }
 
 function getEditorArguments(editor: Editor, path: string, lineNumber?: number): string[] {
-  if (!lineNumber) {
-    return [path];
-  }
-
   switch (editor.id) {
     case 'atom':
     case 'sublime':
-      return [`${path}:${lineNumber}`];
+      return lineNumber ? [`${path}:${lineNumber}`] : [path];
 
     case 'emacs':
     case 'emacsforosx':
     case 'nano':
     case 'neovim':
     case 'vim':
-      return [`+${lineNumber}`, path];
+      return lineNumber ? [`+${lineNumber}`, path] : [path];
 
     case 'android-studio':
     case 'intellij':
     case 'textmate':
     case 'webstorm':
     case 'xcode':
-      return [`--line=${lineNumber}`, path];
+      return lineNumber ? [`--line=${lineNumber}`, path] : [path];
 
     case 'vscode':
     case 'vscodium':
-      return ['-g', `${path}:${lineNumber}`];
+      return lineNumber ? ['-g', `${path}:${lineNumber}`] : ['-g', path];
 
     default:
       return [path];

--- a/packages/@expo/cli/src/utils/editor.ts
+++ b/packages/@expo/cli/src/utils/editor.ts
@@ -25,24 +25,32 @@ export function guessEditor(): editors.Editor {
 /** Open a file path in a given editor. */
 export async function openInEditorAsync(path: string, lineNumber?: number): Promise<boolean> {
   const editor = guessEditor();
-  const fileReference = lineNumber ? `${path}:${lineNumber}` : path;
+  if (!editor.isTerminalEditor) {
+    const fileReference = lineNumber ? `${path}:${lineNumber}` : path;
+    debug(
+      `Opening ${fileReference} in ${editor?.name} (bin: ${editor?.binary}, id: ${editor?.id})`
+    );
 
-  debug(`Opening ${fileReference} in ${editor?.name} (bin: ${editor?.binary}, id: ${editor?.id})`);
-
-  if (editor) {
-    try {
-      await spawnAsync(editor.binary, getEditorArguments(editor, path, lineNumber));
-      return true;
-    } catch (error: any) {
-      debug(
-        `Failed to open ${fileReference} in editor (path: ${path}, binary: ${editor.binary}):`,
-        error
-      );
+    if (editor) {
+      try {
+        await spawnAsync(editor.binary, getEditorArguments(editor, path, lineNumber), {
+          timeout: 1_000,
+        });
+        return true;
+      } catch (error: any) {
+        debug(
+          `Failed to open ${fileReference} in editor (path: ${path}, binary: ${editor.binary}):`,
+          error
+        );
+      }
     }
   }
 
   Log.error(
-    'Could not open editor, you can set it by defining the $EDITOR environment variable with the binary of your editor. (e.g. "vscode" or "atom")'
+    (editor.isTerminalEditor
+      ? `Could not open ${editor.name} as it's a terminal editor.`
+      : 'Could not open editor.') +
+      `\nYou can set an editor for Expo to open automatically by defining the $EDITOR environment variable (e.g. "vscode" or "atom")`
   );
   return false;
 }

--- a/packages/@expo/cli/src/utils/editor.ts
+++ b/packages/@expo/cli/src/utils/editor.ts
@@ -105,8 +105,13 @@ export async function guessFallbackVisualEditor(): Promise<Editor | null> {
   return null;
 }
 
-/** Open a file path in a given editor. */
-export async function openInEditorAsync(path: string, lineNumber?: number): Promise<boolean> {
+let _cachedEditor: Editor | null | undefined;
+
+async function determineEditorAsync(): Promise<Editor | null> {
+  if (_cachedEditor !== undefined) {
+    return _cachedEditor;
+  }
+
   // First: Try to get a known editor
   let editor = guessEditor();
 
@@ -127,6 +132,13 @@ export async function openInEditorAsync(path: string, lineNumber?: number): Prom
       editor = fallback;
     }
   }
+
+  return (_cachedEditor = editor);
+}
+
+/** Open a file path in a given editor. */
+export async function openInEditorAsync(path: string, lineNumber?: number): Promise<boolean> {
+  const editor = await determineEditorAsync();
 
   if (editor && !editor.isTerminalEditor) {
     const fileReference = lineNumber ? `${path}:${lineNumber}` : path;

--- a/packages/@expo/cli/src/utils/editor.ts
+++ b/packages/@expo/cli/src/utils/editor.ts
@@ -1,31 +1,76 @@
 import spawnAsync from '@expo/spawn-async';
-import editors from 'env-editor';
+import path from 'node:path';
+import process from 'node:process';
 
 import { env } from './env';
 import * as Log from '../log';
 
 const debug = require('debug')('expo:utils:editor') as typeof console.log;
 
+type Editor = (typeof EDITORS)[number];
+
+function getEditor(input: string | undefined): Editor | null {
+  if (!input) {
+    return null;
+  }
+  const needle = input.trim().toLowerCase();
+  const binary = needle.split(/[/\\]/).pop()?.replace(/\s/g, '-')?.split('-')[0];
+  const editor =
+    EDITORS.find((editor) => {
+      switch (needle) {
+        case editor.id:
+        case editor.name.toLowerCase():
+        case editor.binary:
+          return true;
+        default:
+          for (const editorPath of editor.paths) {
+            if (path.normalize(needle) === path.normalize(editorPath.toLowerCase())) return true;
+          }
+          for (const keyword of editor.keywords) {
+            if (needle === keyword) return true;
+          }
+          return false;
+      }
+    }) ?? (binary ? EDITORS.find((editor) => editor.binary === binary) : null);
+  return editor || null;
+}
+
 /** Guess what the default editor is and default to VSCode. */
-export function guessEditor(): editors.Editor {
-  try {
-    const editor = env.EXPO_EDITOR;
+export function guessEditor(): Editor | null {
+  let editor: Editor | null = null;
+  if (env.EXPO_EDITOR) {
+    editor = getEditor(env.EXPO_EDITOR);
     if (editor) {
-      debug('Using $EXPO_EDITOR:', editor);
-      return editors.getEditor(editor);
+      debug('Using $EXPO_EDITOR:', editor.name);
     }
-    debug('Falling back on $EDITOR:', editor);
-    return editors.defaultEditor();
-  } catch {
+  }
+
+  if (!editor && process.env.VISUAL) {
+    editor = getEditor(process.env.VISUAL);
+    if (editor) {
+      debug('Using $VISUAL:', editor.name);
+    }
+  }
+
+  if (!editor && process.env.EDITOR) {
+    editor = getEditor(process.env.EDITOR);
+    if (editor) {
+      debug('Using $EDITOR:', editor.name);
+    }
+  }
+
+  if (editor) {
+    return editor;
+  } else {
     debug('Falling back on vscode');
-    return editors.getEditor('vscode');
+    return getEditor('vscode');
   }
 }
 
 /** Open a file path in a given editor. */
 export async function openInEditorAsync(path: string, lineNumber?: number): Promise<boolean> {
   const editor = guessEditor();
-  if (!editor.isTerminalEditor) {
+  if (editor && !editor.isTerminalEditor) {
     const fileReference = lineNumber ? `${path}:${lineNumber}` : path;
     debug(
       `Opening ${fileReference} in ${editor?.name} (bin: ${editor?.binary}, id: ${editor?.id})`
@@ -47,7 +92,7 @@ export async function openInEditorAsync(path: string, lineNumber?: number): Prom
   }
 
   Log.error(
-    (editor.isTerminalEditor
+    (editor?.isTerminalEditor
       ? `Could not open ${editor.name} as it's a terminal editor.`
       : 'Could not open editor.') +
       `\nYou can set an editor for Expo to open automatically by defining the $EDITOR environment variable (e.g. "vscode" or "atom")`
@@ -55,7 +100,7 @@ export async function openInEditorAsync(path: string, lineNumber?: number): Prom
   return false;
 }
 
-function getEditorArguments(editor: editors.Editor, path: string, lineNumber?: number): string[] {
+function getEditorArguments(editor: Editor, path: string, lineNumber?: number): string[] {
   if (!lineNumber) {
     return [path];
   }
@@ -87,3 +132,147 @@ function getEditorArguments(editor: editors.Editor, path: string, lineNumber?: n
       return [path];
   }
 }
+
+const EDITORS = [
+  {
+    id: 'sublime',
+    name: 'Sublime Text',
+    binary: 'subl',
+    isTerminalEditor: false,
+    paths: [
+      '/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl',
+      '/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl',
+    ],
+    keywords: [],
+  },
+  {
+    id: 'atom',
+    name: 'Atom',
+    binary: 'atom',
+    isTerminalEditor: false,
+    paths: ['/Applications/Atom.app/Contents/Resources/app/atom.sh'],
+    keywords: [],
+  },
+  {
+    id: 'vscode-insiders',
+    name: 'Visual Studio Code - Insiders',
+    binary: 'code-insiders',
+    isTerminalEditor: false,
+    paths: [
+      '/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code-insiders',
+    ],
+    keywords: ['vs code insiders', 'code insiders', 'insiders'],
+  },
+  {
+    id: 'vscode',
+    name: 'Visual Studio Code',
+    binary: 'code',
+    isTerminalEditor: false,
+    paths: ['/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code'],
+    keywords: ['vs code'],
+  },
+  {
+    id: 'vscodium',
+    name: 'VSCodium',
+    binary: 'codium',
+    isTerminalEditor: false,
+    paths: ['/Applications/VSCodium.app/Contents/Resources/app/bin/codium'],
+    keywords: [],
+  },
+  {
+    id: 'webstorm',
+    name: 'WebStorm',
+    binary: 'webstorm',
+    isTerminalEditor: false,
+    paths: [],
+    keywords: ['wstorm'],
+  },
+  {
+    id: 'phpstorm',
+    name: 'PhpStorm',
+    binary: 'pstorm',
+    isTerminalEditor: false,
+    paths: [],
+    keywords: ['php'],
+  },
+  {
+    id: 'textmate',
+    name: 'TextMate',
+    binary: 'mate',
+    isTerminalEditor: false,
+    paths: [],
+    keywords: [],
+  },
+  {
+    id: 'vim',
+    name: 'Vim',
+    binary: 'vim',
+    isTerminalEditor: true,
+    paths: [],
+    keywords: ['vi'],
+  },
+  {
+    id: 'neovim',
+    name: 'NeoVim',
+    binary: 'nvim',
+    isTerminalEditor: true,
+    paths: [],
+    keywords: ['vim'],
+  },
+  {
+    id: 'intellij',
+    name: 'IntelliJ IDEA',
+    binary: 'idea',
+    isTerminalEditor: false,
+    paths: [],
+    keywords: ['idea', 'java', 'jetbrains', 'ide'],
+  },
+  {
+    id: 'nano',
+    name: 'GNU nano',
+    binary: 'nano',
+    isTerminalEditor: true,
+    paths: [],
+    keywords: [],
+  },
+  {
+    id: 'emacs',
+    name: 'GNU Emacs',
+    binary: 'emacs',
+    isTerminalEditor: true,
+    paths: [],
+    keywords: [],
+  },
+  {
+    id: 'emacsforosx',
+    name: 'GNU Emacs for Mac OS X',
+    binary: 'Emacs',
+    isTerminalEditor: false,
+    paths: ['/Applications/Emacs.app/Contents/MacOS/Emacs'],
+    keywords: [],
+  },
+  {
+    id: 'android-studio',
+    name: 'Android Studio',
+    binary: 'studio',
+    isTerminalEditor: false,
+    paths: [
+      '/Applications/Android Studio.app/Contents/MacOS/studio',
+      '/usr/local/Android/android-studio/bin/studio.sh',
+      'C:\\Program Files (x86)\\Android\\android-studio\\bin\\studio.exe',
+      'C:\\Program Files\\Android\\android-studio\\bin\\studio64.exe',
+    ],
+    keywords: ['studio'],
+  },
+  {
+    id: 'xcode',
+    name: 'Xcode',
+    binary: 'xed',
+    isTerminalEditor: false,
+    paths: [
+      '/Applications/Xcode.app/Contents/MacOS/Xcode',
+      '/Applications/Xcode-beta.app/Contents/MacOS/Xcode',
+    ],
+    keywords: ['xed'],
+  },
+];

--- a/packages/@expo/cli/src/utils/editor.ts
+++ b/packages/@expo/cli/src/utils/editor.ts
@@ -152,6 +152,10 @@ export async function openInEditorAsync(path: string, lineNumber?: number): Prom
         });
         return true;
       } catch (error: any) {
+        // NOTE(@kitten): The process might explicitly request to be terminated, which is fine
+        if (error?.signal === 'SIGTERM') {
+          return true;
+        }
         debug(
           `Failed to open ${fileReference} in editor (path: ${path}, binary: ${editor.binary}):`,
           error

--- a/packages/@expo/cli/src/utils/editor.ts
+++ b/packages/@expo/cli/src/utils/editor.ts
@@ -8,7 +8,15 @@ import * as Log from '../log';
 
 const debug = require('debug')('expo:utils:editor') as typeof console.log;
 
-type Editor = (typeof EDITORS)[number];
+interface Editor {
+  id: string;
+  name: string;
+  binary: string;
+  isTerminalEditor: boolean;
+  isOSXOnly?: boolean;
+  paths: string[];
+  keywords: string[];
+}
 
 // See: https://github.com/sindresorhus/env-editor/blob/3f6aea10ff53910c877b1bf73a8e0c954a5fbf11/index.js
 // MIT License, Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
@@ -172,6 +180,9 @@ function getEditorArguments(editor: Editor, path: string, lineNumber?: number): 
 
 /** Attempt to resolve an editor against $PATH */
 async function editorExistsInPath(editor: Editor) {
+  if (process.platform !== 'darwin' && editor.isOSXOnly) {
+    return null;
+  }
   const binary = editor.binary;
   const paths = (process.env.PATH || process.env.Path || '')
     .split(path.delimiter)
@@ -210,7 +221,7 @@ async function editorExistsAtPaths(editor: Editor) {
   return null;
 }
 
-const TERMINAL_EDITORS = [
+const TERMINAL_EDITORS: (Editor & { isTerminalEditor: true })[] = [
   {
     id: 'vim',
     name: 'Vim',
@@ -245,7 +256,33 @@ const TERMINAL_EDITORS = [
   },
 ];
 
-const VISUAL_EDITORS = [
+const VISUAL_EDITORS: (Editor & { isTerminalEditor: false })[] = [
+  {
+    id: 'vscode',
+    name: 'Visual Studio Code',
+    binary: 'code',
+    isTerminalEditor: false,
+    paths: ['/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code'],
+    keywords: ['vs code'],
+  },
+  {
+    id: 'vscode-insiders',
+    name: 'Visual Studio Code - Insiders',
+    binary: 'code-insiders',
+    isTerminalEditor: false,
+    paths: [
+      '/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code-insiders',
+    ],
+    keywords: ['vs code insiders', 'code insiders', 'insiders'],
+  },
+  {
+    id: 'vscodium',
+    name: 'VSCodium',
+    binary: 'codium',
+    isTerminalEditor: false,
+    paths: ['/Applications/VSCodium.app/Contents/Resources/app/bin/codium'],
+    keywords: [],
+  },
   {
     id: 'sublime',
     name: 'Sublime Text',
@@ -263,32 +300,6 @@ const VISUAL_EDITORS = [
     binary: 'atom',
     isTerminalEditor: false,
     paths: ['/Applications/Atom.app/Contents/Resources/app/atom.sh'],
-    keywords: [],
-  },
-  {
-    id: 'vscode-insiders',
-    name: 'Visual Studio Code - Insiders',
-    binary: 'code-insiders',
-    isTerminalEditor: false,
-    paths: [
-      '/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code-insiders',
-    ],
-    keywords: ['vs code insiders', 'code insiders', 'insiders'],
-  },
-  {
-    id: 'vscode',
-    name: 'Visual Studio Code',
-    binary: 'code',
-    isTerminalEditor: false,
-    paths: ['/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code'],
-    keywords: ['vs code'],
-  },
-  {
-    id: 'vscodium',
-    name: 'VSCodium',
-    binary: 'codium',
-    isTerminalEditor: false,
-    paths: ['/Applications/VSCodium.app/Contents/Resources/app/bin/codium'],
     keywords: [],
   },
   {
@@ -328,6 +339,7 @@ const VISUAL_EDITORS = [
     name: 'GNU Emacs for Mac OS X',
     binary: 'Emacs',
     isTerminalEditor: false,
+    isOSXOnly: true,
     paths: ['/Applications/Emacs.app/Contents/MacOS/Emacs'],
     keywords: [],
   },
@@ -336,6 +348,7 @@ const VISUAL_EDITORS = [
     name: 'Xcode',
     binary: 'xed',
     isTerminalEditor: false,
+    isOSXOnly: true,
     paths: [
       '/Applications/Xcode.app/Contents/MacOS/Xcode',
       '/Applications/Xcode-beta.app/Contents/MacOS/Xcode',
@@ -357,4 +370,4 @@ const VISUAL_EDITORS = [
   },
 ];
 
-const EDITORS = [...VISUAL_EDITORS, ...TERMINAL_EDITORS];
+const EDITORS: Editor[] = [...VISUAL_EDITORS, ...TERMINAL_EDITORS];

--- a/packages/@expo/cli/src/utils/editor.ts
+++ b/packages/@expo/cli/src/utils/editor.ts
@@ -198,6 +198,11 @@ function getEditorArguments(editor: Editor, path: string, lineNumber?: number): 
     case 'cursor':
       return lineNumber ? ['-g', `${path}:${lineNumber}`] : ['-g', path];
 
+    case 'zed':
+      // '-r': Stands for "--reuse" and ensures we don't use the `zed` GUI binary, since the Zed CLI
+      // is linked as `zed` into `$PATH` when it's actually the CLI
+      return lineNumber ? ['-r', `${path}:${lineNumber}`] : ['-r', path];
+
     default:
       return [path];
   }
@@ -350,6 +355,14 @@ const VISUAL_EDITORS: (Editor & { isTerminalEditor: false })[] = [
     isTerminalEditor: false,
     paths: [],
     keywords: ['php'],
+  },
+  {
+    id: 'zed',
+    name: 'Zed',
+    binary: 'zed',
+    isTerminalEditor: false,
+    paths: ['/Applications/Zed.app/Contents/MacOS/cli'],
+    keywords: [],
   },
   {
     id: 'textmate',

--- a/packages/@expo/cli/src/utils/editor.ts
+++ b/packages/@expo/cli/src/utils/editor.ts
@@ -195,6 +195,7 @@ function getEditorArguments(editor: Editor, path: string, lineNumber?: number): 
 
     case 'vscode':
     case 'vscodium':
+    case 'cursor':
       return lineNumber ? ['-g', `${path}:${lineNumber}`] : ['-g', path];
 
     default:
@@ -305,6 +306,14 @@ const VISUAL_EDITORS: (Editor & { isTerminalEditor: false })[] = [
     binary: 'codium',
     isTerminalEditor: false,
     paths: ['/Applications/VSCodium.app/Contents/Resources/app/bin/codium'],
+    keywords: [],
+  },
+  {
+    id: 'cursor',
+    name: 'Cursor',
+    binary: 'cursor',
+    isTerminalEditor: false,
+    paths: ['/Applications/Cursor.app/Contents/Resources/app/bin/codium'],
     keywords: [],
   },
   {

--- a/packages/@expo/cli/src/utils/editor.ts
+++ b/packages/@expo/cli/src/utils/editor.ts
@@ -2,6 +2,7 @@ import spawnAsync from '@expo/spawn-async';
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
+import { override } from 'prompts';
 
 import { env } from './env';
 import * as Log from '../log';
@@ -20,12 +21,13 @@ interface Editor {
 
 // See: https://github.com/sindresorhus/env-editor/blob/3f6aea10ff53910c877b1bf73a8e0c954a5fbf11/index.js
 // MIT License, Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
-function getEditor(input: string | undefined): Editor | null {
-  if (!input) {
+function getEditor(input: string | undefined, allowAnyEditor = false): Editor | null {
+  const needle = input?.trim().toLowerCase();
+  if (!needle) {
     return null;
   }
-  const needle = input.trim().toLowerCase();
-  const binary = needle.split(/[/\\]/).pop()?.replace(/\s/g, '-')?.split('-')[0];
+  const id = needle.split(/[/\\]/).pop()?.replace(/\s/g, '-');
+  const binary = id?.split('-')[0];
   const editor =
     EDITORS.find((editor) => {
       switch (needle) {
@@ -43,6 +45,16 @@ function getEditor(input: string | undefined): Editor | null {
           return false;
       }
     }) ?? (binary ? EDITORS.find((editor) => editor.binary === binary) : null);
+  if (allowAnyEditor && id && binary && !editor) {
+    return {
+      id,
+      name: needle,
+      binary,
+      isTerminalEditor: false,
+      paths: [],
+      keywords: [],
+    };
+  }
   return editor || null;
 }
 
@@ -70,26 +82,16 @@ export function guessEditor(): Editor | null {
     }
   }
 
-  if (editor) {
-    return editor;
-  } else {
-    debug('Falling back on vscode');
-    return getEditor('vscode');
-  }
+  return editor;
 }
 
-let _cachedVisualEditor: Editor | null | undefined;
-
 export async function guessFallbackVisualEditor(): Promise<Editor | null> {
-  if (_cachedVisualEditor !== undefined) {
-    return _cachedVisualEditor;
-  }
   // We search for editors at known `editor.paths`
   for (const editor of VISUAL_EDITORS) {
     const target = await editorExistsAtPaths(editor);
     if (target) {
       debug('Found visual editor fallback:', editor.name);
-      return (_cachedVisualEditor = { ...editor, binary: target });
+      return { ...editor, binary: target };
     }
   }
   // We search again for a visual editor against `editor.binary` in `$PATH`
@@ -97,17 +99,28 @@ export async function guessFallbackVisualEditor(): Promise<Editor | null> {
     const target = await editorExistsInPath(editor);
     if (target) {
       debug('Found visual editor fallback in $PATH:', editor.name);
-      return (_cachedVisualEditor = { ...editor, binary: target });
+      return { ...editor, binary: target };
     }
   }
-  return (_cachedVisualEditor = null);
+  return null;
 }
 
 /** Open a file path in a given editor. */
 export async function openInEditorAsync(path: string, lineNumber?: number): Promise<boolean> {
+  // First: Try to get a known editor
   let editor = guessEditor();
 
-  // Try to find a fallback visual editor, but keep the found one if we can't find a fallback
+  // Second: If we don't have a known editor, fall back to EXPO_EDITOR / VISUAL resolution
+  // We check if the binary in these environment variables exists in the $PATH
+  const forceEditorName = env.EXPO_EDITOR ?? process.env.VISUAL;
+  if (!editor && forceEditorName) {
+    const forceEditor = getEditor(forceEditorName, true);
+    if (forceEditor && (await editorExistsInPath(forceEditor))) {
+      editor = forceEditor;
+    }
+  }
+
+  // Third: Try to find a fallback visual editor, but keep the found one if we can't find a fallback
   if (editor?.isTerminalEditor) {
     const fallback = await guessFallbackVisualEditor();
     if (fallback) {
@@ -140,7 +153,7 @@ export async function openInEditorAsync(path: string, lineNumber?: number): Prom
     (editor?.isTerminalEditor
       ? `Could not open ${editor.name} as it's a terminal editor.`
       : 'Could not open editor.') +
-      `\nYou can set an editor for Expo to open automatically by defining the $EDITOR environment variable (e.g. "vscode" or "atom")`
+      `\nYou can set an editor for Expo to open by defining the $EXPO_EDITOR or $VISUAL environment variable (e.g. "vscode" or "atom")`
   );
   return false;
 }

--- a/packages/@expo/cli/src/utils/editor.ts
+++ b/packages/@expo/cli/src/utils/editor.ts
@@ -2,7 +2,6 @@ import spawnAsync from '@expo/spawn-async';
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
-import { override } from 'prompts';
 
 import { env } from './env';
 import * as Log from '../log';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7453,11 +7453,6 @@ entities@^4.2.0, entities@^4.4.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
   integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
 
-env-editor@^0.4.1:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/env-editor/-/env-editor-0.4.2.tgz#4e76568d0bd8f5c2b6d314a9412c8fe9aa3ae861"
-  integrity sha512-ObFo8v4rQJAE59M69QzwloxPZtd33TpYEIjtKD1rrFDcM1Gd7IkDxEBU+HriziN6HSHQnBJi8Dmy+JWkav5HKA==
-
 envinfo@^7.8.1:
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.13.0.tgz#81fbb81e5da35d74e814941aeab7c325a606fb31"


### PR DESCRIPTION
# Why

We currently use `env-editor` with a few inputs to determine which editor to open. However, this is prone to failing for multiple reasons:
- When a user intentionally sets an unknown editor, we don't check if it's a valid binary we can call
- We prefer `$EDITOR` as a fallback from the user (which is hard-coded in `env-editor`), which, by convention, over `$VISUAL` is a terminal editor most of the times
- We don't attempt to find any other editor otherwise and assume VSCode is available

This can lead to a few issues when the `code` binary isn't in `$PATH` or when the user has invalid `$EDITOR` values. We also don't take into account that users are very likely to have Android Studio or Xcode installed.

When we spawn `$EDITOR` blindly, we may spawn a terminal editor, which then is spawned as a sub-process. While that's fine, it often will look to the user as if nothing is happening.

# How

Instead, this updates the logic to change what we do:
- Check `$EXPO_EDITOR`, then `$VISUAL`, then `EDITOR` against known editors
- If otherwise `$EXPO_EDITOR` or `$VISUAL` are unknown editors, use them if they resolve in `$PATH`
- If we have a known editor now that is a terminal editor, find a fallback visual editor
  - The fallback visual editor is checked against known paths then in `$PATH`
- If the determined editor is a terminal editor, don't spawn it and instead adjust the error message
- Instruct users to update `$EXPO_EDITOR` or `$VISUAL` and not `$EDITOR`

# Test Plan

- Unit tests updated
- Manually tested by pressing `o` in terminal (erase environment variables mentioned to test fallbacks)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
