### PR TITLE
fix(cli,log-box): Drop obsolete `rawBody` parsing from `createMetroMiddleware`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,11 +8,14 @@
 
 ### 🐛 Bug fixes
 
+- Add missing `Content-Type: application/json` to internal `/symbolicate` call ([#43074](https://github.com/expo/expo/pull/43074) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 - Bump to `dnssd-advertise@^1.1.3` ([#42928](https://github.com/expo/expo/pull/42928) by [@kitten](https://github.com/kitten))
 - Add more compact QR code rendering for terminals that support it, unless `COLOR=0` is set or TTY is non-interactive ([#42834](https://github.com/expo/expo/pull/42834) by [@kitten](https://github.com/kitten))
 - Collapse usage guide on `expo start` if space is insufficient ([#42835](https://github.com/expo/expo/pull/42835) by [@kitten](https://gthub.com/kitten))
+- Drop obsolete `rawBody` parsing from Metro middleware stack ([#43074](https://github.com/expo/expo/pull/43074) by [@kitten](https://github.com/kitten))
 
 ## 55.0.7 — 2026-02-08
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -73,7 +73,7 @@
     "dnssd-advertise": "^1.1.3",
     "env-editor": "^0.4.1",
     "expo-server": "^55.0.3",
-    "fetch-nodeshim": "^0.4.5",
+    "fetch-nodeshim": "^0.4.6",
     "getenv": "^2.0.0",
     "glob": "^13.0.0",
     "lan-network": "^0.1.6",

--- a/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/createMetroMiddleware.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/createMetroMiddleware.test.ts
@@ -85,33 +85,6 @@ describe(createMetroMiddleware, () => {
     expect(openInEditorAsync).toHaveBeenCalledWith('test-file.ts', 1337);
   });
 
-  it('prepares /symbolicate requests with raw body', async () => {
-    // Create a fake middleware to capture the request and respond with OK
-    const middleware = jest.fn((_req, res) => res.end('OK'));
-    // Create a fake symbolicate request body
-    const body = JSON.stringify({
-      stack: [
-        {
-          file: 'test-file.ts',
-          methodName: 'testMethod',
-          arguments: [],
-          lineNumber: 1337,
-          column: 0,
-        },
-      ],
-    });
-
-    // Register the middleware to capture the request
-    metro.middleware.use('/symbolicate', middleware);
-
-    const response = await server.fetch('/symbolicate', { method: 'POST', body });
-
-    // Ensure the request is successful
-    expect(response.status).toBe(200);
-    // Ensure the request body was loaded as `rawBody` string
-    expect(middleware.mock.calls[0][0]).toHaveProperty('rawBody', body);
-  });
-
   describe('websockets', () => {
     it('creates the /message websocket', () => {
       expect(metro.messagesSocket).toBeDefined();

--- a/packages/@expo/cli/src/start/server/metro/log-box/LogBoxSymbolication.ts
+++ b/packages/@expo/cli/src/start/server/metro/log-box/LogBoxSymbolication.ts
@@ -7,6 +7,8 @@
  */
 import { parse, StackFrame as UpstreamStackFrame } from 'stacktrace-parser';
 
+import { fetch } from '../../../../utils/fetch';
+
 export type CodeFrame = {
   content: string;
   location?: {
@@ -86,6 +88,9 @@ async function symbolicateStackTrace(stack: UpstreamStackFrame[]): Promise<Symbo
 
   return fetch(baseUrl + '/symbolicate', {
     method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
     body: JSON.stringify({ stack }),
   }).then((res) => res.json());
 }

--- a/packages/@expo/log-box/CHANGELOG.md
+++ b/packages/@expo/log-box/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add missing `Content-Type: application/json` to `/symbolicate` requests ([#43074](https://github.com/expo/expo/pull/43074) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 55.0.6 — 2026-02-08

--- a/packages/@expo/log-box/src/fetchHelper.ts
+++ b/packages/@expo/log-box/src/fetchHelper.ts
@@ -1,18 +1,6 @@
-export type FetchTextAsync = (
-  input: string,
-  init?: {
-    method?: string;
-    body?: string;
-  }
-) => Promise<string>;
+export type FetchTextAsync = (input: string, init?: RequestInit) => Promise<string>;
 
-function defaultFetchTextAsync(
-  input: string,
-  init?: {
-    method?: string;
-    body?: string;
-  }
-): Promise<string> {
+function defaultFetchTextAsync(input: string, init?: RequestInit): Promise<string> {
   return fetch(input, init).then((res) => res.text());
 }
 
@@ -22,9 +10,6 @@ export function setFetchText(fn: FetchTextAsync) {
   fetchTextAsyncFn = fn;
 }
 
-export function fetchTextAsync(
-  input: string,
-  init?: { method?: string; body?: string }
-): Promise<string> {
+export function fetchTextAsync(input: string, init?: RequestInit): Promise<string> {
   return fetchTextAsyncFn(input, init);
 }

--- a/packages/@expo/log-box/src/utils/devServerEndpoints.ts
+++ b/packages/@expo/log-box/src/utils/devServerEndpoints.ts
@@ -27,7 +27,7 @@ export function getBaseUrl() {
   return window.location.protocol + '//' + window.location.host;
 }
 
-function fetchTextAsyncWithBase(url: string, init?: { method?: string; body?: string }) {
+function fetchTextAsyncWithBase(url: string, init?: RequestInit) {
   const fullUrl = new URL(url, getBaseUrl()).href;
   return fetchTextAsync(fullUrl, init);
 }
@@ -35,6 +35,9 @@ function fetchTextAsyncWithBase(url: string, init?: { method?: string; body?: st
 export function openFileInEditor(file: string, lineNumber: number): void {
   fetchTextAsyncWithBase('/open-stack-frame', {
     method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
     body: JSON.stringify({ file, lineNumber }),
   });
 }
@@ -54,6 +57,9 @@ export async function fetchProjectMetadataAsync(): Promise<{
 async function symbolicateStackTrace(stack: MetroStackFrame[]): Promise<SymbolicatedStackTrace> {
   const response = await fetchTextAsyncWithBase('/symbolicate', {
     method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
     body: JSON.stringify({ stack }),
   });
   return JSON.parse(response);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8468,10 +8468,10 @@ fdir@^6.5.0:
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
-fetch-nodeshim@^0.4.5:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/fetch-nodeshim/-/fetch-nodeshim-0.4.5.tgz#618d643ee1f77040d7dde718147717fd0cbb29a8"
-  integrity sha512-n6dRDiC+/TlluvZxGDBnyNYqPftkDFjJIvXluekSSGildXSXvMWXXo+1/yK363BOZlOI2Q+PitrcLcF5CSolEA==
+fetch-nodeshim@^0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/fetch-nodeshim/-/fetch-nodeshim-0.4.6.tgz#4c7a4848d315b9b27e7366a2be56e11f1eecf368"
+  integrity sha512-RP+zh0GZLp/7bUoS37+pN8zKIhqQ5YuI3m2RQfxZSqPzwYO1wRzwWqq4Va0kWpNPQbtpomEYAQ7zC/VjJWGmIw==
 
 fetch-retry@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
# Why

Supersedes #35757

> This removes a longstanding hack that covered for a lack of JSON body parsing in Metro's `/symbolicate` endpoint. We're now resolving this in https://github.com/facebook/metro/pull/1475 — meaning this can be removed from Expo CLI.
> — @huntie

This also raised that we had two calls to `/symbolicate` that weren't being called with `application/json`. However, without the `rawBody` property, Metro's middlewares now expect the `Content-Type: application/json` header.

# How

- Update `@expo/log-box` to set `Content-Type: application/json` on JSON POST requests
- Update `@expo/cli` to set `Content-Type: application/json` on internal `/symbolicate` request
- Drop `rawBodyMiddleware` from CLI's `createMetroMiddleware`
- Replace `rawBody` with JSON body parsing for `/open-stack-frame`

# Test Plan

- Run app and cause an error with a stack trace
  - The `/symbolicate` call should work as before
  - Clicking a frame, `/open-stack-frame` should work as before

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
