### PR TITLE
feat(cli): Add Node.js version check and warning to CLI startup

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add more compact QR code rendering for terminals that support it, unless `COLOR=0` is set or TTY is non-interactive ([#42834](https://github.com/expo/expo/pull/42834) by [@kitten](https://github.com/kitten))
 - Collapse usage guide on `expo start` if space is insufficient ([#42835](https://github.com/expo/expo/pull/42835) by [@kitten](https://gthub.com/kitten))
 - Drop obsolete `rawBody` parsing from Metro middleware stack ([#43074](https://github.com/expo/expo/pull/43074) by [@kitten](https://github.com/kitten))
+- Add minimum Node.js version check and warning to CLI startup ([#43076](https://github.com/expo/expo/pull/43076) by [@kitten](https://github.com/kitten))
 
 ## 55.0.7 — 2026-02-08
 

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -4,6 +4,18 @@ import chalk from 'chalk';
 import Debug from 'debug';
 import { boolish } from 'getenv';
 
+// Check Node.js version and issue a loud warning if it's too outdated
+// This is sent to stderr (console.error) so it doesn't interfere with programmatic commands
+const NODE_MIN = [20, 19, 4];
+const nodeVersion = process.version?.slice(1).split('.', 3).map(Number);
+if (nodeVersion.some((part, idx) => part && part < NODE_MIN[idx])) {
+  console.error(
+    chalk.red`{bold Node.js (${process.version}) is outdated and unsupported.}`
+      + chalk.red` Please update to a newer Node.js LTS version (required: >=${NODE_MIN.join('.')})\n`
+      + chalk.red`Go to: https://nodejs.org/en/download\n`
+  );
+}
+
 // Setup before requiring `debug`.
 if (boolish('EXPO_DEBUG', false)) {
   Debug.enable('expo:*');

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -8,7 +8,7 @@ import { boolish } from 'getenv';
 // This is sent to stderr (console.error) so it doesn't interfere with programmatic commands
 const NODE_MIN = [20, 19, 4];
 const nodeVersion = process.version?.slice(1).split('.', 3).map(Number);
-if (nodeVersion.some((part, idx) => part && part < NODE_MIN[idx])) {
+if (nodeVersion[0] < NODE_MIN[0] || (nodeVersion[0] === NODE_MIN[0] && nodeVersion[1] < NODE_MIN[1])) {
   console.error(
     chalk.red`{bold Node.js (${process.version}) is outdated and unsupported.}`
       + chalk.red` Please update to a newer Node.js LTS version (required: >=${NODE_MIN.join('.')})\n`


### PR DESCRIPTION
# Why

Usually, the package manager and other tools catch a Node.js version that doesn't comply to the various `package.json:engines.node` versions that our dependencies define. However, sometimes, maybe due to a `--force` flag or for other reasons, this slips through and users may get a confusing error.

While we don't have to block the CLI entirely, we should issue a strong warning to stderr if we know the Node version is too old.

The particular version we're currently checking for is Node.js 20.19.0 from March 2025, as required by Metro and React Native.

# How

- Add early Node.js version check to `@expo/cli/bin/cli.ts`

# Test Plan

- Alter the hard-coded version and start up the CLI to check the error message

This is what it looks like (with versions altered for testing):

<img width="867" height="74" alt="image" src="https://github.com/user-attachments/assets/b41a8293-f985-426b-88b4-3b8689ad1fd9" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
