### PR TITLE
[dev-menu][iOS] Ensures DevMenuWindow is created in the main thread

### DIFF
--- a/apps/brownfield-tester/ios/Podfile
+++ b/apps/brownfield-tester/ios/Podfile
@@ -12,7 +12,6 @@ target 'BrownfieldTester' do
     projectRoot: project_root,
     exclude: [
       'expo-splash-screen',
-      'expo-dev-menu'
     ],
   })
 

--- a/apps/brownfield-tester/ios/Podfile.lock
+++ b/apps/brownfield-tester/ios/Podfile.lock
@@ -37,6 +37,35 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
+  - expo-dev-menu (55.0.5):
+    - boost
+    - DoubleConversion
+    - expo-dev-menu/Main (= 55.0.5)
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - expo-dev-menu-interface (55.0.1)
   - ExpoAsset (55.0.5):
     - ExpoModulesCore
@@ -2951,6 +2980,7 @@ DEPENDENCIES:
   - EXJSONUtils (from `../../../packages/expo-json-utils/ios`)
   - EXManifests (from `../../../packages/expo-manifests/ios`)
   - Expo (from `../../../packages/expo`)
+  - expo-dev-menu (from `../../../packages/expo-dev-menu`)
   - expo-dev-menu-interface (from `../../../packages/expo-dev-menu-interface/ios`)
   - ExpoAsset (from `../../../packages/expo-asset/ios`)
   - ExpoBrownfield (from `../../../packages/expo-brownfield/ios`)
@@ -3076,6 +3106,8 @@ EXTERNAL SOURCES:
     :path: "../../../packages/expo-manifests/ios"
   Expo:
     :path: "../../../packages/expo"
+  expo-dev-menu:
+    :path: "../../../packages/expo-dev-menu"
   expo-dev-menu-interface:
     :path: "../../../packages/expo-dev-menu-interface/ios"
   ExpoAsset:
@@ -3388,6 +3420,6 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 3d56e80930898685da43cbf53b5843932df8e765
 
-PODFILE CHECKSUM: 138a890cb547592c982ba14a2a7126f821424938
+PODFILE CHECKSUM: 1ca978f73a30f65633c68b87b4dcd2037d2b9a00
 
 COCOAPODS: 1.16.2

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [iOS] Ensures DevMenuWindow is created in the main thread ([#43078](https://github.com/expo/expo/pull/43078) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 55.0.6 — 2026-02-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -249,7 +249,7 @@ open class DevMenuManager: NSObject {
 
   override init() {
     super.init()
-    self.window = DevMenuWindow(manager: self)
+    self.window = Dispatch.mainSync { DevMenuWindow(manager: self) }
     self.packagerConnectionHandler = DevMenuPackagerConnectionHandler(manager: self)
     self.packagerConnectionHandler?.setup()
     DevMenuPreferences.setup()

--- a/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift
+++ b/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift
@@ -10,10 +10,12 @@ class DevMenuKeyCommandsInterceptor {
   static var isInstalled: Bool = false {
     willSet {
       if isInstalled != newValue {
-        if newValue {
-          registerKeyCommands()
-        } else {
-          unregisterKeyCommands()
+        DispatchQueue.main.async {
+          if newValue {
+            registerKeyCommands()
+          } else {
+            unregisterKeyCommands()
+          }
         }
       }
     }


### PR DESCRIPTION
# Why

While running the integrated brownfield-tester app on iOS with dev-menu got an `Call must be made on main thread"` crash 

<img width="737" height="154" alt="image" src="https://github.com/user-attachments/assets/804d0fec-0c96-422e-abf4-86a7e06adacf" />

 
# How

Add `DispatchQueue.main` to `registerKeyCommands` calls and `UIViewController` creation, to ensure these are always invoked from the main thread#

# Test Plan

Run integrated brownfield-tester app on iOS 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
