### PR TITLE
[ci] Fix pr-labeler workflow 'Argument list too long' error

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -51,7 +51,7 @@ jobs:
         uses: ./.github/actions/expo-caches
         id: expo-caches
         with:
-          yarn-workspace: 'true'
+          yarn-workspace: "true"
       - name: 🧶 Install node modules in root dir
         run: yarn install --frozen-lockfile
       - name: Get the base commit
@@ -66,6 +66,7 @@ jobs:
           working-directory: apps/bare-expo
           previous-git-commit: ${{ steps.base-commit.outputs.base-commit }}
           fingerprint-db-cache-path: .fingerprint.db
+          fingerprint-state-output-file: ${{ runner.temp }}/fingerprint-state.json
 
       - name: 👀 Debug fingerprint
         run: |
@@ -125,7 +126,7 @@ jobs:
         id: old_comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'expo-bot'
+          comment-author: "expo-bot"
           body-includes: <!-- pr-labeler comment -->
       - name: 💬 Add comment with fingerprint
         if: ${{ github.event_name == 'pull_request' && steps.fingerprint.outputs.previous-fingerprint != '' && steps.fingerprint.outputs.fingerprint-diff != '[]' && steps.old_comment.outputs.comment-id == '' }}
@@ -133,9 +134,11 @@ jobs:
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
-            const diff = JSON.stringify(${{ steps.fingerprint.outputs.fingerprint-diff}}, null, 2);
+            const fs = require('fs');
+            const state = JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + '/fingerprint-state.json', 'utf8'));
+            const diff = JSON.stringify(state.diff, null, 2);
             const body = `<!-- pr-labeler comment -->
-            The Pull Request introduced fingerprint changes against the base commit: ${{ steps.fingerprint.outputs.previous-git-commit }}
+            The Pull Request introduced fingerprint changes against the base commit: ${state.previousGitCommitHash}
             <details><summary>Fingerprint diff</summary>
 
             \`\`\`json
@@ -160,9 +163,11 @@ jobs:
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
-            const diff = JSON.stringify(${{ steps.fingerprint.outputs.fingerprint-diff}}, null, 2);
+            const fs = require('fs');
+            const state = JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + '/fingerprint-state.json', 'utf8'));
+            const diff = JSON.stringify(state.diff, null, 2);
             const body = `<!-- pr-labeler comment -->
-            The Pull Request introduced fingerprint changes against the base commit: ${{ steps.fingerprint.outputs.previous-git-commit }}
+            The Pull Request introduced fingerprint changes against the base commit: ${state.previousGitCommitHash}
             <details><summary>Fingerprint diff</summary>
 
             \`\`\`json


### PR DESCRIPTION
# Why

The pr-labeler workflow fails with `Argument list too long` when the fingerprint diff is large (>2MB). The fingerprint-diff output gets expanded inline by the GitHub Actions runner, and any approach that passes it through shell arguments or environment variables hits Linux's ARG_MAX limit.


Before: https://github.com/expo/expo/actions/runs/21922360042/job/63305722298?pr=43018
After: https://github.com/expo/expo/actions/runs/22238462171/job/64335899522?pr=43081

# How

Use the fingerprint file input that the action already supports. This makes the action write the entire state (including the diff) directly to a JSON file on disk, completely bypassing shell argument/env var size limits.


# Test Plan


Verify the pr-labeler workflow passes on CI for a PR that triggers fingerprint changes.


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
