### PR TITLE
[core] Accept typed arrays for ArrayBuffer arguments

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- `NativeArrayBuffer` and `JavaScriptArrayBuffer` arguments now also accept typed arrays. ([#43082](https://github.com/expo/expo/pull/43082) by [@barthap](https://github.com/barthap))
+
 ### 🐛 Bug fixes
 
 - [iOS] Fixed `field.options.insert()` silently failing in `fieldsOf()` due to mutation on protocol existential. ([#43341](https://github.com/expo/expo/pull/43341) by [@just1and0](https://github.com/just1and0))

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/ArrayBufferConversionTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/ArrayBufferConversionTest.kt
@@ -25,6 +25,18 @@ class ArrayBufferConversionTest {
   )
 
   @Test
+  fun array_buffer_should_be_convertible_from_u8array() = conversionTest<JavaScriptArrayBuffer, _>(
+    jsValue = "new Uint8Array([0x00, 0xff])",
+    nativeAssertion = { arrayBuffer ->
+      Truth.assertThat(arrayBuffer.size()).isEqualTo(2)
+      Truth.assertThat(arrayBuffer.readByte(0)).isEqualTo(0x00.toByte())
+      Truth.assertThat(arrayBuffer.readByte(1)).isEqualTo(0xff.toByte())
+    },
+    map = {},
+    jsAssertion = {}
+  )
+
+  @Test
   fun js_array_buffer_should_be_returned() = conversionTest<JavaScriptArrayBuffer, _>(
     jsValue = "new Uint8Array([0x00, 0xff]).buffer",
     nativeAssertion = { arrayBuffer ->

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/ArrayBufferConversionTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/ArrayBufferConversionTest.kt
@@ -25,12 +25,36 @@ class ArrayBufferConversionTest {
   )
 
   @Test
-  fun array_buffer_should_be_convertible_from_u8array() = conversionTest<JavaScriptArrayBuffer, _>(
+  fun js_array_buffer_accepts_full_typed_array() = conversionTest<JavaScriptArrayBuffer, _>(
     jsValue = "new Uint8Array([0x00, 0xff])",
     nativeAssertion = { arrayBuffer ->
       Truth.assertThat(arrayBuffer.size()).isEqualTo(2)
       Truth.assertThat(arrayBuffer.readByte(0)).isEqualTo(0x00.toByte())
       Truth.assertThat(arrayBuffer.readByte(1)).isEqualTo(0xff.toByte())
+    },
+    map = {},
+    jsAssertion = {}
+  )
+
+  @Test
+  fun js_array_buffer_accepts_partial_typed_array_view() = conversionTest<JavaScriptArrayBuffer, _>(
+    jsValue = "new Uint8Array(new Uint8Array([1,2,3,4,5]).buffer, 1, 2)",
+    nativeAssertion = { arrayBuffer ->
+      Truth.assertThat(arrayBuffer.size()).isEqualTo(2)
+      Truth.assertThat(arrayBuffer.readByte(0)).isEqualTo(2.toByte())
+      Truth.assertThat(arrayBuffer.readByte(1)).isEqualTo(3.toByte())
+    },
+    map = {},
+    jsAssertion = {}
+  )
+
+  @Test
+  fun native_array_buffer_accepts_partial_typed_array_view() = conversionTest<NativeArrayBuffer, _>(
+    jsValue = "new Uint8Array(new Uint8Array([1,2,3,4,5]).buffer, 1, 2)",
+    nativeAssertion = { arrayBuffer ->
+      Truth.assertThat(arrayBuffer.size()).isEqualTo(2)
+      Truth.assertThat(arrayBuffer.readByte(0)).isEqualTo(2.toByte())
+      Truth.assertThat(arrayBuffer.readByte(1)).isEqualTo(3.toByte())
     },
     map = {},
     jsAssertion = {}

--- a/packages/expo-modules-core/android/src/main/cpp/NativeArrayBuffer.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/NativeArrayBuffer.cpp
@@ -59,6 +59,21 @@ NativeArrayBuffer::newInstance(JSIContext *jsiContext, jsi::Runtime &runtime,
   return value;
 }
 
+jni::local_ref<NativeArrayBuffer::javaobject>
+NativeArrayBuffer::newInstance(JSIContext *jsiContext, jsi::Runtime &runtime,
+                               expo::TypedArray& typedArray) {
+
+  size_t size = typedArray.byteLength(runtime);
+
+  auto byteBuffer = jni::JByteBuffer::allocateDirect(static_cast<jint>(size));
+  byteBuffer->order(jni::JByteOrder::nativeOrder());
+  memcpy(byteBuffer->getDirectAddress(), typedArray.getRawPointer(runtime), size);
+
+  auto value = NativeArrayBuffer::newObjectCxxArgs(byteBuffer);
+  jsiContext->jniDeallocator->addReference(value);
+  return value;
+}
+
 NativeArrayBuffer::NativeArrayBuffer(const jni::alias_ref<jni::JByteBuffer> &byteBuffer)
   : buffer(std::make_shared<ByteBufferJSIWrapper>(byteBuffer)) { }
 

--- a/packages/expo-modules-core/android/src/main/cpp/NativeArrayBuffer.h
+++ b/packages/expo-modules-core/android/src/main/cpp/NativeArrayBuffer.h
@@ -7,6 +7,8 @@
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
 
+#include "TypedArray.h"
+
 #include <memory>
 
 namespace expo {
@@ -49,10 +51,23 @@ public:
     jni::alias_ref<jni::JByteBuffer> byteBuffer
   );
 
+  /**
+   * Allocates a new NativeArrayBuffer by copying the contents of the given ArrayBuffer.
+   */
   static jni::local_ref<NativeArrayBuffer::javaobject> newInstance(
     JSIContext *jsiContext,
     jsi::Runtime& runtime,
     jsi::ArrayBuffer& arrayBuffer
+  );
+
+  /**
+   * Allocates a new NativeArrayBuffer by copying only the bytes within the typed array's
+   * view range — not the entire backing buffer.
+   */
+  static jni::local_ref<NativeArrayBuffer::javaobject> newInstance(
+    JSIContext *jsiContext,
+    jsi::Runtime& runtime,
+    expo::TypedArray& typedArray
   );
 
   explicit NativeArrayBuffer(const jni::alias_ref<jni::JByteBuffer>& byteBuffer);

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
@@ -207,7 +207,10 @@ jobject NativeArrayBufferFrontendConverter::convert(
   const jsi::Value &value
 ) const {
   JSIContext *jsiContext = getJSIContext(rt);
-  auto arrayBuffer = value.asObject(rt).getArrayBuffer(rt);
+  auto object = value.asObject(rt);
+  auto arrayBuffer = isTypedArray(rt, object) ?
+    object.getProperty(rt, "buffer").asObject(rt).getArrayBuffer(rt) :
+    object.getArrayBuffer(rt);
   return NativeArrayBuffer::newInstance(
     jsiContext,
     rt,
@@ -221,7 +224,7 @@ bool NativeArrayBufferFrontendConverter::canConvert(
 ) const {
   if (value.isObject()) {
     auto object = value.getObject(rt);
-    return object.isArrayBuffer(rt);
+    return object.isArrayBuffer(rt) || isTypedArray(rt, object);
   }
   return false;
 }
@@ -270,10 +273,14 @@ jobject JavaScriptArrayBufferFrontendConverter::convert(
   const jsi::Value &value
 ) const {
   JSIContext *jsiContext = getJSIContext(rt);
+  auto object = value.asObject(rt);
+  auto arrayBuffer = isTypedArray(rt, object) ?
+    object.getProperty(rt, "buffer").asObject(rt).getArrayBuffer(rt) :
+    object.getArrayBuffer(rt);
   return JavaScriptArrayBuffer::newInstance(
     jsiContext,
     jsiContext->runtimeHolder->weak_from_this(),
-    std::make_shared<jsi::ArrayBuffer>(value.asObject(rt).getArrayBuffer(rt))
+    std::make_shared<jsi::ArrayBuffer>(std::move(arrayBuffer))
   ).release();
 }
 
@@ -281,7 +288,11 @@ bool JavaScriptArrayBufferFrontendConverter::canConvert(
   jsi::Runtime &rt,
   const jsi::Value &value
 ) const {
-  return value.isObject() && value.getObject(rt).isArrayBuffer(rt);
+  if (value.isObject()) {
+    auto object = value.getObject(rt);
+    return object.isArrayBuffer(rt) || isTypedArray(rt, object);
+  }
+  return false;
 }
 
 jobject JavaScriptFunctionFrontendConverter::convert(

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
@@ -208,9 +208,13 @@ jobject NativeArrayBufferFrontendConverter::convert(
 ) const {
   JSIContext *jsiContext = getJSIContext(rt);
   auto object = value.asObject(rt);
-  auto arrayBuffer = isTypedArray(rt, object) ?
-    object.getProperty(rt, "buffer").asObject(rt).getArrayBuffer(rt) :
-    object.getArrayBuffer(rt);
+
+  if (isTypedArray(rt, object)) {
+    auto typedArray = TypedArray(rt, object);
+    return NativeArrayBuffer::newInstance(jsiContext, rt, typedArray).release();
+  }
+
+  auto arrayBuffer = object.getArrayBuffer(rt);
   return NativeArrayBuffer::newInstance(
     jsiContext,
     rt,
@@ -275,7 +279,7 @@ jobject JavaScriptArrayBufferFrontendConverter::convert(
   JSIContext *jsiContext = getJSIContext(rt);
   auto object = value.asObject(rt);
   auto arrayBuffer = isTypedArray(rt, object) ?
-    object.getProperty(rt, "buffer").asObject(rt).getArrayBuffer(rt) :
+    TypedArray(rt, object).getViewedBufferSlice(rt) :
     object.getArrayBuffer(rt);
   return JavaScriptArrayBuffer::newInstance(
     jsiContext,

--- a/packages/expo-modules-core/common/cpp/JSI/TypedArray.cpp
+++ b/packages/expo-modules-core/common/cpp/JSI/TypedArray.cpp
@@ -51,6 +51,27 @@ jsi::ArrayBuffer TypedArray::getBuffer(jsi::Runtime &runtime) const {
   }
 }
 
+jsi::ArrayBuffer TypedArray::getViewedBufferSlice(jsi::Runtime &runtime) const {
+  auto buffer = getBuffer(runtime);
+
+  auto offset = byteOffset(runtime);
+  auto length = byteLength(runtime);
+
+  if (offset == 0 && length == buffer.size(runtime)) {
+    return buffer;
+  }
+
+  jsi::Function sliceFunc = buffer.getPropertyAsFunction(runtime, "slice");
+
+  // ArrayBuffer.prototype.slice(begin, end)
+  // Note: end is byteOffset + byteLength
+  auto slicedBuffer = sliceFunc.callWithThis(runtime, buffer, {
+    jsi::Value((double)offset),
+    jsi::Value((double)offset + length)
+  });
+  return slicedBuffer.asObject(runtime).getArrayBuffer(runtime);
+}
+
 void* TypedArray::getRawPointer(jsi::Runtime &runtime) const {
   return reinterpret_cast<void *>(getBuffer(runtime).data(runtime) + byteOffset(runtime));
 }

--- a/packages/expo-modules-core/common/cpp/JSI/TypedArray.h
+++ b/packages/expo-modules-core/common/cpp/JSI/TypedArray.h
@@ -38,7 +38,19 @@ class TypedArray : public jsi::Object {
 
   size_t byteLength(jsi::Runtime &runtime) const;
 
+  /**
+   * Returns the typed array's backing ArrayBuffer.
+   * Always returns the full buffer, even when the typed array covers only a subset of it.
+   */
   jsi::ArrayBuffer getBuffer(jsi::Runtime &runtime) const;
+
+  /**
+   * Returns only the portion of the backing buffer spanned by this typed array's view.
+   * If the view covers the entire buffer, returns the buffer directly (zero-copy).
+   * If the view is a subset, allocates a new ArrayBuffer containing only that slice
+   * via ArrayBuffer.prototype.slice() — this involves a data copy.
+   */
+  jsi::ArrayBuffer getViewedBufferSlice(jsi::Runtime &runtime) const;
 
   void* getRawPointer(jsi::Runtime &runtime) const;
 };

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicArrayBufferType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicArrayBufferType.swift
@@ -18,7 +18,11 @@ internal struct DynamicArrayBufferType: AnyDynamicType {
    Converts JS array buffer to its native representation.
    */
   func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
-    guard let rawArrayBuffer = jsValue.getArrayBuffer() else {
+    let rawArrayBuffer = if let arrayBuffer = jsValue.getArrayBuffer() {
+      arrayBuffer
+    } else if let typedArray = jsValue.getTypedArray() {
+      typedArray.getBuffer()
+    } else {
       throw NotArrayBufferException(innerType)
     }
     let jsArrayBuffer = JavaScriptArrayBuffer(rawArrayBuffer)

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicArrayBufferType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicArrayBufferType.swift
@@ -18,15 +18,23 @@ internal struct DynamicArrayBufferType: AnyDynamicType {
    Converts JS array buffer to its native representation.
    */
   func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
-    let rawArrayBuffer = if let arrayBuffer = jsValue.getArrayBuffer() {
-      arrayBuffer
-    } else if let typedArray = jsValue.getTypedArray() {
-      typedArray.getBuffer()
-    } else {
+    if let jsTypedArray = jsValue.getTypedArray() {
+      switch innerType {
+        case is JavaScriptArrayBuffer.Type:
+          return JavaScriptArrayBuffer(jsTypedArray.getViewedBufferSlice())
+        case is NativeArrayBuffer.Type:
+          let typedArray = TypedArray(jsTypedArray)
+          return NativeArrayBuffer.copy(of: typedArray.rawPointer, count: typedArray.byteLength)
+        default:
+          throw ArrayBufferArgumentTypeException(innerType)
+      }
+    }
+
+    guard let rawArrayBuffer = jsValue.getArrayBuffer() else {
       throw NotArrayBufferException(innerType)
     }
-    let jsArrayBuffer = JavaScriptArrayBuffer(rawArrayBuffer)
 
+    let jsArrayBuffer = JavaScriptArrayBuffer(rawArrayBuffer)
     return switch innerType {
       case is JavaScriptArrayBuffer.Type: jsArrayBuffer
       case is NativeArrayBuffer.Type: jsArrayBuffer.copy()

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptTypedArray.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptTypedArray.h
@@ -3,6 +3,7 @@
 #import <Foundation/Foundation.h>
 #import <ExpoModulesJSI/EXJavaScriptObject.h>
 #import <ExpoModulesJSI/EXJavaScriptRuntime.h>
+#import <ExpoModulesJSI/EXRawJavaScriptArrayBuffer.h>
 
 // We need to redefine the C++ enum (see TypedArray.h) in an Objective-C way to expose it to Swift.
 // Please keep them in-sync!
@@ -26,5 +27,7 @@ NS_SWIFT_NAME(JavaScriptTypedArray)
 @property (nonatomic) EXTypedArrayKind kind;
 
 - (nonnull void *)getUnsafeMutableRawPointer;
+
+- (nonnull EXJavaScriptArrayBuffer *)getBuffer;
 
 @end

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptTypedArray.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptTypedArray.h
@@ -30,4 +30,6 @@ NS_SWIFT_NAME(JavaScriptTypedArray)
 
 - (nonnull EXJavaScriptArrayBuffer *)getBuffer;
 
+- (nonnull EXJavaScriptArrayBuffer *)getViewedBufferSlice;
+
 @end

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptTypedArray.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptTypedArray.mm
@@ -26,4 +26,10 @@
   return _typedArrayPtr->getRawPointer(*[_runtime get]);
 }
 
+- (nonnull EXJavaScriptArrayBuffer *)getBuffer
+{
+  auto bufferObject = std::make_shared<jsi::Object>(_typedArrayPtr->getBuffer(*[_runtime get]));
+  return [[EXJavaScriptArrayBuffer alloc] initWith:bufferObject runtime:_runtime];
+}
+
 @end

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptTypedArray.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptTypedArray.mm
@@ -32,4 +32,10 @@
   return [[EXJavaScriptArrayBuffer alloc] initWith:bufferObject runtime:_runtime];
 }
 
+- (nonnull EXJavaScriptArrayBuffer *)getViewedBufferSlice
+{
+  auto bufferObject = std::make_shared<jsi::Object>(_typedArrayPtr->getViewedBufferSlice(*[_runtime get]));
+  return [[EXJavaScriptArrayBuffer alloc] initWith:bufferObject runtime:_runtime];
+}
+
 @end

--- a/packages/expo-modules-core/ios/JSI/EXRawJavaScriptArrayBuffer.h
+++ b/packages/expo-modules-core/ios/JSI/EXRawJavaScriptArrayBuffer.h
@@ -11,5 +11,10 @@
 NS_SWIFT_NAME(RawJavaScriptArrayBuffer)
 @interface EXJavaScriptArrayBuffer : EXJavaScriptObject<EXArrayBuffer>
 
+#ifdef __cplusplus
+- (nonnull instancetype)initWith:(std::shared_ptr<jsi::Object>)jsObjectPtr
+                         runtime:(EXJavaScriptRuntime *)runtime;
+#endif
+
 @end
 

--- a/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
@@ -199,6 +199,17 @@ struct ArrayBufferTests {
     }
 
     @Test
+    func `ArrayBuffer argument accepts Typed Arrays`() throws {
+      let result = try runtime.eval([
+        "typedArray = new Uint8Array([42, 84])",
+        "expo.modules.ArrayBufferTests.readBytesAsArray(typedArray, 2)"
+      ]).asArray()
+
+      #expect(try result[0]?.asInt() == 42)
+      #expect(try result[1]?.asInt() == 84)
+    }
+
+    @Test
     func `returns ArrayBuffer to JavaScript`() throws {
       let buffer = try runtime.eval("expo.modules.ArrayBufferTests.createNative(32)").asArrayBuffer()
 

--- a/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ArrayBufferTests.swift
@@ -199,7 +199,7 @@ struct ArrayBufferTests {
     }
 
     @Test
-    func `ArrayBuffer argument accepts Typed Arrays`() throws {
+    func `ArrayBuffer argument accepts full typed arrays`() throws {
       let result = try runtime.eval([
         "typedArray = new Uint8Array([42, 84])",
         "expo.modules.ArrayBufferTests.readBytesAsArray(typedArray, 2)"
@@ -207,6 +207,29 @@ struct ArrayBufferTests {
 
       #expect(try result[0]?.asInt() == 42)
       #expect(try result[1]?.asInt() == 84)
+    }
+
+    @Test
+    func `JavaScriptArrayBuffer accepts partial typed array view`() throws {
+      let result = try runtime.eval([
+        "arrayBuffer = new Uint8Array([1,2,3,4,5]).buffer",
+        "view = new Uint8Array(arrayBuffer, 1, 2)",
+        "expo.modules.ArrayBufferTests.readBytesAsArray(view, 2)"
+      ]).asArray()
+
+      #expect(try result[0]?.asInt() == 2)
+      #expect(try result[1]?.asInt() == 3)
+    }
+
+    @Test
+    func `NativeArrayBuffer accepts partial typed array view`() throws {
+      let result = try runtime.eval([
+        "view = new Uint8Array(new Uint8Array([1,2,3,4,5]).buffer, 1, 2)",
+        "expo.modules.ArrayBufferTests.readNativeBufferBytesAsArray(view, 2)"
+      ]).asArray()
+
+      #expect(try result[0]?.asInt() == 2)
+      #expect(try result[1]?.asInt() == 3)
     }
 
     @Test
@@ -371,6 +394,11 @@ private final class ArrayBufferTestModule: Module {
     }
 
     Function("readBytesAsArray") { (buffer: JavaScriptArrayBuffer, count: Int) -> [UInt8] in
+      let data = Data(bytes: buffer.rawPointer, count: min(count, buffer.byteLength))
+      return Array(data)
+    }
+    
+    Function("readNativeBufferBytesAsArray") { (buffer: NativeArrayBuffer, count: Int) -> [UInt8] in
       let data = Data(bytes: buffer.rawPointer, count: min(count, buffer.byteLength))
       return Array(data)
     }


### PR DESCRIPTION
# Why

Makes it easier to migrate functions taking `Data` / `ByteArray` as arguments into `ArrayBuffer`-like arguments without breaking changes.

# How

When a function expects `NativeArrayBuffer` or `JavaScriptArrayBuffer` argument, but e.g. `Uint8Array` is passed instead, access its `buffer` property instead of throwing.
This also supports partial views, when a typed array is only a view over a subrange of its backing buffer - a copy is performed in such cases (parity with `Uint8Array` convertible)

# Test Plan

- Unit tests
- Manual testing

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
