### PR TITLE
[core][iOS] - Fix Dynamic type tests

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Added `DynamicBoolType` to correctly distinguish boolean values from numeric 0/1. ([#42978](https://github.com/expo/expo/pull/42978) by [@nishan](https://github.com/intergalacticspacehighway))
+- [iOS] Fixed `DynamicBoolType` to throw `NullCastException` for nil values, matching `DynamicRawType` behavior. ([#43085](https://github.com/expo/expo/pull/43085) by [@nishan](https://github.com/intergalacticspacehighway))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicBoolType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicBoolType.swift
@@ -12,6 +12,9 @@ internal struct DynamicBoolType: AnyDynamicType {
   }
 
   func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
+    if Optional.isNil(value) {
+      throw Conversions.NullCastException<Bool>()
+    }
     // `as? Bool` matches any NSNumber with value 0 or 1, not just actual booleans
     // This causes `Either<Bool, Double>` to incorrectly decode numbers 0/1 as Bool instead of Double.
     if let nsNumber = value as? NSNumber {

--- a/packages/expo-modules-core/ios/Tests/DynamicTypeTests.swift
+++ b/packages/expo-modules-core/ios/Tests/DynamicTypeTests.swift
@@ -31,7 +31,7 @@ struct DynamicTypeTests {
     @Test
     func `is created`() {
       #expect(~Any.self is DynamicRawType<Any>)
-      #expect(~Bool.self is DynamicRawType<Bool>)
+      #expect(~Bool.self is DynamicBoolType)
       #expect(~DynamicRawTypeTests.self is DynamicRawType<DynamicRawTypeTests>)
     }
 


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/42978 broke a few tests in `DynamicTypeTests`.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Check nil values in bool cast
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
