### PR TITLE
[maps][ios] refactor distance and hit detection

### DIFF
--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [ios] refactor distance and hit detection ([#43087](https://github.com/expo/expo/pull/43087) by [@vonovak](https://github.com/vonovak))
+
 ## 55.0.6 — 2026-02-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-maps/ios/AppleMapsViewiOS18.swift
+++ b/packages/expo-maps/ios/AppleMapsViewiOS18.swift
@@ -22,7 +22,6 @@ extension MKMapPoint {
       x: a.x + clamped * dx,
       y: a.y + clamped * dy
     )
-
     return distance(to: proj)
   }
 }
@@ -281,14 +280,15 @@ struct AppleMapsViewiOS18: View, AppleMapsViewProtocol {
     let threshold = props.properties.polylineTapThreshold
 
     return props.polylines.first { line in
-      let pts = line.hitTestCoordinates.map(MKMapPoint.init)
+      let coords = line.hitTestCoordinates
+      guard var prev = coords.first.map(MKMapPoint.init) else { return false }
 
-      var minDist = CLLocationDistance.greatestFiniteMagnitude
-      for (a, b) in zip(pts, pts.dropFirst()) {
-        minDist = min(minDist, tapPoint.distance(toSegmentFrom: a, to: b))
-        if minDist < threshold {
+      for coord in coords.dropFirst() {
+        let curr = MKMapPoint(coord)
+        if tapPoint.distance(toSegmentFrom: prev, to: curr) < threshold {
           return true
         }
+        prev = curr
       }
       return false
     }
@@ -320,16 +320,8 @@ struct AppleMapsViewiOS18: View, AppleMapsViewProtocol {
   func isTapInsideCircle(
     tapCoordinate: CLLocationCoordinate2D, circleCenter: CLLocationCoordinate2D, radius: Double
   ) -> Bool {
-    // Convert coordinates to CLLocation for distance calculation
-    let tapLocation = CLLocation(
-      latitude: tapCoordinate.latitude, longitude: tapCoordinate.longitude)
-    let circleCenterLocation = CLLocation(
-      latitude: circleCenter.latitude, longitude: circleCenter.longitude)
-
-    // Calculate distance between tap and circle center (in meters)
-    let distance = tapLocation.distance(from: circleCenterLocation)
-
-    // Return true if distance is less than or equal to the radius
-    return distance <= radius
+    let tapPoint = MKMapPoint(tapCoordinate)
+    let centerPoint = MKMapPoint(circleCenter)
+    return tapPoint.distance(to: centerPoint) <= radius
   }
 }


### PR DESCRIPTION
# Why

minor refactor - polyline tap detection allocated an intermediate [MKMapPoint] array on every tap and `isTapInsideCircle` could be simplified.                           

# How

 - Polyline hit test: Replace map + zip iteration with a prev/curr loop that converts coordinates to MKMapPoint on the fly, avoiding the intermediate array allocation.
  - Circle hit test: Use MKMapPoint.distance(to:) for minor simplification

# Test Plan

- Open the expo-maps/polyline screen in NCL on iOS, tap on and off the polyline, verify onPolylineClick fires correctly.
- Open the expo-maps/circle screen in NCL on iOS, tap inside and outside the circle, verify onCircleClick fires correctly.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
