### PR TITLE
[docs] Fix stray bullet rendered after Experimental and Deprecated tags

### DIFF
--- a/docs/components/plugins/api/components/APISectionPlatformTags.tsx
+++ b/docs/components/plugins/api/components/APISectionPlatformTags.tsx
@@ -63,7 +63,9 @@ export const APISectionPlatformTags = ({
       {experimentalData.length > 0 && (
         <div className="inline-flex flex-row">
           <StatusTag status="experimental" className="!mr-0" />
-          <span className={mergeClasses(STYLES_SECONDARY)}>&ensp;&bull;&ensp;</span>
+          {!!platformNames?.length && (
+            <span className={mergeClasses(STYLES_SECONDARY)}>&ensp;&bull;&ensp;</span>
+          )}
         </div>
       )}
       <PlatformTags

--- a/docs/ui/components/ConfigSection/ConfigPluginProperties.tsx
+++ b/docs/ui/components/ConfigSection/ConfigPluginProperties.tsx
@@ -39,13 +39,21 @@ export const ConfigPluginProperties = ({ children, properties }: Props) => (
                     {property.deprecated && (
                       <>
                         <StatusTag status="deprecated" className="!mr-0" />
-                        <span className={mergeClasses(STYLES_SECONDARY)}>&ensp;&bull;&ensp;</span>
+                        {(property.experimental || property.platform) && (
+                          <span className={mergeClasses(STYLES_SECONDARY)}>
+                            &ensp;&bull;&ensp;
+                          </span>
+                        )}
                       </>
                     )}
                     {property.experimental && (
                       <>
                         <StatusTag status="experimental" className="!mr-0" />
-                        <span className={mergeClasses(STYLES_SECONDARY)}>&ensp;&bull;&ensp;</span>
+                        {!!property.platform && (
+                          <span className={mergeClasses(STYLES_SECONDARY)}>
+                            &ensp;&bull;&ensp;
+                          </span>
+                        )}
                       </>
                     )}
                   </div>

--- a/docs/ui/components/ConfigSection/ConfigPluginProperties.tsx
+++ b/docs/ui/components/ConfigSection/ConfigPluginProperties.tsx
@@ -40,9 +40,7 @@ export const ConfigPluginProperties = ({ children, properties }: Props) => (
                       <>
                         <StatusTag status="deprecated" className="!mr-0" />
                         {(property.experimental || property.platform) && (
-                          <span className={mergeClasses(STYLES_SECONDARY)}>
-                            &ensp;&bull;&ensp;
-                          </span>
+                          <span className={mergeClasses(STYLES_SECONDARY)}>&ensp;&bull;&ensp;</span>
                         )}
                       </>
                     )}
@@ -50,9 +48,7 @@ export const ConfigPluginProperties = ({ children, properties }: Props) => (
                       <>
                         <StatusTag status="experimental" className="!mr-0" />
                         {!!property.platform && (
-                          <span className={mergeClasses(STYLES_SECONDARY)}>
-                            &ensp;&bull;&ensp;
-                          </span>
+                          <span className={mergeClasses(STYLES_SECONDARY)}>&ensp;&bull;&ensp;</span>
                         )}
                       </>
                     )}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The "Experimental" and "Deprecated" status tags in API reference tables and config plugin property tables render a stray bullet separator (•) after the tag, even when there is no subsequent content (such as platform tags) to separate from. This results in a visual artifact visible on pages like the Expo Router reference.

<img width="2410" height="324" alt="CleanShot 2026-02-12 at 17 51 34@2x" src="https://github.com/user-attachments/assets/c50b8577-1e39-410f-bb94-acf5490cd876" />


# How

<!--
How did you build this feature or fix this bug and why?
-->

- In APISectionPlatformTags.tsx, conditionally render the bullet separator after the "Experimental" tag only when there are platform tags following it.
- In ConfigPluginProperties.tsx, conditionally render the bullet separator after the "Deprecated" tag only when an "Experimental" tag or platform tag follows it, and after the "Experimental" tag only when a platform tag follows it.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

From Expo Router SDK 55 reference page:

<img width="2562" height="718" alt="CleanShot 2026-02-12 at 17 54 15@2x" src="https://github.com/user-attachments/assets/f82b3bf2-8a08-482d-a323-7a229fec3ff0" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
