### PR TITLE
IOS - Treat asset hash as optional when parsing update

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [IOS] Fix optional value handling for asset hash in ExpoUpdatesUpdate. ([#42436](https://github.com/expo/expo/pull/42436) by [@billysutomo](https://github.com/billysutomo))
+- [IOS] Fix optional value handling for asset hash in ExpoUpdatesUpdate. ([#42436](https://github.com/expo/expo/pull/43093) by [@billysutomo](https://github.com/billysutomo))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [IOS] Fix optional value handling for asset hash in ExpoUpdatesUpdate. ([#42436](https://github.com/expo/expo/pull/43093) by [@billysutomo](https://github.com/billysutomo))
+- [IOS] Fix optional value handling for asset hash in ExpoUpdatesUpdate. ([#43093](https://github.com/expo/expo/pull/43093) by [@billysutomo](https://github.com/billysutomo))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [IOS] Fix optional value handling for asset hash in ExpoUpdatesUpdate. ([#42436](https://github.com/expo/expo/pull/42436) by [@billysutomo](https://github.com/billysutomo))
+
 ### 💡 Others
 
 ## 55.0.7 — 2026-02-08

--- a/packages/expo-updates/ios/EXUpdates/Update/ExpoUpdatesUpdate.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/ExpoUpdatesUpdate.swift
@@ -50,7 +50,7 @@ public final class ExpoUpdatesUpdate: Update {
       let fileExtension: String = assetDict.requiredValue(forKey: "fileExtension")
       let metadata: [String: Any]? = assetDict.optionalValue(forKey: "metadata")
       let mainBundleFilename: String? = assetDict.optionalValue(forKey: "mainBundleFilename")
-      let expectedHash: String = assetDict.requiredValue(forKey: "hash")
+      let expectedHash: String? = assetDict.optionalValue(forKey: "hash")
       let url = URL(string: urlString).require("asset url should be a valid URL")
 
       let asset = UpdateAsset(key: key, type: fileExtension)


### PR DESCRIPTION
# Why

Fix [issue](https://github.com/expo/expo/issues/42919)
The hash field should be optional according to the Android implementation and the Expo Updates spec.

# How

change `hash` variable to optional

# Test Plan
implement expo update server with Expo iOS
1. API `/api/manifest` returns assets without `hash` key
2. IOS expo app get update
3. Expect that the app does not crash

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
