### PR TITLE
[docs] Add cross-page type links for expo-router sub-packages

### DIFF
--- a/docs/components/plugins/api/APIStaticData.ts
+++ b/docs/components/plugins/api/APIStaticData.ts
@@ -160,7 +160,6 @@ export const nonLinkableTypes = [
   'UnknownOutputParams',
   'UploadProgressData',
   'UseFontHook',
-  'VectorIconProps',
   'WritingOptions',
 ];
 
@@ -361,4 +360,5 @@ export const sdkVersionHardcodedTypeLinks: Record<string, Record<string, string 
 
 export const packageLinks: Record<string, string> = {
   'expo-manifests': 'manifests',
+  'expo-router': 'router',
 };

--- a/docs/components/plugins/api/APIStaticData.ts
+++ b/docs/components/plugins/api/APIStaticData.ts
@@ -14,7 +14,6 @@ export const nonLinkableTypes = [
   'B',
   'BackButtonDisplayMode',
   'BackgroundNotificationResult',
-  'BaseNativeTabsTriggerIconProps',
   'BasicTextStyle',
   'BlurEffectTypes',
   'BlurViewState',
@@ -82,9 +81,6 @@ export const nonLinkableTypes = [
   'NativeBoundaryEventCallback',
   'NativeSyntheticEvent',
   'NativeTabNavigationEventMap',
-  'NativeTabsTriggerBadgeProps',
-  'NativeTabsTriggerIconProps',
-  'NativeTabsTriggerLabelProps',
   'NavigationContainerRefWithCurrent',
   'NavigationAction',
   'NavigationProp',
@@ -139,7 +135,6 @@ export const nonLinkableTypes = [
   'SQLiteTaggedQueryResult',
   'StyleProp',
   'T',
-  'TabsProps',
   'TabsScreenProps',
   'TaskOptions',
   'TEventListener',
@@ -151,7 +146,6 @@ export const nonLinkableTypes = [
   'TOptions',
   'TParams',
   'Transaction',
-  'TriggerProps',
   'TRoute',
   'TSegments',
   'TState',
@@ -321,6 +315,7 @@ export const sdkVersionHardcodedTypeLinks: Record<string, Record<string, string 
     Href: '/versions/v54.0.0/sdk/router/#href-1',
     BufferOptions: '/versions/v54.0.0/sdk/video/#bufferoptions-1',
     CameraPosition: '/versions/v54.0.0/sdk/maps/#cameraposition-2',
+    VectorIconProps: '/versions/v54.0.0/sdk/router/#vectoriconprops',
   },
   'v55.0.0': {
     EventEmitter: '/versions/v55.0.0/sdk/expo/#eventemittertype',
@@ -333,6 +328,17 @@ export const sdkVersionHardcodedTypeLinks: Record<string, Record<string, string 
     CameraPosition: '/versions/v55.0.0/sdk/maps/#cameraposition-2',
     ScrubbingModeOptions: '/versions/v55.0.0/sdk/video/#scrubbingmodeoptions-1',
     SeekTolerance: '/versions/v55.0.0/sdk/video/#scrubbingmodeoptions-1',
+    BaseNativeTabsTriggerIconProps:
+      '/versions/v55.0.0/sdk/router-native-tabs/#basenativetabstriggericonprops',
+    NativeTabsTriggerBadgeProps:
+      '/versions/v55.0.0/sdk/router-native-tabs/#nativetabstriggerbadgeprops',
+    NativeTabsTriggerIconProps:
+      '/versions/v55.0.0/sdk/router-native-tabs/#nativetabstriggericonprops',
+    NativeTabsTriggerLabelProps:
+      '/versions/v55.0.0/sdk/router-native-tabs/#nativetabstriggerlabelprops',
+    TabsProps: '/versions/v55.0.0/sdk/router-ui/#tabsprops',
+    TriggerProps: '/versions/v55.0.0/sdk/router-ui/#triggerprops',
+    VectorIconProps: '/versions/v55.0.0/sdk/router/#vectoriconprops',
   },
   latest: {
     EventEmitter: '/versions/latest/sdk/expo/#eventemittertype',
@@ -343,6 +349,17 @@ export const sdkVersionHardcodedTypeLinks: Record<string, Record<string, string 
     Href: '/versions/latest/sdk/router/#href-1',
     BufferOptions: '/versions/latest/sdk/video/#bufferoptions-1',
     CameraPosition: '/versions/latest/sdk/maps/#cameraposition-2',
+    BaseNativeTabsTriggerIconProps:
+      '/versions/latest/sdk/router-native-tabs/#basenativetabstriggericonprops',
+    NativeTabsTriggerBadgeProps:
+      '/versions/latest/sdk/router-native-tabs/#nativetabstriggerbadgeprops',
+    NativeTabsTriggerIconProps:
+      '/versions/latest/sdk/router-native-tabs/#nativetabstriggericonprops',
+    NativeTabsTriggerLabelProps:
+      '/versions/latest/sdk/router-native-tabs/#nativetabstriggerlabelprops',
+    TabsProps: '/versions/latest/sdk/router-ui/#tabsprops',
+    TriggerProps: '/versions/latest/sdk/router-ui/#triggerprops',
+    VectorIconProps: '/versions/latest/sdk/router/#vectoriconprops',
   },
   unversioned: {
     EventEmitter: '/versions/unversioned/sdk/expo/#eventemittertype',
@@ -355,10 +372,20 @@ export const sdkVersionHardcodedTypeLinks: Record<string, Record<string, string 
     CameraPosition: '/versions/unversioned/sdk/maps/#cameraposition-2',
     ScrubbingModeOptions: '/versions/unversioned/sdk/video/#scrubbingmodeoptions-1',
     SeekTolerance: '/versions/unversioned/sdk/video/#scrubbingmodeoptions-1',
+    BaseNativeTabsTriggerIconProps:
+      '/versions/unversioned/sdk/router-native-tabs/#basenativetabstriggericonprops',
+    NativeTabsTriggerBadgeProps:
+      '/versions/unversioned/sdk/router-native-tabs/#nativetabstriggerbadgeprops',
+    NativeTabsTriggerIconProps:
+      '/versions/unversioned/sdk/router-native-tabs/#nativetabstriggericonprops',
+    NativeTabsTriggerLabelProps:
+      '/versions/unversioned/sdk/router-native-tabs/#nativetabstriggerlabelprops',
+    TabsProps: '/versions/unversioned/sdk/router-ui/#tabsprops',
+    TriggerProps: '/versions/unversioned/sdk/router-ui/#triggerprops',
+    VectorIconProps: '/versions/unversioned/sdk/router/#vectoriconprops',
   },
 };
 
 export const packageLinks: Record<string, string> = {
   'expo-manifests': 'manifests',
-  'expo-router': 'router',
 };


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Types defined in expo-router sub-packages (native-tabs, ui) are referenced across API pages but render as plain text because they were listed in `nonLinkableTypes`. Since all these types share `package: "expo-router"` in TypeDoc data, the generic `packageLinks` mapping cannot distinguish which sub-page they belong to, so cross-page links were missing.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Remove 7 types from nonLinkableTypes so they become linkable: `BaseNativeTabsTriggerIconProps`, `NativeTabsTriggerBadgeProps`, `NativeTabsTriggerIconProps`, `NativeTabsTriggerLabelProps`, `TabsProps`, `TriggerProps`, `VectorIconProps`.
- Add versioned entries in sdkVersionHardcodedTypeLinks (v54, v55, latest, unversioned) pointing each type to its correct sub-page.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview


https://github.com/user-attachments/assets/18d27b4a-2792-433f-866f-e7f855663e61

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
