### PR TITLE
[widgets] Fix publishing

### DIFF
--- a/packages/expo-widgets/package.json
+++ b/packages/expo-widgets/package.json
@@ -7,11 +7,10 @@
   "scripts": {
     "build": "expo-module build",
     "build:plugin": "expo-module build plugin",
-    "build:bundle": "tsc --build bundle",
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "expo-module test",
-    "prepare": "node bundle/build/index.js && expo-module prepare",
+    "prepare": "expo-module prepare",
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module"
   },


### PR DESCRIPTION
# Why

Our Publishing CI workflow is failing because of non existing invokation in the prepare script of expo-widgets
https://github.com/expo/expo/actions/runs/21930039336/job/63331746481

# How

Fix publishing by removing the extra `node bundle/build/index.js` call

# Test Plan

`npm pack --json --foreground-scripts=false` now works fine

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
