### PR TITLE
[ios][brownfield] fix framework search paths settings

### DIFF
--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] fix framework search paths settings ([#43106](https://github.com/expo/expo/pull/43106) by [@pmleczek](https://github.com/pmleczek))
+
 ### 💡 Others
 
 - [test] add compilation verification and optimize brownfield workflow in [#42894](https://github.com/expo/expo/pull/42894) by [@pmleczek](https://github.com/pmleczek)

--- a/packages/expo-brownfield/plugin/build/ios/utils/project.js
+++ b/packages/expo-brownfield/plugin/build/ios/utils/project.js
@@ -70,7 +70,6 @@ const getCommonBuildSettings = (targetName, currentProjectVersion, bundleIdentif
         DEBUG_INFORMATION_FORMAT = dwarf;
         DEVELOPMENT_TEAM = ;
         GCC_C_LANGUAGE_STANDARD = gnu11;
-        LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
         MARKETING_VERSION = 1.0;
         MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
         MTL_FAST_MATH = YES;
@@ -83,6 +82,8 @@ const getCommonBuildSettings = (targetName, currentProjectVersion, bundleIdentif
         TARGETED_DEVICE_FAMILY: `"1,2"`,
         INFOPLIST_FILE: `${targetName}/Info.plist`,
         CURRENT_PROJECT_VERSION: `"${currentProjectVersion}"`,
+        LD_RUNPATH_SEARCH_PATHS: '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
+        DYLIB_INSTALL_NAME_BASE: '"@rpath"',
         // IPHONEOS_DEPLOYMENT_TARGET: `"${deploymentTarget}"`,
         PRODUCT_BUNDLE_IDENTIFIER: `"${bundleIdentifier}"`,
         GENERATE_INFOPLIST_FILE: `"YES"`,

--- a/packages/expo-brownfield/plugin/src/ios/utils/project.ts
+++ b/packages/expo-brownfield/plugin/src/ios/utils/project.ts
@@ -139,7 +139,6 @@ const getCommonBuildSettings = (
     DEBUG_INFORMATION_FORMAT = dwarf;
     DEVELOPMENT_TEAM = ;
     GCC_C_LANGUAGE_STANDARD = gnu11;
-    LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
     MARKETING_VERSION = 1.0;
     MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
     MTL_FAST_MATH = YES;
@@ -152,6 +151,9 @@ const getCommonBuildSettings = (
     TARGETED_DEVICE_FAMILY: `"1,2"`,
     INFOPLIST_FILE: `${targetName}/Info.plist`,
     CURRENT_PROJECT_VERSION: `"${currentProjectVersion}"`,
+    LD_RUNPATH_SEARCH_PATHS:
+      '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
+    DYLIB_INSTALL_NAME_BASE: '"@rpath"',
     // IPHONEOS_DEPLOYMENT_TARGET: `"${deploymentTarget}"`,
     PRODUCT_BUNDLE_IDENTIFIER: `"${bundleIdentifier}"`,
     GENERATE_INFOPLIST_FILE: `"YES"`,


### PR DESCRIPTION
# Why

Framework search path base was defaulting to `/Library/Frameworks` which caused crash on 2nd (or 1st non-Xcode) launch of the consuming app.

# How

Fixed by explicitly setting `LD_RUNPATH_SEARCH_PATHS` and `DYLIB_INSTALL_NAME_BASE`

# Test Plan

Validated using `brownfield-tester` apps: `expo-app` and `ios-integrated` in both Debug and Release

# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
