### PR TITLE
[docs] Fix the xcasset native-tabs example

### DIFF
--- a/docs/pages/router/advanced/native-tabs.mdx
+++ b/docs/pages/router/advanced/native-tabs.mdx
@@ -359,13 +359,11 @@ Pass a string with the asset name to use the same icon for both default and sele
 ```tsx app/_layout.tsx
 import { NativeTabs } from 'expo-router/unstable-native-tabs';
 
-const { Icon } = NativeTabs.Trigger;
-
 export default function TabLayout() {
   return (
     <NativeTabs>
       <NativeTabs.Trigger name="index">
-        <Icon xcasset="home-icon" />
+        <NativeTabs.Trigger.Icon xcasset="home-icon" />
       </NativeTabs.Trigger>
     </NativeTabs>
   );
@@ -377,13 +375,16 @@ To use different icons for default and selected states, pass an object:
 ```tsx app/_layout.tsx
 import { NativeTabs } from 'expo-router/unstable-native-tabs';
 
-const { Icon } = NativeTabs.Trigger;
-
 export default function TabLayout() {
   return (
     <NativeTabs>
       <NativeTabs.Trigger name="index">
-        <Icon xcasset={{ default: 'home-outline', selected: 'home-filled' }} />
+        <NativeTabs.Trigger.Icon
+          xcasset={{
+            default: 'home-outline',
+            selected: 'home-filled',
+          }}
+        />
       </NativeTabs.Trigger>
     </NativeTabs>
   );


### PR DESCRIPTION
# Why

Native tabs xassets example is using incorrect tab API

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
