### PR TITLE
[docs] Add foreground notification behavior callout to notifications reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -205,6 +205,8 @@ async function registerForPushNotificationsAsync() {
 
 </SnackInline>
 
+> **info** By default, notifications received while your app is in the foreground are not shown to the user. To display them, you must call [`Notifications.setNotificationHandler`](#setnotificationhandlerhandler) to configure foreground notification behavior. See [Handle incoming notifications](/push-notifications/receiving-notifications/#foreground-notification-behavior) for details.
+
 ### Present a local (in-app) notification to the user
 
 ```ts
@@ -470,6 +472,8 @@ This value will be one of the following, accessible under `Notifications.IosAuth
 Notification events include incoming notifications, interactions your users perform with notifications (this can be tapping on a notification, or interacting with it via [notification categories](#manage-notification-categories-interactive-notifications)), and rare occasions when your notifications may be dropped.
 
 Several listeners are exposed and documented in the [Push notification behaviors](/push-notifications/what-you-need-to-know/#push-notification-behaviors) section.
+
+To learn how to handle foreground notifications and respond to notification events, see [Handle incoming notifications](/push-notifications/receiving-notifications/).
 
 ## Headless (Background) notifications
 

--- a/docs/pages/versions/v55.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/notifications.mdx
@@ -205,6 +205,8 @@ async function registerForPushNotificationsAsync() {
 
 </SnackInline>
 
+> **info** By default, notifications received while your app is in the foreground are not shown to the user. To display them, you must call [`Notifications.setNotificationHandler`](#setnotificationhandlerhandler) to configure foreground notification behavior. See [Handle incoming notifications](/push-notifications/receiving-notifications/#foreground-notification-behavior) for details.
+
 ### Present a local (in-app) notification to the user
 
 ```ts
@@ -470,6 +472,8 @@ This value will be one of the following, accessible under `Notifications.IosAuth
 Notification events include incoming notifications, interactions your users perform with notifications (this can be tapping on a notification, or interacting with it via [notification categories](#manage-notification-categories-interactive-notifications)), and rare occasions when your notifications may be dropped.
 
 Several listeners are exposed and documented in the [Push notification behaviors](/push-notifications/what-you-need-to-know/#push-notification-behaviors) section.
+
+To learn how to handle foreground notifications and respond to notification events, see [Handle incoming notifications](/push-notifications/receiving-notifications/).
 
 ## Headless (Background) notifications
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18558

# How

<!--
How did you build this feature or fix this bug and why?
-->

In Notification reference:
- Add an info callout after the Usage code example in notifications.mdx that explicitly states foreground notifications are not shown by default, points to `setNotificationHandler`, and links to the Handle incoming notifications guide.
- Add a link to the Handle incoming notifications guide in the "Notification events listeners" section.
- Apply changes to both unversioned and v55.0.0 versions.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
<img width="1112" height="210" alt="CleanShot 2026-02-13 at 18 14 28" src="https://github.com/user-attachments/assets/03c3edc8-f688-4339-b0f4-b1ab2be549d3" />

<img width="1212" height="674" alt="CleanShot 2026-02-13 at 18 14 14" src="https://github.com/user-attachments/assets/29c62c7c-5927-4619-b2c6-ede923c9b589" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
