### PR TITLE
[expo-router] fix link preview background color

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [web] Fix route URL detection in `useLoaderData` ([#42912](https://github.com/expo/expo/pull/42912) by [@hassankhan](https://github.com/hassankhan))
 - [web] Key loader data by `contextKey` instead of URL pathname ([#43017](https://github.com/expo/expo/pull/43017) by [@hassankhan]
 - [ios] fix immediate navigation when opening Link.Preview ([#43071](https://github.com/expo/expo/pull/43071) by [@Ubax](https://github.com/Ubax))
+- [ios] fix link preview background color ([#43120](https://github.com/expo/expo/pull/43120) by [@Ubax](https://github.com/Ubax))
 
 ### 💡 Others
 

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeView.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeView.swift
@@ -139,7 +139,7 @@ class NativeLinkPreviewView: RouterViewWithLogger, UIContextMenuInteractionDeleg
         container: superview, center: self.convert(triggerView.center, to: superview))
 
       let parameters = UIPreviewParameters()
-      parameters.backgroundColor = .clear
+      parameters.backgroundColor = triggerView.backgroundColor ?? .clear
 
       return UITargetedPreview(view: triggerView, parameters: parameters, target: target)
     }


### PR DESCRIPTION
# Why

## Before

https://github.com/user-attachments/assets/b539c273-1bf6-4f1e-8990-429d13aa518f

## After

https://github.com/user-attachments/assets/308c328b-6f62-412e-aac1-6f7ae9b31273

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
