### PR TITLE
[android][audio] Improve event handling

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### 💡 Others
 
+- [Android][Web] Improve `isLoaded` reliability and threading improvements.
+
 ## 55.0.5 — 2026-02-08
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### 💡 Others
 
-- [Android] Improve `isLoaded` reliability and threading improvements.
+- [Android] Improve event handling.
 
 ## 55.0.5 — 2026-02-08
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### 💡 Others
 
-- [Android][Web] Improve `isLoaded` reliability and threading improvements.
+- [Android] Improve `isLoaded` reliability and threading improvements.
 
 ## 55.0.5 — 2026-02-08
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### 💡 Others
 
-- [Android] Improve event handling.
+- [Android] Improve event handling. ([#43121](https://github.com/expo/expo/pull/43121) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 55.0.5 — 2026-02-08
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
@@ -164,7 +164,7 @@ class AudioPlayer(
     }
 
     override fun onIsLoadingChanged(isLoading: Boolean) {
-      sendPlayerUpdate(mapOf("isLoaded" to (ref.playbackState == Player.STATE_READY && !isLoading)))
+      sendPlayerUpdate()
     }
 
     override fun onPlaybackStateChanged(playbackState: Int) {
@@ -230,7 +230,7 @@ class AudioPlayer(
   fun currentStatus(): Map<String, Any?> {
     val isMuted = ref.volume == 0f
     val isLooping = ref.repeatMode == Player.REPEAT_MODE_ONE
-    val isLoaded = ref.playbackState == Player.STATE_READY && !ref.isLoading
+    val isLoaded = ref.playbackState == Player.STATE_READY
     val isBuffering = ref.playbackState == Player.STATE_BUFFERING
     val playingStatus = if (isBuffering) intendedPlayingState else ref.isPlaying
 


### PR DESCRIPTION
# Why
I noticed that we were doing a lot of unnecessary thread hops when handling events. I had thought running the update loop on a background thread made sense but because we only ever dealt with the event on the main thread we had to make a jump anyway. Moving to the main thread from the start removes a ton of hops that are not needed. 

# How
Change playerScope to `Dispatchers.Main`

# Test Plan
Bare expo
