### PR TITLE
[ui][Android] Use MaterialExpressiveTheme for M3 Expressive support

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### 💡 Others
 
-- [jetpack-compose] Use `MaterialExpressiveTheme` instead of `MaterialTheme` in `HostView` for M3 Expressive support. by [@kimchi-developer](https://github.com/kimchi-developer)
+- [jetpack-compose] Use `MaterialExpressiveTheme` instead of `MaterialTheme` in `HostView` for M3 Expressive support. by [@kimchi-developer](https://github.com/kimchi-developer) ([#43128](https://github.com/expo/expo/pull/43128) by [@kimchi-developer](https://github.com/kimchi-developer))
 
 ## 55.0.0-preview.5 — 2026-02-08
 

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### 💡 Others
 
+- [jetpack-compose] Use `MaterialExpressiveTheme` instead of `MaterialTheme` in `HostView` for M3 Expressive support. by [@kimchi-developer](https://github.com/kimchi-developer)
+
 ## 55.0.0-preview.5 — 2026-02-08
 
 ### 🐛 Bug fixes

--- a/packages/expo-ui/android/build.gradle
+++ b/packages/expo-ui/android/build.gradle
@@ -31,8 +31,8 @@ android {
 dependencies {
   implementation 'androidx.compose.foundation:foundation-android:1.9.1'
   implementation 'androidx.compose.ui:ui-android:1.9.1'
-  implementation "androidx.compose.material3:material3:1.5.0-alpha08"
-  implementation 'androidx.compose.material3:material3-android:1.5.0-alpha08'
+  implementation "androidx.compose.material3:material3:1.5.0-alpha14"
+  implementation 'androidx.compose.material3:material3-android:1.5.0-alpha14'
   implementation 'androidx.lifecycle:lifecycle-runtime:2.9.3'
   implementation 'androidx.fragment:fragment-ktx:1.8.9'
   implementation "androidx.graphics:graphics-shapes:1.0.1"

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/HostView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/HostView.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+
 package expo.modules.ui
 
 import android.annotation.SuppressLint
@@ -12,7 +14,8 @@ import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.ColorScheme
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialExpressiveTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
@@ -103,7 +106,7 @@ internal class HostView(context: Context, appContext: AppContext) :
     val layoutDirection = props.layoutDirection.value.toLayoutDirection()
 
     CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
-      MaterialTheme(colorScheme = colorScheme) {
+      MaterialExpressiveTheme(colorScheme = colorScheme) {
         MaybeMatchContentsLayout {
           Children(this@Content)
         }


### PR DESCRIPTION
## Summary

Replace `MaterialTheme` with `MaterialExpressiveTheme` in `HostView` to enable Material 3 Expressive defaults for all expo-ui Android components. Also bumps the material3 dependency from `1.5.0-alpha08` to `1.5.0-alpha14` (latest alpha).

### What this enables

- **Expressive motion**: Spring-based `MotionScheme.expressive()` applied by default to all M3 component animations
- **Expressive shapes**: 35 new shape tokens available through the theme
- **Expressive typography**: Refined type scale with expressive defaults

### Why this is safe

`MaterialExpressiveTheme` is a superset of `MaterialTheme` — it sets up the same composition locals (`LocalColorScheme`, `LocalTypography`, `LocalShapes`). All existing code accessing `MaterialTheme.colorScheme`, `MaterialTheme.typography`, or `MaterialTheme.shapes` continues to work without changes.

### Changes

| File | Change |
|------|--------|
| `HostView.kt` | `MaterialTheme` → `MaterialExpressiveTheme` + `@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)` |
| `build.gradle` | `material3:1.5.0-alpha08` → `1.5.0-alpha14` |
| `CHANGELOG.md` | Entry in Unpublished section |

## Test plan

- [ ] Run native-component-list on Android and verify all expo-ui screens render correctly
- [ ] Verify Switch, Picker, Slider, Progress, Chip, DatePicker, Shape, AlertDialog, Carousel components
- [ ] Confirm expressive motion is visible (spring-based animations on component interactions)