### PR TITLE
[brownfield][cli] update copied hermes framework name to hermesvm.xcframework

### DIFF
--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- [cli] update copied hermes framework name to hermesvm.xcframework ([#43138](https://github.com/expo/expo/pull/43138) by [@pmleczek](https://github.com/pmleczek))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-brownfield/cli/build/commands/ios/build.js
+++ b/packages/expo-brownfield/cli/build/commands/ios/build.js
@@ -109,17 +109,17 @@ const packageFrameworks = async (config) => {
 };
 const copyHermesFramework = async (config) => {
     if (config.dryRun) {
-        console.log(`Copying hermes XCFramework from ${config.hermesFrameworkPath} to ${config.artifacts}/hermes.xcframework`);
+        console.log(`Copying hermes XCFramework from ${config.hermesFrameworkPath} to ${config.artifacts}/hermesvm.xcframework`);
         return;
     }
     return (0, utils_1.withSpinner)({
-        operation: () => promises_1.default.cp(`./ios/${config.hermesFrameworkPath}`, `${config.artifacts}/hermes.xcframework`, {
+        operation: () => promises_1.default.cp(`./ios/${config.hermesFrameworkPath}`, `${config.artifacts}/hermesvm.xcframework`, {
             force: true,
             recursive: true,
         }),
-        loaderMessage: 'Copying hermes.xcframework to the artifacts directory...',
-        successMessage: 'Copying hermes.xcframework to the artifacts directory succeeded',
-        errorMessage: 'Copying hermes.xcframework to the artifacts directory failed',
+        loaderMessage: 'Copying hermesvm.xcframework to the artifacts directory...',
+        successMessage: 'Copying hermesvm.xcframework to the artifacts directory succeeded',
+        errorMessage: 'Copying hermesvm.xcframework to the artifacts directory failed',
         verbose: config.verbose,
     });
 };

--- a/packages/expo-brownfield/cli/src/commands/ios/build.ts
+++ b/packages/expo-brownfield/cli/src/commands/ios/build.ts
@@ -135,20 +135,20 @@ const packageFrameworks = async (config: BuildConfigIos) => {
 const copyHermesFramework = async (config: BuildConfigIos) => {
   if (config.dryRun) {
     console.log(
-      `Copying hermes XCFramework from ${config.hermesFrameworkPath} to ${config.artifacts}/hermes.xcframework`
+      `Copying hermes XCFramework from ${config.hermesFrameworkPath} to ${config.artifacts}/hermesvm.xcframework`
     );
     return;
   }
 
   return withSpinner({
     operation: () =>
-      fs.cp(`./ios/${config.hermesFrameworkPath}`, `${config.artifacts}/hermes.xcframework`, {
+      fs.cp(`./ios/${config.hermesFrameworkPath}`, `${config.artifacts}/hermesvm.xcframework`, {
         force: true,
         recursive: true,
       }),
-    loaderMessage: 'Copying hermes.xcframework to the artifacts directory...',
-    successMessage: 'Copying hermes.xcframework to the artifacts directory succeeded',
-    errorMessage: 'Copying hermes.xcframework to the artifacts directory failed',
+    loaderMessage: 'Copying hermesvm.xcframework to the artifacts directory...',
+    successMessage: 'Copying hermesvm.xcframework to the artifacts directory succeeded',
+    errorMessage: 'Copying hermesvm.xcframework to the artifacts directory failed',
     verbose: config.verbose,
   });
 };


### PR DESCRIPTION
# Why

The hrems XCFramework names has been updated to `hermesvm.xcframework` but the CLI still copies it under `hermes.xcframework`

# How

Updated the name to `hermesvm.xcframework` to match the new name

# Test Plan

- E2E tests for CLI on the CI
- Tested manually verifying compilation and name of the XCFramework

# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).