### PR TITLE
[ui][Android] Add detent/height control and fitToContents to BottomSheet

### DIFF
--- a/apps/native-component-list/src/screens/UI/BottomSheetScreen.android.tsx
+++ b/apps/native-component-list/src/screens/UI/BottomSheetScreen.android.tsx
@@ -1,33 +1,262 @@
-import { Button, BottomSheet, Host } from '@expo/ui/jetpack-compose';
+import { Button, BottomSheet, Host, Switch } from '@expo/ui/jetpack-compose';
+import type { PresentationDetent } from '@expo/ui/jetpack-compose';
 import * as React from 'react';
-import { ScrollView, Text, View } from 'react-native';
+import { ScrollView, Text, TextInput, View, Pressable, StyleSheet } from 'react-native';
+
+function formatDetent(detent: PresentationDetent): string {
+  if (typeof detent === 'string') return detent;
+  if ('fraction' in detent) return `${detent.fraction * 100}%`;
+  return `${detent.height}dp`;
+}
 
 export default function BottomSheetScreen() {
-  const [isOpened, setIsOpened] = React.useState<boolean>(false);
+  const [showBasic, setShowBasic] = React.useState(false);
+  const [showFitsContent, setShowFitsContent] = React.useState(false);
+
+  const [showDetents, setShowDetents] = React.useState(false);
+  const [useMedium, setUseMedium] = React.useState(true);
+  const [useLarge, setUseLarge] = React.useState(false);
+
+  const [showFraction, setShowFraction] = React.useState(false);
+  const [fractionText, setFractionText] = React.useState('40');
+  const fractionValue = Math.max(1, Math.min(100, parseInt(fractionText, 10) || 40)) / 100;
+
+  const [showHeight, setShowHeight] = React.useState(false);
+  const [heightText, setHeightText] = React.useState('200');
+  const heightValue = Math.max(50, parseInt(heightText, 10) || 200);
+
+  const [showSelection, setShowSelection] = React.useState(false);
+  const [selectedDetent, setSelectedDetent] = React.useState<PresentationDetent>('medium');
+
+  const detents: PresentationDetent[] = (() => {
+    const d: PresentationDetent[] = [];
+    if (useMedium) d.push('medium');
+    if (useLarge) d.push('large');
+    return d.length > 0 ? d : ['medium'];
+  })();
 
   return (
-    <ScrollView
-      contentContainerStyle={{
-        flex: 1,
-        justifyContent: 'flex-start',
-        alignItems: 'flex-start',
-        padding: 8,
-      }}>
+    <ScrollView contentContainerStyle={styles.container}>
+      {/* Basic */}
+      <Text style={styles.sectionTitle}>Basic</Text>
       <Host matchContents>
-        <Button onPress={() => setIsOpened((h) => !h)}>Toggle</Button>
+        <Button onPress={() => setShowBasic(true)}>Open Basic Sheet</Button>
+        <BottomSheet isOpened={showBasic} onIsOpenedChange={setShowBasic}>
+          <View style={styles.sheetContent}>
+            <Text style={styles.sheetTitle}>Basic Bottom Sheet</Text>
+            <Text style={styles.sheetSubtitle}>Swipe down or tap outside to dismiss</Text>
+          </View>
+        </BottomSheet>
       </Host>
 
-      <Text>isOpened: {isOpened ? 'yes' : 'no'}</Text>
+      {/* Fits Content */}
+      <Text style={styles.sectionTitle}>Fits Content</Text>
+      <Text style={styles.detentInfo}>Sheet automatically sizes to fit its content</Text>
       <Host matchContents>
-        <BottomSheet isOpened={isOpened} onIsOpenedChange={(e) => setIsOpened(e)}>
-          <View style={{ padding: 20 }}>
-            <Text>Hello world</Text>
+        <Button onPress={() => setShowFitsContent(true)}>Open Fits Content Sheet</Button>
+        <BottomSheet
+          isOpened={showFitsContent}
+          onIsOpenedChange={setShowFitsContent}
+          fitToContents>
+          <View style={styles.sheetContent}>
+            <Text style={styles.sheetTitle}>Fits Content</Text>
+            <Text style={styles.sheetSubtitle}>
+              This sheet sizes to fit its content automatically.
+            </Text>
+            <Text style={styles.sheetSubtitle}>It only takes as much space as needed.</Text>
+            <Pressable style={styles.pressable} onPress={() => setShowFitsContent(false)}>
+              <Text style={styles.pressableText}>Close</Text>
+            </Pressable>
+          </View>
+        </BottomSheet>
+      </Host>
+
+      {/* Detents: medium / large */}
+      <Text style={styles.sectionTitle}>Detents</Text>
+      <View style={styles.row}>
+        <Text style={styles.label}>Medium</Text>
+        <Host style={styles.switchHost}>
+          <Switch value={useMedium} onValueChange={setUseMedium} />
+        </Host>
+      </View>
+      <View style={styles.row}>
+        <Text style={styles.label}>Large</Text>
+        <Host style={styles.switchHost}>
+          <Switch value={useLarge} onValueChange={setUseLarge} />
+        </Host>
+      </View>
+      <Text style={styles.detentInfo}>Active: {detents.map(formatDetent).join(', ')}</Text>
+      <Host matchContents>
+        <Button onPress={() => setShowDetents(true)}>Open Detents Sheet</Button>
+        <BottomSheet
+          isOpened={showDetents}
+          onIsOpenedChange={setShowDetents}
+          detents={detents}
+          selectedDetent={detents[0]}>
+          <View style={styles.sheetContent}>
+            <Text style={styles.sheetTitle}>Detents Sheet</Text>
+            <Text style={styles.sheetSubtitle}>Detents: {detents.map(formatDetent).join(', ')}</Text>
+          </View>
+        </BottomSheet>
+      </Host>
+
+      {/* Custom Fraction */}
+      <Text style={styles.sectionTitle}>Custom Fraction</Text>
+      <View style={styles.row}>
+        <Text style={styles.label}>Percent (1–100):</Text>
+        <TextInput
+          style={styles.input}
+          value={fractionText}
+          onChangeText={setFractionText}
+          keyboardType="number-pad"
+          maxLength={3}
+        />
+        <Text style={styles.label}>%</Text>
+      </View>
+      <Text style={styles.detentInfo}>Will open at {Math.round(fractionValue * 100)}% of screen</Text>
+      <Host matchContents>
+        <Button onPress={() => setShowFraction(true)}>
+          Open {Math.round(fractionValue * 100)}% Sheet
+        </Button>
+        <BottomSheet
+          isOpened={showFraction}
+          onIsOpenedChange={setShowFraction}
+          detents={[{ fraction: fractionValue }]}
+          selectedDetent={{ fraction: fractionValue }}>
+          <View style={styles.sheetContent}>
+            <Text style={styles.sheetTitle}>{Math.round(fractionValue * 100)}% Height Sheet</Text>
+            <Text style={styles.sheetSubtitle}>fraction: {fractionValue}</Text>
+          </View>
+        </BottomSheet>
+      </Host>
+
+      {/* Custom Height */}
+      <Text style={styles.sectionTitle}>Custom Height</Text>
+      <View style={styles.row}>
+        <Text style={styles.label}>Height (dp):</Text>
+        <TextInput
+          style={styles.input}
+          value={heightText}
+          onChangeText={setHeightText}
+          keyboardType="number-pad"
+          maxLength={4}
+        />
+        <Text style={styles.label}>dp</Text>
+      </View>
+      <Text style={styles.detentInfo}>Will open at {heightValue}dp</Text>
+      <Host matchContents>
+        <Button onPress={() => setShowHeight(true)}>Open {heightValue}dp Sheet</Button>
+        <BottomSheet
+          isOpened={showHeight}
+          onIsOpenedChange={setShowHeight}
+          detents={[{ height: heightValue }]}
+          selectedDetent={{ height: heightValue }}>
+          <View style={styles.sheetContent}>
+            <Text style={styles.sheetTitle}>{heightValue}dp Height Sheet</Text>
+            <Text style={styles.sheetSubtitle}>height: {heightValue}</Text>
+          </View>
+        </BottomSheet>
+      </Host>
+
+      {/* Selection tracking */}
+      <Text style={styles.sectionTitle}>Selection Tracking</Text>
+      <Text style={styles.detentInfo}>Current: {formatDetent(selectedDetent)}</Text>
+      <Host matchContents>
+        <Button onPress={() => setShowSelection(true)}>Open Selection Sheet</Button>
+        <BottomSheet
+          isOpened={showSelection}
+          onIsOpenedChange={setShowSelection}
+          detents={['medium', 'large']}
+          selectedDetent={selectedDetent}
+          onSelectedDetentChange={setSelectedDetent}>
+          <View style={styles.sheetContent}>
+            <Text style={styles.sheetTitle}>Selection Tracking</Text>
+            <Text style={styles.sheetSubtitle}>Current: {formatDetent(selectedDetent)}</Text>
+            <Text style={styles.sheetSubtitle}>Drag to change between medium and large</Text>
+            <View style={styles.buttonRow}>
+              <Pressable style={styles.pressable} onPress={() => setSelectedDetent('medium')}>
+                <Text style={styles.pressableText}>Medium</Text>
+              </Pressable>
+              <Pressable style={styles.pressable} onPress={() => setSelectedDetent('large')}>
+                <Text style={styles.pressableText}>Large</Text>
+              </Pressable>
+            </View>
           </View>
         </BottomSheet>
       </Host>
     </ScrollView>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 12,
+    paddingBottom: 40,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginTop: 16,
+    marginBottom: 8,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 4,
+    gap: 8,
+  },
+  label: {
+    fontSize: 14,
+  },
+  switchHost: {
+    width: 60,
+    height: 32,
+  },
+  input: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    fontSize: 16,
+    textAlign: 'center',
+  },
+  detentInfo: {
+    fontSize: 12,
+    color: '#666',
+    marginBottom: 8,
+  },
+  sheetContent: {
+    padding: 20,
+  },
+  sheetTitle: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 8,
+  },
+  sheetSubtitle: {
+    color: '#666',
+    marginBottom: 8,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginTop: 12,
+  },
+  pressable: {
+    backgroundColor: '#007AFF',
+    padding: 12,
+    borderRadius: 8,
+    flex: 1,
+    alignItems: 'center',
+  },
+  pressableText: {
+    color: 'white',
+    fontWeight: '600',
+  },
+});
 
 BottomSheetScreen.navigationOptions = {
   title: 'BottomSheet',

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/BottomSheetView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/BottomSheetView.kt
@@ -2,34 +2,116 @@ package expo.modules.ui
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.dp
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
+import kotlinx.coroutines.flow.drop
 import java.io.Serializable
 
 open class IsOpenedChangeEvent(
   @Field open val isOpened: Boolean = false
 ) : Record, Serializable
 
+open class SelectedDetentChangeEvent(
+  @Field open val selectedDetentIndex: Int = 0
+) : Record, Serializable
+
+data class DetentConfig(
+  val skipPartiallyExpanded: Boolean,
+  val sheetModifier: Modifier,
+  val contentModifier: Modifier
+)
+
+fun parseDetent(detent: Any?, screenHeightDp: Float): DetentConfig {
+  val defaultSheetModifier = Modifier.fillMaxHeight()
+  return when (detent) {
+    "medium" -> DetentConfig(skipPartiallyExpanded = false, sheetModifier = defaultSheetModifier, contentModifier = Modifier)
+    "large" -> DetentConfig(skipPartiallyExpanded = true, sheetModifier = defaultSheetModifier, contentModifier = Modifier.fillMaxHeight())
+    is Map<*, *> -> {
+      val fraction = (detent["fraction"] as? Number)?.toFloat()
+      val height = (detent["height"] as? Number)?.toFloat()
+      when {
+        fraction != null -> DetentConfig(
+          skipPartiallyExpanded = false,
+          sheetModifier = defaultSheetModifier,
+          contentModifier = Modifier.height((screenHeightDp * fraction).dp)
+        )
+        height != null -> DetentConfig(
+          skipPartiallyExpanded = false,
+          sheetModifier = defaultSheetModifier,
+          contentModifier = Modifier.height(height.dp)
+        )
+        else -> DetentConfig(skipPartiallyExpanded = false, sheetModifier = defaultSheetModifier, contentModifier = Modifier)
+      }
+    }
+    else -> DetentConfig(skipPartiallyExpanded = false, sheetModifier = defaultSheetModifier, contentModifier = Modifier)
+  }
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun BottomSheetComposable(skipPartiallyExpanded: Boolean, isOpened: Boolean, onIsOpenedChange: (Boolean) -> Unit, content: @Composable () -> Unit) {
-  val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded)
+fun BottomSheetComposable(
+  skipPartiallyExpanded: Boolean,
+  isOpened: Boolean,
+  onIsOpenedChange: (Boolean) -> Unit,
+  fitToContents: Boolean = false,
+  detents: List<Any>? = null,
+  selectedDetent: Any? = null,
+  onSelectedDetentChange: ((Int) -> Unit)? = null,
+  content: @Composable () -> Unit
+) {
+  val screenHeightDp = LocalConfiguration.current.screenHeightDp.toFloat()
+  val detentConfig = if (fitToContents) {
+    // No fillMaxHeight on sheet so it sizes to content; skip partial so it expands to content height
+    DetentConfig(skipPartiallyExpanded = true, sheetModifier = Modifier, contentModifier = Modifier)
+  } else {
+    val activeDetent = selectedDetent ?: detents?.firstOrNull()
+    if (activeDetent != null) {
+      parseDetent(activeDetent, screenHeightDp)
+    } else {
+      DetentConfig(skipPartiallyExpanded = skipPartiallyExpanded, sheetModifier = Modifier.fillMaxHeight(), contentModifier = Modifier)
+    }
+  }
+
+  val sheetState = rememberModalBottomSheetState(detentConfig.skipPartiallyExpanded)
 
   if (isOpened) {
+    if (onSelectedDetentChange != null && detents != null && detents.size > 1) {
+      LaunchedEffect(sheetState) {
+        snapshotFlow { sheetState.currentValue }
+          .drop(1)
+          .collect { value ->
+            val newDetentIndex = when (value) {
+              SheetValue.PartiallyExpanded -> 0
+              SheetValue.Expanded -> detents.size - 1
+              else -> return@collect
+            }
+            onSelectedDetentChange(newDetentIndex)
+          }
+      }
+    }
+
     ModalBottomSheet(
       sheetState = sheetState,
-      modifier = Modifier.fillMaxHeight(),
+      modifier = detentConfig.sheetModifier,
       onDismissRequest = { onIsOpenedChange(false) }
     ) {
-      content()
+      Box(modifier = detentConfig.contentModifier) {
+        content()
+      }
     }
   }
 }
@@ -37,16 +119,31 @@ fun BottomSheetComposable(skipPartiallyExpanded: Boolean, isOpened: Boolean, onI
 data class BottomSheetProps(
   val isOpened: Boolean = false,
   val skipPartiallyExpanded: Boolean = false,
+  val fitToContents: Boolean = false,
+  val detents: List<Any>? = null,
+  val selectedDetent: Any? = null,
   val modifiers: ModifierList = emptyList()
 ) : ComposeProps
 
 @Composable
-fun FunctionalComposableScope.BottomSheetContent(props: BottomSheetProps, onIsOpenedChange: (IsOpenedChangeEvent) -> Unit) {
+fun FunctionalComposableScope.BottomSheetContent(
+  props: BottomSheetProps,
+  onIsOpenedChange: (IsOpenedChangeEvent) -> Unit,
+  onSelectedDetentChange: ((SelectedDetentChangeEvent) -> Unit)? = null
+) {
   Box {
     BottomSheetComposable(
       props.skipPartiallyExpanded,
       props.isOpened,
-      onIsOpenedChange = { value -> onIsOpenedChange(IsOpenedChangeEvent(value)) }
+      onIsOpenedChange = { value -> onIsOpenedChange(IsOpenedChangeEvent(value)) },
+      fitToContents = props.fitToContents,
+      detents = props.detents,
+      selectedDetent = props.selectedDetent,
+      onSelectedDetentChange = if (onSelectedDetentChange != null) {
+        { index -> onSelectedDetentChange(SelectedDetentChangeEvent(index)) }
+      } else {
+        null
+      }
     ) {
       Children(ComposableScope())
     }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ExpoUIModule.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ExpoUIModule.kt
@@ -34,10 +34,11 @@ class ExpoUIModule : Module() {
     //region Expo UI views
 
     ExpoUIView("BottomSheetView", events = {
-      Events("onIsOpenedChange")
+      Events("onIsOpenedChange", "onSelectedDetentChange")
     }) { props: BottomSheetProps ->
       val onIsOpenedChange by remember { EventDispatcher<IsOpenedChangeEvent>() }
-      BottomSheetContent(props) { onIsOpenedChange(it) }
+      val onSelectedDetentChange by remember { EventDispatcher<SelectedDetentChangeEvent>() }
+      BottomSheetContent(props, { onIsOpenedChange(it) }, { onSelectedDetentChange(it) })
     }
 
     // Defines a single view for now – a single choice segmented control

--- a/packages/expo-ui/src/jetpack-compose/BottomSheet/index.tsx
+++ b/packages/expo-ui/src/jetpack-compose/BottomSheet/index.tsx
@@ -2,6 +2,15 @@ import { requireNativeView } from 'expo';
 import React from 'react';
 import { NativeSyntheticEvent } from 'react-native';
 
+/**
+ * Presentation detent type for controlling sheet heights.
+ * - `'medium'`: System medium height (approximately half screen)
+ * - `'large'`: System large height (full screen)
+ * - `{ fraction: number }`: Fraction of screen height (0-1)
+ * - `{ height: number }`: Fixed height in dp
+ */
+export type PresentationDetent = 'medium' | 'large' | { fraction: number } | { height: number };
+
 export type BottomSheetProps = {
   /**
    * The children of the `BottomSheet` component.
@@ -19,10 +28,33 @@ export type BottomSheetProps = {
    * Immediately opens the bottom sheet in full screen.
    */
   skipPartiallyExpanded?: boolean;
+  /**
+   * When `true`, the sheet automatically sizes itself to fit its content.
+   * @default false
+   */
+  fitToContents?: boolean;
+  /**
+   * Available detents (heights) for the bottom sheet.
+   */
+  detents?: PresentationDetent[];
+  /**
+   * The currently selected detent. Defaults to the first detent in the array.
+   */
+  selectedDetent?: PresentationDetent;
+  /**
+   * Callback fired when the active detent changes (e.g., user drags the sheet).
+   */
+  onSelectedDetentChange?: (detent: PresentationDetent) => void;
 };
 
-type NativeBottomSheetProps = Omit<BottomSheetProps, 'onIsOpenedChange'> & {
+type NativeBottomSheetProps = Omit<
+  BottomSheetProps,
+  'onIsOpenedChange' | 'onSelectedDetentChange'
+> & {
   onIsOpenedChange: (event: NativeSyntheticEvent<{ isOpened: boolean }>) => void;
+  onSelectedDetentChange?: (
+    event: NativeSyntheticEvent<{ selectedDetentIndex: number }>
+  ) => void;
   skipPartiallyExpanded: boolean;
 };
 
@@ -34,10 +66,19 @@ const BottomSheetNativeView: React.ComponentType<NativeBottomSheetProps> = requi
 function transformBottomSheetProps(props: BottomSheetProps): NativeBottomSheetProps {
   return {
     ...props,
-    skipPartiallyExpanded: props.skipPartiallyExpanded ?? false,
+    skipPartiallyExpanded: props.fitToContents ? false : (props.skipPartiallyExpanded ?? false),
     onIsOpenedChange: ({ nativeEvent: { isOpened } }) => {
       props.onIsOpenedChange(isOpened);
     },
+    onSelectedDetentChange:
+      props.onSelectedDetentChange && props.detents
+        ? ({ nativeEvent: { selectedDetentIndex } }) => {
+            const detent = props.detents![selectedDetentIndex];
+            if (detent !== undefined) {
+              props.onSelectedDetentChange!(detent);
+            }
+          }
+        : undefined,
   };
 }
 


### PR DESCRIPTION
## Summary
- Add `detents`, `selectedDetent`, `onSelectedDetentChange`, and `fitToContents` props to the Android `BottomSheet` component for feature parity with iOS
- `'medium'` maps to native partial expansion, `'large'` to full screen, `{ fraction }` and `{ height }` constrain content to custom sizes
- `fitToContents` removes `fillMaxHeight()` from the sheet so it sizes exactly to its content
- Expand NCL BottomSheet demo with interactive controls: toggle medium/large, custom fraction % input, custom height dp input, selection tracking, and fit-to-contents

## Test plan
- [ ] Open NCL > BottomSheet on Android
- [ ] Verify "Basic" sheet opens with default behavior
- [ ] Verify "Fits Content" sheet wraps tightly to content
- [ ] Toggle medium/large detents and verify sheet height changes
- [ ] Enter custom fraction (e.g. 30%) and verify sheet opens at ~30% screen height
- [ ] Enter custom height (e.g. 300dp) and verify sheet opens at 300dp
- [ ] Verify "Selection Tracking" reports current detent when dragging between medium/large