### PR TITLE
[expo-router] Ignore files in _ prefixed directories to suppress warnings

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### 💡 Others
 
+- Stop emitting spurious "missing default export" warnings for files inside `_` prefixed directories (e.g. `_lib/`, `_utils/`). (by [@chriskrogh](https://github.com/chriskrogh))
 - Bump peer dependency to `@testing-library/react-native@^13.2.0` ([#43084](https://github.com/expo/expo/pull/43084) by [@hassankhan](https://github.com/hassankhan))
 
 ## 55.0.0-preview.7 — 2026-02-08

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### 💡 Others
 
-- Stop emitting spurious "missing default export" warnings for files inside `_` prefixed directories (e.g. `_lib/`, `_utils/`). (by [@chriskrogh](https://github.com/chriskrogh))
+- Stop emitting spurious "missing default export" warnings for files inside `_` prefixed directories (e.g. `_lib/`, `_utils/`). (by [@chriskrogh](https://github.com/chriskrogh)) ([#43159](https://github.com/expo/expo/pull/43159) by [@chriskrogh](https://github.com/chriskrogh))
 - Bump peer dependency to `@testing-library/react-native@^13.2.0` ([#43084](https://github.com/expo/expo/pull/43084) by [@hassankhan](https://github.com/hassankhan))
 
 ## 55.0.0-preview.7 — 2026-02-08

--- a/packages/expo-router/src/__tests__/getRoutes.test.ios.ts
+++ b/packages/expo-router/src/__tests__/getRoutes.test.ios.ts
@@ -1182,4 +1182,33 @@ describe('redirects', () => {
       type: 'layout',
     });
   });
+
+  it('should ignore files inside _ prefixed directories', () => {
+    expect(
+      getRoutes(
+        inMemoryContext({
+          './(app)/index': () => null,
+          './(app)/settings/_lib/helpers': () => null,
+          './(app)/settings/_lib/SettingsForm': () => null,
+          './(app)/settings/_utils/format': () => null,
+        }),
+        { internal_stripLoadRoute: true, skipGenerated: true, ignoreEntryPoints: true }
+      )
+    ).toEqual({
+      children: [
+        {
+          children: [],
+          contextKey: './(app)/index.js',
+          dynamic: null,
+          route: '(app)/index',
+          type: 'route',
+        },
+      ],
+      contextKey: 'expo-router/build/views/Navigator.js',
+      dynamic: null,
+      generated: true,
+      route: '',
+      type: 'layout',
+    });
+  });
 });

--- a/packages/expo-router/src/getRoutesCore.ts
+++ b/packages/expo-router/src/getRoutesCore.ts
@@ -198,6 +198,11 @@ function getDirectoryTree(contextModule: RequireContext, options: Options) {
   // Always ignore middleware files in regular route processing
   ignoreList.push(/\+middleware$/, /\+middleware\.[tj]sx?$/);
 
+  // Ignore files inside directories that start with `_` (e.g. `_lib/`, `_utils/`).
+  // These are treated as private/non-route directories. This does not affect `_layout`
+  // or `_sitemap` files since those are filenames (no trailing `/`).
+  ignoreList.push(/\/_[^/]+\//);
+
   const rootDirectory: DirectoryNode = {
     files: new Map(),
     subdirectories: new Map(),


### PR DESCRIPTION
# Why

When you use `_` prefixed directories (for example, `_lib/`, `_utils/`) to co-locate helper files alongside route files, Expo Router emits spurious warnings in development:

```
WARN  Route "./(logged-in)/dashboard/settings/mfa/_lib/EnrollmentButton.tsx" is missing the required default export. Ensure a React component is exported as default.
```

Directories starting with `_` are private and their contents should not be treated as routes. The router already skips these files from becoming actual routes (they `continue` past the warning), but the warning itself is still emitted because the files are never excluded from route processing in the first place.

# How

This adds a regex (`/\/_[^/]+\//`) to the `ignoreList` in `getDirectoryTree()` in `packages/expo-router/src/getRoutesCore.ts`. The pattern matches any file path containing a directory segment that starts with `_`, which skips the file before route processing and the default-export check run.

The regex only matches directory segments (it requires both a leading and trailing `/`), so it does not affect special files like `_layout.tsx` or `_sitemap.tsx`, which are filenames at the end of a path.

# Test Plan

This adds a unit test in `packages/expo-router/src/__tests__/getRoutes.test.ios.ts` (`'should ignore files inside _ prefixed directories'`). The test creates a context with files in `_lib/` and `_utils/` directories alongside a normal route and verifies that only the normal route appears in the resulting route tree.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
