### PR TITLE
[docs] Revert extractFrontmatter to include full frontmatter in .md files

### DIFF
--- a/docs/scripts/generate-markdown-pages-utils.test.ts
+++ b/docs/scripts/generate-markdown-pages-utils.test.ts
@@ -1352,7 +1352,6 @@ describe('extractFrontmatter', () => {
       path.join(tmpDir, 'full.mdx'),
       [
         '---',
-        'modificationDate: July 08, 2025',
         'title: Camera',
         'description: A camera component.',
         "platforms: ['android', 'ios']",
@@ -1385,13 +1384,12 @@ describe('extractFrontmatter', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('extracts only modificationDate including delimiters', () => {
+  it('extracts full frontmatter including delimiters', () => {
     const result = extractFrontmatter(path.join(tmpDir, 'full.mdx'));
     expect(result).not.toBeNull();
-    expect(result).toContain('modificationDate: July 08, 2025');
-    expect(result).not.toContain('title: Camera');
-    expect(result).not.toContain('description: A camera component.');
-    expect(result).not.toContain('platforms:');
+    expect(result).toContain('title: Camera');
+    expect(result).toContain('description: A camera component.');
+    expect(result).toContain('platforms:');
     // Should include --- delimiters
     expect(result).toMatch(/^---\n/);
     expect(result).toMatch(/\n---\n$/);
@@ -1399,14 +1397,19 @@ describe('extractFrontmatter', () => {
     expect(result).not.toContain('import');
   });
 
-  it('returns null when frontmatter has no modificationDate', () => {
+  it('extracts minimal frontmatter', () => {
     const result = extractFrontmatter(path.join(tmpDir, 'minimal.mdx'));
-    expect(result).toBeNull();
+    expect(result).not.toBeNull();
+    expect(result).toContain('title: Minimal');
+    expect(result).not.toContain('# Minimal');
   });
 
-  it('returns null when modificationDate is empty', () => {
+  it('strips lines with empty values', () => {
     const result = extractFrontmatter(path.join(tmpDir, 'empty-values.mdx'));
-    expect(result).toBeNull();
+    expect(result).not.toBeNull();
+    expect(result).toContain('title: Camera');
+    expect(result).toContain('description: A camera.');
+    expect(result).not.toContain('modificationDate');
   });
 
   it('returns null when all frontmatter fields are empty', () => {

--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -25,7 +25,8 @@ export function findMdxSource(htmlPath: string, outDir: string, pagesDir: string
 
 /**
  * Extract the raw YAML frontmatter block (including --- delimiters) from an MDX file.
- * Keeps only non-empty `modificationDate` and drops other frontmatter fields.
+ * Strips lines with empty values (e.g. `modificationDate:` injected by append-dates.js
+ * with no value in shallow CI clones).
  * Returns the frontmatter string with trailing newline, or null if no frontmatter found.
  */
 export function extractFrontmatter(mdxPath: string): string | null {
@@ -36,12 +37,12 @@ export function extractFrontmatter(mdxPath: string): string | null {
   }
   const filtered = match[1]
     .split('\n')
-    .filter(line => /^modificationDate:\s+\S/.test(line))
+    .filter(line => !/^\w+:\s*$/.test(line))
     .join('\n');
   if (!filtered.trim()) {
     return null;
   }
-  return '---\n' + filtered + '\n---\n';
+  return '---\n' + filtered + '---\n';
 }
 
 function createTurndownService(): TurndownService {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/expo/pull/43044

## How

- Reverted `extractFrontmatter()` in `scripts/generate-markdown-pages-utils.ts` to keep all frontmatter fields, only stripping lines with empty values (e.g. `modificationDate:` with no value from shallow CI clones).
- Restored the original filter regex from `/^modificationDate:\s+\S/` (keep only modificationDate) back to `/^\w+:\s*$/` (strip empty-value lines).
- Fixed the return delimiter format from `'---\n' + filtered + '\n---\n'` back to `'---\n' + filtered + '---\n'`.
- Reverted the corresponding tests in `scripts/generate-markdown-pages-utils.test.ts` to match the pre-#43044 behavior.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn run export-preview` and then serve the `out` directory using `npx serve out`. Then, open a page in docs and click  View Markdown:

<img width="1922" height="464" alt="CleanShot 2026-02-16 at 12 42 31@2x" src="https://github.com/user-attachments/assets/b6724c72-27f4-4788-b519-c7af981f1925" />

Run `yarn test` and confirm the `extractFrontmatter` tests pass.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
