### PR TITLE
[chore] update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/0-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/0-bug_report.yml
@@ -11,7 +11,12 @@ body:
   - type: markdown
     attributes:
       value: |
-        > [!IMPORTANT]  
+        > [!TIP]
+        > **Try debugging with AI first.** Set up the [Expo MCP Server](https://docs.expo.dev/eas/ai/mcp/) to give your AI coding assistant access to your dev environment, Expo docs, or even EAS build logs. It can help diagnose and fix both runtime issues in your app and build failures. Point it to our [CONTRIBUTING.md](https://github.com/expo/expo/blob/main/CONTRIBUTING.md) for codebase context — AI tools can often even [submit a PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) with a fix!
+  - type: markdown
+    attributes:
+      value: |
+        > [!IMPORTANT]
         > Reproductions are necessary for **most** bug reports.
         > Without one, maintainers will be forced to first reproduce the issue and craft missing context, rather than being able to address the report immediately.
         > Issues without a reproduction link may be closed without further notice.


### PR DESCRIPTION
# Why

Add a tip to the bug report template encouraging users to try debugging with AI first using the Expo MCP Server before submitting a bug report.

# How

Updated the bug report template to include a new TIP section at the beginning that:
- Suggests using the Expo MCP Server for AI-assisted debugging
- Explains how AI can help diagnose runtime issues and build failures
- Mentions that AI can potentially submit a PR with a fix

# Test Plan



# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)