### PR TITLE
[github][brownfield] split android e2e into two jobs

### DIFF
--- a/.github/workflows/test-suite-brownfield-isolated.yml
+++ b/.github/workflows/test-suite-brownfield-isolated.yml
@@ -120,7 +120,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: expo-brownfield-android-release
-          path: apps/brownfield-tester/android-integrated/app/build/outputs/apk/release/app-release.apk
+          path: apps/brownfield-tester/android-integrated/apk
       - name: 🍺 Install Maestro
         run: |
           curl -Ls "https://get.maestro.mobile.dev" | bash
@@ -131,7 +131,7 @@ jobs:
           avd-api: ${{ matrix.api-level }}
           avd-name: avd-${{ matrix.api-level }}
           script: |
-            adb install -r apps/brownfield-tester/android-integrated/app/build/outputs/apk/release/app-release.apk
+            adb install -r apps/brownfield-tester/android-integrated/*.apk
             cd packages/expo-brownfield/e2e && maestro test maestro/__tests__/android
       - name: 🔔 Notify on Slack
         uses: ./.github/actions/slack-notify

--- a/.github/workflows/test-suite-brownfield-isolated.yml
+++ b/.github/workflows/test-suite-brownfield-isolated.yml
@@ -131,7 +131,7 @@ jobs:
           avd-api: ${{ matrix.api-level }}
           avd-name: avd-${{ matrix.api-level }}
           script: |
-            adb install -r apps/brownfield-tester/android-integrated/*.apk
+            adb install -r apps/brownfield-tester/android-integrated/apk/*.apk
             cd packages/expo-brownfield/e2e && maestro test maestro/__tests__/android
       - name: 🔔 Notify on Slack
         uses: ./.github/actions/slack-notify

--- a/.github/workflows/test-suite-brownfield-isolated.yml
+++ b/.github/workflows/test-suite-brownfield-isolated.yml
@@ -46,13 +46,10 @@ jobs:
             "packages/expo-brownfield/src/**",
             "packages/expo-brownfield/e2e/maestro/**"
 
-  android-e2e:
+  android-build:
     runs-on: ubuntu-24.04
     needs: detect-platform-for-e2e
     if: needs.detect-platform-for-e2e.outputs.should_run_android == 'true'
-    strategy:
-      matrix:
-        api-level: [36]
     env:
       ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
       GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx4096m -XX:MaxMetaspaceSize=4096m"
@@ -84,11 +81,46 @@ jobs:
           react-native-gradle-downloads: 'true'
       - name: 🧶 Install workspace node modules
         run: yarn install --frozen-lockfile
+      - name: 👷 Build Expo CLI
+        run: yarn workspace @expo/cli prepare
       - name: 🤖 Build and publish Android artifacts (apps/brownfield-tester/expo-app)
         run: |
           npx expo prebuild --clean -p android
           npx expo-brownfield build:android --repo MavenLocal --verbose
         working-directory: apps/brownfield-tester/expo-app
+      - name: 🏗️ Build APK
+        run: |
+          ./gradlew clean
+          ./gradlew assembleRelease --refresh-dependencies
+        working-directory: apps/brownfield-tester/android-integrated
+      - name: 💾 Store APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: expo-brownfield-android-release
+          path: apps/brownfield-tester/android-integrated/app/build/outputs/apk/release/app-release.apk
+
+  android-e2e:
+    runs-on: ubuntu-24.04
+    needs: android-build
+    strategy:
+      matrix:
+        api-level: [36]
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v5
+      - name: 🧹 Cleanup GitHub Linux runner disk space
+        uses: ./.github/actions/cleanup-linux-disk-space
+      - name: 🏗️ Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
+          # TODO(cedric): swap `latest` back once the issue is resolved
+          bun-version: latest
+      - name: 🌠 Download builds
+        uses: actions/download-artifact@v4
+        with:
+          name: expo-brownfield-android-release
+          path: apps/brownfield-tester/android-integrated/app/build/outputs/apk/release/app-release.apk
       - name: 🍺 Install Maestro
         run: |
           curl -Ls "https://get.maestro.mobile.dev" | bash
@@ -99,7 +131,7 @@ jobs:
           avd-api: ${{ matrix.api-level }}
           avd-name: avd-${{ matrix.api-level }}
           script: |
-            cd apps/brownfield-tester/android-integrated && ./gradlew clean && ./gradlew installRelease --refresh-dependencies
+            adb install -r apps/brownfield-tester/android-integrated/app/build/outputs/apk/release/app-release.apk
             cd packages/expo-brownfield/e2e && maestro test maestro/__tests__/android
       - name: 🔔 Notify on Slack
         uses: ./.github/actions/slack-notify


### PR DESCRIPTION
# Why

The tests in the previous setup:

- Brownfield artifacts publishing
- Test app build
- Maestro execution on emulator

All executed in a single job were unstable, ending in:

```sh
FATAL        | Not enough space to create userdata partition. Available: 4031.36 MB \
     at /home/runner/.android/avd/avd-36.avd, need 7372.80 MB.
```

# How

Split the publishing & building app and test execution into two jobs, similar to other E2E workflows

# Test Plan

Ensured the updated setup works on CI

# Checklist

N / A
