### PR TITLE
[@expo/ui][iOS] Fix TextField multiline tap area hit-testing

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix TextField multiline tap area hit-testing when using frame with minHeight. ([#43167](https://github.com/expo/expo/pull/43167) by [@d1coach](https://github.com/d1coach))
 - [iOS] Fix rendering `0` in SwiftUI Text. ([#43036](https://github.com/expo/expo/pull/43036) by [@jakex7](https://github.com/jakex7))
 - [iOS] Set initial state in `init` instead of `onAppear` in `DatePicker`, `Section`, `DisclosureGroup`, `Popover`, and `ColorPicker` components. ([#42933](https://github.com/expo/expo/pull/42933) by [@nishan](https://github.com/intergalacticspacehighway))
 

--- a/packages/expo-ui/ios/TextFieldView.swift
+++ b/packages/expo-ui/ios/TextFieldView.swift
@@ -187,6 +187,8 @@ struct TextFieldView: ExpoSwiftUI.View, ExpoSwiftUI.FocusableView {
 
   var body: some View {
     let baseView = text
+      .contentShape(Rectangle())
+      .onTapGesture { isFocused = true }
       .onAppear {
         textManager.text = props.defaultValue
         if props.autoFocus {


### PR DESCRIPTION
## Summary

Fixes #43166

When a multiline `TextField` has a `frame` modifier (e.g. `minHeight: 200`), only the top-left corner where text content sits is tappable. Tapping anywhere else in the frame does nothing — the keyboard doesn't appear and the field doesn't focus.

This is a [well-documented SwiftUI limitation](https://developer.apple.com/forums/thread/703257) where `TextField` hit-test area doesn't expand to fill its frame.

## Fix

Two standard SwiftUI modifiers added to `body` in `TextFieldView.swift`:

- `.contentShape(Rectangle())` — expands the hit-test area to the full frame
- `.onTapGesture { isFocused = true }` — programmatically focuses the field on tap

### Why this is safe

- `.contentShape(Rectangle())` only changes the hit-test area — no layout, sizing, or visual changes
- `.onTapGesture` with `isFocused = true` is the [standard SwiftUI pattern](https://www.hackingwithswift.com/forums/swiftui/increasing-textfield-padding-does-not-increase-tappable-area/15972) for expanding TextField tap targets
- No props, modifiers, or frame behavior changes

## Test Plan

- [ ] Create a multiline `TextField` with `style={{ minHeight: 200 }}`
- [ ] Tap in the middle/bottom of the frame area → field should now focus
- [ ] Tap the top-left corner (existing behavior) → still works
- [ ] Type text → `onChangeText` fires correctly
- [ ] Single-line `TextField` → no behavior change