### PR TITLE
[ci] Ignore web files in Test Suite e2e

### DIFF
--- a/.github/actions/detect-platform-change/action.yml
+++ b/.github/actions/detect-platform-change/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: 'Paths to ignore for all platforms'
     required: false
     default: >-
-      "!{**/*.md,**/LICENSE*,**/.gitignore,**/CHANGELOG*,**/.npmignore,**/.eslintrc*,**/.prettierrc*,**/.gitattributes,**/.watchmanconfig,**/.fingerprintignore}"
+      "!{**/*.md,**/LICENSE*,**/.gitignore,**/CHANGELOG*,**/.npmignore,**/.eslintrc*,**/.prettierrc*,**/.gitattributes,**/.watchmanconfig,**/.fingerprintignore,**/*.web.*}"
 
 outputs:
   should_run_android:


### PR DESCRIPTION
# Why
Changes to `*.web.*` files do not affect Android and iOS builds, so they shouldn't trigger the test suite E2E. 
This is the case here: https://github.com/expo/expo/pull/43153

# How
Add `**/*.web.*` to `shared-ignores`.
List of affected files: [web.txt](https://github.com/user-attachments/files/25339421/web.txt)

# Test Plan
Tested on a stacked PR.