### PR TITLE
[github][brownfield] optimize runner usage for ios compilation test

### DIFF
--- a/.github/workflows/brownfield.yml
+++ b/.github/workflows/brownfield.yml
@@ -275,10 +275,6 @@ jobs:
     runs-on: macos-15
     needs: analyze-changes
     if: needs.analyze-changes.outputs.compilation_test_ios == 'true' || needs.analyze-changes.outputs.all_tests == 'true'
-    strategy:
-      fail-fast: true
-      matrix:
-        build-type: [debug, release]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v5
@@ -302,10 +298,13 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: 👷 Build Expo CLI
         run: yarn workspace @expo/cli prepare
-      - name: 🍏 Build iOS artifacts
+      - name: 🍏 Build iOS artifacts (Release)
         run: |
           npx expo prebuild --clean --platform ios
-          npx expo-brownfield build:ios --${{ matrix.build-type }} --verbose
+          npx expo-brownfield build:ios --release --verbose
+        working-directory: apps/brownfield-tester/expo-app
+      - name: 🍏 Build iOS artifacts (Debug)
+        run: npx expo-brownfield build:ios --debug --verbose
         working-directory: apps/brownfield-tester/expo-app
       - name: 🔔 Notify on Slack
         uses: ./.github/actions/slack-notify


### PR DESCRIPTION
# Why

There were some insights from the team, that compilation test for iOS is clogging the CI, as it occupies two runners for around an hour

# How

iOS compilation test now runs as a single job, thus occupying only one runner for roughly two hours

# Test Plan

Ensured that the updated workflow passes on the CI

# Checklist

N / A
