### PR TITLE
[updates][Android] Remove `registerErrorHandlerImplBridgeless`

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecovery.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecovery.kt
@@ -2,16 +2,12 @@ package expo.modules.updates.errorrecovery
 
 import android.os.Handler
 import android.os.HandlerThread
-import com.facebook.react.bridge.DefaultJSExceptionHandler
-import com.facebook.react.bridge.JSExceptionHandler
 import com.facebook.react.bridge.ReactMarker
 import com.facebook.react.bridge.ReactMarker.MarkerListener
 import com.facebook.react.bridge.ReactMarkerConstants
-import com.facebook.react.devsupport.ReleaseDevSupportManager
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import expo.modules.updates.logging.UpdatesErrorCode
 import expo.modules.updates.logging.UpdatesLogger
-import java.lang.ref.WeakReference
 
 /**
  * Entry point for the error recovery flow. Responsible for initializing the error recovery handler
@@ -32,8 +28,6 @@ class ErrorRecovery(
   internal val handlerThread = HandlerThread("expo-updates-error-recovery")
   internal lateinit var handler: Handler
 
-  private var weakDevSupportManager: WeakReference<DevSupportManager>? = null
-  private var previousExceptionHandler: DefaultJSExceptionHandler? = null
   private var shouldHandleReactInstanceException = false
 
   fun initialize(delegate: ErrorRecoveryDelegate) {
@@ -97,58 +91,10 @@ class ErrorRecovery(
   }
 
   private fun registerErrorHandler(devSupportManager: DevSupportManager) {
-    registerErrorHandlerImplBridgeless()
-  }
-
-  private fun registerErrorHandlerImplBridgeless() {
     shouldHandleReactInstanceException = true
   }
 
-  private fun registerErrorHandlerImplBridge(devSupportManager: DevSupportManager) {
-    if (devSupportManager !is ReleaseDevSupportManager) {
-      logger.debug("Unexpected type of ReactInstanceManager.DevSupportManager. expo-updates error recovery will not behave properly.")
-      return
-    }
-
-    val defaultJSExceptionHandler = JSExceptionHandler { e -> this@ErrorRecovery.handleException(e) }
-
-    val devSupportManagerClass = devSupportManager.javaClass
-    previousExceptionHandler = devSupportManagerClass.getDeclaredField("defaultJSExceptionHandler").let { field ->
-      field.isAccessible = true
-      val previousValue = field[devSupportManager]
-      field[devSupportManager] = defaultJSExceptionHandler
-      return@let previousValue as DefaultJSExceptionHandler
-    }
-    weakDevSupportManager = WeakReference(devSupportManager)
-  }
-
   private fun unregisterErrorHandler() {
-    unregisterErrorHandlerImplBridgeless()
-  }
-
-  private fun unregisterErrorHandlerImplBridgeless() {
     shouldHandleReactInstanceException = false
-  }
-
-  private fun unregisterErrorHandlerImplBridge() {
-    weakDevSupportManager?.get()?.let { devSupportManager ->
-      if (devSupportManager !is ReleaseDevSupportManager) {
-        logger.debug("Unexpected type of ReactInstanceManager.DevSupportManager. expo-updates could not unregister its error handler")
-        return
-      }
-      if (previousExceptionHandler == null) {
-        return
-      }
-
-      val devSupportManagerClass = devSupportManager.javaClass
-      devSupportManagerClass.getDeclaredField("defaultJSExceptionHandler").let { field ->
-        field.isAccessible = true
-        field[devSupportManager] = previousExceptionHandler
-      }
-      weakDevSupportManager = null
-    }
-    // quitSafely will wait for processing messages to finish but cancel all messages scheduled for
-    // a future time, so delay for a few more seconds in case there are any scheduled messages
-    handler.postDelayed({ handlerThread.quitSafely() }, 10000)
   }
 }


### PR DESCRIPTION
# Why

Removes `registerErrorHandlerImplBridgeless`
A follow-up to the https://github.com/expo/expo/pull/42905#discussion_r2804864096

# Test Plan

- bare-expo ✅ 