### PR TITLE
[ui][ios] Fix ColorPicker onSelectionChange callback never firing

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `ColorPicker` `onSelectionChange` callback never firing due to native event name mismatch. ([#43180](https://github.com/expo/expo/pull/43180) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix `clipShape` and `mask` modifiers silently falling through to `Rectangle()` for `capsule` and `ellipse` shapes. ([#43158](https://github.com/expo/expo/pull/43158) by [@ramonclaudio](https://github.com/ramonclaudio))
 - [iOS] Fix rendering `0` in SwiftUI Text. ([#43036](https://github.com/expo/expo/pull/43036) by [@jakex7](https://github.com/jakex7))
 - [iOS] Set initial state in `init` instead of `onAppear` in `DatePicker`, `Section`, `DisclosureGroup`, `Popover`, and `ColorPicker` components. ([#42933](https://github.com/expo/expo/pull/42933) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/ios/ColorPickerView.swift
+++ b/packages/expo-ui/ios/ColorPickerView.swift
@@ -7,7 +7,7 @@ final class ColorPickerProps: UIBaseViewProps {
   @Field var selection: Color = .clear
   @Field var label: String?
   @Field var supportsOpacity: Bool = true
-  var onValueChanged = EventDispatcher()
+  var onSelectionChange = EventDispatcher()
 }
 
 struct ColorPickerView: ExpoSwiftUI.View {
@@ -29,7 +29,7 @@ struct ColorPickerView: ExpoSwiftUI.View {
         if newHex != previousHex {
           previousHex = newHex
           let payload = ["value": newHex]
-          props.onValueChanged(payload)
+          props.onSelectionChange(payload)
         }
       }
 #else


### PR DESCRIPTION
## Summary
- Fixes #43178
- Renames `onValueChanged` to `onSelectionChange` in `ColorPickerView.swift` to match the JS prop name introduced in https://github.com/expo/expo/pull/41725

The JS-side prop was renamed from `onValueChanged` to `onSelectionChange`, but the native Swift `EventDispatcher` was not updated, causing the callback to silently never fire.

## Test plan
- Open a development build with a `<ColorPicker>` component using `onSelectionChange`
- Pick a new color — the callback should now fire and update state
- Verify the [reproduction repo](https://github.com/mmaksitaliev/colorpicker-repro) works correctly with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)