### PR TITLE
[docs] Update instructions for installing expo-image library

### DIFF
--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -63,8 +63,7 @@ Now that we've broken down the UI into smaller chunks, we're ready to start codi
 
 We'll use `expo-image` library to display the image in the app. It provides a cross-platform `<Image>` component to load and render an image.
 
-The `expo-image` library comes out of the box, but in case if you don't have it, stop the development server by pressing <kbd>Ctrl</kbd> + <kbd>c</kbd> in the terminal.
-Then, install the `expo-image` library:
+The `expo-image` library comes out of the box, but if you don't have it, stop the development server by pressing <kbd>Ctrl</kbd> + <kbd>c</kbd> in the terminal. Then, install the `expo-image` library:
 
 <Terminal cmd={['$ npx expo install expo-image']} />
 

--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -63,7 +63,8 @@ Now that we've broken down the UI into smaller chunks, we're ready to start codi
 
 We'll use `expo-image` library to display the image in the app. It provides a cross-platform `<Image>` component to load and render an image.
 
-Stop the development server by pressing <kbd>Ctrl</kbd> + <kbd>c</kbd> in the terminal. Then, install the `expo-image` library:
+The `expo-image` library comes out of the box, but in case if you don't have it, stop the development server by pressing <kbd>Ctrl</kbd> + <kbd>c</kbd> in the terminal.
+Then, install the `expo-image` library:
 
 <Terminal cmd={['$ npx expo install expo-image']} />
 


### PR DESCRIPTION
Clarify that the `expo-image` library is included by default and provide installation instructions.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
