### PR TITLE
[docs] Add info about new IcoMoon app

### DIFF
--- a/docs/pages/guides/icons.mdx
+++ b/docs/pages/guides/icons.mdx
@@ -69,7 +69,7 @@ export default function CustomIconExample() {
 
 The `createIconSetFromIcoMoon` method is used to create a custom font based on an [IcoMoon](https://icomoon.io/) config file. You have to save the **selection.json** and **.ttf** in your project, preferably in the **assets** directory, and then load the font using either `useFonts` hook or `Font.loadAsync` method from `expo-font`.
 
-> **IcoMoon app versions:** The [new IcoMoon app](https://icomoon.io/new-app) exports a different JSON format than the [old IcoMoon app](https://icomoon.io/app). The current `createIconSetFromIcoMoon` function only supports the old app's output. [PR #356](https://github.com/expo/vector-icons/pull/356) adds support for the new format. This support will work once released in `@expo/vector-icons`.
+> **IcoMoon app versions:** The [new IcoMoon app](https://icomoon.io/new-app) exports a different JSON format than the [old IcoMoon app](https://icomoon.io/app). The current `createIconSetFromIcoMoon` function only supports the old app's output. See the [Pull Request on Github](https://github.com/expo/vector-icons/pull/356), which adds support for the new format. This support will work once released in `@expo/vector-icons`.
 
 See the example below that uses the `useFonts` hook to load the font:
 

--- a/docs/pages/guides/icons.mdx
+++ b/docs/pages/guides/icons.mdx
@@ -69,6 +69,8 @@ export default function CustomIconExample() {
 
 The `createIconSetFromIcoMoon` method is used to create a custom font based on an [IcoMoon](https://icomoon.io/) config file. You have to save the **selection.json** and **.ttf** in your project, preferably in the **assets** directory, and then load the font using either `useFonts` hook or `Font.loadAsync` method from `expo-font`.
 
+> **IcoMoon app versions:** The [new IcoMoon app](https://icomoon.io/new-app) exports a different JSON format than the [old IcoMoon app](https://icomoon.io/app). The current `createIconSetFromIcoMoon` function only supports the old app's output. Support for the new app format is available in [PR #356](https://github.com/expo/vector-icons/pull/356) and will work once it is released in `@expo/vector-icons`.
+
 See the example below that uses the `useFonts` hook to load the font:
 
 <SnackInline

--- a/docs/pages/guides/icons.mdx
+++ b/docs/pages/guides/icons.mdx
@@ -69,7 +69,7 @@ export default function CustomIconExample() {
 
 The `createIconSetFromIcoMoon` method is used to create a custom font based on an [IcoMoon](https://icomoon.io/) config file. You have to save the **selection.json** and **.ttf** in your project, preferably in the **assets** directory, and then load the font using either `useFonts` hook or `Font.loadAsync` method from `expo-font`.
 
-> **IcoMoon app versions:** The [new IcoMoon app](https://icomoon.io/new-app) exports a different JSON format than the [old IcoMoon app](https://icomoon.io/app). The current `createIconSetFromIcoMoon` function only supports the old app's output. Support for the new app format is available in [PR #356](https://github.com/expo/vector-icons/pull/356) and will work once it is released in `@expo/vector-icons`.
+> **IcoMoon app versions:** The [new IcoMoon app](https://icomoon.io/new-app) exports a different JSON format than the [old IcoMoon app](https://icomoon.io/app). The current `createIconSetFromIcoMoon` function only supports the old app's output. [PR #356](https://github.com/expo/vector-icons/pull/356) adds support for the new format. This support will work once released in `@expo/vector-icons`.
 
 See the example below that uses the `useFonts` hook to load the font:
 

--- a/docs/pages/guides/icons.mdx
+++ b/docs/pages/guides/icons.mdx
@@ -69,7 +69,7 @@ export default function CustomIconExample() {
 
 The `createIconSetFromIcoMoon` method is used to create a custom font based on an [IcoMoon](https://icomoon.io/) config file. You have to save the **selection.json** and **.ttf** in your project, preferably in the **assets** directory, and then load the font using either `useFonts` hook or `Font.loadAsync` method from `expo-font`.
 
-> **IcoMoon app versions:** The [new IcoMoon app](https://icomoon.io/new-app) exports a different JSON format than the [old IcoMoon app](https://icomoon.io/app). The current `createIconSetFromIcoMoon` function only supports the old app's output. See the [Pull Request on Github](https://github.com/expo/vector-icons/pull/356), which adds support for the new format. This support will work once released in `@expo/vector-icons`.
+> **IcoMoon app versions:** The [new IcoMoon app](https://icomoon.io/new-app) exports a different JSON format than the [old IcoMoon app](https://icomoon.io/app). The current `createIconSetFromIcoMoon` function only supports the old app's output. See the [Pull Request on GitHub](https://github.com/expo/vector-icons/pull/356), which adds support for the new format. This support will work once released in `@expo/vector-icons`.
 
 See the example below that uses the `useFonts` hook to load the font:
 


### PR DESCRIPTION
# Why

The [new IcoMoon app](https://icomoon.io/new-app) exports a different JSON format than the [old IcoMoon app](https://icomoon.io/app). The current `createIconSetFromIcoMoon` function in `@expo/vector-icons` only supports the old app's output, so users who export from the new app encounter issues. https://github.com/expo/vector-icons/pull/356 adds support for the new format. This documentation update clarifies the situation and points users to that PR until it is released.

# How

Added a note in the `createIconSetFromIcoMoon` section in the docs about icons.

# Test Plan

Make sure that the `createIconSetFromIcoMoon` section renders correctly.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)