### PR TITLE
Fix grammar when referring to the expo package

### DIFF
--- a/docs/pages/develop/tools.mdx
+++ b/docs/pages/develop/tools.mdx
@@ -16,7 +16,7 @@ When you create a new project with Expo, learning about the following essential 
 
 ## Expo CLI
 
-Expo CLI is a development tool and is installed automatically with `expo` package when you create a new project. You can use it by leveraging `npx` (a Node.js package runner).
+Expo CLI is a development tool and is installed automatically with the `expo` package when you create a new project. You can use it by leveraging `npx` (a Node.js package runner).
 
 It is designed to help you move faster during the app development phase. For example, your first interaction with Expo CLI is starting the development server by running the command: `npx expo start`.
 


### PR DESCRIPTION
# Why

In the documentation page `Home` → `Develop` → `Tools for development`, I noticed that the sentence _"Expo CLI is a development tool and is installed automatically with `expo` package ..."_ was missing the word "the", so reads poorly in English.

# How

I added the word `the`.

# Test Plan

Visual test via markdown preview only.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
