### PR TITLE
[docs] Fix link reference for native directory generation

### DIFF
--- a/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
+++ b/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
@@ -38,7 +38,7 @@ The Expo Dev Client library includes the launcher UI (shown in the screenshots b
 
 With Expo Go, you only needed to build the JavaScript bundle, but with development builds you also need to compile the native app. With Expo, there are two parts to building your native app:
 
-1. Generate the native **android** and/or **ios** directories ([read more](/develop/development-builds/expo-go-to-dev-build/#cng-and-prebuild) on when and how you'll need to do this)
+1. Generate the native **android** and/or **ios** directories ([read more](/develop/development-builds/expo-go-to-dev-build/#prebuild) on when and how you'll need to do this)
 2. Use native build tools to compile the native app(s)
 
 Once you've built your native app, you won't need to build it again unless you add or update a library with native code, or change any native code or configuration, such as the app name.


### PR DESCRIPTION
# Why

In the documentation page `Home` → `Develop` → `Development Builds` → `Switch from Expo Go to a development build`, I noticed that link _prebuild_ was incorrect & hence didn't work.

# How

I corrected the link

# Test Plan

Visually with markdown preview

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
