### PR TITLE
[expo-router] add notes about React 19 and React Compiler to Claude.md

### DIFF
--- a/packages/expo-router/CLAUDE.md
+++ b/packages/expo-router/CLAUDE.md
@@ -190,8 +190,12 @@ jest.mock('react-native-screens', () => {
 
 ```ts
 let spy: jest.SpyInstance;
-beforeEach(() => { spy = jest.spyOn(Module, 'fn'); }); // or jest.spyOn(console, 'warn').mockImplementation(() => {})
-afterEach(() => { spy.mockRestore(); });
+beforeEach(() => {
+  spy = jest.spyOn(Module, 'fn');
+}); // or jest.spyOn(console, 'warn').mockImplementation(() => {})
+afterEach(() => {
+  spy.mockRestore();
+});
 ```
 
 **Mock call assertions:** Use array index access. Comment non-zero indices:
@@ -300,6 +304,12 @@ To run the docs site locally run `yarn dev` in the `docs/` directory of the mono
 - http://localhost:3002/versions/unversioned/sdk/router-native-tabs/ for native tabs
 - http://localhost:3002/versions/unversioned/sdk/router-split-view/ for split view
 - http://localhost:3002/versions/unversioned/sdk/router-ui/ for headless tabs
+
+## Coding style
+
+- Always use latest React 19 hooks and patterns - `use` instead of `useContext`, `useId`, etc.
+- Make sure the code works with and without React Compiler enabled.
+- Don't use `any` types, unless strictly necessary. Use `unknown` instead and narrow types as much as possible.
 
 ## Maintaining This Document
 


### PR DESCRIPTION
# Why

When writing code in `expo-router` Claude tends to use `useContext` instead of `use`, and hardly ever uses React 19 features. Additionally it often tries to use `any` to fix the types

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
