### PR TITLE
[docs] Upgrade @expo/styleguide-search-ui

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -36,7 +36,7 @@
     "@expo/styleguide": "^9.3.1",
     "@expo/styleguide-base": "^2.0.5",
     "@expo/styleguide-icons": "^2.3.4",
-    "@expo/styleguide-search-ui": "^3.3.1",
+    "@expo/styleguide-search-ui": "^3.3.3",
     "@kapaai/react-sdk": "^0.9.0",
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/mdx": "^3.1.1",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1006,9 +1006,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/styleguide-search-ui@npm:^3.3.1":
-  version: 3.3.1
-  resolution: "@expo/styleguide-search-ui@npm:3.3.1"
+"@expo/styleguide-search-ui@npm:^3.3.3":
+  version: 3.3.3
+  resolution: "@expo/styleguide-search-ui@npm:3.3.3"
   dependencies:
     "@expo/styleguide": "npm:^9.3.1"
     "@expo/styleguide-icons": "npm:^2.3.4"
@@ -1024,7 +1024,7 @@ __metadata:
   peerDependencies:
     next: ">= 13"
     react: ">= 19"
-  checksum: 10c0/ff149cf84459e50fe7bc33134db043e3d4afcb5e287e89d6c9cdab7f2d2c57c4bdfc93f454d98a64ee075551c3889c5cdf79740fc9cb56ea4701ccceb845ca0e
+  checksum: 10c0/fa48338c1ff3fb6be6de7e08a0fa7b6ec005e290771af7443fc35628c120d41f2bf24c761031fc95b83a94ce7d3e5b7ff6e803d1ba2ad7aa3e3145c4e7c3b25a
   languageName: node
   linkType: hard
 
@@ -7959,7 +7959,7 @@ __metadata:
     "@expo/styleguide": "npm:^9.3.1"
     "@expo/styleguide-base": "npm:^2.0.5"
     "@expo/styleguide-icons": "npm:^2.3.4"
-    "@expo/styleguide-search-ui": "npm:^3.3.1"
+    "@expo/styleguide-search-ui": "npm:^3.3.3"
     "@kapaai/react-sdk": "npm:^0.9.0"
     "@mdx-js/loader": "npm:^3.1.1"
     "@mdx-js/mdx": "npm:^3.1.1"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/styleguide/pull/167

The `@expo/styleguide-search-ui` package is outdated at v3.3.1. Upgrading to v3.3.3 picks up the latest fixes and improvements to the docs search UI.

## How

- Bump `@expo/styleguide-search-ui` from `^3.3.1` to `^3.3.3` in `package.json`.
- Update `yarn.lock` to reflect the new resolved version.

## Test Plan

Run `yarn` to install dependencies. Open the docs site locally and verify the search UI works correctly, including opening search, typing a query, and navigating to a result.

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)