### PR TITLE
[docs] Fix auto-generated docs for colors type in LinearGradient

### DIFF
--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -239,11 +239,13 @@ export const resolveTypeName = (
           sdkVersion,
         });
       } else if (type === 'array') {
-        return resolveTypeName(elementType, sdkVersion) + '[]';
+        return <>{resolveTypeName(elementType, sdkVersion)}[]</>;
       }
       return elementType.name + type;
+    } else if (type === 'rest' && elementType) {
+      return <>...{resolveTypeName(elementType, sdkVersion)}</>;
     } else if (elementType?.type === 'array') {
-      return resolveTypeName(elementType, sdkVersion) + '[]';
+      return <>{resolveTypeName(elementType, sdkVersion)}[]</>;
     } else if (elementType?.declaration) {
       if (type === 'array') {
         const { parameters, type: paramType } = elementType.declaration.indexSignature ?? {};
@@ -395,8 +397,6 @@ export const resolveTypeName = (
       return operator ?? 'undefined';
     } else if (type === 'intrinsic') {
       return name ?? 'undefined';
-    } else if (type === 'rest' && elementType) {
-      return <>...{resolveTypeName(elementType, sdkVersion)}</>;
     } else if (value === null) {
       return 'null';
     }

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -619,7 +619,8 @@ exports[`APISectionUtils.resolveTypeName union of array values 1`] = `
 exports[`APISectionUtils.resolveTypeName union with array 1`] = `
 <div>
   <span>
-    number[]
+    number
+    []
     <span
       class="text-quaternary"
     >


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-19531

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Move the rest type handling earlier in the conditional chain in `resolveTypeName` so it is evaluated before the generic `elementType?.type === 'array'` branch.
- Wrap array type returns in JSX fragments (`<>...[]</>`) instead of string concatenation, so the resolved child type (which may itself be a JSX element with links) renders correctly.
- Update the corresponding test snapshot to reflect the new JSX fragment rendering.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/versions/latest/sdk/linear-gradient/#colors

<img width="2174" height="410" alt="CleanShot 2026-02-17 at 16 54 50@2x" src="https://github.com/user-attachments/assets/43ad9206-cc99-493e-9216-50160a0c7663" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)