### PR TITLE
[notifications] add FCM intent origin validation

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- add FCM intent origin validation ([#43206](https://github.com/expo/expo/pull/43206) by [@vonovak](https://github.com/vonovak))
 - Fixed crash in `NotificationForwarderActivity` on Android 11/12 when Parcelable extras fail to deserialize by using byte array serialization as fallback. ([#43203](https://github.com/expo/expo/pull/43203) by [@vonovak](https://github.com/vonovak))
 
 ### 💡 Others

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
@@ -6,6 +6,8 @@ import static expo.modules.notifications.notifications.model.NotificationRespons
 
 import android.os.Bundle;
 
+import expo.modules.notifications.service.NotificationsService;
+
 import androidx.annotation.Nullable;
 
 import com.google.firebase.messaging.RemoteMessage;
@@ -206,7 +208,7 @@ public class NotificationSerializer {
     serializedTrigger.putString("channelId", extras.getString("channelId"));
 
     Bundle serializedRequest = new Bundle();
-    serializedRequest.putString("identifier", extras.getString("google.message_id"));
+    serializedRequest.putString("identifier", extras.getString(NotificationsService.GOOGLE_MESSAGE_ID_KEY));
     serializedRequest.putBundle("trigger", serializedTrigger);
     serializedRequest.putBundle("content", serializedContent);
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
@@ -64,6 +64,10 @@ open class NotificationsService : BroadcastReceiver() {
     const val EXCEPTION_KEY = "exception"
     const val RECEIVER_KEY = "receiver"
 
+    // FCM always includes this key in intent extras for push notifications.
+    // Used to distinguish real notification intents from OEM-injected extras.
+    const val GOOGLE_MESSAGE_ID_KEY = "google.message_id"
+
     // Specific messages parts
     const val NOTIFICATION_KEY = "notification"
     const val NOTIFICATION_RESPONSE_KEY = "notificationResponse"


### PR DESCRIPTION
# Why

closes https://github.com/expo/expo/issues/34523

This PR fixes an issue with notification handling on Android by properly filtering out OEM-injected extras that aren't actual FCM notifications. Some device manufacturers (like Samsung) inject extras into intents that can be mistakenly processed as notifications.

# How

- Added a constant `GOOGLE_MESSAGE_ID_KEY` to reference the FCM message ID key consistently
- Added validation in `ExpoNotificationLifecycleListener` to check if intents contain the FCM message ID before processing them as notifications

# Test Plan

- notification tester app on device - send push notification to a killed app, tap it, observe `isFCMIntent` returning `true` in `ExpoNotificationLifecycleListener`

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)