### PR TITLE
[core][Android] Add missing fields to pom

### DIFF
--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -82,7 +82,10 @@ internal fun Project.applyPublishing(expoModulesExtension: ExpoModuleExtension) 
 
     publishingExtension()
       .publications
-      .createReleasePublication(publicationInfo)
+      .createReleasePublication(
+        publicationInfo,
+        expoModulesExtension.pomConfigurator
+      )
 
     createExpoPublishToMavenLocalTask(publicationInfo, expoModulesExtension)
 

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/gradle/ExpoModuleExtension.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/gradle/ExpoModuleExtension.kt
@@ -2,12 +2,16 @@ package expo.modules.plugin.gradle
 
 import expo.modules.plugin.AutolinkingIntegration
 import expo.modules.plugin.AutolinkingIntegrationImpl
-import org.gradle.api.Project
-import java.io.File
-import java.util.Properties
 import expo.modules.plugin.Version
 import expo.modules.plugin.safeGet
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.api.publish.maven.MavenPom
 import org.gradle.internal.extensions.core.extra
+import java.io.File
+import java.util.Properties
+
+typealias POMConfigurator = Action<MavenPom>
 
 /**
  * An user-facing interface to interact with the `ExpoGradleHelperExtension`.
@@ -39,4 +43,10 @@ open class ExpoModuleExtension(val project: Project) {
   }
 
   var canBePublished: Boolean = true
+
+  internal var pomConfigurator: POMConfigurator? = null
+
+  fun pom(configurator: POMConfigurator) {
+    pomConfigurator = configurator
+  }
 }


### PR DESCRIPTION
# Why

Adds missing fields to the pom that are required to push the artifact to Maven Central. 
Also, I've added a way to replace the default POM.

# Test Plan

- run `./gradlew :expo-blur:expoPublish --no-configuration-cache` and check the generated pom file ✅ 