### PR TITLE
[docs] Restructure runtime issues page for better debugging flow

### DIFF
--- a/docs/pages/debugging/runtime-issues.mdx
+++ b/docs/pages/debugging/runtime-issues.mdx
@@ -101,7 +101,7 @@ You can now utilize [**Low-level debugger (LLDB)**](https://developer.apple.com/
 
 </Step>
 
-> You can delete the **ios** directory when you are done with this process. This ensures that your project remains managed by Expo CLI. Keeping the directory around and manually modifying it outside of `npx expo prebuild` means you'll need to manually upgrade and configure native libraries yourself.
+> You can delete or gitignore the **ios** directory when you are done with this process. This ensures that your project remains managed by Expo CLI. Keeping the directory around and manually modifying it outside of `npx expo prebuild` means you'll need to manually upgrade and configure native libraries yourself.
 
 ## Viewing native logs
 
@@ -123,7 +123,7 @@ The Android Debug Bridge (`adb`) program is part of the Android SDK and allows y
 
 ### iOS: Console app
 
-You can use the **Console** app in Xcode by connecting your device to your macOS (or using a simulator). Follow the steps below to access the Console app:
+You can use the **Console** app in Xcode by connecting your device to your Mac (or while running an iOS Simulator). Follow the steps below to access the Console app:
 
 <Step label="1">
 

--- a/docs/pages/debugging/runtime-issues.mdx
+++ b/docs/pages/debugging/runtime-issues.mdx
@@ -101,40 +101,31 @@ You can now utilize [**Low-level debugger (LLDB)**](https://developer.apple.com/
 
 > You can delete the **ios** directory when you are done with this process. This ensures that your project remains managed by Expo CLI. Keeping the directory around and manually modifying it outside of `npx expo prebuild` means you'll need to manually upgrade and configure native libraries yourself.
 
-## Production errors
+## Viewing native logs
 
-Errors or bugs in your production app can be much harder to solve, mainly because you have less context around the error (that is, where, how, and why did the error occur?).
+When your app crashes or behaves unexpectedly, the JavaScript error provides minimal information to look into when it happens. It's important to reproduce the issue, and to find any related crash reports.
 
-**The best first step in addressing a production error is to reproduce it locally.** Once you reproduce an error locally, you can follow the [development debugging process](#development-errors) to isolate and address the root cause.
-
-> **info** **Tip**: Sometimes, running your app in **production mode** locally will show errors that normally wouldn't be thrown. You can run the app locally in production by running `npx expo start --no-dev --minify`.
-> `--no-dev` tells the server not to be run in development mode, and `--minify` is used to minify your code the same way it is for production JavaScript bundles.
-
-### Production app is crashing
-
-It can be a frustrating scenario when a production app crashes. There is very little information to look into when it happens. It's important to reproduce the issue, and even if you can't do that, to find any related crash reports.
-
-Start by reproducing the crash using your production app and then **find an associated crash report**. For Android, you can use `adb logcat` and for iOS you can use the Console app in Xcode.
+Native logs from Android and iOS can reveal crash reasons, native module errors, and system-level warnings that don't surface in the Metro bundler or React Native DevTools. This applies to development or investigating a production crash.
 
 <VideoBoxLink
   videoId="LvCci4Bwmpc"
-  title="How to use Logcat & macOS Console to debug"
+  title="How to use ADB Logcat & macOS Console to debug"
   description="In this tutorial, you'll learn how to use native device logging features like ADB Logcat and macOS Console to find bugs in your code and quickly fix them."
 />
 
-#### Crash reports using adb logcat
+### Android: adb logcat
 
-If your Android app is on Google Play, refer to the crashes section of the [Google Play Console](https://play.google.com/console/about/), or connect your Android device to your computer and run the following command:
+Connect your Android device and run the following command:
 
 <Terminal cmd={['$ adb logcat']} />
 
-The Android Debug Bridge (`adb`) program is part of the Android SDK and allows you to view streaming logs. An alternative to avoid installing Android SDK is to use [WebADB](https://webadb.com/) in Chrome.
+The Android Debug Bridge (`adb`) program is part of the Android SDK and allows you to view streaming logs. An alternative to avoid installing the Android SDK is to use [WebADB](https://webadb.com/) in Chrome.
 
-#### Crash reports using Console app
+**If your Android app is on Google Play Store**, you can also refer to the crashes section of the [Google Play Console](https://play.google.com/console/about/) for crash reports from your users.
 
-If your iOS app is on TestFlight or the App Store, you can use the [Crashes Organizer](https://developer.apple.com/news/?id=nra79npr) in Xcode.
+### iOS: Console app
 
-If not, you can use the **Console** app in Xcode by connecting your device to your Mac. Follow the steps below on how to access the Console app:
+You can use the **Console** app in Xcode by connecting your device to your macOS or using a simulator. Follow the steps below to access the Console app:
 
 <Step label="1">
 
@@ -158,7 +149,7 @@ If you have connected a physical device, select it under **Devices**. Otherwise,
 Click on **Open Console** button shown in the window to open the console app.
 
 <ContentSpotlight
-  alt="Devices and Simulators window in Xcode."
+  alt="Open Console button in Devices and Simulators window in Xcode."
   src="/static/images/debugging/open-console.png"
 />
 
@@ -166,7 +157,24 @@ This will open the console app for you to view logs from your device or simulato
 
 </Step>
 
-For more information, see Apple's [Diagnosing Issues Using Crash Reports and Device Logs](https://developer.apple.com/documentation/xcode/diagnosing-issues-using-crash-reports-and-device-logs) guide.
+**If your iOS app is on TestFlight or the Apple App Store,** you can also use the [Crashes Organizer](https://developer.apple.com/news/?id=nra79npr) in Xcode.
+
+> **Note:** For more information, see Apple's [Diagnosing Issues Using Crash Reports and Device Logs](https://developer.apple.com/documentation/xcode/diagnosing-issues-using-crash-reports-and-device-logs) guide.
+
+## Production errors
+
+Errors or bugs in your production app can be much harder to solve, mainly because you have less context around the error (that is, where, how, and why did the error occur?).
+
+**The best first step in addressing a production error is to reproduce it locally.** Once you reproduce an error locally, you can follow the [development debugging process](#development-errors) to isolate and address the root cause.
+
+> **info** **Tip**: Sometimes, running your app in **production mode** locally will show errors that normally wouldn't be thrown. You can run the app locally in production by running `npx expo start --no-dev --minify`.
+> `--no-dev` tells the server not to be run in development mode, and `--minify` is used to minify your code the same way it is for production JavaScript bundles.
+
+### Production app is crashing
+
+It can be a frustrating scenario when a production app crashes. There is very little information to look into when it happens. It's important to reproduce the issue, and even if you can't do that, to find any related crash reports.
+
+Try to reproduce the crash locally, then use [native log tools](#viewing-native-logs) to find the associated crash report. Native logs often contain the information needed to identify the root cause, even when JavaScript error boundaries don't catch the problem.
 
 ### App crashes on certain (older) devices
 

--- a/docs/pages/debugging/runtime-issues.mdx
+++ b/docs/pages/debugging/runtime-issues.mdx
@@ -17,6 +17,8 @@ Whether you're developing your app locally, sending it out to select beta tester
 
 Let's go through recommended practices when dealing with each of the above situations.
 
+> **info** Already familiar with React Native debugging? See [Debugging tools](/debugging/tools/) for Expo-specific tooling like React Native DevTools and the built-in profiler.
+
 ## Development errors
 
 They are common errors that you encounter while developing your app. Delving into them isn't always straightforward. Usually, debugging when running your app with [Expo CLI](/more/expo-cli/) is enough.

--- a/docs/pages/debugging/runtime-issues.mdx
+++ b/docs/pages/debugging/runtime-issues.mdx
@@ -121,7 +121,7 @@ The Android Debug Bridge (`adb`) program is part of the Android SDK and allows y
 
 ### iOS: Console app
 
-You can use the **Console** app in Xcode by connecting your device to your Mac (or using a simulator). Follow the steps below to access the Console app:
+You can use the **Console** app in Xcode by connecting your device to your macOS (or using a simulator). Follow the steps below to access the Console app:
 
 <Step label="1">
 

--- a/docs/pages/debugging/runtime-issues.mdx
+++ b/docs/pages/debugging/runtime-issues.mdx
@@ -103,9 +103,7 @@ You can now utilize [**Low-level debugger (LLDB)**](https://developer.apple.com/
 
 ## Viewing native logs
 
-When your app crashes or behaves unexpectedly, the JavaScript error provides minimal information to look into when it happens. It's important to reproduce the issue, and to find any related crash reports.
-
-Native logs from Android and iOS can reveal crash reasons, native module errors, and system-level warnings that don't surface in the Metro bundler or React Native DevTools. This applies to development or investigating a production crash.
+When your app crashes or behaves unexpectedly, the JavaScript error output doesn't always tell the full story. Native logs from Android and iOS can reveal crash reasons, native module errors, and system-level warnings that don't surface in the Metro bundler or React Native DevTools.
 
 <VideoBoxLink
   videoId="LvCci4Bwmpc"
@@ -115,17 +113,15 @@ Native logs from Android and iOS can reveal crash reasons, native module errors,
 
 ### Android: adb logcat
 
-Connect your Android device and run the following command:
+Connect your Android device (or use an emulator) and run the following command:
 
 <Terminal cmd={['$ adb logcat']} />
 
 The Android Debug Bridge (`adb`) program is part of the Android SDK and allows you to view streaming logs. An alternative to avoid installing the Android SDK is to use [WebADB](https://webadb.com/) in Chrome.
 
-**If your Android app is on Google Play Store**, you can also refer to the crashes section of the [Google Play Console](https://play.google.com/console/about/) for crash reports from your users.
-
 ### iOS: Console app
 
-You can use the **Console** app in Xcode by connecting your device to your macOS or using a simulator. Follow the steps below to access the Console app:
+You can use the **Console** app in Xcode by connecting your device to your Mac (or using a simulator). Follow the steps below to access the Console app:
 
 <Step label="1">
 
@@ -157,24 +153,22 @@ This will open the console app for you to view logs from your device or simulato
 
 </Step>
 
-**If your iOS app is on TestFlight or the Apple App Store,** you can also use the [Crashes Organizer](https://developer.apple.com/news/?id=nra79npr) in Xcode.
-
-> **Note:** For more information, see Apple's [Diagnosing Issues Using Crash Reports and Device Logs](https://developer.apple.com/documentation/xcode/diagnosing-issues-using-crash-reports-and-device-logs) guide.
-
 ## Production errors
 
 Errors or bugs in your production app can be much harder to solve, mainly because you have less context around the error (that is, where, how, and why did the error occur?).
 
 **The best first step in addressing a production error is to reproduce it locally.** Once you reproduce an error locally, you can follow the [development debugging process](#development-errors) to isolate and address the root cause.
 
-> **info** **Tip**: Sometimes, running your app in **production mode** locally will show errors that normally wouldn't be thrown. You can run the app locally in production by running `npx expo start --no-dev --minify`.
-> `--no-dev` tells the server not to be run in development mode, and `--minify` is used to minify your code the same way it is for production JavaScript bundles.
-
 ### Production app is crashing
 
-It can be a frustrating scenario when a production app crashes. There is very little information to look into when it happens. It's important to reproduce the issue, and even if you can't do that, to find any related crash reports.
+When a production app crashes, there is very little information available compared to development. Start by trying to reproduce the crash locally, then work through these steps to narrow down the cause:
 
-Try to reproduce the crash locally, then use [native log tools](#viewing-native-logs) to find the associated crash report. Native logs often contain the information needed to identify the root cause, even when JavaScript error boundaries don't catch the problem.
+- **Check platform-specific crash reports.**
+  - For Android apps on Google Play Store, refer to the crashes section of the [Google Play Console](https://play.google.com/console/about/).
+  - For iOS apps on TestFlight or the App Store, use the [Crashes Organizer](https://developer.apple.com/news/?id=nra79npr) in Xcode. See also Apple's [Diagnosing Issues Using Crash Reports and Device Logs](https://developer.apple.com/documentation/xcode/diagnosing-issues-using-crash-reports-and-device-logs) guide.
+- **Use native log tools.** Connect a device that reproduces the crash and use [`adb logcat` or the Console app](#viewing-native-logs) to capture the native log output. Native logs often reveal the root cause when JavaScript error boundaries don't catch the problem.
+- **Try production mode locally.** Running your app in **production mode** locally will show errors that normally wouldn't be thrown. To do so, you can run `npx expo start --no-dev --minify`. The `--no-dev` flag tells the server to run in production mode, and `--minify` is used to minify your code the same way it is for production JavaScript bundles.
+- **Check your crash reporting dashboard.** If you use [Sentry](/guides/using-sentry/), [BugSnag](/guides/using-bugsnag/), or a similar service, check for the crash there first. These services provide stack traces, device info, and reproduction context.
 
 ### App crashes on certain (older) devices
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-17363

As pointed out in the original task, the "Production errors" section in the runtime issues page mixed two concerns: viewing native logs (a general debugging technique) and handling production crashes (a specific scenario). This made the native log instructions harder to find for developers who weren't specifically debugging production issues. 

The section also lacked actionable steps for production crashes, instead of spreading relevant guidance (crash reporting dashboards, production mode testing) across disconnected paragraphs. (A problem identified while going through the doc myself, not part of the OG issue).

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Extract native log instructions (`adb logcat` and Console app) into a new "Viewing native logs" section placed before so they're discoverable as a general debugging tool, not just a production crash technique.
- Rewrite "Production app is crashing" as a concise checklist of actionable steps: check platform crash reports, use native log tools (linking back to the new section), try production mode locally, and check crash reporting dashboards (Sentry, BugSnag).
- Add an info callout near the top of the page linking to [Debugging tools](/debugging/tools/) for readers already familiar with React Native debugging.
- Minor copy improvements: clarify video title ("ADB Logcat" instead of just "Logcat"), fix "macOS" casing, improve alt text for the Console screenshot.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Visit the preview link, https://pr-43208.expo-docs.pages.dev/debugging/runtime-issues/, and manually verify:
- The new "Viewing native logs" section renders correctly with the video embed, Terminal component, and Step components.
- The "Production errors" section flows logically and links to the native logs section via the anchor `#viewing-native-logs`.
- All existing links (Google Play Console, Crashes Organizer, Apple docs, Sentry, BugSnag, WebADB) resolve correctly.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
