### PR TITLE
[core][Android] Improve accessing `internal_backingMap` of `ReactStylesDiffMap`

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/com/facebook/react/uimanager/ReactStylesDiffMapBackingFieldAccessor.java
+++ b/packages/expo-modules-core/android/src/main/java/com/facebook/react/uimanager/ReactStylesDiffMapBackingFieldAccessor.java
@@ -1,0 +1,12 @@
+package com.facebook.react.uimanager;
+
+import com.facebook.react.bridge.ReadableMap;
+
+/**
+ * Access the package private property declared inside of [ReactStylesDiffMap]
+ */
+public class ReactStylesDiffMapBackingFieldAccessor {
+  static ReadableMap getBackingMap(ReactStylesDiffMap diffMap) {
+    return diffMap.internal_backingMap();
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/com/facebook/react/uimanager/ReactStylesDiffMapHelper.kt
+++ b/packages/expo-modules-core/android/src/main/java/com/facebook/react/uimanager/ReactStylesDiffMapHelper.kt
@@ -1,25 +1,7 @@
 package com.facebook.react.uimanager
 
 import com.facebook.react.bridge.ReadableMap
-import expo.modules.core.interfaces.DoNotStrip
-import java.lang.reflect.Field
 
-@get:DoNotStrip
-private val backingMapField: Field by lazy {
-  ReactStylesDiffMap::class.java.getDeclaredField("backingMap").apply {
-    isAccessible = true
-  }
-}
-
-/**
- * Access the package private property declared inside of [ReactStylesDiffMap]
- * TODO: We should stop using this field and find a better way to access the backing map:
- * See: https://github.com/facebook/react-native/pull/51386
- */
 fun ReactStylesDiffMap.getBackingMap(): ReadableMap {
-  return try {
-    backingMapField.get(this) as ReadableMap
-  } catch (e: ReflectiveOperationException) {
-    throw RuntimeException("Unable to access internal_backingMap via reflection", e)
-  }
+  return ReactStylesDiffMapBackingFieldAccessor.getBackingMap(this)
 }


### PR DESCRIPTION
# Why

Improves accessing the `internal_backingMap` of the `ReactStylesDiffMap` by accessing it via Java instead of reflection. It also makes this code faster.

# Test Plan

- bare-expo ✅ 