### PR TITLE
[docs] Strip UI-only frontmatter fields from LLM markdown generation

### DIFF
--- a/docs/scripts/generate-markdown-pages-utils.test.ts
+++ b/docs/scripts/generate-markdown-pages-utils.test.ts
@@ -1378,6 +1378,34 @@ describe('extractFrontmatter', () => {
       path.join(tmpDir, 'no-frontmatter.mdx'),
       "import Foo from './Foo';\n\n# Hello\n"
     );
+
+    fs.writeFileSync(
+      path.join(tmpDir, 'ui-fields.mdx'),
+      [
+        '---',
+        'title: Camera',
+        'description: A camera component.',
+        'hideTOC: true',
+        'maxHeadingDepth: 4',
+        'hideFromSearch: true',
+        'hideInSidebar: true',
+        'sidebar_title: Cam',
+        'searchRank: 10',
+        'searchPosition: 5',
+        'hasVideoLink: true',
+        'isDeprecated: true',
+        'isAlpha: true',
+        '---',
+        '',
+        '# Camera',
+        '',
+      ].join('\n')
+    );
+
+    fs.writeFileSync(
+      path.join(tmpDir, 'only-ui-fields.mdx'),
+      '---\nhideTOC: true\nmaxHeadingDepth: 4\n---\n\n# Page\n'
+    );
   });
 
   afterAll(() => {
@@ -1419,6 +1447,30 @@ describe('extractFrontmatter', () => {
 
   it('returns null when no frontmatter exists', () => {
     const result = extractFrontmatter(path.join(tmpDir, 'no-frontmatter.mdx'));
+    expect(result).toBeNull();
+  });
+
+  it('strips UI-only fields and keeps semantic fields', () => {
+    const result = extractFrontmatter(path.join(tmpDir, 'ui-fields.mdx'));
+    expect(result).not.toBeNull();
+    // Semantic fields are preserved
+    expect(result).toContain('title: Camera');
+    expect(result).toContain('description: A camera component.');
+    expect(result).toContain('isDeprecated: true');
+    expect(result).toContain('isAlpha: true');
+    // UI-only fields are stripped
+    expect(result).not.toContain('hideTOC');
+    expect(result).not.toContain('maxHeadingDepth');
+    expect(result).not.toContain('hideFromSearch');
+    expect(result).not.toContain('hideInSidebar');
+    expect(result).not.toContain('sidebar_title');
+    expect(result).not.toContain('searchRank');
+    expect(result).not.toContain('searchPosition');
+    expect(result).not.toContain('hasVideoLink');
+  });
+
+  it('returns null when all fields are UI-only', () => {
+    const result = extractFrontmatter(path.join(tmpDir, 'only-ui-fields.mdx'));
     expect(result).toBeNull();
   });
 });

--- a/docs/scripts/generate-markdown-pages-utils.test.ts
+++ b/docs/scripts/generate-markdown-pages-utils.test.ts
@@ -1393,6 +1393,7 @@ describe('extractFrontmatter', () => {
         'searchRank: 10',
         'searchPosition: 5',
         'hasVideoLink: true',
+        'packageName: expo-camera',
         'isDeprecated: true',
         'isAlpha: true',
         '---',
@@ -1458,6 +1459,7 @@ describe('extractFrontmatter', () => {
     expect(result).toContain('description: A camera component.');
     expect(result).toContain('isDeprecated: true');
     expect(result).toContain('isAlpha: true');
+    expect(result).toContain('packageName: expo-camera');
     // UI-only fields are stripped
     expect(result).not.toContain('hideTOC');
     expect(result).not.toContain('maxHeadingDepth');

--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -26,6 +26,9 @@ export function findMdxSource(htmlPath: string, outDir: string, pagesDir: string
 /**
  * Frontmatter fields that only affect the docs website UI (sidebar, TOC, search ranking)
  * and carry no semantic value for LLM or MCP consumers. Stripped during markdown generation.
+ *
+ * Note: `packageName` is intentionally kept because the Expo docs MCP tool uses it
+ * to map pages to their npm packages.
  */
 const UI_ONLY_FRONTMATTER_FIELDS = new Set([
   'hideTOC',

--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -24,9 +24,24 @@ export function findMdxSource(htmlPath: string, outDir: string, pagesDir: string
 }
 
 /**
+ * Frontmatter fields that only affect the docs website UI (sidebar, TOC, search ranking)
+ * and carry no semantic value for LLM or MCP consumers. Stripped during markdown generation.
+ */
+const UI_ONLY_FRONTMATTER_FIELDS = new Set([
+  'hideTOC',
+  'maxHeadingDepth',
+  'hideFromSearch',
+  'hideInSidebar',
+  'sidebar_title',
+  'searchRank',
+  'searchPosition',
+  'hasVideoLink',
+]);
+
+/**
  * Extract the raw YAML frontmatter block (including --- delimiters) from an MDX file.
  * Strips lines with empty values (e.g. `modificationDate:` injected by append-dates.js
- * with no value in shallow CI clones).
+ * with no value in shallow CI clones) and UI-only fields that are irrelevant to LLM consumers.
  * Returns the frontmatter string with trailing newline, or null if no frontmatter found.
  */
 export function extractFrontmatter(mdxPath: string): string | null {
@@ -38,6 +53,10 @@ export function extractFrontmatter(mdxPath: string): string | null {
   const filtered = match[1]
     .split('\n')
     .filter(line => !/^\w+:\s*$/.test(line))
+    .filter(line => {
+      const key = line.match(/^(\w+):/)?.[1];
+      return !key || !UI_ONLY_FRONTMATTER_FIELDS.has(key);
+    })
     .join('\n');
   if (!filtered.trim()) {
     return null;


### PR DESCRIPTION
## Why

Fix ENG-19537



## How

- Added a `UI_ONLY_FRONTMATTER_FIELDS` set in `scripts/generate-markdown-pages-utils.ts` listing the 8 fields to strip: `hideTOC`, `maxHeadingDepth`, `hideFromSearch`, `hideInSidebar`, `sidebar_title`, `searchRank`, `searchPosition`, `hasVideoLink`.
- Added a second `.filter()` step in `extractFrontmatter()` that checks each YAML line's key against the set and drops matches.
- Added two test cases in `scripts/generate-markdown-pages-utils.test.ts`: one verifying UI-only fields are stripped while semantic fields (`isDeprecated`, `isAlpha`) are preserved, and one verifying that frontmatter containing only UI-only fields returns `null`.
- Semantic fields like `title`, `description`, `modificationDate`, `isDeprecated`, `isAlpha`, `isNew`, and `cliVersion` are preserved since they provide useful signals.

## Test Plan

Run `yarn run generate-markdown-pages` then `yarn run generate-llms`
- Verify that `llms-eas.txt`, `llms-full.txt`, and `llms-sdk.txt` no longer contain `hideTOC`, `maxHeadingDepth`, `sidebar_title`, `searchRank`, `searchPosition`, `hideFromSearch`, `hideInSidebar`, or `hasVideoLink` in frontmatter blocks. 
- Confirm that `title`, `description`, `modificationDate`, `isDeprecated`, `isAlpha`, and `isNew` are still present. 

<img width="1716" height="272" alt="CleanShot 2026-02-17 at 19 39 53@2x" src="https://github.com/user-attachments/assets/dcfa0a75-b147-41c7-af2a-f327a9f073c9" />

<img width="1356" height="304" alt="CleanShot 2026-02-17 at 19 40 23@2x" src="https://github.com/user-attachments/assets/66d100ac-dbcb-4bfe-9d53-fa9f7b735cbd" />

**Alternatively, you can run `yarn export` and `npx serve out`** and visit pages like "Create and use config plugins" and "Using existing credentials" and click View Markdown button on these pages. 

## Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
