### PR TITLE
fix(babel-preset-expo): strip loaders from server bundles

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Strip loaders from server bundles ([#43212](https://github.com/expo/expo/pull/43212) by [@hassankhan](https://github.com/hassankhan))
+
 ### 💡 Others
 
 ## 55.0.5 — 2026-02-16

--- a/packages/babel-preset-expo/build/server-data-loaders-plugin.js
+++ b/packages/babel-preset-expo/build/server-data-loaders-plugin.js
@@ -7,7 +7,6 @@ const LOADER_EXPORT_NAME = 'loader';
 function serverDataLoadersPlugin(api) {
     const { types: t } = api;
     const routerAbsoluteRoot = api.caller(common_1.getExpoRouterAbsoluteAppRoot);
-    const isServer = api.caller(common_1.getIsServer);
     const isLoaderBundle = api.caller(common_1.getIsLoaderBundle);
     return {
         name: 'expo-server-data-loaders',
@@ -26,11 +25,6 @@ function serverDataLoadersPlugin(api) {
                 path.remove();
             },
             ExportNamedDeclaration(path, state) {
-                // NOTE(@hassankhan): Server bundles currently preserve loaders for SSG, a followup is
-                // required to remove them.
-                if (isServer && !isLoaderBundle) {
-                    return;
-                }
                 // Early exit if file is not within the `app/` directory
                 if (!isInAppDirectory(state.file.opts.filename ?? '', routerAbsoluteRoot)) {
                     debug('Skipping file outside app directory:', state.file.opts.filename);

--- a/packages/babel-preset-expo/src/__tests__/server-data-loaders-plugin.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/server-data-loaders-plugin.test.ts
@@ -63,8 +63,10 @@ afterAll(() => {
   process.env = { ...originalEnv };
 });
 
+type BundleTypes = 'client' | 'server' | 'loader';
+
 type TransformTestOptions = Partial<typeof DEF_OPTIONS> & {
-  bundleType: 'client' | 'server' | 'loader';
+  bundleType: BundleTypes;
 };
 
 function transformTest(code: string, { bundleType, ...defaultOverrideOpts }: TransformTestOptions) {
@@ -91,11 +93,13 @@ function transformTest(code: string, { bundleType, ...defaultOverrideOpts }: Tra
   };
 }
 
-describe('client', () => {
-  describe('removes loader exports', () => {
-    it('removes `export async function loader() {}`', () => {
-      const res = transformTest(
-        `
+describe('client and server', () => {
+  describe.each(['client', 'server'])(
+    'removes loader exports for %s bundles',
+    (bundleType: BundleTypes) => {
+      it('removes `export async function loader() {}`', () => {
+        const res = transformTest(
+          `
       import { useLoaderData } from 'expo-router';
 
       export async function loader() {
@@ -107,26 +111,26 @@ describe('client', () => {
         return <div>{data.data}</div>;
       }
     `,
-        { bundleType: 'client' }
-      );
+          { bundleType }
+        );
 
-      expect(res.metadata.performConstantFolding).toBe(true);
-      expect(res.metadata.loaderReference).toBe('/app/index');
-      expect(res.code).toMatchInlineSnapshot(`
-      "import { useLoaderData } from 'expo-router';
-      import { jsx as _jsx } from "react/jsx-runtime";
-      export default function Index() {
-        const data = useLoaderData();
-        return /*#__PURE__*/_jsx("div", {
-          children: data.data
-        });
-      }"
-    `);
-    });
+        expect(res.metadata.performConstantFolding).toBe(true);
+        expect(res.metadata.loaderReference).toBe('/app/index');
+        expect(res.code).toMatchInlineSnapshot(`
+          "import { useLoaderData } from 'expo-router';
+          import { jsx as _jsx } from "react/jsx-runtime";
+          export default function Index() {
+            const data = useLoaderData();
+            return /*#__PURE__*/_jsx("div", {
+              children: data.data
+            });
+          }"
+      `);
+      });
 
-    it('removes `export function loader() {}`', () => {
-      const res = transformTest(
-        `
+      it('removes `export function loader() {}`', () => {
+        const res = transformTest(
+          `
       import { useLoaderData } from 'expo-router';
 
       export function loader() {
@@ -138,26 +142,26 @@ describe('client', () => {
         return <div>{data.data}</div>;
       }
     `,
-        { bundleType: 'client' }
-      );
+          { bundleType }
+        );
 
-      expect(res.metadata.performConstantFolding).toBe(true);
-      expect(res.metadata.loaderReference).toBe('/app/index');
-      expect(res.code).toMatchInlineSnapshot(`
-      "import { useLoaderData } from 'expo-router';
-      import { jsx as _jsx } from "react/jsx-runtime";
-      export default function Index() {
-        const data = useLoaderData();
-        return /*#__PURE__*/_jsx("div", {
-          children: data.data
-        });
-      }"
-    `);
-    });
+        expect(res.metadata.performConstantFolding).toBe(true);
+        expect(res.metadata.loaderReference).toBe('/app/index');
+        expect(res.code).toMatchInlineSnapshot(`
+              "import { useLoaderData } from 'expo-router';
+              import { jsx as _jsx } from "react/jsx-runtime";
+              export default function Index() {
+                const data = useLoaderData();
+                return /*#__PURE__*/_jsx("div", {
+                  children: data.data
+                });
+              }"
+          `);
+      });
 
-    it('removes `export const loader = async () => {}`', () => {
-      const res = transformTest(
-        `
+      it('removes `export const loader = async () => {}`', () => {
+        const res = transformTest(
+          `
       import { useLoaderData } from 'expo-router';
 
       export const loader = async () => {
@@ -169,26 +173,26 @@ describe('client', () => {
         return <div>{data.data}</div>;
       }
     `,
-        { bundleType: 'client' }
-      );
+          { bundleType }
+        );
 
-      expect(res.metadata.performConstantFolding).toBe(true);
-      expect(res.metadata.loaderReference).toBe('/app/index');
-      expect(res.code).toMatchInlineSnapshot(`
-      "import { useLoaderData } from 'expo-router';
-      import { jsx as _jsx } from "react/jsx-runtime";
-      export default function Index() {
-        const data = useLoaderData();
-        return /*#__PURE__*/_jsx("div", {
-          children: data.data
-        });
-      }"
-    `);
-    });
+        expect(res.metadata.performConstantFolding).toBe(true);
+        expect(res.metadata.loaderReference).toBe('/app/index');
+        expect(res.code).toMatchInlineSnapshot(`
+              "import { useLoaderData } from 'expo-router';
+              import { jsx as _jsx } from "react/jsx-runtime";
+              export default function Index() {
+                const data = useLoaderData();
+                return /*#__PURE__*/_jsx("div", {
+                  children: data.data
+                });
+              }"
+          `);
+      });
 
-    it('removes `export const loader = () => {}`', () => {
-      const res = transformTest(
-        `
+      it('removes `export const loader = () => {}`', () => {
+        const res = transformTest(
+          `
       import { useLoaderData } from 'expo-router';
 
       export const loader = () => {
@@ -200,26 +204,26 @@ describe('client', () => {
         return <div>{data.data}</div>;
       }
     `,
-        { bundleType: 'client' }
-      );
+          { bundleType }
+        );
 
-      expect(res.metadata.performConstantFolding).toBe(true);
-      expect(res.metadata.loaderReference).toBe('/app/index');
-      expect(res.code).toMatchInlineSnapshot(`
-      "import { useLoaderData } from 'expo-router';
-      import { jsx as _jsx } from "react/jsx-runtime";
-      export default function Index() {
-        const data = useLoaderData();
-        return /*#__PURE__*/_jsx("div", {
-          children: data.data
-        });
-      }"
-    `);
-    });
+        expect(res.metadata.performConstantFolding).toBe(true);
+        expect(res.metadata.loaderReference).toBe('/app/index');
+        expect(res.code).toMatchInlineSnapshot(`
+              "import { useLoaderData } from 'expo-router';
+              import { jsx as _jsx } from "react/jsx-runtime";
+              export default function Index() {
+                const data = useLoaderData();
+                return /*#__PURE__*/_jsx("div", {
+                  children: data.data
+                });
+              }"
+          `);
+      });
 
-    it('removes `export const loader = async function() {}`', () => {
-      const res = transformTest(
-        `
+      it('removes `export const loader = async function() {}`', () => {
+        const res = transformTest(
+          `
       import { useLoaderData } from 'expo-router';
 
       export const loader = async function() {
@@ -231,26 +235,26 @@ describe('client', () => {
         return <div>{data.data}</div>;
       }
     `,
-        { bundleType: 'client' }
-      );
+          { bundleType }
+        );
 
-      expect(res.metadata.performConstantFolding).toBe(true);
-      expect(res.metadata.loaderReference).toBe('/app/index');
-      expect(res.code).toMatchInlineSnapshot(`
-      "import { useLoaderData } from 'expo-router';
-      import { jsx as _jsx } from "react/jsx-runtime";
-      export default function Index() {
-        const data = useLoaderData();
-        return /*#__PURE__*/_jsx("div", {
-          children: data.data
-        });
-      }"
-    `);
-    });
+        expect(res.metadata.performConstantFolding).toBe(true);
+        expect(res.metadata.loaderReference).toBe('/app/index');
+        expect(res.code).toMatchInlineSnapshot(`
+              "import { useLoaderData } from 'expo-router';
+              import { jsx as _jsx } from "react/jsx-runtime";
+              export default function Index() {
+                const data = useLoaderData();
+                return /*#__PURE__*/_jsx("div", {
+                  children: data.data
+                });
+              }"
+          `);
+      });
 
-    it('removes `export const loader = function() {}`', () => {
-      const res = transformTest(
-        `
+      it('removes `export const loader = function() {}`', () => {
+        const res = transformTest(
+          `
       import { useLoaderData } from 'expo-router';
 
       export const loader = function() {
@@ -262,24 +266,27 @@ describe('client', () => {
         return <div>{data.data}</div>;
       }
     `,
-        { bundleType: 'client' }
-      );
+          { bundleType }
+        );
 
-      expect(res.metadata.performConstantFolding).toBe(true);
-      expect(res.metadata.loaderReference).toBe('/app/index');
-      expect(res.code).toMatchInlineSnapshot(`
-      "import { useLoaderData } from 'expo-router';
-      import { jsx as _jsx } from "react/jsx-runtime";
-      export default function Index() {
-        const data = useLoaderData();
-        return /*#__PURE__*/_jsx("div", {
-          children: data.data
-        });
-      }"
-    `);
-    });
-  });
+        expect(res.metadata.performConstantFolding).toBe(true);
+        expect(res.metadata.loaderReference).toBe('/app/index');
+        expect(res.code).toMatchInlineSnapshot(`
+              "import { useLoaderData } from 'expo-router';
+              import { jsx as _jsx } from "react/jsx-runtime";
+              export default function Index() {
+                const data = useLoaderData();
+                return /*#__PURE__*/_jsx("div", {
+                  children: data.data
+                });
+              }"
+          `);
+      });
+    }
+  );
+});
 
+describe('client', () => {
   describe('preserves non-loader exports', () => {
     it('preserves other named exports', () => {
       const res = transformTest(
@@ -303,18 +310,18 @@ describe('client', () => {
       expect(res.metadata.performConstantFolding).toBe(true);
       expect(res.metadata.loaderReference).toBe('/app/index');
       expect(res.code).toMatchInlineSnapshot(`
-      "import { useLoaderData } from 'expo-router';
-      import { jsx as _jsx } from "react/jsx-runtime";
-      export const unstable_settings = {
-        anchor: 'index'
-      };
-      export default function Index() {
-        const data = useLoaderData();
-        return /*#__PURE__*/_jsx("div", {
-          children: data.data
-        });
-      }"
-    `);
+        "import { useLoaderData } from 'expo-router';
+        import { jsx as _jsx } from "react/jsx-runtime";
+        export const unstable_settings = {
+          anchor: 'index'
+        };
+        export default function Index() {
+          const data = useLoaderData();
+          return /*#__PURE__*/_jsx("div", {
+            children: data.data
+          });
+        }"
+      `);
     });
 
     it('preserves multiple exports in same declaration', () => {
@@ -341,23 +348,23 @@ describe('client', () => {
       expect(res.metadata.performConstantFolding).toBe(true);
       expect(res.metadata.loaderReference).toBe('/app/index');
       expect(res.code).toMatchInlineSnapshot(`
-      "import { useLoaderData } from 'expo-router';
-      import { jsx as _jsx } from "react/jsx-runtime";
-      export const unstable_settings = {
-          anchor: 'index'
-        },
-        generateStaticParams = () => [{
-          id: '1'
-        }, {
-          id: '2'
-        }];
-      export default function Index() {
-        const data = useLoaderData();
-        return /*#__PURE__*/_jsx("div", {
-          children: data.data
-        });
-      }"
-    `);
+        "import { useLoaderData } from 'expo-router';
+        import { jsx as _jsx } from "react/jsx-runtime";
+        export const unstable_settings = {
+            anchor: 'index'
+          },
+          generateStaticParams = () => [{
+            id: '1'
+          }, {
+            id: '2'
+          }];
+        export default function Index() {
+          const data = useLoaderData();
+          return /*#__PURE__*/_jsx("div", {
+            children: data.data
+          });
+        }"
+      `);
     });
   });
 
@@ -375,13 +382,13 @@ describe('client', () => {
       expect(res.metadata.performConstantFolding).toBeUndefined();
       expect(res.metadata.loaderReference).toBeUndefined();
       expect(res.code).toMatchInlineSnapshot(`
-      "import { jsx as _jsx } from "react/jsx-runtime";
-      export default function Index() {
-        return /*#__PURE__*/_jsx("div", {
-          children: "Index"
-        });
-      }"
-    `);
+        "import { jsx as _jsx } from "react/jsx-runtime";
+        export default function Index() {
+          return /*#__PURE__*/_jsx("div", {
+            children: "Index"
+          });
+        }"
+      `);
     });
 
     it('handles files with only loader export', () => {
@@ -424,67 +431,29 @@ describe('client', () => {
 
       expect(res.metadata.performConstantFolding).toBeUndefined();
       expect(res.code).toMatchInlineSnapshot(`
-      "import { jsx as _jsx } from "react/jsx-runtime";
-      export function loader() {
-        return {
-          data: 'test'
-        };
-      }
-      function noop() {
-        return;
-      }
-      export function MyComponent() {
-        noop();
-        const data = loader();
-        return /*#__PURE__*/_jsx("div", {
-          children: data.data
-        });
-      }"
-    `);
+        "import { jsx as _jsx } from "react/jsx-runtime";
+        export function loader() {
+          return {
+            data: 'test'
+          };
+        }
+        function noop() {
+          return;
+        }
+        export function MyComponent() {
+          noop();
+          const data = loader();
+          return /*#__PURE__*/_jsx("div", {
+            children: data.data
+          });
+        }"
+      `);
     });
   });
 });
 
-// NOTE(@hassankhan): Server bundles preserve loaders for SSG. A followup is required to strip
-// loaders from server bundles.
 describe('server', () => {
   describe('preserves exports', () => {
-    it('preserves loader exports', () => {
-      const res = transformTest(
-        `
-      import { useLoaderData } from 'expo-router';
-
-      export async function loader() {
-        return { data: 'test' };
-      }
-
-      export default function Index() {
-        const data = useLoaderData();
-        return <div>{data.data}</div>;
-      }
-    `,
-        { bundleType: 'server' }
-      );
-
-      expect(res.metadata.performConstantFolding).toBeUndefined();
-      expect(res.metadata.loaderReference).toBeUndefined();
-      expect(res.code).toMatchInlineSnapshot(`
-      "import { useLoaderData } from 'expo-router';
-      import { jsx as _jsx } from "react/jsx-runtime";
-      export async function loader() {
-        return {
-          data: 'test'
-        };
-      }
-      export default function Index() {
-        const data = useLoaderData();
-        return /*#__PURE__*/_jsx("div", {
-          children: data.data
-        });
-      }"
-    `);
-    });
-
     it('preserves non-loader exports', () => {
       const res = transformTest(
         `
@@ -501,23 +470,19 @@ describe('server', () => {
         { bundleType: 'server' }
       );
 
-      expect(res.metadata.performConstantFolding).toBeUndefined();
+      expect(res.metadata.performConstantFolding).toBe(true);
+      expect(res.metadata.loaderReference).toBe('/app/index');
       expect(res.code).toMatchInlineSnapshot(`
-      "import { jsx as _jsx } from "react/jsx-runtime";
-      export async function loader() {
-        return {
-          data: 'test'
+        "import { jsx as _jsx } from "react/jsx-runtime";
+        export const unstable_settings = {
+          anchor: 'index'
         };
-      }
-      export const unstable_settings = {
-        anchor: 'index'
-      };
-      export default function Index() {
-        return /*#__PURE__*/_jsx("div", {
-          children: "Index"
-        });
-      }"
-    `);
+        export default function Index() {
+          return /*#__PURE__*/_jsx("div", {
+            children: "Index"
+          });
+        }"
+      `);
     });
   });
 });
@@ -544,13 +509,13 @@ describe('loader', () => {
       expect(res.metadata.performConstantFolding).toBe(true);
       expect(res.metadata.loaderReference).toBe('/app/index');
       expect(res.code).toMatchInlineSnapshot(`
-      "import { useLoaderData } from 'expo-router';
-      export async function loader() {
-        return {
-          data: 'test'
-        };
-      }"
-    `);
+        "import { useLoaderData } from 'expo-router';
+        export async function loader() {
+          return {
+            data: 'test'
+          };
+        }"
+      `);
     });
 
     it('removes other named exports in loader bundles', () => {
@@ -576,12 +541,12 @@ describe('loader', () => {
       expect(res.metadata.performConstantFolding).toBe(true);
       expect(res.metadata.loaderReference).toBe('/app/index');
       expect(res.code).toMatchInlineSnapshot(`
-      "export async function loader() {
-        return {
-          data: 'test'
-        };
-      }"
-    `);
+        "export async function loader() {
+          return {
+            data: 'test'
+          };
+        }"
+      `);
     });
   });
 
@@ -603,12 +568,12 @@ describe('loader', () => {
       expect(res.metadata.performConstantFolding).toBe(true);
       expect(res.metadata.loaderReference).toBe('/app/index');
       expect(res.code).toMatchInlineSnapshot(`
-      "export function loader() {
-        return {
-          data: 'test'
-        };
-      }"
-    `);
+        "export function loader() {
+          return {
+            data: 'test'
+          };
+        }"
+      `);
     });
 
     it('preserves loader const arrow function', () => {
@@ -628,12 +593,12 @@ describe('loader', () => {
       expect(res.metadata.performConstantFolding).toBe(true);
       expect(res.metadata.loaderReference).toBe('/app/index');
       expect(res.code).toMatchInlineSnapshot(`
-      "export const loader = async () => {
-        return {
-          data: 'test'
-        };
-      };"
-    `);
+        "export const loader = async () => {
+          return {
+            data: 'test'
+          };
+        };"
+      `);
     });
 
     it('preserves loader const function expression', () => {
@@ -653,12 +618,12 @@ describe('loader', () => {
       expect(res.metadata.performConstantFolding).toBe(true);
       expect(res.metadata.loaderReference).toBe('/app/index');
       expect(res.code).toMatchInlineSnapshot(`
-      "export const loader = function () {
-        return {
-          data: 'test'
-        };
-      };"
-    `);
+        "export const loader = function () {
+          return {
+            data: 'test'
+          };
+        };"
+      `);
     });
 
     it('extracts loader from multi-declaration export', () => {
@@ -682,12 +647,12 @@ describe('loader', () => {
       expect(res.metadata.performConstantFolding).toBe(true);
       expect(res.metadata.loaderReference).toBe('/app/index');
       expect(res.code).toMatchInlineSnapshot(`
-      "export const loader = async () => {
-        return {
-          data: 'test'
-        };
-      };"
-    `);
+        "export const loader = async () => {
+          return {
+            data: 'test'
+          };
+        };"
+      `);
     });
 
     it('preserves loader and its dependencies', () => {
@@ -716,22 +681,22 @@ describe('loader', () => {
       expect(res.metadata.performConstantFolding).toBe(true);
       expect(res.metadata.loaderReference).toBe('/app/index');
       expect(res.code).toMatchInlineSnapshot(`
-      "import { fetchData } from './api';
-      const CACHE_TTL = 3600;
-      async function getData(id) {
-        return fetchData(id, {
-          ttl: CACHE_TTL
-        });
-      }
-      export async function loader({
-        params
-      }) {
-        const data = await getData(params.id);
-        return {
-          data
-        };
-      }"
-    `);
+        "import { fetchData } from './api';
+        const CACHE_TTL = 3600;
+        async function getData(id) {
+          return fetchData(id, {
+            ttl: CACHE_TTL
+          });
+        }
+        export async function loader({
+          params
+        }) {
+          const data = await getData(params.id);
+          return {
+            data
+          };
+        }"
+      `);
     });
   });
 
@@ -771,18 +736,18 @@ describe('loader', () => {
       expect(res.metadata.performConstantFolding).toBeUndefined();
       expect(res.metadata.loaderReference).toBeUndefined();
       expect(res.code).toMatchInlineSnapshot(`
-      "import { jsx as _jsx } from "react/jsx-runtime";
-      export function loader() {
-        return {
-          data: 'test'
-        };
-      }
-      export default function MyComponent() {
-        return /*#__PURE__*/_jsx("div", {
-          children: "Component"
-        });
-      }"
-    `);
+        "import { jsx as _jsx } from "react/jsx-runtime";
+        export function loader() {
+          return {
+            data: 'test'
+          };
+        }
+        export default function MyComponent() {
+          return /*#__PURE__*/_jsx("div", {
+            children: "Component"
+          });
+        }"
+      `);
     });
   });
 });

--- a/packages/babel-preset-expo/src/server-data-loaders-plugin.ts
+++ b/packages/babel-preset-expo/src/server-data-loaders-plugin.ts
@@ -21,7 +21,6 @@ export function serverDataLoadersPlugin(api: ConfigAPI & typeof import('@babel/c
   const { types: t } = api;
 
   const routerAbsoluteRoot = api.caller(getExpoRouterAbsoluteAppRoot);
-  const isServer = api.caller(getIsServer);
   const isLoaderBundle = api.caller(getIsLoaderBundle);
 
   return {
@@ -44,12 +43,6 @@ export function serverDataLoadersPlugin(api: ConfigAPI & typeof import('@babel/c
       },
 
       ExportNamedDeclaration(path, state) {
-        // NOTE(@hassankhan): Server bundles currently preserve loaders for SSG, a followup is
-        // required to remove them.
-        if (isServer && !isLoaderBundle) {
-          return;
-        }
-
         // Early exit if file is not within the `app/` directory
         if (!isInAppDirectory(state.file.opts.filename ?? '', routerAbsoluteRoot)) {
           debug('Skipping file outside app directory:', state.file.opts.filename);


### PR DESCRIPTION
# Why

During development and for both SSG and SSR exports, loaders are bundled using the `isLoader: true` caller option, and are completely isolated from the main/server bundle. However, SSR bundles still included `loader` exports, as previously the SSG codepath still expected them to be in the server bundle when exporting.

# How

Removed an early return in the loaders' Babel plugin that skipped loader stripping for server bundles.

# Test Plan

- CI

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
