### PR TITLE
[ios][dev-launcher] Make network permission UI informational only

### DIFF
--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -197,13 +197,13 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
   };
 
 #if TARGET_OS_SIMULATOR
-  BOOL hasCompletedPermissionFlow = YES;
+  BOOL hasGrantedNetworkPermission = YES;
 #else
-  BOOL hasCompletedPermissionFlow = [[NSUserDefaults standardUserDefaults] boolForKey:@"expo.devlauncher.hasCompletedNetworkPermissionFlow"];
+  BOOL hasGrantedNetworkPermission = [[NSUserDefaults standardUserDefaults] boolForKey:@"expo.devlauncher.hasGrantedNetworkPermission"];
 #endif
 
   NSURL* initialUrl = [EXDevLauncherController initialUrlFromProcessInfo];
-  if (initialUrl && hasCompletedPermissionFlow) {
+  if (initialUrl && hasGrantedNetworkPermission) {
     [self loadApp:initialUrl withProjectUrl:nil onSuccess:nil onError:navigateToLauncher];
     return;
   }
@@ -211,7 +211,7 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
   NSNumber *devClientTryToLaunchLastBundleValue = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE"];
   BOOL shouldTryToLaunchLastOpenedBundle = (devClientTryToLaunchLastBundleValue != nil) ? [devClientTryToLaunchLastBundleValue boolValue] : YES;
 
-  if (!hasCompletedPermissionFlow) {
+  if (!hasGrantedNetworkPermission) {
     shouldTryToLaunchLastOpenedBundle = NO;
   }
   

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViews.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViews.swift
@@ -9,8 +9,8 @@ public struct DevLauncherRootView: View {
 
   init(viewModel: DevLauncherViewModel) {
     self.viewModel = viewModel
-    let shouldSkipPermissionFlow = Self.isSimulator 
-      || UserDefaults.standard.bool(forKey: "expo.devlauncher.hasCompletedNetworkPermissionFlow")
+    let shouldSkipPermissionFlow = Self.isSimulator
+      || UserDefaults.standard.bool(forKey: "expo.devlauncher.hasGrantedNetworkPermission")
     _hasCompletedPermissionFlow = State(initialValue: shouldSkipPermissionFlow)
   }
   
@@ -24,12 +24,9 @@ public struct DevLauncherRootView: View {
 
   public var body: some View {
     if !hasCompletedPermissionFlow {
-      LocalNetworkPermissionView(
-        viewModel: viewModel,
-        onPermissionGranted: {
-          hasCompletedPermissionFlow = true
-        }
-      )
+      LocalNetworkPermissionView {
+        hasCompletedPermissionFlow = true
+      }
     } else {
       mainContent
     }

--- a/packages/expo-dev-launcher/ios/SwiftUI/LocalNetworkPermissionView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/LocalNetworkPermissionView.swift
@@ -2,315 +2,76 @@
 
 import SwiftUI
 
-enum LocalNetworkPermissionStatus: Equatable, Sendable {
-  case unknown
-  case checking
-  case granted
-  case denied
-}
-
 struct LocalNetworkPermissionView: View {
-  @ObservedObject var viewModel: DevLauncherViewModel
-  let onPermissionGranted: () -> Void
-  @State private var isCheckingPermission = false
-  @State private var timeoutTask: Task<Void, Never>?
-  @State private var hasTimedOut = false
+  let onContinue: () -> Void
 
-  private var isLoading: Bool {
-    isCheckingPermission || viewModel.permissionStatus == .checking
-  }
-  
   var body: some View {
     VStack(spacing: 0) {
       Spacer()
-      
-      if hasTimedOut {
-        PermissionTimeoutView {
-          retryPermissionCheck()
-        } continueWithoutPermission: {
-          continueWithoutPermission()
+
+      VStack(spacing: 24) {
+        Image(systemName: "wifi")
+          .font(.system(size: 64))
+          .foregroundColor(.accentColor)
+
+        VStack(spacing: 12) {
+          Text("Find Dev Servers")
+            .font(.title)
+            .fontWeight(.bold)
+
+          Text("Expo Dev Launcher needs to access your local network to discover development servers running on your computer.")
+            .font(.body)
+            .foregroundColor(.secondary)
+            .multilineTextAlignment(.center)
         }
-      } else {
-        switch viewModel.permissionStatus {
-        case .unknown, .checking:
-          RequestPermissionView(isLoading: isLoading) {
-            triggerPermissionCheck()
-          }
-        case .granted:
-          ProgressView()
-        case .denied:
-          PermissionsDeniedView(appName: appName) {
-            openSettings()
-          } continueWithoutPermission: {
-            continueWithoutPermission()
-          }
+
+        HStack(alignment: .center, spacing: 8) {
+          Image(systemName: "info.circle")
+          Text("You'll see a system prompt asking for local network access.\nTap \"Allow\" to continue.")
+            .multilineTextAlignment(.center)
         }
-      }
-      
-      Spacer()
-      
-      Footer()
-    }
-    .padding(.horizontal, 24)
-    .padding(.vertical, 32)
-    .background(Color.expoSystemBackground)
-    .onDisappear {
-      timeoutTask?.cancel()
-      timeoutTask = nil
-    }
-    .onChange(of: viewModel.permissionStatus) { newStatus in
-      timeoutTask?.cancel()
-      timeoutTask = nil
+        .frame(maxWidth: .infinity)
+        .padding()
+        .background(Color.expoSecondarySystemBackground)
+        .cornerRadius(12)
+        .font(.callout)
+        .foregroundColor(.secondary)
 
-      if newStatus == .granted {
-        hasTimedOut = false
-        viewModel.markPermissionFlowCompleted()
-        onPermissionGranted()
-      } else if newStatus == .denied {
-        isCheckingPermission = false
-        hasTimedOut = false
-      }
-    }
-  }
-  
-  private var appName: String {
-    Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
-      ?? Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String
-      ?? "this app"
-  }
-  
-  private func triggerPermissionCheck() {
-    isCheckingPermission = true
-    hasTimedOut = false
-    viewModel.startDiscoveryForPermissionCheck()
-
-    timeoutTask?.cancel()
-    timeoutTask = Task {
-      do {
-        try await Task.sleep(nanoseconds: 15_000_000_000)
-        await MainActor.run {
-          if viewModel.permissionStatus == .checking {
-            hasTimedOut = true
-            isCheckingPermission = false
-            viewModel.stopServerDiscovery()
-            viewModel.permissionStatus = .unknown
-          }
-        }
-      } catch {}
-    }
-  }
-
-  private func retryPermissionCheck() {
-    hasTimedOut = false
-    triggerPermissionCheck()
-  }
-  
-  private func openSettings() {
-    #if os(iOS)
-    if let url = URL(string: UIApplication.openSettingsURLString) {
-      UIApplication.shared.open(url)
-    }
-    #endif
-  }
-  
-  private func continueWithoutPermission() {
-    viewModel.markPermissionFlowCompleted()
-    onPermissionGranted()
-  }
-}
-
-struct RequestPermissionView: View {
-  let isLoading: Bool
-  let triggerPermissionCheck: () -> Void
-
-  var body: some View {
-    VStack(spacing: 24) {
-      Image(systemName: "wifi")
-        .font(.system(size: 64))
-        .foregroundColor(.accentColor)
-      
-      VStack(spacing: 12) {
-        Text("Find Dev Servers")
-          .font(.title)
-          .fontWeight(.bold)
-        
-        Text("Expo Dev Launcher needs to access your local network to discover development servers running on your computer.")
-          .font(.body)
-          .foregroundColor(.secondary)
-          .multilineTextAlignment(.center)
-      }
-      
-      VStack(spacing: 8) {
-        Image(systemName: "info.circle")
-          .foregroundColor(.secondary)
-        Text("You'll see a system prompt asking for local network access. Tap \"Allow\" to continue.")
-          .font(.footnote)
-          .foregroundColor(.secondary)
-          .multilineTextAlignment(.center)
-      }
-      .padding()
-      .background(Color.expoSecondarySystemBackground)
-      .cornerRadius(12)
-      
-      Button {
-        triggerPermissionCheck()
-      } label: {
-        if isLoading {
-          ProgressView()
-            .progressViewStyle(CircularProgressViewStyle(tint: .white))
-            .frame(maxWidth: .infinity)
-            .padding()
-        } else {
+        Button {
+          onContinue()
+        } label: {
           Text("Continue")
             .fontWeight(.semibold)
             .frame(maxWidth: .infinity)
             .padding()
         }
-      }
-      .background(Color.accentColor)
-      .foregroundColor(.white)
-      .cornerRadius(12)
-      .disabled(isLoading)
-    }
-  }
-}
-
-struct PermissionsDeniedView: View {
-  let appName: String
-  let openSettings: () -> Void
-  let continueWithoutPermission: () -> Void
-  
-  var body: some View {
-    VStack(spacing: 24) {
-      Image(systemName: "wifi.slash")
-        .font(.system(size: 64))
-        .foregroundColor(.orange)
-      
-      VStack(spacing: 12) {
-        Text("Local Network Access Required")
-          .font(.title)
-          .fontWeight(.bold)
-        
-        Text("Without local network access, Dev Launcher can't find development servers on your network. You can still enter server URLs manually.")
-          .font(.body)
-          .foregroundColor(.secondary)
-          .multilineTextAlignment(.center)
-      }
-      
-      VStack(spacing: 12) {
-        Button {
-          openSettings()
-        } label: {
-          HStack {
-            Image(systemName: "gear")
-            Text("Open Settings")
-              .fontWeight(.semibold)
-          }
-          .frame(maxWidth: .infinity)
-          .padding()
-        }
         .background(Color.accentColor)
         .foregroundColor(.white)
         .cornerRadius(12)
-        
-        Button {
-          continueWithoutPermission()
-        } label: {
-          Text("Continue Without Discovery")
-            .fontWeight(.medium)
-            .frame(maxWidth: .infinity)
-            .padding()
-        }
-        .foregroundColor(.accentColor)
       }
-      
-      Text("To enable later: Settings → Privacy & Security → Local Network → \(appName)")
-        .font(.caption)
-        .foregroundColor(.secondary)
-        .multilineTextAlignment(.center)
-    }
-  }
-}
 
-struct PermissionTimeoutView: View {
-  let retryPermissionCheck: () -> Void
-  let continueWithoutPermission: () -> Void
-  
-  var body: some View {
-    VStack(spacing: 24) {
-      Image(systemName: "exclamationmark.triangle")
-        .font(.system(size: 64))
-        .foregroundColor(.orange)
+      Spacer()
 
-      VStack(spacing: 12) {
-        Text("Permission Check Timed Out")
-          .font(.title)
-          .fontWeight(.bold)
-
-        Text("The permission check is taking longer than expected. This might happen if you dismissed the system dialog or if there's a network issue.")
-          .font(.body)
+      VStack(spacing: 4) {
+        Text("Why is this needed?")
+          .font(.footnote)
+          .fontWeight(.medium)
+        Text("Dev servers advertise themselves on your local network using Bonjour. This permission allows the app to discover them automatically.")
+          .font(.caption)
           .foregroundColor(.secondary)
           .multilineTextAlignment(.center)
       }
-
-      VStack(spacing: 12) {
-        Button {
-          retryPermissionCheck()
-        }
-        label: {
-          HStack {
-            Image(systemName: "arrow.clockwise")
-            Text("Try Again")
-              .fontWeight(.semibold)
-          }
-          .frame(maxWidth: .infinity)
-          .padding()
-        }
-        .background(Color.accentColor)
-        .foregroundColor(.white)
-        .cornerRadius(12)
-
-        Button {
-          continueWithoutPermission()
-        }
-        label: {
-          Text("Continue Without Discovery")
-            .fontWeight(.medium)
-            .frame(maxWidth: .infinity)
-            .padding()
-        }
-        .foregroundColor(.accentColor)
-      }
-
-      Text("You can enable discovery later in Settings if needed.")
-        .font(.caption)
-        .foregroundColor(.secondary)
-        .multilineTextAlignment(.center)
     }
-  }
-}
-
-struct Footer: View {
-  var body: some View {
-    VStack(spacing: 4) {
-      Text("Why is this needed?")
-        .font(.footnote)
-        .fontWeight(.medium)
-      Text("Dev servers advertise themselves on your local network using Bonjour. This permission allows the app to discover them automatically.")
-        .font(.caption)
-        .foregroundColor(.secondary)
-        .multilineTextAlignment(.center)
-    }
+    .padding(.horizontal, 24)
+    .padding(.vertical, 32)
+    .background(Color.expoSystemBackground)
   }
 }
 
 #if DEBUG
 struct LocalNetworkPermissionView_Previews: PreviewProvider {
   static var previews: some View {
-    LocalNetworkPermissionView(
-      viewModel: DevLauncherViewModel(),
-      onPermissionGranted: {}
-    )
+    LocalNetworkPermissionView(onContinue: {})
   }
 }
 #endif

--- a/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
@@ -259,7 +259,7 @@ struct SettingsTabView: View {
         HStack {
           Text("First Launch Check")
           Spacer()
-          Text(viewModel.isFirstPermissionCheck ? "Pending" : "Completed")
+          Text(viewModel.hasGrantedNetworkPermission ? "Granted" : "Pending")
             .foregroundColor(.secondary)
         }
         .padding()
@@ -327,20 +327,18 @@ struct SettingsTabView: View {
   private func checkNetworkPermission() {
     isCheckingPermission = true
     permissionCheckResult = "Checking..."
-    viewModel.startDiscoveryForPermissionCheck()
+    viewModel.stopServerDiscovery()
+    viewModel.startServerDiscovery()
   }
-  
+
   private func updatePermissionResultFromStatus() {
     isCheckingPermission = false
-    switch viewModel.permissionStatus {
-    case .granted:
+    if viewModel.hasGrantedNetworkPermission {
       permissionCheckResult = "✅ Granted"
-    case .denied:
+    } else if viewModel.permissionStatus == .denied {
       permissionCheckResult = "❌ Denied"
-    case .unknown:
+    } else {
       permissionCheckResult = "⚠️ Unknown"
-    case .checking:
-      permissionCheckResult = "🔄 Checking"
     }
   }
 


### PR DESCRIPTION
# Why
Originally, I wanted to trigger the network permissions prompt after the user tapped the continue button, but due to the lack of an api and how this prompt works, there was a number of issues with this.

- NWBrowser.ready doesn't mean permission was granted
- No way to distinguish "already granted" from "never asked"
- If an existing app without dev launcher already accepted the permissions, after installing dev launcher, the permissions ui would get stuck on screen waiting for a response that would not arrive.

# How
Simplify the approach. `startServerDiscovery` will automatically trigger the prompt when it starts. The permissions UI just explains to the user that this is about to happen and why it's needed. 

# Test Plan
Sandbox
- Clean install with dev launcher ✅
- Deny permission and enable from ios settings ✅
- Install app without dev launcher, accept permission, install dev launcher. We still show the permission UI in this case but we can't avoid it as we have no way to query the current state. Once dismissed, bonjour discovery works as normal and it won't show again ✅
