### PR TITLE
[dev-launcher] fix crash when disabling notification permissions

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [android] fixed crash when returning from notification settings after disabling notification permissions
+- [android] fixed crash when returning from notification settings after disabling notification permissions ([#43217](https://github.com/expo/expo/pull/43217) by [@vonovak](https://github.com/vonovak))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [android] fixed crash when returning from notification settings after disabling notification permissions
+
 ### 💡 Others
 
 ## 55.0.7 — 2026-02-16

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/react/activitydelegates/DevLauncherReactActivityNOPDelegate.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/react/activitydelegates/DevLauncherReactActivityNOPDelegate.kt
@@ -16,6 +16,7 @@ open class DevLauncherReactActivityNOPDelegate(activity: ReactActivity) :
   override fun onNewIntent(intent: Intent?): Boolean = true
   override fun onBackPressed(): Boolean = true
   override fun onWindowFocusChanged(hasFocus: Boolean) {}
+  override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {}
   override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {}
   override fun onConfigurationChanged(newConfig: Configuration) {}
 }


### PR DESCRIPTION
# Why

Fixed a crash on Android when users return to the app after disabling notification permissions in the system settings.

closes #34814 (development-only crash)

# How

Added the missing `onActivityResult` method implementation in the `DevLauncherReactActivityNOPDelegate` class to properly handle the activity result when returning from notification settings.

When using `IntentLauncher.startActivityAsync` with `APP_NOTIFICATION_SETTINGS` and the user  toggles notification permissions, Android kills the app process. When the user navigates back, Android recreates the activity in a new process and delivers the pending `onActivityResult`. In dev builds, `expo-dev-launcher` resets to LAUNCHER mode (in-memory state is lost), so the `DevLauncherReactActivityNOPDelegate` is used. This delegate overrides every lifecycle method as a no-op — except `onActivityResult`, which falls through to `ReactActivityDelegate.onActivityResult` where mReactDelegate is null, causing an NPE crash.

# Test Plan

- bare expo using repro from the issue

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).