### PR TITLE
[create-expo-module] Allow specifying auth token for third-party registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 📚 3rd party library updates
 
-- **`create-expo-module`**
-  - Allow specifying authentication token for third party npm registries
-
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 📚 3rd party library updates
 
+- **`create-expo-module`**
+  - Allow specifying authentication token for third party npm registries
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/packages/create-expo-module/CHANGELOG.md
+++ b/packages/create-expo-module/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unpublished
+
+- Allow specifying authentication token for third party npm registries

--- a/packages/create-expo-module/CHANGELOG.md
+++ b/packages/create-expo-module/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## Unpublished
 
-- Allow specifying authentication token for third party npm registries
+- Allow specifying authentication token for third party npm registries ([#43219](https://github.com/expo/expo/pull/43219) by [@rliljest](https://github.com/rliljest))

--- a/packages/create-expo-module/src/create-expo-module.ts
+++ b/packages/create-expo-module/src/create-expo-module.ts
@@ -111,7 +111,7 @@ async function main(target: string | undefined, options: CommandOptions) {
   const packageManager = resolvePackageManager();
   const packagePath = options.source
     ? path.join(CWD, options.source)
-    : await downloadPackageAsync(targetDir, options.local);
+    : await downloadPackageAsync(targetDir, options.local, options.authToken);
 
   await logEventAsync(eventCreateExpoModule(packageManager, options));
 
@@ -251,15 +251,21 @@ async function getTemplateVersion(isLocal: boolean) {
 /**
  * Downloads the template from NPM registry.
  */
-async function downloadPackageAsync(targetDir: string, isLocal = false): Promise<string> {
+async function downloadPackageAsync(targetDir: string, isLocal = false, authToken?: string): Promise<string> {
   return await newStep('Downloading module template from npm', async (step) => {
     const templateVersion = await getTemplateVersion(isLocal);
     const packageName = isLocal ? 'expo-module-template-local' : 'expo-module-template';
+    const getOpts = authToken ? {
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+      },
+    } : undefined
 
     try {
       await downloadAndExtractTarball({
         url: await getNpmTarballUrl(packageName, templateVersion),
         dir: targetDir,
+        getOpts,
       });
     } catch {
       console.log();
@@ -271,6 +277,7 @@ async function downloadPackageAsync(targetDir: string, isLocal = false): Promise
       await downloadAndExtractTarball({
         url: await getNpmTarballUrl(packageName, 'latest'),
         dir: targetDir,
+        getOpts,
       });
     }
 
@@ -499,6 +506,10 @@ program
     '--local',
     'Whether to create a local module in the current project, skipping installing node_modules and creating the example directory.',
     false
+  )
+  .option(
+    '--auth-token <string>',
+    'Use a specific authentication token when connecting to the registry, typically only needed for third-party registries'
   )
   .action(main);
 

--- a/packages/create-expo-module/src/telemetry.ts
+++ b/packages/create-expo-module/src/telemetry.ts
@@ -122,6 +122,7 @@ export function eventCreateExpoModule(packageManager: string, options: CommandOp
       withChangelog: options.withChangelog,
       withExample: options.example,
       local: !!options.local,
+      authToken: options.authToken ? '[TOKEN]' : undefined,
     },
   };
 }

--- a/packages/create-expo-module/src/types.ts
+++ b/packages/create-expo-module/src/types.ts
@@ -10,6 +10,7 @@ export type CommandOptions = {
   withChangelog: boolean;
   example: boolean;
   local: boolean;
+  authToken?: string;
 };
 
 /**


### PR DESCRIPTION
# Why

In some enterprise environments, we are blocked from using npmjs directly and are required to use a third-party registry that may require authentication. Currently there is no way to run `create-expo-app` and provide an authentication token, so `create-expo-app` cannot be used in environments that require authentication for downloading tarballs

# How

I extended the cli arguments to allow an `--auth-token` argument, and if provided it will pass that as the `Authorization: Bearer ...` header when attempting to download tarballs from the registry.

This is very similar to another [pull request](https://github.com/react-native-community/cli/pull/2721) that I put together for [react-native-community/cli](https://github.com/react-native-community/cli)

# Test Plan

I ran these changes locally in my environment, which uses a third-party registry that requires authentication. Unfortunately I'm not aware of publicly available third-party registries that can be used that require authentication

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
