### PR TITLE
[docs] Add EAS CLI installation link to EAS intro/overview pages

### DIFF
--- a/docs/pages/build/introduction.mdx
+++ b/docs/pages/build/introduction.mdx
@@ -19,6 +19,8 @@ EAS Build is also designed to work for any native project, whether or not you us
 
 ## Quick start
 
+> **info** The `eas` commands below require EAS CLI. See [How to install EAS CLI](/eas/cli/#installation) for more information.
+
 To build your app, run the following command:
 
 <Terminal cmd={['$ eas build --platform all']} />

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -21,9 +21,14 @@ EAS Update makes fixing small bugs and pushing quick fixes a snap in between app
 
 ## Quick start
 
+> **info** The `eas` commands below require EAS CLI. See [How to install EAS CLI](/eas/cli/#installation) for more information.
+
 Install the `expo-updates` library and configure EAS Update:
 
-<Terminal cmd={['$ npx expo install expo-updates', '', '$ eas update:configure']} />
+<Terminal
+  cmd={['$ npx expo install expo-updates', '', '$ eas update:configure']}
+  cmdCopy="npx expo install expo-updates && eas update:configure"
+/>
 
 You need to create a new build for Android or iOS to include the `expo-updates` library in your build. After that, you can push an update to the production channel:
 

--- a/docs/pages/eas/hosting/introduction.mdx
+++ b/docs/pages/eas/hosting/introduction.mdx
@@ -18,6 +18,8 @@ EAS Hosting offers the fastest path from `npx create-expo-app` to a fully deploy
 
 ## Quick start
 
+> **info** The `eas` commands below require EAS CLI. See [How to install EAS CLI](/eas/cli/#installation) for more information.
+
 To deploy your web app, you need to create a static build of your web project. Run the following command to export your web project into a **dist** directory:
 
 <Terminal cmd={['$ npx expo export --platform web']} />

--- a/docs/pages/eas/metadata/index.mdx
+++ b/docs/pages/eas/metadata/index.mdx
@@ -21,6 +21,8 @@ EAS Metadata uses a [**store.config.json**](/eas/metadata/config/#static-store-c
 
 ## Quick start
 
+> **info** The `eas` commands below require EAS CLI. See [How to install EAS CLI](/eas/cli/#installation) for more information.
+
 You can push the store config to the app stores by running the following command:
 
 <Terminal cmd={['$ eas metadata:push']} />

--- a/docs/pages/eas/workflows/introduction.mdx
+++ b/docs/pages/eas/workflows/introduction.mdx
@@ -28,9 +28,11 @@ EAS Workflows run in managed cloud environments with pre-packaged job types desi
 
 ## Quick start
 
+> **info** The `eas` commands below require EAS CLI. See [How to install EAS CLI](/eas/cli/#installation) for more information.
+
 Workflows are defined as YAML files in the **.eas/workflows/** directory at the root of your project. Each file specifies a `name`, optional triggers (`on`), and one or more `jobs` that run in the cloud. You can run a workflow with EAS CLI with the following command:
 
-<Terminal cmd={['$ npx eas-cli@latest workflow:run .eas/workflows/your-workflow.yml']} />
+<Terminal cmd={['$ eas workflow:run .eas/workflows/your-workflow.yml']} />
 
 ## Key features
 

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -21,6 +21,8 @@ EAS Submit works with apps built with [EAS Build](/build/introduction/) or local
 
 ## Quick start
 
+> **info** The `eas` commands below require EAS CLI. See [How to install EAS CLI](/eas/cli/#installation) for more information.
+
 Submit an Android build:
 
 <Terminal cmd={['$ eas submit --platform android']} />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-19540

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add an info callout to the Quick Start section of 6 EAS introduction/overview pages linking to the EAS CLI installation section: build/introduction, submit/introduction, eas-update/introduction, eas/metadata/index, eas/hosting/introduction, eas/workflows/introduction.
- Revert `npx eas-cli@latest workflow:run` to `eas workflow:run` on the EAS Workflows introduction page for consistency with the link-based approach.
- Add `cmdCopy` prop to the multi-command `<Terminal>` on the EAS Update introduction page so the copy button produces a runnable command.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Visit each of the 6 modified pages in local dev (`yarn run dev`) and confirm the info callout renders correctly under the Quick Start heading with a working link to /eas/cli/#installation.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
