### PR TITLE
[docs] Fix lint for Windows

### DIFF
--- a/docs/scripts/lint.js
+++ b/docs/scripts/lint.js
@@ -21,7 +21,10 @@ const eslintArgs = [
 function runTsc() {
   return new Promise(resolve => {
     const chunks = [];
-    const proc = spawn('tsc', ['--noEmit', '--pretty'], { stdio: ['ignore', 'pipe', 'pipe'] });
+    const proc = spawn('tsc', ['--noEmit', '--pretty'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: true,
+    });
     proc.stdout.on('data', d => chunks.push(d));
     proc.stderr.on('data', d => chunks.push(d));
     proc.on('close', status => {
@@ -34,6 +37,7 @@ function runTsc() {
 function runEslint() {
   const { status, stderr } = spawnSync('eslint', eslintArgs, {
     stdio: ['inherit', 'inherit', 'pipe'],
+    shell: true,
   });
 
   // If ESLint fails with a fatal error, the cache may be stale. Clear it and retry once.
@@ -44,6 +48,7 @@ function runEslint() {
     } catch {}
     const retry = spawnSync('eslint', eslintArgs, {
       stdio: ['inherit', 'inherit', 'pipe'],
+      shell: true,
     });
     return { status: retry.status, stderr: retry.stderr };
   }


### PR DESCRIPTION
# Why

Resolves ENG-18267

`yarn lint` on Windows errors for the docs site.

<img width="470" height="230" alt="image" src="https://github.com/user-attachments/assets/2632222e-b6ed-4877-aae2-53858cb3bf72" />



This is because `scripts/lint.js` uses `spawn('tsc', ...)` and `spawnSync('eslint', ...)` without `shell: true`.

On Windows, Node's spawn cannot resolve `.cmd` shims (like `tsc.cmd` and `eslint.cmd` in `node_modules/.bin`) without a shell. On macOS/Linux this works fine because the binaries are plain scripts with shebangs, but on Windows they're `.cmd` wrappers that require a shell to execute.                                                           

# How

Added shell: true to all three spawn calls in `scripts/lint.js`

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Run `yarn lint` on Windows to verify it no longer errors

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
