### PR TITLE
[docs] clarify update system boundaries

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -550,6 +550,7 @@ export const eas = [
       makePage('eas-update/how-it-works.mdx'),
       makePage('eas-update/eas-cli.mdx'),
       makePage('eas-update/runtime-versions.mdx'),
+      makePage('eas-update/system-boundaries.mdx'),
     ]),
     makeGroup('Troubleshooting', [
       makePage('eas-update/debug.mdx'),

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -93,6 +93,8 @@ App Store rules regularly change and just as you need to follow them if you were
 
 EAS Update is a great way to quickly deliver improvements to the people who use your apps. For example, consider an app that has a critical bug that needs to be fixed. With EAS Update, you can quickly get the fix out and later follow up with a new submission that includes the fix built in.
 
+For more information, see [store policies for interpreted code](/faq/#what-are-the-store-policies-regarding-interpreted-code) and the [system boundaries of EAS Update](/eas-update/system-boundaries/).
+
 </Collapsible>
 
 <Collapsible summary={<>How are "monthly active users" counted for a billing cycle?</>}>

--- a/docs/pages/eas-update/system-boundaries.mdx
+++ b/docs/pages/eas-update/system-boundaries.mdx
@@ -6,7 +6,7 @@ description: Learn about the key constraints of the EAS Update system.
 EAS Update provides JavaScript, images, fonts, and other assets to your app. It does not change the self-contained contents of your native app and its signed binary, which include:
 
 - Native modules included in the binary
-- Platform entitlements and provisioning
+- Platform entitlements and provisioning profiles
 - Declared system permissions
 - Compiled frameworks and native code
 - Background modes and OS-level capabilities

--- a/docs/pages/eas-update/system-boundaries.mdx
+++ b/docs/pages/eas-update/system-boundaries.mdx
@@ -30,7 +30,7 @@ Updates do not:
 - Replace the JavaScript engine
 - Modify system capabilities
 
-Hermes bytecode is simply an optimized format of JavaScript that improves startup performance. It runs within the same runtime boundaries as standard JavaScript.
+Hermes bytecode is an optimized format of JavaScript that improves startup performance. It runs within the same runtime boundaries as standard JavaScript.
 
 ## Native compatibility
 

--- a/docs/pages/eas-update/system-boundaries.mdx
+++ b/docs/pages/eas-update/system-boundaries.mdx
@@ -3,13 +3,15 @@ title: System boundaries
 description: Learn about the key constraints of the EAS Update system.
 ---
 
-EAS Update changes only runtime JavaScript and static assets. It does not modify the compiled native binary. The following parts of your app are fixed at build time and cannot be changed through updates:
+EAS Update delivers changes to your app's runtime JavaScript and update-downloaded assets (images, fonts, etc.). It does not change anything that's embedded in the signed native app binary, which includes:
 
 - Native modules included in the binary
 - Platform entitlements and provisioning
 - Declared system permissions
 - Compiled frameworks and native code
 - Background modes and OS-level capabilities
+- App identity and embedded configuration (bundle ID/package name, app name/short name, URL schemes/deep-link schemes)
+- Store-facing, build-time resources (app icon, launch screen/splash screen)
 
 Updates always run inside the runtime environment defined by the original binary.
 
@@ -39,3 +41,5 @@ Each [EAS Build](/build/introduction/) is associated with a specific native runt
 - The capabilities declared at build time
 
 If you need to change native functionality, you must create a new build.
+
+You can use [Expo Fingerprint](/versions/latest/sdk/fingerprint) to track whether changes in your project affect the native runtime (for example, adding/removing native dependencies or changing native configuration). When the fingerprint changes, it’s a strong signal you should produce a new build rather than shipping an update.

--- a/docs/pages/eas-update/system-boundaries.mdx
+++ b/docs/pages/eas-update/system-boundaries.mdx
@@ -26,7 +26,7 @@ In both cases, the code runs inside the JavaScript engine that was compiled into
 
 Updates do not:
 
-- Introduce native code
+- Introduce native code or access to native APIs
 - Replace the JavaScript engine
 - Modify system capabilities
 

--- a/docs/pages/eas-update/system-boundaries.mdx
+++ b/docs/pages/eas-update/system-boundaries.mdx
@@ -1,0 +1,41 @@
+---
+title: System boundaries
+description: Learn about the key constraints of the EAS Update system
+---
+
+EAS Update changes only runtime JavaScript and static assets. It does not modify the compiled native binary. The following parts of your app are fixed at build time and cannot be changed through updates:
+
+- Native modules included in the binary
+- Platform entitlements and provisioning
+- Declared system permissions
+- Compiled frameworks and native code
+- Background modes and OS-level capabilities
+
+Updates always run inside the runtime environment defined by the original binary.
+
+## JavaScript and Hermes Bytecode
+
+Updates may be delivered as:
+
+- Javascript source code, or
+- Javascript bytecode for the [Hermes engine](https://reactnative.dev/docs/hermes)
+
+In both cases, the code runs inside the JavaScript engine that was compiled into the app at build time.
+
+Updates do not:
+
+- Introduce native code
+- Replace the JavaScript engine
+- Modify system capabilities
+
+Hermes bytecode is simply an optimized format of Javascript that improves startup performance. It runs within the same runtime boundaries as standard JavaScript.
+
+## **Native Compatibility**
+
+Each build is associated with a specific native runtime. Updates must stay compatible with:
+
+- The native modules included in the binary
+- The APIs those modules expose
+- The capabilities declared at build time
+
+If you need to change native functionality, you must create a new build.

--- a/docs/pages/eas-update/system-boundaries.mdx
+++ b/docs/pages/eas-update/system-boundaries.mdx
@@ -42,4 +42,4 @@ Each [EAS Build](/build/introduction/) is associated with a specific native runt
 
 If you need to change native functionality, you must create a new build.
 
-You can use [Expo Fingerprint](/versions/latest/sdk/fingerprint) to track whether changes in your project affect the native runtime (for example, adding/removing native dependencies or changing native configuration). When the fingerprint changes, it’s a strong signal you should produce a new build rather than shipping an update.
+You can use [Expo Fingerprint](/versions/latest/sdk/fingerprint) to track whether changes in your project affect the native runtime (for example, adding or removing native dependencies or changing native configuration). When the fingerprint changes, it's a strong signal you should create and publish a new build of your app.

--- a/docs/pages/eas-update/system-boundaries.mdx
+++ b/docs/pages/eas-update/system-boundaries.mdx
@@ -1,6 +1,6 @@
 ---
 title: System boundaries
-description: Learn about the key constraints of the EAS Update system
+description: Learn about the key constraints of the EAS Update system.
 ---
 
 EAS Update changes only runtime JavaScript and static assets. It does not modify the compiled native binary. The following parts of your app are fixed at build time and cannot be changed through updates:

--- a/docs/pages/eas-update/system-boundaries.mdx
+++ b/docs/pages/eas-update/system-boundaries.mdx
@@ -17,7 +17,7 @@ Updates always run inside the runtime environment defined by the original binary
 
 ## JavaScript and Hermes Bytecode
 
-Updates may be delivered as:
+Apps may run:
 
 - JavaScript source code
 - JavaScript bytecode for the [Hermes engine](https://reactnative.dev/docs/hermes)

--- a/docs/pages/eas-update/system-boundaries.mdx
+++ b/docs/pages/eas-update/system-boundaries.mdx
@@ -17,7 +17,7 @@ Updates always run inside the runtime environment defined by the original binary
 
 Updates may be delivered as:
 
-- Javascript source code, or
+- JavaScript source code
 - Javascript bytecode for the [Hermes engine](https://reactnative.dev/docs/hermes)
 
 In both cases, the code runs inside the JavaScript engine that was compiled into the app at build time.
@@ -30,9 +30,9 @@ Updates do not:
 
 Hermes bytecode is simply an optimized format of Javascript that improves startup performance. It runs within the same runtime boundaries as standard JavaScript.
 
-## **Native Compatibility**
+## Native compatibility
 
-Each build is associated with a specific native runtime. Updates must stay compatible with:
+Each [EAS Build](/build/introduction/) is associated with a specific native runtime. Updates must stay compatible with:
 
 - The native modules included in the binary
 - The APIs those modules expose

--- a/docs/pages/eas-update/system-boundaries.mdx
+++ b/docs/pages/eas-update/system-boundaries.mdx
@@ -10,7 +10,7 @@ EAS Update provides JavaScript, images, fonts, and other assets to your app. It 
 - Declared system permissions
 - Compiled frameworks and native code
 - Background modes and OS-level capabilities
-- App identity and embedded configuration (bundle ID/package name, app name/short name, URL schemes/deep-link schemes)
+- App identity and embedded configuration (application ID, app name, URL schemes)
 - Build-time resources (app icon, launch screen)
 
 Updates always run inside the runtime environment defined by the original binary.

--- a/docs/pages/eas-update/system-boundaries.mdx
+++ b/docs/pages/eas-update/system-boundaries.mdx
@@ -18,7 +18,7 @@ Updates always run inside the runtime environment defined by the original binary
 Updates may be delivered as:
 
 - JavaScript source code
-- Javascript bytecode for the [Hermes engine](https://reactnative.dev/docs/hermes)
+- JavaScript bytecode for the [Hermes engine](https://reactnative.dev/docs/hermes)
 
 In both cases, the code runs inside the JavaScript engine that was compiled into the app at build time.
 
@@ -28,7 +28,7 @@ Updates do not:
 - Replace the JavaScript engine
 - Modify system capabilities
 
-Hermes bytecode is simply an optimized format of Javascript that improves startup performance. It runs within the same runtime boundaries as standard JavaScript.
+Hermes bytecode is simply an optimized format of JavaScript that improves startup performance. It runs within the same runtime boundaries as standard JavaScript.
 
 ## Native compatibility
 

--- a/docs/pages/eas-update/system-boundaries.mdx
+++ b/docs/pages/eas-update/system-boundaries.mdx
@@ -3,7 +3,7 @@ title: System boundaries
 description: Learn about the key constraints of the EAS Update system.
 ---
 
-EAS Update delivers changes to your app's runtime JavaScript and update-downloaded assets (images, fonts, etc.). It does not change anything that's embedded in the signed native app binary, which includes:
+EAS Update provides JavaScript, images, fonts, and other assets to your app. It does not change the self-contained contents of your native app and its signed binary, which include:
 
 - Native modules included in the binary
 - Platform entitlements and provisioning

--- a/docs/pages/eas-update/system-boundaries.mdx
+++ b/docs/pages/eas-update/system-boundaries.mdx
@@ -11,7 +11,7 @@ EAS Update provides JavaScript, images, fonts, and other assets to your app. It 
 - Compiled frameworks and native code
 - Background modes and OS-level capabilities
 - App identity and embedded configuration (bundle ID/package name, app name/short name, URL schemes/deep-link schemes)
-- Store-facing, build-time resources (app icon, launch screen/splash screen)
+- Build-time resources (app icon, launch screen)
 
 Updates always run inside the runtime environment defined by the original binary.
 


### PR DESCRIPTION
# Why

Add documentation about the system boundaries of EAS Update to clarify what can and cannot be changed through updates.

# How

- Added a new page `system-boundaries.mdx` that explains the limitations of EAS Update
- Added the new page to the navigation menu under the EAS Update section
- Added a reference to the new page from the introduction page

# Test Plan

Run `yarn dev`:
- Verified the new page appears in the navigation menu (http://localhost:3002/eas-update/system-boundaries/)
- Checked that the link from the introduction page works correctly (http://localhost:3002/eas-update/introduction/#frequently-asked-questions-faq)

# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)