### PR TITLE
[ci] add summary output to platform change detection workflow

### DIFF
--- a/.github/actions/detect-platform-change/action.yml
+++ b/.github/actions/detect-platform-change/action.yml
@@ -41,3 +41,14 @@ runs:
           ios: [ ${{ inputs.ios-paths }}, ${{ inputs.shared-ignores }} ]
           android: [ ${{ inputs.android-paths }}, ${{ inputs.shared-ignores }} ]
           common: [ ${{ inputs.common-paths }}, ${{ inputs.shared-ignores }} ]
+    - name: 📋 Print detection summary
+      shell: bash
+      run: |
+        echo "### Platform detection results"
+        echo ""
+        echo "**iOS-specific changed files:** ${{ steps.changes.outputs.ios_all_changed_files || '(none)' }}"
+        echo "**Android-specific changed files:** ${{ steps.changes.outputs.android_all_changed_files || '(none)' }}"
+        echo "**Common changed files:** ${{ steps.changes.outputs.common_all_changed_files || '(none)' }}"
+        echo ""
+        echo "**should_run_ios:** ${{ steps.changes.outputs.ios_any_changed == 'true' || steps.changes.outputs.common_any_changed == 'true' }}"
+        echo "**should_run_android:** ${{ steps.changes.outputs.android_any_changed == 'true' || steps.changes.outputs.common_any_changed == 'true' }}"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [main, 'sdk-*']
     paths:
+      - .github/actions/detect-platform-change/action.yml
       - .github/workflows/test-suite.yml
       - .github/actions/use-android-emulator/action.yml
       - apps/bare-expo/**
@@ -17,6 +18,7 @@ on:
       - '!**/__mocks__/**'
   pull_request:
     paths:
+      - .github/actions/detect-platform-change/action.yml
       - .github/workflows/test-suite.yml
       - .github/actions/use-android-emulator/action.yml
       - apps/bare-expo/**


### PR DESCRIPTION
# Why

Add a summary step to the platform change detection action to make it easier to understand which files were changed and whether iOS or Android builds should run.

# How

Added a new step to the platform change detection action that prints a summary of the detection results.

This makes it easier to debug and understand the platform detection logic in GitHub Actions workflows.

# Test Plan

- ci

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)