### PR TITLE
[core][Android] Remove `takeIfInstanceOf`

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/utilities/KotlinUtilities.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/utilities/KotlinUtilities.kt
@@ -10,14 +10,3 @@ package expo.modules.core.utilities
  * ```
  */
 inline fun <T> T?.ifNull(block: () -> T): T = this ?: block()
-
-/**
- * If the receiver is instance of `T`, returns the receiver, otherwise returns `null`
- *
- * Works the same as the `as?` operator, but allows method chaining without parentheses:
- * ```
- *   val x = a.b.takeIfInstanceOf<Number>?.someMethod()
- *   val y = (a.b as? Number)?.someMethod() // same, but needs parenthesis
- * ```
- */
-inline fun <reified T> Any?.takeIfInstanceOf(): T? = this as? T


### PR DESCRIPTION
# Why

Removes `takeIfInstanceOf` as it's unused. 
