### PR TITLE
[docs] Move npx expo install explanation to image picker chapter in Expo tutorial

### DIFF
--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -60,7 +60,6 @@ Now that we've broken down the UI into smaller chunks, we're ready to start codi
 
 ## Display the image
 
-
 We'll use `expo-image` library to display the image in the app. It provides a cross-platform `<Image>` component to load and render an image. It is already included in the default project template we're using.
 
 The Image component takes the source of an image as its value. The source can be either a [static asset](https://reactnative.dev/docs/images#static-image-resources) or a URL. For example, the source required from **assets/images** directory is static. It can also come from [Network](https://reactnative.dev/docs/images#network-images) as a `uri` property.

--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -7,7 +7,6 @@ hasVideoLink: true
 import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { ProgressTracker } from '~/ui/components/ProgressTracker';
-import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { CODE } from '~/ui/components/Text';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
@@ -61,15 +60,8 @@ Now that we've broken down the UI into smaller chunks, we're ready to start codi
 
 ## Display the image
 
-We'll use `expo-image` library to display the image in the app. It provides a cross-platform `<Image>` component to load and render an image.
 
-The `expo-image` library comes out of the box, but if you don't have it, stop the development server by pressing <kbd>Ctrl</kbd> + <kbd>c</kbd> in the terminal. Then, install the `expo-image` library:
-
-<Terminal cmd={['$ npx expo install expo-image']} />
-
-The [`npx expo install`](/more/expo-cli/#installation) command will install the library and add it to the project's dependencies in **package.json**.
-
-> **info** **Tip:** Any time we install a new library in our project, stop the development server by pressing <kbd>Ctrl</kbd> + <kbd>c</kbd> in the terminal and then run the installation command. After the installation completes, we can start the development server again by running `npx expo start` from the same terminal window.
+We'll use `expo-image` library to display the image in the app. It provides a cross-platform `<Image>` component to load and render an image. It is already included in the default project template we're using.
 
 The Image component takes the source of an image as its value. The source can be either a [static asset](https://reactnative.dev/docs/images#static-image-resources) or a URL. For example, the source required from **assets/images** directory is static. It can also come from [Network](https://reactnative.dev/docs/images#network-images) as a `uri` property.
 

--- a/docs/pages/tutorial/image-picker.mdx
+++ b/docs/pages/tutorial/image-picker.mdx
@@ -28,9 +28,13 @@ We'll use [`expo-image-picker`](/versions/latest/sdk/imagepicker), a library fro
 
 ## Install expo-image-picker
 
-To install the library, run the following command:
+To install the `expo-image-picker` library, stop the development server by pressing <kbd>Ctrl</kbd> + <kbd>c</kbd> in the terminal, then run the following command:
 
 <Terminal cmd={['$ npx expo install expo-image-picker']} />
+
+The [`npx expo install`](/more/expo-cli/#installation) command will install the library and add it to the project's dependencies in **package.json**.
+
+> **info** **Tip:** Any time we install a new library in the project, stop the development server by pressing <kbd>Ctrl</kbd> + <kbd>c</kbd> in the terminal and then run the installation command. After the installation completes, start the development server again by running `npx expo start`.
 
 </Step>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/expo/pull/43190

The `expo-image` library is already included in default tempalte which is used for the Expo tutorial. The installatio instruction and context about `npx expo install` should move to the next chapter.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Remove the `expo-image` install instruction, `<Terminal>` block, npx expo install explanation, and the tip callout from Build a screen chapter. Replace with a sentence noting that the library is already included in the default template.
 - Add the `npx expo install` explanation and the dev server tip callout to Image Picker chapter, right after the install command.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
<img width="2466" height="610" alt="CleanShot 2026-02-18 at 21 38 25@2x" src="https://github.com/user-attachments/assets/3a0094c2-d0db-493e-99cc-e40199105034" />

<img width="2538" height="876" alt="CleanShot 2026-02-18 at 21 38 20@2x" src="https://github.com/user-attachments/assets/07d845b6-cfc6-462b-9da4-10398f8ee39b" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
