### PR TITLE
[notifications] fix background tasks not executing

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] fix background task not consistently executing ([#43245](https://github.com/expo/expo/pull/43245) by [@vonovak](https://github.com/vonovak))
 - [Android] fix `deleteNotificationChannelGroupAsync` export ([#43244](https://github.com/expo/expo/pull/43244) by [@vonovak](https://github.com/vonovak))
 - add FCM intent origin validation ([#43206](https://github.com/expo/expo/pull/43206) by [@vonovak](https://github.com/vonovak))
 - Fixed crash in `NotificationForwarderActivity` on Android 11/12 when Parcelable extras fail to deserialize by using byte array serialization as fallback. ([#43203](https://github.com/expo/expo/pull/43203) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/background/BackgroundRemoteNotificationTaskConsumer.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/background/BackgroundRemoteNotificationTaskConsumer.java
@@ -53,6 +53,7 @@ public class BackgroundRemoteNotificationTaskConsumer extends TaskConsumer imple
 
   @Override
   public void didUnregister() {
+    FirebaseMessagingDelegate.Companion.removeBackgroundTaskConsumer(this);
     mTask = null;
   }
 

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskService.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskService.java
@@ -366,7 +366,8 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
   }
 
   public void executeTask(TaskInterface task, Bundle data, Error error, TaskExecutionCallback callback) {
-    TaskManagerInterface taskManager = getTaskManager(task.getAppScopeKey());
+    String appScopeKey = task.getAppScopeKey();
+    TaskManagerInterface taskManager = getTaskManager(appScopeKey);
     Bundle body = createExecutionEventBody(task, data, error);
     Bundle executionInfo = body.getBundle("executionInfo");
 
@@ -376,7 +377,6 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
     }
 
     String eventId = executionInfo.getString("eventId");
-    String appScopeKey = task.getAppScopeKey();
 
     if (callback != null) {
       sTaskCallbacks.put(eventId, callback);


### PR DESCRIPTION
# Why

closes #38223

The above issue didn't include full repro steps so here they are:

### Prerequisites

- An Expo app with `expo-notifications` and `expo-task-manager` configured
- A registered `BACKGROUND_NOTIFICATION_TASK` via `TaskManager.defineTask` and `Notifications.registerTaskAsync`

### Sending push notifications

Install `expo-server-sdk`:

```bash
mkdir /tmp/expo-push-test && cd /tmp/expo-push-test
npm init -y && npm install expo-server-sdk
```

Create `send.mjs`:

```js
import { Expo } from "expo-server-sdk";

const expo = new Expo();
const token = "ExponentPushToken[YOUR_TOKEN_HERE]";
const mode = process.argv[2] // data (headless) or regular notification

const message = mode === "data"
  ? { to: token, data: { type: "background_task", timestamp: String(Date.now()) }, _contentAvailable: true }
  : { to: token, title: "Test", body: `Notification at ${new Date().toLocaleTimeString()}` };

const [chunk] = expo.chunkPushNotifications([message]);
console.log(`Sending ${mode} notification...`);
const result = await expo.sendPushNotificationsAsync(chunk);
console.log("Result:", JSON.stringify(result, null, 2));
```

### Reproduction steps

1. **Launch the app** and confirm it's in the foreground
2. **Send a display notification:**
3. **Kill the app** (swipe away from recents)
4. **Tap the notification** from the system tray — the app opens
5. **Wait for the app to fully load**
6. **Send a data-only notification:**

### Expected behavior

The `BACKGROUND_NOTIFICATION_TASK` executes and JS receives the notification.

### Actual behavior (before fix)

The background task silently fails. All subsequent data-only notifications also fail — the task never runs again until the app is force-stopped and restarted.

### Root cause

When tapping the notification in step 4, `handleNotificationResponse` called `runTaskManagerTasks` while the app was still launching. This started a headless React instance that raced with the foreground app. The foreground `TaskManager` got misclassified as headless (via `isStartedByHeadlessLoader`), then wiped by `invalidateAppRecord` — permanently breaking background task execution for the session.

# How

Only call `runTaskManagerTasks` for non-default notification actions (custom action buttons like "Mark as read").

The default tap (`DEFAULT_ACTION_IDENTIFIER`) always opens the app, so there's no need for headless task execution — the foreground app handles the response via listeners.



The fix is in `if (!isAppInForeground() && notificationResponse.actionIdentifier != NotificationResponse.DEFAULT_ACTION_IDENTIFIER)` but I also resolved one older TODO around an awkward use of `WeakHashMap`.

# Test Plan

- tested on device using the repro steps

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)