### PR TITLE
feat(cli): Expand debug events

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Replace `minimatch` with `picomatch` and update ([#43323](https://github.com/expo/expo/pull/43323) by [@kitten](https://github.com/kitten))
+- Expand logging events ([#43247](https://github.com/expo/expo/pull/43247) by [@kitten](https://github.com/kitten))
 
 ## 55.0.10 — 2026-02-20
 

--- a/packages/@expo/cli/e2e/__tests__/run-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/run-test.ts
@@ -21,6 +21,8 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/run').expoRun`);
   expect(modules).toStrictEqual([
+    '@expo/cli/build/src/events/index.js',
+    '@expo/cli/build/src/events/stream.js',
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/run/hints.js',
     '@expo/cli/build/src/run/index.js',

--- a/packages/@expo/cli/src/events/builder.ts
+++ b/packages/@expo/cli/src/events/builder.ts
@@ -58,6 +58,9 @@ interface EventLoggerType<Category, Events> {
 
 export interface EventLogger<Category, Events> extends EventLoggerType<Category, Events> {
   <EventName extends keyof Events>(event: EventName, data: Events[EventName]): void;
+
+  path(target: string): string;
+  path(target: string | null | undefined): string | null;
 }
 
 export interface EventBuilder {

--- a/packages/@expo/cli/src/events/index.ts
+++ b/packages/@expo/cli/src/events/index.ts
@@ -11,6 +11,7 @@ interface InitMetadata {
   version: string;
 }
 
+let logPath = process.cwd();
 let logStream: LogStream | undefined;
 
 function parseLogTarget(env: string | undefined) {
@@ -23,6 +24,7 @@ function parseLogTarget(env: string | undefined) {
       try {
         const parsedPath = path.parse(env);
         logDestination = path.format(parsedPath);
+        logPath = parsedPath.dir;
       } catch {
         logDestination = undefined;
       }
@@ -110,6 +112,17 @@ export const events: EventLoggerBuilder = ((
     }
   }
   log.category = category;
+
+  log.path = function relativePath(target: string | undefined | null): string | null {
+    try {
+      return target != null && path.isAbsolute(target)
+        ? path.relative(logPath, target).replace(/\\/, '/') || '.'
+        : (target ?? null);
+    } catch {
+      return target || null;
+    }
+  };
+
   return log;
 }) as EventLoggerBuilder;
 

--- a/packages/@expo/cli/src/events/types.ts
+++ b/packages/@expo/cli/src/events/types.ts
@@ -1,5 +1,6 @@
 import type { rootEvent } from './index';
 import type { collectEventLoggers } from '../events/builder';
+import type { event as metroBundlerDevServerEvent } from '../start/server/metro/MetroBundlerDevServer';
 import type { event as metroTerminalReporterEvent } from '../start/server/metro/MetroTerminalReporter';
 import type { event as instantiateMetroEvent } from '../start/server/metro/instantiateMetro';
 
@@ -9,5 +10,10 @@ import type { event as instantiateMetroEvent } from '../start/server/metro/insta
  * add it to add its types to this union type.
  */
 export type Events = collectEventLoggers<
-  [typeof rootEvent, typeof metroTerminalReporterEvent, typeof instantiateMetroEvent]
+  [
+    typeof rootEvent,
+    typeof metroBundlerDevServerEvent,
+    typeof metroTerminalReporterEvent,
+    typeof instantiateMetroEvent,
+  ]
 >;

--- a/packages/@expo/cli/src/events/types.ts
+++ b/packages/@expo/cli/src/events/types.ts
@@ -1,10 +1,13 @@
 import type { rootEvent } from './index';
 import type { collectEventLoggers } from '../events/builder';
 import type { event as metroTerminalReporterEvent } from '../start/server/metro/MetroTerminalReporter';
+import type { event as instantiateMetroEvent } from '../start/server/metro/instantiateMetro';
 
 /** Collection of all event logger events
  * @privateRemarks
  * When creating a new logger with `events()`, import it here and
  * add it to add its types to this union type.
  */
-export type Events = collectEventLoggers<[typeof rootEvent, typeof metroTerminalReporterEvent]>;
+export type Events = collectEventLoggers<
+  [typeof rootEvent, typeof metroTerminalReporterEvent, typeof instantiateMetroEvent]
+>;

--- a/packages/@expo/cli/src/events/types.ts
+++ b/packages/@expo/cli/src/events/types.ts
@@ -3,6 +3,7 @@ import type { collectEventLoggers } from '../events/builder';
 import type { event as metroBundlerDevServerEvent } from '../start/server/metro/MetroBundlerDevServer';
 import type { event as metroTerminalReporterEvent } from '../start/server/metro/MetroTerminalReporter';
 import type { event as instantiateMetroEvent } from '../start/server/metro/instantiateMetro';
+import type { event as nodeEnvEvent } from '../utils/nodeEnv';
 
 /** Collection of all event logger events
  * @privateRemarks
@@ -15,5 +16,6 @@ export type Events = collectEventLoggers<
     typeof metroBundlerDevServerEvent,
     typeof metroTerminalReporterEvent,
     typeof instantiateMetroEvent,
+    typeof nodeEnvEvent,
   ]
 >;

--- a/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
@@ -234,7 +234,9 @@ export class MetroTerminalReporter extends TerminalReporter {
 
   _logInitializing(port: number, hasReducedPerformance: boolean): void {
     // Don't print a giant logo...
-    this.terminal.log(chalk.dim('Starting Metro Bundler') + '\n');
+    if (!shouldReduceLogs()) {
+      this.terminal.log(chalk.dim('Starting Metro Bundler') + '\n');
+    }
   }
 
   shouldFilterClientLog(event: { type: 'client_log'; data: unknown[] }): boolean {

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -23,6 +23,7 @@ import { createDebugMiddleware } from './debugging/createDebugMiddleware';
 import { createMetroMiddleware } from './dev-server/createMetroMiddleware';
 import { runServer } from './runServer-fork';
 import { withMetroMultiPlatformAsync } from './withMetroMultiPlatform';
+import { events } from '../../../events';
 import { Log } from '../../../log';
 import { env } from '../../../utils/env';
 import { CommandError } from '../../../utils/errors';
@@ -30,6 +31,30 @@ import { createCorsMiddleware } from '../middleware/CorsMiddleware';
 import { createJsInspectorMiddleware } from '../middleware/inspector/createJsInspectorMiddleware';
 import { prependMiddleware } from '../middleware/mutations';
 import { getPlatformBundlers } from '../platformBundlers';
+
+// prettier-ignore
+export const event = events('metro', (t) => [
+  t.event<'config', {
+    serverRoot: string;
+    projectRoot: string;
+    exporting: boolean;
+    flags: {
+      autolinkingModuleResolution: boolean;
+      serverActions: boolean;
+      serverComponents: boolean;
+      reactCompiler: boolean;
+      optimizeGraph?: boolean;
+      treeshaking?: boolean;
+      logbox?: boolean;
+    };
+  }>(),
+  t.event<'instantiate', {
+    atlas: boolean;
+    workers: number | null;
+    host: string | null;
+    port: number | null;
+  }>(),
+]);
 
 // NOTE(@kitten): We pass a custom createStableModuleIdFactory function into the Metro module ID factory sometimes
 interface MetroServerWithModuleIdMod extends MetroServer {
@@ -108,13 +133,13 @@ export async function loadMetroConfigAsync(
 
   const serverActionsEnabled =
     exp.experiments?.reactServerFunctions ?? env.EXPO_UNSTABLE_SERVER_FUNCTIONS;
-
+  const serverComponentsEnabled = !!exp.experiments?.reactServerComponentRoutes;
   if (serverActionsEnabled) {
     process.env.EXPO_UNSTABLE_SERVER_FUNCTIONS = '1';
   }
 
   // NOTE: Enable all the experimental Metro flags when RSC is enabled.
-  if (exp.experiments?.reactServerComponentRoutes || serverActionsEnabled) {
+  if (serverComponentsEnabled || serverActionsEnabled) {
     process.env.EXPO_USE_METRO_REQUIRE = '1';
   }
 
@@ -182,7 +207,8 @@ export async function loadMetroConfigAsync(
 
   const platformBundlers = getPlatformBundlers(projectRoot, exp);
 
-  if (exp.experiments?.reactCompiler) {
+  const reactCompilerEnabled = !!exp.experiments?.reactCompiler;
+  if (reactCompilerEnabled) {
     Log.log(chalk.gray`React Compiler enabled`);
   }
 
@@ -220,8 +246,23 @@ export async function loadMetroConfigAsync(
     isAutolinkingResolverEnabled: autolinkingModuleResolutionEnabled,
     isExporting,
     isNamedRequiresEnabled: env.EXPO_USE_METRO_REQUIRE,
-    isReactServerComponentsEnabled: !!exp.experiments?.reactServerComponentRoutes,
+    isReactServerComponentsEnabled: serverComponentsEnabled,
     getMetroBundler,
+  });
+
+  event('config', {
+    serverRoot: event.path(serverRoot),
+    projectRoot: event.path(projectRoot),
+    exporting: isExporting,
+    flags: {
+      autolinkingModuleResolution: autolinkingModuleResolutionEnabled,
+      serverActions: serverActionsEnabled,
+      serverComponents: serverComponentsEnabled,
+      reactCompiler: reactCompilerEnabled,
+      optimizeGraph: env.EXPO_UNSTABLE_METRO_OPTIMIZE_GRAPH,
+      treeshaking: env.EXPO_UNSTABLE_TREE_SHAKING,
+      logbox: env.EXPO_UNSTABLE_LOG_BOX,
+    },
   });
 
   return {
@@ -317,7 +358,7 @@ export async function instantiateMetroAsync(
     resetAtlasFile: isExporting,
   });
 
-  const { server, hmrServer, metro } = await runServer(
+  const { address, server, hmrServer, metro } = await runServer(
     metroBundler,
     metroConfig,
     {
@@ -329,6 +370,13 @@ export async function instantiateMetroAsync(
       mockServer: isExporting,
     }
   );
+
+  event('instantiate', {
+    atlas: env.EXPO_ATLAS,
+    workers: metroConfig.maxWorkers ?? null,
+    host: address?.address ?? null,
+    port: address?.port ?? null,
+  });
 
   // Patch transform file to remove inconvenient customTransformOptions which are only used in single well-known files.
   const originalTransformFile = metro

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -23,7 +23,7 @@ import { createDebugMiddleware } from './debugging/createDebugMiddleware';
 import { createMetroMiddleware } from './dev-server/createMetroMiddleware';
 import { runServer } from './runServer-fork';
 import { withMetroMultiPlatformAsync } from './withMetroMultiPlatform';
-import { events } from '../../../events';
+import { events, shouldReduceLogs } from '../../../events';
 import { Log } from '../../../log';
 import { env } from '../../../utils/env';
 import { CommandError } from '../../../utils/errors';
@@ -206,13 +206,14 @@ export async function loadMetroConfigAsync(
   }
 
   const platformBundlers = getPlatformBundlers(projectRoot, exp);
+  const reduceLogs = shouldReduceLogs();
 
   const reactCompilerEnabled = !!exp.experiments?.reactCompiler;
-  if (reactCompilerEnabled) {
+  if (!reduceLogs && reactCompilerEnabled) {
     Log.log(chalk.gray`React Compiler enabled`);
   }
 
-  if (autolinkingModuleResolutionEnabled) {
+  if (!reduceLogs && autolinkingModuleResolutionEnabled) {
     Log.log(chalk.gray`Expo Autolinking module resolution enabled`);
   }
 
@@ -222,17 +223,17 @@ export async function loadMetroConfigAsync(
     );
   }
 
-  if (env.EXPO_UNSTABLE_METRO_OPTIMIZE_GRAPH) {
+  if (!reduceLogs && env.EXPO_UNSTABLE_METRO_OPTIMIZE_GRAPH) {
     Log.warn(`Experimental bundle optimization is enabled.`);
   }
-  if (env.EXPO_UNSTABLE_TREE_SHAKING) {
+  if (!reduceLogs && env.EXPO_UNSTABLE_TREE_SHAKING) {
     Log.warn(`Experimental tree shaking is enabled.`);
   }
-  if (env.EXPO_UNSTABLE_LOG_BOX) {
+  if (!reduceLogs && env.EXPO_UNSTABLE_LOG_BOX) {
     Log.warn(`Experimental Expo LogBox is enabled.`);
   }
 
-  if (serverActionsEnabled) {
+  if (!reduceLogs && serverActionsEnabled) {
     Log.warn(
       `React Server Functions (beta) are enabled. Route rendering mode: ${exp.experiments?.reactServerComponentRoutes ? 'server' : 'client'}`
     );

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -241,7 +241,7 @@ export function withExtendedResolver(
       : null;
 
   // TODO: Move this to be a transform key for invalidation.
-  if (!isExporting && isInteractive()) {
+  if (!isExporting && !env.CI) {
     if (isTsconfigPathsEnabled) {
       // TODO: We should track all the files that used imports and invalidate them
       // currently the user will need to save all the files that use imports to

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -1,6 +1,7 @@
 import { getConfig } from '@expo/config';
 import chalk from 'chalk';
 
+import { shouldReduceLogs } from '../events';
 import { SimulatorAppPrerequisite } from './doctor/apple/SimulatorAppPrerequisite';
 import { getXcodeVersionAsync } from './doctor/apple/XcodePrerequisite';
 import { validateDependenciesVersionsAsync } from './doctor/dependencies/validateDependenciesVersions';
@@ -17,8 +18,6 @@ import { isInteractive } from '../utils/interactive';
 import { profile } from '../utils/profile';
 import { maybeCreateMCPServerAsync } from './server/MCP';
 import { addMcpCapabilities } from './server/MCPDevToolsPluginCLIExtensions';
-
-const debug = require('debug')('expo:start');
 
 async function getMultiBundlerStartOptions(
   projectRoot: string,
@@ -69,7 +68,9 @@ export async function startAsync(
   options: Options,
   settings: { webOnly?: boolean }
 ) {
-  Log.log(chalk.gray(`Starting project at ${projectRoot}`));
+  if (!shouldReduceLogs()) {
+    Log.log(chalk.gray(`Starting project at ${projectRoot}`));
+  }
 
   const { exp, pkg } = profile(getConfig)(projectRoot);
 

--- a/packages/@expo/cli/src/utils/interactive.ts
+++ b/packages/@expo/cli/src/utils/interactive.ts
@@ -1,6 +1,7 @@
+import { shouldReduceLogs } from '../events';
 import { env } from './env';
 
 /** @returns `true` if the process is interactive. */
 export function isInteractive(): boolean {
-  return !env.CI && process.stdout.isTTY;
+  return !shouldReduceLogs() && !env.CI && process.stdout.isTTY;
 }

--- a/packages/@expo/cli/src/utils/nodeEnv.ts
+++ b/packages/@expo/cli/src/utils/nodeEnv.ts
@@ -1,6 +1,8 @@
 import * as env from '@expo/env';
 import path from 'node:path';
 
+import { events, shouldReduceLogs } from '../events';
+
 type EnvOutput = Record<string, string | undefined>;
 
 // TODO(@kitten): We assign this here to run server-side code bundled by metro
@@ -8,6 +10,20 @@ type EnvOutput = Record<string, string | undefined>;
 declare namespace globalThis {
   let __DEV__: boolean | undefined;
 }
+
+// prettier-ignore
+export const event = events('env', (t) => [
+  t.event<'mode', {
+    nodeEnv: string;
+    babelEnv: string;
+    mode: 'development' | 'production';
+  }>(),
+  t.event<'load', {
+    mode: string;
+    files: string[];
+    env: Record<string, string | undefined>;
+  }>(),
+]);
 
 /**
  * Set the environment to production or development
@@ -17,6 +33,18 @@ export function setNodeEnv(mode: 'development' | 'production') {
   process.env.NODE_ENV = process.env.NODE_ENV || mode;
   process.env.BABEL_ENV = process.env.BABEL_ENV || process.env.NODE_ENV;
   globalThis.__DEV__ = process.env.NODE_ENV !== 'production';
+
+  event('mode', {
+    nodeEnv: process.env.NODE_ENV,
+    babelEnv: process.env.BABEL_ENV,
+    mode,
+  });
+}
+
+interface LoadEnvFilesOptions {
+  force?: boolean;
+  silent?: boolean;
+  mode?: string;
 }
 
 interface LoadEnvFilesOptions {
@@ -34,8 +62,8 @@ let prevEnvKeys: Set<string> | undefined;
 export function loadEnvFiles(projectRoot: string, options?: LoadEnvFilesOptions) {
   const params = {
     ...options,
+    silent: !!options?.silent || shouldReduceLogs(),
     force: !!options?.force,
-    silent: !!options?.silent,
     mode: process.env.NODE_ENV,
     systemEnv: process.env,
   };
@@ -50,7 +78,17 @@ export function loadEnvFiles(projectRoot: string, options?: LoadEnvFilesOptions)
     }
   }
 
-  env.logLoadedEnv(envInfo, params);
+  if (envInfo.result === 'loaded') {
+    event('load', {
+      mode: params.mode,
+      files: envInfo.files.map((file) => event.path(file)),
+      env: envOutput,
+    });
+  }
+
+  if (!params.silent) {
+    env.logLoadedEnv(envInfo, params);
+  }
   return process.env;
 }
 
@@ -86,5 +124,11 @@ export function reloadEnvFiles(projectRoot: string) {
         }
       }
     }
+
+    event('load', {
+      mode: params.mode,
+      files: envInfo.files.map((file) => event.path(file)),
+      env: envOutput,
+    });
   }
 }

--- a/packages/@expo/cli/src/utils/nodeEnv.ts
+++ b/packages/@expo/cli/src/utils/nodeEnv.ts
@@ -19,7 +19,7 @@ export const event = events('env', (t) => [
     mode: 'development' | 'production';
   }>(),
   t.event<'load', {
-    mode: string;
+    mode: string | undefined;
     files: string[];
     env: Record<string, string | undefined>;
   }>(),
@@ -39,12 +39,6 @@ export function setNodeEnv(mode: 'development' | 'production') {
     babelEnv: process.env.BABEL_ENV,
     mode,
   });
-}
-
-interface LoadEnvFilesOptions {
-  force?: boolean;
-  silent?: boolean;
-  mode?: string;
 }
 
 interface LoadEnvFilesOptions {


### PR DESCRIPTION
# Why

Follows-up on: #43013

# How

- Add event for env and nodeEnv
- Add event for start implementation (Metro)
- Add event for config/instantiation (Metro)
- Reduce output further when logs+headless are enabled

# Test Plan

- quick tests with `LOG_EVENTS=1 EXPO_UNSTABLE_HEADLESS=1 expo start`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
