### PR TITLE
[android][image] Add `CookieJar` to image request client

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Uses shared cookie jar for image requests.
+
 ### 💡 Others
 
 ## 55.0.3 — 2026-01-27

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Uses shared cookie jar for image requests.
+- [Android] Uses shared cookie jar for image requests. ([#43257](https://github.com/expo/expo/pull/43257) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/okhttp/ExpoImageOkHttpClientGlideModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/okhttp/ExpoImageOkHttpClientGlideModule.kt
@@ -88,11 +88,9 @@ private object SharedCookieJar : CookieJar {
     return cookieString.split(";").mapNotNull { Cookie.parse(url, it.trim()) }
   }
 
-  private fun getCookieManager(): CookieManager? = try {
+  private fun getCookieManager(): CookieManager? = runCatching {
     CookieManager.getInstance()
-  } catch (e: Exception) {
-    null
-  }
+  }.getOrNull()
 }
 
 @GlideModule

--- a/packages/expo-image/android/src/main/java/expo/modules/image/okhttp/ExpoImageOkHttpClientGlideModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/okhttp/ExpoImageOkHttpClientGlideModule.kt
@@ -1,6 +1,7 @@
 package expo.modules.image.okhttp
 
 import android.content.Context
+import android.webkit.CookieManager
 import com.bumptech.glide.Glide
 import com.bumptech.glide.Registry
 import com.bumptech.glide.annotation.GlideModule
@@ -9,6 +10,9 @@ import com.bumptech.glide.load.model.GlideUrl
 import com.bumptech.glide.load.model.Headers
 import com.bumptech.glide.module.LibraryGlideModule
 import expo.modules.image.events.OkHttpProgressListener
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import java.io.InputStream
 
@@ -68,10 +72,35 @@ data class GlideUrlWrapper(val glideUrl: GlideUrl) {
   }
 }
 
+private object SharedCookieJar : CookieJar {
+  override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+    val cookieManager = getCookieManager() ?: return
+    val urlString = url.toString()
+    for (cookie in cookies) {
+      cookieManager.setCookie(urlString, cookie.toString())
+    }
+    cookieManager.flush()
+  }
+
+  override fun loadForRequest(url: HttpUrl): List<Cookie> {
+    val cookieManager = getCookieManager() ?: return emptyList()
+    val cookieString = cookieManager.getCookie(url.toString()) ?: return emptyList()
+    return cookieString.split(";").mapNotNull { Cookie.parse(url, it.trim()) }
+  }
+
+  private fun getCookieManager(): CookieManager? = try {
+    CookieManager.getInstance()
+  } catch (e: Exception) {
+    null
+  }
+}
+
 @GlideModule
 class ExpoImageOkHttpClientGlideModule : LibraryGlideModule() {
   override fun registerComponents(context: Context, glide: Glide, registry: Registry) {
-    val client = OkHttpClient()
+    val client = OkHttpClient.Builder()
+      .cookieJar(SharedCookieJar)
+      .build()
     // We don't use the `GlideUrl` directly but we want to replace the default okhttp loader anyway
     // to make sure that the app will use only one client.
     registry.replace(GlideUrl::class.java, InputStream::class.java, OkHttpUrlLoader.Factory(client))


### PR DESCRIPTION
# Why
Closes #43229
Currently, cookies sent through fetch are not shared with image requests made by expo image. This is because we create our own client but don't configure it to use the global CookieManager. 

# How
Implement `CookieJar`, read and write cookies to the shared manager and add it to the `OkHttpClient` builder.

# Test Plan
Tested in the provided repro
