### PR TITLE
[core][Android] Remove `Function` interface

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/Function.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/Function.java
@@ -1,7 +1,0 @@
-package expo.modules.core.interfaces;
-
-public interface Function<T, R> {
-
-  R apply(T t);
-
-}


### PR DESCRIPTION
# Why

Removes unused `Function` interface

# Test Plan

- bare-expo ✅ 