### PR TITLE
[brownfield][ios] cleanup ios test app

### DIFF
--- a/apps/brownfield-tester/ios-integrated/BrownfieldIntegratedTester.xcodeproj/project.pbxproj
+++ b/apps/brownfield-tester/ios-integrated/BrownfieldIntegratedTester.xcodeproj/project.pbxproj
@@ -6,15 +6,21 @@
 	objectVersion = 77;
 	objects = {
 
-/* Begin PBXBuildFile section */
-		C0AD1A072F180C2B005A1DBD /* hermes.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C0AD1A052F180C2B005A1DBD /* hermes.xcframework */; };
-		C0AD1A0E2F182AAA005A1DBD /* minimaltesterbrownfield.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C0AD1A0D2F182AAA005A1DBD /* minimaltesterbrownfield.xcframework */; };
-/* End PBXBuildFile section */
+/* Begin PBXCopyFilesBuildPhase section */
+		87F31DDB2F47363100B37DF8 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		C0AD19F12F180368005A1DBD /* BrownfieldIntegratedTester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BrownfieldIntegratedTester.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		C0AD1A052F180C2B005A1DBD /* hermes.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = hermes.xcframework; sourceTree = "<group>"; };
-		C0AD1A0D2F182AAA005A1DBD /* minimaltesterbrownfield.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = minimaltesterbrownfield.xcframework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -30,8 +36,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C0AD1A0E2F182AAA005A1DBD /* minimaltesterbrownfield.xcframework in Frameworks */,
-				C0AD1A072F180C2B005A1DBD /* hermes.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -43,8 +47,6 @@
 			children = (
 				C0AD19F32F180368005A1DBD /* BrownfieldIntegratedTester */,
 				C0AD19F22F180368005A1DBD /* Products */,
-				C0AD1A052F180C2B005A1DBD /* hermes.xcframework */,
-				C0AD1A0D2F182AAA005A1DBD /* minimaltesterbrownfield.xcframework */,
 			);
 			sourceTree = "<group>";
 		};
@@ -66,6 +68,7 @@
 				C0AD19ED2F180368005A1DBD /* Sources */,
 				C0AD19EE2F180368005A1DBD /* Frameworks */,
 				C0AD19EF2F180368005A1DBD /* Resources */,
+				87F31DDB2F47363100B37DF8 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/apps/brownfield-tester/ios-integrated/BrownfieldIntegratedTester/BrownfieldIntegratedTesterApp.swift
+++ b/apps/brownfield-tester/ios-integrated/BrownfieldIntegratedTester/BrownfieldIntegratedTesterApp.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-import minimaltesterbrownfield
+import expoappbrownfield
 
 @main
 struct BrownfieldIntegratedTesterApp: App {

--- a/apps/brownfield-tester/ios-integrated/BrownfieldIntegratedTester/BrownfieldTester.swift
+++ b/apps/brownfield-tester/ios-integrated/BrownfieldIntegratedTester/BrownfieldTester.swift
@@ -1,0 +1,67 @@
+import Combine
+import SwiftUI
+import expoappbrownfield
+
+class BrownfieldTester: ObservableObject {
+    @Published var alertMessage: String = ""
+    @Published var showAlert: Bool = false
+    
+    // MARK: - Internal State
+    
+    private var listenerId: String?
+    private var messageTimer: Timer?
+    private var messageCounter = 0
+    
+    // MARK: - Lifecycle Methods
+    
+    func start() {
+        setupListener()
+        startTimer()
+    }
+    
+    func stop() {
+        if let listenerId = listenerId {
+            BrownfieldMessaging.removeListener(id: listenerId)
+        }
+        messageTimer?.invalidate()
+        messageTimer = nil
+    }
+    
+    // MARK: - Private Logic
+    
+    private func setupListener() {
+        listenerId = BrownfieldMessaging.addListener { [weak self] message in
+            guard let self = self else { return }
+            
+            let sender = message["sender"] as? String ?? "Unknown"
+            let nested = message["source"] as? [String: Any?] ?? [:]
+            let platform = nested["platform"] as? String ?? "Unknown"
+            
+            DispatchQueue.main.async {
+                self.alertMessage = "\(platform)(\(sender))"
+                self.showAlert = true
+                print(self.alertMessage, self.showAlert)
+            }
+        }
+    }
+    
+    private func startTimer() {
+        messageTimer = Timer.scheduledTimer(withTimeInterval: 2.5, repeats: true) { [weak self] _ in
+            self?.sendMessage()
+        }
+    }
+    
+    private func sendMessage() {
+        messageCounter += 1
+        
+        let nativeMessage: [String: Any] = [
+            "source": ["platform": "iOS"],
+            "counter": messageCounter,
+            "timestamp": Int64(Date().timeIntervalSince1970 * 1000),
+            "array": ["ab", "c", false, 1, 2.45] as [Any]
+        ]
+        
+        BrownfieldMessaging.sendMessage(nativeMessage)
+        print("Sent: \(nativeMessage)")
+    }
+}

--- a/apps/brownfield-tester/ios-integrated/BrownfieldIntegratedTester/ContentView.swift
+++ b/apps/brownfield-tester/ios-integrated/BrownfieldIntegratedTester/ContentView.swift
@@ -1,16 +1,24 @@
 import SwiftUI
-import minimaltesterbrownfield
+import expoappbrownfield
 
 struct ContentView: View {
+    @StateObject private var brownfieldTester = BrownfieldTester()
+    
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
-            ReactNativeView(moduleName: "main")
+        NavigationStack {
+            NavigationLink(destination: ReactNativeView(moduleName: "main"), label: {
+                Text("Open React Native App")
+                    .accessibilityIdentifier("openReactNativeButton")
+                    .font(.largeTitle)
+            })
         }
-        .padding()
+        .onAppear { brownfieldTester.start() }
+        .onDisappear { brownfieldTester.stop() }
+        .alert("Message from Native", isPresented: $brownfieldTester.showAlert) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(brownfieldTester.alertMessage)
+        }
     }
 }
 


### PR DESCRIPTION
# Why

- We did similar cleanup for Android in https://github.com/expo/expo/pull/43097
- The View with RN app was too cluttered and hard to read

# How

Extracted all brownfield testing code to a separate `ObservableObject`

# Test Plan

Verified that the test app works as previously and communication API works

# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
