### PR TITLE
[core][Android] Promote `Either` type to stable

### DIFF
--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.kt
@@ -35,7 +35,6 @@ import expo.modules.core.utilities.ifNull
 import expo.modules.interfaces.permissions.Permissions
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.activityresult.AppContextActivityResultLauncher
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.functions.Coroutine
@@ -44,7 +43,6 @@ import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.kotlin.types.Either
 import java.text.ParseException
 
-@OptIn(EitherType::class)
 class CalendarModule : Module() {
   private val reactContext
     get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/event/EventRepository.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/event/EventRepository.kt
@@ -13,7 +13,6 @@ import expo.modules.calendar.exceptions.EventNotSavedException
 import expo.modules.calendar.extensions.DateTimeInput
 import expo.modules.calendar.extensions.getTimeInMillis
 import expo.modules.calendar.domain.event.records.input.RemoveEventInput
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.exception.Exceptions
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
@@ -27,7 +26,6 @@ class EventRepository(context: Context) {
   private val contentResolver
     get() = contextRef.get()?.contentResolver ?: throw Exceptions.ReactContextLost()
 
-  @OptIn(EitherType::class)
   suspend fun findEvents(startDate: DateTimeInput, endDate: DateTimeInput, calendars: List<String>): List<EventEntity> =
     withContext(Dispatchers.IO) {
       val eStartDate = requireNotNull(startDate.getTimeInMillis())

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/event/records/input/EventInputBase.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/event/records/input/EventInputBase.kt
@@ -7,11 +7,9 @@ import expo.modules.calendar.domain.event.enums.EventAccessLevel
 import expo.modules.calendar.domain.event.records.Alarm
 import expo.modules.calendar.extensions.DateTimeInput
 import expo.modules.calendar.extensions.getTimeInMillis
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.records.Field
 import java.util.TimeZone
 
-@OptIn(EitherType::class)
 abstract class EventInputBase {
   @Field val alarms: List<Alarm>? = null
 

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/event/records/input/RecurrenceRuleInput.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/event/records/input/RecurrenceRuleInput.kt
@@ -3,12 +3,10 @@ package expo.modules.calendar.domain.event.records.input
 import expo.modules.calendar.CalendarUtils.recurrenceRuleSDF
 import expo.modules.calendar.extensions.DateTimeInput
 import expo.modules.calendar.extensions.getTimeInMillis
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import java.util.Calendar
 
-@OptIn(EitherType::class)
 data class RecurrenceRuleInput(
   @Field val frequency: String = "",
   @Field val interval: Int? = null,

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/event/records/input/RemoveEventInput.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/event/records/input/RemoveEventInput.kt
@@ -1,12 +1,10 @@
 package expo.modules.calendar.domain.event.records.input
 
 import expo.modules.calendar.extensions.DateTimeInput
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.records.Required
 
-@OptIn(EitherType::class)
 data class RemoveEventInput(
   @Field @Required val id: String,
   @Field val instanceStartDate: DateTimeInput?

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/extensions/EitherExtensions.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/extensions/EitherExtensions.kt
@@ -2,17 +2,14 @@ package expo.modules.calendar.extensions
 
 import expo.modules.calendar.CalendarUtils
 import expo.modules.calendar.exceptions.DateParseException
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.types.Either
 import java.text.ParseException
 import java.util.Calendar
 
 // Represents date/time input from JS. Can be either string or number.
-@OptIn(EitherType::class)
 typealias DateTimeInput = Either<String, Long>
 
 // Returns Unix timestamp in milliseconds.
-@OptIn(EitherType::class)
 fun DateTimeInput.getTimeInMillis(): Long? {
   if (this.`is`(Long::class)) {
     return this.second()

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/EventRecurrenceTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/EventRecurrenceTest.kt
@@ -2,7 +2,6 @@ package expo.modules.calendar
 
 import expo.modules.calendar.domain.event.records.RecurrenceRuleEntity
 import expo.modules.calendar.domain.event.records.input.RecurrenceRuleInput
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.types.ConvertedValue
 import expo.modules.kotlin.types.Either
 import expo.modules.kotlin.types.IncompatibleValue
@@ -25,7 +24,6 @@ class EventRecurrenceUtilsTest {
     TimeZone.setDefault(null)
   }
 
-  @OptIn(EitherType::class)
   @Test
   fun testCreateRecurrenceRule_withAllFields() {
     val opts =
@@ -120,7 +118,6 @@ class EventRecurrenceUtilsTest {
   }
 }
 
-@OptIn(EitherType::class)
 private inline fun <reified L : Any, reified R : Any> eitherWithFirst(value: L): Either<L, R> {
   val types = listOf(typeOf<L>(), typeOf<R>())
 

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/mappers/ContactPatchBuilder.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/mappers/ContactPatchBuilder.kt
@@ -8,7 +8,6 @@ import expo.modules.contacts.next.domain.wrappers.ContactId
 import expo.modules.contacts.next.domain.wrappers.RawContactId
 import expo.modules.contacts.next.records.NewRecord
 import expo.modules.contacts.next.records.PatchRecord
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.types.Either
 import expo.modules.kotlin.types.ValueOrUndefined
 import expo.modules.kotlin.types.toKClass
@@ -33,7 +32,6 @@ class ContactPatchBuilder(
     toAppend.add(appendable)
   }
 
-  @OptIn(EitherType::class)
   inline fun <reified T : PatchRecord, reified R : NewRecord> withListProperty(
     property: ValueOrUndefined<List<Either<T, R>>?>,
     field: ExtractableField.Data<*>

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/mappers/ContactRecordDomainMapper.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/mappers/ContactRecordDomainMapper.kt
@@ -39,7 +39,6 @@ import expo.modules.contacts.next.records.*
 import expo.modules.contacts.next.records.contact.*
 import expo.modules.contacts.next.records.fields.*
 import expo.modules.contacts.next.services.ImageByteArrayConverter
-import expo.modules.kotlin.apifeatures.EitherType
 
 class ContactRecordDomainMapper(imageByteArrayConverter: ImageByteArrayConverter) {
   val contactMapper = ContactMapper(imageByteArrayConverter)
@@ -180,7 +179,6 @@ class ContactRecordDomainMapper(imageByteArrayConverter: ImageByteArrayConverter
     return UpdateContact(rawContactId, existingStarred, modelsToAppend)
   }
 
-  @OptIn(EitherType::class)
   fun toPatchContact(
     record: PatchContactRecord,
     rawContactId: RawContactId,

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/contact/PatchContactRecord.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/contact/PatchContactRecord.kt
@@ -7,13 +7,11 @@ import expo.modules.contacts.next.records.fields.PhoneRecord
 import expo.modules.contacts.next.records.fields.AddressRecord
 import expo.modules.contacts.next.records.fields.RelationRecord
 import expo.modules.contacts.next.records.fields.UrlAddressRecord
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Either
 import expo.modules.kotlin.types.ValueOrUndefined
 
-@OptIn(EitherType::class)
 data class PatchContactRecord(
   @Field val isFavourite: ValueOrUndefined<Boolean> = ValueOrUndefined.Undefined(),
   @Field val givenName: ValueOrUndefined<String?> = ValueOrUndefined.Undefined(),

--- a/packages/expo-crypto/android/src/main/java/expo/modules/crypto/aes/AesCryptoModule.kt
+++ b/packages/expo-crypto/android/src/main/java/expo/modules/crypto/aes/AesCryptoModule.kt
@@ -16,7 +16,6 @@ import expo.modules.crypto.aes.records.CiphertextOptions
 import expo.modules.crypto.aes.records.DecryptOptions
 import expo.modules.crypto.aes.records.EncryptOptions
 import expo.modules.crypto.aes.records.SealedDataConfig
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
@@ -26,10 +25,9 @@ import java.security.SecureRandom
 import javax.crypto.Cipher
 import javax.crypto.spec.GCMParameterSpec
 
-@OptIn(EitherType::class)
 typealias BinaryInput = Either<ByteArray, String>
 
-@OptIn(EitherType::class, ExperimentalStdlibApi::class)
+@OptIn(ExperimentalStdlibApi::class)
 class AesCryptoModule : Module() {
   private val rng: SecureRandom by lazy { SecureRandom() }
 

--- a/packages/expo-crypto/android/src/main/java/expo/modules/crypto/aes/records/DecryptOptions.kt
+++ b/packages/expo-crypto/android/src/main/java/expo/modules/crypto/aes/records/DecryptOptions.kt
@@ -2,11 +2,9 @@ package expo.modules.crypto.aes.records
 
 import expo.modules.crypto.aes.BinaryInput
 import expo.modules.crypto.aes.enums.DataFormat
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 
-@OptIn(EitherType::class)
 class DecryptOptions : Record {
   @Field
   val output: DataFormat = DataFormat.BYTES

--- a/packages/expo-crypto/android/src/main/java/expo/modules/crypto/aes/records/EncryptOptions.kt
+++ b/packages/expo-crypto/android/src/main/java/expo/modules/crypto/aes/records/EncryptOptions.kt
@@ -4,14 +4,12 @@ import android.util.Base64
 import expo.modules.crypto.aes.AesConfig.DEFAULT_IV_SIZE
 import expo.modules.crypto.aes.AesConfig.DEFAULT_TAG_SIZE
 import expo.modules.crypto.aes.BinaryInput
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.EitherOfThree
 import java.security.SecureRandom
 import javax.crypto.spec.GCMParameterSpec
 
-@OptIn(EitherType::class)
 class EncryptOptions : Record {
   @Field
   val nonce: EitherOfThree<String, ByteArray, Int>? = null

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt
@@ -3,12 +3,10 @@ package expo.modules.filesystem
 import android.net.Uri
 import android.util.Base64
 import expo.modules.interfaces.filesystem.Permission
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.typedarray.TypedArray
 import java.io.FileOutputStream
 import java.security.MessageDigest
 
-@OptIn(EitherType::class)
 class FileSystemFile(uri: Uri) : FileSystemPath(uri) {
   // Kept empty for now, but can be used to validate if the uri is a valid file uri. // TODO: Move to the constructor once also moved on iOS
   fun validatePath() {

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
@@ -8,7 +8,6 @@ import android.webkit.URLUtil
 import androidx.annotation.RequiresApi
 import expo.modules.interfaces.filesystem.Permission
 import expo.modules.kotlin.activityresult.AppContextActivityResultLauncher
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.devtools.await
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.functions.Coroutine
@@ -27,7 +26,6 @@ class FileSystemModule : Module() {
     get() = appContext.reactContext ?: throw Exceptions.AppContextLost()
 
   @RequiresApi(Build.VERSION_CODES.O)
-  @OptIn(EitherType::class)
   override fun definition() = ModuleDefinition {
     Name("FileSystem")
 

--- a/packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageManipulatorModule.kt
+++ b/packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageManipulatorModule.kt
@@ -1,5 +1,3 @@
-@file:OptIn(EitherType::class)
-
 package expo.modules.imagemanipulator
 
 import android.content.Context
@@ -14,7 +12,6 @@ import expo.modules.imagemanipulator.transformers.ResizeTransformer
 import expo.modules.imagemanipulator.transformers.RotateTransformer
 import expo.modules.interfaces.imageloader.ImageLoaderInterface
 import expo.modules.interfaces.imageloader.ImageLoaderInterface.ResultListener
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.exception.toCodedException
 import expo.modules.kotlin.functions.Coroutine

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
@@ -1,5 +1,3 @@
-@file:OptIn(EitherType::class)
-
 package expo.modules.image
 
 import android.graphics.Bitmap
@@ -33,7 +31,6 @@ import expo.modules.image.records.ImageTransition
 import expo.modules.image.records.SourceMap
 import expo.modules.image.thumbhash.ThumbhashEncoder
 import expo.modules.kotlin.Promise
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.functions.Coroutine
 import expo.modules.kotlin.functions.Queues

--- a/packages/expo-maps/android/src/main/java/expo/modules/maps/GoogleMapsView.kt
+++ b/packages/expo-maps/android/src/main/java/expo/modules/maps/GoogleMapsView.kt
@@ -1,5 +1,3 @@
-@file:OptIn(EitherType::class)
-
 package expo.modules.maps
 
 import android.annotation.SuppressLint
@@ -32,7 +30,6 @@ import com.google.maps.android.compose.Polygon
 import com.google.maps.android.compose.Circle
 import com.google.maps.android.compose.Polyline
 import expo.modules.kotlin.AppContext
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.sharedobjects.SharedRef
 import expo.modules.kotlin.types.toKClass
 import expo.modules.kotlin.viewevent.EventDispatcher

--- a/packages/expo-maps/android/src/main/java/expo/modules/maps/Records.kt
+++ b/packages/expo-maps/android/src/main/java/expo/modules/maps/Records.kt
@@ -1,5 +1,3 @@
-@file:OptIn(EitherType::class)
-
 package expo.modules.maps
 
 import android.graphics.Bitmap
@@ -12,7 +10,6 @@ import com.google.maps.android.compose.ComposeMapColorScheme
 import com.google.maps.android.compose.MapProperties
 import com.google.maps.android.compose.MapType
 import com.google.maps.android.compose.MapUiSettings
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.sharedobjects.SharedRef

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/MediaLibraryNextModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/MediaLibraryNextModule.kt
@@ -3,7 +3,6 @@ package expo.modules.medialibrary.next
 import android.net.Uri
 import android.os.Build
 import expo.modules.kotlin.Promise
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.functions.Coroutine
 import expo.modules.kotlin.modules.Module
@@ -28,7 +27,6 @@ import expo.modules.medialibrary.next.permissions.enums.GranularPermission
 import expo.modules.medialibrary.next.records.AssetField
 import expo.modules.medialibrary.next.records.SortDescriptor
 
-@OptIn(EitherType::class)
 class MediaLibraryNextModule : Module() {
   private val context
     get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
@@ -221,7 +219,6 @@ class MediaLibraryNextModule : Module() {
       return@Coroutine assetFactory.create(filePath, album?.getRelativePath())
     }
 
-    @OptIn(EitherType::class)
     AsyncFunction("createAlbum") Coroutine { name: String, assetRefs: Either<List<Asset>, List<Uri>>, move: Boolean ->
       val assetListKClass = toKClass<List<Asset>>()
       if (assetRefs.`is`(assetListKClass)) {

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/query/MediaStoreQueryFormatter.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/query/MediaStoreQueryFormatter.kt
@@ -1,13 +1,11 @@
 package expo.modules.medialibrary.next.objects.query
 
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.types.Either
 import expo.modules.medialibrary.next.objects.wrappers.MediaType
 import expo.modules.medialibrary.next.records.AssetField
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
-@OptIn(EitherType::class)
 class MediaStoreQueryFormatter {
   companion object {
     fun parse(field: AssetField, value: Either<MediaType, Long>): String {

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - Fixed view updates for Jetpack Compose integration. ([#42732](https://github.com/expo/expo/pull/42732) by [@kudo](https://github.com/kudo))
-- [Android] Promoted `Either` type stable.
+- [Android] Promoted `Either` type stable. ([#43267](https://github.com/expo/expo/pull/43267) by [@lukmccall](https://github.com/lukmccall))
 
 ## 55.0.9 — 2026-02-16
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Fixed view updates for Jetpack Compose integration. ([#42732](https://github.com/expo/expo/pull/42732) by [@kudo](https://github.com/kudo))
+- [Android] Promoted `Either` type stable.
 
 ## 55.0.9 — 2026-02-16
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
@@ -2,7 +2,6 @@ package expo.modules.kotlin.jni
 
 import com.google.common.truth.Truth
 import expo.modules.kotlin.runtime.Runtime
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.JavaScriptEvaluateException
 import expo.modules.kotlin.jni.extensions.addSingleQuotes
@@ -523,7 +522,6 @@ class JSIFunctionsTest {
     }
   }
 
-  @OptIn(EitherType::class)
   @Test
   fun either_should_be_convertible() = withSingleModule({
     Function("eitherFirst") { either: Either<Int, String> ->

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/EitherTypeConversionTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/EitherTypeConversionTest.kt
@@ -1,10 +1,7 @@
-@file:OptIn(EitherType::class)
-
 package expo.modules.kotlin.jni.types
 
 import com.facebook.react.bridge.DynamicFromObject
 import com.google.common.truth.Truth
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.exception.JavaScriptEvaluateException
 import expo.modules.kotlin.jni.SharedString
 import expo.modules.kotlin.jni.extensions.addSingleQuotes
@@ -15,7 +12,6 @@ import expo.modules.kotlin.types.convert
 import org.junit.Test
 import java.net.URL
 
-@EitherType
 class EitherTypeConversionTest {
   @Test
   fun either_should_be_convertible() = conversionTest(

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/apifeatures/Features.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/apifeatures/Features.kt
@@ -3,4 +3,5 @@ package expo.modules.kotlin.apifeatures
 @RequiresOptIn(message = "This API is experimental. It may be changed in the future without notice.", level = RequiresOptIn.Level.WARNING)
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Deprecated("The Either type is not longer experimental, so this annotation is no longer needed. This annotation will be removed in the future.")
 annotation class EitherType

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Either.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Either.kt
@@ -5,7 +5,6 @@ package expo.modules.kotlin.types
 import com.facebook.react.bridge.Dynamic
 import expo.modules.core.interfaces.DoNotStrip
 import expo.modules.kotlin.AppContext
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.unwrap
 import java.lang.ref.WeakReference
 import kotlin.reflect.KClass
@@ -43,7 +42,6 @@ data class ConvertedValue(val convertedValue: Any) : DeferredValue()
  */
 inline fun <reified T : Any> toKClass(): KClass<T> = T::class
 
-@EitherType
 @DoNotStrip
 // We can't strip this class because typeOf<Either<T,P>> won't work in the release builds.
 open class Either<FirstType : Any, SecondType : Any>(
@@ -106,7 +104,6 @@ open class Either<FirstType : Any, SecondType : Any>(
   fun second(): SecondType = get(1) as SecondType
 }
 
-@EitherType
 @DoNotStrip
 open class EitherOfThree<FirstType : Any, SecondType : Any, ThirdType : Any>(
   bareValue: Any,
@@ -122,7 +119,6 @@ open class EitherOfThree<FirstType : Any, SecondType : Any, ThirdType : Any>(
   fun third(): ThirdType = get(2) as ThirdType
 }
 
-@EitherType
 @DoNotStrip
 class EitherOfFour<FirstType : Any, SecondType : Any, ThirdType : Any, FourthType : Any>(
   bareValue: Any,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EitherTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EitherTypeConverter.kt
@@ -2,7 +2,6 @@ package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
 import expo.modules.kotlin.AppContext
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.jni.ExpectedType
 import kotlin.reflect.KType
 
@@ -66,7 +65,6 @@ private fun createDeferredValues(
   return result
 }
 
-@EitherType
 class EitherTypeConverter<FirstType : Any, SecondType : Any>(
   converterProvider: TypeConverterProvider,
   eitherType: KType
@@ -108,7 +106,6 @@ class EitherTypeConverter<FirstType : Any, SecondType : Any>(
   override fun isTrivial(): Boolean = false
 }
 
-@EitherType
 class EitherOfThreeTypeConverter<FirstType : Any, SecondType : Any, ThirdType : Any>(
   converterProvider: TypeConverterProvider,
   eitherType: KType
@@ -155,7 +152,6 @@ class EitherOfThreeTypeConverter<FirstType : Any, SecondType : Any, ThirdType : 
     ExpectedType.merge(firstType, secondType, thirdType)
 }
 
-@EitherType
 class EitherOfFourTypeConverter<FirstType : Any, SecondType : Any, ThirdType : Any, FourthType : Any>(
   converterProvider: TypeConverterProvider,
   eitherType: KType

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -7,7 +7,6 @@ import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import expo.modules.core.arguments.ReadableArguments
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.MissingTypeConverter
 import expo.modules.kotlin.jni.CppType
@@ -173,7 +172,6 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       ?: throw MissingTypeConverter(type)
   }
 
-  @OptIn(EitherType::class)
   private fun handelEither(type: KType, jClass: Class<*>): TypeConverter<*>? {
     if (Either::class.java.isAssignableFrom(jClass)) {
       if (EitherOfFour::class.java.isAssignableFrom(jClass)) {

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/CarouselView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/CarouselView.kt
@@ -1,5 +1,3 @@
-@file:OptIn(EitherType::class)
-
 package expo.modules.ui
 
 import androidx.compose.foundation.gestures.TargetedFlingBehavior
@@ -12,7 +10,6 @@ import androidx.compose.material3.carousel.rememberCarouselState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
 import androidx.core.view.size
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Either

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ComposeViews.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ComposeViews.kt
@@ -1,4 +1,4 @@
-@file:OptIn(ExperimentalMaterial3ExpressiveApi::class, EitherType::class, ExperimentalLayoutApi::class)
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalLayoutApi::class)
 
 package expo.modules.ui
 
@@ -15,7 +15,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.types.Enumerable
 import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/LazyColumnView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/LazyColumnView.kt
@@ -1,5 +1,3 @@
-@file:OptIn(EitherType::class)
-
 package expo.modules.ui
 
 import android.annotation.SuppressLint
@@ -17,7 +15,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
 import expo.modules.kotlin.AppContext
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposableScope

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/convertibles/Arrangement.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/convertibles/Arrangement.kt
@@ -1,10 +1,7 @@
-@file:OptIn(EitherType::class)
-
 package expo.modules.ui.convertibles
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.ui.unit.dp
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Either

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
@@ -1,5 +1,3 @@
-@file:OptIn(EitherType::class)
-
 package expo.modules.video
 
 import android.net.Uri
@@ -8,7 +6,6 @@ import androidx.media3.common.Player.REPEAT_MODE_OFF
 import androidx.media3.common.Player.REPEAT_MODE_ONE
 import androidx.media3.common.util.UnstableApi
 import expo.modules.kotlin.Promise
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.functions.Coroutine
 import expo.modules.kotlin.functions.Queues
 import expo.modules.kotlin.modules.Module


### PR DESCRIPTION
# Why

Promotes `Either` type to stable

# How

I think it's time to promote the `Either` type to be stable and remove the requirement of using the `either` feature annotation. The annotation is still in the code to avoid breaking users' libraries.

# Test Plan

- bare-expo ✅ 