### PR TITLE
[ci] Add restore ccache to expo-caches

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -36,6 +36,9 @@ inputs:
     description: 'NDK version used'
     default: '23.1.7779620'
     required: false
+  ccache:
+    description: 'Restore ccache'
+    required: false
   git-lfs:
     description: 'Restore Git LFS cache'
     required: false
@@ -190,6 +193,14 @@ runs:
       if: inputs.ndk == 'true' && steps.cache-android-ndk.outputs.cache-hit != 'true'
       shell: bash
       run: sudo $ANDROID_SDK_ROOT/tools/bin/sdkmanager --install "ndk;${{ inputs.ndk-version }}"
+
+    - name: ♻️ Restore ccache
+      if: inputs.ccache == 'true'
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.temp }}/.ccache
+        key: ${{ runner.os }}-ccache-${{ hashFiles('yarn.lock', 'packages/**/*.cpp', 'packages/**/*.h', 'packages/**/*.mm', 'packages/**/*.m') }}
+        restore-keys: ${{ runner.os }}-ccache-
 
     - name: 🔍️ Get cache key of Git LFS files
       if: inputs.git-lfs == 'true'


### PR DESCRIPTION
# Why

This is a base for the following PRs that introduce the implementation of ccache for iOS and Android builds: 
https://github.com/expo/expo/pull/43274 
https://github.com/expo/expo/pull/43285
It adds a new cache to `expo-caches`, which will be used there. 

# How

Adds a new `Restore ccache` step to `expo-caches`. 
The key for this cache consists of:
- `yarn.lock` - to follow changes in `node_modules`
- `packages/**/*.cpp`, `packages/**/*.h`, `packages/**/*.mm`, `packages/**/*.m` - these files are cached by ccache

A `restore-key` was added because the hash doesn't have to match exactly and the cache can be partially reused. 

# Test Plan

Green CI, tested on a stacked PR.