### PR TITLE
[ci][android] Optimize build time with ccache

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -36,6 +36,9 @@ inputs:
     description: 'NDK version used'
     default: '23.1.7779620'
     required: false
+  ccache:
+    description: 'Restore ccache'
+    required: false
   git-lfs:
     description: 'Restore Git LFS cache'
     required: false
@@ -190,6 +193,14 @@ runs:
       if: inputs.ndk == 'true' && steps.cache-android-ndk.outputs.cache-hit != 'true'
       shell: bash
       run: sudo $ANDROID_SDK_ROOT/tools/bin/sdkmanager --install "ndk;${{ inputs.ndk-version }}"
+
+    - name: ♻️ Restore ccache
+      if: inputs.ccache == 'true'
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.temp }}/.ccache
+        key: ${{ runner.os }}-ccache-${{ hashFiles('yarn.lock', 'packages/**/*.cpp', 'packages/**/*.h', 'packages/**/*.mm', 'packages/**/*.m') }}
+        restore-keys: ${{ runner.os }}-ccache-
 
     - name: 🔍️ Get cache key of Git LFS files
       if: inputs.git-lfs == 'true'

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -340,16 +340,45 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+      - name: Install ccache
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ccache
+      - name: Configure ccache
+        run: |
+          # It must be the same as in .github/actions/expo-caches/action.yml 
+          echo "CCACHE_DIR=${{ runner.temp }}/.ccache" >> $GITHUB_ENV
+
+          # By default ccache includes mtime of a compiler in hashes, for each CI run mtime varies.
+          echo "CCACHE_COMPILERCHECK=content" >> $GITHUB_ENV
+
+          # Calculate hash based on a relative path - this prevents cache misses when an absolute path changes.
+          echo "CCACHE_BASEDIR=${{ github.workspace }}" >> $GITHUB_ENV
+
+          # Default is 5GB, this cache takes only ~300MB.
+          echo "CCACHE_MAXSIZE=1G" >> $GITHUB_ENV
+
+          # Sloppiness options disable some of the ccache checks to increase hit rate. 
+          # In our case we exclude ctime and mtime so cache is hit based on file content. 
+          # time_macros might help if in included modules there are macros like __TIME__ which would trigger a cache miss.
+          echo "CCACHE_SLOPPINESS=include_file_ctime,include_file_mtime,time_macros" >> $GITHUB_ENV
+
+          # Replaces compiler with ccache 
+          echo "CMAKE_C_COMPILER_LAUNCHER=$(which ccache)" >> $GITHUB_ENV
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=$(which ccache)" >> $GITHUB_ENV
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches
         with:
+          ccache: 'true'
           gradle: 'true'
           yarn-workspace: 'true'
           yarn-tools: 'true'
           react-native-gradle-downloads: 'true'
+      - name: Reset ccache stats
+        run: ccache -z
       - name: 🧶 Install workspace node modules
         run: yarn install --frozen-lockfile
       - name: 🧶 Install image comparison server node modules
@@ -392,6 +421,8 @@ jobs:
             ./scripts/start-android-e2e-test.ts --build
           build-output: apps/bare-expo/android/app/build/outputs/apk/release
           artifact-name: bare-expo-android-builds
+      - name: Show ccache stats
+        run: ccache -s -v
       - name: 🔔 Notify on Slack
         uses: ./.github/actions/slack-notify
         if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))


### PR DESCRIPTION
# Why

This PR introduces ccache for Android builds. It speeds up the most demanding task for Android builds, which is cpp compilation.

# Results

- **Hit rate: 87%** - that's the percentage of c++ files which didn't have to be compiled. 
- **Build time drop:** My tests showed a **4-minute** reduction in build time. This time varies based on runner performance, so the most precise numbers will be visible after some time in our performance metrics.

# How

- Downloads ccache.
- Replaces the default compiler with ccache.
- Adds custom configuration for ccache, which is described in the comments.

# Test Plan
Green CI, tested on a stacked PR.