### PR TITLE
[create-expo-module] Fix private registry access

### DIFF
--- a/packages/create-expo-module/src/utils/tar.ts
+++ b/packages/create-expo-module/src/utils/tar.ts
@@ -1,35 +1,11 @@
-import { Readable, Stream } from 'node:stream';
+import fs from 'node:fs';
+import { Stream } from 'node:stream';
 import { promisify } from 'node:util';
 import { extract as tarExtract } from 'tar';
 
-import { fetch } from './fetch';
-
-const debug = require('debug')('create-expo-module:tar') as typeof console.log;
 const pipeline = promisify(Stream.pipeline);
 
-type DownloadAndExtractTarballOptions = {
-  /** The publicly accessible URL to download the tarball from */
-  url: string;
-  /** The local folder to extract to */
-  dir: string;
-};
-
-/** Download and extract tarballs directly from a publicly accessible URL */
-export async function downloadAndExtractTarball({ url, dir }: DownloadAndExtractTarballOptions) {
-  const response = await fetch(url);
-
-  if (!response.ok) {
-    debug(`Failed to fetch "%s", received response: %O`, url, response);
-    throw new Error(`Failed to download "${url}", received response status ${response.status}.`);
-  }
-
-  if (!response.body) {
-    debug(`Failed to fetch "%s", received no response body: %O`, url, response);
-    throw new Error(`Failed to download "${url}", received no response body.`);
-  }
-
-  await pipeline(
-    Readable.fromWeb(response.body as ReadableStream<Uint8Array>),
-    tarExtract({ cwd: dir })
-  );
+/** Extract a local tarball file to a directory */
+export async function extractLocalTarball({ filePath, dir }: { filePath: string; dir: string }) {
+  await pipeline(fs.createReadStream(filePath), tarExtract({ cwd: dir }));
 }


### PR DESCRIPTION
# Why
Closes #43213
`create-expo-module` currently can't access private registries because we use `npm view` + a manual fetch to download the tarball. This will fail for registries requiring auth. 

# How
Switch to `npm pack`. Same as `create-expo`

# Test Plan
Create a local module. Works as normal.

