### PR TITLE
[dev-launcher] rephrase LocalNetworkPermissionView message

### DIFF
--- a/packages/expo-dev-launcher/ios/SwiftUI/LocalNetworkPermissionView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/LocalNetworkPermissionView.swift
@@ -67,7 +67,7 @@ struct LocalNetworkPermissionView: View {
       }
       Button("OK", role: .cancel) {}
     } message: {
-      Text("Local network access is still disabled. Enable it in Settings \u{2192} Privacy & Security \u{2192} Local Network to discover dev servers.")
+      Text("Local network access is still disabled. To discover dev servers, enable it in Settings \u{2192} Privacy & Security \u{2192} Local Network.")
     }
     .alert("Permission Already Granted", isPresented: $showAlreadyGrantedAlert) {
       Button("OK") {


### PR DESCRIPTION
# Why

Improve the clarity of the local network permission alert message by restructuring the sentence. Some people could think theres "Local Network to discover dev servers." in the Settings after reading the sentence (though maybe that's just me).

![IMG_7899.PNG](https://app.graphite.com/user-attachments/assets/16beb061-af88-4bcb-a5c1-4d57da9d01de.png)

# How

Reworded the alert message

# Test Plan



# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)