### PR TITLE
Add support for external subtitle tracks on iOS and Android

### DIFF
--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/SubtitleSource.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/SubtitleSource.kt
@@ -1,0 +1,12 @@
+package expo.modules.video.records
+
+import android.net.Uri
+import expo.modules.kotlin.records.Field
+import expo.modules.kotlin.records.Record
+import java.io.Serializable
+
+class SubtitleSource(
+  @Field val uri: Uri? = null,
+  @Field val language: String? = null,
+  @Field val label: String? = null
+) : Record, Serializable

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/VideoSource.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/VideoSource.kt
@@ -26,7 +26,8 @@ class VideoSource(
   @Field var metadata: VideoMetadata? = null,
   @Field var headers: Map<String, String>? = null,
   @Field var useCaching: Boolean = false,
-  @Field val contentType: ContentType = ContentType.AUTO
+  @Field val contentType: ContentType = ContentType.AUTO,
+  @Field val subtitles: List<SubtitleSource>? = null
 ) : Record, Serializable {
   private fun toMediaId(): String {
     return "uri:${this.uri}" +
@@ -72,6 +73,24 @@ class VideoSource(
           }
         }.build()
       )
+      subtitles?.forEach { subtitleSource ->
+        subtitleSource.uri?.let { subtitleUri ->
+          val subtitleConfig = MediaItem.SubtitleConfiguration.Builder(subtitleUri).apply {
+            // WebVTT is the most widely supported sidecar subtitle format on Android.
+            // Fall back to WebVTT as the default when the URI extension is not recognised.
+            val mimeType = when (subtitleUri.lastPathSegment?.substringAfterLast(".")?.lowercase()) {
+              "srt" -> androidx.media3.common.MimeTypes.APPLICATION_SUBRIP
+              "ttml", "xml", "dfxp" -> androidx.media3.common.MimeTypes.APPLICATION_TTML
+              "ssa", "ass" -> androidx.media3.common.MimeTypes.TEXT_SSA
+              else -> androidx.media3.common.MimeTypes.TEXT_VTT
+            }
+            setMimeType(mimeType)
+            subtitleSource.language?.let { setLanguage(it) }
+            subtitleSource.label?.let { setLabel(it) }
+          }.build()
+          addSubtitleConfiguration(subtitleConfig)
+        }
+      }
     }
     .build()
 

--- a/packages/expo-video/ios/Records/SubtitleSource.swift
+++ b/packages/expo-video/ios/Records/SubtitleSource.swift
@@ -1,0 +1,16 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+import ExpoModulesCore
+
+// swiftlint:disable redundant_optional_initialization - Initialization with nil is necessary
+internal struct SubtitleSource: Record {
+  @Field
+  var uri: URL? = nil
+
+  @Field
+  var language: String? = nil
+
+  @Field
+  var label: String? = nil
+}
+// swiftlint:enable redundant_optional_initialization

--- a/packages/expo-video/ios/Records/VideoSource.swift
+++ b/packages/expo-video/ios/Records/VideoSource.swift
@@ -21,5 +21,8 @@ internal struct VideoSource: Record {
 
   @Field
   var contentType: ContentType = .auto
+
+  @Field
+  var subtitles: [SubtitleSource]? = nil
 }
 // swiftlint:enable redundant_optional_initialization

--- a/packages/expo-video/ios/VideoPlayerItem.swift
+++ b/packages/expo-video/ios/VideoPlayerItem.swift
@@ -45,7 +45,17 @@ class VideoPlayerItem: AVPlayerItem {
         // Catch block is intentionally left empty
     }
 
-    super.init(asset: urlAsset, automaticallyLoadedAssetKeys: nil)
+    // When the source provides external subtitle files and the content is not HLS (which already
+    // embeds its own subtitle tracks in the manifest), build an AVMutableComposition that mixes in
+    // the sidecar subtitle tracks. This makes the external subtitles appear in the player's
+    // `mediaSelectionGroup(forMediaCharacteristic: .legible)` just like embedded ones.
+    if let externalSubtitles = videoSource.subtitles, !externalSubtitles.isEmpty, !self.isHls {
+      let composition = await Self.buildComposition(videoAsset: asset, subtitleSources: externalSubtitles)
+      super.init(asset: composition, automaticallyLoadedAssetKeys: nil)
+    } else {
+      super.init(asset: urlAsset, automaticallyLoadedAssetKeys: nil)
+    }
+
     self.createTracksLoadingTask()
   }
 
@@ -73,6 +83,121 @@ class VideoPlayerItem: AVPlayerItem {
       let hlsTracks = await loadHlsTracks(mainUrl: mainUrl)
       return tracks + hlsTracks
     }
+  }
+
+  // MARK: - Composition builder
+
+  /// Builds an `AVMutableComposition` containing the video and audio tracks from `videoAsset`
+  /// together with text subtitle tracks loaded from each `SubtitleSource`.
+  ///
+  /// The resulting composition is used as the backing asset for the `AVPlayerItem` so that
+  /// external WebVTT subtitle files appear in the player's media-selection group alongside any
+  /// subtitles embedded in the stream.
+  static func buildComposition(
+    videoAsset: AVURLAsset,
+    subtitleSources: [SubtitleSource]
+  ) async -> AVMutableComposition {
+    let composition = AVMutableComposition()
+
+    // Determine duration from the video asset (fall back to .indefinite if unavailable).
+    let duration = (try? await videoAsset.load(.duration)) ?? .indefinite
+    let timeRange = CMTimeRange(start: .zero, duration: duration)
+
+    // Copy video tracks.
+    if let videoTracks = try? await videoAsset.loadTracks(withMediaType: .video) {
+      for track in videoTracks {
+        if let compositionTrack = composition.addMutableTrack(
+          withMediaType: .video,
+          preferredTrackID: kCMPersistentTrackID_Invalid
+        ) {
+          try? compositionTrack.insertTimeRange(timeRange, of: track, at: .zero)
+        }
+      }
+    }
+
+    // Copy audio tracks.
+    if let audioTracks = try? await videoAsset.loadTracks(withMediaType: .audio) {
+      for track in audioTracks {
+        if let compositionTrack = composition.addMutableTrack(
+          withMediaType: .audio,
+          preferredTrackID: kCMPersistentTrackID_Invalid
+        ) {
+          try? compositionTrack.insertTimeRange(timeRange, of: track, at: .zero)
+        }
+      }
+    }
+
+    // Add external subtitle tracks.
+    for subtitleSource in subtitleSources {
+      guard let subtitleURL = subtitleSource.uri else {
+        continue
+      }
+
+      let subtitleAsset = AVURLAsset(url: subtitleURL)
+
+      // WebVTT files are loaded as .text tracks; closed-caption files as .closedCaption.
+      let textTracks = (try? await subtitleAsset.loadTracks(withMediaType: .text)) ?? []
+      let ccTracks = (try? await subtitleAsset.loadTracks(withMediaType: .closedCaption)) ?? []
+      let allSubtitleTracks = textTracks + ccTracks
+
+      guard !allSubtitleTracks.isEmpty else {
+        log.warn("[expo-video] No subtitle tracks found in: \(subtitleURL.absoluteString)")
+        continue
+      }
+
+      for subtitleTrack in allSubtitleTracks {
+        let mediaType = (try? await subtitleTrack.load(.mediaType)) ?? .text
+        guard let compositionTrack = composition.addMutableTrack(
+          withMediaType: mediaType,
+          preferredTrackID: kCMPersistentTrackID_Invalid
+        ) else {
+          continue
+        }
+
+        let subtitleDuration = (try? await subtitleAsset.load(.duration)) ?? duration
+        let subtitleRange = CMTimeRange(start: .zero, duration: subtitleDuration)
+        try? compositionTrack.insertTimeRange(subtitleRange, of: subtitleTrack, at: .zero)
+
+        // Attach locale metadata so that AVFoundation exposes this track through
+        // `mediaSelectionGroup(forMediaCharacteristic: .legible)`.
+        compositionTrack.metadata = Self.makeSubtitleMetadata(
+          language: subtitleSource.language,
+          label: subtitleSource.label
+        )
+
+        // Set the BCP-47 language tag so AVFoundation can resolve a Locale for this track.
+        if let language = subtitleSource.language {
+          compositionTrack.extendedLanguageTag = language
+        }
+      }
+    }
+
+    return composition
+  }
+
+  /// Builds the AVMetadataItem array that associates a language and optional label with a
+  /// composition subtitle track, enabling AVFoundation to surface it via media selection.
+  private static func makeSubtitleMetadata(language: String?, label: String?) -> [AVMetadataItem] {
+    var items: [AVMetadataItem] = []
+
+    if let language {
+      let langItem = AVMutableMetadataItem()
+      langItem.keySpace = .common
+      langItem.key = AVMetadataKey.commonKeyLanguage as NSString
+      langItem.value = language as NSString
+      langItem.locale = Locale(identifier: language)
+      items.append(langItem)
+    }
+
+    if let label {
+      let titleItem = AVMutableMetadataItem()
+      titleItem.keySpace = .common
+      titleItem.key = AVMetadataKey.commonKeyTitle as NSString
+      titleItem.value = label as NSString
+      items.append(titleItem)
+    }
+
+    return items
   }
 
   // MARK: - HLS Helpers

--- a/packages/expo-video/ios/VideoPlayerSubtitles.swift
+++ b/packages/expo-video/ios/VideoPlayerSubtitles.swift
@@ -41,8 +41,18 @@ class VideoPlayerSubtitles {
     }
 
     if let group = currentItem.asset.mediaSelectionGroup(forMediaCharacteristic: .legible) {
-      let option = group.options.first {
-        $0.displayName == subtitleTrack?.label && $0.locale?.identifier == subtitleTrack?.language
+      let option: AVMediaSelectionOption?
+      if let subtitleTrack {
+        // Match by language identifier first; fall back to display name so that composition-based
+        // tracks (whose locale comes from the `extendedLanguageTag` we set) are also found.
+        option = group.options.first {
+          ($0.locale?.identifier == subtitleTrack.language || $0.extendedLanguageTag == subtitleTrack.language)
+            && ($0.displayName == subtitleTrack.label || subtitleTrack.label == nil)
+        } ?? group.options.first {
+          $0.locale?.identifier == subtitleTrack.language || $0.extendedLanguageTag == subtitleTrack.language
+        }
+      } else {
+        option = nil
       }
       currentItem.select(option, in: group)
     }

--- a/packages/expo-video/src/VideoPlayer.types.ts
+++ b/packages/expo-video/src/VideoPlayer.types.ts
@@ -400,6 +400,42 @@ export type VideoSourceObject = {
    * @platform ios
    */
   contentType?: ContentType;
+
+  /**
+   * Specifies external subtitle tracks to be loaded alongside the video.
+   *
+   * On iOS, subtitles are composed with the video using `AVMutableComposition`, which allows sidecar
+   * subtitle files (WebVTT `.vtt`) to be used with non-HLS video sources.
+   * On Android, subtitles are added via `MediaItem.SubtitleConfiguration` (ExoPlayer).
+   *
+   * > For HLS sources on iOS the subtitles embedded in the manifest are already available and do not
+   * > need to be specified here. This field is primarily intended for progressive video sources.
+   *
+   * @platform android
+   * @platform ios
+   */
+  subtitles?: SubtitleSource[];
+};
+
+/**
+ * Describes an external subtitle track that can be sideloaded with a video source.
+ */
+export type SubtitleSource = {
+  /**
+   * The URI of the subtitle file. WebVTT (`.vtt`) files are supported on both Android and iOS.
+   * SubRip (`.srt`) files are supported on Android only.
+   */
+  uri: string;
+
+  /**
+   * BCP-47 language tag for this subtitle track. For example `'en'`, `'fr'`, `'de'`.
+   */
+  language?: string;
+
+  /**
+   * Human-readable label for this subtitle track shown in the track picker.
+   */
+  label?: string;
 };
 
 /**


### PR DESCRIPTION
## Summary
This PR adds support for loading external subtitle files alongside video sources on both iOS and Android platforms. On iOS, external subtitles are composed with the video using `AVMutableComposition`, while on Android they are added via ExoPlayer's `MediaItem.SubtitleConfiguration`.

## Key Changes

- **New `SubtitleSource` type**: Added a new record type to represent external subtitle tracks with `uri`, `language`, and `label` fields on both platforms
- **iOS composition-based subtitles**: Implemented `buildComposition()` method that creates an `AVMutableComposition` mixing video, audio, and external subtitle tracks. This allows sidecar subtitle files (WebVTT) to appear in the player's media selection group alongside embedded subtitles
- **Android ExoPlayer integration**: Extended `VideoSource` to accept a list of `SubtitleSource` objects and configure them via `MediaItem.SubtitleConfiguration` with automatic MIME type detection based on file extension (WebVTT, SubRip, TTML, SSA/ASS)
- **Subtitle metadata handling**: Added `makeSubtitleMetadata()` helper on iOS to attach language and label metadata to composition tracks, enabling proper AVFoundation media selection
- **Improved subtitle track matching**: Enhanced `VideoPlayerSubtitles` to match tracks by both locale identifier and extended language tag, with fallback logic to handle composition-based tracks

## Notable Implementation Details

- On iOS, external subtitles are only composed for non-HLS sources (HLS already embeds subtitles in the manifest)
- The composition builder gracefully handles missing or unavailable tracks with try-catch blocks
- Android automatically detects subtitle format from file extension, defaulting to WebVTT for unrecognized formats
- Subtitle tracks are properly integrated into the player's media selection UI on both platforms

https://claude.ai/code/session_01Qxgw1TpSsYTBAbTbLK1Jw8