### PR TITLE
[core][ios] Fix PersistentFileLog crash

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix crash from `PersistentFileLog`.
+
 ### 💡 Others
 
 - Fixed view updates for Jetpack Compose integration. ([#42732](https://github.com/expo/expo/pull/42732) by [@kudo](https://github.com/kudo))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix crash from `PersistentFileLog`.
+- [iOS] Fix crash from `PersistentFileLog`. ([#43283](https://github.com/expo/expo/pull/43283) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Core/Logging/PersistentFileLog.swift
+++ b/packages/expo-modules-core/ios/Core/Logging/PersistentFileLog.swift
@@ -117,10 +117,13 @@ public class PersistentFileLog {
 
   private func appendTextToFile(text: String) throws {
     if let data = text.data(using: .utf8) {
-      let fileURL = URL(fileURLWithPath: filePath)
-      var existingData = (try? Data(contentsOf: fileURL)) ?? Data()
-      existingData.append(data)
-      try existingData.write(to: fileURL, options: .atomic)
+      if let fileHandle = FileHandle(forWritingAtPath: filePath) {
+        try EXUtilities.catchException {
+          fileHandle.seekToEndOfFile()
+          fileHandle.write(data)
+          fileHandle.closeFile()
+        }
+      }
     }
   }
 

--- a/packages/expo-modules-core/ios/Core/Logging/PersistentFileLog.swift
+++ b/packages/expo-modules-core/ios/Core/Logging/PersistentFileLog.swift
@@ -117,11 +117,10 @@ public class PersistentFileLog {
 
   private func appendTextToFile(text: String) throws {
     if let data = text.data(using: .utf8) {
-      if let fileHandle = FileHandle(forWritingAtPath: filePath) {
-        fileHandle.seekToEndOfFile()
-        try fileHandle.write(data)
-        fileHandle.closeFile()
-      }
+      let fileURL = URL(fileURLWithPath: filePath)
+      var existingData = (try? Data(contentsOf: fileURL)) ?? Data()
+      existingData.append(data)
+      try existingData.write(to: fileURL, options: .atomic)
     }
   }
 


### PR DESCRIPTION
# Why
Closes #43139 
The issue reporter is correct, errors from `FileHandle` cannot be handled by swift leading to a hard crash

# How
This was likely chosen for performance reasons but it's better for this to be a bit slower than hard crash. 

# Test Plan
n/a
