### PR TITLE
[ci][iOS] Optimize build time with ccache

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -36,6 +36,9 @@ inputs:
     description: 'NDK version used'
     default: '23.1.7779620'
     required: false
+  ccache:
+    description: 'Restore ccache'
+    required: false
   git-lfs:
     description: 'Restore Git LFS cache'
     required: false
@@ -190,6 +193,14 @@ runs:
       if: inputs.ndk == 'true' && steps.cache-android-ndk.outputs.cache-hit != 'true'
       shell: bash
       run: sudo $ANDROID_SDK_ROOT/tools/bin/sdkmanager --install "ndk;${{ inputs.ndk-version }}"
+
+    - name: ♻️ Restore ccache
+      if: inputs.ccache == 'true'
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.temp }}/.ccache
+        key: ${{ runner.os }}-ccache-${{ hashFiles('yarn.lock', 'packages/**/*.cpp', 'packages/**/*.h', 'packages/**/*.mm', 'packages/**/*.m') }}
+        restore-keys: ${{ runner.os }}-ccache-
 
     - name: 🔍️ Get cache key of Git LFS files
       if: inputs.git-lfs == 'true'

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -152,13 +152,50 @@ jobs:
         with:
           bundler-cache: true
           ruby-version: 3.2.2
+      - name: Setup ccache
+        run: |
+          brew install ccache
+
+          # In order to use ccache with Xcode, unlike on Android, we can't just change env variables - we need to change PATH.
+          MKDIR_PATH=$HOME/.ccache_bin
+          mkdir -p $MKDIR_PATH
+          ln -sf $(which ccache) $MKDIR_PATH/clang
+          ln -sf $(which ccache) $MKDIR_PATH/clang++
+          ln -sf $(which ccache) $MKDIR_PATH/cc
+          ln -sf $(which ccache) $MKDIR_PATH/c++
+          echo "$MKDIR_PATH" >> $GITHUB_PATH
+          echo "CC=$MKDIR_PATH/clang" >> $GITHUB_ENV
+          echo "CXX=$MKDIR_PATH/clang++" >> $GITHUB_ENV
+          echo "LD=$MKDIR_PATH/clang++" >> $GITHUB_ENV
+          echo "LDPLUSPLUS=$MKDIR_PATH/clang++" >> $GITHUB_ENV
+
+          # By default ccache includes mtime of a compiler in hashes, for each CI run mtime varies.
+          echo "CCACHE_COMPILERCHECK=content" >> $GITHUB_ENV
+
+          # It must be the same as in .github/actions/expo-caches/action.yml
+          echo "CCACHE_DIR=${{ runner.temp }}/.ccache" >> $GITHUB_ENV
+
+          # Sloppiness options disable some of the ccache checks to increase hit rate.
+          # We exclude ctime and mtime so the cache is hit based on file content.
+          # time_macros might help if in included modules there are macros like __TIME__ which would trigger a cache miss.
+          # modules, clang_index_store, system_headers, and ivfsoverlay are Xcode-specific options.
+          echo "CCACHE_SLOPPINESS=include_file_mtime,include_file_ctime,time_macros,modules,clang_index_store,system_headers,ivfsoverlay" >> $GITHUB_ENV
+
+          # Speeds up the process on cache misses by skipping the preprocessing step.
+          echo "CCACHE_DEPEND=true" >> $GITHUB_ENV
+
+          # Speeds up copying files on cache hits; natively supported by macOS APFS.
+          echo "CCACHE_FILECLONE=true" >> $GITHUB_ENV
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches
         with:
+          ccache: 'true'
           yarn-workspace: 'true'
           yarn-tools: 'true'
           bare-expo-pods: 'true'
+      - name: Reset ccache stats
+        run: ccache -z
       - name: 🧶 Install node modules in root dir
         run: yarn install --frozen-lockfile
       - name: 🕵️ Debug CocoaPods lockfiles
@@ -205,6 +242,8 @@ jobs:
             ./scripts/start-ios-e2e-test.ts --build
           build-output: apps/bare-expo/ios/build/BareExpo.app
           artifact-name: bare-expo-ios-builds
+      - name: Show ccache stats
+        run: ccache -s -v
       - name: 🔔 Notify on Slack
         uses: ./.github/actions/slack-notify
         if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))


### PR DESCRIPTION
# Why

This PR introduces ccache for iOS builds. It speeds up the compilation of .cpp, .mm, and .m files.

# Results

- **Hit rate for subsequent clean builds: ~100% (2436 files)** the percentage of files that didn't have to be compiled.
 - **Drop in build time:** my tests showed around a **10-minute** reduction. This time varies based on runner performance, so more precise numbers will be available later in performance metrics.

# How
- Downloads ccache.
 - Forces Xcode to use ccache for compilation.
 - Adds custom configuration for ccache, described in the YAML file comments.

# Test Plan

Green CI, tested on a stacked PR.