### PR TITLE
[docs] Document zoom transition delays and iOS requirements

### DIFF
--- a/docs/pages/router/advanced/zoom-transition.mdx
+++ b/docs/pages/router/advanced/zoom-transition.mdx
@@ -335,6 +335,12 @@ Both `Link.AppleZoom` and `Link.AppleZoomTarget` only accept a single child comp
 
 </Collapsible>
 
+<Collapsible summary="Noticeable delay when opening or dismissing screens">
+
+You may experience a noticeable delay (~1 second) when navigating to or dismissing screens that use zoom transitions, especially when performing rapid open/close/open gestures. This latency is higher than what you would see with the default push transition or native iOS apps using the same zoom transition API. This is an upstream issue in `react-native-screens` related to how it handles transitions on iOS and is not something that can be fixed in expo-router directly. The Expo team is actively working with the `react-native-screens` team to improve this. See [#42797](https://github.com/expo/expo/issues/42797) for updates.
+
+</Collapsible>
+
 <Collapsible summary="Supported only within router's Stack navigator">
 
 The zoom transition feature is only supported when using the router's built-in Stack navigator.

--- a/docs/pages/router/advanced/zoom-transition.mdx
+++ b/docs/pages/router/advanced/zoom-transition.mdx
@@ -339,7 +339,7 @@ Both `Link.AppleZoom` and `Link.AppleZoomTarget` only accept a single child comp
 
 You may experience a noticeable delay (approximately 1 second) when navigating to or dismissing screens that use zoom transitions, especially when performing rapid open/close/open gestures. This latency is higher than what you would see with native iOS apps using the same zoom transition API.
 
-This is an upstream issue in `react-native-screens` related to how it handles transitions on iOS. The Expo team is actively working with the `react-native-screens` team to improve this. See this [GitHub PR](https://github.com/expo/expo/issues/42797) for updates and more details.
+This is an upstream issue in `react-native-screens` related to how it handles transitions on iOS. The Expo team is actively working with the `react-native-screens` team to improve this. See this [GitHub Issue](https://github.com/expo/expo/issues/42797) for updates and more details.
 
 </Collapsible>
 

--- a/docs/pages/router/advanced/zoom-transition.mdx
+++ b/docs/pages/router/advanced/zoom-transition.mdx
@@ -337,7 +337,7 @@ Both `Link.AppleZoom` and `Link.AppleZoomTarget` only accept a single child comp
 
 <Collapsible summary="Noticeable delay when opening or dismissing screens">
 
-You may experience a noticeable delay (approximately 1 second) when navigating to or dismissing screens that use zoom transitions, especially when performing rapid open/close/open gestures. This latency is higher than what you would see with the default push transition or native iOS apps using the same zoom transition API. 
+You may experience a noticeable delay (approximately 1 second) when navigating to or dismissing screens that use zoom transitions, especially when performing rapid open/close/open gestures. This latency is higher than what you would see with native iOS apps using the same zoom transition API.
 
 This is an upstream issue in `react-native-screens` related to how it handles transitions on iOS. The Expo team is actively working with the `react-native-screens` team to improve this. See this [GitHub PR](https://github.com/expo/expo/issues/42797) for updates and more details.
 

--- a/docs/pages/router/advanced/zoom-transition.mdx
+++ b/docs/pages/router/advanced/zoom-transition.mdx
@@ -337,7 +337,9 @@ Both `Link.AppleZoom` and `Link.AppleZoomTarget` only accept a single child comp
 
 <Collapsible summary="Noticeable delay when opening or dismissing screens">
 
-You may experience a noticeable delay (~1 second) when navigating to or dismissing screens that use zoom transitions, especially when performing rapid open/close/open gestures. This latency is higher than what you would see with the default push transition or native iOS apps using the same zoom transition API. This is an upstream issue in `react-native-screens` related to how it handles transitions on iOS and is not something that can be fixed in expo-router directly. The Expo team is actively working with the `react-native-screens` team to improve this. See [#42797](https://github.com/expo/expo/issues/42797) for updates.
+You may experience a noticeable delay (approximately 1 second) when navigating to or dismissing screens that use zoom transitions, especially when performing rapid open/close/open gestures. This latency is higher than what you would see with the default push transition or native iOS apps using the same zoom transition API. 
+
+This is an upstream issue in `react-native-screens` related to how it handles transitions on iOS. The Expo team is actively working with the `react-native-screens` team to improve this. See this [GitHub PR](https://github.com/expo/expo/issues/42797) for updates and more details.
 
 </Collapsible>
 


### PR DESCRIPTION
## Why

Following up on the discussion in [#42797](https://github.com/expo/expo/issues/42797), this PR adds a known limitation entry for the noticeable latency users experience when opening or dismissing screens that use zoom transitions. Users report a delay of approximately 1 second, especially when performing rapid open/close/open gestures. This delay feels significantly higher than the default push transition or native iOS apps using the same zoom transition API. The issue is upstream in `react-native-screens` related to how it handles transitions on iOS 18+, and expo-router cannot fix it directly.

## How

- Added a new collapsible entry to "Known limitations" section in the zoom transition documentation page.
- The warning describes the delay, clarifies that this is an upstream `react-native-screens` issue (not an expo-router bug), notes that the Expo team is actively working with the `react-native-screens` team to improve this, and links to the tracking issue for updates.

## Test Plan

Add the collapsible and verify it renders correctly using the docs Next.js dev server.

## Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)