### PR TITLE
[brownfield][ios] pass additional settings to generate CFBundleShortVersionString

### DIFF
--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] improve security of env injection in publishing in [#43059](https://github.com/expo/expo/pull/43059) by [@pmleczek](https://github.com/pmleczek)
+- [ios] pass additional settings to generate CFBundleShortVersionString ([#43289](https://github.com/expo/expo/pull/43289) by [@pmleczek](https://github.com/pmleczek))
 
 ### 💡 Others
 

--- a/packages/expo-brownfield/plugin/build/ios/plugins/withXcodeProjectPlugin.js
+++ b/packages/expo-brownfield/plugin/build/ios/plugins/withXcodeProjectPlugin.js
@@ -48,7 +48,7 @@ const withXcodeProjectPlugin = (config, pluginConfig) => {
         // - Add template files to the compile sources phase
         (0, utils_1.configureBuildPhases)(xcodeProject, target, pluginConfig.targetName, projectName, templateFiles.map((file) => `${pluginConfig.targetName}/${file}`));
         // Add the required build settings
-        (0, utils_1.configureBuildSettings)(xcodeProject, pluginConfig.targetName, config.ios?.buildNumber || '1', pluginConfig.bundleIdentifier);
+        (0, utils_1.configureBuildSettings)(xcodeProject, pluginConfig.targetName, config.ios?.buildNumber || '1', pluginConfig.bundleIdentifier, config.ios?.version || config.version);
         return config;
     });
 };

--- a/packages/expo-brownfield/plugin/build/ios/utils/project.d.ts
+++ b/packages/expo-brownfield/plugin/build/ios/utils/project.d.ts
@@ -4,5 +4,5 @@ export declare const createFramework: (project: XcodeProject, targetName: string
 export declare const getGroupByUUID: (project: XcodeProject, uuid: string) => PbxGroup;
 export declare const createGroup: (project: XcodeProject, name: string, path: string, files?: string[]) => Group;
 export declare const configureBuildPhases: (project: XcodeProject, target: Target, targetName: string, projectName: string, files?: string[]) => void;
-export declare const configureBuildSettings: (project: XcodeProject, targetName: string, currentProjectVersion: string, bundleIdentifier: string) => void;
+export declare const configureBuildSettings: (project: XcodeProject, targetName: string, currentProjectVersion: string, bundleIdentifier: string, version?: string) => void;
 export declare const inferProjectName: (platformProjectRoot: string) => string;

--- a/packages/expo-brownfield/plugin/build/ios/utils/project.js
+++ b/packages/expo-brownfield/plugin/build/ios/utils/project.js
@@ -29,8 +29,8 @@ const configureBuildPhases = (project, target, targetName, projectName, files = 
     project.addBuildPhase(files, constants_1.Constants.BuildPhase.Sources, target.pbxNativeTarget.name, target.uuid, constants_1.Constants.Target.Framework, constants_1.Constants.Utils.XCEmptyString);
 };
 exports.configureBuildPhases = configureBuildPhases;
-const configureBuildSettings = (project, targetName, currentProjectVersion, bundleIdentifier) => {
-    const commonBuildSettings = getCommonBuildSettings(targetName, currentProjectVersion, bundleIdentifier);
+const configureBuildSettings = (project, targetName, currentProjectVersion, bundleIdentifier, version = '1.0') => {
+    const commonBuildSettings = getCommonBuildSettings(targetName, currentProjectVersion, bundleIdentifier, version);
     const buildConfigurationList = [
         {
             name: 'Debug',
@@ -55,7 +55,7 @@ const configureBuildSettings = (project, targetName, currentProjectVersion, bund
     destTarget.buildConfigurationList = configurationList.uuid;
 };
 exports.configureBuildSettings = configureBuildSettings;
-const getCommonBuildSettings = (targetName, currentProjectVersion, bundleIdentifier) => {
+const getCommonBuildSettings = (targetName, currentProjectVersion, bundleIdentifier, version) => {
     return {
         /* ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
         ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
@@ -70,10 +70,8 @@ const getCommonBuildSettings = (targetName, currentProjectVersion, bundleIdentif
         DEBUG_INFORMATION_FORMAT = dwarf;
         DEVELOPMENT_TEAM = ;
         GCC_C_LANGUAGE_STANDARD = gnu11;
-        MARKETING_VERSION = 1.0;
         MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
         MTL_FAST_MATH = YES;
-        SKIP_INSTALL = YES;
         SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
         SWIFT_EMIT_LOC_STRINGS = YES;
         SWIFT_OPTIMIZATION_LEVEL = "-Onone"; */
@@ -89,7 +87,8 @@ const getCommonBuildSettings = (targetName, currentProjectVersion, bundleIdentif
         GENERATE_INFOPLIST_FILE: `"YES"`,
         INFOPLIST_KEY_CFBundleDisplayName: targetName,
         INFOPLIST_KEY_NSHumanReadableCopyright: `""`,
-        // MARKETING_VERSION: `"${marketingVersion}"`,
+        INFOPLIST_KEY_CFBundleShortVersionString: `"${version}"`,
+        MARKETING_VERSION: `"${version}"`,
         SWIFT_OPTIMIZATION_LEVEL: `"-Onone"`,
         CODE_SIGN_ENTITLEMENTS: `"${targetName}/${targetName}.entitlements"`,
         // DEVELOPMENT_TEAM: `""`,

--- a/packages/expo-brownfield/plugin/src/ios/plugins/withXcodeProjectPlugin.ts
+++ b/packages/expo-brownfield/plugin/src/ios/plugins/withXcodeProjectPlugin.ts
@@ -83,7 +83,8 @@ const withXcodeProjectPlugin: ConfigPlugin<PluginConfig> = (config, pluginConfig
       xcodeProject,
       pluginConfig.targetName,
       config.ios?.buildNumber || '1',
-      pluginConfig.bundleIdentifier
+      pluginConfig.bundleIdentifier,
+      config.ios?.version || config.version,
     );
 
     return config;

--- a/packages/expo-brownfield/plugin/src/ios/plugins/withXcodeProjectPlugin.ts
+++ b/packages/expo-brownfield/plugin/src/ios/plugins/withXcodeProjectPlugin.ts
@@ -84,7 +84,7 @@ const withXcodeProjectPlugin: ConfigPlugin<PluginConfig> = (config, pluginConfig
       pluginConfig.targetName,
       config.ios?.buildNumber || '1',
       pluginConfig.bundleIdentifier,
-      config.ios?.version || config.version,
+      config.ios?.version || config.version
     );
 
     return config;

--- a/packages/expo-brownfield/plugin/src/ios/utils/project.ts
+++ b/packages/expo-brownfield/plugin/src/ios/utils/project.ts
@@ -77,12 +77,14 @@ export const configureBuildSettings = (
   project: XcodeProject,
   targetName: string,
   currentProjectVersion: string,
-  bundleIdentifier: string
+  bundleIdentifier: string,
+  version: string = '1.0'
 ) => {
   const commonBuildSettings = getCommonBuildSettings(
     targetName,
     currentProjectVersion,
-    bundleIdentifier
+    bundleIdentifier,
+    version
   );
 
   const buildConfigurationList = [
@@ -123,7 +125,8 @@ export const configureBuildSettings = (
 const getCommonBuildSettings = (
   targetName: string,
   currentProjectVersion: string,
-  bundleIdentifier: string
+  bundleIdentifier: string,
+  version: string
 ): Record<string, string> => {
   return {
     /* ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -139,10 +142,8 @@ const getCommonBuildSettings = (
     DEBUG_INFORMATION_FORMAT = dwarf;
     DEVELOPMENT_TEAM = ;
     GCC_C_LANGUAGE_STANDARD = gnu11;
-    MARKETING_VERSION = 1.0;
     MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
     MTL_FAST_MATH = YES;
-    SKIP_INSTALL = YES;
     SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
     SWIFT_EMIT_LOC_STRINGS = YES;
     SWIFT_OPTIMIZATION_LEVEL = "-Onone"; */
@@ -159,7 +160,8 @@ const getCommonBuildSettings = (
     GENERATE_INFOPLIST_FILE: `"YES"`,
     INFOPLIST_KEY_CFBundleDisplayName: targetName,
     INFOPLIST_KEY_NSHumanReadableCopyright: `""`,
-    // MARKETING_VERSION: `"${marketingVersion}"`,
+    INFOPLIST_KEY_CFBundleShortVersionString: `"${version}"`,
+    MARKETING_VERSION: `"${version}"`,
     SWIFT_OPTIMIZATION_LEVEL: `"-Onone"`,
     CODE_SIGN_ENTITLEMENTS: `"${targetName}/${targetName}.entitlements"`,
     // DEVELOPMENT_TEAM: `""`,


### PR DESCRIPTION
# Why

An issue has been reported in the previoust repository: https://github.com/software-mansion-labs/expo-brownfield-target/issues/42 reporting that not having `CFBundleShortVersionString` in the Plist generated in the framework causes validation failure when uploading to App Store Connect:

```
Validation failed
The bundle 'Payload/MyApp.app/Frameworks/MyLibName.framework' is missing plist key. 
The Info.plist file is missing the required key: CFBundleShortVersionString. 
Please find more information about CFBundleShortVersionString at https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring 
```

# How

Since we already pass some hardcoded version in the `Info.plist` template and issue is still reproducible, it's related to the generated Plist file configured via build settings in the config plugin. Updated the build settings with two additional properties:

```ts
  INFOPLIST_KEY_CFBundleShortVersionString: `"${version}"`,
  ...
  MARKETING_VERSION: `"${version}"`,
```

Where `version` is either `config.ios.version`, `config.version` or `1.0` if neither is present

# Test Plan

Verified compiled framework before and after the changes:

BEFORE:

```json
{
  "BuildMachineOSBuild" => "25A362"
  "CFBundleDevelopmentRegion" => "en"
  "CFBundleDisplayName" => "expoappbrownfield"
  "CFBundleExecutable" => "expoappbrownfield"
  "CFBundleIdentifier" => "host.exp.expoappbrownfield"
  "CFBundleInfoDictionaryVersion" => "6.0"
  "CFBundleName" => "expoappbrownfield"
  "CFBundlePackageType" => "FMWK"
  "CFBundleSupportedPlatforms" => [
    0 => "iPhoneOS"
  ]
  "CFBundleVersion" => "1"
  ...
}
```

AFTER:

```json
{
  "BuildMachineOSBuild" => "25A362"
  "CFBundleDevelopmentRegion" => "en"
  "CFBundleDisplayName" => "expoappbrownfield"
  "CFBundleExecutable" => "expoappbrownfield"
  "CFBundleIdentifier" => "host.exp.expoappbrownfield"
  "CFBundleInfoDictionaryVersion" => "6.0"
  "CFBundleName" => "expoappbrownfield"
  "CFBundlePackageType" => "FMWK"
  "CFBundleShortVersionString" => "1.0.0" <------------- ADDED
  "CFBundleSupportedPlatforms" => [
    0 => "iPhoneOS"
  ]
  "CFBundleVersion" => "1"
  ...
}
```

# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
