### PR TITLE
[docs] Fix internal links in Guides overview

### DIFF
--- a/docs/pages/guides/overview.mdx
+++ b/docs/pages/guides/overview.mdx
@@ -17,7 +17,7 @@ Learn about the process of [building an app with Expo](/workflow/overview/) to h
 
 ### <span className="inline-flex items-center gap-2"><RouterLogo />Expo Router</span>
 
-Learn about using different navigation functionalities from the [Expo Router](/router/basics/layout/#root-layout) library. It also covers a comprehensive [Hooks API](/router/reference/hooks/) that the library provides and other aspects of navigation such as [Authentication](/router/reference/authentication/), [Redirects](/router/reference/redirects/), [Testing](/router/reference/testing/), and more.
+Learn about using different navigation functionalities from the [Expo Router](/router/introduction/) library. It also covers a comprehensive [Hooks API](/versions/latest/sdk/router/#hooks) that the library provides and other aspects of navigation such as [Authentication](/router/advanced/authentication/), [Redirects](/router/reference/redirects/), [Testing](/router/reference/testing/), and more.
 
 ### <span className="inline-flex items-center gap-2"><CpuChip01Icon />Expo Modules API</span>
 


### PR DESCRIPTION
## Why

The Expo Router section on the Guides overview page (`/guides/overview/`) has three internal links pointing to old paths that no longer exist. These links either rely on redirects or lead to 404s.

## How

- Update the "Expo Router" link from `/router/basics/layout/#root-layout` to `/router/introduction/`, which is the correct landing page for the Expo Router docs.
- Update the "Hooks API" link from `/router/reference/hooks/` to `/versions/latest/sdk/router/#hooks`, where the hooks documentation now lives.
- Update the "Authentication" link from `/router/reference/authentication/` to `/router/advanced/authentication/`, matching the current file location.

## Test Plan

Visit the Guides overview page and verify all five links in the Expo Router section navigate to the correct pages without relying on redirects.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
