### PR TITLE
[docs] Remove alpha notices for `experiments.autolinkingModuleResolution`

### DIFF
--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -240,11 +240,11 @@ For [npm](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#overrides),
 
 #### Deduplicating auto-linked native modules
 
-> **important** This is an alpha feature starting in SDK 54 and later. The process will be automated and have better support in future versions.
-
 Often, duplicate dependencies won't cause any problems. However, native modules should never be duplicated, because only one version of a native module can be compiled for an app build at a time. Unlike JavaScript dependencies, native builds cannot contain two conflicting versions of a single native module.
 
 From **SDK 54**, you can set `experiments.autolinkingModuleResolution` to `true` in your **app.json** to apply autolinking to Expo CLI and Metro bundler automatically. This will force dependencies that Metro resolves to match the native modules that [autolinking](/modules/autolinking/) links for your native builds.
+
+From **SDK 55**, this is enabled automatically for apps in monorepos.
 
 ### Script '...' does not exist
 

--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -257,13 +257,13 @@ For example, with the `--platform ios` option, it returns an object in **react-n
 
 ## Dependency resolution and conflicts
 
-> **important** This is an alpha feature starting in SDK 54 and later.
-
 Autolinking and Node resolution have different goals and the module resolution algorithm in Node and Metro can sometimes come into conflict. If your app contains duplicate installations of a native module that is picked up by autolinking, your JavaScript bundle may contain both versions of the native module, while autolinking and your native app will only contain one version. This might cause runtime crashes and risks incompatibilities.
 
 This is an especially common problem with isolated dependencies or monorepos, and you should [check for and deduplicate native modules in your dependencies](/guides/monorepos/#duplicate-native-packages-within-monorepos).
 
 From **SDK 54**, you can set `experiments.autolinkingModuleResolution` to `true` in your [app config](/workflow/configuration/) to apply autolinking to Expo CLI and Metro bundler automatically. This will force dependencies that Metro resolves to match the native modules that **autolinking** resolves.
+
+From **SDK 55**, the `experiments.autolinkingModuleResolution` flag is enabled by default for apps in monorepos.
 
 ## Common questions
 


### PR DESCRIPTION
# Why

The `experiments.autolinkingModuleResolution` option will be auto-enabled for monorepos in SDK 55. It's also not considered "alpha-quality" any longer, and the `experiments` flag is sufficient to communicate that it's (usually) not the default, and we shouldn't warn people that it's an early preview anymore.

This is safe to enable regardless of whether apps are on SDK 54 or 55, and we'll backport any fixes (no fixes had to be backported so far)

# How

- Remove alpha callouts for `autolinkingModuleResolution`
- Add notes that the option is enabled for monorepos by default