### PR TITLE
[docs] Update to re-designed cookie consent banner

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@expo/styleguide": "^9.3.1",
     "@expo/styleguide-base": "^2.0.5",
-    "@expo/styleguide-cookie-consent": "^0.1.11",
+    "@expo/styleguide-cookie-consent": "^0.1.12",
     "@expo/styleguide-icons": "^2.3.4",
     "@expo/styleguide-search-ui": "^3.3.3",
     "@kapaai/react-sdk": "^0.9.0",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -794,9 +794,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/styleguide-cookie-consent@npm:^0.1.11":
-  version: 0.1.11
-  resolution: "@expo/styleguide-cookie-consent@npm:0.1.11"
+"@expo/styleguide-cookie-consent@npm:^0.1.12":
+  version: 0.1.12
+  resolution: "@expo/styleguide-cookie-consent@npm:0.1.12"
   dependencies:
     "@radix-ui/react-accordion": "npm:^1.2.4"
     "@radix-ui/react-slot": "npm:^1.2.0"
@@ -805,7 +805,7 @@ __metadata:
     zustand: "npm:^5.0.3"
   peerDependencies:
     react: ">= 19"
-  checksum: 10c0/a5eea96abb9716b42eb9aa498898c472e771e81d7c10a7e47bb980c6b609b8a5728505eafb5e2a80323f0184b5883dbfebfc50c1e8d776fdb7615b1e98fa2e29
+  checksum: 10c0/4f50cea9e8e0674c320d36f97d3bbe4e1f0839a3bcd715faf892386e1aaa48a769f35e0586140d79d7a3d23f3820db103d358e3308315f992f514a34bb5f19f4
   languageName: node
   linkType: hard
 
@@ -7565,7 +7565,7 @@ __metadata:
     "@expo/spawn-async": "npm:^1.7.2"
     "@expo/styleguide": "npm:^9.3.1"
     "@expo/styleguide-base": "npm:^2.0.5"
-    "@expo/styleguide-cookie-consent": "npm:^0.1.11"
+    "@expo/styleguide-cookie-consent": "npm:^0.1.12"
     "@expo/styleguide-icons": "npm:^2.3.4"
     "@expo/styleguide-search-ui": "npm:^3.3.3"
     "@kapaai/react-sdk": "npm:^0.9.0"


### PR DESCRIPTION
# Why

Upgrade `@expo/styleguide-cookie-consent` from `^0.1.11` to `^0.1.12` to pick up the redesigned cookie consent UI.

# How

Bumped the `@expo/styleguide-cookie-consent` dependency version in both `server/website/package.json` and `server/website/blog/package.json`, and updated the lockfile.

# Test Plan

### Actions

1. Run `cd docs && yarn start`
2. Open the site and trigger the cookie consent banner

### Assertions

- The cookie consent banner renders with the new redesigned UI from `0.1.12`
- No regressions in existing cookie consent behavior

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)