### PR TITLE
Omit built files from VS Code search

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,8 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
-  "eslint.workingDirectories": [
-    { "pattern": "*" },
-  ]
+  "eslint.workingDirectories": [{ "pattern": "*" }],
+  "search.exclude": {
+    "packages/**/build": true,
+    "docs/public/static/data": true
+  }
 }


### PR DESCRIPTION
# Why

VS Code search results in this monorepo include build artifacts (`packages/**/build`) and generated docs data (`docs/public/static/data`), adding noise when searching for code.

# How

Added `search.exclude` entries to `.vscode/settings.json` to omit these directories from search results.

# Test Plan

Open the repo in VS Code and confirm that searching no longer returns results from `packages/**/build` or `docs/public/static/data`.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)