### PR TITLE
[ci] Ignore create-expo scripts in test suite

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -70,7 +70,7 @@ jobs:
             "apps/test-suite/**",
             "packages/**",
             "!packages/@expo/cli/**",
-            "!packages/{create-expo,create-expo-nightly,create-expo-module}/**""
+            "!packages/{create-expo,create-expo-nightly,create-expo-module}/**",
             yarn.lock,
             "!packages/**/{ios,android}/**",
             "!apps/bare-expo/**/{ios,android}/**"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -13,6 +13,9 @@ on:
       - packages/**
       - yarn.lock
       - '!packages/@expo/cli/**'
+      - '!packages/create-expo/**'
+      - '!packages/create-expo-nightly/**'
+      - '!packages/create-expo-module/**'
       - '!**.md'
       - '!**/__tests__/**'
       - '!**/__mocks__/**'
@@ -26,6 +29,9 @@ on:
       - packages/**
       - yarn.lock
       - '!packages/@expo/cli/**'
+      - '!packages/create-expo/**'
+      - '!packages/create-expo-nightly/**'
+      - '!packages/create-expo-module/**'
       - '!**.md'
       - '!**/__tests__/**'
       - '!**/__mocks__/**'
@@ -63,6 +69,8 @@ jobs:
             "apps/bare-expo/**",
             "apps/test-suite/**",
             "packages/**",
+            "!packages/@expo/cli/**",
+            "!packages/{create-expo,create-expo-nightly,create-expo-module}/**""
             yarn.lock,
             "!packages/**/{ios,android}/**",
             "!apps/bare-expo/**/{ios,android}/**"


### PR DESCRIPTION
# Why
Changes to the following packages:
- create-expo
- create-expo-nightly
- create-expo-module
- @expo/cli 

shouldn't trigger the test suite 

# How
Adds new negations to paths which trigger the workflow and to `common-paths` in `Detect build-relevant platform changes`

# Test Plan
Green CI