### PR TITLE
[go][Android] Fix compilation error after removing interfaces from `e-m-c`

### DIFF
--- a/apps/expo-go/android/app/src/main/java/host/exp/exponent/MainApplication.kt
+++ b/apps/expo-go/android/app/src/main/java/host/exp/exponent/MainApplication.kt
@@ -1,22 +1,8 @@
 package host.exp.exponent
 
-import com.facebook.react.ReactPackage
-import expo.modules.ExpoModulesPackageList
-import expo.modules.apploader.AppLoaderPackagesProviderInterface
-import expo.modules.core.interfaces.Package
-
 // Needed for `react-native link`
 // import com.facebook.react.ReactApplication;
-class MainApplication : ExpoApplication(), AppLoaderPackagesProviderInterface<ReactPackage?> {
+class MainApplication : ExpoApplication() {
   override val isDebug: Boolean
     get() = BuildConfig.DEBUG
-
-  // Needed for `react-native link`
-  override fun getPackages(): List<ReactPackage> {
-    return mutableListOf()
-  }
-
-  override fun getExpoPackages(): List<Package> {
-    return ExpoModulesPackageList.getPackageList()
-  }
 }

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/notifications/managers/SchedulerManagerImpl.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/notifications/managers/SchedulerManagerImpl.kt
@@ -2,7 +2,6 @@ package host.exp.exponent.notifications.managers
 
 import android.content.Context
 import com.raizlabs.android.dbflow.sql.language.SQLite
-import expo.modules.core.interfaces.Function
 import host.exp.exponent.kernel.ExperienceKey
 import host.exp.exponent.notifications.exceptions.UnableToScheduleException
 import host.exp.exponent.notifications.schedulers.*
@@ -82,7 +81,7 @@ internal class SchedulerManagerImpl(private val applicationContext: Context) : S
     }
   }
 
-  override fun addScheduler(scheduler: Scheduler, handler: Function<String, Boolean>) {
+  override fun addScheduler(scheduler: Scheduler, handler: (String?) -> Boolean) {
     fetchSchedulersMap()
 
     scheduler.setApplicationContext(applicationContext)
@@ -97,7 +96,7 @@ internal class SchedulerManagerImpl(private val applicationContext: Context) : S
       null
     }
 
-    handler.apply(idToApply)
+    handler.invoke(idToApply)
   }
 
   private fun fetchSchedulersMap() {

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/notifications/managers/SchedulersManager.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/notifications/managers/SchedulersManager.kt
@@ -1,6 +1,5 @@
 package host.exp.exponent.notifications.managers
 
-import expo.modules.core.interfaces.Function
 import host.exp.exponent.kernel.ExperienceKey
 import host.exp.exponent.notifications.schedulers.Scheduler
 
@@ -10,5 +9,5 @@ interface SchedulersManager {
   fun cancelAlreadyScheduled(experienceKey: ExperienceKey?)
   fun rescheduleOrDelete(id: String?)
   fun removeScheduler(id: String?)
-  fun addScheduler(scheduler: Scheduler, handler: Function<String, Boolean>)
+  fun addScheduler(scheduler: Scheduler, handler: (String?) -> Boolean)
 }

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/notifications/managers/SchedulersManagerProxy.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/notifications/managers/SchedulersManagerProxy.kt
@@ -1,7 +1,6 @@
 package host.exp.exponent.notifications.managers
 
 import android.content.Context
-import expo.modules.core.interfaces.Function
 import host.exp.exponent.kernel.ExperienceKey
 import host.exp.exponent.notifications.schedulers.*
 import java.util.concurrent.Executor
@@ -30,7 +29,7 @@ class SchedulersManagerProxy private constructor(private val schedulersManager: 
     singleThreadExecutor.execute { schedulersManager.removeScheduler(id) }
   }
 
-  override fun addScheduler(scheduler: Scheduler, handler: Function<String, Boolean>) {
+  override fun addScheduler(scheduler: Scheduler, handler: (String?) -> Boolean) {
     singleThreadExecutor.execute { schedulersManager.addScheduler(scheduler, handler) }
   }
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/taskManager/ExpoHeadlessAppLoader.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/taskManager/ExpoHeadlessAppLoader.kt
@@ -2,19 +2,15 @@ package host.exp.exponent.taskManager
 
 import android.content.Context
 import android.util.Log
-import expo.modules.adapters.react.apploader.HeadlessAppLoaderNotifier
 import expo.modules.apploader.HeadlessAppLoader
-import expo.modules.apploader.HeadlessAppLoader.AppConfigurationError
 import expo.modules.core.interfaces.Consumer
 import expo.modules.core.interfaces.DoNotStrip
 import host.exp.exponent.headless.InternalHeadlessAppLoader
-import java.util.*
 
 @DoNotStrip
 class ExpoHeadlessAppLoader @DoNotStrip constructor(context: Context?) : HeadlessAppLoader {
   private val appScopeKeysToAppRecords = mutableMapOf<String, AppRecordInterface>()
 
-  @Throws(AppConfigurationError::class)
   override fun loadApp(
     context: Context,
     params: HeadlessAppLoader.Params,
@@ -24,38 +20,36 @@ class ExpoHeadlessAppLoader @DoNotStrip constructor(context: Context?) : Headles
     val appLoader = createAppLoader(context)
 
     if (params.appUrl == null) {
-      throw AppConfigurationError("Cannot execute background task because application URL is invalid")
-    } else {
-      if (appScopeKeysToAppRecords.containsKey(params.appScopeKey)) {
-        alreadyRunning.run()
-      } else {
-        Log.i(
-          TAG,
-          "Loading headless app '" + params.appScopeKey + "' with url '" + params.appUrl + "'."
-        )
-        val appRecord = appLoader.loadApp(
-          params.appUrl,
-          mapOf()
-        ) { success, exception ->
-          if (exception != null) {
-            exception.printStackTrace()
-            Log.e(TAG, exception.message!!)
-          }
-          HeadlessAppLoaderNotifier.notifyAppLoaded(params.appScopeKey)
-          callback.apply(success)
-          if (!success) {
-            appScopeKeysToAppRecords.remove(params.appScopeKey)
-          }
-        }
+      throw IllegalArgumentException("Params must be set with appScopeKey!")
+    }
 
-        appScopeKeysToAppRecords[params.appScopeKey] = appRecord
+    if (appScopeKeysToAppRecords.containsKey(params.appScopeKey)) {
+      alreadyRunning.run()
+    } else {
+      Log.i(
+        TAG,
+        "Loading headless app '" + params.appScopeKey + "' with url '" + params.appUrl + "'."
+      )
+      val appRecord = appLoader.loadApp(
+        params.appUrl,
+        mapOf()
+      ) { success, exception ->
+        if (exception != null) {
+          exception.printStackTrace()
+          Log.e(TAG, exception.message!!)
+        }
+        callback.apply(success)
+        if (!success) {
+          appScopeKeysToAppRecords.remove(params.appScopeKey)
+        }
       }
+
+      appScopeKeysToAppRecords[params.appScopeKey] = appRecord
     }
   }
 
   override fun invalidateApp(appScopeKey: String): Boolean {
     appScopeKeysToAppRecords.remove(appScopeKey)
-    HeadlessAppLoaderNotifier.notifyAppLoaded(appScopeKey)
     return false
   }
 


### PR DESCRIPTION
# Why

Fixes compilation error after removing some interfaces from `e-m-c`. I had to miss that `Function` and stuff connected with the task manager were used in Expo Go. Now, it should be fixed.

# Test Plan

- Expo Go ✅ 