### PR TITLE
[docs] Fix cookie consent styling issue

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@expo/styleguide": "^9.3.1",
     "@expo/styleguide-base": "^2.0.5",
-    "@expo/styleguide-cookie-consent": "^0.1.12",
+    "@expo/styleguide-cookie-consent": "^0.1.13",
     "@expo/styleguide-icons": "^2.3.4",
     "@expo/styleguide-search-ui": "^3.3.3",
     "@kapaai/react-sdk": "^0.9.0",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -794,9 +794,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/styleguide-cookie-consent@npm:^0.1.12":
-  version: 0.1.12
-  resolution: "@expo/styleguide-cookie-consent@npm:0.1.12"
+"@expo/styleguide-cookie-consent@npm:^0.1.13":
+  version: 0.1.13
+  resolution: "@expo/styleguide-cookie-consent@npm:0.1.13"
   dependencies:
     "@radix-ui/react-accordion": "npm:^1.2.4"
     "@radix-ui/react-slot": "npm:^1.2.0"
@@ -805,7 +805,7 @@ __metadata:
     zustand: "npm:^5.0.3"
   peerDependencies:
     react: ">= 19"
-  checksum: 10c0/4f50cea9e8e0674c320d36f97d3bbe4e1f0839a3bcd715faf892386e1aaa48a769f35e0586140d79d7a3d23f3820db103d358e3308315f992f514a34bb5f19f4
+  checksum: 10c0/165284e01ceb731ac8d611ecc6e1910171420d5d2813bd38b287970fd8b35cc1870351821e7a7fdf6da3bc93ef7085668a72ef335d3dffb8fd3764cb055217f0
   languageName: node
   linkType: hard
 
@@ -7565,7 +7565,7 @@ __metadata:
     "@expo/spawn-async": "npm:^1.7.2"
     "@expo/styleguide": "npm:^9.3.1"
     "@expo/styleguide-base": "npm:^2.0.5"
-    "@expo/styleguide-cookie-consent": "npm:^0.1.12"
+    "@expo/styleguide-cookie-consent": "npm:^0.1.13"
     "@expo/styleguide-icons": "npm:^2.3.4"
     "@expo/styleguide-search-ui": "npm:^3.3.3"
     "@kapaai/react-sdk": "npm:^0.9.0"


### PR DESCRIPTION
# Why

This PR updates the `@expo/styleguide-cookie-consent` dependency from version `^0.1.12` to `^0.1.13` in the documentation package.

# How

Updated the version constraint in `package.json` and regenerated the lock file to reflect the new dependency version.

# Test Plan

Verify that the documentation site builds and runs correctly with the updated cookie consent component. Test that cookie consent functionality continues to work as expected.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)