### PR TITLE
[contacts][next] Fix `contact.editWithForm()`

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `editWithForm` throws error
+- Fix `editWithForm` throws error ([#43315](https://github.com/expo/expo/pull/43315) by [@Wenszel](https://github.com/Wenszel))
 
 ### 💡 Others
 

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `editWithForm` throws error
+
 ### 💡 Others
 
 ## 55.0.6 — 2026-02-16

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/Contact.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/Contact.kt
@@ -133,7 +133,7 @@ class Contact(
     return mapper.toRecord(existingContact)
   }
 
-  suspend fun presentEditForm() = withContext(Dispatchers.IO) {
+  suspend fun editWithForm() = withContext(Dispatchers.IO) {
     intentDelegate.launchEditContact(getLookupKeyUri())
   }
 

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/ContactsNextModule.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/ContactsNextModule.kt
@@ -328,8 +328,8 @@ class ContactsNextModule : Module() {
         self.urlAddresses.delete(urlAddressRecord)
       }
 
-      AsyncFunction("presentEditForm") Coroutine { self: Contact ->
-        self.presentEditForm()
+      AsyncFunction("editWithForm") Coroutine { self: Contact ->
+        self.editWithForm()
       }
 
       StaticAsyncFunction("create") Coroutine { createContactRecord: CreateContactRecord ->

--- a/packages/expo-contacts/ios/next/ContactsNextModule.swift
+++ b/packages/expo-contacts/ios/next/ContactsNextModule.swift
@@ -334,8 +334,8 @@ public class ContactsNextModule: Module {
         try this.thumbnail.get()
       }
 
-      AsyncFunction("presentEditForm") { (this: ContactNext, options: FormOptions?, promise: Promise) in
-        try formDelegate.presentEditForm(for: this, options: options, promise: promise)
+      AsyncFunction("editWithForm") { (this: ContactNext, options: FormOptions?, promise: Promise) in
+        try formDelegate.editWithForm(for: this, options: options, promise: promise)
       }.runOnQueue(.main)
 
       StaticAsyncFunction("getAll") { (queryOptions: ContactQueryOptions?) in

--- a/packages/expo-contacts/ios/next/form/FormDelegate.swift
+++ b/packages/expo-contacts/ios/next/form/FormDelegate.swift
@@ -28,7 +28,7 @@ class FormDelegate: OnContactPickingResultHandler {
   private var contactPickingPromise: Promise?
   private var contactManipulationPromise: Promise?
 
-  func presentEditForm(for contact: ContactNext, options: FormOptions?, promise: Promise) throws {
+  func editWithForm(for contact: ContactNext, options: FormOptions?, promise: Promise) throws {
     if contactManipulationPromise != nil {
       throw ContactManipulationInProgressException()
     }


### PR DESCRIPTION
# Why
`contact.editWithForm()` throws an error because of the function names mismatch.

# How
Renamed the function on the native side.

# Test Plan
bare expo ✅