### PR TITLE
[docs][submit] Fix links for Android and iOS options

### DIFF
--- a/docs/pages/submit/eas-json.mdx
+++ b/docs/pages/submit/eas-json.mdx
@@ -35,7 +35,7 @@ The `production` profile shown below is required to run Android and iOS submissi
 }
 ```
 
-Learn more about the values you can set with the [Android specific options](/eas/json/#android-specific-options) and the [iOS specific options](/eas/json/#ios-specific-options). You can also learn how to submit to the [Apple App Store](/submit/ios) and the [Google Play Store](/submit/android).
+Learn more about the values you can set with the [Android specific options](/eas/json/#android-specific-options-1) and the [iOS specific options](/eas/json/#ios-specific-options-1). You can also learn how to submit to the [Apple App Store](/submit/ios) and the [Google Play Store](/submit/android).
 
 ## Multiple profiles
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

In Submit's docs, current links for iOS and Android specific options are currently pointing to specific options for `Build`.
Related issue: https://github.com/expo/expo/issues/43313

# How

<!--
How did you build this feature or fix this bug and why?
-->

This fix add suffix `-1` to existing links, to actually point to the right anchors.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Test by running dev docs locally and checking links point to the right anchors.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
