### PR TITLE
feat(create-expo-module): Add non-interactive mode and CI support

### DIFF
--- a/.github/workflows/create-expo-module.yml
+++ b/.github/workflows/create-expo-module.yml
@@ -1,0 +1,52 @@
+name: Create Expo Module
+
+on:
+  push:
+    branches: [main, 'sdk-*']
+    paths:
+      - .github/workflows/create-expo-module.yml
+      - packages/create-expo-module/**
+      - yarn.lock
+  pull_request:
+    paths:
+      - .github/workflows/create-expo-module.yml
+      - packages/create-expo-module/**
+      - yarn.lock
+  schedule:
+    - cron: 0 14 * * *
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22]
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 100
+      - name: ⬇️ Fetch commits from base branch
+        run: git fetch origin ${{ github.event.before || github.base_ref || 'main' }}:${{ github.event.before || github.base_ref || 'main' }} --depth 100
+        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+      - name: ♻️ Restore caches
+        uses: ./.github/actions/expo-caches
+        id: expo-caches
+        with:
+          yarn-workspace: 'true'
+      - name: 🧶 Install node modules in root dir
+        run: yarn install --frozen-lockfile
+      - name: 🛠 Build create-expo-module
+        run: yarn prepare
+        working-directory: packages/create-expo-module
+      - name: 🧪 E2E Test create-expo-module
+        run: yarn test:e2e
+        working-directory: packages/create-expo-module

--- a/packages/create-expo-module/e2e/__tests__/index-test.ts
+++ b/packages/create-expo-module/e2e/__tests__/index-test.ts
@@ -1,0 +1,109 @@
+import fs from 'fs';
+
+import {
+  createTestPath,
+  ensureFolderExists,
+  executePassing,
+  expectFileExists,
+  getTestPath,
+  projectRoot,
+  readJson,
+} from './utils';
+
+beforeAll(async () => {
+  ensureFolderExists(projectRoot);
+});
+
+afterAll(async () => {
+  // Clean up the entire test directory
+  if (fs.existsSync(projectRoot)) {
+    await fs.promises.rm(projectRoot, { recursive: true, force: true });
+  }
+});
+
+describe('CLI flags', () => {
+  it('shows help with --help flag', async () => {
+    const result = await executePassing(['--help']);
+
+    expect(result.stdout).toMatch(/create-expo-module/i);
+    expect(result.stdout).toMatch(/--name/);
+    expect(result.stdout).toMatch(/--description/);
+    expect(result.stdout).toMatch(/--package/);
+    expect(result.stdout).toMatch(/--author-name/);
+  });
+
+  it('shows version with --version flag', async () => {
+    const result = await executePassing(['--version']);
+
+    // Should output a semver version
+    expect(result.stdout).toMatch(/\d+\.\d+\.\d+/);
+  });
+});
+
+describe('non-interactive module creation', () => {
+  it('creates a module with CLI options in CI mode', async () => {
+    const projectName = 'ci-module';
+
+    await executePassing([
+      projectName,
+      '--no-example',
+      '--name',
+      'TestModule',
+      '--description',
+      'A test module',
+      '--package',
+      'com.test.module',
+      '--author-name',
+      'Test Author',
+      '--author-email',
+      'test@example.com',
+      '--author-url',
+      'https://github.com/test',
+      '--repo',
+      'https://github.com/test/ci-module',
+    ]);
+
+    // Check essential files exist
+    expectFileExists(projectName, 'package.json');
+    expectFileExists(projectName, 'src/index.ts');
+    expectFileExists(projectName, 'android');
+    expectFileExists(projectName, 'ios');
+
+    // Verify package.json content
+    const packageJson = readJson(projectName, 'package.json');
+    expect(packageJson.name).toBe('ci-module');
+    expect(packageJson.version).toBe('0.1.0');
+    expect(packageJson.description).toBe('A test module');
+    expect(packageJson.author).toBe('Test Author <test@example.com> (https://github.com/test)');
+    expect(packageJson.repository).toBe('https://github.com/test/ci-module');
+
+    // Verify Android package structure
+    expectFileExists(projectName, 'android/src/main/java/com/test/module');
+
+    // The module should be built (TypeScript compiled)
+    expectFileExists(projectName, 'build');
+  });
+
+  it('warns when target directory is not empty but continues', async () => {
+    const projectName = 'non-empty-dir';
+
+    // Create directory with existing file
+    createTestPath(projectName);
+    fs.writeFileSync(getTestPath(projectName, 'existing-file.txt'), 'existing content');
+
+    const result = await executePassing([
+      projectName,
+      '--no-example',
+      '--name',
+      'NonEmpty',
+      '--package',
+      'com.test.nonempty',
+    ]);
+
+    // Should warn about non-empty directory
+    expect(result.stdout).toMatch(/not empty/i);
+
+    // Should still create the module
+    expectFileExists(projectName, 'package.json');
+  });
+});

--- a/packages/create-expo-module/e2e/__tests__/utils.ts
+++ b/packages/create-expo-module/e2e/__tests__/utils.ts
@@ -1,0 +1,99 @@
+import type { SpawnResult, SpawnOptions } from '@expo/spawn-async';
+import spawnAsync from '@expo/spawn-async';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+/** The (local) binary for `create-expo-module` */
+export const bin = require.resolve('../../build/index.js');
+
+/** The default temporary path for all e2e tests */
+export const projectRoot = getTemporaryPath();
+
+/** Create a new temporary path for e2e tests */
+export function getTemporaryPath() {
+  return path.join(os.tmpdir(), 'create-expo-module-e2e-' + Math.random().toString(36).substring(2));
+}
+
+/** Get the path within the default project root or temporary path */
+export function getTestPath(...args: string[]) {
+  return path.join(projectRoot, ...args);
+}
+
+/** Get the path witihin the default project root, and ensure that folder exists */
+export function createTestPath(...args: string[]) {
+  const testPath = getTestPath(...args);
+  ensureFolderExists(testPath);
+  return testPath;
+}
+
+/** Ensure the absolute folder path exists */
+export function ensureFolderExists(folder: string) {
+  fs.mkdirSync(folder, { recursive: true });
+}
+
+/** Run `create-expo-module` asynchronously, with default settings for CI */
+export function execute(args: string[], { env = {}, cwd = projectRoot }: SpawnOptions = {}) {
+  const cwdPath = typeof cwd === 'string' ? cwd : cwd?.toString() ?? projectRoot;
+  return spawnAsync('node', [bin, ...args], {
+    cwd: cwdPath,
+    env: {
+      ...process.env,
+      // Force non-interactive mode for CI
+      CI: '1',
+      // Disable telemetry
+      EXPO_NO_TELEMETRY: '1',
+      // Set INIT_CWD to ensure the CLI uses the correct working directory
+      // (the CLI checks INIT_CWD first before process.cwd())
+      INIT_CWD: cwdPath,
+      ...env,
+    },
+  });
+}
+
+/** Run `create-expo-module` asynchronously, with default settings, and validate the status is `0` */
+export async function executePassing(args: string[], options?: SpawnOptions) {
+  let result: SpawnResult | null = null;
+
+  try {
+    result = await execute(args, options);
+  } catch (error: any) {
+    result = error;
+  }
+
+  return expectExecutePassing(result!);
+}
+
+/** Expect the received spawn result to be ok or "passing" */
+export function expectExecutePassing(spawn: SpawnResult) {
+  // Copy the spawn result, that could be an error, and force Jest to list out stdout/stderr when status is not 0
+  expect({ status: spawn.status, stdout: spawn.stdout, stderr: spawn.stderr }).toEqual(
+    expect.objectContaining({
+      status: 0,
+      stdout: expect.any(String),
+      stderr: expect.any(String),
+    })
+  );
+  return spawn;
+}
+
+/** Expect the file to exist, using proper failure message when it does not */
+export function expectFileExists(projectName: string, ...filePath: string[]) {
+  const targetPath = getTestPath(projectName, ...filePath);
+  // Force Jest to list the path when it does not exist
+  expect({ [targetPath]: fs.existsSync(targetPath) }).toEqual({ [targetPath]: true });
+}
+
+/** Expect the file to not-exist, using proper failure message when it does not */
+export function expectFileNotExists(projectName: string, ...filePath: string[]) {
+  const targetPath = getTestPath(projectName, ...filePath);
+  // Force Jest to list the path when it does exist
+  expect({ [targetPath]: fs.existsSync(targetPath) }).toEqual({ [targetPath]: false });
+}
+
+/** Read and parse a JSON file from the test project */
+export function readJson(projectName: string, ...filePath: string[]) {
+  const targetPath = getTestPath(projectName, ...filePath);
+  return JSON.parse(fs.readFileSync(targetPath, { encoding: 'utf8' }));
+}
+

--- a/packages/create-expo-module/e2e/jest.config.js
+++ b/packages/create-expo-module/e2e/jest.config.js
@@ -1,0 +1,20 @@
+const path = require('path');
+
+/** @type {import('jest').Config} */
+module.exports = {
+  testEnvironment: 'node',
+  testTimeout: 1000 * 60 * 5, // e2e tests can be slow, default to 5m (module creation includes npm install)
+  testRegex: '/__tests__/.*(test|spec)\\.[jt]sx?$',
+  watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname'],
+  rootDir: path.resolve(__dirname),
+  displayName: require('../package').name,
+  roots: ['.'],
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: path.resolve(__dirname, 'tsconfig.json'),
+      },
+    ],
+  },
+};

--- a/packages/create-expo-module/e2e/tsconfig.json
+++ b/packages/create-expo-module/e2e/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@tsconfig/node18/tsconfig.json",
+  "include": ["./__tests__"],
+  "compilerOptions": {
+    "outDir": "./build",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "types": ["node", "jest"],
+    "typeRoots": ["../../../node_modules/@types"],
+    "sourceMap": true,
+    "strictNullChecks": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  }
+}

--- a/packages/create-expo-module/jest.config.js
+++ b/packages/create-expo-module/jest.config.js
@@ -1,0 +1,7 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  ...require('expo-module-scripts/jest-preset-cli'),
+  displayName: require('./package').name,
+  rootDir: __dirname,
+  testPathIgnorePatterns: ['<rootDir>/e2e/', '<rootDir>/node_modules/'],
+};

--- a/packages/create-expo-module/package.json
+++ b/packages/create-expo-module/package.json
@@ -37,6 +37,8 @@
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "typecheck": "expo-module typecheck",
+    "test": "expo-module test",
+    "test:e2e": "expo-module test --config e2e/jest.config.js --runInBand",
     "watch": "yarn run build --watch"
   },
   "devDependencies": {

--- a/packages/create-expo-module/src/create-expo-module.ts
+++ b/packages/create-expo-module/src/create-expo-module.ts
@@ -458,7 +458,8 @@ async function askForSubstitutionDataAsync(
   };
 
   // Get values from prompts
-  const promptedValues = filteredPrompts.length > 0 ? await prompts(filteredPrompts, { onCancel }) : {};
+  const promptedValues =
+    filteredPrompts.length > 0 ? await prompts(filteredPrompts, { onCancel }) : {};
 
   // Merge CLI-provided values with prompted values
   const name = options.name ?? promptedValues.name ?? slugToModuleName(slug);
@@ -479,11 +480,12 @@ async function askForSubstitutionDataAsync(
 
   const description = options.description ?? promptedValues.description ?? 'My new module';
   const authorName = options.authorName ?? promptedValues.authorName ?? (await findMyName()) ?? '';
-  const authorEmail = options.authorEmail ?? promptedValues.authorEmail ?? (await findGitHubEmail()) ?? '';
+  const authorEmail =
+    options.authorEmail ?? promptedValues.authorEmail ?? (await findGitHubEmail()) ?? '';
   const authorUrl =
     options.authorUrl ??
     promptedValues.authorUrl ??
-    (authorEmail ? (await findGitHubUserFromEmail(authorEmail)) ?? '' : '');
+    (authorEmail ? ((await findGitHubUserFromEmail(authorEmail)) ?? '') : '');
   const repo = options.repo ?? promptedValues.repo ?? (await guessRepoUrl(authorUrl, slug)) ?? '';
 
   return {
@@ -558,7 +560,7 @@ async function getSubstitutionDataFromOptions(
   const authorName = options.authorName ?? (await findMyName()) ?? '';
   const authorEmail = options.authorEmail ?? (await findGitHubEmail()) ?? '';
   const authorUrl =
-    options.authorUrl ?? (authorEmail ? (await findGitHubUserFromEmail(authorEmail)) ?? '' : '');
+    options.authorUrl ?? (authorEmail ? ((await findGitHubUserFromEmail(authorEmail)) ?? '') : '');
   const repo = options.repo ?? (await guessRepoUrl(authorUrl, slug)) ?? '';
 
   debug(

--- a/packages/create-expo-module/src/create-expo-module.ts
+++ b/packages/create-expo-module/src/create-expo-module.ts
@@ -5,6 +5,7 @@ import ejs from 'ejs';
 import fs from 'node:fs';
 import path from 'node:path';
 import prompts from 'prompts';
+import validateNpmPackage from 'validate-npm-package-name';
 
 import { createExampleApp } from './createExampleApp';
 import {
@@ -22,6 +23,8 @@ import {
 import { eventCreateExpoModule, getTelemetryClient, logEventAsync } from './telemetry';
 import type { CommandOptions, LocalSubstitutionData, SubstitutionData } from './types';
 import { env } from './utils/env';
+import { findGitHubEmail, findMyName } from './utils/git';
+import { findGitHubUserFromEmail, guessRepoUrl } from './utils/github';
 import { newStep } from './utils/ora';
 import { downloadAndExtractTarball } from './utils/tar';
 
@@ -46,6 +49,44 @@ const IGNORES_PATHS = [
 const DOCS_URL = 'https://docs.expo.dev/modules';
 
 const FYI_LOCAL_DIR = 'https://expo.fyi/expo-module-local-autolinking.md';
+
+/**
+ * Determines if we're in an interactive environment.
+ * Non-interactive when: CI=1/true or non-TTY stdin.
+ */
+function isInteractive(): boolean {
+  // Check for CI environment
+  const ci = process.env.CI;
+  if (ci === '1' || ci === 'true' || ci?.toLowerCase() === 'true') {
+    return false;
+  }
+  // Check for TTY
+  if (!process.stdin.isTTY) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Converts a slug to a native module name (PascalCase).
+ */
+function slugToModuleName(slug: string): string {
+  return slug
+    .replace(/^@/, '')
+    .replace(/^./, (match) => match.toUpperCase())
+    .replace(/\W+(\w)/g, (_, p1) => p1.toUpperCase());
+}
+
+/**
+ * Converts a slug to an Android package name.
+ */
+function slugToAndroidPackage(slug: string): string {
+  const namespace = slug
+    .replace(/\W/g, '')
+    .replace(/^(expo|reactnative)/, '')
+    .toLowerCase();
+  return `expo.modules.${namespace}`;
+}
 
 async function getCorrectLocalDirectory(targetOrSlug: string) {
   let packageJsonPath: string | null = null;
@@ -79,6 +120,11 @@ async function getCorrectLocalDirectory(targetOrSlug: string) {
  * @param options An options object for `commander`.
  */
 async function main(target: string | undefined, options: CommandOptions) {
+  const interactive = isInteractive();
+  if (!interactive) {
+    debug('Running in non-interactive mode');
+  }
+
   if (options.local) {
     console.log();
     console.log(
@@ -90,7 +136,7 @@ async function main(target: string | undefined, options: CommandOptions) {
     );
     console.log();
   }
-  const slug = await askForPackageSlugAsync(target, options.local);
+  const slug = await askForPackageSlugAsync(target, options.local, options);
   const targetDir = options.local
     ? await getCorrectLocalDirectory(target || slug)
     : path.join(CWD, target || slug);
@@ -99,11 +145,11 @@ async function main(target: string | undefined, options: CommandOptions) {
     return;
   }
   await fs.promises.mkdir(targetDir, { recursive: true });
-  await confirmTargetDirAsync(targetDir);
+  await confirmTargetDirAsync(targetDir, options);
 
   options.target = targetDir;
 
-  const data = await askForSubstitutionDataAsync(slug, options.local);
+  const data = await askForSubstitutionDataAsync(slug, options.local, options);
 
   // Make one line break between prompts and progress logs
   console.log();
@@ -348,8 +394,26 @@ async function createGitRepositoryAsync(targetDir: string) {
 
 /**
  * Asks the user for the package slug (npm package name).
+ * In non-interactive mode, uses the target path or 'my-module' as default.
  */
-async function askForPackageSlugAsync(customTargetPath?: string, isLocal = false): Promise<string> {
+async function askForPackageSlugAsync(
+  customTargetPath: string | undefined,
+  isLocal: boolean,
+  options: CommandOptions
+): Promise<string> {
+  const interactive = isInteractive();
+
+  // In non-interactive mode, derive slug from target path or use default
+  if (!interactive) {
+    const targetBasename = customTargetPath && path.basename(customTargetPath);
+    const slug =
+      targetBasename && validateNpmPackage(targetBasename).validForNewPackages
+        ? targetBasename
+        : 'my-module';
+    debug(`Non-interactive mode: using slug "${slug}"`);
+    return slug;
+  }
+
   const { slug } = await prompts(
     (isLocal ? getLocalFolderNamePrompt : getSlugPrompt)(customTargetPath),
     {
@@ -362,29 +426,43 @@ async function askForPackageSlugAsync(customTargetPath?: string, isLocal = false
 /**
  * Asks the user for some data necessary to render the template.
  * Some values may already be provided by command options, the prompt is skipped in that case.
+ * In non-interactive mode, uses defaults or CLI-provided values.
  */
 async function askForSubstitutionDataAsync(
   slug: string,
-  isLocal = false
+  isLocal: boolean,
+  options: CommandOptions
 ): Promise<SubstitutionData | LocalSubstitutionData> {
+  const interactive = isInteractive();
+
+  // Non-interactive mode: use CLI options and defaults
+  if (!interactive) {
+    return getSubstitutionDataFromOptions(slug, isLocal, options);
+  }
+
+  // Interactive mode: prompt for values, but skip prompts for CLI-provided values
   const promptQueries = await (
     isLocal ? getLocalSubstitutionDataPrompts : getSubstitutionDataPrompts
   )(slug);
+
+  // Filter out prompts for values already provided via CLI
+  const filteredPrompts = promptQueries.filter((prompt) => {
+    const name = prompt.name as string;
+    const cliValue = getCliValueForPrompt(name, options);
+    return cliValue === undefined;
+  });
 
   // Stop the process when the user cancels/exits the prompt.
   const onCancel = () => {
     process.exit(0);
   };
 
-  const {
-    name,
-    description,
-    package: projectPackage,
-    authorName,
-    authorEmail,
-    authorUrl,
-    repo,
-  } = await prompts(promptQueries, { onCancel });
+  // Get values from prompts
+  const promptedValues = filteredPrompts.length > 0 ? await prompts(filteredPrompts, { onCancel }) : {};
+
+  // Merge CLI-provided values with prompted values
+  const name = options.name ?? promptedValues.name ?? slugToModuleName(slug);
+  const projectPackage = options.package ?? promptedValues.package ?? slugToAndroidPackage(slug);
 
   if (isLocal) {
     return {
@@ -398,6 +476,94 @@ async function askForSubstitutionDataAsync(
       type: 'local',
     };
   }
+
+  const description = options.description ?? promptedValues.description ?? 'My new module';
+  const authorName = options.authorName ?? promptedValues.authorName ?? (await findMyName()) ?? '';
+  const authorEmail = options.authorEmail ?? promptedValues.authorEmail ?? (await findGitHubEmail()) ?? '';
+  const authorUrl =
+    options.authorUrl ??
+    promptedValues.authorUrl ??
+    (authorEmail ? (await findGitHubUserFromEmail(authorEmail)) ?? '' : '');
+  const repo = options.repo ?? promptedValues.repo ?? (await guessRepoUrl(authorUrl, slug)) ?? '';
+
+  return {
+    project: {
+      slug,
+      name,
+      version: '0.1.0',
+      description,
+      package: projectPackage,
+      moduleName: handleSuffix(name, 'Module'),
+      viewName: handleSuffix(name, 'View'),
+    },
+    author: `${authorName} <${authorEmail}> (${authorUrl})`,
+    license: 'MIT',
+    repo,
+    type: 'remote',
+  };
+}
+
+/**
+ * Gets the CLI value for a given prompt name.
+ */
+function getCliValueForPrompt(promptName: string, options: CommandOptions): string | undefined {
+  switch (promptName) {
+    case 'name':
+      return options.name;
+    case 'description':
+      return options.description;
+    case 'package':
+      return options.package;
+    case 'authorName':
+      return options.authorName;
+    case 'authorEmail':
+      return options.authorEmail;
+    case 'authorUrl':
+      return options.authorUrl;
+    case 'repo':
+      return options.repo;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Gets substitution data from CLI options and defaults (for non-interactive mode).
+ */
+async function getSubstitutionDataFromOptions(
+  slug: string,
+  isLocal: boolean,
+  options: CommandOptions
+): Promise<SubstitutionData | LocalSubstitutionData> {
+  const name = options.name ?? slugToModuleName(slug);
+  const projectPackage = options.package ?? slugToAndroidPackage(slug);
+
+  debug(`Non-interactive mode: name="${name}", package="${projectPackage}"`);
+
+  if (isLocal) {
+    return {
+      project: {
+        slug,
+        name,
+        package: projectPackage,
+        moduleName: handleSuffix(name, 'Module'),
+        viewName: handleSuffix(name, 'View'),
+      },
+      type: 'local',
+    };
+  }
+
+  // For remote modules, resolve author info
+  const description = options.description ?? 'My new module';
+  const authorName = options.authorName ?? (await findMyName()) ?? '';
+  const authorEmail = options.authorEmail ?? (await findGitHubEmail()) ?? '';
+  const authorUrl =
+    options.authorUrl ?? (authorEmail ? (await findGitHubUserFromEmail(authorEmail)) ?? '' : '');
+  const repo = options.repo ?? (await guessRepoUrl(authorUrl, slug)) ?? '';
+
+  debug(
+    `Non-interactive mode: description="${description}", authorName="${authorName}", authorEmail="${authorEmail}", authorUrl="${authorUrl}", repo="${repo}"`
+  );
 
   return {
     project: {
@@ -418,12 +584,25 @@ async function askForSubstitutionDataAsync(
 
 /**
  * Checks whether the target directory is empty and if not, asks the user to confirm if he wants to continue.
+ * In non-interactive mode, automatically continues (assumes intent to overwrite).
  */
-async function confirmTargetDirAsync(targetDir: string): Promise<void> {
+async function confirmTargetDirAsync(targetDir: string, options: CommandOptions): Promise<void> {
   const files = await fs.promises.readdir(targetDir);
   if (files.length === 0) {
     return;
   }
+
+  // In non-interactive mode, proceed automatically
+  if (!isInteractive()) {
+    debug(`Non-interactive mode: target directory "${targetDir}" is not empty, continuing anyway`);
+    console.log(
+      chalk.yellow(
+        `Warning: Target directory ${chalk.magenta(targetDir)} is not empty, continuing anyway.`
+      )
+    );
+    return;
+  }
+
   const { shouldContinue } = await prompts(
     {
       type: 'confirm',
@@ -500,6 +679,14 @@ program
     'Whether to create a local module in the current project, skipping installing node_modules and creating the example directory.',
     false
   )
+  // Module configuration options (skip prompts when provided)
+  .option('--name <name>', 'Native module name (e.g., MyModule).')
+  .option('--description <description>', 'Module description.')
+  .option('--package <package>', 'Android package name (e.g., expo.modules.mymodule).')
+  .option('--author-name <name>', 'Author name for package.json.')
+  .option('--author-email <email>', 'Author email for package.json.')
+  .option('--author-url <url>', "URL to the author's profile (e.g., GitHub profile).")
+  .option('--repo <url>', 'URL of the repository.')
   .action(main);
 
 program

--- a/packages/create-expo-module/src/types.ts
+++ b/packages/create-expo-module/src/types.ts
@@ -10,6 +10,14 @@ export type CommandOptions = {
   withChangelog: boolean;
   example: boolean;
   local: boolean;
+  // Module configuration options (skip prompts when provided)
+  name?: string;
+  description?: string;
+  package?: string;
+  authorName?: string;
+  authorEmail?: string;
+  authorUrl?: string;
+  repo?: string;
 };
 
 /**


### PR DESCRIPTION
## Summary
- Add full support for non-interactive mode in `create-expo-module` for CI/CD environments
- Add CLI options to provide all module configuration values without prompts
- Add E2E tests that run in CI

## Changes

### Non-interactive mode detection
- Automatically enabled when `CI=1` or `CI=true`
- Automatically enabled when stdin is not a TTY

### New CLI options
- `--name <name>` - Native module name (e.g., MyModule)
- `--description <description>` - Module description
- `--package <package>` - Android package name (e.g., expo.modules.mymodule)
- `--author-name <name>` - Author name for package.json
- `--author-email <email>` - Author email for package.json
- `--author-url <url>` - URL to the author's profile
- `--repo <url>` - URL of the repository

### E2E tests
- Added `e2e/` directory with Jest tests
- Tests CLI flags and module creation in CI mode
- Added GitHub Actions workflow for CI

## Test plan
- [x] `yarn test:e2e` passes locally
- [x] Tests run in ~40 seconds (4 tests)
- [x] Module creation works with `CI=1`

## Usage example
```bash
# CI mode (auto-detected)
CI=1 npx create-expo-module my-module --no-example

# With custom values
npx create-expo-module my-module \
  --no-example \
  --name MyModule \
  --description "My awesome module" \
  --package com.mycompany.mymodule \
  --author-name "John Doe"
```

🤖 Generated with [Claude Code](https://claude.ai/code)