### PR TITLE
[template] fix icons on iOS by using template rendering mode

### DIFF
--- a/templates/expo-template-default/src/components/app-tabs.tsx
+++ b/templates/expo-template-default/src/components/app-tabs.tsx
@@ -15,12 +15,18 @@ export default function AppTabs() {
       labelStyle={{ selected: { color: colors.text } }}>
       <NativeTabs.Trigger name="index">
         <NativeTabs.Trigger.Label>Home</NativeTabs.Trigger.Label>
-        <NativeTabs.Trigger.Icon src={require('@/assets/images/tabIcons/home.png')} />
+        <NativeTabs.Trigger.Icon
+          src={require('@/assets/images/tabIcons/home.png')}
+          renderingMode="template"
+        />
       </NativeTabs.Trigger>
 
       <NativeTabs.Trigger name="explore">
         <NativeTabs.Trigger.Label>Explore</NativeTabs.Trigger.Label>
-        <NativeTabs.Trigger.Icon src={require('@/assets/images/tabIcons/explore.png')} />
+        <NativeTabs.Trigger.Icon
+          src={require('@/assets/images/tabIcons/explore.png')}
+          renderingMode="template"
+        />
       </NativeTabs.Trigger>
     </NativeTabs>
   );


### PR DESCRIPTION
# Why

When no tint color is used, custom icons use original rendering mode - they use original color scheme instead of the tinted one.

# How

Use `renderMode="template"` for both icons to apply tint color

# Test Plan

https://github.com/user-attachments/assets/d5d85e37-6273-4941-b3a7-af70c25329a7

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
