### PR TITLE
fix(cli): implement retrying for transient devicectl disconnects

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Implement exponential retry for transient `devicectl` disconnects and fix null error logs. ([#43326](https://github.com/expo/expo/pull/43326) by [@balenamiaa](https://github.com/balenamiaa))
+
 ### 💡 Others
 
 ## 55.0.10 — 2026-02-20

--- a/packages/@expo/cli/src/start/platforms/ios/devicectl.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/devicectl.ts
@@ -216,6 +216,34 @@ async function installAppWithDeviceCtlAsync(
   bundleIdOrAppPath: string,
   onProgress: (event: { status: string; isComplete: boolean; progress: number }) => void
 ): Promise<void> {
+  const maxAttempts = 3;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await installAppWithDeviceCtlInternalAsync(uuid, bundleIdOrAppPath, onProgress, attempt);
+      return;
+    } catch (error: any) {
+      if (error.code === 'detached') {
+        throw error;
+      }
+      const isTransientDisconnect =
+        error.message &&
+        (error.message.includes('CoreDeviceError') || error.message.includes('0xFA0'));
+
+      if (!isTransientDisconnect || attempt === maxAttempts) {
+        throw error;
+      }
+      const backoffDelay = 500 + Math.pow(2, attempt - 1) * 500;
+      await new Promise(resolve => setTimeout(resolve, backoffDelay));
+    }
+  }
+}
+
+async function installAppWithDeviceCtlInternalAsync(
+  uuid: string,
+  bundleIdOrAppPath: string,
+  onProgress: (event: { status: string; isComplete: boolean; progress: number }) => void,
+  attempt: number
+): Promise<void> {
   // 𝝠 xcrun devicectl device install app --device 00001110-001111110110101A /Users/evanbacon/Library/Developer/Xcode/DerivedData/Router-hgbqaxzhrhkiftfweydvhgttadvn/Build/Products/Debug-iphoneos/Router.app --verbose
   return new Promise((resolve, reject) => {
     const args: string[] = [
@@ -239,10 +267,11 @@ async function installAppWithDeviceCtlAsync(
         return;
       }
       currentProgress = progress;
+      const statusPrefix = attempt > 1 ? `Installing (attempt ${attempt})` : 'Installing';
       onProgress({
         progress,
         isComplete: progress === 100,
-        status: 'Installing',
+        status: statusPrefix,
       });
     }
 
@@ -271,13 +300,17 @@ async function installAppWithDeviceCtlAsync(
       debug('[stdout]:', strings);
     });
 
+    let stderrBuffer = '';
+    childProcess.stderr.on('data', (data: Buffer) => {
+      stderrBuffer += data.toString();
+    });
+
     childProcess.on('close', (code) => {
       debug('[close]: ' + code);
       if (code === 0) {
         resolve();
       } else {
-        const stderr = childProcess.stderr.read();
-        const err = new Error(stderr);
+        const err = new Error(stderrBuffer || `Command failed with exit code ${code}`);
         (err as any).code = code;
         detach(err);
       }
@@ -287,9 +320,8 @@ async function installAppWithDeviceCtlAsync(
       off?.();
       if (childProcess) {
         return new Promise<void>((resolve) => {
-          childProcess?.on('close', resolve);
+          childProcess?.on('close', () => resolve());
           childProcess?.kill();
-          // childProcess = null;
           reject(err ?? new CommandError('detached'));
         });
       }

--- a/packages/@expo/cli/src/start/platforms/ios/devicectl.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/devicectl.ts
@@ -233,7 +233,7 @@ async function installAppWithDeviceCtlAsync(
         throw error;
       }
       const backoffDelay = 500 + Math.pow(2, attempt - 1) * 500;
-      await new Promise(resolve => setTimeout(resolve, backoffDelay));
+      await new Promise((resolve) => setTimeout(resolve, backoffDelay));
     }
   }
 }


### PR DESCRIPTION
# Why

When installing an app onto a physical iOS device, Apple's xcrun devicectl tool frequently drops the connection immediately after the initial handshake, throwing com.apple.dt.CoreDeviceError error 4000 (0xFA0).

Because @expo/cli currently reads stderr synchronously on the process close event (childProcess.stderr.read()), this error is often swallowed if the stream is already flushed. This results in an unhelpful Error: null crash that leaves developers confused and without any actionable debugging information. Furthermore, the lack of a retry mechanism means these transient network/USB disconnects strictly fail the build every time.

# How

1. Fixed `Error: null` masking: Replaced the synchronous stderr.read() call with an asynchronous stderr.on('data', ...) buffer accumulator to reliably capture and surface the true error output from the Apple toolchain.
2. Added Exponential Backoff: Wrapped the devicectl spawn logic in an exponential backoff retry loop (up to 3 attempts).
3. Targeted Retries: The retry loop strictly checks the error message and only intercepts transient disconnect errors (CoreDeviceError / 0xFA0). All other deterministic errors fail immediately.
4. Preserved Cancellation: Explicitly catches error.code === 'detached' to ensure that user cancellations (e.g., pressing Ctrl+C) immediately abort the process instead of trapping the developer in the retry loop.
5. Preserved UX: Maintained the asynchronous spawn approach and standard IO parsing so the CLI ora spinner and 34%... progress updates remain fully functional.

# Test Plan

- Ran npx expo run:ios --device <uuid> targeting a physical iPhone via USB.
- Before: Observed an immediate CLI crash outputting Error: null.
- After (Error surfacing): Verified that the CLI successfully captures and prints the underlying CoreDeviceError error 4000 (0xFA0).
- After (Retry Logic): Verified that the CLI catches the transient error, waits 2 seconds, updates the ora spinner to Installing (attempt 2), and successfully installs the app on the second attempt without breaking the event loop.
- Cancellation: Verified that pressing Ctrl+C during an installation attempt successfully and immediately aborts the process.

# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
