### PR TITLE
[expo-module-scripts] Add more files to the `.npmignore` template

### DIFF
--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Add more files to the `.npmignore` template. ([#43327](https://github.com/expo/expo/pull/43327) by [@cornejobarraza](https://github.com/cornejobarraza))
+
 ## 55.0.2 — 2026-01-23
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-module-scripts/templates/.npmignore
+++ b/packages/expo-module-scripts/templates/.npmignore
@@ -16,3 +16,8 @@ __rsc_tests__
 /android/src/androidTest/
 /android/src/test/
 /ios/Tests
+
+.eslintrc.js
+eslint.config.js
+plugin/jest.config.js
+plugin/tsconfig.tsbuildinfo


### PR DESCRIPTION
# Why

Some irrelevant files are being packaged with Expo Modules such as:

- `.eslintrc.js` in the root of the project
- `jest.config.js` inside the plugin folder

# How

Added said files to the `.npmignore` template

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
