### PR TITLE
[glass-effect] - `isInteractive` with animate and glass view rendering on non initial tab

### DIFF
--- a/packages/expo-glass-effect/CHANGELOG.md
+++ b/packages/expo-glass-effect/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### 🐛 Bug fixes
 
-- [ios] Fix `isInteractive` not applying when `glassEffectStyle` has `animate: true`. ([#43330](https://github.com/expo/expo/pull/43330) by [@nishan](https://github.com/intergalacticspacehighway))
+- Fix `isInteractive` not applying when `glassEffectStyle` has `animate: true`. ([#43330](https://github.com/expo/expo/pull/43330) by [@nishan](https://github.com/intergalacticspacehighway))
+- Fix glass effect not rendering on first visit to a non-initial tab in tab navigator. ([#43330](https://github.com/expo/expo/pull/43330) by [@nishan](https://github.com/intergalacticspacehighway))
 
 ### 💡 Others
 

--- a/packages/expo-glass-effect/CHANGELOG.md
+++ b/packages/expo-glass-effect/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Fix `isInteractive` not applying when `glassEffectStyle` has `animate: true`. ([#43330](https://github.com/expo/expo/pull/43330) by [@nishan](https://github.com/intergalacticspacehighway))
+
 ### 💡 Others
 
 ## 55.0.6 — 2026-02-16

--- a/packages/expo-glass-effect/ios/GlassView.swift
+++ b/packages/expo-glass-effect/ios/GlassView.swift
@@ -6,6 +6,10 @@ import React
 public final class GlassView: ExpoView {
   private var glassEffect: Any?
   private var glassEffectView = UIVisualEffectView()
+  // TODO: Find a better fix
+  // Glass effect does not work sometimes if view has not been laid out yet
+  // https://github.com/expo/expo/issues/41024#issuecomment-3867466289
+  private var isMounted = false
 
   private var glassStyle: GlassStyle?
   private var glassTintColor: UIColor?
@@ -43,6 +47,14 @@ public final class GlassView: ExpoView {
     }
     #endif
     return false
+  }
+
+  override public func layoutSubviews() {
+    super.layoutSubviews()
+    if !isMounted {
+      isMounted = true
+      updateEffect()
+    }
   }
 
   func updateBorderRadius() {
@@ -213,6 +225,9 @@ public final class GlassView: ExpoView {
   }
 
   private func updateEffect() {
+    if !isMounted {
+      return
+    }
     guard isGlassEffectAvailable() else {
       return
     }

--- a/packages/expo-glass-effect/ios/GlassView.swift
+++ b/packages/expo-glass-effect/ios/GlassView.swift
@@ -103,9 +103,7 @@ public final class GlassView: ExpoView {
         #if compiler(>=6.2) // Xcode 26
         let applyEffect = {
           if let uiStyle = newStyle.toUIGlassEffectStyle() {
-            let effect = UIGlassEffect(style: uiStyle)
-            self.glassEffectView.effect = effect
-            self.glassEffect = effect
+            self.glassEffect = UIGlassEffect(style: uiStyle)
             self.updateEffect()
           } else {
             // TODO: revisit this in newer versions of iOS


### PR DESCRIPTION
# Why

This PR fixes 2 issues:
1. https://github.com/expo/expo/issues/41024#issuecomment-3936363575 reported by @AlirezaHadjar 
2. https://github.com/expo/expo/issues/41024#issuecomment-3867466289 reported by @eli-provenform

### 1. `isInteractive` not working with animate 
When effect is added to the view, internally `isInteractive` gets initialised to `false`. Later we update it in `updateEffect`, which does not work because `isInteractive` can only be set once, which is a weird behaviour with `UIGlassEffect`.

### 2. Glass effect does not apply when it is used in a non initial Tab in tab navigator

This is again some glass view quirk where iOS does not render the glass view if the view is not laid out. So we apply the glass view in `layoutSubviews`

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

1. Let `updateEffect` set the `isInteractive` first and then assign the effect to the view.
2. Initialise glass effect in `layoutSubviews` for the first mount.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested repro in NCL
Fix confirmed here:
1. https://github.com/expo/expo/issues/41024#issuecomment-3939103335
2. https://github.com/expo/expo/issues/41024#issuecomment-3939258798
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
