### PR TITLE
[docs] Parse ReactFlow diagrams into text for .md generation

### DIFF
--- a/docs/scripts/generate-markdown-pages-utils.test.ts
+++ b/docs/scripts/generate-markdown-pages-utils.test.ts
@@ -287,8 +287,8 @@ describe('diagram elements', () => {
       <p>More content below.</p>
     </main>`;
     const md = convertHtmlToMarkdown(html);
-    expect(md).toContain('withMyPlugin [Config Plugin]');
-    expect(md).toContain('[Plugin Function]');
+    expect(md).toContain('```\nwithMyPlugin [Config Plugin]');
+    expect(md).toContain('[Plugin Function]\n```');
     expect(md).not.toContain('react-flow');
     expect(md).not.toContain('interactive content');
   });

--- a/docs/scripts/generate-markdown-pages-utils.test.ts
+++ b/docs/scripts/generate-markdown-pages-utils.test.ts
@@ -293,6 +293,16 @@ describe('diagram elements', () => {
     expect(md).not.toContain('interactive content');
   });
 
+  it('escapes special HTML characters in diagram alt text', () => {
+    const html = `<main>
+      <div data-md="diagram" data-md-alt="A <B> & C"></div>
+    </main>`;
+    const md = convertHtmlToMarkdown(html);
+    expect(md).toContain('A <B> & C');
+    expect(md).not.toContain('&lt;');
+    expect(md).not.toContain('&amp;');
+  });
+
   it('removes data-md="diagram" with no alt text', () => {
     const html = `<main>
       <h2>Overview</h2>

--- a/docs/scripts/generate-markdown-pages-utils.test.ts
+++ b/docs/scripts/generate-markdown-pages-utils.test.ts
@@ -277,6 +277,34 @@ describe('cleanHtml', () => {
   });
 });
 
+describe('diagram elements', () => {
+  it('replaces data-md="diagram" with its alt text', () => {
+    const html = `<main>
+      <p>The following diagram shows the hierarchy:</p>
+      <div data-md="diagram" data-md-alt="withMyPlugin [Config Plugin] → withAndroidPlugin [Plugin Function]">
+        <div class="react-flow">node labels and other interactive content</div>
+      </div>
+      <p>More content below.</p>
+    </main>`;
+    const md = convertHtmlToMarkdown(html);
+    expect(md).toContain('withMyPlugin [Config Plugin]');
+    expect(md).toContain('[Plugin Function]');
+    expect(md).not.toContain('react-flow');
+    expect(md).not.toContain('interactive content');
+  });
+
+  it('removes data-md="diagram" with no alt text', () => {
+    const html = `<main>
+      <h2>Overview</h2>
+      <div data-md="diagram"><div>canvas content</div></div>
+      <p>Text after.</p>
+    </main>`;
+    const md = convertHtmlToMarkdown(html);
+    expect(md).not.toContain('canvas content');
+    expect(md).toContain('Text after.');
+  });
+});
+
 describe('cleanMarkdown', () => {
   it('removes empty headings', () => {
     expect(cleanMarkdown('## Content\n\n## \n\nMore text')).toBe('## Content\n\nMore text');

--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -339,7 +339,7 @@ export function cleanHtml($: CheerioAPI, main: Cheerio<AnyNode>): void {
     const $el = $(el);
     const alt = $el.attr('data-md-alt')?.trim();
     if (alt) {
-      $el.replaceWith(`<p>${alt}</p>`);
+      $el.replaceWith(`<pre><code>${alt}</code></pre>`);
     } else {
       $el.remove();
     }

--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -333,6 +333,18 @@ export function cleanHtml($: CheerioAPI, main: Cheerio<AnyNode>): void {
   });
   main.find('svg').remove();
 
+  // Replace interactive diagrams (ReactFlow, etc.) with a text description.
+  // data-md="diagram" is the stable marker; data-md-alt contains the fallback text.
+  main.find('[data-md="diagram"]').each((_, el) => {
+    const $el = $(el);
+    const alt = $el.attr('data-md-alt')?.trim();
+    if (alt) {
+      $el.replaceWith(`<p>${alt}</p>`);
+    } else {
+      $el.remove();
+    }
+  });
+
   // Unwrap block elements inside headings — a <div> or nested <span> inside <h2> is invalid HTML
   // and breaks Turndown, splitting the heading into an empty "## " and a standalone paragraph.
   // Empty wrappers (leftover from icon removal) are removed; non-empty ones are unwrapped.

--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -339,7 +339,11 @@ export function cleanHtml($: CheerioAPI, main: Cheerio<AnyNode>): void {
     const $el = $(el);
     const alt = $el.attr('data-md-alt')?.trim();
     if (alt) {
-      $el.replaceWith(`<pre><code>${alt}</code></pre>`);
+      const $pre = $('<pre></pre>');
+      const $code = $('<code></code>');
+      $code.text(alt);
+      $pre.append($code);
+      $el.replaceWith($pre);
     } else {
       $el.remove();
     }

--- a/docs/ui/components/ConfigPluginHierarchy/index.tsx
+++ b/docs/ui/components/ConfigPluginHierarchy/index.tsx
@@ -164,7 +164,8 @@ export const ConfigPluginHierarchy: React.FC<ConfigPluginHierarchyProps> = ({
   const diagramAlt = nodesData
     .map(n => {
       const names = [n.title, n.extraTitle].filter(Boolean).join(', ');
-      return `${names} [${n.badge}]`;
+      const sub = n.subtitle ? ` (${n.subtitle})` : '';
+      return `${names}${sub} [${n.badge}]`;
     })
     .join(' → ');
 

--- a/docs/ui/components/ConfigPluginHierarchy/index.tsx
+++ b/docs/ui/components/ConfigPluginHierarchy/index.tsx
@@ -161,8 +161,18 @@ export const ConfigPluginHierarchy: React.FC<ConfigPluginHierarchyProps> = ({
     setNodes(createNodes(highlightedNodeId, highlightedNodeIds));
   }, [highlightedNodeId, highlightedNodeIds, setNodes]);
 
+  const diagramAlt = nodesData
+    .map(n => {
+      const names = [n.title, n.extraTitle].filter(Boolean).join(', ');
+      return `${names} [${n.badge}]`;
+    })
+    .join(' → ');
+
   return (
-    <div className="mb-4 h-[300px] w-full overflow-hidden rounded-lg border border-default bg-default">
+    <div
+      className="mb-4 h-[300px] w-full overflow-hidden rounded-lg border border-default bg-default"
+      data-md="diagram"
+      data-md-alt={diagramAlt}>
       <style dangerouslySetInnerHTML={{ __html: nodeHandleStyles }} />
       <ReactFlow
         nodes={nodes}

--- a/docs/ui/components/ConfigPluginHierarchy/index.tsx
+++ b/docs/ui/components/ConfigPluginHierarchy/index.tsx
@@ -167,7 +167,7 @@ export const ConfigPluginHierarchy: React.FC<ConfigPluginHierarchyProps> = ({
       const sub = n.subtitle ? ` (${n.subtitle})` : '';
       return `${names}${sub} [${n.badge}]`;
     })
-    .join(' → ');
+    .join('\n→ ');
 
   return (
     <div


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-19524

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add data-md="diagram" and data-md-alt attributes to the `ConfigPluginHierarchy` component's wrapper div, following the established data-md convention used by Terminal, DiffBlock, Steps, and other interactive components. The alt text is dynamically generated from the node data so it stays in sync if nodes change.
- Add test cases for the new handler: one verifying alt text renders as a code block, one verifying diagrams without alt text are removed cleanly, and  one verifying special HTML characters are properly escaped.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview: https://pr-43333.expo-docs.pages.dev/config-plugins/introduction/index.md

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
