### PR TITLE
[iOS][expo-dev-menu] Fix zoom dismiss gesture in dev builds

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix zoom dismiss gesture not animating in dev builds and Expo Go ([#43338](https://github.com/expo/expo/pull/43338) by [@just1and0](https://github.com/just1and0))
+
 ### 💡 Others
 
 ## 55.0.7 — 2026-02-20

--- a/packages/expo-dev-menu/ios/DevMenuGestureRecognizer.swift
+++ b/packages/expo-dev-menu/ios/DevMenuGestureRecognizer.swift
@@ -43,7 +43,33 @@ class DevMenuGestureRecognizer: UILongPressGestureRecognizer {
     minimumPressDuration = 0.5
     #endif
     allowableMovement = 30
+    cancelsTouchesInView = false
+    delaysTouchesBegan = false
+    delaysTouchesEnded = false
   }
+
+  // Never prevent other gesture recognizers from recognizing.
+  override func canPrevent(_ preventedGestureRecognizer: UIGestureRecognizer) -> Bool {
+    return false
+  }
+
+  override func canBePrevented(by preventingGestureRecognizer: UIGestureRecognizer) -> Bool {
+    return false
+  }
+
+  #if !os(tvOS)
+  // Fail immediately when the initial touch count is below the required
+  // threshold. This removes the recognizer from UIKit's gesture resolution
+  // pipeline for single- and double-finger interactions (like the zoom
+  // dismiss transition), preventing it from interfering with their animations.
+  override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
+    super.touchesBegan(touches, with: event)
+    let touchCount = event.allTouches?.count ?? touches.count
+    if touchCount < numberOfTouchesRequired {
+      state = .failed
+    }
+  }
+  #endif
 }
 
 #endif

--- a/packages/expo-dev-menu/ios/Interceptors/DevMenuTouchInterceptor.swift
+++ b/packages/expo-dev-menu/ios/Interceptors/DevMenuTouchInterceptor.swift
@@ -6,6 +6,7 @@ import UIKit
 
 class DevMenuTouchInterceptor {
   static fileprivate let recognizer: DevMenuGestureRecognizer = DevMenuGestureRecognizer()
+  static private var observers: [NSObjectProtocol] = []
 
   /**
    Returns bool value whether the dev menu touch gestures are being intercepted.
@@ -13,44 +14,86 @@ class DevMenuTouchInterceptor {
   static var isInstalled: Bool = false {
     willSet {
       if isInstalled != newValue {
-        // Capture touch gesture from any window by swizzling default implementation from UIWindow.
-        swizzle()
-
         // Make sure recognizer is enabled/disabled accordingly.
         recognizer.isEnabled = newValue
+
+        if newValue {
+          // Attach to the root view controller's view and observe window/scene
+          // changes so we can re-attach when the active window changes.
+          attachRecognizerToRootView()
+          startObserving()
+        } else {
+          stopObserving()
+          recognizer.view?.removeGestureRecognizer(recognizer)
+        }
       }
     }
   }
 
-  static private func swizzle() {
-    DevMenuUtils.swizzle(
-      selector: #selector(getter: UIWindow.gestureRecognizers),
-      withSelector: #selector(getter: UIWindow.EXDevMenu_gestureRecognizers),
-      forClass: UIWindow.self
+  static private func attachRecognizerToRootView() {
+    guard let rootView = Self.findRootView(), recognizer.view != rootView else {
+      return
+    }
+    recognizer.view?.removeGestureRecognizer(recognizer)
+    rootView.addGestureRecognizer(recognizer)
+  }
+
+  static private func findRootView() -> UIView? {
+    let window = UIApplication.shared.connectedScenes
+      .compactMap { $0 as? UIWindowScene }
+      .filter { $0.activationState == .foregroundActive }
+      .flatMap { $0.windows }
+      .first { $0.isKeyWindow && !Self.isOverlayWindow($0) }
+    return window?.rootViewController?.view
+  }
+
+  static private func startObserving() {
+    guard observers.isEmpty else { return }
+
+    // Re-attach when a different window becomes key
+    observers.append(
+      NotificationCenter.default.addObserver(
+        forName: UIWindow.didBecomeKeyNotification,
+        object: nil,
+        queue: .main
+      ) { _ in
+        if isInstalled {
+          attachRecognizerToRootView()
+        }
+      }
+    )
+
+    // Re-attach when a scene activates (e.g. app comes to foreground)
+    observers.append(
+      NotificationCenter.default.addObserver(
+        forName: UIScene.didActivateNotification,
+        object: nil,
+        queue: .main
+      ) { _ in
+        if isInstalled {
+          attachRecognizerToRootView()
+        }
+      }
     )
   }
-}
 
-extension UIWindow {
-  @objc open var EXDevMenu_gestureRecognizers: [UIGestureRecognizer]? {
-    // Just for thread safety, someone may uninstall the interceptor in the meantime and we would fall into recursive loop.
-    if !DevMenuTouchInterceptor.isInstalled {
-      return self.gestureRecognizers
+  static private func stopObserving() {
+    for observer in observers {
+      NotificationCenter.default.removeObserver(observer)
     }
+    observers.removeAll()
+  }
 
-    // Check for the case where singleton instance of gesture recognizer is not created yet or is attached to different window.
-    let recognizer = DevMenuTouchInterceptor.recognizer
-    if recognizer.view != self {
-      // Remove it from the window it's attached to.
-      recognizer.view?.removeGestureRecognizer(recognizer)
-
-      // Attach to this window.
-      self.addGestureRecognizer(recognizer)
+  static private func isOverlayWindow(_ window: UIWindow) -> Bool {
+    if window is DevMenuWindow {
+      return true
     }
-
-    // `EXDevMenu_gestureRecognizers` implementation has been swizzled with `gestureRecognizers`
-    // It might be confusing that we call it recursively, but we don't.
-    return self.EXDevMenu_gestureRecognizers
+    #if !os(tvOS)
+    if window is DevMenuFABWindow {
+      return true
+    }
+    #endif
+    return false
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes `Link.AppleZoom` dismiss gesture not animating in dev builds and Expo Go.

The dev menu's 3-finger long press gesture recognizer (`DevMenuGestureRecognizer`) was interfering with UIKit's zoom transition interactive dismiss gesture. Even though it requires 3 touches, the `UILongPressGestureRecognizer` stays in the `.possible` state while tracking single-finger touches, participating in UIKit's gesture resolution pipeline and disrupting the zoom dismiss animation.

### Changes

**`DevMenuTouchInterceptor.swift`**
- Replaced the `UIWindow.gestureRecognizers` swizzle with a notification-based approach
- Attaches the gesture recognizer to `rootViewController.view` instead of the `UIWindow` directly, avoiding interference with window-level gesture handling
- Filters out overlay windows (`DevMenuWindow`, `DevMenuFABWindow`) when finding the key window
- Observes `UIWindow.didBecomeKeyNotification` / `UIScene.didActivateNotification` to re-attach when the active window changes

**`DevMenuGestureRecognizer.swift`**
- Overrides `touchesBegan` to immediately set `state = .failed` when fewer than 3 fingers are present — this removes the recognizer from UIKit's gesture resolution pipeline for single- and double-finger interactions like the zoom dismiss transition
- Sets `cancelsTouchesInView = false`, `delaysTouchesBegan = false`, `delaysTouchesEnded = false` so the recognizer never interferes with touch delivery
- Overrides `canPrevent(_:)` to return `false` so it never blocks other gesture recognizers

## Test plan

Reproduction repo: https://github.com/gutosanches/expo-zoom-dismiss-repro

**Setup — linking local `expo-dev-menu`:**

1. Clone the expo repo alongside the repro project
2. Add the following to the repro project's `package.json` to point `expo-dev-menu` to your local expo checkout:
```json
   "overrides": {
     "expo-dev-menu": "file:../expo/packages/expo-dev-menu"
   }
```
3. Run `npm install`, then symlink the local package:
rm -rf node_modules/expo-dev-menu
ln -s /path/to/expo/packages/expo-dev-menu node_modules/expo-dev-menu
4. `npx expo prebuild --platform ios --clean` → `npx expo run:ios`

**Bare native build (baseline — no expo-dev-client):**
- [x] Remove `expo-dev-client` from `package.json` → `npx expo prebuild --platform ios --clean` → `npx expo run:ios`
- [x] Zoom dismiss gesture animates correctly (expected — no dev menu involved)

**Dev client build (with fix):**
- [x] Add `expo-dev-client` back → link local `expo-dev-menu` (see setup above) → `npx expo prebuild --platform ios --clean` → `npx expo run:ios`
- [x] Zoom-in animation works (tap any card)
- [x] Zoom dismiss gesture now animates smoothly (drag down to dismiss)
- [ ] Verify 3-finger long press still opens dev menu

**Expo Go:**
- Uses the same `expo-dev-menu` code — fix will apply when Expo Go ships with the updated package

Fixes #43253


