### PR TITLE
[iOS][expo-modules-core] Fix field.options mutation lost on protocol existential

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed `field.options.insert()` silently failing in `fieldsOf()` due to mutation on protocol existential. ([#43103](https://github.com/expo/expo/pull/43103) by [@just1and0](https://github.com/just1and0))
+
 ### 💡 Others
 
 ## 55.0.10 — 2026-02-20

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed `field.options.insert()` silently failing in `fieldsOf()` due to mutation on protocol existential. ([#43103](https://github.com/expo/expo/pull/43103) by [@just1and0](https://github.com/just1and0))
+- [iOS] Fixed `field.options.insert()` silently failing in `fieldsOf()` due to mutation on protocol existential. ([#43341](https://github.com/expo/expo/pull/43341) by [@just1and0](https://github.com/just1and0))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Core/Records/Record.swift
+++ b/packages/expo-modules-core/ios/Core/Records/Record.swift
@@ -97,7 +97,7 @@ internal func fieldsOf(_ record: Record) -> [AnyFieldInternal] {
     guard var field = value as? AnyFieldInternal, let key = field.key ?? convertLabelToKey(label) else {
       return nil
     }
-    field.options.insert(.keyed(key))
+    field.options = field.options.union([.keyed(key)])
     return field
   }
 }


### PR DESCRIPTION
## Summary

Fixes `field.options.insert(.keyed(key))` silently discarding the mutation in `fieldsOf()` because `field` is typed as `AnyFieldInternal` (a protocol existential) and `Set<FieldOption>` is a value type.

When Swift evaluates `field.options.insert(...)` through a protocol existential:
1. The getter returns a **copy** of the `Set`
2. `insert()` mutates that copy
3. The copy is discarded — the **setter is never called**
4. `.keyed(key)` is never added to the field's options

**Fix:** Use explicit assignment via `union()` so the setter is invoked:
```diff
- field.options.insert(.keyed(key))
+ field.options = field.options.union([.keyed(key)])
```

### Swift reproduction of the underlying issue
```swift
protocol AnyFieldInternal {
    var options: Set<String> { get set }
}
struct Field: AnyFieldInternal {
    var options: Set<String> = []
}

var field: AnyFieldInternal = Field()
field.options.insert("keyed")
print(field.options) // [] ← empty, mutation lost!

field.options = field.options.union(["keyed"])
print(field.options) // ["keyed"] ← correct
```

### Impact
Record fields don't get their `.keyed(key)` metadata registered during reflection, which can break field key resolution in Record serialization/deserialization.

resolves #43103

## Test plan

- Verified the fix in a standalone Swift playground reproducing the protocol existential mutation issue
- Shipping with a `patch-package` patch in production app confirming the fix resolves the issue
