### PR TITLE
fix(notifications): thread-safe static initialization in EXNotificationSerializer

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Fix `EXC_BAD_ACCESS` crash in `EXNotificationSerializer` caused by thread-unsafe static `NSDictionary` initialization during cold launch from notification tap. ([#43342](https://github.com/expo/expo/pull/43342) by [@just1and0](https://github.com/just1and0))
+
 ### 💡 Others
 
 ## 0.31.5 — 2026-01-31

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationSerializer.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationSerializer.m
@@ -64,15 +64,16 @@ static NSString * const EXNotificationResponseDefaultActionIdentifier = @"expo.m
 
 + (NSString *)serializedInterruptionLevel:(UNNotificationInterruptionLevel)interruptionLevel API_AVAILABLE(ios(15.0)) {
   static NSDictionary<NSNumber *, NSString *> *interruptionLevelMap;
-  if (!interruptionLevelMap) {
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
     interruptionLevelMap = @{
       @(UNNotificationInterruptionLevelPassive): @"passive",
       @(UNNotificationInterruptionLevelActive): @"active",
       @(UNNotificationInterruptionLevelTimeSensitive): @"timeSensitive",
       @(UNNotificationInterruptionLevelCritical): @"critical"
     };
-  }
-  
+  });
+
   return [interruptionLevelMap objectForKey:@(interruptionLevel)];
 }
 
@@ -169,7 +170,8 @@ static NSString * const EXNotificationResponseDefaultActionIdentifier = @"expo.m
 + (NSDictionary *)calendarUnitsConversionMap
 {
   static NSDictionary *keysMap = nil;
-  if (!keysMap) {
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
     keysMap = @{
       @(NSCalendarUnitEra): @"era",
       @(NSCalendarUnitYear): @"year",
@@ -188,7 +190,7 @@ static NSString * const EXNotificationResponseDefaultActionIdentifier = @"expo.m
       // NSCalendarUnitCalendar and NSCalendarUnitTimeZone
       // should be handled separately
     };
-  }
+  });
   return keysMap;
 }
 


### PR DESCRIPTION
# Why

Fixes #43096

`EXC_BAD_ACCESS` (`KERN_INVALID_ADDRESS`) crash in `EXNotificationSerializer.serializedInterruptionLevel:` during cold launch from a notification tap. The static `NSDictionary` used for mapping values is initialized with a bare `if (!map)` check, which is not thread-safe — concurrent GCD threads can read the pointer in a partially-written state.

# How

Replaced the bare `if (!map)` guard with `dispatch_once` in two locations:

- **`serializedInterruptionLevel:`** — maps `UNNotificationInterruptionLevel` enum values to strings
- **`calendarUnitsConversionMap`** — maps `NSCalendarUnit` values to strings (same vulnerable pattern)

`dispatch_once` guarantees the block executes exactly once, even when called concurrently from multiple threads.

# Test Plan

- [x] Verified `dispatch_once` guarantees one-time, thread-safe initialization of both static dictionaries
- [ ] Cold launch from notification tap no longer crashes (non-deterministic race condition — hard to reproduce reliably)

> **Note:** The `main` branch has already been rewritten in Swift (`NotificationSerializer.swift`) which uses a proper Swift enum and is inherently thread-safe. This fix targets `sdk-53` which still uses the Obj-C implementation.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)