### PR TITLE
fix(calendar): use Long instead of Int for calendar/event IDs on Android

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `NumberFormatException` crash on Android when calendar/event IDs exceed `Integer.MAX_VALUE`. ([#43344](https://github.com/expo/expo/pull/43344) by [@olivier-bouillet](https://github.com/olivier-bouillet))
+
 ### 💡 Others
 
 ## 55.0.7 — 2026-02-20

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.kt
@@ -217,7 +217,7 @@ class CalendarModule : Module() {
 
   //endregion
 
-  private suspend fun saveEvent(eventInput: Either<NewEventInput, EventUpdateInput>): Int {
+  private suspend fun saveEvent(eventInput: Either<NewEventInput, EventUpdateInput>): Long {
     return if (eventInput.`is`(EventUpdateInput::class)) {
       eventRepository.updateEvent(eventInput.second())
     } else {

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/attendee/AttendeeRepository.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/attendee/AttendeeRepository.kt
@@ -31,7 +31,7 @@ class AttendeeRepository(context: Context) {
     }
   }
 
-  suspend fun saveAttendeeForEvent(attendee: Attendee, eventID: String?): Int {
+  suspend fun saveAttendeeForEvent(attendee: Attendee, eventID: String?): Long {
     return if (attendee.isNewAttendeePayload) {
       contentResolver.insertAttendee(attendee, eventID)
     } else {
@@ -40,7 +40,7 @@ class AttendeeRepository(context: Context) {
   }
 
   suspend fun deleteAttendee(attendeeId: String): Boolean {
-    val uri = ContentUris.withAppendedId(CalendarContract.Attendees.CONTENT_URI, attendeeId.toInt().toLong())
+    val uri = ContentUris.withAppendedId(CalendarContract.Attendees.CONTENT_URI, attendeeId.toLong())
     val rows = withContext(Dispatchers.IO) {
       contentResolver.delete(uri, null, null)
     }
@@ -59,9 +59,9 @@ class AttendeeRepository(context: Context) {
   }
 }
 
-private suspend fun ContentResolver.insertAttendee(attendee: Attendee, eventID: String?): Int {
+private suspend fun ContentResolver.insertAttendee(attendee: Attendee, eventID: String?): Long {
   val contentValues = attendee.toContentValues().apply {
-    put(CalendarContract.Attendees.EVENT_ID, eventID?.toInt())
+    put(CalendarContract.Attendees.EVENT_ID, eventID?.toLong())
   }
 
   val attendeesUri = CalendarContract.Attendees.CONTENT_URI
@@ -69,13 +69,13 @@ private suspend fun ContentResolver.insertAttendee(attendee: Attendee, eventID: 
   val attendeeId = requireNotNull(attendeeUri?.lastPathSegment) {
     "Couldn't decode attendee ID from inserted content URI"
   }
-  return attendeeId.toInt()
+  return attendeeId.toLong()
 }
 
-private suspend fun ContentResolver.updateAttendee(attendee: Attendee): Int {
-  val attendeeId = requireNotNull(attendee.id?.toInt()) { "Attendee ID must be present when updating" }
+private suspend fun ContentResolver.updateAttendee(attendee: Attendee): Long {
+  val attendeeId = requireNotNull(attendee.id?.toLong()) { "Attendee ID must be present when updating" }
 
-  val updateUri = ContentUris.withAppendedId(CalendarContract.Attendees.CONTENT_URI, attendeeId.toLong())
+  val updateUri = ContentUris.withAppendedId(CalendarContract.Attendees.CONTENT_URI, attendeeId)
 
   withContext(Dispatchers.IO) {
     update(updateUri, attendee.toContentValues(), null, null)

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/calendar/CalendarRepository.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/calendar/CalendarRepository.kt
@@ -32,7 +32,7 @@ class CalendarRepository(context: Context) {
   }
 
   suspend fun findCalendarById(calendarId: String): CalendarEntity? = withContext(Dispatchers.IO) {
-    val uri = ContentUris.withAppendedId(CalendarContract.Calendars.CONTENT_URI, calendarId.toInt().toLong())
+    val uri = ContentUris.withAppendedId(CalendarContract.Calendars.CONTENT_URI, calendarId.toLong())
     val cursor = contentResolver.query(
       uri,
       findCalendarByIdQueryFields,
@@ -46,7 +46,7 @@ class CalendarRepository(context: Context) {
     }
   }
 
-  suspend fun createCalendar(calendarInput: NewCalendarInput): Int {
+  suspend fun createCalendar(calendarInput: NewCalendarInput): Long {
     val uriBuilder = CalendarContract.Calendars.CONTENT_URI
       .buildUpon()
       .appendQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER, "true")
@@ -60,12 +60,12 @@ class CalendarRepository(context: Context) {
     val calendarId = requireNotNull(calendarUri?.lastPathSegment) {
       "Couldn't decode calendar ID from inserted content URI"
     }
-    return calendarId.toInt()
+    return calendarId.toLong()
   }
 
-  suspend fun updateCalendar(updateInput: CalendarUpdateInput): Int {
-    val calendarId = updateInput.id.toInt()
-    val updateUri = ContentUris.withAppendedId(CalendarContract.Calendars.CONTENT_URI, calendarId.toLong())
+  suspend fun updateCalendar(updateInput: CalendarUpdateInput): Long {
+    val calendarId = updateInput.id.toLong()
+    val updateUri = ContentUris.withAppendedId(CalendarContract.Calendars.CONTENT_URI, calendarId)
     withContext(Dispatchers.IO) {
       contentResolver.update(updateUri, updateInput.toContentValues(), null, null)
     }
@@ -74,7 +74,7 @@ class CalendarRepository(context: Context) {
 
   @Throws(SecurityException::class)
   suspend fun deleteCalendar(calendarId: String): Boolean {
-    val uri = ContentUris.withAppendedId(CalendarContract.Calendars.CONTENT_URI, calendarId.toInt().toLong())
+    val uri = ContentUris.withAppendedId(CalendarContract.Calendars.CONTENT_URI, calendarId.toLong())
     val rows = withContext(Dispatchers.IO) {
       contentResolver.delete(uri, null, null)
     }

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/ExpoCalendar.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/ExpoCalendar.kt
@@ -204,7 +204,7 @@ class ExpoCalendar(
 
           val calendarsUri = uriBuilder.build()
           val calendarUri = contentResolver.insert(calendarsUri, values)
-          val calendarId = calendarUri?.lastPathSegment!!.toInt()
+          val calendarId = calendarUri?.lastPathSegment!!.toLong()
           calendarId
         } else {
           val uri = CalendarContract.Calendars.CONTENT_URI.buildUpon().appendPath(calendarRecord.id).build()
@@ -212,7 +212,7 @@ class ExpoCalendar(
           if (rowsUpdated == 0) {
             throw CalendarCouldNotBeUpdatedException("Failed to update calendar")
           }
-          calendarRecord.id!!.toInt()
+          calendarRecord.id!!.toLong()
         }
       }
     }
@@ -240,7 +240,7 @@ class ExpoCalendar(
 
     suspend fun findExpoCalendarById(context: AppContext, calendarID: String): ExpoCalendar? {
       return withContext(Dispatchers.IO) {
-        val uri = ContentUris.withAppendedId(CalendarContract.Calendars.CONTENT_URI, calendarID.toInt().toLong())
+        val uri = ContentUris.withAppendedId(CalendarContract.Calendars.CONTENT_URI, calendarID.toLong())
         val contentResolver = (
           context.reactContext
             ?: throw Exceptions.ReactContextLost()

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/ExpoCalendar.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/ExpoCalendar.kt
@@ -52,9 +52,9 @@ class ExpoCalendar(
 
   suspend fun deleteCalendar(): Boolean {
     return withContext(Dispatchers.IO) {
-      val calendarID = calendarRecord?.id?.toIntOrNull()
+      val calendarID = calendarRecord?.id?.toLongOrNull()
         ?: throw EventNotFoundException("Calendar id is null")
-      val uri = ContentUris.withAppendedId(CalendarContract.Calendars.CONTENT_URI, calendarID.toLong())
+      val uri = ContentUris.withAppendedId(CalendarContract.Calendars.CONTENT_URI, calendarID)
       val contentResolver = reactContext.contentResolver
       val rows = contentResolver.delete(uri, null, null)
       calendarRecord = null
@@ -123,7 +123,7 @@ class ExpoCalendar(
   }
 
   companion object {
-    suspend fun updateCalendar(appContext: AppContext, calendarRecord: CalendarRecord, isNew: Boolean = false): Int {
+    suspend fun updateCalendar(appContext: AppContext, calendarRecord: CalendarRecord, isNew: Boolean = false): Long {
       return withContext(Dispatchers.IO) {
         if (isNew) {
           if (calendarRecord.title == null) {

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/ExpoCalendarAttendee.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/ExpoCalendarAttendee.kt
@@ -27,7 +27,7 @@ class ExpoCalendarAttendee(
   val reactContext: Context
     get() = appContext?.reactContext ?: throw Exceptions.ReactContextLost()
 
-  suspend fun saveAttendee(attendeeRecord: AttendeeRecord, eventId: Int? = null, nullableFields: List<String>? = null): String {
+  suspend fun saveAttendee(attendeeRecord: AttendeeRecord, eventId: Long? = null, nullableFields: List<String>? = null): String {
     return withContext(Dispatchers.IO) {
       val attendeeValues = buildAttendeeContentValues(attendeeRecord, eventId)
       val contentResolver = reactContext.contentResolver
@@ -55,12 +55,12 @@ class ExpoCalendarAttendee(
 
   suspend fun deleteAttendee() {
     return withContext(Dispatchers.IO) {
-      val attendeeID = attendeeRecord?.id?.toIntOrNull()
+      val attendeeID = attendeeRecord?.id?.toLongOrNull()
         ?: throw AttendeeCouldNotBeDeletedException("Attendee ID not found")
 
       val contentResolver = reactContext.contentResolver
 
-      val uri = ContentUris.withAppendedId(CalendarContract.Attendees.CONTENT_URI, attendeeID.toLong())
+      val uri = ContentUris.withAppendedId(CalendarContract.Attendees.CONTENT_URI, attendeeID)
       val rows = contentResolver.delete(uri, null, null)
       attendeeRecord = null
       check(rows > 0) { throw AttendeeCouldNotBeDeletedException("An error occurred while deleting attendee") }
@@ -69,11 +69,11 @@ class ExpoCalendarAttendee(
 
   suspend fun reloadAttendee(attendeeID: String? = null) {
     withContext(Dispatchers.IO) {
-      val attendeeID = (attendeeID ?: attendeeRecord?.id)?.toIntOrNull()
+      val attendeeID = (attendeeID ?: attendeeRecord?.id)?.toLongOrNull()
         ?: throw AttendeeNotFoundException("Attendee ID not found")
 
       val contentResolver = reactContext.contentResolver
-      val uri = ContentUris.withAppendedId(CalendarContract.Attendees.CONTENT_URI, attendeeID.toLong())
+      val uri = ContentUris.withAppendedId(CalendarContract.Attendees.CONTENT_URI, attendeeID)
       val projection = AttendeeRepository.findAttendeesByEventIdQueryParameters
       val cursor = contentResolver.query(uri, projection, null, null, null)
       requireNotNull(cursor) { "Cursor shouldn't be null" }
@@ -104,7 +104,7 @@ class ExpoCalendarAttendee(
     }
   }
 
-  private fun buildAttendeeContentValues(attendeeRecord: AttendeeRecord, eventId: Int?): ContentValues {
+  private fun buildAttendeeContentValues(attendeeRecord: AttendeeRecord, eventId: Long?): ContentValues {
     val values = ContentValues()
 
     eventId?.let { values.put(CalendarContract.Attendees.EVENT_ID, it) }

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/ExpoCalendarEvent.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/ExpoCalendarEvent.kt
@@ -39,7 +39,7 @@ class ExpoCalendarEvent(
   val reactContext: Context
     get() = appContext?.reactContext ?: throw Exceptions.ReactContextLost()
 
-  suspend fun saveEvent(eventRecord: EventRecord, calendarId: String? = null, nullableFields: List<String>? = null): Int? {
+  suspend fun saveEvent(eventRecord: EventRecord, calendarId: String? = null, nullableFields: List<String>? = null): Long? {
     return withContext(Dispatchers.IO) {
       val eventBuilder = CalendarBuilderNext()
 
@@ -92,10 +92,10 @@ class ExpoCalendarEvent(
 
       if (this@ExpoCalendarEvent.eventRecord?.id != null) {
         // Update current event
-        val eventID = this@ExpoCalendarEvent.eventRecord?.id?.toIntOrNull()
+        val eventID = this@ExpoCalendarEvent.eventRecord?.id?.toLongOrNull()
           ?: throw EventNotFoundException("Event ID is required")
 
-        val updateUri = ContentUris.withAppendedId(CalendarContract.Events.CONTENT_URI, eventID.toLong())
+        val updateUri = ContentUris.withAppendedId(CalendarContract.Events.CONTENT_URI, eventID)
         val contentResolver = reactContext.contentResolver
 
         contentResolver.update(updateUri, eventBuilder.build(), null, null)
@@ -127,7 +127,7 @@ class ExpoCalendarEvent(
 
   suspend fun createAttendee(attendeeRecord: AttendeeRecord): ExpoCalendarAttendee? {
     val attendee = ExpoCalendarAttendee(appContext ?: throw Exceptions.AppContextLost())
-    val eventId = eventRecord?.id?.toIntOrNull()
+    val eventId = eventRecord?.id?.toLongOrNull()
       ?: throw EventNotFoundException("Event ID is required")
 
     val newAttendeeId = attendee.saveAttendee(attendeeRecord, eventId)
@@ -169,7 +169,7 @@ class ExpoCalendarEvent(
         exceptionValues.put(CalendarContract.Events.ORIGINAL_INSTANCE_TIME, startCal.timeInMillis)
         exceptionValues.put(CalendarContract.Events.STATUS, CalendarContract.Events.STATUS_CANCELED)
 
-        val exceptionUri = ContentUris.withAppendedId(CalendarContract.Events.CONTENT_EXCEPTION_URI, eventID.toLong())
+        val exceptionUri = ContentUris.withAppendedId(CalendarContract.Events.CONTENT_EXCEPTION_URI, eventID)
         contentResolver.insert(exceptionUri, exceptionValues)
       }
     }
@@ -177,11 +177,11 @@ class ExpoCalendarEvent(
 
   suspend fun reloadEvent(eventId: String? = null) {
     withContext(Dispatchers.IO) {
-      val eventID = (eventId ?: eventRecord?.id)?.toIntOrNull()
+      val eventID = (eventId ?: eventRecord?.id)?.toLongOrNull()
         ?: throw EventNotFoundException("Event ID is required")
 
       val contentResolver = reactContext.contentResolver
-      val uri = ContentUris.withAppendedId(CalendarContract.Events.CONTENT_URI, eventID.toLong())
+      val uri = ContentUris.withAppendedId(CalendarContract.Events.CONTENT_URI, eventID)
       val projection = EventRepository.findEventByIdQueryParameters
       val cursor = contentResolver.query(uri, projection, null, null, null)
 
@@ -255,7 +255,7 @@ class ExpoCalendarEvent(
     }
   }
 
-  private fun createRemindersForEvent(eventID: Int, reminders: List<AlarmRecord>) {
+  private fun createRemindersForEvent(eventID: Long, reminders: List<AlarmRecord>) {
     val contentResolver = reactContext.contentResolver
     reminders
       .filter { it.relativeOffset != null }

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/ExpoCalendarEvent.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/ExpoCalendarEvent.kt
@@ -111,12 +111,12 @@ class ExpoCalendarEvent(
         if (calendarId == null) {
           throw InvalidArgumentException("CalendarId is required.")
         }
-        eventBuilder.put(CalendarContract.Events.CALENDAR_ID, calendarId.toInt())
+        eventBuilder.put(CalendarContract.Events.CALENDAR_ID, calendarId.toLong())
         val eventsUri = CalendarContract.Events.CONTENT_URI
         val contentResolver = reactContext.contentResolver
         val eventUri = contentResolver.insert(eventsUri, eventBuilder.build())
           ?: throw EventsCouldNotBeCreatedException("Failed to insert event into the database")
-        val eventID = eventUri.lastPathSegment!!.toInt()
+        val eventID = eventUri.lastPathSegment!!.toLong()
         if (eventRecord.alarms != null) {
           createRemindersForEvent(eventID, eventRecord.alarms)
         }
@@ -137,7 +137,7 @@ class ExpoCalendarEvent(
 
   suspend fun deleteEvent() {
     withContext(Dispatchers.IO) {
-      val eventID = eventRecord?.id?.toInt()
+      val eventID = eventRecord?.id?.toLong()
         ?: throw EventCouldNotBeDeletedException("Event ID is required")
 
       val contentResolver = reactContext.contentResolver
@@ -145,7 +145,7 @@ class ExpoCalendarEvent(
       if (options?.futureEvents == null || options?.futureEvents == false) {
         val url = ContentUris.withAppendedId(
           CalendarContract.Events.CONTENT_URI,
-          eventID.toLong()
+          eventID
         )
         contentResolver
           .delete(url, null, null)
@@ -290,7 +290,7 @@ class ExpoCalendarEvent(
   companion object {
     suspend fun findEventById(eventID: String, appContext: AppContext): ExpoCalendarEvent? {
       return withContext(Dispatchers.IO) {
-        val uri = ContentUris.withAppendedId(CalendarContract.Events.CONTENT_URI, eventID.toInt().toLong())
+        val uri = ContentUris.withAppendedId(CalendarContract.Events.CONTENT_URI, eventID.toLong())
         val selection = "((${CalendarContract.Events.DELETED} != 1))"
         val projection = EventRepository.findEventByIdQueryParameters
         val contentResolver = appContext.reactContext?.contentResolver

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/utils/EventNextUtils.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/utils/EventNextUtils.kt
@@ -38,13 +38,13 @@ fun dateToMilliseconds(stringValue: String?): Long? {
   return cal.timeInMillis
 }
 
-fun removeRemindersForEvent(contentResolver: ContentResolver, eventID: Int) {
+fun removeRemindersForEvent(contentResolver: ContentResolver, eventID: Long) {
   val projection = arrayOf(
     CalendarContract.Reminders._ID
   )
   val cursor = CalendarContract.Reminders.query(
     contentResolver,
-    eventID.toLong(),
+    eventID,
     projection
   )
 


### PR DESCRIPTION
## Summary

Fixes `NumberFormatException` when calendar/event/attendee IDs exceed `Integer.MAX_VALUE` (2,147,483,647). This can happen on some Android devices with synced Google calendars where IDs can be very large (e.g., `471329298580`).

## Changes

Changed all ID parsing from `.toInt()` to `.toLong()` and updated function return types from `Int` to `Long` where applicable.

### Legacy API layer (`domain/`)
- `CalendarModule.kt` - return type of `saveEvent`
- `CalendarRepository.kt` - `findCalendarById`, `createCalendar`, `updateCalendar`, `deleteCalendar`
- `EventRepository.kt` - `findEventById`, `createEvent`, `updateEvent`, `createRemindersForEvent`, `removeRemindersForEvent`
- `AttendeeRepository.kt` - `saveAttendeeForEvent`, `deleteAttendee`, `insertAttendee`, `updateAttendee`

### Next API layer (`next/`)
- `ExpoCalendar.kt` - `updateCalendar` return type, `deleteCalendar` ID parsing
- `ExpoCalendarEvent.kt` - `saveEvent` return type, `createRemindersForEvent` param, all `toIntOrNull()` → `toLongOrNull()` in `createAttendee`, `reloadEvent`, `deleteEvent`
- `ExpoCalendarAttendee.kt` - `saveAttendee` and `buildAttendeeContentValues` params, all `toIntOrNull()` → `toLongOrNull()` in `deleteAttendee`, `reloadAttendee`
- `EventNextUtils.kt` - `removeRemindersForEvent` param

## Backward Compatibility

This is fully backward compatible since all IDs are converted to strings via `.toString()` before being sent to JavaScript. JavaScript numbers can safely handle values up to `Number.MAX_SAFE_INTEGER` (9,007,199,254,740,991).

## Test Plan

- Tested on device with large calendar IDs that previously crashed
- No changes to JavaScript API

Fixes #43343