### PR TITLE
[image] Fix compilation errors in Xcode 26.4 Beta 1

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed compilation errors in Xcode 26.4 Beta 1
+- [iOS] Fixed compilation errors in Xcode 26.4 Beta 1 ([#43346](https://github.com/expo/expo/pull/43346) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed compilation errors in Xcode 26.4 Beta 1
+
 ### 💡 Others
 
 ## 55.0.4 — 2026-02-20

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -11,10 +11,10 @@ typealias SDWebImageContext = [SDWebImageContextOption: Any]
 
 // swiftlint:disable:next type_body_length
 public final class ImageView: ExpoView {
-  static let contextSourceKey = SDWebImageContextOption(rawValue: "source")
-  static let screenScaleKey = SDWebImageContextOption(rawValue: "screenScale")
-  static let contentFitKey = SDWebImageContextOption(rawValue: "contentFit")
-  static let frameSizeKey = SDWebImageContextOption(rawValue: "frameSize")
+  nonisolated static let contextSourceKey = SDWebImageContextOption(rawValue: "source")
+  nonisolated static let screenScaleKey = SDWebImageContextOption(rawValue: "screenScale")
+  nonisolated static let contentFitKey = SDWebImageContextOption(rawValue: "contentFit")
+  nonisolated static let frameSizeKey = SDWebImageContextOption(rawValue: "frameSize")
 
   let sdImageView = SDAnimatedImageView(frame: .zero)
 


### PR DESCRIPTION
# Why

Fixes #43337
Xcode 26.4 ships with Swift 6.3 that has even more compiler checks preventing us from possible data races.

# How

- `SDWebImage` doesn't use modern concurrency model so we need to trick the compiler by adding `@preconcurrency` to the import and `@Sendable` to the completion closure.
- Taking advantage of the fact that I'm changing something here, I also migrated our thumbhash and blurhash loaders to use `Task` and `MainActor.run` instead of dispatch queues.

# Test Plan

bare-expo app compiles on Xcode 26.4 Beta 1 and the examples for hashed placeholders render as expected