### PR TITLE
[iOS][core] Isolate view prop setter to MainActor

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fixed `field.options.insert()` silently failing in `fieldsOf()` due to mutation on protocol existential. ([#43341](https://github.com/expo/expo/pull/43341) by [@just1and0](https://github.com/just1and0))
+- [iOS] Fixed warnings in `Prop` definition component by isolating its setter to the main actor. ([#43348](https://github.com/expo/expo/pull/43348) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Api/Factories/ViewFactories.swift
+++ b/packages/expo-modules-core/ios/Api/Factories/ViewFactories.swift
@@ -37,7 +37,7 @@ public func View<Props: ExpoSwiftUI.ViewProps, ViewType: ExpoSwiftUI.View>(
  */
 public func Prop<ViewType: UIView, PropType: AnyArgument>(
   _ name: String,
-  @_implicitSelfCapture _ setter: @escaping (ViewType, PropType) -> Void
+  @_implicitSelfCapture _ setter: @escaping @MainActor (ViewType, PropType) -> Void
 ) -> ConcreteViewProp<ViewType, PropType> {
   return ConcreteViewProp(
     name: name,
@@ -52,7 +52,7 @@ public func Prop<ViewType: UIView, PropType: AnyArgument>(
 public func Prop<ViewType: UIView, PropType: AnyArgument>(
   _ name: String,
   _ defaultValue: PropType,
-  @_implicitSelfCapture _ setter: @escaping (ViewType, PropType) -> Void
+  @_implicitSelfCapture _ setter: @escaping @MainActor (ViewType, PropType) -> Void
 ) -> ConcreteViewProp<ViewType, PropType> {
   return ConcreteViewProp(
     name: name,
@@ -68,7 +68,7 @@ public func Prop<ViewType: UIView, PropType: AnyArgument>(
  Defines the view lifecycle method that is called when the view finished updating all props.
  */
 public func OnViewDidUpdateProps<ViewType: UIView>(
-  @_implicitSelfCapture _ closure: @escaping (_ view: ViewType) -> Void
+  @_implicitSelfCapture _ closure: @escaping @MainActor (_ view: ViewType) -> Void
 ) -> ViewLifecycleMethod<ViewType> {
   return ViewLifecycleMethod(type: .didUpdateProps, closure: closure)
 }

--- a/packages/expo-modules-core/ios/Core/Protocols/AnyViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Protocols/AnyViewDefinition.swift
@@ -37,6 +37,7 @@ public protocol AnyViewDefinition: Sendable {
   /**
    Calls defined lifecycle methods with the given type.
    */
+  @MainActor
   func callLifecycleMethods(withType type: ViewLifecycleMethodType, forView view: AppleView)
 
   /**

--- a/packages/expo-modules-core/ios/Core/Views/ComponentData.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ComponentData.swift
@@ -86,7 +86,9 @@ public final class ComponentData: RCTComponentDataSwiftAdapter {
     // Let the base class `RCTComponentData` handle all remaining props.
     super.setProps(remainingProps, forView: view)
 
-    viewDefinition.callLifecycleMethods(withType: .didUpdateProps, forView: AppleView.uikit(view))
+    MainActor.assumeIsolated {
+      viewDefinition.callLifecycleMethods(withType: .didUpdateProps, forView: AppleView.uikit(view))
+    }
   }
 
   /**

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualView.swift
@@ -93,7 +93,6 @@ extension ExpoSwiftUI {
      Calls lifecycle methods registered by `OnViewDidUpdateProps` definition component.
      */
     @MainActor
-    @preconcurrency
     override func viewDidUpdateProps() {
       guard let viewDefinition else {
         return

--- a/packages/expo-modules-core/ios/Core/Views/ViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ViewDefinition.swift
@@ -82,6 +82,7 @@ public class ViewDefinition<ViewType>: ObjectDefinition, AnyViewDefinition, @unc
     return eventNames
   }
 
+  @MainActor
   public func callLifecycleMethods(withType type: ViewLifecycleMethodType, forView view: AppleView) {
     for method in lifecycleMethods where method.type == type {
       method(view)

--- a/packages/expo-modules-core/ios/Core/Views/ViewLifecycleMethod.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ViewLifecycleMethod.swift
@@ -19,6 +19,7 @@ internal protocol AnyViewLifecycleMethod: AnyDefinition {
   /**
    Calls the lifecycle method for the given view.
    */
+  @MainActor
   func callAsFunction(_ view: AppleView)
 }
 
@@ -26,18 +27,21 @@ internal protocol AnyViewLifecycleMethod: AnyDefinition {
  Element of the view definition that represents a lifecycle method, such as `OnViewDidUpdateProps`.
  */
 public final class ViewLifecycleMethod<ViewType>: AnyViewLifecycleMethod {
+  public typealias Closure = @MainActor (ViewType) -> Void
+
   /**
    The actual closure that gets called when the view signals an event in view's lifecycle.
    */
-  let closure: (ViewType) -> Void
+  let closure: Closure
 
   let type: ViewLifecycleMethodType
 
-  init(type: ViewLifecycleMethodType, closure: @escaping (ViewType) -> Void) {
+  init(type: ViewLifecycleMethodType, closure: @escaping Closure) {
     self.type = type
     self.closure = closure
   }
 
+  @MainActor
   func callAsFunction(_ view: AppleView) {
     switch view {
     case .uikit(let view):

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
@@ -76,6 +76,7 @@ open class ExpoFabricView: ExpoFabricViewObjC, AnyExpoView {
 
   // MARK: - ExpoFabricViewInterface
 
+  @MainActor
   public override func updateProps(_ props: [String: Any]) {
     guard let context = appContext, let propsDict = viewManagerPropDict else {
       return
@@ -115,6 +116,7 @@ open class ExpoFabricView: ExpoFabricViewObjC, AnyExpoView {
   /**
    Calls lifecycle methods registered by `OnViewDidUpdateProps` definition component.
    */
+  @MainActor
   public override func viewDidUpdateProps() {
     guard let viewDefinition else {
       return

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
@@ -29,7 +29,7 @@
 
 - (void)updateProps:(nonnull NSDictionary<NSString *, id> *)props;
 
-- (void)viewDidUpdateProps;
+- (void)viewDidUpdateProps NS_SWIFT_UI_ACTOR;
 
 - (void)setShadowNodeSize:(float)width height:(float)height;
 


### PR DESCRIPTION
# Why

In Xcode 26.4 (Swift 6.3) there are much more warnings in our codebase, possibly as a result of `UIView` now being fully isolated to the main actor. All view members are now MainActor-isolated, so in the new Xcode we can see such 👇 warnings in most `Prop` components.

<img width="992" height="411" alt="Screenshot 2026-02-23 at 00 18 40" src="https://github.com/user-attachments/assets/a3332275-459c-4179-b225-fa6e53272829" />

# How

Isolated `Prop` setter to the main actor and did some more changes that were necessary to compile it successfully. Unfortunately we can't avoid using `nonisolated(unsafe)` and `MainActor.assumeIsolated`, mostly because protocols in RN do not define the isolation.

# Test Plan

- bare-expo compiles on Xcode 26.4 and our components seem to render as expected
- the above warnings disappeared