### PR TITLE
fix(expo-widgets): Fix bundling to respect project root and apply normal resolution

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix iOS bundle build for irregularly hoisted dependencies or monorepos ([#43350](https://github.com/expo/expo/pull/43350) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 55.0.0-alpha.8 — 2026-02-20

--- a/packages/expo-widgets/ios/ExpoWidgets.podspec
+++ b/packages/expo-widgets/ios/ExpoWidgets.podspec
@@ -33,12 +33,10 @@ Pod::Spec.new do |s|
     s.source_files = "**/*.{h,m,swift}"
   end
 
+  project_root_env_var = ENV['PROJECT_ROOT'] ? "export PROJECT_ROOT=#{ENV['PROJECT_ROOT']}\n" : ""
   build_bundle_script = {
     :name => 'Build ExpoWidgets Bundle',
-    :script => %Q{
-      echo "Building ExpoWidgets.bundle..."
-      #{__dir__}/../scripts/with-node.sh #{__dir__}/../scripts/build-bundle.mjs
-    },
+    :script => project_root_env_var + 'bash -l -c "$PODS_TARGET_SRCROOT/../scripts/xcode-build-bundle.sh"',
     :execution_position => :before_compile,
     # NOTE(@krystofwoldrich): Ideally we would specify `__dir__/**/*`, but Xcode doesn't support patterns
     :input_files  => ["#{__dir__}/../package.json"],

--- a/packages/expo-widgets/metro.config.js
+++ b/packages/expo-widgets/metro.config.js
@@ -1,9 +1,7 @@
 const { getDefaultConfig } = require('expo/metro-config');
-const resolve = require('metro-resolver').resolve;
 const path = require('path');
 
 const config = getDefaultConfig(__dirname);
-const emptyModulePath = require.resolve('metro-runtime/src/modules/empty-module');
 const expoStubPath = path.resolve(__dirname, './bundle/expo-module-stub.ts');
 const reactStubPath = path.resolve(__dirname, './bundle/react-stub.ts');
 const jsxRuntimeStubPath = path.resolve(__dirname, './bundle/jsx-runtime-stub.ts');
@@ -12,39 +10,27 @@ const buildConfig = {
   ...config,
   resolver: {
     ...config.resolver,
-    resolveRequest(context, moduleName) {
-      const resolvedPlatform = 'ios';
+    resolveRequest(context, moduleName, platform) {
       if (moduleName === 'expo') {
         return { type: 'sourceFile', filePath: expoStubPath };
-      }
-      if (moduleName === 'react') {
+      } else if (moduleName === 'react') {
         return { type: 'sourceFile', filePath: reactStubPath };
-      }
-      if (moduleName === 'react/jsx-runtime') {
+      } else if (moduleName === 'react/jsx-runtime') {
         return { type: 'sourceFile', filePath: jsxRuntimeStubPath };
-      }
-      if (moduleName === 'react/jsx-dev-runtime') {
+      } else if (moduleName === 'react/jsx-dev-runtime') {
         return { type: 'sourceFile', filePath: jsxRuntimeStubPath };
+      } else {
+        return context.resolveRequest(context, moduleName, platform);
       }
-
-      if (
-        moduleName.startsWith('@expo/ui') ||
-        moduleName.startsWith('@babel/runtime') ||
-        moduleName.startsWith('./') ||
-        moduleName.startsWith('../') ||
-        path.isAbsolute(moduleName)
-      ) {
-        return resolve(context, moduleName, resolvedPlatform);
-      }
-
-      return { type: 'sourceFile', filePath: emptyModulePath };
     },
   },
   transformer: {
     ...config.transformer,
-    babelTransformerPath: require.resolve('@expo/metro-config/build/babel-transformer'),
     getTransformOptions: async () => ({
-      transform: { experimentalImportSupport: false, inlineRequires: false },
+      transform: {
+        experimentalImportSupport: true,
+        inlineRequires: false,
+      },
     }),
   },
   serializer: {

--- a/packages/expo-widgets/metro.config.js
+++ b/packages/expo-widgets/metro.config.js
@@ -39,7 +39,7 @@ const buildConfig = {
   transformer: {
     ...config.transformer,
     getTransformOptions: async () => ({
-      transform: { experimentalImportSupport: true, inlineRequires: false },
+      transform: { experimentalImportSupport: false, inlineRequires: false },
     }),
   },
   serializer: {

--- a/packages/expo-widgets/metro.config.js
+++ b/packages/expo-widgets/metro.config.js
@@ -17,16 +17,22 @@ const buildConfig = {
   resolver: {
     ...config.resolver,
     resolveRequest(context, moduleName, platform) {
-      if (moduleName === 'expo') {
-        return { type: 'sourceFile', filePath: expoStubPath };
-      } else if (moduleName === 'react') {
-        return { type: 'sourceFile', filePath: reactStubPath };
-      } else if (moduleName === 'react/jsx-runtime') {
-        return { type: 'sourceFile', filePath: jsxRuntimeStubPath };
-      } else if (moduleName === 'react/jsx-dev-runtime') {
-        return { type: 'sourceFile', filePath: jsxRuntimeStubPath };
-      } else {
+      const fileSpecifierRe = /^[\\/]|^\.\.?(?:$|[\\/])/i;
+      if (fileSpecifierRe.test(moduleName)) {
         return context.resolveRequest(context, moduleName, platform);
+      }
+      switch (moduleName) {
+        case 'expo':
+          return { type: 'sourceFile', filePath: expoStubPath };
+        case 'react':
+          return { type: 'sourceFile', filePath: reactStubPath };
+        case 'react/jsx-runtime':
+        case 'react/jsx-dev-runtime':
+          return { type: 'sourceFile', filePath: jsxRuntimeStubPath };
+        case 'react-native':
+          return { type: 'empty' };
+        default:
+          return context.resolveRequest(context, moduleName, platform);
       }
     },
   },

--- a/packages/expo-widgets/metro.config.js
+++ b/packages/expo-widgets/metro.config.js
@@ -1,13 +1,19 @@
 const { getDefaultConfig } = require('expo/metro-config');
 const path = require('path');
 
-const config = getDefaultConfig(__dirname);
+const config = getDefaultConfig(process.cwd());
+
 const expoStubPath = path.resolve(__dirname, './bundle/expo-module-stub.ts');
 const reactStubPath = path.resolve(__dirname, './bundle/react-stub.ts');
 const jsxRuntimeStubPath = path.resolve(__dirname, './bundle/jsx-runtime-stub.ts');
 
 const buildConfig = {
   ...config,
+  projectRoot: __dirname,
+  watchFolders: [
+    ...config.watchFolders,
+    __dirname,
+  ],
   resolver: {
     ...config.resolver,
     resolveRequest(context, moduleName, platform) {
@@ -27,10 +33,7 @@ const buildConfig = {
   transformer: {
     ...config.transformer,
     getTransformOptions: async () => ({
-      transform: {
-        experimentalImportSupport: true,
-        inlineRequires: false,
-      },
+      transform: { experimentalImportSupport: true, inlineRequires: false },
     }),
   },
   serializer: {

--- a/packages/expo-widgets/scripts/build-bundle.mjs
+++ b/packages/expo-widgets/scripts/build-bundle.mjs
@@ -4,42 +4,57 @@
 // Use `yarn build:bundle` to run this script.
 
 import spawn from '@expo/spawn-async';
-import { rm } from 'node:fs/promises';
+import fs from 'node:fs';
 import { createRequire } from 'node:module';
-import { dirname, join } from 'path';
-import { argv } from 'process';
-import { fileURLToPath } from 'url';
+import path from 'node:path';
+import { argv } from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+// NOTE: Modified from expo-constants/expo-updates entrypoint. We cd into the right folder anyway
+const possibleProjectRoot = process.argv[2] ?? process.cwd();
+
+// TODO: Verify we can remove projectRoot validation, now that we no longer
+// support React Native <= 62
+let projectRoot;
+if (fs.existsSync(path.join(possibleProjectRoot, 'package.json'))) {
+  projectRoot = possibleProjectRoot;
+} else if (fs.existsSync(path.join(possibleProjectRoot, '..', 'package.json'))) {
+  projectRoot = path.resolve(possibleProjectRoot, '..');
+} else {
+  throw new Error(
+    `Unable to locate project (no package.json found) at path: ${possibleProjectRoot}`
+  );
+}
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+const __dirname = path.dirname(__filename);
+const require = createRequire(__dirname);
 
 // NODE_BINARY is set for Xcode builds via the `with-node.sh` script.
 const nodePath = process.env.NODE_BINARY || 'node';
-const outputDir = join(__dirname, '../bundle/build');
-const appBundlePath = join(outputDir, 'ExpoWidgets.bundle');
+const outputDir = path.join(__dirname, '../bundle/build');
+const appBundlePath = path.join(outputDir, 'ExpoWidgets.bundle');
 
-await rm(outputDir, { recursive: true, force: true });
-
-const expoCliJs = createRequire(__dirname).resolve('expo/bin/cli');
+await fs.promises.rm(outputDir, { recursive: true, force: true });
 
 const result = await spawn(
   nodePath,
   [
-    expoCliJs,
+    require.resolve('expo/bin/cli'),
     'export:embed',
     '--platform',
     'ios',
     '--bundle-output',
     appBundlePath,
     '--entry-file',
-    join(__dirname, '../bundle/index.ts'),
+    path.join(__dirname, '../bundle/index.ts'),
     '--dev',
     false,
     ...argv.slice(2),
   ],
   {
     stdio: 'inherit',
-    cwd: join(__dirname, '..'),
+    cwd: projectRoot,
   }
 );
 

--- a/packages/expo-widgets/scripts/build-bundle.mjs
+++ b/packages/expo-widgets/scripts/build-bundle.mjs
@@ -55,6 +55,10 @@ const result = await spawn(
   {
     stdio: 'inherit',
     cwd: projectRoot,
+    env: {
+      ...process.env,
+      EXPO_OVERRIDE_METRO_CONFIG: path.join(__dirname, '../metro.config.js'),
+    },
   }
 );
 

--- a/packages/expo-widgets/scripts/xcode-build-bundle.sh
+++ b/packages/expo-widgets/scripts/xcode-build-bundle.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+EXPO_WIDGETS_PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
+# For classic main project build phases integration, will be no-op to prevent duplicated bundle creation.
+#
+# `$PROJECT_DIR` is passed by Xcode as the directory to the xcodeproj file.
+# in classic main project setup it is something like /path/to/app/ios
+# in new style pod project setup it is something like /path/to/app/ios/Pods
+PROJECT_DIR_BASENAME=$(basename $PROJECT_DIR)
+if [ "x$PROJECT_DIR_BASENAME" != "xPods" ]; then
+  exit 0
+fi
+
+# If PROJECT_ROOT is not specified, fallback to use Xcode PROJECT_DIR
+PROJECT_ROOT=${PROJECT_ROOT:-"$PROJECT_DIR/../.."}
+PROJECT_ROOT=${PROJECT_ROOT:-"$EXPO_WIDGETS_PACKAGE_DIR/../.."}
+
+cd "$PROJECT_ROOT" || exit
+
+"${EXPO_WIDGETS_PACKAGE_DIR}/scripts/with-node.sh" "${EXPO_WIDGETS_PACKAGE_DIR}/scripts/build-bundle.mjs" "$PROJECT_ROOT"


### PR DESCRIPTION
# Why

The current implementation in `expo-widgets` sets the project root to the module itself. This can have unintended consequences, since the location of `expo-widgets` itself isn't guaranteed. This breaks with irregularly hoisted `node_modules` (e.g. higher hoisting, nested location), with monorepos, or with isolated dependencies.

The current configuration also circumvents many protections that `@expo/cli` puts in place by overridding the resolver.

The individual commits have notes with step by step changes and why they happened.

**Note:** @krystofwoldrich: I don't know how much of this also applies to `@expo/log-box` and whether the log-box also bundles from scratch when packaged and installed from npm. If this also applies to `@expo/log-box`, some of this will need to be copied over.

# How

- Create wrapper script (like `expo-constants` and `expo-updates`) and accept `PROJECT_ROOT` with usual protections and fallbacks
- Pass `PROJECT_ROOT` in podspec to wrapper script
- Refactor bundle script to use cwd/project root and use custom metro config via env override
- Fix up metro config to remove invalid overrides (e.g. bypassing standard CLI resolver with protections, like the fallback resolver)
- Refactor resolver to not noop random modules (if we're not sure, we probably shouldn't exclude it, since that's brittle)
- Add `watchFolders` addition, just in case, for testing with linked `expo-widgets`

# Test Plan

Without these changes, `expo-widgets`' bundle will fail to build in a pnpm monorepo with isolated dependencies. This could likely also be reproduced with regular pnpm and isolated dependencies, which is probably the most straightforward reproduction path. The resolver error that should pop up first is for `@babel/runtime/*` dependencies (which the fallback resolver protects us from)

Once e.g. a live activity is registered in test code, the fixes are applied, and after a full clean prebuild (unclean prebuild currently leads to errors), a rebuild succeeds to register the live activity: 

<img width="402" height="293" alt="image" src="https://github.com/user-attachments/assets/1638baff-21af-48b7-a054-212312776696" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
