### PR TITLE
[tools] Rewrite `et github-inspect` as an interactive TUI

### DIFF
--- a/tools/src/commands/GitHubInspectCommand.ts
+++ b/tools/src/commands/GitHubInspectCommand.ts
@@ -1,5 +1,6 @@
 import { Command } from '@expo/commander';
 import chalk from 'chalk';
+import ora from 'ora';
 
 import {
   getAuthenticatedUserAsync,
@@ -15,11 +16,8 @@ import {
 } from '../GitHub';
 import logger from '../Logger';
 
-// --- Types ---
-
 type ActionOptions = {
   week?: string;
-  inspect?: string;
   label?: string;
   staleDays?: string;
 };
@@ -39,8 +37,6 @@ type DashboardData = {
   externalPRs: PRWithReviews[];
   staleDays: number;
 };
-
-// --- Date utilities ---
 
 function getISOWeekNumber(date: Date): number {
   const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
@@ -92,8 +88,6 @@ function parseDateRange(weekOption?: string): [Date, Date, number, Date] {
   return [monday, dataEndDate, targetWeek, friday];
 }
 
-// --- Helpers ---
-
 function isIssue(item: IssueItem): boolean {
   return !('pull_request' in item && item.pull_request);
 }
@@ -110,87 +104,10 @@ function getLabels(issue: { labels: IssueItem['labels'] }): { name?: string }[] 
   return issue.labels as { name?: string }[];
 }
 
-function ageDays(date: Date | string): number {
-  const d = typeof date === 'string' ? new Date(date) : date;
-  return Math.floor((Date.now() - d.getTime()) / (1000 * 60 * 60 * 24));
-}
-
-function formatAge(date: Date | string): string {
-  const days = ageDays(date);
-  if (days < 1) return '<1d';
-  if (days < 7) return `${days}d`;
-  if (days < 30) return `${Math.floor(days / 7)}w`;
-  if (days < 365) return `${Math.floor(days / 30)}mo`;
-  return `${Math.floor(days / 365)}y`;
-}
-
-function extractArea(labels: { name?: string }[]): string {
-  for (const label of labels) {
-    const name = label.name ?? '';
-    const moduleMatch = name.match(/^Module:\s*(.+)/i);
-    if (moduleMatch) return moduleMatch[1];
-    const pkgMatch = name.match(/^packages\/(.+)/i);
-    if (pkgMatch) return pkgMatch[1];
-  }
-  return '-';
-}
-
-function summarizeReviews(reviews: { state?: string }[]): string {
-  if (reviews.length === 0) return 'no reviews';
-  const approved = reviews.filter((r) => r.state === 'APPROVED').length;
-  const changesRequested = reviews.filter((r) => r.state === 'CHANGES_REQUESTED').length;
-  if (changesRequested > 0) return chalk.red(`changes requested (${changesRequested})`);
-  if (approved > 0) return chalk.green(`${approved} approved`);
-  return `${reviews.length} review(s)`;
-}
-
 function truncate(str: string, len: number): string {
   if (str.length <= len) return str;
   return str.slice(0, len - 1) + '…';
 }
-
-const MAX_ITEMS = 30;
-
-// --- Display helpers ---
-
-type Column<T> = {
-  label: string;
-  width: number;
-  value: (item: T) => string;
-  color?: (val: string) => string;
-};
-
-function displayTable<T>(
-  title: string,
-  items: T[],
-  columns: Column<T>[],
-  emptyMessage = '  No items found.'
-): void {
-  logger.info('');
-  logger.info(chalk.bold.underline(title));
-  if (items.length === 0) {
-    logger.info(chalk.gray(emptyMessage));
-    return;
-  }
-
-  const display = items.slice(0, MAX_ITEMS);
-  const header = columns.map((c) => chalk.gray(c.label.padEnd(c.width))).join(' ');
-  logger.info(`  ${header}`);
-  for (const item of display) {
-    const row = columns
-      .map((c) => {
-        const val = c.value(item).padEnd(c.width);
-        return c.color ? c.color(val) : val;
-      })
-      .join(' ');
-    logger.info(`  ${row}`);
-  }
-  if (items.length > MAX_ITEMS) {
-    logger.info(chalk.gray(`  ... and ${items.length - MAX_ITEMS} more`));
-  }
-}
-
-// --- Batch helper ---
 
 async function batchAsync<T, R>(
   items: T[],
@@ -206,42 +123,11 @@ async function batchAsync<T, R>(
   return results;
 }
 
-// --- Dashboard sections ---
-
-// --- Issue column definitions (reused across sections) ---
-
-const issueColumns: Column<IssueItem>[] = [
-  { label: '#', width: 7, value: (i) => `#${i.number}`, color: chalk.cyan },
-  { label: 'Title', width: 52, value: (i) => truncate(i.title, 50) },
-  {
-    label: 'Author',
-    width: 18,
-    value: (i) => truncate(i.user?.login ?? '-', 16),
-    color: chalk.dim,
-  },
-  { label: 'Age', width: 6, value: (i) => formatAge(i.created_at) },
-  { label: 'Area', width: 0, value: (i) => extractArea(getLabels(i)), color: chalk.yellow },
-];
-
-const assignedIssueColumns: Column<IssueItem>[] = [
-  { label: '#', width: 7, value: (i) => `#${i.number}`, color: chalk.cyan },
-  { label: 'Title', width: 42, value: (i) => truncate(i.title, 40) },
-  {
-    label: 'Assignee',
-    width: 18,
-    value: (i) => truncate((i.assignees ?? []).map((a: any) => a.login).join(', ') || '-', 16),
-    color: chalk.dim,
-  },
-  { label: 'Age', width: 6, value: (i) => formatAge(i.created_at) },
-  { label: 'Area', width: 0, value: (i) => extractArea(getLabels(i)), color: chalk.yellow },
-];
-
-// --- Dashboard sections ---
-
 async function fetchNeedsReviewIssues(
-  labelFilter?: string
+  labelFilter?: string,
+  spinner?: ora.Ora
 ): Promise<{ unassigned: IssueItem[]; assigned: IssueItem[] }> {
-  logger.info(chalk.gray('Fetching issues with "needs review" label...'));
+  if (spinner) spinner.text = 'Fetching issues with "needs review" label…';
   const labels = labelFilter ? `needs review,${labelFilter}` : 'needs review';
   const issues = await listAllOpenIssuesAsync({ labels, limit: 100 });
   const filtered = issues.filter(isIssue);
@@ -251,32 +137,23 @@ async function fetchNeedsReviewIssues(
   };
 }
 
-async function fetchAcceptedUnassigned(labelFilter?: string): Promise<IssueItem[]> {
-  logger.info(chalk.gray('Fetching "issue accepted" issues without assignee...'));
+async function fetchAcceptedUnassigned(
+  labelFilter?: string,
+  spinner?: ora.Ora
+): Promise<IssueItem[]> {
+  if (spinner) spinner.text = 'Fetching "issue accepted" issues without assignee…';
   const labels = labelFilter ? `issue accepted,${labelFilter}` : 'issue accepted';
   const issues = await listAllOpenIssuesAsync({ labels, limit: 100 });
   return issues.filter((i) => isIssue(i) && !isAssigned(i));
 }
 
-function displayNeedsReviewIssues(unassigned: IssueItem[], assigned: IssueItem[]): void {
-  // Newest first per runbook
-  const sorted = [...unassigned].sort(
-    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-  );
-  displayTable('Needs Review — Unassigned (on-call owns these)', sorted, issueColumns);
-  displayTable('Needs Review — Assigned (owned by assignee)', assigned, assignedIssueColumns);
-}
-
-function displayAcceptedUnassigned(items: IssueItem[]): void {
-  displayTable('Issue Accepted — Unassigned (needs Linear task follow-up)', items, issueColumns);
-}
-
 async function fetchUnrespondedIssues(
   startDate: Date,
   endDate: Date,
-  labelFilter?: string
+  labelFilter?: string,
+  spinner?: ora.Ora
 ): Promise<IssueItem[]> {
-  logger.info(chalk.gray('Fetching new/unresponded issues...'));
+  if (spinner) spinner.text = 'Fetching new/unresponded issues…';
   // Note: GitHub's `since` means "updated since", not "created since".
   // We filter by created_at below to get issues actually opened in this period.
   const issues = await listRecentIssuesAsync({
@@ -308,27 +185,12 @@ async function fetchUnrespondedIssues(
   return results.filter((r) => !r.hasTeamResponse).map((r) => r.issue);
 }
 
-function displayUnrespondedIssues(unresponded: IssueItem[]): void {
-  displayTable('New/Unresponded Issues', unresponded, [
-    { label: '#', width: 7, value: (i) => `#${i.number}`, color: chalk.cyan },
-    { label: 'Title', width: 52, value: (i) => truncate(i.title, 50) },
-    {
-      label: 'Author',
-      width: 18,
-      value: (i) => truncate(i.user?.login ?? '-', 16),
-      color: chalk.dim,
-    },
-    {
-      label: 'Created',
-      width: 12,
-      value: (i) => new Date(i.created_at).toISOString().slice(0, 10),
-    },
-    { label: 'Comments', width: 0, value: (i) => String(i.comments) },
-  ]);
-}
-
-async function fetchStaleIssues(staleDays: number, labelFilter?: string): Promise<IssueItem[]> {
-  logger.info(chalk.gray(`Fetching stale issues (no activity for ${staleDays}+ days)...`));
+async function fetchStaleIssues(
+  staleDays: number,
+  labelFilter?: string,
+  spinner?: ora.Ora
+): Promise<IssueItem[]> {
+  if (spinner) spinner.text = `Fetching stale issues (no activity for ${staleDays}+ days)…`;
   const threshold = new Date();
   threshold.setDate(threshold.getDate() - staleDays);
 
@@ -343,22 +205,8 @@ async function fetchStaleIssues(staleDays: number, labelFilter?: string): Promis
   return issues.filter((i) => isIssue(i) && new Date(i.updated_at) < threshold);
 }
 
-function displayStaleIssues(stale: IssueItem[]): void {
-  displayTable('Stale Issues', stale, [
-    { label: '#', width: 7, value: (i) => `#${i.number}`, color: chalk.cyan },
-    { label: 'Title', width: 52, value: (i) => truncate(i.title, 50) },
-    {
-      label: 'Last Activity',
-      width: 14,
-      value: (i) => new Date(i.updated_at).toISOString().slice(0, 10),
-    },
-    { label: 'Days', width: 6, value: (i) => String(ageDays(i.updated_at)), color: chalk.red },
-    { label: 'Area', width: 0, value: (i) => extractArea(getLabels(i)), color: chalk.yellow },
-  ]);
-}
-
-async function fetchExternalPRs(): Promise<PRWithReviews[]> {
-  logger.info(chalk.gray('Fetching external PRs awaiting review...'));
+async function fetchExternalPRs(spinner?: ora.Ora): Promise<PRWithReviews[]> {
+  if (spinner) spinner.text = 'Fetching external PRs awaiting review…';
   const prs = await listOpenPullRequestsAsync({ per_page: 100 });
   const external = prs.filter((pr) => pr.head.repo?.full_name !== 'expo/expo');
 
@@ -372,240 +220,400 @@ async function fetchExternalPRs(): Promise<PRWithReviews[]> {
   });
 }
 
-function displayExternalPRs(prsWithReviews: PRWithReviews[]): void {
-  displayTable('External PRs Awaiting Review', prsWithReviews, [
-    { label: '#', width: 7, value: (p) => `#${p.pr.number}`, color: chalk.cyan },
-    { label: 'Title', width: 52, value: (p) => truncate(p.pr.title, 50) },
-    {
-      label: 'Author',
-      width: 18,
-      value: (p) => truncate(p.pr.user?.login ?? '-', 16),
-      color: chalk.dim,
-    },
-    { label: 'Age', width: 6, value: (p) => formatAge(p.pr.created_at) },
-    { label: 'Review Status', width: 0, value: (p) => summarizeReviews(p.reviews) },
-  ]);
-}
+function waitForKey(validKeys: string[]): Promise<string> {
+  return new Promise((resolve) => {
+    const { stdin } = process;
+    const wasRaw = stdin.isRaw;
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding('utf8');
 
-// --- Suggestions engine ---
+    const onData = (data: string) => {
+      // Ctrl+C
+      if (data === '\u0003') {
+        stdin.setRawMode(wasRaw ?? false);
+        stdin.pause();
+        stdin.removeListener('data', onData);
+        process.exit(0);
+      }
 
-function showSuggestions(data: DashboardData): void {
-  const suggestions: { priority: number; icon: string; text: string }[] = [];
+      // Arrow keys and escape
+      let key: string;
+      if (data === '\u001b[A') {
+        key = 'up';
+      } else if (data === '\u001b[B') {
+        key = 'down';
+      } else if (data === '\u001b' || data === '\u001b\u001b') {
+        key = 'escape';
+      } else if (data === '\r' || data === '\n') {
+        key = 'enter';
+      } else {
+        key = data.toLowerCase();
+      }
 
-  // --- Priority 1: "needs review, unassigned" — on-call owns these (newest first per runbook) ---
-  if (data.needsReviewUnassigned.length > 0) {
-    const newest = [...data.needsReviewUnassigned].sort(
-      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-    )[0];
-    suggestions.push({
-      priority: 1,
-      icon: '>>',
-      text:
-        `Triage ${data.needsReviewUnassigned.length} "needs review" unassigned issue(s), newest first. ` +
-        `Start with #${newest.number} — ${chalk.cyan(`et gi --inspect ${newest.number}`)}`,
-    });
-    suggestions.push({
-      priority: 1,
-      icon: '  ',
-      text:
-        chalk.dim('Timebox ~10 min per issue: verify validity, identify module/area, ') +
-        chalk.dim(
-          'then move to "issue accepted" + assign owner, or assign module lead and summarize findings.'
-        ),
-    });
-  }
+      if (validKeys.includes(key)) {
+        stdin.setRawMode(wasRaw ?? false);
+        stdin.pause();
+        stdin.removeListener('data', onData);
+        resolve(key);
+      }
+    };
 
-  // --- Priority 2: Unresponded issues (opened this week, no team reply yet) ---
-  if (data.unresponded.length > 0) {
-    const oldest = data.unresponded.reduce((a, b) =>
-      new Date(a.created_at) < new Date(b.created_at) ? a : b
-    );
-    const age = ageDays(oldest.created_at);
-    suggestions.push({
-      priority: 2,
-      icon: '>>',
-      text:
-        `Respond to ${data.unresponded.length} new issue(s) with no team response. ` +
-        `Oldest: #${oldest.number} (${age}d) — ${chalk.cyan(`et gi --inspect ${oldest.number}`)}`,
-    });
-  }
-
-  // --- Priority 3: "issue accepted, unassigned" — needs Linear task follow-up ---
-  if (data.acceptedUnassigned.length > 0) {
-    const oldest = data.acceptedUnassigned.reduce((a, b) =>
-      new Date(a.created_at) < new Date(b.created_at) ? a : b
-    );
-    suggestions.push({
-      priority: 3,
-      icon: '>>',
-      text:
-        `${data.acceptedUnassigned.length} accepted issue(s) have no assignee — ` +
-        `locate their Linear tasks and ensure they are assigned to the appropriate lead. ` +
-        `Start with #${oldest.number} — ${chalk.cyan(`et gi --inspect ${oldest.number}`)}`,
-    });
-  }
-
-  // --- Priority 4: External PRs with no reviews (community contributions) ---
-  const unreviewed = data.externalPRs.filter((p) => p.reviews.length === 0);
-  if (unreviewed.length > 0) {
-    const oldest = unreviewed.reduce((a, b) =>
-      new Date(a.pr.created_at) < new Date(b.pr.created_at) ? a : b
-    );
-    const age = ageDays(oldest.pr.created_at);
-    suggestions.push({
-      priority: 4,
-      icon: '>>',
-      text:
-        `Review ${unreviewed.length} community PR(s) with no reviews. ` +
-        `Start with #${oldest.pr.number} (${age}d) — ${chalk.cyan(`et gi --inspect ${oldest.pr.number}`)}`,
-    });
-  }
-
-  // External PRs with changes requested (author may have addressed feedback)
-  const changesRequested = data.externalPRs.filter((p) =>
-    p.reviews.some((r) => r.state === 'CHANGES_REQUESTED')
-  );
-  if (changesRequested.length > 0) {
-    suggestions.push({
-      priority: 4,
-      icon: '  ',
-      text: `${changesRequested.length} external PR(s) have "changes requested" — check if authors addressed feedback.`,
-    });
-  }
-
-  // --- Priority 5: "needs review, assigned" — informational only ---
-  if (data.needsReviewAssigned.length > 0) {
-    suggestions.push({
-      priority: 5,
-      icon: '  ',
-      text: chalk.dim(
-        `${data.needsReviewAssigned.length} "needs review" issue(s) are assigned — no action needed unless explicitly requested.`
-      ),
-    });
-  }
-
-  // --- Priority 6: Stale issues (housekeeping) ---
-  if (data.stale.length > 0) {
-    const veryStale = data.stale.filter((i) => ageDays(i.updated_at) > data.staleDays * 2);
-    if (veryStale.length > 0) {
-      suggestions.push({
-        priority: 6,
-        icon: '  ',
-        text: `${veryStale.length} issue(s) stale for ${data.staleDays * 2}+ days — consider closing or requesting updates.`,
-      });
-    }
-    if (data.stale.length > veryStale.length) {
-      suggestions.push({
-        priority: 6,
-        icon: '  ',
-        text: `${data.stale.length - veryStale.length} more issue(s) approaching stale threshold — triage when time permits.`,
-      });
-    }
-  }
-
-  // --- Area hotspots: identify modules with the most open items ---
-  const areaCounts = new Map<string, number>();
-  const allIssues = [
-    ...data.needsReviewUnassigned,
-    ...data.acceptedUnassigned,
-    ...data.unresponded,
-    ...data.stale,
-  ];
-  for (const issue of allIssues) {
-    const area = extractArea(getLabels(issue));
-    if (area !== '-') {
-      areaCounts.set(area, (areaCounts.get(area) ?? 0) + 1);
-    }
-  }
-  const hotspots = [...areaCounts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 3);
-  if (hotspots.length > 0 && hotspots[0][1] >= 3) {
-    const hotspotStr = hotspots.map(([area, count]) => `${area} (${count})`).join(', ');
-    suggestions.push({
-      priority: 7,
-      icon: '  ',
-      text: `Area hotspots: ${hotspotStr} — consider focused triage with ${chalk.cyan(`et gi --label "Module: <name>"`)}`,
-    });
-  }
-
-  // --- All clear ---
-  if (suggestions.length === 0) {
-    suggestions.push({
-      priority: 99,
-      icon: '  ',
-      text: 'No urgent items. Good time to review open issues for quick wins or obvious follow-ups.',
-    });
-  }
-
-  // Render — only action items (>>) get numbered; sub-items are indented continuations
-  logger.info('');
-  logger.info(chalk.bold.underline('Suggested Next Steps'));
-  suggestions.sort((a, b) => a.priority - b.priority);
-  let stepNum = 0;
-  for (const s of suggestions) {
-    if (s.icon === '>>') {
-      stepNum++;
-      logger.info(`  ${chalk.green('>>')} ${stepNum}. ${s.text}`);
-    } else {
-      logger.info(`        ${s.text}`);
-    }
-  }
-}
-
-// --- Dashboard orchestrator ---
-
-async function showDashboard(options: ActionOptions) {
-  const [startDate, endDate, weekNum, weekFriday] = parseDateRange(options.week);
-  const staleDays = parseInt(options.staleDays ?? '14', 10);
-  const today = new Date().toISOString().slice(0, 10);
-
-  logger.info(
-    chalk.bold(
-      `GitHub Inspect Dashboard — Week ${weekNum} (${startDate.toISOString().slice(0, 10)} → ${weekFriday.toISOString().slice(0, 10)})`
-    )
-  );
-  logger.info(chalk.gray(`Today: ${today}`));
-  logger.info('');
-
-  // Fetch all data
-  const { unassigned: needsReviewUnassigned, assigned: needsReviewAssigned } =
-    await fetchNeedsReviewIssues(options.label);
-  const acceptedUnassigned = await fetchAcceptedUnassigned(options.label);
-  const unresponded = await fetchUnrespondedIssues(startDate, endDate, options.label);
-  const stale = await fetchStaleIssues(staleDays, options.label);
-  const externalPRs = await fetchExternalPRs();
-
-  // Display sections
-  displayNeedsReviewIssues(needsReviewUnassigned, needsReviewAssigned);
-  displayAcceptedUnassigned(acceptedUnassigned);
-  displayUnrespondedIssues(unresponded);
-  displayStaleIssues(stale);
-  displayExternalPRs(externalPRs);
-
-  // Summary
-  logger.info('');
-  logger.info(chalk.bold('Summary'));
-  logger.info(
-    `  ${chalk.cyan(String(needsReviewUnassigned.length))} needs review (unassigned), ` +
-      `${chalk.dim(String(needsReviewAssigned.length))} needs review (assigned), ` +
-      `${chalk.yellow(String(acceptedUnassigned.length))} accepted (unassigned), ` +
-      `${chalk.yellow(String(unresponded.length))} unresponded, ` +
-      `${chalk.red(String(stale.length))} stale, ` +
-      `${chalk.magenta(String(externalPRs.length))} external PRs`
-  );
-
-  // Suggestions
-  showSuggestions({
-    needsReviewUnassigned,
-    needsReviewAssigned,
-    acceptedUnassigned,
-    unresponded,
-    stale,
-    externalPRs,
-    staleDays,
+    stdin.on('data', onData);
   });
 }
 
-// --- Inspect mode ---
+type QueueItem = {
+  number: number;
+  title: string;
+  author: string;
+  category: string;
+  isPR: boolean;
+};
+
+type CategoryInfo = {
+  key: string;
+  label: string;
+  guidance: string;
+  items: QueueItem[];
+};
+
+function buildCategories(data: DashboardData): CategoryInfo[] {
+  const categories: CategoryInfo[] = [];
+
+  // Priority 1: "needs review, unassigned" — newest first
+  const nrSorted = [...data.needsReviewUnassigned].sort(
+    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+  );
+  if (nrSorted.length > 0) {
+    categories.push({
+      key: 'needs-review',
+      label: 'Needs Review — Unassigned',
+      guidance:
+        'On-call owns these. Timebox ~10 min per issue: verify validity, identify module/area, ' +
+        'then move to "issue accepted" + assign owner, or assign module lead and summarize findings.',
+      items: nrSorted.map((i) => ({
+        number: i.number,
+        title: i.title,
+        author: i.user?.login ?? '-',
+        category: 'Needs Review — Unassigned',
+        isPR: false,
+      })),
+    });
+  }
+
+  // Priority 2: Unresponded issues — oldest first
+  const unrespondedSorted = [...data.unresponded].sort(
+    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+  );
+  if (unrespondedSorted.length > 0) {
+    categories.push({
+      key: 'unresponded',
+      label: 'Unresponded Issues',
+      guidance:
+        'New issues with no team response yet. Add an initial reply acknowledging the report, ' +
+        'ask for reproduction steps if missing, and apply appropriate labels.',
+      items: unrespondedSorted.map((i) => ({
+        number: i.number,
+        title: i.title,
+        author: i.user?.login ?? '-',
+        category: 'Unresponded Issue',
+        isPR: false,
+      })),
+    });
+  }
+
+  // Priority 3: "issue accepted, unassigned" — oldest first
+  const acceptedSorted = [...data.acceptedUnassigned].sort(
+    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+  );
+  if (acceptedSorted.length > 0) {
+    categories.push({
+      key: 'accepted',
+      label: 'Accepted — Unassigned',
+      guidance:
+        'These issues are validated but have no owner. Locate their Linear tasks and ensure ' +
+        'they are assigned to the appropriate module lead.',
+      items: acceptedSorted.map((i) => ({
+        number: i.number,
+        title: i.title,
+        author: i.user?.login ?? '-',
+        category: 'Accepted — Unassigned',
+        isPR: false,
+      })),
+    });
+  }
+
+  // Priority 4: External PRs with no reviews — oldest first
+  const unreviewedPRs = data.externalPRs
+    .filter((p) => p.reviews.length === 0)
+    .sort((a, b) => new Date(a.pr.created_at).getTime() - new Date(b.pr.created_at).getTime());
+  if (unreviewedPRs.length > 0) {
+    categories.push({
+      key: 'external-prs',
+      label: 'External PRs — No Reviews',
+      guidance:
+        'Community contributions waiting for a first review. Check code quality, test coverage, ' +
+        'and alignment with project standards. A quick comment goes a long way.',
+      items: unreviewedPRs.map((p) => ({
+        number: p.pr.number,
+        title: p.pr.title,
+        author: p.pr.user?.login ?? '-',
+        category: 'External PR — No Reviews',
+        isPR: true,
+      })),
+    });
+  }
+
+  // Priority 5: Stale issues — oldest first
+  const staleSorted = [...data.stale].sort(
+    (a, b) => new Date(a.updated_at).getTime() - new Date(b.updated_at).getTime()
+  );
+  if (staleSorted.length > 0) {
+    categories.push({
+      key: 'stale',
+      label: 'Stale Issues',
+      guidance:
+        `No activity for ${data.staleDays}+ days. Consider closing if no longer relevant, ` +
+        'requesting an update from the reporter, or bumping priority if still valid.',
+      items: staleSorted.map((i) => ({
+        number: i.number,
+        title: i.title,
+        author: i.user?.login ?? '-',
+        category: 'Stale Issue',
+        isPR: false,
+      })),
+    });
+  }
+
+  return categories;
+}
+
+function showCompactStatus(weekNum: number, weekFriday: Date, categories: CategoryInfo[]): void {
+  const startStr = getMondayOfWeek(weekNum, new Date().getFullYear()).toISOString().slice(0, 10);
+  const endStr = weekFriday.toISOString().slice(0, 10);
+
+  logger.info('');
+  logger.info(chalk.bold(`GitHub Inspect — Week ${weekNum} (${startStr} → ${endStr})`));
+  logger.info('');
+
+  if (categories.length === 0) {
+    logger.info('  No actionable items. All clear!');
+    logger.info('');
+    return;
+  }
+
+  const totalItems = categories.reduce((sum, c) => sum + c.items.length, 0);
+  logger.info(`  ${totalItems} items across ${categories.length} categories.`);
+  logger.info('');
+}
+
+async function fetchAllData(
+  options: ActionOptions,
+  spinner?: ora.Ora
+): Promise<{ data: DashboardData; weekNum: number; weekFriday: Date }> {
+  const [startDate, endDate, weekNum, weekFriday] = parseDateRange(options.week);
+  const staleDays = parseInt(options.staleDays ?? '14', 10);
+
+  const { unassigned: needsReviewUnassigned, assigned: needsReviewAssigned } =
+    await fetchNeedsReviewIssues(options.label, spinner);
+  const acceptedUnassigned = await fetchAcceptedUnassigned(options.label, spinner);
+  const unresponded = await fetchUnrespondedIssues(startDate, endDate, options.label, spinner);
+  const stale = await fetchStaleIssues(staleDays, options.label, spinner);
+  const externalPRs = await fetchExternalPRs(spinner);
+
+  return {
+    data: {
+      needsReviewUnassigned,
+      needsReviewAssigned,
+      acceptedUnassigned,
+      unresponded,
+      stale,
+      externalPRs,
+      staleDays,
+    },
+    weekNum,
+    weekFriday,
+  };
+}
+
+function showItemHeader(item: QueueItem, index: number, total: number, selected: boolean): void {
+  const prefix = selected ? chalk.green('\u25b6') : ' ';
+  const num = chalk.cyan(`#${item.number}`);
+  const title = truncate(item.title, 60);
+  const author = chalk.dim(item.author);
+  const pos = chalk.gray(`${index + 1}/${total}`);
+  logger.info(`  ${prefix} ${pos} ${num} ${title} ${author}`);
+}
+
+function showCategoryList(categories: CategoryInfo[], selectedIndex: number): void {
+  for (let i = 0; i < categories.length; i++) {
+    const cat = categories[i];
+    const prefix = i === selectedIndex ? chalk.green('\u25b6') : ' ';
+    const recommended = i === 0 ? chalk.bgGreen.black(' RECOMMENDED ') + ' ' : '';
+    logger.info(
+      `  ${prefix} ${chalk.green(`${i + 1}.`)} ${recommended}${chalk.bold(cat.label)} ${chalk.cyan(`(${cat.items.length})`)}`
+    );
+    logger.info(chalk.dim(`       ${cat.guidance}`));
+    logger.info('');
+  }
+  logger.info(chalk.gray('  \u2191\u2193 navigate / Enter select / Esc quit'));
+}
+
+const MAX_VISIBLE_ITEMS = 15;
+
+function getScrollWindow(total: number, selectedIndex: number): { start: number; end: number } {
+  if (total <= MAX_VISIBLE_ITEMS) {
+    return { start: 0, end: total };
+  }
+  // Keep selected item roughly centered
+  let start = selectedIndex - Math.floor(MAX_VISIBLE_ITEMS / 2);
+  start = Math.max(0, Math.min(start, total - MAX_VISIBLE_ITEMS));
+  return { start, end: start + MAX_VISIBLE_ITEMS };
+}
+
+function showItemList(category: CategoryInfo, selectedIndex: number): void {
+  const total = category.items.length;
+  const { start, end } = getScrollWindow(total, selectedIndex);
+
+  logger.info(chalk.bold(category.label));
+  logger.info(chalk.dim(`  ${category.guidance}`));
+  logger.info('');
+
+  if (start > 0) {
+    logger.info(chalk.gray(`  \u25b2 ${start} more above`));
+  }
+
+  for (let i = start; i < end; i++) {
+    showItemHeader(category.items[i], i, total, i === selectedIndex);
+  }
+
+  if (end < total) {
+    logger.info(chalk.gray(`  \u25bc ${total - end} more below`));
+  }
+
+  logger.info('');
+  logger.info(chalk.gray('  \u2191\u2193 navigate / Enter expand / Esc back'));
+}
+
+function clearLines(count: number): void {
+  for (let i = 0; i < count; i++) {
+    process.stdout.write('\x1b[1A\x1b[2K');
+  }
+}
+
+function categoryLineCount(categories: CategoryInfo[]): number {
+  // Each category: prefix line + guidance line + blank line, plus the hint line
+  return categories.length * 3 + 1;
+}
+
+function itemListLineCount(category: CategoryInfo, selectedIndex: number): number {
+  const total = category.items.length;
+  const { start, end } = getScrollWindow(total, selectedIndex);
+  const visibleItems = end - start;
+  const hasAbove = start > 0 ? 1 : 0;
+  const hasBelow = end < total ? 1 : 0;
+  // Title + guidance + blank + above? + items + below? + blank + hint
+  return 3 + hasAbove + visibleItems + hasBelow + 2;
+}
+
+async function interactiveDashboard(options: ActionOptions, spinner: ora.Ora) {
+  let { data, weekNum, weekFriday } = await fetchAllData(options, spinner);
+  spinner.stop();
+  let categories = buildCategories(data);
+  showCompactStatus(weekNum, weekFriday, categories);
+
+  if (categories.length === 0) {
+    return;
+  }
+
+  // Category selection
+  let catIndex = 0;
+  showCategoryList(categories, catIndex);
+
+  while (true) {
+    const key = await waitForKey(['up', 'down', 'enter', 'escape']);
+
+    if (key === 'escape') {
+      clearLines(categoryLineCount(categories));
+      return;
+    } else if (key === 'up') {
+      if (catIndex > 0) {
+        clearLines(categoryLineCount(categories));
+        catIndex--;
+        showCategoryList(categories, catIndex);
+      }
+    } else if (key === 'down') {
+      if (catIndex < categories.length - 1) {
+        clearLines(categoryLineCount(categories));
+        catIndex++;
+        showCategoryList(categories, catIndex);
+      }
+    } else if (key === 'enter') {
+      clearLines(categoryLineCount(categories));
+      const selectedCategory = categories[catIndex];
+
+      // Item browsing within category
+      let itemIndex = 0;
+      showItemList(selectedCategory, itemIndex);
+
+      let lastLineCount = itemListLineCount(selectedCategory, itemIndex);
+      let backToCategories = false;
+      while (true) {
+        const itemKey = await waitForKey(['up', 'down', 'enter', 'escape', 'r']);
+
+        if (itemKey === 'escape') {
+          clearLines(lastLineCount);
+          backToCategories = true;
+          break;
+        } else if (itemKey === 'up') {
+          if (itemIndex > 0) {
+            clearLines(lastLineCount);
+            itemIndex--;
+            showItemList(selectedCategory, itemIndex);
+            lastLineCount = itemListLineCount(selectedCategory, itemIndex);
+          }
+        } else if (itemKey === 'down') {
+          if (itemIndex < selectedCategory.items.length - 1) {
+            clearLines(lastLineCount);
+            itemIndex++;
+            showItemList(selectedCategory, itemIndex);
+            lastLineCount = itemListLineCount(selectedCategory, itemIndex);
+          }
+        } else if (itemKey === 'enter') {
+          clearLines(lastLineCount);
+          const item = selectedCategory.items[itemIndex];
+
+          await showDetailInteractive(item);
+
+          // Re-show item list
+          showItemList(selectedCategory, itemIndex);
+          lastLineCount = itemListLineCount(selectedCategory, itemIndex);
+        } else if (itemKey === 'r') {
+          clearLines(lastLineCount);
+          const reloadSpinner = ora('Reloading data from GitHub…').start();
+          const reloaded = await fetchAllData(options, reloadSpinner);
+          reloadSpinner.stop();
+          data = reloaded.data;
+          weekNum = reloaded.weekNum;
+          weekFriday = reloaded.weekFriday;
+          categories = buildCategories(data);
+          showCompactStatus(weekNum, weekFriday, categories);
+          if (categories.length === 0) {
+            return;
+          }
+          catIndex = 0;
+          backToCategories = true;
+          break;
+        }
+      }
+
+      if (backToCategories) {
+        showCategoryList(categories, catIndex);
+      }
+    }
+  }
+}
 
 function formatLabels(item: { labels: IssueItem['labels'] }): string {
   return (
@@ -615,174 +623,245 @@ function formatLabels(item: { labels: IssueItem['labels'] }): string {
   );
 }
 
-async function displayComments(issueNumber: number, commentCount: number): Promise<void> {
-  logger.info(chalk.bold('--- Comments ---'));
-  if (commentCount === 0) {
-    logger.info(chalk.gray('  No comments.'));
-    return;
-  }
-  const comments = await listAllCommentsAsync(issueNumber);
-  for (const comment of comments) {
-    const badge = isTeamResponse(comment) ? chalk.green('[TEAM]') : chalk.gray('[EXT]');
-    const date = new Date(comment.created_at).toISOString().slice(0, 10);
-    logger.info(`  ${badge} ${chalk.dim(comment.user?.login ?? '-')} (${date})`);
-    logger.info(`    ${truncate(comment.body ?? '', 300)}`);
-    logger.info('');
-  }
-}
+type DetailData = {
+  isPR: boolean;
+  number: number;
+  url: string;
+  title: string;
+  state: string;
+  author: string;
+  labels: string;
+  created: string;
+  updated: string;
+  comments: number;
+  body: string | null;
+  // PR-specific
+  branch?: string;
+  mergeable?: string;
+  diffStats?: string;
+  reviews?: { login: string; state: string; date: string }[];
+  // Issue-specific
+  reproLinks?: string[];
+  referencedIssues?: string[];
+  closedBy?: string;
+};
 
-async function inspectIssue(issue: Awaited<ReturnType<typeof getIssueAsync>>) {
-  logger.info(chalk.bold('=== Issue #' + issue.number + ' ==='));
-  logger.info(`URL:     ${chalk.blue(issue.html_url)}`);
-  logger.info(`Title:   ${issue.title}`);
-  logger.info(`State:   ${issue.state}`);
-  logger.info(`Author:  ${issue.user?.login ?? '-'}`);
-  logger.info(`Labels:  ${formatLabels(issue)}`);
-  logger.info(`Created: ${issue.created_at}`);
-  logger.info(`Updated: ${issue.updated_at}`);
-  logger.info('');
+async function fetchDetailData(item: QueueItem): Promise<DetailData> {
+  const issue = await getIssueAsync(item.number);
+  const isPR = item.isPR || ('pull_request' in issue && !!issue.pull_request);
 
-  // Body
-  logger.info(chalk.bold('--- Body ---'));
-  if (issue.body) {
-    logger.info(truncate(issue.body, 500));
-  } else {
-    logger.info(chalk.gray('(no body)'));
-  }
-  logger.info('');
+  const base: DetailData = {
+    isPR,
+    number: issue.number,
+    url: issue.html_url,
+    title: issue.title,
+    state: issue.state ?? 'open',
+    author: issue.user?.login ?? '-',
+    labels: formatLabels(issue),
+    created: issue.created_at,
+    updated: issue.updated_at,
+    comments: issue.comments,
+    body: issue.body ?? null,
+  };
 
-  // Reproduction URL detection
-  if (issue.body) {
-    const repoUrls = issue.body.match(/https?:\/\/(snack\.expo\.dev|github\.com)\/[^\s)]+/g);
-    if (repoUrls && repoUrls.length > 0) {
-      logger.info(chalk.bold('--- Reproduction Links ---'));
-      for (const url of repoUrls) {
-        logger.info(`  ${chalk.blue(url)}`);
-      }
-      logger.info('');
-    }
-  }
-
-  await displayComments(issue.number, issue.comments);
-
-  // Linked PRs — scan body for #NNNN references
-  if (issue.body) {
-    const refs = [...new Set(issue.body.match(/#(\d{4,6})/g) ?? [])];
-    if (refs.length > 0) {
-      logger.info(chalk.bold('--- Referenced Issues/PRs ---'));
-      for (const ref of refs) {
-        logger.info(`  ${ref}`);
-      }
-      logger.info('');
-    }
-  }
-
-  // If closed, try to find closer PR
-  if (issue.state === 'closed') {
+  if (isPR) {
+    const pr = await getPullRequestAsync(issue.number);
+    base.branch = `${pr.base.ref} \u2190 ${pr.head.ref}`;
+    base.mergeable = String(pr.mergeable ?? 'unknown');
+    base.diffStats = `${chalk.green(`+${pr.additions}`)} ${chalk.red(`-${pr.deletions}`)} in ${pr.changed_files} files`;
     try {
-      const closerUrl = await getIssueCloserPrUrlAsync(issue.number);
-      if (closerUrl) {
-        logger.info(chalk.bold('--- Closed By ---'));
-        logger.info(`  ${chalk.blue(closerUrl)}`);
-        logger.info('');
-      }
+      const reviews = await listPullRequestReviewsAsync(pr.number);
+      base.reviews = reviews.map((r) => ({
+        login: r.user?.login ?? '-',
+        state: r.state ?? '-',
+        date: r.submitted_at ? new Date(r.submitted_at).toISOString().slice(0, 10) : '-',
+      }));
     } catch {
-      // ignore
+      base.reviews = [];
+    }
+  } else {
+    // Reproduction links
+    if (issue.body) {
+      const urls = issue.body.match(/https?:\/\/(snack\.expo\.dev|github\.com)\/[^\s)]+/g);
+      if (urls && urls.length > 0) base.reproLinks = urls;
+      const refs = [...new Set(issue.body.match(/#(\d{4,6})/g) ?? [])];
+      if (refs.length > 0) base.referencedIssues = refs;
+    }
+    if (issue.state === 'closed') {
+      try {
+        const closerUrl = await getIssueCloserPrUrlAsync(issue.number);
+        if (closerUrl) base.closedBy = closerUrl;
+      } catch {
+        // ignore
+      }
     }
   }
+
+  return base;
 }
 
-async function inspectPR(issue: Awaited<ReturnType<typeof getIssueAsync>>) {
-  const pr = await getPullRequestAsync(issue.number);
+function renderDetailView(detail: DetailData, showBody: boolean, showComments: boolean): string[] {
+  const lines: string[] = [];
+  const type = detail.isPR ? 'PR' : 'Issue';
 
-  logger.info(chalk.bold('=== PR #' + pr.number + ' ==='));
-  logger.info(`URL:      ${chalk.blue(pr.html_url)}`);
-  logger.info(`Title:    ${pr.title}`);
-  logger.info(`State:    ${pr.state}`);
-  logger.info(`Author:   ${pr.user?.login ?? '-'}`);
-  logger.info(`Labels:   ${formatLabels(pr)}`);
-  logger.info(`Branch:   ${pr.base.ref} ← ${pr.head.ref}`);
-  logger.info(`Created:  ${pr.created_at}`);
-  logger.info(`Updated:  ${pr.updated_at}`);
-  logger.info(`Mergeable: ${pr.mergeable ?? 'unknown'}`);
-  logger.info('');
+  lines.push(chalk.bold(`=== ${type} #${detail.number} ===`));
+  lines.push(`  URL:     ${chalk.blue(detail.url)}`);
+  lines.push(`  Title:   ${detail.title}`);
+  lines.push(`  State:   ${detail.state}`);
+  lines.push(`  Author:  ${detail.author}`);
+  lines.push(`  Labels:  ${detail.labels}`);
+  lines.push(`  Created: ${detail.created}`);
+  lines.push(`  Updated: ${detail.updated}`);
 
-  // Diff stats
-  logger.info(chalk.bold('--- Diff Stats ---'));
-  logger.info(
-    `  ${chalk.green(`+${pr.additions}`)} ${chalk.red(`-${pr.deletions}`)} in ${pr.changed_files} files`
-  );
-  logger.info('');
-
-  // Body
-  logger.info(chalk.bold('--- Body ---'));
-  if (pr.body) {
-    logger.info(truncate(pr.body, 500));
-  } else {
-    logger.info(chalk.gray('(no body)'));
-  }
-  logger.info('');
-
-  // Reviews
-  logger.info(chalk.bold('--- Reviews ---'));
-  try {
-    const reviews = await listPullRequestReviewsAsync(pr.number);
-    if (reviews.length === 0) {
-      logger.info(chalk.gray('  No reviews.'));
-    } else {
-      for (const review of reviews) {
-        const stateColor =
-          review.state === 'APPROVED'
+  if (detail.isPR) {
+    lines.push(`  Branch:  ${detail.branch}`);
+    lines.push(`  Merge:   ${detail.mergeable}`);
+    lines.push(`  Diff:    ${detail.diffStats}`);
+    if (detail.reviews && detail.reviews.length > 0) {
+      lines.push('');
+      lines.push(chalk.bold('  Reviews:'));
+      for (const r of detail.reviews) {
+        const color =
+          r.state === 'APPROVED'
             ? chalk.green
-            : review.state === 'CHANGES_REQUESTED'
+            : r.state === 'CHANGES_REQUESTED'
               ? chalk.red
               : chalk.gray;
-        const date = review.submitted_at
-          ? new Date(review.submitted_at).toISOString().slice(0, 10)
-          : '-';
-        logger.info(
-          `  ${chalk.dim(review.user?.login ?? '-')} — ${stateColor(review.state ?? '-')} (${date})`
-        );
+        lines.push(`    ${chalk.dim(r.login)} — ${color(r.state)} (${r.date})`);
       }
     }
-  } catch {
-    logger.info(chalk.gray('  Could not fetch reviews.'));
-  }
-  logger.info('');
-
-  await displayComments(issue.number, issue.comments);
-}
-
-async function inspectItem(number: number) {
-  const issue = await getIssueAsync(number);
-  if ('pull_request' in issue && issue.pull_request) {
-    await inspectPR(issue);
   } else {
-    await inspectIssue(issue);
+    if (detail.reproLinks) {
+      lines.push('');
+      lines.push(chalk.bold('  Repro links:'));
+      for (const url of detail.reproLinks) lines.push(`    ${chalk.blue(url)}`);
+    }
+    if (detail.referencedIssues) {
+      lines.push(`  Refs:    ${detail.referencedIssues.join(' ')}`);
+    }
+    if (detail.closedBy) {
+      lines.push(`  Closed:  ${chalk.blue(detail.closedBy)}`);
+    }
   }
+
+  if (showBody) {
+    lines.push('');
+    lines.push(chalk.bold('  --- Body ---'));
+    if (detail.body) {
+      for (const line of truncate(detail.body, 800).split('\n')) {
+        lines.push(`  ${line}`);
+      }
+    } else {
+      lines.push(chalk.gray('  (no body)'));
+    }
+  }
+
+  if (showComments) {
+    lines.push('');
+    lines.push(chalk.bold(`  --- Comments (${detail.comments}) ---`));
+    // Comments are loaded asynchronously, rendered separately
+    lines.push(chalk.gray('  Loading...'));
+  }
+
+  lines.push('');
+
+  // Hint line
+  const bodyToggle = showBody ? chalk.yellow('(b)ody') : chalk.green('(b)ody');
+  const commentsLabel = `(c)omments (${detail.comments})`;
+  const commentsToggle = showComments ? chalk.yellow(commentsLabel) : chalk.green(commentsLabel);
+  const parts = [bodyToggle, commentsToggle, chalk.gray('Esc back')];
+  lines.push(chalk.gray('  ') + parts.join(chalk.gray(' / ')));
+
+  return lines;
 }
 
-// --- Entry point ---
+async function showDetailInteractive(item: QueueItem): Promise<void> {
+  logger.info(chalk.gray('  Loading...'));
+  const detail = await fetchDetailData(item);
+  clearLines(1); // remove "Loading..."
+
+  let showBody = false;
+  let showComments = false;
+  let commentLines: string[] | null = null;
+  let lastRenderedCount = 0;
+
+  const render = () => {
+    if (lastRenderedCount > 0) clearLines(lastRenderedCount);
+
+    const lines = renderDetailView(detail, showBody, showComments);
+
+    // Replace "Loading..." placeholders with cached content
+    if (showComments && commentLines) {
+      for (let i = 0; i < lines.length; i++) {
+        if (
+          lines[i].includes('Comments') &&
+          i + 1 < lines.length &&
+          lines[i + 1].includes('Loading...')
+        ) {
+          lines.splice(i + 1, 1, ...commentLines);
+          break;
+        }
+      }
+    }
+
+    for (const line of lines) logger.info(line);
+    lastRenderedCount = lines.length;
+  };
+
+  render();
+
+  const validKeys = ['escape', 'b', 'c'];
+
+  while (true) {
+    const key = await waitForKey(validKeys);
+
+    if (key === 'escape') {
+      if (showBody || showComments) {
+        showBody = false;
+        showComments = false;
+        render();
+      } else {
+        clearLines(lastRenderedCount);
+        return;
+      }
+    } else if (key === 'b') {
+      showBody = !showBody;
+      render();
+    } else if (key === 'c') {
+      showComments = !showComments;
+      if (showComments && !commentLines) {
+        render(); // show "Loading..."
+        const comments = detail.comments > 0 ? await listAllCommentsAsync(detail.number) : [];
+        commentLines = [];
+        if (comments.length === 0) {
+          commentLines.push(chalk.gray('  No comments.'));
+        } else {
+          for (const comment of comments) {
+            const badge = isTeamResponse(comment) ? chalk.green('[TEAM]') : chalk.gray('[EXT]');
+            const date = new Date(comment.created_at).toISOString().slice(0, 10);
+            commentLines.push(`  ${badge} ${chalk.dim(comment.user?.login ?? '-')} (${date})`);
+            commentLines.push(`    ${truncate(comment.body ?? '', 300)}`);
+            commentLines.push('');
+          }
+        }
+      }
+      render();
+    }
+  }
+}
 
 async function action(options: ActionOptions) {
+  const spinner = ora('Authenticating…').start();
+
   // Auth check
   try {
     await getAuthenticatedUserAsync();
   } catch {
-    logger.error('GitHub authentication failed. Set the GITHUB_TOKEN environment variable.');
+    spinner.fail('GitHub authentication failed. Set the GITHUB_TOKEN environment variable.');
     process.exit(1);
   }
 
-  if (options.inspect) {
-    const number = parseInt(options.inspect, 10);
-    if (isNaN(number)) {
-      logger.error(`Invalid issue/PR number: ${options.inspect}`);
-      process.exit(1);
-    }
-    await inspectItem(number);
-  } else {
-    await showDashboard(options);
-  }
+  await interactiveDashboard(options, spinner);
 }
 
 export default (program: Command) => {
@@ -790,15 +869,13 @@ export default (program: Command) => {
     .command('github-inspect')
     .alias('gi', 'ghi')
     .description(
-      'Actionable GitHub dashboard for SDK support on-call. ' +
-        'Shows issues needing review, unresponded issues, stale issues, and external PRs. ' +
-        'Use --inspect to deep-dive into a specific issue or PR.'
+      'Interactive GitHub dashboard for SDK support on-call. ' +
+        'Browse issues needing review, unresponded issues, stale issues, and external PRs.'
     )
     .option(
       '-w, --week <week>',
       'ISO week number (1-53), or "last"/"prev" for previous week. Defaults to current week.'
     )
-    .option('-i, --inspect <number>', 'Deep-dive into a specific issue or PR by number.')
     .option('-l, --label <label>', 'Filter by GitHub label.')
     .option('-s, --stale-days <days>', 'Custom stale threshold in days (default: 14).')
     .asyncAction(action);


### PR DESCRIPTION
# Why

The batch dashboard output (5 tables + suggestions) was a bit overwhelming.. 

# How

Replaced it with a keyboard-driven interactive workflow: compact status overview, category selection with work guidance, scrollable item lists, and a detail view with toggleable body/comments sections.

# How

- Single-keypress navigation (arrow keys, Enter, Escape)
- Scrolling viewport for large item lists (max 15 visible)
- Layered Escape behavior (collapse sections before navigating back)
- ora spinner for loading status instead of scrolling log lines
- Remove --inspect flag (no longer needed with interactive browsing)

# Test Plan

Run the tool `et gi`

<img width="1344" height="291" alt="image" src="https://github.com/user-attachments/assets/9d90420f-4b9f-4994-b388-894f86ff387c" />

<img width="1291" height="363" alt="image" src="https://github.com/user-attachments/assets/137dab60-8657-479b-81f1-45d7141901a8" />


<img width="770" height="291" alt="image" src="https://github.com/user-attachments/assets/abb52e97-9c9b-4377-aa29-e7c771543447" />


# Checklist
