### PR TITLE
[dev launcher] do not truncate dev server discovery labels

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Fix truncated text labels in `LocalNetworkPermissionView`
+
 ### 💡 Others
 
 ## 55.0.8 — 2026-02-20

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [ios] Fix truncated text labels in `LocalNetworkPermissionView`
+- [ios] Fix truncated text labels in `LocalNetworkPermissionView` ([#43353](https://github.com/expo/expo/pull/43353) by [@vonovak](https://github.com/vonovak))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/LocalNetworkPermissionView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/LocalNetworkPermissionView.swift
@@ -130,7 +130,7 @@ struct LocalNetworkPermissionView: View {
 
   private var noAccessButtons: some View {
     Group {
-      Text("Local network permission was not granted. Please enable it in Settings \u{2192} Privacy & Security \u{2192} Local Network.")
+      Text("Local network permission was not granted. Enable it in Settings \u{2192} Privacy & Security \u{2192} Local Network.")
         .font(.footnote)
         .foregroundColor(.secondary)
         .multilineTextAlignment(.center)

--- a/packages/expo-dev-launcher/ios/SwiftUI/LocalNetworkPermissionView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/LocalNetworkPermissionView.swift
@@ -34,7 +34,8 @@ struct LocalNetworkPermissionView: View {
           .font(.body)
           .foregroundColor(.secondary)
           .multilineTextAlignment(.center)
-        
+          .fixedSize(horizontal: false, vertical: true)
+
         VStack(spacing: 12) {
           if !hasRequestedPermission {
             continueButton
@@ -98,6 +99,7 @@ struct LocalNetworkPermissionView: View {
         .font(.footnote)
         .foregroundColor(.secondary)
         .multilineTextAlignment(.center)
+        .fixedSize(horizontal: false, vertical: true)
     }
   }
 
@@ -132,6 +134,7 @@ struct LocalNetworkPermissionView: View {
         .font(.footnote)
         .foregroundColor(.secondary)
         .multilineTextAlignment(.center)
+        .fixedSize(horizontal: false, vertical: true)
 
       Button {
         #if os(iOS)


### PR DESCRIPTION
# Why

Text labels in the `LocalNetworkPermissionView` were being truncated, making it difficult to read the full permission instructions and explanations.

# How

Added `.fixedSize(horizontal: false, vertical: true)` modifier 

# Test Plan

<details>
<summary>before</summary>

- iphone 16
 
<img width="603" height="1311" alt="Screenshot 2026-02-23 at 11 46 55" src="https://github.com/user-attachments/assets/dc64db83-2a11-42e6-8210-af89cdbeef6a" />


</details>

<details>
<summary>after</summary>

- tried the UI on iphone SE 3rd gen and all fits

![Simulator Screenshot - iPhone SE (3rd generation) - 2026-02-23 at 11.37.36.png](https://app.graphite.com/user-attachments/assets/21326024-d92d-4901-af60-06210a7ad7c9.png)]

</details>

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)