### PR TITLE
[docs] Fix StructuredData component for multiple JSON-LD blocks per page

### DIFF
--- a/docs/ui/components/StructuredData/index.tsx
+++ b/docs/ui/components/StructuredData/index.tsx
@@ -1,16 +1,19 @@
 import Head from 'next/head';
 
-type Props = {
+type StructuredDataProps = {
   data: Record<string, any>;
+  id?: string;
 };
 
-export function StructuredData({ data }: Props) {
+export function StructuredData({ data, id = 'data-structured' }: StructuredDataProps) {
   return (
     <Head>
       <script
-        key="structured-data"
+        key={id}
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(data).replace(/</g, '\\u003c'),
+        }}
       />
     </Head>
   );

--- a/docs/ui/components/StructuredData/index.tsx
+++ b/docs/ui/components/StructuredData/index.tsx
@@ -1,11 +1,11 @@
 import Head from 'next/head';
 
-type StructuredDataProps = {
+export type StructuredDataProps = {
   data: Record<string, any>;
-  id?: string;
+  id: string;
 };
 
-export function StructuredData({ data, id = 'data-structured' }: StructuredDataProps) {
+export function StructuredData({ data, id }: StructuredDataProps) {
   return (
     <Head>
       <script


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-19525

## How

- Add a required `id` prop to `StructuredData` so each JSON-LD block gets a unique `key` in `<Head>`. Making it required (no default) ensures TypeScript catches missing keys at compile time, preventing silent collisions.
- Add `.replace(/</g, '\\u003c')` after `JSON.stringify` to sanitize against script injection per the Next.js JSON-LD guide: https://nextjs.org/docs/app/guides/json-ld.

## Test Plan

Run `yarn tsc` and `yarn lint` to confirm no type or lint errors. Run `yarn test` to confirm all 298 existing tests pass. The component is currently unused, so there is no runtime impact. It will be consumed in the next set of tasks from the GEO project.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
