### PR TITLE
[core][Android] Inline `Permission` enum

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedFilePermissionModule.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedFilePermissionModule.kt
@@ -1,6 +1,5 @@
 package versioned.host.exp.exponent.modules.universal
 
-import expo.modules.interfaces.filesystem.Permission
 import expo.modules.kotlin.services.FilePermissionService
 import host.exp.exponent.utils.ScopedContext
 import java.io.File

--- a/packages/expo-asset/android/src/main/java/expo/modules/asset/AssetModule.kt
+++ b/packages/expo-asset/android/src/main/java/expo/modules/asset/AssetModule.kt
@@ -3,13 +3,13 @@ package expo.modules.asset
 import android.content.Context
 import android.net.Uri
 import android.util.Log
-import expo.modules.interfaces.filesystem.Permission
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.functions.Coroutine
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
+import expo.modules.kotlin.services.FilePermissionService
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileInputStream
@@ -50,7 +50,8 @@ class AssetModule : Module() {
       localUrl.mkdirs()
     }
 
-    if (!appContext.filePermission.getPathPermissions(context, requireNotNull(localUrl.parent)).contains(Permission.WRITE)) {
+    if (!appContext.filePermission.getPathPermissions(context, requireNotNull(localUrl.parent))
+        .contains(FilePermissionService.Permission.WRITE)) {
       throw UnableToDownloadAssetException(uri.toString())
     }
 

--- a/packages/expo-asset/android/src/main/java/expo/modules/asset/AssetModule.kt
+++ b/packages/expo-asset/android/src/main/java/expo/modules/asset/AssetModule.kt
@@ -51,7 +51,8 @@ class AssetModule : Module() {
     }
 
     if (!appContext.filePermission.getPathPermissions(context, requireNotNull(localUrl.parent))
-        .contains(FilePermissionService.Permission.WRITE)) {
+        .contains(FilePermissionService.Permission.WRITE)
+    ) {
       throw UnableToDownloadAssetException(uri.toString())
     }
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemDirectory.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemDirectory.kt
@@ -1,7 +1,7 @@
 package expo.modules.filesystem
 
 import android.net.Uri
-import expo.modules.interfaces.filesystem.Permission
+import expo.modules.kotlin.services.FilePermissionService
 
 class FileSystemDirectory(uri: Uri) : FileSystemPath(uri) {
   fun validatePath() {
@@ -15,7 +15,7 @@ class FileSystemDirectory(uri: Uri) : FileSystemPath(uri) {
   }
 
   val exists: Boolean get() {
-    return if (checkPermission(Permission.READ)) {
+    return if (checkPermission(FilePermissionService.Permission.READ)) {
       file.isDirectory()
     } else {
       false
@@ -23,14 +23,14 @@ class FileSystemDirectory(uri: Uri) : FileSystemPath(uri) {
   }
 
   val size: Long get() {
-    validatePermission(Permission.READ)
+    validatePermission(FilePermissionService.Permission.READ)
     validateType()
     return file.walkTopDown().filter { it.isFile() }.map { it.length() }.sum()
   }
 
   fun info(): DirectoryInfo {
     validateType()
-    validatePermission(Permission.READ)
+    validatePermission(FilePermissionService.Permission.READ)
     if (!file.exists()) {
       val directoryInfo = DirectoryInfo(
         exists = false,
@@ -52,7 +52,7 @@ class FileSystemDirectory(uri: Uri) : FileSystemPath(uri) {
 
   fun create(options: CreateOptions = CreateOptions()) {
     validateType()
-    validatePermission(Permission.WRITE)
+    validatePermission(FilePermissionService.Permission.WRITE)
     if (!needsCreation(options)) {
       return
     }
@@ -75,22 +75,24 @@ class FileSystemDirectory(uri: Uri) : FileSystemPath(uri) {
 
   fun createFile(mimeType: String?, fileName: String): FileSystemFile {
     validateType()
-    validatePermission(Permission.WRITE)
-    val newFile = file.createFile(mimeType ?: "text/plain", fileName) ?: throw UnableToCreateException("file could not be created")
+    validatePermission(FilePermissionService.Permission.WRITE)
+    val newFile = file.createFile(mimeType ?: "text/plain", fileName)
+      ?: throw UnableToCreateException("file could not be created")
     return FileSystemFile(newFile.uri)
   }
 
   fun createDirectory(fileName: String): FileSystemDirectory {
     validateType()
-    validatePermission(Permission.WRITE)
-    val newDirectory = file.createDirectory(fileName) ?: throw UnableToCreateException("directory could not be created")
+    validatePermission(FilePermissionService.Permission.WRITE)
+    val newDirectory = file.createDirectory(fileName)
+      ?: throw UnableToCreateException("directory could not be created")
     return FileSystemDirectory(newDirectory.uri)
   }
 
   // this function is internal and will be removed in the future (when returning arrays of shared objects is supported)
   fun listAsRecords(): List<Map<String, Any>> {
     validateType()
-    validatePermission(Permission.READ)
+    validatePermission(FilePermissionService.Permission.READ)
     return file.listFilesAsUnified().map {
       val uriString = it.uri.toString()
       val isDir = it.isDirectory()

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemExceptions.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemExceptions.kt
@@ -1,6 +1,6 @@
 package expo.modules.filesystem
-import expo.modules.interfaces.filesystem.Permission
 import expo.modules.kotlin.exception.CodedException
+import expo.modules.kotlin.services.FilePermissionService
 
 internal class CopyOrMoveDirectoryToFileException :
   CodedException("Unable to copy or move a folder to a file")
@@ -29,7 +29,7 @@ internal class UnableToCreateException(reason: String) :
     "Unable to create file or directory: $reason"
   )
 
-internal class InvalidPermissionException(permission: Permission) :
+internal class InvalidPermissionException(permission: FilePermissionService.Permission) :
   CodedException(
     "Missing '${permission.name}' permission for accessing the file."
   )

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt
@@ -2,7 +2,7 @@ package expo.modules.filesystem
 
 import android.net.Uri
 import android.util.Base64
-import expo.modules.interfaces.filesystem.Permission
+import expo.modules.kotlin.services.FilePermissionService
 import expo.modules.kotlin.typedarray.TypedArray
 import java.io.FileOutputStream
 import java.security.MessageDigest
@@ -15,14 +15,14 @@ class FileSystemFile(uri: Uri) : FileSystemPath(uri) {
   // This makes sure that if a file already exists at a location, it is the correct type so that all available operations perform as expected.
   // After calling this function, we can use the `isDirectory` and `isFile` functions safely as they will match the shared class used.
   override fun validateType() {
-    validatePermission(Permission.READ)
+    validatePermission(FilePermissionService.Permission.READ)
     if (file.exists() && file.isDirectory()) {
       throw InvalidTypeFileException()
     }
   }
 
   val exists: Boolean get() {
-    return if (checkPermission(Permission.READ)) {
+    return if (checkPermission(FilePermissionService.Permission.READ)) {
       file.isFile()
     } else {
       false
@@ -31,7 +31,7 @@ class FileSystemFile(uri: Uri) : FileSystemPath(uri) {
 
   fun create(options: CreateOptions = CreateOptions()) {
     validateType()
-    validatePermission(Permission.WRITE)
+    validatePermission(FilePermissionService.Permission.WRITE)
     validateCanCreate(options)
     if (uri.isContentUri) {
       throw UnableToCreateException("create function does not work with SAF Uris, use `createDirectory` and `createFile` instead")
@@ -50,7 +50,7 @@ class FileSystemFile(uri: Uri) : FileSystemPath(uri) {
 
   fun write(content: String, append: Boolean = false) {
     validateType()
-    validatePermission(Permission.WRITE)
+    validatePermission(FilePermissionService.Permission.WRITE)
     if (!exists) {
       create()
     }
@@ -61,7 +61,7 @@ class FileSystemFile(uri: Uri) : FileSystemPath(uri) {
 
   fun write(content: TypedArray, append: Boolean = false) {
     validateType()
-    validatePermission(Permission.WRITE)
+    validatePermission(FilePermissionService.Permission.WRITE)
     if (!exists) {
       create()
     }
@@ -80,7 +80,7 @@ class FileSystemFile(uri: Uri) : FileSystemPath(uri) {
 
   fun write(content: ByteArray, append: Boolean = false) {
     validateType()
-    validatePermission(Permission.WRITE)
+    validatePermission(FilePermissionService.Permission.WRITE)
     if (!exists) {
       create()
     }
@@ -102,7 +102,7 @@ class FileSystemFile(uri: Uri) : FileSystemPath(uri) {
 
   fun text(): String {
     validateType()
-    validatePermission(Permission.READ)
+    validatePermission(FilePermissionService.Permission.READ)
     return file.inputStream().use { inputStream ->
       inputStream.bufferedReader().use { it.readText() }
     }
@@ -110,7 +110,7 @@ class FileSystemFile(uri: Uri) : FileSystemPath(uri) {
 
   fun base64(): String {
     validateType()
-    validatePermission(Permission.READ)
+    validatePermission(FilePermissionService.Permission.READ)
     file.inputStream().use {
       return Base64.encodeToString(it.readBytes(), Base64.NO_WRAP)
     }
@@ -118,7 +118,7 @@ class FileSystemFile(uri: Uri) : FileSystemPath(uri) {
 
   fun bytes(): ByteArray {
     validateType()
-    validatePermission(Permission.READ)
+    validatePermission(FilePermissionService.Permission.READ)
     file.inputStream().use {
       return it.readBytes()
     }
@@ -126,13 +126,13 @@ class FileSystemFile(uri: Uri) : FileSystemPath(uri) {
 
   fun asContentUri(): Uri {
     validateType()
-    validatePermission(Permission.READ)
+    validatePermission(FilePermissionService.Permission.READ)
     return file.getContentUri(appContext ?: throw MissingAppContextException())
   }
 
   @OptIn(ExperimentalStdlibApi::class)
   val md5: String get() {
-    validatePermission(Permission.READ)
+    validatePermission(FilePermissionService.Permission.READ)
     val md = MessageDigest.getInstance("MD5")
     file.inputStream().use {
       val digest = md.digest(it.readBytes())
@@ -154,7 +154,7 @@ class FileSystemFile(uri: Uri) : FileSystemPath(uri) {
 
   fun info(options: InfoOptions?): FileInfo {
     validateType()
-    validatePermission(Permission.READ)
+    validatePermission(FilePermissionService.Permission.READ)
     if (!file.exists()) {
       val fileInfo = FileInfo(
         exists = false,

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
@@ -6,13 +6,13 @@ import android.os.Build
 import android.util.Base64
 import android.webkit.URLUtil
 import androidx.annotation.RequiresApi
-import expo.modules.interfaces.filesystem.Permission
 import expo.modules.kotlin.activityresult.AppContextActivityResultLauncher
 import expo.modules.kotlin.devtools.await
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.functions.Coroutine
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
+import expo.modules.kotlin.services.FilePermissionService
 import expo.modules.kotlin.typedarray.TypedArray
 import expo.modules.kotlin.types.Either
 import okhttp3.OkHttpClient
@@ -50,7 +50,7 @@ class FileSystemModule : Module() {
     }
 
     AsyncFunction("downloadFileAsync") Coroutine { url: URI, to: FileSystemPath, options: DownloadOptions? ->
-      to.validatePermission(Permission.WRITE)
+      to.validatePermission(FilePermissionService.Permission.WRITE)
       val requestBuilder = Request.Builder().url(url.toURL())
 
       options?.headers?.forEach { (key, value) ->
@@ -124,7 +124,7 @@ class FileSystemModule : Module() {
           appContext.reactContext ?: throw Exceptions.ReactContextLost(),
           file.path
         )
-      if (permissions.contains(Permission.READ) && file.exists()) {
+      if (permissions.contains(FilePermissionService.Permission.READ) && file.exists()) {
         PathInfo(exists = file.exists(), isDirectory = file.isDirectory)
       } else {
         PathInfo(exists = false, isDirectory = null)

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemPath.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemPath.kt
@@ -7,8 +7,8 @@ import expo.modules.filesystem.unifiedfile.AssetFile
 import expo.modules.filesystem.unifiedfile.JavaFile
 import expo.modules.filesystem.unifiedfile.SAFDocumentFile
 import expo.modules.filesystem.unifiedfile.UnifiedFileInterface
-import expo.modules.interfaces.filesystem.Permission
 import expo.modules.kotlin.exception.Exceptions
+import expo.modules.kotlin.services.FilePermissionService
 import expo.modules.kotlin.sharedobjects.SharedObject
 import java.io.File
 import java.util.EnumSet
@@ -107,13 +107,13 @@ abstract class FileSystemPath(var uri: Uri) : SharedObject() {
     return destination.javaFile
   }
 
-  fun validatePermission(permission: Permission) {
+  fun validatePermission(permission: FilePermissionService.Permission) {
     if (!checkPermission(permission)) {
       throw InvalidPermissionException(permission)
     }
   }
 
-  fun checkPermission(permission: Permission): Boolean {
+  fun checkPermission(permission: FilePermissionService.Permission): Boolean {
     if (uri.isContentUri) {
       // TODO: Consider adding a check for content URIs (not in legacy FS)
       return true
@@ -125,7 +125,7 @@ abstract class FileSystemPath(var uri: Uri) : SharedObject() {
 
     val permissions = appContext?.filePermission?.getPathPermissions(
       appContext?.reactContext ?: throw Exceptions.ReactContextLost(), javaFile.path
-    ) ?: EnumSet.noneOf(Permission::class.java)
+    ) ?: EnumSet.noneOf(FilePermissionService.Permission::class.java)
     return permissions.contains(permission)
   }
 
@@ -138,8 +138,8 @@ abstract class FileSystemPath(var uri: Uri) : SharedObject() {
   fun copy(to: FileSystemPath) {
     validateType()
     to.validateType()
-    validatePermission(Permission.READ)
-    to.validatePermission(Permission.WRITE)
+    validatePermission(FilePermissionService.Permission.READ)
+    to.validatePermission(FilePermissionService.Permission.WRITE)
 
     javaFile.copyRecursively(getMoveOrCopyPath(to))
   }
@@ -147,8 +147,8 @@ abstract class FileSystemPath(var uri: Uri) : SharedObject() {
   fun move(to: FileSystemPath) {
     validateType()
     to.validateType()
-    validatePermission(Permission.WRITE)
-    to.validatePermission(Permission.WRITE)
+    validatePermission(FilePermissionService.Permission.WRITE)
+    to.validatePermission(FilePermissionService.Permission.WRITE)
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       val destination = getMoveOrCopyPath(to)
@@ -163,7 +163,7 @@ abstract class FileSystemPath(var uri: Uri) : SharedObject() {
 
   fun rename(newName: String) {
     validateType()
-    validatePermission(Permission.WRITE)
+    validatePermission(FilePermissionService.Permission.WRITE)
     val newFile = File(javaFile.parent, newName)
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       javaFile.toPath().moveTo(newFile.toPath())

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/interfaces/filesystem/Permission.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/interfaces/filesystem/Permission.java
@@ -1,5 +1,0 @@
-package expo.modules.interfaces.filesystem;
-
-public enum Permission {
-  READ, WRITE,
-}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/interfaces/filesystem/Permission.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/interfaces/filesystem/Permission.kt
@@ -1,0 +1,6 @@
+package expo.modules.interfaces.filesystem
+
+import expo.modules.kotlin.services.FilePermissionService
+
+@Deprecated("Use FilePermissionService.Permission instead", ReplaceWith("FilePermissionService.Permission"))
+typealias Permission = FilePermissionService.Permission

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/services/FilePermissionService.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/services/FilePermissionService.kt
@@ -8,7 +8,8 @@ import java.util.EnumSet
 // The class needs to be 'open', because it's inherited in expoview
 open class FilePermissionService : Service {
   enum class Permission {
-    READ, WRITE,
+    READ,
+    WRITE
   }
 
   open fun getPathPermissions(context: Context, path: String): EnumSet<Permission> =

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/services/FilePermissionService.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/services/FilePermissionService.kt
@@ -1,13 +1,16 @@
 package expo.modules.kotlin.services
 
 import android.content.Context
-import expo.modules.interfaces.filesystem.Permission
 import java.io.File
 import java.io.IOException
 import java.util.EnumSet
 
 // The class needs to be 'open', because it's inherited in expoview
 open class FilePermissionService : Service {
+  enum class Permission {
+    READ, WRITE,
+  }
+
   open fun getPathPermissions(context: Context, path: String): EnumSet<Permission> =
     getInternalPathPermissions(path, context) ?: getExternalPathPermissions(path)
 

--- a/packages/expo-sharing/android/src/main/java/expo/modules/sharing/SharingModule.kt
+++ b/packages/expo-sharing/android/src/main/java/expo/modules/sharing/SharingModule.kt
@@ -6,11 +6,11 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import androidx.core.content.FileProvider
 import expo.modules.core.errors.InvalidArgumentException
-import expo.modules.interfaces.filesystem.Permission
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
+import expo.modules.kotlin.services.FilePermissionService
 import java.io.File
 import java.net.URLConnection
 
@@ -110,7 +110,7 @@ class SharingModule : Module() {
 
     return permissions
       .getPathPermissions(context, url)
-      .contains(Permission.READ)
+      .contains(FilePermissionService.Permission.READ)
   }
 
   private fun createSharingIntent(uri: Uri, mimeType: String?) =

--- a/packages/expo-video-thumbnails/android/src/main/java/expo/modules/videothumbnails/VideoThumbnailsModule.kt
+++ b/packages/expo-video-thumbnails/android/src/main/java/expo/modules/videothumbnails/VideoThumbnailsModule.kt
@@ -8,12 +8,12 @@ import android.util.Log
 import android.webkit.URLUtil
 import expo.modules.core.errors.ModuleDestroyedException
 import expo.modules.core.utilities.FileUtilities
-import expo.modules.interfaces.filesystem.Permission
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
+import expo.modules.kotlin.services.FilePermissionService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
@@ -115,7 +115,8 @@ class VideoThumbnailsModule : Module() {
   private fun isAllowedToRead(url: String): Boolean {
     val permissionModuleInterface = appContext.filePermission
       ?: throw FilePermissionsModuleNotFound()
-    return permissionModuleInterface.getPathPermissions(context, url).contains(Permission.READ)
+    return permissionModuleInterface.getPathPermissions(context, url)
+      .contains(FilePermissionService.Permission.READ)
   }
 
   private inline fun withModuleScope(promise: Promise, crossinline block: () -> Unit) = moduleCoroutineScope.launch {


### PR DESCRIPTION
# Why

Inlines `Permission` enum to live inside the `FilePermissionService`. In my opion, it makes the code more readable, and it's easier to find the correct native types.

# Test Plan

- Expo Go ✅ 