### PR TITLE
[expo-router][ios] use reactSuperview to findViewController for zoom transition

### DIFF
--- a/packages/expo-router/ios/LinkPreview/LinkZoomTransition.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkZoomTransition.swift
@@ -278,9 +278,7 @@ class LinkZoomTransitionEnabler: LinkZoomExpoView {
       // When dismissalBoundsRect changes, re-setup the zoom transition
       // to include/exclude interactiveDismissShouldBegin callback
       if superview != nil {
-        DispatchQueue.main.async {
-          self.setupZoomTransition()
-        }
+        self.setupZoomTransition()
       }
     }
   }
@@ -399,12 +397,12 @@ class LinkZoomTransitionEnabler: LinkZoomExpoView {
   }
 
   private func findViewController() -> RNSScreen? {
-    var responder: UIResponder? = self
-    while let r = responder {
-      if let r = r as? RNSScreen {
-        return r
+    var view: UIView? = self
+    while let v = view {
+      if let r = v as? RNSScreenView {
+        return r.controller
       }
-      responder = r.next
+      view = v.reactSuperview()
     }
     return nil
   }


### PR DESCRIPTION
# Why

In rare cases the `setupZoomTransition` was called to late. 

# How

By using `reactSuperview` hierarchy, we can call `setupZoomTransition` directly in `didMoveToSuperview`, since the react hierarchy exist (the UIKit one is not fully bound yet).

# Test Plan

Manual testing of zoom transition

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
