### PR TITLE
[ios][video] Fix crash when requesting an AVAsset for a PHAsset URL fails

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix crash when loading PHAsset url fails ([#43373](https://github.com/expo/expo/pull/43373) by [@fractalbeauty](https://github.com/fractalbeauty))
+
 ### 💡 Others
 
 ## 55.0.8 — 2026-02-20

--- a/packages/expo-video/ios/Utils/URL+MediaLibraryAssets.swift
+++ b/packages/expo-video/ios/Utils/URL+MediaLibraryAssets.swift
@@ -58,6 +58,7 @@ private extension PHImageManager {
 
         if let error = info?[PHImageErrorKey] as? Error {
           continuation.resume(throwing: PlayerItemLoadException("Failed to request an AVAsset for \(urlString): \(error.localizedDescription)"))
+          return
         }
 
         continuation.resume(returning: asset)


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR fixes a crash in `expo-video` on iOS when requesting an AVAsset for a PHAsset URL fails. `PHImageManager.requestAVAsset` resumes a continuation twice, which causes a crash.

# How

<!--
How did you build this feature or fix this bug and why?
-->

In our case, it was related to an iCloud permissions error in the iOS simulator. The stack trace in XCode pointed to the 2nd resumption after the error branch which seemed likely to be the cause.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Adding this fix in our project fixed the crash for us.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
