### PR TITLE
[notifications] avoid higher QoS thread waiting for lower QoS thread in permission request

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [ios] avoid higher quality-of-service thread waiting on lower quality-of-service thread when requesting permissions
+- [ios] avoid higher quality-of-service thread waiting on lower quality-of-service thread when requesting permissions ([#43377](https://github.com/expo/expo/pull/43377) by [@vonovak](https://github.com/vonovak))
 
 ## 55.0.9 — 2026-02-20
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [ios] avoid higher quality-of-service thread waiting on lower quality-of-service thread when requesting permissions
+
 ## 55.0.9 — 2026-02-20
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-notifications/ios/ExpoNotifications/Permissions/ExpoNotificationsPermissionsRequester.swift
+++ b/packages/expo-notifications/ios/ExpoNotifications/Permissions/ExpoNotificationsPermissionsRequester.swift
@@ -20,8 +20,8 @@ public class ExpoNotificationsPermissionsRequester: NSObject, EXPermissionsReque
     let semaphore = DispatchSemaphore(value: 0)
     var result: [AnyHashable: Any] = [:]
 
-    Task.detached {
-      result = await self.getPermissionsAsync()
+    UNUserNotificationCenter.current().getNotificationSettings { settings in
+      result = self.makePermissionsResult(from: settings)
       semaphore.signal()
     }
 
@@ -31,15 +31,17 @@ public class ExpoNotificationsPermissionsRequester: NSObject, EXPermissionsReque
 
   private func getPermissionsAsync() async -> [AnyHashable: Any] {
     let settings = await UNUserNotificationCenter.current().notificationSettings()
+    return makePermissionsResult(from: settings)
+  }
 
-    let generalStatus: EXPermissionStatus = switch settings.authorizationStatus {
-    case .authorized:
-      EXPermissionStatusGranted
-    case .denied:
-      EXPermissionStatusDenied
-    default:
-      EXPermissionStatusUndetermined
-    }
+  private func makePermissionsResult(from settings: UNNotificationSettings) -> [AnyHashable: Any] {
+    let generalStatus: EXPermissionStatus = {
+      return switch settings.authorizationStatus {
+      case .authorized: EXPermissionStatusGranted
+      case .denied: EXPermissionStatusDenied
+      default: EXPermissionStatusUndetermined
+      }
+    }()
 
     let status: [String: Any?] = [
       "status": settings.authorizationStatus.rawValue,

--- a/packages/expo-notifications/ios/ExpoNotifications/Permissions/ExpoNotificationsPermissionsRequester.swift
+++ b/packages/expo-notifications/ios/ExpoNotifications/Permissions/ExpoNotificationsPermissionsRequester.swift
@@ -35,13 +35,14 @@ public class ExpoNotificationsPermissionsRequester: NSObject, EXPermissionsReque
   }
 
   private func makePermissionsResult(from settings: UNNotificationSettings) -> [AnyHashable: Any] {
-    let generalStatus: EXPermissionStatus = {
-      return switch settings.authorizationStatus {
-      case .authorized: EXPermissionStatusGranted
-      case .denied: EXPermissionStatusDenied
-      default: EXPermissionStatusUndetermined
-      }
-    }()
+    let generalStatus: EXPermissionStatus = switch settings.authorizationStatus {
+    case .authorized:
+      EXPermissionStatusGranted
+    case .denied:
+      EXPermissionStatusDenied
+    default:
+      EXPermissionStatusUndetermined
+    }
 
     let status: [String: Any?] = [
       "status": settings.authorizationStatus.rawValue,


### PR DESCRIPTION
# Why

This PR fixes a threading issue in iOS notification permissions where a higher quality-of-service thread was waiting on a lower quality-of-service thread.

# How

Replaced the async `Task.detached` approach with the callback-based `getNotificationSettings` method to avoid thread priority inversion.

# Test Plan

- notification tester app

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)