### PR TITLE
[notifications] fix  not forwarding new options to the OS when permissions were already granted

### DIFF
--- a/apps/expo-go/ios/Exponent/Versioned/Core/UniversalModules/Permissions/EXScopedPermissions.m
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/UniversalModules/Permissions/EXScopedPermissions.m
@@ -164,7 +164,7 @@
 
 - (BOOL)shouldVerifyScopedPermission:(NSString *)permissionType
 {
-  // temporarily exclude notifactions from permissions per experience; system brightness is always granted
+  // exclude notifications from permissions per experience; system brightness is always granted
   return ![@[@"notifications", @"userFacingNotifications", @"systemBrightness"] containsObject:permissionType];
 }
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [ios] Fixed `requestPermissionsAsync` not forwarding new options to the OS when notifications were already granted
+- [ios] Fixed `requestPermissionsAsync` not forwarding new options to the OS when notifications were already granted ([#43378](https://github.com/expo/expo/pull/43378) by [@vonovak](https://github.com/vonovak))
 
 ### 💡 Others
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,9 +8,9 @@
 
 ### 🐛 Bug fixes
 
-### 💡 Others
+- [ios] Fixed `requestPermissionsAsync` not forwarding new options to the OS when notifications were already granted
 
-- [ios] avoid higher quality-of-service thread waiting on lower quality-of-service thread when requesting permissions ([#43377](https://github.com/expo/expo/pull/43377) by [@vonovak](https://github.com/vonovak))
+### 💡 Others
 
 ## 55.0.9 — 2026-02-20
 

--- a/packages/expo-notifications/ios/ExpoNotifications/Permissions/PermissionsModule.swift
+++ b/packages/expo-notifications/ios/ExpoNotifications/Permissions/PermissionsModule.swift
@@ -2,7 +2,6 @@
 
 import ExpoModulesCore
 import UIKit
-import MachO
 
 public class PermissionsModule: Module {
   var permissionsManager: (any EXPermissionsInterface)?
@@ -34,13 +33,11 @@ public class PermissionsModule: Module {
         : defaultAuthorizationOptions
       requester.setAuthorizationOptions(options)
 
-      appContext?
-        .permissions?
-        .askForPermission(
-          usingRequesterClass: ExpoNotificationsPermissionsRequester.self,
-          resolve: promise.resolver,
-          reject: promise.legacyRejecter
-        )
+      // Call requestAuthorization directly to ensure new options are always
+      // forwarded to the OS, even if notifications were previously granted.
+      // iOS safely handles repeated calls to requestAuthorization(options:).
+      // expo go notifications permissions are not scoped
+      requester.requestAuthorizationOptions(options, resolver: promise.resolver, rejecter: promise.legacyRejecter)
     }
   }
 }

--- a/packages/expo-notifications/ios/ExpoNotifications/Permissions/PermissionsModule.swift
+++ b/packages/expo-notifications/ios/ExpoNotifications/Permissions/PermissionsModule.swift
@@ -33,10 +33,10 @@ public class PermissionsModule: Module {
         : defaultAuthorizationOptions
       requester.setAuthorizationOptions(options)
 
-      // Call requestAuthorization directly to ensure new options are always
+      // Call `requestAuthorization` directly to ensure new options are always
       // forwarded to the OS, even if notifications were previously granted.
-      // iOS safely handles repeated calls to requestAuthorization(options:).
-      // expo go notifications permissions are not scoped
+      // iOS safely handles repeated calls to `requestAuthorization(options:)`.
+      // Expo Go notifications permissions are not scoped
       requester.requestAuthorizationOptions(options, resolver: promise.resolver, rejecter: promise.legacyRejecter)
     }
   }


### PR DESCRIPTION
# Why

Fixes an issue on iOS where `requestPermissionsAsync` would not forward new authorization options to the operating system when notification permissions were previously granted. This prevented users from requesting additional notification permissions (like alerts, badges, or sounds) after the initial permission grant.

closes #20086, closes #20072

# How

Changed the implementation to call `requestAuthorizationOptions` directly instead of going through the general permissions system.

A previous attempt (#20086) was rejected because expo go's permission scoping. However, I noticed that notification permissions on expo go are not scoped because some 7 years ago they were "temporarily" excluded from scoping.
So question is, do we want to handle this in a smarter way or have the exclusion be permanent?

# Test Plan

- notification tester app

<details>
<summary>Details</summary>

```
/**
 * Manual test for https://github.com/expo/expo/issues/20072
 * Verifies that requestPermissionsAsync forwards new options to the OS
 * even when notifications are already granted.
 *
 * Steps to verify the fix:
 * 1. Press "Request: alert only" → grants notifications with alert
 * 2. Press "Get permissions" → note allowsSound is false
 * 3. Press "Request: alert + sound" → should update options
 * 4. Press "Get permissions" → allowsSound should now be true
 *
 * Before the fix, step 3 would short-circuit and step 4 would still show allowsSound: false.
 */
function PermissionOptionsTest() {
  const [result, setResult] = useState<string>('');

  if (Platform.OS !== 'ios') {
    return null;
  }

  return (
    <>
      <HeadingText>Permission options test (#20072)</HeadingText>
      <Button
        title="1. Request: alert only"
        onPress={async () => {
          const res = await ExpoNotifications.requestPermissionsAsync({
            ios: { allowAlert: true, allowSound: false, allowBadge: false },
          });
          setResult(JSON.stringify(res, null, 2));
        }}
      />
      <Button
        title="2. Request: alert + sound"
        onPress={async () => {
          const res = await ExpoNotifications.requestPermissionsAsync({
            ios: { allowAlert: true, allowSound: true, allowBadge: true },
          });
          setResult(JSON.stringify(res, null, 2));
        }}
      />
      <Button
        title="Get permissions"
        onPress={async () => {
          const res = await ExpoNotifications.getPermissionsAsync();
          setResult(JSON.stringify(res, null, 2));
        }}
      />
      <Text
        selectable
        style={{
          fontFamily: Platform.select({ ios: 'Menlo', default: 'monospace' }),
          fontSize: 11,
        }}>
        {result}
      </Text>
    </>
  );
}
```

</details>

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)