### PR TITLE
Upgrade screens to 4.24.0

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2947,7 +2947,7 @@ PODS:
     - ReactNativeDependencies
     - RNWorklets
     - Yoga
-  - RNScreens (4.23.0):
+  - RNScreens (4.24.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2969,9 +2969,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNScreens/common (= 4.23.0)
+    - RNScreens/common (= 4.24.0)
     - Yoga
-  - RNScreens/common (4.23.0):
+  - RNScreens/common (4.24.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3885,7 +3885,7 @@ SPEC CHECKSUMS:
   EXUpdates: bb7f327834c1663bb138a44e4b9e03b1c4acd657
   EXUpdatesInterface: 29d3993072380e2d91188335ffef666bb2bfd650
   FBLazyVector: 32e9ed0301d0fcbc1b2b341dd7fcbf291f51eb83
-  hermes-engine: 1566042511e927d64254f2efe08ae744a5eb9a00
+  hermes-engine: 32f15eb56763138f43fea0c89fe160318f47f5b5
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -3903,7 +3903,7 @@ SPEC CHECKSUMS:
   React: f4edc7518ccb0b54a6f580d89dd91471844b4990
   React-callinvoker: 79ef4e3f1c021571f6d2dafbe45ca432b2f3a146
   React-Core: 469995a2b6ef0ffff38ed123ccd202287703939e
-  React-Core-prebuilt: e71199b350bcaeade83eea6e463e818dcc46d718
+  React-Core-prebuilt: 3ad7030e5e3f741d62bbfc5c8cf9eabb96310a10
   React-CoreModules: db3b65cb984dfc7e0b00db517712cff8d938fc3f
   React-cxxreact: 8551bebcc6bc624ce774dccae20c383844aa9d06
   React-debug: 4f6739c820d7da9c20f48caa985573b6a847e5f5
@@ -3973,14 +3973,14 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 1976cdf5076a7e34718a56ead2f2069c7f54ebe9
   ReactCodegen: 4e2863f450e4aec6b66a7e91d41a209aa4601c97
   ReactCommon: 696163beb1630cf1f7590dbc8bfc542e40bdbe76
-  ReactNativeDependencies: d804b447c01215d21137868e3b5b5a920fc9f7f4
+  ReactNativeDependencies: fc06a98e1cc602a110da5a24971e0fce1ddece5e
   RNCAsyncStorage: e85a99325df9eb0191a6ee2b2a842644c7eb29f4
   RNCMaskedView: 3c9d7586e2b9bbab573591dcb823918bc4668005
   RNCPicker: e0149590451d5eae242cf686014a6f6d808f93c7
   RNDateTimePicker: 5e0666de98f1edfac67ee7dde6be8a5415e487a0
   RNGestureHandler: 8e4a9372425d4caa9e3da5072a8dda7a54ed1097
   RNReanimated: 61462806110686a6f5d7c45c6f910cf73cd57dd9
-  RNScreens: fb11b7412bcbdc0ffafcaf9174938d998d4e2bc4
+  RNScreens: 088d923c4327c63c9f8c942cae17a9d038f47d97
   RNSVG: b5bd4454de003a99d3130a3c6a1b1c949c89d37d
   RNWorklets: 87faff8e75d34d1240c75189e490e92901dd3544
   SDWebImage: f29024626962457f3470184232766516dee8dfea

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -76,7 +76,7 @@
     "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "5.6.2",
     "react-native-svg": "15.15.3",
-    "react-native-screens": "4.23.0",
+    "react-native-screens": "4.24.0",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.16.0",
     "react-native-worklets": "0.7.2",

--- a/apps/brownfield-tester/expo-app/package.json
+++ b/apps/brownfield-tester/expo-app/package.json
@@ -35,7 +35,7 @@
     "react-native-worklets": "0.7.2",
     "react-native-reanimated": "~4.2.1",
     "react-native-safe-area-context": "~5.6.2",
-    "react-native-screens": "~4.23.0",
+    "react-native-screens": "~4.24.0",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3732,7 +3732,7 @@ PODS:
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNScreens (4.23.0):
+  - RNScreens (4.24.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3759,10 +3759,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.23.0)
+    - RNScreens/common (= 4.24.0)
     - SocketRocket
     - Yoga
-  - RNScreens/common (4.23.0):
+  - RNScreens/common (4.24.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -4759,7 +4759,7 @@ SPEC CHECKSUMS:
   GoogleAppMeasurement: 8a82b93a6400c8e6551c0bcd66a9177f2e067aed
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: d59202edb9173c808259b0945bb161d1e24963f0
+  hermes-engine: 4fd957b81383719d07171a90988b689b845cb9c5
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -4857,7 +4857,7 @@ SPEC CHECKSUMS:
   RNDateTimePicker: e9e210197c267461f70f3f47bec705401ff72077
   RNGestureHandler: 77eecab5fd636666ca73a55bb61e2f1a685b7e84
   RNReanimated: 31da8d5f1605f5367e2392748ba9f4ba6eaf1178
-  RNScreens: ec8bdc9f024d5828e5adf4f5e8870d5260cff616
+  RNScreens: 7179cc1ba31b4e18ed29f10abf20c24a7961cf4c
   RNSVG: 8744ec9d5c0ca0f51cdd7a577c30ce01cd3d76b0
   RNWorklets: 8e934a6b6d5a2710b9250e63a18a2d2f8b875a18
   SDWebImage: f29024626962457f3470184232766516dee8dfea

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -78,7 +78,7 @@
     "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "5.6.2",
     "react-native-svg": "15.15.3",
-    "react-native-screens": "4.23.0",
+    "react-native-screens": "4.24.0",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.16.0",
     "react-native-worklets": "0.7.2",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -153,7 +153,7 @@
     "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "5.6.2",
     "react-native-svg": "15.15.3",
-    "react-native-screens": "4.23.0",
+    "react-native-screens": "4.24.0",
     "react-native-view-shot": "4.0.3",
     "react-native-web": "~0.21.0",
     "react-native-webview": "13.16.0",

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -36,7 +36,7 @@
     "react": "19.2.0",
     "react-native": "0.83.2",
     "react-native-safe-area-context": "5.6.2",
-    "react-native-screens": "4.23.0"
+    "react-native-screens": "4.24.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -71,7 +71,7 @@
     "react": "19.2.0",
     "react-native": "0.83.2",
     "react-native-safe-area-context": "5.6.2",
-    "react-native-screens": "4.23.0",
+    "react-native-screens": "4.24.0",
     "react-native-webview": "13.16.0"
   },
   "devDependencies": {

--- a/packages/@expo/cli/e2e/fixtures/with-monorepo/apps/app-a/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-monorepo/apps/app-a/package.json
@@ -13,7 +13,7 @@
     "react-dom": "19.2.0",
     "react-native": "0.83.2",
     "react-native-safe-area-context": "~5.6.2",
-    "react-native-screens": "~4.23.0",
+    "react-native-screens": "~4.24.0",
     "react-native-web": "~0.21.0"
   }
 }

--- a/packages/@expo/cli/e2e/fixtures/with-monorepo/apps/app-b/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-monorepo/apps/app-b/package.json
@@ -13,7 +13,7 @@
     "react-dom": "19.2.0",
     "react-native": "0.83.2",
     "react-native-safe-area-context": "~5.6.2",
-    "react-native-screens": "~4.23.0",
+    "react-native-screens": "~4.24.0",
     "react-native-web": "~0.21.0"
   }
 }

--- a/packages/@expo/cli/e2e/fixtures/with-router-typed-routes/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-router-typed-routes/package.json
@@ -13,7 +13,7 @@
     "react-dom": "19.2.0",
     "react-native": "0.83.2",
     "react-native-safe-area-context": "~5.6.2",
-    "react-native-screens": "~4.23.0",
+    "react-native-screens": "~4.24.0",
     "react-native-web": "~0.21.0"
   }
 }

--- a/packages/@expo/cli/e2e/fixtures/with-router/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-router/package.json
@@ -12,7 +12,7 @@
     "react-dom": "19.2.0",
     "react-native": "0.83.2",
     "react-native-safe-area-context": "~5.6.2",
-    "react-native-screens": "~4.23.0",
+    "react-native-screens": "~4.24.0",
     "react-native-web": "~0.21.0"
   }
 }

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Pin screens to 4.24.0 ([#43379](https://github.com/expo/expo/pull/43379) by [@Ubax](https://github.com/Ubax))
+
 ## 55.0.0-preview.9 — 2026-02-20
 
 ### 🎉 New features

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeNavigation.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeNavigation.swift
@@ -48,7 +48,7 @@ internal class LinkPreviewNativeNavigation {
     guard let stackOrTabView else {
       return
     }
-    if let tabView = stackOrTabView as? RNSBottomTabsScreenComponentView {
+    if let tabView = stackOrTabView as? RNSTabsScreenComponentView {
       let newTabKeys = tabPath?.path.map { $0.newTabKey } ?? []
       // The order is important here. findStackViewWithScreenIdInSubViews must be called
       // even if screenId is nil to compute the tabChangeCommands.
@@ -150,7 +150,7 @@ internal class LinkPreviewNativeNavigation {
     if let result =
       enumeratedViews
       .first(where: { _, view in
-        guard let tabView = view as? RNSBottomTabsScreenComponentView, let tabKey = tabView.tabKey
+        guard let tabView = view as? RNSTabsScreenComponentView, let tabKey = tabView.tabKey
         else {
           return false
         }
@@ -162,10 +162,10 @@ internal class LinkPreviewNativeNavigation {
   }
 
   private func getTabBarControllerFromTabView(view: UIView) -> UITabBarController? {
-    if let tabScreenView = view as? RNSBottomTabsScreenComponentView {
+    if let tabScreenView = view as? RNSTabsScreenComponentView {
       return tabScreenView.reactViewController()?.tabBarController as? UITabBarController
     }
-    if let tabHostView = view as? RNSBottomTabsHostComponentView {
+    if let tabHostView = view as? RNSTabsHostComponentView {
       return tabHostView.controller as? UITabBarController
     }
     return nil
@@ -182,7 +182,7 @@ internal class LinkPreviewNativeNavigation {
         if view.screenIds.contains(screenId) {
           return view
         }
-      } else if let tabView = nextResponder as? RNSBottomTabsScreenComponentView {
+      } else if let tabView = nextResponder as? RNSTabsScreenComponentView {
         if let tabKey = tabView.tabKey, tabKeys.contains(tabKey) {
           return tabView
         }

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -95,7 +95,6 @@
     "react-native-gesture-handler": "*",
     "react-native-reanimated": "*",
     "react-native-safe-area-context": ">= 5.4.0",
-    "react-native-screens": "*",
     "react-native-web": "*",
     "react-server-dom-webpack": "~19.0.4 || ~19.1.5 || ~19.2.4"
   },
@@ -153,6 +152,7 @@
     "query-string": "^7.1.3",
     "react-fast-compare": "^3.2.2",
     "react-native-is-edge-to-edge": "^1.2.1",
+    "react-native-screens": "4.24.0",
     "semver": "~7.6.3",
     "server-only": "^0.0.1",
     "sf-symbols-typescript": "^2.1.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -104,7 +104,7 @@
   "react-native-pager-view": "8.0.0",
   "react-native-worklets": "0.7.2",
   "react-native-reanimated": "~4.2.1",
-  "react-native-screens": "~4.23.0",
+  "react-native-screens": "~4.24.0",
   "react-native-safe-area-context": "~5.6.2",
   "react-native-svg": "15.15.3",
   "react-native-view-shot": "4.0.3",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -36,7 +36,7 @@
     "react-native-worklets": "0.7.2",
     "react-native-reanimated": "~4.2.1",
     "react-native-safe-area-context": "~5.6.2",
-    "react-native-screens": "~4.23.0",
+    "react-native-screens": "~4.24.0",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -27,7 +27,7 @@
     "react-native-worklets": "0.7.2",
     "react-native-reanimated": "~4.2.1",
     "react-native-safe-area-context": "~5.6.2",
-    "react-native-screens": "~4.23.0",
+    "react-native-screens": "~4.24.0",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13413,10 +13413,10 @@ react-native-screens@4.11.1-nightly-20250611-8b82e081e:
     react-native-is-edge-to-edge "^1.1.7"
     warn-once "^0.1.0"
 
-react-native-screens@4.23.0, react-native-screens@~4.23.0:
-  version "4.23.0"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.23.0.tgz#81574b1b0cc4ac6c9ed63e46eca7126f37affe86"
-  integrity sha512-XhO3aK0UeLpBn4kLecd+J+EDeRRJlI/Ro9Fze06vo1q163VeYtzfU9QS09/VyDFMWR1qxDC1iazCArTPSFFiPw==
+react-native-screens@4.24.0, react-native-screens@~4.24.0:
+  version "4.24.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.24.0.tgz#dbe8f610b5d2e31f71425d2ea3caaff1b9a7e2de"
+  integrity sha512-SyoiGaDofiyGPFrUkn1oGsAzkRuX1JUvTD9YQQK3G1JGQ5VWkvHgYSsc1K9OrLsDQxN7NmV71O0sHCAh8cBetA==
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"


### PR DESCRIPTION
# Why

There was new react-native-screens release, which introduces several features needed in router:
- `show` method for SplitView
- support for images in header items sub menus
- fixes the scroll view automatic insets in tabs

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

1. Build bare-expo
2. Build router
3. Unit tests in router
4. Test all the navigation features of router

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
