### PR TITLE
[docs] Update EAS environment variable and `eas update` docs for required --environment flag in SDK 55

### DIFF
--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -261,7 +261,7 @@ Publishing an update allows:
 - Fixing bugs and quickly updating non-native parts of a project instead of creating a new build
 - [Sharing a preview version of an app](/review/overview/) using internal distribution
 
-To publish an update with changes from your project, use the `eas update` command, and specify a name for the channel, a `message` to describe the update and if using [EAS environment variables](/eas/environment-variables/), the environment pull variables from (leave unspecified to use the **.env** files present in your project directory):
+To publish an update with changes from your project, use the `eas update` command, and specify a name for the channel, a `message` to describe the update, and the `--environment` flag to specify which [EAS environment variables](/eas/environment-variables/) to use (required in SDK 55 and later):
 
 <Terminal
   cmd={[

--- a/docs/pages/eas/environment-variables/faq.mdx
+++ b/docs/pages/eas/environment-variables/faq.mdx
@@ -20,9 +20,9 @@ To avoid confusing overrides during cloud jobs and leaking sensitive information
 
 ### Use the `--environment` flag with `eas update`
 
-When publishing updates, use the `--environment` flag with the `eas update` command to ensure that the same environment variables are used for your updates as your build jobs.
+When publishing updates, the `--environment` flag is required with the `eas update` command. This ensures the same environment variables are used for your updates as your build jobs.
 
-When the `--environment` flag is provided, `eas update` will use the environment variables on EAS servers for the update job and won't use the **.env** files present in your project often used for local development.
+When the `--environment` flag is provided, `eas update` will use the environment variables on EAS servers for the update job and ignore the **.env** files present in your project often used for local development.
 
 ### Sync the environment variables for local development using `eas env:pull`
 
@@ -65,9 +65,9 @@ One of the differences between using environment variables with the Expo framewo
 - Local app config resolution, done by EAS CLI when preparing the app config
 - Remote jobs happening on EAS servers, which often don't have access to your local **.env** files that are git ignored
 
-Using `eas update` is the one exception to this rule. By default, for backward compatibility reasons, it uses **.env** files present in your project directory to set environment variables for the update job, the same way [Expo CLI](/guides/environment-variables) does (it executes the `npx expo export` command under the hood).
+Prior to SDK 55, `eas update` was an exception to this rule. By default, it used **.env** files present in your project directory to set environment variables for the update job, the same way [Expo CLI](/guides/environment-variables) does (it executes the `npx expo export` command under the hood). In **SDK 55 or later**, the `--environment` flag is required, and `eas update` uses only the environment variables set on EAS servers.
 
-To ensure that you can use the same environment variables in your updates as your build jobs, you can use the `--environment` flag with the `eas update` command to force it to use **only** the environment variables set on the EAS servers instead of the **.env** files present in your project directory. It will ignore environment variables from **.env**.
+For projects on SDK 54 or earlier, you can use the `--environment` flag with the `eas update` command to opt into this behavior.
 
 ## Are there any limitations to using environment variables in EAS?
 

--- a/docs/pages/eas/environment-variables/faq.mdx
+++ b/docs/pages/eas/environment-variables/faq.mdx
@@ -65,7 +65,7 @@ One of the differences between using environment variables with the Expo framewo
 - Local app config resolution, done by EAS CLI when preparing the app config
 - Remote jobs happening on EAS servers, which often don't have access to your local **.env** files that are git ignored
 
-Prior to SDK 55, `eas update` was an exception to this rule. By default, it used **.env** files present in your project directory to set environment variables for the update job, the same way [Expo CLI](/guides/environment-variables) does (it executes the `npx expo export` command under the hood). In **SDK 55 or later**, the `--environment` flag is required, and `eas update` uses only the environment variables set on EAS servers.
+In **SDK 54 and earlier**, `eas update` was an exception to this rule. By default, it used **.env** files present in your project directory to set environment variables for the update job, the same way [Expo CLI](/guides/environment-variables) does (it executes the `npx expo export` command under the hood). In **SDK 55 or later**, the `--environment` flag is required, and `eas update` uses only the environment variables set on EAS servers.
 
 For projects on SDK 54 or earlier, you can use the `--environment` flag with the `eas update` command to opt into this behavior.
 

--- a/docs/pages/eas/environment-variables/index.mdx
+++ b/docs/pages/eas/environment-variables/index.mdx
@@ -98,7 +98,7 @@ By default, EAS supports three environments for environment variables: `developm
 
 Each environment is an independent set of variables that can be used to customize your app in different contexts. For example, you can use different API keys for development and production, or use different bundle identifiers for app store releases.
 
-Every EAS Build and Workflows job runs using environment variables from one of the available environments. You can also use environments for updates, allowing you to use the same set of environment variables for your build jobs. You can do this when publishing an update by providing the `--environment` flag.
+Every EAS Build and Workflows job runs using environment variables from one of the available environments. You can also use environments for updates, allowing you to use the same set of environment variables for your build jobs. When publishing an update, specify the environment with the required `--environment` flag.
 
 Environment variables can be assigned to multiple environments and have the same value across all of them, or be created for a single environment.
 

--- a/docs/pages/eas/environment-variables/usage.mdx
+++ b/docs/pages/eas/environment-variables/usage.mdx
@@ -76,17 +76,17 @@ The following environment variables are additional system environment variables 
 
 ## Using environment variables with EAS Update
 
-By default, EAS Update uses environment variables from the local **.env** files present in your project directory when you omit the `--environment` flag with the `eas update` command.
+In **SDK 55 or later**, the `--environment` flag is required when running `eas update`. The environment variables from the specified EAS environment will be used during the update process. For projects using SDK 54 or earlier, `eas update` falls back to local **.env** files when the `--environment` flag is omitted.
 
-The most convenient way to use EAS environment variables with EAS Update is to run the `eas update` command with the `--environment` flag specified:
+To use EAS environment variables with EAS Update, run the `eas update` command with the `--environment` flag:
 
 <Terminal cmd={['$ eas update --environment production']} />
 
-When the `--environment` flag is used, **only the environment variables from the specified EAS environment will be used during the update process** and won't use the **.env** files present in your project. This flag allows you to use the same environment variables while creating updates as with creating builds.
+When the `--environment` flag is used, **only the environment variables from the specified EAS environment will be used during the update process** and won't use the **.env** files present in your project. This ensures the same environment variables are used for both your updates and builds.
 
 Expo CLI will substitute prefixed variables in your code (for example, `process.env.EXPO_PUBLIC_VARNAME`) with the corresponding plain text and sensitive environment variable values set on EAS servers for the environment specified with the `--environment` flag. Any `EXPO_PUBLIC_` variables in your application code will be replaced inline with the corresponding values from your EAS environment whether that is your local machine or your CI/CD server.
 
-We recommend using the `--environment` flag to ensure the same environment variables are used both for your update and build jobs.
+The `--environment` flag ensures the same environment variables are used for both your update and build jobs.
 
 > **info** The secret variables will not be available during the update process as they are not readable outside of EAS servers.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-19592

## How

- Update EAS environment variable docs to state that `--environment` is required in SDK 55+, with a note that SDK 54 and earlier falls back to `.env` files. 
- Update EAS Update getting started guide to note that the `--environment` flag is required in SDK 55 and later.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Proofread and verify the language accurately reflects that `--environment` is required for SDK 55+ and that SDK 54 fallback behavior is documented where necessary.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
