### PR TITLE
[cli] Fixed missing guard when loading expo-modules.config.json files

### DIFF
--- a/packages/@expo/cli/src/start/server/DevToolsPluginManager.ts
+++ b/packages/@expo/cli/src/start/server/DevToolsPluginManager.ts
@@ -37,7 +37,17 @@ export default class DevToolsPluginManager {
     ).filter((maybePlugin) => maybePlugin != null);
     debug('Found autolinked plugins', plugins);
     return plugins
-      .map((pluginInfo) => new DevToolsPlugin(pluginInfo, this.projectRoot))
+      .map((pluginInfo) => {
+        try {
+          return new DevToolsPlugin(pluginInfo, this.projectRoot);
+        } catch (error: any) {
+          Log.warn(
+            `Skipping plugin "${pluginInfo.packageName}": ${error.message ?? 'invalid configuration'}`
+          );
+          debug('Plugin validation error for %s: %O', pluginInfo.packageName, error);
+          return null;
+        }
+      })
       .filter((p) => p != null) as DevToolsPlugin[];
   }
 }

--- a/packages/@expo/cli/src/start/server/__tests__/DevToolsPluginManager-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/DevToolsPluginManager-test.ts
@@ -1,0 +1,94 @@
+import { Log } from '../../../log';
+import DevToolsPluginManager from '../DevToolsPluginManager';
+
+jest.mock('../../../log');
+
+// Mock the autolinking module
+jest.mock('expo/internal/unstable-autolinking-exports', () => ({
+  makeCachedDependenciesLinker: jest.fn(),
+  scanExpoModuleResolutionsForPlatform: jest.fn(),
+  getLinkingImplementationForPlatform: jest.fn(),
+}));
+
+const autolinking = require('expo/internal/unstable-autolinking-exports') as jest.Mocked<
+  typeof import('expo-modules-autolinking/exports')
+>;
+
+function mockAutolinkingPlugins(
+  plugins: { packageName: string; packageRoot: string; cliExtensions?: any; webpageRoot?: string }[]
+) {
+  const revisions: Record<string, { name: string }> = {};
+  const descriptors: Record<string, any> = {};
+
+  for (const plugin of plugins) {
+    revisions[plugin.packageName] = { name: plugin.packageName };
+    descriptors[plugin.packageName] = plugin;
+  }
+
+  autolinking.makeCachedDependenciesLinker.mockReturnValue({} as any);
+  autolinking.scanExpoModuleResolutionsForPlatform.mockResolvedValue(revisions as any);
+  autolinking.getLinkingImplementationForPlatform.mockReturnValue({
+    resolveModuleAsync: jest.fn(async (name: string) => descriptors[name] ?? null),
+  } as any);
+}
+
+describe('DevToolsPluginManager', () => {
+  it('should return valid plugins', async () => {
+    mockAutolinkingPlugins([
+      {
+        packageName: 'valid-plugin',
+        packageRoot: '/path/to/valid-plugin',
+        webpageRoot: '/web',
+      },
+    ]);
+
+    const manager = new DevToolsPluginManager('/project');
+    const plugins = await manager.queryPluginsAsync();
+
+    expect(plugins.length).toBe(1);
+    expect(plugins[0].packageName).toBe('valid-plugin');
+  });
+
+  it('should skip a plugin with an invalid config without affecting other valid plugins', async () => {
+    mockAutolinkingPlugins([
+      {
+        packageName: 'valid-plugin',
+        packageRoot: '/path/to/valid-plugin',
+        webpageRoot: '/web',
+      },
+      {
+        packageName: 'invalid-plugin',
+        packageRoot: '/path/to/invalid-plugin',
+        cliExtensions: {
+          // Missing required `commands` and `entryPoint` fields
+          description: 'An invalid extension',
+        },
+      },
+      {
+        packageName: 'another-valid-plugin',
+        packageRoot: '/path/to/another-valid-plugin',
+        cliExtensions: {
+          description: 'A valid CLI extension',
+          entryPoint: 'index.js',
+          commands: [
+            {
+              name: 'test-cmd',
+              title: 'Test Command',
+              environments: ['cli'],
+            },
+          ],
+        },
+      },
+    ]);
+
+    const manager = new DevToolsPluginManager('/project');
+    const plugins = await manager.queryPluginsAsync();
+
+    expect(plugins.length).toBe(2);
+    expect(plugins[0].packageName).toBe('valid-plugin');
+    expect(plugins[1].packageName).toBe('another-valid-plugin');
+    expect(Log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Skipping plugin "invalid-plugin"')
+    );
+  });
+});


### PR DESCRIPTION
# Why

When loading expo-modules.config.json files, we don't have a guard for wrong configurations.

# How

Added unit tests to check problem, and wrapped loading in try..catch with clear warnings.

# Test Plan

Test in BareExpo

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
