### PR TITLE
fix(expo-go): add RCTBridge forward declaration for EXScopedReactNativeAdapter

### DIFF
--- a/apps/expo-go/ios/Exponent/Versioned/Core/UniversalModules/EXScopedReactNativeAdapter.h
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/UniversalModules/EXScopedReactNativeAdapter.h
@@ -1,5 +1,7 @@
 // Copyright © 2018 650 Industries. All rights reserved.
 
+@class RCTBridge;
+
 #import <ExpoModulesCore/EXReactNativeAdapter.h>
 
 @interface EXScopedReactNativeAdapter : EXReactNativeAdapter


### PR DESCRIPTION
# Why

It's a cherrypick from `sdk-55` branch to fix compilation errors in Expo Go on `main`