### PR TITLE
[CI] Fix "iOS Client (Expo Go) - EAS Build"

### DIFF
--- a/packages/expo-modules-core/ios/Legacy/Services/EXReactNativeAdapter.h
+++ b/packages/expo-modules-core/ios/Legacy/Services/EXReactNativeAdapter.h
@@ -7,6 +7,8 @@
 #import <ExpoModulesCore/EXModuleRegistryConsumer.h>
 #import <ExpoModulesCore/EXJavaScriptContextProvider.h>
 
+@class RCTBridge;
+
 @interface EXReactNativeAdapter : NSObject <EXInternalModule, EXAppLifecycleService, EXUIManager, EXJavaScriptContextProvider, EXModuleRegistryConsumer>
 
 - (void)setBridge:(RCTBridge *)bridge;


### PR DESCRIPTION
# Why

Fixes [iOS Client Expo Go EAS build failure](https://expo.dev/accounts/expo-ci/projects/unversioned-expo-go/workflows/019c8e17-1004-7002-865b-e73aadf24119#job-019c8e17-1535-7e2b-aeb5-1e296878cad7)


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Logs indicate below errors. So this PR forward declares `@class RCTBridge;`. The actual header gets imported in `EXReactNativeAdapter.mm` via `<React/RCTUIManager.h>`.

```
/Users/expo/workingdir/build/apps/expo-go/ios/Pods/Headers/Public/ExpoModulesCore/ExpoModulesCore/EXReactNativeAdapter.h:12:20: error: expected a type
   12 | - (void)setBridge:(RCTBridge *)bridge;
      |                    ^
/Users/expo/workingdir/build/apps/expo-go/ios/Exponent/Versioned/Core/UniversalModules/EXScopedReactNativeAdapter.m:13:20: error: expected a type
   13 | - (void)setBridge:(RCTBridge *)bridge
      |                    ^
2 errors generated.
```

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
