### PR TITLE
[expo-router] Move react-native-screens from dependencies to peerDependencies

### DIFF
--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -95,6 +95,7 @@
     "react-native-gesture-handler": "*",
     "react-native-reanimated": "*",
     "react-native-safe-area-context": ">= 5.4.0",
+    "react-native-screens": "~4.24.0",
     "react-native-web": "*",
     "react-server-dom-webpack": "~19.0.4 || ~19.1.5 || ~19.2.4"
   },
@@ -152,7 +153,7 @@
     "query-string": "^7.1.3",
     "react-fast-compare": "^3.2.2",
     "react-native-is-edge-to-edge": "^1.2.1",
-    "react-native-screens": "4.24.0",
+    "react-native-screens": "~4.24.0",
     "semver": "~7.6.3",
     "server-only": "^0.0.1",
     "sf-symbols-typescript": "^2.1.0",


### PR DESCRIPTION
# Why

Reverts part of https://github.com/expo/expo/pull/43379

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
