### PR TITLE
[docs] Fix tab route name to avoid Android header title

### DIFF
--- a/docs/pages/tutorial/add-navigation.mdx
+++ b/docs/pages/tutorial/add-navigation.mdx
@@ -236,7 +236,7 @@ export default function RootLayout() {
   return (
     <Stack>
       /* @tutinfo This is how a tab navigator is nested inside a stack navigator, especially when the Root layout is composed of a parent stack navigator. We're also setting the <CODE>headerShown</CODE> option to <CODE>false</CODE> to hide the header for the tab navigator. Otherwise, there will be two headers displayed on each screen. */
-      <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+      <Stack.Screen name="tabs" options={{ headerShown: false }} />
       /* @end */
     </Stack>
   );


### PR DESCRIPTION
# Why
In the docs, name="(tabs)" causes Android to render a header title (“(tabs)”) at the top of the screen, which doesn’t match the tutorial screenshots and can confuse readers. Changing the route name to name="tabs" keeps the example aligned with the expected UI.

# How

Update the documentation example by replacing name="(tabs)" with name="tabs" so the route name is treated as a normal identifier and doesn’t appear as a visible header title on Android.

# Test Plan

I verified the change by running the example on Android and confirming that the top header title no longer shows “(tabs)”, and the UI now matches the tutorial screenshots.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
