### PR TITLE
[widgets] Fix "blinking" on interactions.

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix "blinking" on interactions.
+- Fix "blinking" on interactions. ([#43416](https://github.com/expo/expo/pull/43416) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix "blinking" on interactions.
+
 ### 💡 Others
 
 ## 55.0.0 — 2026-02-25

--- a/packages/expo-widgets/ios/Widgets/DynamicView.swift
+++ b/packages/expo-widgets/ios/Widgets/DynamicView.swift
@@ -112,7 +112,8 @@ public struct WidgetsDynamicView: View, ExpoSwiftUI.AnyChild {
         if let rawProps = node["props"] as? [String: Any] {
           let props = try propsType.init(rawProps: rawProps, context: WidgetsContext.shared.context)
           try updateProps?(props)
-          return AnyView(UIBaseView<P, V>(props: props))
+          // TODO(@jakex7): Prevent unwanted transition when view is updated with new props - we want to have the same view instance recreated with new props instead of creating a new view instance and transitioning to it
+          return AnyView(UIBaseView<P, V>(props: props).transition(.identity))
         }
         return AnyView(EmptyView())
       } catch {

--- a/packages/expo-widgets/ios/Widgets/LiveActivityBanner.swift
+++ b/packages/expo-widgets/ios/Widgets/LiveActivityBanner.swift
@@ -6,7 +6,7 @@ struct LiveActivityBanner: View {
   @Environment(\.activityFamily) var activityFamily
   var context: ActivityViewContext<LiveActivityAttributes>
   var nodes: [String: Any]?
-  
+
   var body: some View {
     if activityFamily == .small, let node = nodes?["bannerSmall"] as? [String: Any] {
       WidgetsDynamicView(source: context.activityID, kind: .liveActivity, node: node)

--- a/packages/expo-widgets/ios/Widgets/Utils.swift
+++ b/packages/expo-widgets/ios/Widgets/Utils.swift
@@ -4,8 +4,8 @@ import Foundation
 func parseTimeline(identifier: String, name: String, family: WidgetFamily) -> [WidgetsTimelineEntry] {
   let layout = WidgetsStorage.getString(forKey: "__expo_widgets_\(name)_layout") ?? ""
   let timeline = WidgetsStorage.getArray(forKey: "__expo_widgets_\(name)_timeline") ?? []
-  
-  let entries: [WidgetsTimelineEntry?] = timeline.enumerated().map { (index, entry) in
+
+  let entries: [WidgetsTimelineEntry?] = timeline.enumerated().map { index, entry in
     if let entry = entry as? [String: Any], let timestamp = entry["timestamp"] as? Int, let props = entry["props"] as? [String: Any] {
       let node = evaluateLayout(layout: layout, props: props, timestamp: timestamp, family: family)
       return WidgetsTimelineEntry(
@@ -17,7 +17,7 @@ func parseTimeline(identifier: String, name: String, family: WidgetFamily) -> [W
     }
     return nil
   }
-  
+
   return entries.compactMap(\.self)
 }
 


### PR DESCRIPTION
# Why

Every time the props change, the entire widget is re-rendered which results in unwanted transitions (_"blinking"_).

# How

For now, we've completely turned off the transitions as a workaround.

# Test Plan

```tsx
import { Button, Text, VStack } from '@expo/ui/swift-ui';
import { font, foregroundStyle } from '@expo/ui/swift-ui/modifiers';
import { createWidget, WidgetBase } from 'expo-widgets';

type Props = { count: number };

const CoffeeCounter = (p: WidgetBase<Props>) => {
  'widget';

  return (
    <VStack spacing={8}>
      <Text modifiers={[font({ size: 48 })]}>☕</Text>
      <Text modifiers={[font({ size: 32, weight: 'bold' })]}>{p.count}</Text>
      <Button
        modifiers={[foregroundStyle('white')]}
        label="+"
        target="increment"
        onPress={() => ({ count: p.count + 1 })}
      />
    </VStack>
  );
};

export default createWidget('CoffeeCounter', CoffeeCounter);
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
