### PR TITLE
[docs] Bump iOS and Xcode versions for SDK 55

### DIFF
--- a/docs/ui/components/SDKTables/sdk-versions.json
+++ b/docs/ui/components/SDKTables/sdk-versions.json
@@ -1,12 +1,12 @@
 {
   "sdkVersions": [
-        {
+    {
       "sdk": "55.0.0",
       "android": "7+",
       "compileSdkVersion": "36",
       "targetSdkVersion": "36",
-      "ios": "15.1+",
-      "xcode": "16.1+",
+      "ios": "17.0+",
+      "xcode": "26.2+",
       "react-native": "0.83",
       "react-native-web": "0.21.0",
       "react-native-tvos": "0.83-stable",

--- a/docs/ui/components/SDKTables/sdk-versions.json
+++ b/docs/ui/components/SDKTables/sdk-versions.json
@@ -5,7 +5,7 @@
       "android": "7+",
       "compileSdkVersion": "36",
       "targetSdkVersion": "36",
-      "ios": "17.0+",
+      "ios": "15.1+",
       "xcode": "26.2+",
       "react-native": "0.83",
       "react-native-web": "0.21.0",


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/expo/pull/43420

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update iOS and Xcode versions for SDK 55 compatibilty table.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
<img width="2630" height="1150" alt="CleanShot 2026-02-25 at 17 00 44@2x" src="https://github.com/user-attachments/assets/6a5a5172-5deb-4f72-be98-e89639640200" />



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
