### PR TITLE
[dev-launcher] remove dev server advertisement info label

### DIFF
--- a/packages/expo-dev-launcher/ios/SwiftUI/LocalNetworkPermissionView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/LocalNetworkPermissionView.swift
@@ -46,15 +46,7 @@ struct LocalNetworkPermissionView: View {
           }
         }
       }
-
       Spacer()
-      
-      HStack(alignment: .firstTextBaseline) {
-        Image(systemName: "info.circle")
-        Text("Dev servers advertise themselves on your local network using Bonjour. This permission allows the development client to discover them automatically.")
-          .fontWeight(.semibold)
-      }
-      .foregroundColor(.secondary)
     }
     .padding()
     .background(Color.expoSystemBackground)


### PR DESCRIPTION
# Why

Remove the informational text about Bonjour and local network discovery from the LocalNetworkPermissionView to simplify the user interface.

# How

Removed the HStack containing the info icon and explanatory text about dev servers using Bonjour for local network discovery from the SwiftUI view.

# Test Plan

<details>
<summary>screenshot</summary>

<img width="603" height="1311" alt="Screenshot 2026-02-25 at 12 40 17" src="https://github.com/user-attachments/assets/917d7c7c-ef42-4fa3-ab79-57c9286993a5" />


</details>


# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)