### PR TITLE
[docs] Update create-expo-app commands for SDK 55

### DIFF
--- a/docs/pages/brownfield/integrated-approach.mdx
+++ b/docs/pages/brownfield/integrated-approach.mdx
@@ -34,7 +34,7 @@ Learn more from the [Set up environment guide](/get-started/set-up-your-environm
 
 First, create an Expo project inside your existing native project's root directory.
 
-<Terminal cmd={['$ npx create-expo-app my-project']} />
+<Terminal cmd={['$ npx create-expo-app@latest my-project --template default@sdk-55']} />
 
 This command creates a new directory named **my-project** that contains your new Expo project. While you can name the project anything, this guide uses **my-project** for consistency. The new project includes an example TypeScript application to help you get started.
 

--- a/docs/pages/brownfield/isolated-approach.mdx
+++ b/docs/pages/brownfield/isolated-approach.mdx
@@ -35,7 +35,7 @@ Learn more from the [Set up environment guide](/get-started/set-up-your-environm
 
 Run the following command to create a new directory named **my-project** that contains your new Expo project. While you can name the project anything, this guide uses **my-project** for consistency.
 
-<Terminal cmd={['$ npx create-expo-app@latest my-project']} />
+<Terminal cmd={['$ npx create-expo-app@latest my-project --template default@sdk-55']} />
 
 The **my-project** does not need to live inside your existing native app and can be created in a separate repository or a monorepo. The new project includes an example TypeScript application to help you get started.
 

--- a/docs/pages/build/setup.mdx
+++ b/docs/pages/build/setup.mdx
@@ -25,7 +25,7 @@ Don't have a project yet? No problem. It's quick and easy to create a "Hello wor
 
 Run the following command to create a new project:
 
-<Terminal cmd={['$ npx create-expo-app my-app']} />
+<Terminal cmd={['$ npx create-expo-app@latest my-app --template default@sdk-55']} />
 
 EAS Build also works well with projects created by `npx create-react-native-app`, `npx react-native`, `ignite-cli`, and other project bootstrapping tools.
 

--- a/docs/pages/develop/app-navigation.mdx
+++ b/docs/pages/develop/app-navigation.mdx
@@ -31,7 +31,7 @@ The library offers platform-specific look-and-feel with smooth animations and ge
 
 Expo Router is a file-based routing library for Expo and React Native projects and is a built on top of React Navigation. By following the **app** directory convention, it turns files into routes and is integrated with Expo for [Expo CLI](/more/expo-cli/) and bundling without additional setup. The library also adds features such as typed routes, dynamic routes, lazy bundling in development, static rendering for the web, and automatic deep linking.
 
-New Expo projects created with `npx create-expo-app@latest` include Expo Router by default so you can ship cross-platform navigation quickly while still being able to reach for React Navigation APIs when needed.
+New Expo projects created with `npx create-expo-app@latest --template default@sdk-55` include Expo Router by default so you can ship cross-platform navigation quickly while still being able to reach for React Navigation APIs when needed.
 
 <BoxLink
   title="Introduction to Expo Router"

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -32,7 +32,7 @@ Don't have a project yet? No problem. It's quick and easy to create a "Hello wor
 
 Run the following command to create a new project:
 
-<Terminal cmd={['$ npx create-expo-app my-app']} />
+<Terminal cmd={['$ npx create-expo-app@latest my-app --template default@sdk-55']} />
 
 EAS Update also works well with projects created by `npx create-react-native-app`, `npx react-native`, `ignite-cli`, and other project bootstrapping tools.
 

--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -56,7 +56,7 @@ The complete table of [MCP capabilities](#available-mcp-capabilities) documents 
 Before using Expo MCP Server, ensure you have:
 
 - An Expo account with an EAS paid plan
-- An Expo project created either with `npx create-expo-app@latest` or has the latest `expo` package version installed
+- An Expo project created either with `npx create-expo-app@latest --template default@sdk-55` or has the latest `expo` package version installed
 - AI-assisted tools with remote MCP server support (Claude Code, Cursor, VS Code, and so on)
 
 ## Installation and setup

--- a/docs/pages/eas/hosting/get-started.mdx
+++ b/docs/pages/eas/hosting/get-started.mdx
@@ -33,7 +33,7 @@ Don't have a project yet? No problem. It's quick and easy to create a "Hello wor
 
 Run the following command to create a new project:
 
-<Terminal cmd={['$ npx create-expo-app@latest my-app']} />
+<Terminal cmd={['$ npx create-expo-app@latest my-app --template default@sdk-55']} />
 
 </Collapsible>
 

--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -21,7 +21,7 @@ This page walks you through the process of creating your first EAS Workflow for 
   <Requirement number={2} title="Create a project">
     You'll need to create a project with the following command:
 
-    <Terminal cmd={['$ npx create-expo-app@latest']} />
+    <Terminal cmd={['$ npx create-expo-app@latest --template default@sdk-55']} />
 
   </Requirement>
   <Requirement number={3} title="Sync the project with EAS">

--- a/docs/pages/get-started/create-a-project.mdx
+++ b/docs/pages/get-started/create-a-project.mdx
@@ -15,7 +15,9 @@ We recommend starting with the default project created by `create-expo-app`. The
 
 To create a new project, run the following command:
 
-<Terminal cmd={['$ npx create-expo-app@latest']} />
+<Terminal cmd={['$ npx create-expo-app@latest --template default@sdk-55']} />
+
+> **Note:** During the SDK 55 transition period, `create-expo-app@latest` without the `--template` flag creates an SDK 54 project. Use `--template default@sdk-55` to create an SDK 55 project.
 
 > You can choose a different template by adding the [`--template` option](/more/create-expo/#--template).
 

--- a/docs/pages/get-started/create-a-project.mdx
+++ b/docs/pages/get-started/create-a-project.mdx
@@ -17,7 +17,7 @@ To create a new project, run the following command:
 
 <Terminal cmd={['$ npx create-expo-app@latest --template default@sdk-55']} />
 
-> During the SDK 55 transition period, `create-expo-app@latest` without the `--template` flag creates an SDK 54 project. Use `--template default@sdk-55` to create an SDK 55 project. You can also choose a different template by adding the [`--template` option](/more/create-expo/#--template).
+> During the SDK 55 transition period, `create-expo-app@latest` without the `--template` flag creates an SDK 54 project. If you plan to use Expo Go on a physical device, use an SDK 54 project. Otherwise, use `--template default@sdk-55` to create an SDK 55 project. You can also choose a different template by adding the [`--template` option](/more/create-expo/#--template).
 
 ## Next step
 

--- a/docs/pages/get-started/create-a-project.mdx
+++ b/docs/pages/get-started/create-a-project.mdx
@@ -17,7 +17,7 @@ To create a new project, run the following command:
 
 <Terminal cmd={['$ npx create-expo-app@latest --template default@sdk-55']} />
 
-> During the SDK 55 transition period, `create-expo-app@latest` without the `--template` flag creates an SDK 54 project. If you plan to use Expo Go on a physical device, use an SDK 54 project. Otherwise, use `--template default@sdk-55` to create an SDK 55 project. You can also choose a different template by adding the [`--template` option](/more/create-expo/#--template).
+> **Note:** During the SDK 55 transition period, `create-expo-app@latest` without the `--template` flag creates an SDK 54 project. If you plan to use Expo Go on a physical device, use an SDK 54 project. Otherwise, use `--template default@sdk-55` to create an SDK 55 project. You can also choose a different template by adding the [`--template` option](/more/create-expo/#--template).
 
 ## Next step
 

--- a/docs/pages/get-started/create-a-project.mdx
+++ b/docs/pages/get-started/create-a-project.mdx
@@ -17,9 +17,7 @@ To create a new project, run the following command:
 
 <Terminal cmd={['$ npx create-expo-app@latest --template default@sdk-55']} />
 
-> **Note:** During the SDK 55 transition period, `create-expo-app@latest` without the `--template` flag creates an SDK 54 project. Use `--template default@sdk-55` to create an SDK 55 project.
-
-> You can choose a different template by adding the [`--template` option](/more/create-expo/#--template).
+> During the SDK 55 transition period, `create-expo-app@latest` without the `--template` flag creates an SDK 54 project. Use `--template default@sdk-55` to create an SDK 55 project. You can also choose a different template by adding the [`--template` option](/more/create-expo/#--template).
 
 ## Next step
 

--- a/docs/pages/guides/local-https-development.mdx
+++ b/docs/pages/guides/local-https-development.mdx
@@ -31,7 +31,7 @@ Create or navigate to your Expo project:
 <Terminal
   cmd={[
     '# Create a new project (if needed)',
-    '$ npx create-expo-app@latest example-app',
+    '$ npx create-expo-app@latest example-app --template default@sdk-55',
     '$ cd example-app',
     '',
     '# Or navigate to existing project',

--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -99,10 +99,10 @@ Before you create your app, you have to create the **apps** directory. This dire
 
 <Terminal
   cmd={{
-    npm: ['$ npx create-expo-app@latest apps/cool-app'],
-    yarn: ['$ yarn create expo-app apps/cool-app'],
-    pnpm: ['$ pnpm create expo-app apps/cool-app'],
-    bun: ['$ bun create expo apps/cool-app'],
+    npm: ['$ npx create-expo-app@latest --template default@sdk-55 apps/cool-app'],
+    yarn: ['$ yarn create expo-app --template default@sdk-55 apps/cool-app'],
+    pnpm: ['$ pnpm create expo-app --template default@sdk-55 apps/cool-app'],
+    bun: ['$ bun create expo --template default@sdk-55 apps/cool-app'],
   }}
 />
 

--- a/docs/pages/guides/new-architecture.mdx
+++ b/docs/pages/guides/new-architecture.mdx
@@ -85,7 +85,7 @@ You can configure the React Native Directory check in your **package.json** file
 
 **As of SDK 52**, all new projects will be initialized with the New Architecture enabled by default.
 
-<Terminal cmd={['$ npx create-expo-app@latest']} />
+<Terminal cmd={['$ npx create-expo-app@latest --template default@sdk-55']} />
 
 ## Enable the New Architecture in an existing project
 

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -19,7 +19,7 @@ This guide provides a quick way to get started for a new project and also steps 
 
 To create a new project, use the default template which includes base TypeScript configuration, example code, and basic navigation structure:
 
-<Terminal cmd={['$ npx create-expo-app@latest']} />
+<Terminal cmd={['$ npx create-expo-app@latest --template default@sdk-55']} />
 
 After you create a new project using the command above, make sure to follow instructions from:
 

--- a/docs/pages/modules/use-standalone-expo-module-in-your-project.mdx
+++ b/docs/pages/modules/use-standalone-expo-module-in-your-project.mdx
@@ -172,8 +172,8 @@ Apart from publishing your module to npm, you can use it in your project in the 
 To test the published module in a new project, create a new app and install the module as a dependency by running the following command:
 
 <Terminal
-  cmdCopy="npx create-expo-app my-app && cd my-app && npx expo install expo-settings"
-  cmd={['$ npx create-expo-app my-app', '$ cd my-app', '$ npx expo install expo-settings']}
+  cmdCopy="npx create-expo-app@latest my-app --template default@sdk-55 && cd my-app && npx expo install expo-settings"
+  cmd={['$ npx create-expo-app@latest my-app --template default@sdk-55', '$ cd my-app', '$ npx expo install expo-settings']}
 />
 
 You can now use the module in your app! To test it, edit **app/(tabs)/index.tsx** and render the text message from **expo-settings**.

--- a/docs/pages/modules/use-standalone-expo-module-in-your-project.mdx
+++ b/docs/pages/modules/use-standalone-expo-module-in-your-project.mdx
@@ -173,7 +173,11 @@ To test the published module in a new project, create a new app and install the 
 
 <Terminal
   cmdCopy="npx create-expo-app@latest my-app --template default@sdk-55 && cd my-app && npx expo install expo-settings"
-  cmd={['$ npx create-expo-app@latest my-app --template default@sdk-55', '$ cd my-app', '$ npx expo install expo-settings']}
+  cmd={[
+    '$ npx create-expo-app@latest my-app --template default@sdk-55',
+    '$ cd my-app',
+    '$ npx expo install expo-settings',
+  ]}
 />
 
 You can now use the module in your app! To test it, edit **app/(tabs)/index.tsx** and render the text message from **expo-settings**.

--- a/docs/pages/more/create-expo.mdx
+++ b/docs/pages/more/create-expo.mdx
@@ -21,7 +21,7 @@ To create a new project, run the following command:
   }}
 />
 
-> During the SDK 55 transition period, `create-expo-app@latest` without the `--template` flag creates an SDK 54 project. If you plan to use Expo Go on a physical device, use an SDK 54 project. Otherwise, use `--template default@sdk-55` to create an SDK 55 project.
+> **Note:** During the SDK 55 transition period, `create-expo-app@latest` without the `--template` flag creates an SDK 54 project. If you plan to use Expo Go on a physical device, use an SDK 54 project. Otherwise, use `--template default@sdk-55` to create an SDK 55 project.
 
 Running the above command will prompt you to enter the app name of your project. This app name is also used in the app config's [`name`](/versions/latest/config/app/#name) property.
 

--- a/docs/pages/more/create-expo.mdx
+++ b/docs/pages/more/create-expo.mdx
@@ -14,10 +14,10 @@ To create a new project, run the following command:
 
 <Terminal
   cmd={{
-    npm: ['$ npx create-expo-app@latest'],
-    yarn: ['$ yarn create expo-app'],
-    pnpm: ['$ pnpm create expo-app'],
-    bun: ['$ bun create expo'],
+    npm: ['$ npx create-expo-app@latest --template default@sdk-55'],
+    yarn: ['$ yarn create expo-app --template default@sdk-55'],
+    pnpm: ['$ pnpm create expo-app --template default@sdk-55'],
+    bun: ['$ bun create expo --template default@sdk-55'],
   }}
 />
 

--- a/docs/pages/more/create-expo.mdx
+++ b/docs/pages/more/create-expo.mdx
@@ -21,6 +21,8 @@ To create a new project, run the following command:
   }}
 />
 
+> During the SDK 55 transition period, `create-expo-app@latest` without the `--template` flag creates an SDK 54 project. If you plan to use Expo Go on a physical device, use an SDK 54 project. Otherwise, use `--template default@sdk-55` to create an SDK 55 project.
+
 Running the above command will prompt you to enter the app name of your project. This app name is also used in the app config's [`name`](/versions/latest/config/app/#name) property.
 
 <Terminal cmd={['What is your app named? my-app']} />

--- a/docs/pages/router/introduction.mdx
+++ b/docs/pages/router/introduction.mdx
@@ -28,10 +28,10 @@ We recommend creating a new Expo app using `create-expo-app` to create a project
 
 <Terminal
   cmd={{
-    npm: ['$ npx create-expo-app@latest'],
-    yarn: ['$ yarn create expo-app'],
-    pnpm: ['$ pnpm create expo-app'],
-    bun: ['$ bun create expo'],
+    npm: ['$ npx create-expo-app@latest --template default@sdk-55'],
+    yarn: ['$ yarn create expo-app --template default@sdk-55'],
+    pnpm: ['$ pnpm create expo-app --template default@sdk-55'],
+    bun: ['$ bun create expo --template default@sdk-55'],
   }}
 />
 

--- a/docs/pages/router/introduction.mdx
+++ b/docs/pages/router/introduction.mdx
@@ -35,6 +35,8 @@ We recommend creating a new Expo app using `create-expo-app` to create a project
   }}
 />
 
+> During the SDK 55 transition period, `create-expo-app@latest` without the `--template` flag creates an SDK 54 project. If you plan to use Expo Go on a physical device, use an SDK 54 project. Otherwise, use `--template default@sdk-55` to create an SDK 55 project.
+
 </Step>
 
 <Step label="2">

--- a/docs/pages/router/introduction.mdx
+++ b/docs/pages/router/introduction.mdx
@@ -35,7 +35,7 @@ We recommend creating a new Expo app using `create-expo-app` to create a project
   }}
 />
 
-> During the SDK 55 transition period, `create-expo-app@latest` without the `--template` flag creates an SDK 54 project. If you plan to use Expo Go on a physical device, use an SDK 54 project. Otherwise, use `--template default@sdk-55` to create an SDK 55 project.
+> **Note:** During the SDK 55 transition period, `create-expo-app@latest` without the `--template` flag creates an SDK 54 project. If you plan to use Expo Go on a physical device, use an SDK 54 project. Otherwise, use `--template default@sdk-55` to create an SDK 55 project.
 
 </Step>
 

--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -51,6 +51,8 @@ We'll use [`create-expo-app`](/more/create-expo/) to initialize a new Expo app. 
 
 This command will create a new project directory named StickerSmash, using the [default](/more/create-expo/#--template) template. This template has essential boilerplate code and libraries needed to build our app, including Expo Router. We'll continue to add more libraries throughout this tutorial as needed.
 
+> **info** `create-expo-app@latest` currently creates an SDK 54 project. This tutorial is designed for SDK 54, so no `--template` flag is needed.
+
 <Collapsible summary="Benefits of using the default template">
 
 - Creates a new React Native project with `expo` package installed

--- a/docs/pages/tutorial/follow-up.mdx
+++ b/docs/pages/tutorial/follow-up.mdx
@@ -11,6 +11,8 @@ Now that the example app is done, let's learn more about the technologies we use
 
 To start creating a new app on your machine you can use `npx create-expo-app@latest --template default@sdk-55` and [set up your development environment](/get-started/set-up-your-environment/) sequentially.
 
+> **Note:** During the SDK 55 transition period, `create-expo-app@latest` without the `--template` flag creates an SDK 54 project. If you plan to use Expo Go on a physical device, use an SDK 54 project. Otherwise, use `--template default@sdk-55` to create an SDK 55 project.
+
 ### Recommended resources
 
 Once you've created your new project, you can learn more about different tools and concepts that will help you on your app development journey:

--- a/docs/pages/tutorial/follow-up.mdx
+++ b/docs/pages/tutorial/follow-up.mdx
@@ -9,7 +9,7 @@ Now that the example app is done, let's learn more about the technologies we use
 
 ## Build your project into an app
 
-To start creating a new app on your machine you can use `npx create-expo-app@latest` and [set up your development environment](/get-started/set-up-your-environment/) sequentially.
+To start creating a new app on your machine you can use `npx create-expo-app@latest --template default@sdk-55` and [set up your development environment](/get-started/set-up-your-environment/) sequentially.
 
 ### Recommended resources
 

--- a/docs/pages/workflow/overview.mdx
+++ b/docs/pages/workflow/overview.mdx
@@ -105,7 +105,7 @@ The following three commands result in more or less the same project:
 
 <Terminal
   cmd={[
-    '$ npx create-expo-app MyApp && cd MyApp && npx expo prebuild',
+    '$ npx create-expo-app@latest --template default@sdk-55 MyApp && cd MyApp && npx expo prebuild',
     '',
     '$ npx create-expo-app --template bare-minimum',
     '',


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-19854

## How

- Updated `create-expo-app` Terminal commands across 17 pages to include `--template default@sdk-55`
- Updated multi-package-manager variants (npm, yarn, pnpm, bun) in `router/introduction.mdx`, `more/create-expo.mdx`, and `guides/monorepos.mdx`
- Updated prose mentions of `create-expo-app@latest` in `develop/app-navigation.mdx`, `eas/ai/mcp.mdx`, and `tutorial/follow-up.mdx`
- Added a transition note on `get-started/create-a-project.mdx` explaining why `--template default@sdk-55` is needed
- Added an info callout on `tutorial/create-your-first-app.mdx` noting the tutorial is designed for SDK 54
- Kept the tutorial command (`StickerSmash`) on SDK 54 intentionally

## Test Plan

Check each updated page to confirm the `--template default@sdk-55` flag appears in the correct Terminal commands. 

- https://pr-43424.expo-docs.pages.dev/get-started/create-a-project/
- https://pr-43424.expo-docs.pages.dev/router/introduction/

Confirm the tutorial page still uses the SDK 54 command with the info callout.
- https://pr-43424.expo-docs.pages.dev/tutorial/create-your-first-app/#initialize-a-new-expo-app

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
