### PR TITLE
[widgets] Generate WidgetBundle for live activity even when there are no widgets

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix "blinking" on interactions. ([#43416](https://github.com/expo/expo/pull/43416) by [@jakex7](https://github.com/jakex7))
+- Generate WidgetBundle for live activity even when there are no widgets. ([#43425](https://github.com/expo/expo/pull/43425) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-widgets/plugin/build/withWidgetSourceFiles.js
+++ b/packages/expo-widgets/plugin/build/withWidgetSourceFiles.js
@@ -71,12 +71,17 @@ const createIndexSwift = (widgets, targetPath) => {
 import SwiftUI
 internal import ExpoWidgets
 `;
-    for (let i = 0; i < numberOfBundles; i++) {
-        const start = i * 4;
-        const end = Math.min(start + 4, numberOfWidgets);
-        const widgetChunk = widgets.slice(start, end);
-        const isLastChunk = i === numberOfBundles - 1;
-        output += addIndexSwiftChunk(widgetChunk, i, isLastChunk);
+    if (numberOfWidgets > 0) {
+        for (let i = 0; i < numberOfBundles; i++) {
+            const start = i * 4;
+            const end = Math.min(start + 4, numberOfWidgets);
+            const widgetChunk = widgets.slice(start, end);
+            const isLastChunk = i === numberOfBundles - 1;
+            output += addIndexSwiftChunk(widgetChunk, i, isLastChunk);
+        }
+    }
+    else {
+        output += addIndexSwiftChunk([], 0, true);
     }
     fs.writeFileSync(indexFilePath, output);
     return indexFilePath;
@@ -95,7 +100,7 @@ const addIndexSwiftChunk = (widgets, index, isLastChunk) => `
 ${index === 0 ? '@main' : ''}
 struct ExportWidgets${index}: WidgetBundle {
   var body: some Widget {
-    ${widgets.map((widget) => `${widget.name}()`).join('\n\t\t')}
+    ${widgets.map((widget) => `${widget.name}()`).join('\n\t')}
     ${!isLastChunk ? `ExportWidgets${index + 1}().body` : `WidgetLiveActivity()`}
   }
 }`;

--- a/packages/expo-widgets/plugin/src/withWidgetSourceFiles.ts
+++ b/packages/expo-widgets/plugin/src/withWidgetSourceFiles.ts
@@ -52,12 +52,16 @@ import SwiftUI
 internal import ExpoWidgets
 `;
 
-  for (let i = 0; i < numberOfBundles; i++) {
-    const start = i * 4;
-    const end = Math.min(start + 4, numberOfWidgets);
-    const widgetChunk = widgets.slice(start, end);
-    const isLastChunk = i === numberOfBundles - 1;
-    output += addIndexSwiftChunk(widgetChunk, i, isLastChunk);
+  if (numberOfWidgets > 0) {
+    for (let i = 0; i < numberOfBundles; i++) {
+      const start = i * 4;
+      const end = Math.min(start + 4, numberOfWidgets);
+      const widgetChunk = widgets.slice(start, end);
+      const isLastChunk = i === numberOfBundles - 1;
+      output += addIndexSwiftChunk(widgetChunk, i, isLastChunk);
+    }
+  } else {
+    output += addIndexSwiftChunk([], 0, true);
   }
 
   fs.writeFileSync(indexFilePath, output);
@@ -84,7 +88,7 @@ const addIndexSwiftChunk = (
 ${index === 0 ? '@main' : ''}
 struct ExportWidgets${index}: WidgetBundle {
   var body: some Widget {
-    ${widgets.map((widget) => `${widget.name}()`).join('\n\t\t')}
+    ${widgets.map((widget) => `${widget.name}()`).join('\n\t')}
     ${!isLastChunk ? `ExportWidgets${index + 1}().body` : `WidgetLiveActivity()`}
   }
 }`;


### PR DESCRIPTION
# Why

If there are no widgets specified in `app.json`, config plugin does not generate `WidgetBundle` at all.

# How

Generate `WidgetBundle` for Live Activity.

# Test Plan

Run prebuild without specifying widgets field.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
