### PR TITLE
[docs] Update all internal links for SDK 55

### DIFF
--- a/docs/components/plugins/api/APIStaticData.ts
+++ b/docs/components/plugins/api/APIStaticData.ts
@@ -349,6 +349,8 @@ export const sdkVersionHardcodedTypeLinks: Record<string, Record<string, string 
     Href: '/versions/latest/sdk/router/#href-1',
     BufferOptions: '/versions/latest/sdk/video/#bufferoptions-1',
     CameraPosition: '/versions/latest/sdk/maps/#cameraposition-2',
+    ScrubbingModeOptions: '/versions/latest/sdk/video/#scrubbingmodeoptions-1',
+    SeekTolerance: '/versions/latest/sdk/video/#scrubbingmodeoptions-1',
     BaseNativeTabsTriggerIconProps:
       '/versions/latest/sdk/router-native-tabs/#basenativetabstriggericonprops',
     NativeTabsTriggerBadgeProps:

--- a/docs/pages/guides/expo-ui-swift-ui/extending.mdx
+++ b/docs/pages/guides/expo-ui-swift-ui/extending.mdx
@@ -56,7 +56,7 @@ end
 
 Create your SwiftUI view with two parts:
 
-1. **Props class**: Extends `UIBaseViewProps` from `ExpoUI` to get automatic support for the [`modifiers`](/versions/unversioned/sdk/ui/swift-ui/modifiers/) prop
+1. **Props class**: Extends `UIBaseViewProps` from `ExpoUI` to get automatic support for the [`modifiers`](/versions/latest/sdk/ui/swift-ui/modifiers/) prop
 2. **View struct**: Conforms to `ExpoSwiftUI.View` protocol, which requires an `@ObservedObject` props property and a `body`
 
 ```swift my-ui/ios/MyCustomView.swift

--- a/docs/pages/router/advanced/stack-toolbar.mdx
+++ b/docs/pages/router/advanced/stack-toolbar.mdx
@@ -7,11 +7,11 @@ import { Collapsible } from '~/ui/components/Collapsible';
 
 > **important** `Stack.Toolbar` is an alpha API available on **iOS only** in **Expo SDK 55** and later. The API is subject to breaking changes.
 
-[`Stack.Toolbar`](/versions/unversioned/sdk/router/#stacktoolbar) lets you add native iOS toolbar items to your Stack screens. You can place buttons, menus, and custom views in the header (left or right side) or in the bottom toolbar area.
+[`Stack.Toolbar`](/versions/latest/sdk/router/#stacktoolbar) lets you add native iOS toolbar items to your Stack screens. You can place buttons, menus, and custom views in the header (left or right side) or in the bottom toolbar area.
 
 ## Adding header buttons
 
-Use [`Stack.Toolbar.Button`](/versions/unversioned/sdk/router/#stacktoolbarbutton) within `Stack.Toolbar` with `placement="right"` or `placement="left"` to add buttons to the navigation header. This is useful for actions like favoriting, sharing, or editing content.
+Use [`Stack.Toolbar.Button`](/versions/latest/sdk/router/#stacktoolbarbutton) within `Stack.Toolbar` with `placement="right"` or `placement="left"` to add buttons to the navigation header. This is useful for actions like favoriting, sharing, or editing content.
 
 ```tsx app/notes/[id].tsx
 import { useState } from 'react';
@@ -104,7 +104,7 @@ export default function Page() {
 
 ## Building action menus
 
-For screens with multiple actions, use [`Stack.Toolbar.Menu`](/versions/unversioned/sdk/router/#stacktoolbarmenu) to group them into a dropdown menu:
+For screens with multiple actions, use [`Stack.Toolbar.Menu`](/versions/latest/sdk/router/#stacktoolbarmenu) to group them into a dropdown menu:
 
 ```tsx app/mail/[id].tsx
 import { useState } from 'react';
@@ -148,7 +148,7 @@ export default function EmailScreen() {
 }
 ```
 
-The `isOn` prop on [`Stack.Toolbar.MenuAction`](/versions/unversioned/sdk/router/#stacktoolbarmenuaction) shows a checkmark next to the action, useful for toggle states. The `destructive` prop styles the action in red to indicate a dangerous operation.
+The `isOn` prop on [`Stack.Toolbar.MenuAction`](/versions/latest/sdk/router/#stacktoolbarmenuaction) shows a checkmark next to the action, useful for toggle states. The `destructive` prop styles the action in red to indicate a dangerous operation.
 
 ### Nested submenus
 
@@ -220,13 +220,13 @@ export default function PhotosScreen() {
 }
 ```
 
-[`Stack.Toolbar.Spacer`](/versions/unversioned/sdk/router/#stacktoolbarspacer) creates flexible space between items, pushing them to opposite sides. This is how you achieve layouts like having buttons on both ends of the toolbar.
+[`Stack.Toolbar.Spacer`](/versions/latest/sdk/router/#stacktoolbarspacer) creates flexible space between items, pushing them to opposite sides. This is how you achieve layouts like having buttons on both ends of the toolbar.
 
 > **info** Bottom toolbars can only be used inside page components, not in layout files.
 
 ## Adding badges to buttons
 
-In header toolbars, you can add badges to indicate counts or status. Use [`Stack.Toolbar.Icon`](/versions/unversioned/sdk/router/#stacktoolbaricon), [`Stack.Toolbar.Label`](/versions/unversioned/sdk/router/#stacktoolbarlabel), and [`Stack.Toolbar.Badge`](/versions/unversioned/sdk/router/#stacktoolbarbadge) to compose the button content:
+In header toolbars, you can add badges to indicate counts or status. Use [`Stack.Toolbar.Icon`](/versions/latest/sdk/router/#stacktoolbaricon), [`Stack.Toolbar.Label`](/versions/latest/sdk/router/#stacktoolbarlabel), and [`Stack.Toolbar.Badge`](/versions/latest/sdk/router/#stacktoolbarbadge) to compose the button content:
 
 ```tsx app/inbox.tsx
 import { Stack } from 'expo-router';
@@ -253,7 +253,7 @@ export default function InboxScreen() {
 
 ## Embedding custom views
 
-When you need something beyond buttons and menus, use [`Stack.Toolbar.View`](/versions/unversioned/sdk/router/#stacktoolbarview) to embed any React Native component:
+When you need something beyond buttons and menus, use [`Stack.Toolbar.View`](/versions/latest/sdk/router/#stacktoolbarview) to embed any React Native component:
 
 ```tsx app/search.tsx
 import { Stack } from 'expo-router';
@@ -431,4 +431,4 @@ You cannot nest `Stack.Toolbar` components inside each other.
 
 ## Learn more
 
-For complete API documentation, including all available props, see the [`Stack.Toolbar` API reference](/versions/unversioned/sdk/router/#stacktoolbar).
+For complete API documentation, including all available props, see the [`Stack.Toolbar` API reference](/versions/latest/sdk/router/#stacktoolbar).

--- a/docs/pages/router/advanced/zoom-transition.mdx
+++ b/docs/pages/router/advanced/zoom-transition.mdx
@@ -233,7 +233,7 @@ const styles = StyleSheet.create({
 
 ## Controlling dismissal gestures
 
-The [`usePreventZoomTransitionDismissal`](/versions/unversioned/sdk/router/#usepreventzoomtransitiondismissal_options) hook allows you to control the interactive swipe-to-dismiss gesture on screens using zoom transitions. This is useful when you want to prevent accidental dismissals or restrict dismissal to specific screen areas.
+The [`usePreventZoomTransitionDismissal`](/versions/latest/sdk/router/#usepreventzoomtransitiondismissal_options) hook allows you to control the interactive swipe-to-dismiss gesture on screens using zoom transitions. This is useful when you want to prevent accidental dismissals or restrict dismissal to specific screen areas.
 
 ### Disabling dismissal completely
 

--- a/docs/pages/router/web/data-loaders.mdx
+++ b/docs/pages/router/web/data-loaders.mdx
@@ -10,7 +10,7 @@ import { Step } from '~/ui/components/Step';
 
 > **important** Data loaders are in alpha and are available in SDK 55 and later. They require either [static rendering](/router/web/static-rendering) or [server rendering](/router/web/server-rendering).
 
-Data loaders enable server-side data fetching for your routes. By exporting a `loader` function from a route file, you can fetch data on the server and access it in your component using the [`useLoaderData`](/versions/unversioned/sdk/router/#useloaderdata) hook. This lets you keep sensitive data and API keys on the server while providing your components with the data they need.
+Data loaders enable server-side data fetching for your routes. By exporting a `loader` function from a route file, you can fetch data on the server and access it in your component using the [`useLoaderData`](/versions/latest/sdk/router/#useloaderdata) hook. This lets you keep sensitive data and API keys on the server while providing your components with the data they need.
 
 ## Setup
 
@@ -72,7 +72,7 @@ Start the development server:
 
 ## Basic example
 
-Export a `loader` function from your route file and use the [`useLoaderData`](/versions/unversioned/sdk/router/#useloaderdata) hook to access the data in your component:
+Export a `loader` function from your route file and use the [`useLoaderData`](/versions/latest/sdk/router/#useloaderdata) hook to access the data in your component:
 
 ```tsx app/index.tsx
 import { Text, View } from 'react-native';
@@ -95,13 +95,13 @@ export default function Home() {
 }
 ```
 
-The `loader` function executes on the server, and its return value is serialized and passed to your component. This means you can safely use server-side secrets, database connections, and other resources that should not be exposed to the client. When using TypeScript, passing `typeof loader` as the generic parameter to [`useLoaderData`](/versions/unversioned/sdk/router/#useloaderdata) allows the hook to infer the return type from your loader function.
+The `loader` function executes on the server, and its return value is serialized and passed to your component. This means you can safely use server-side secrets, database connections, and other resources that should not be exposed to the client. When using TypeScript, passing `typeof loader` as the generic parameter to [`useLoaderData`](/versions/latest/sdk/router/#useloaderdata) allows the hook to infer the return type from your loader function.
 
-> **info** The [`useLoaderData`](/versions/unversioned/sdk/router/#useloaderdata) hook does not need to be called in the route component itself. It can be called in any child component within the route's component tree.
+> **info** The [`useLoaderData`](/versions/latest/sdk/router/#useloaderdata) hook does not need to be called in the route component itself. It can be called in any child component within the route's component tree.
 
 ### Using Suspense
 
-When a component calls the [`useLoaderData`](/versions/unversioned/sdk/router/#useloaderdata) hook while data is still loading, React suspends that component. The loading state cascades up the component tree until it reaches the nearest [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary, which then renders its fallback.
+When a component calls the [`useLoaderData`](/versions/latest/sdk/router/#useloaderdata) hook while data is still loading, React suspends that component. The loading state cascades up the component tree until it reaches the nearest [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary, which then renders its fallback.
 
 This lets you control exactly where loading fallbacks appear by placing [`<Suspense>`](https://react.dev/reference/react/Suspense) boundaries in your component tree:
 
@@ -132,7 +132,7 @@ function DataSection() {
 }
 ```
 
-In the above example, [`useLoaderData`](/versions/unversioned/sdk/router/#useloaderdata) is in a child component of `<Home>` and wrapped it with [`<Suspense>`](https://react.dev/reference/react/Suspense) to show a loading state.
+In the above example, [`useLoaderData`](/versions/latest/sdk/router/#useloaderdata) is in a child component of `<Home>` and wrapped it with [`<Suspense>`](https://react.dev/reference/react/Suspense) to show a loading state.
 
 ### Error handling
 

--- a/docs/pages/versions/unversioned/sdk/dev-menu.mdx
+++ b/docs/pages/versions/unversioned/sdk/dev-menu.mdx
@@ -11,7 +11,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 
-The `expo-dev-menu` can be used as a **standalone library** in any Expo project. It is especially useful in [brownfield apps](/versions/unversioned/sdk/brownfield/) that don't need the full [`expo-dev-client`](/versions/unversioned/sdk/dev-client/) launcher interface.
+The `expo-dev-menu` can be used as a **standalone library** in any Expo project. It is especially useful in [brownfield apps](/versions/latest/sdk/brownfield/) that don't need the full [`expo-dev-client`](/versions/latest/sdk/dev-client/) launcher interface.
 
 `expo-dev-menu` provides a developer menu UI for React Native apps that includes:
 

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/label.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/label.mdx
@@ -49,7 +49,7 @@ export default function LabelCustomIconExample() {
 
 ### Icon only
 
-Use the [`labelStyle`](/versions/unversioned/sdk/ui/swift-ui/modifiers/#labelstyle) modifier with `iconOnly` to display only the icon. Always provide a `title` for accessibility even though it won't be visible.
+Use the [`labelStyle`](/versions/latest/sdk/ui/swift-ui/modifiers/#labelstyle) modifier with `iconOnly` to display only the icon. Always provide a `title` for accessibility even though it won't be visible.
 
 ```tsx LabelIconOnlyExample.tsx
 import { Host, Label } from '@expo/ui/swift-ui';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/rnhostview.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/rnhostview.mdx
@@ -88,7 +88,7 @@ function Example() {
 
 ### Usage with Popover
 
-`RNHostView` works well inside [`Popover`](/versions/unversioned/sdk/ui/swift-ui/popover) to display interactive React Native content.
+`RNHostView` works well inside [`Popover`](/versions/latest/sdk/ui/swift-ui/popover) to display interactive React Native content.
 
 ```tsx RNHostView in Popover
 import { useState } from 'react';

--- a/docs/pages/versions/v55.0.0/sdk/ui/swift-ui/label.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/ui/swift-ui/label.mdx
@@ -49,7 +49,7 @@ export default function LabelCustomIconExample() {
 
 ### Icon only
 
-Use the [`labelStyle`](/versions/unversioned/sdk/ui/swift-ui/modifiers/#labelstyle) modifier with `iconOnly` to display only the icon. Always provide a `title` for accessibility even though it won't be visible.
+Use the [`labelStyle`](/versions/latest/sdk/ui/swift-ui/modifiers/#labelstyle) modifier with `iconOnly` to display only the icon. Always provide a `title` for accessibility even though it won't be visible.
 
 ```tsx LabelIconOnlyExample.tsx
 import { Host, Label } from '@expo/ui/swift-ui';

--- a/docs/pages/versions/v55.0.0/sdk/ui/swift-ui/rnhostview.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/ui/swift-ui/rnhostview.mdx
@@ -88,7 +88,7 @@ function Example() {
 
 ### Usage with Popover
 
-`RNHostView` works well inside [`Popover`](/versions/unversioned/sdk/ui/swift-ui/popover) to display interactive React Native content.
+`RNHostView` works well inside [`Popover`](/versions/latest/sdk/ui/swift-ui/popover) to display interactive React Native content.
 
 ```tsx RNHostView in Popover
 import { useState } from 'react';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Update all internal links for SDK 55.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Change `/versions/unversioned/` to /versions/latest/` for internal URLs in multiple pages.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
