### PR TITLE
[image-picker] bump Android-Image-Cropper dependency

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [android] bump Android-Image-Cropper dependency
+- [android] bump Android-Image-Cropper dependency ([#43433](https://github.com/expo/expo/pull/43433) by [@vonovak](https://github.com/vonovak))
 
 ## 55.0.9 — 2026-02-25
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [android] bump Android-Image-Cropper dependency
+
 ## 55.0.9 — 2026-02-25
 
 _This version does not introduce any user-facing changes._
@@ -63,7 +65,7 @@ _This version does not introduce any user-facing changes._
 
 ### 💡 Others
 
-- [Android] Add `android:maxSdkVersion` annotation to  `READ_EXTERNAL_STORAGE` and `WRITE_EXTERNAL_STORAGE` permissions. ([#40976](https://github.com/expo/expo/pull/40976) by [@behenate](https://github.com/behenate))
+- [Android] Add `android:maxSdkVersion` annotation to `READ_EXTERNAL_STORAGE` and `WRITE_EXTERNAL_STORAGE` permissions. ([#40976](https://github.com/expo/expo/pull/40976) by [@behenate](https://github.com/behenate))
 
 ## 17.0.9 - 2025-12-05
 

--- a/packages/expo-image-picker/android/build.gradle
+++ b/packages/expo-image-picker/android/build.gradle
@@ -22,7 +22,7 @@ dependencies {
   implementation "androidx.activity:activity-ktx:1.11.0"
   implementation "androidx.appcompat:appcompat:1.7.1"
   implementation "androidx.exifinterface:exifinterface:1.4.1"
-  implementation "com.vanniktech:android-image-cropper:4.6.0"
+  implementation "com.vanniktech:android-image-cropper:4.7.0"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2"
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.graphics.Bitmap
 import android.os.Build
 import android.os.Bundle
 import android.os.OperationCanceledException
@@ -211,8 +212,12 @@ class ImagePickerModule : Module() {
         result.data.size == 1 &&
         result.data[0].first == MediaType.IMAGE
       ) {
+        val sourceUri = result.data[0].second
+        val mediaType = getType(context.contentResolver, sourceUri)
+        val compressFormat = mediaType?.toBitmapCompressFormat() ?: Bitmap.CompressFormat.JPEG
+        val outputFile = createOutputFile(cacheDirectory, compressFormat.toImageFileExtension())
         result = launchPicker {
-          cropImageLauncher.launch(CropImageContractOptions(result.data[0].second.toString(), options))
+          cropImageLauncher.launch(CropImageContractOptions(sourceUri.toString(), options, outputFile, compressFormat))
         }
       }
       mediaHandler.readExtras(result.data, options)

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerUtils.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerUtils.kt
@@ -62,11 +62,18 @@ private fun getTypeFromFileUrl(url: String): String? {
 }
 
 /**
+ * Convert this [File] to [Uri] that might be accessed by 3rd party Activities but don't mask the exception
+ */
+internal fun File.getContentUri(context: Context): Uri {
+  return FileProvider.getUriForFile(context, context.packageName + ".ImagePickerFileProvider", this)
+}
+
+/**
  * Convert this [File] to [Uri] that might be accessed by 3rd party Activities, eg. by camera application
  */
 internal fun File.toContentUri(context: Context): Uri {
   return try {
-    FileProvider.getUriForFile(context, context.packageName + ".ImagePickerFileProvider", this)
+    this.getContentUri(context)
   } catch (e: Exception) {
     Uri.fromFile(this)
   }

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CropImageContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CropImageContract.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Build
-import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import androidx.core.os.bundleOf
 import com.canhub.cropper.CropImage
@@ -15,9 +14,7 @@ import expo.modules.imagepicker.CropShape
 import expo.modules.imagepicker.ImagePickerOptions
 import expo.modules.imagepicker.MediaType
 import expo.modules.imagepicker.copyExifData
-import expo.modules.imagepicker.createOutputFile
-import expo.modules.imagepicker.toBitmapCompressFormat
-import expo.modules.imagepicker.toImageFileExtension
+import expo.modules.imagepicker.getContentUri
 import expo.modules.kotlin.activityresult.AppContextActivityResultContract
 import expo.modules.kotlin.providers.AppContextProvider
 import kotlinx.coroutines.runBlocking
@@ -27,22 +24,15 @@ import java.io.Serializable
 internal class CropImageContract(
   private val appContextProvider: AppContextProvider
 ) : AppContextActivityResultContract<CropImageContractOptions, ImagePickerContractResult> {
-  private var outputFile: File? = null
-
   override fun createIntent(context: Context, input: CropImageContractOptions) = Intent(context, expo.modules.imagepicker.ExpoCropImageActivity::class.java).apply {
-    val mediaType = expo.modules.imagepicker.getType(context.contentResolver, input.sourceUri.toUri())
-    val compressFormat = mediaType?.toBitmapCompressFormat() ?: Bitmap.CompressFormat.JPEG
-    val cacheDirectory = appContextProvider.appContext.cacheDirectory
-    val file = createOutputFile(cacheDirectory, compressFormat.toImageFileExtension())
-    outputFile = file
-    val outputUri = FileProvider.getUriForFile(context, context.packageName + ".ImagePickerFileProvider", file)
+    val outputUri = input.outputFile.getContentUri(context)
 
     putExtra(
       CropImage.CROP_IMAGE_EXTRA_BUNDLE,
       bundleOf(
         CropImage.CROP_IMAGE_EXTRA_SOURCE to input.sourceUri.toUri(),
         CropImage.CROP_IMAGE_EXTRA_OPTIONS to CropImageOptions().apply {
-          outputCompressFormat = compressFormat
+          outputCompressFormat = input.compressFormat
           outputCompressQuality = (input.options.quality * 100).toInt()
 
           this.customOutputUri = outputUri
@@ -73,15 +63,16 @@ internal class CropImageContract(
     if (resultCode == Activity.RESULT_CANCELED || result == null) {
       return ImagePickerContractResult.Cancelled
     }
-    val targetFile = requireNotNull(outputFile)
     val targetUri = requireNotNull(result.uriContent)
     val contentResolver = requireNotNull(appContextProvider.appContext.reactContext) { "React Application Context is null" }.contentResolver
-    runBlocking { copyExifData(input.sourceUri.toUri(), targetFile, contentResolver) }
+    runBlocking { copyExifData(input.sourceUri.toUri(), input.outputFile, contentResolver) }
     return ImagePickerContractResult.Success(listOf(MediaType.IMAGE to targetUri))
   }
 }
 
 internal data class CropImageContractOptions(
   val sourceUri: String,
-  val options: ImagePickerOptions
+  val options: ImagePickerOptions,
+  val outputFile: File,
+  val compressFormat: Bitmap.CompressFormat
 ) : Serializable


### PR DESCRIPTION
# Why

This PR updates the Android-Image-Cropper dependency to the latest version to close #43396

# How

Updated the `com.vanniktech:android-image-cropper` dependency from version 4.6.0 to 4.7.0

# Test Plan

- bare expo

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)