### PR TITLE
[dev-menu] Bring over improvements to tools button from 55

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -3885,7 +3885,7 @@ SPEC CHECKSUMS:
   EXUpdates: c5a64985f393cf4f8beb4463f86a885c90b4fccc
   EXUpdatesInterface: 26412751a0f7a7130614655929e316f684552aab
   FBLazyVector: 32e9ed0301d0fcbc1b2b341dd7fcbf291f51eb83
-  hermes-engine: 9e7dfb4eb5867a67fb30760f9f6f8646b9f77d28
+  hermes-engine: 1566042511e927d64254f2efe08ae744a5eb9a00
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -3903,7 +3903,7 @@ SPEC CHECKSUMS:
   React: f4edc7518ccb0b54a6f580d89dd91471844b4990
   React-callinvoker: 79ef4e3f1c021571f6d2dafbe45ca432b2f3a146
   React-Core: 469995a2b6ef0ffff38ed123ccd202287703939e
-  React-Core-prebuilt: b5ea7a06af79de343ee95cb48e56d682a29763ab
+  React-Core-prebuilt: e71199b350bcaeade83eea6e463e818dcc46d718
   React-CoreModules: db3b65cb984dfc7e0b00db517712cff8d938fc3f
   React-cxxreact: 8551bebcc6bc624ce774dccae20c383844aa9d06
   React-debug: 4f6739c820d7da9c20f48caa985573b6a847e5f5
@@ -3973,7 +3973,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 1976cdf5076a7e34718a56ead2f2069c7f54ebe9
   ReactCodegen: 4e2863f450e4aec6b66a7e91d41a209aa4601c97
   ReactCommon: 696163beb1630cf1f7590dbc8bfc542e40bdbe76
-  ReactNativeDependencies: 5dd7d57944d42324ba59e9c95ae58b4f7c7a9882
+  ReactNativeDependencies: d804b447c01215d21137868e3b5b5a920fc9f7f4
   RNCAsyncStorage: e85a99325df9eb0191a6ee2b2a842644c7eb29f4
   RNCMaskedView: 3c9d7586e2b9bbab573591dcb823918bc4668005
   RNCPicker: e0149590451d5eae242cf686014a6f6d808f93c7

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -4759,7 +4759,7 @@ SPEC CHECKSUMS:
   GoogleAppMeasurement: 8a82b93a6400c8e6551c0bcd66a9177f2e067aed
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: ca6495d9d859ae100566305c4d0afe7a0c777a46
+  hermes-engine: a785894172be9ea26a2d808760e5954874576bd8
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
@@ -337,7 +337,7 @@ class DevLauncherViewModel: ObservableObject {
     }
 
     browser?.browseResultsChangedHandler = { [weak self] results, _ in
-      guard let self = self else { return }
+      guard let self else { return }
       Task { @MainActor [weak self, results] in
         guard let self else { return }
         self.markNetworkPermissionGranted()

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -547,9 +547,9 @@ open class DevMenuManager: NSObject {
     fabWindow = DevMenuFABWindow(manager: self, windowScene: windowScene)
   }
 
-  public func updateFABVisibility(menuDismissing: Bool = false) {
+  public func updateFABVisibility() {
     DispatchQueue.main.async { [weak self] in
-      guard let self = self else { return }
+      guard let self else { return }
 
       if self.fabWindow == nil {
         if let windowScene = UIApplication.shared.connectedScenes
@@ -559,7 +559,7 @@ open class DevMenuManager: NSObject {
       }
 
       let shouldShow = DevMenuPreferences.showFloatingActionButton
-        && (menuDismissing || !self.isVisible)
+        && !self.isVisible
         && self.currentBridge != nil
         && !self.isNavigatingHome
         && DevMenuPreferences.isOnboardingFinished
@@ -567,7 +567,7 @@ open class DevMenuManager: NSObject {
     }
   }
   #else
-  public func updateFABVisibility(menuDismissing: Bool = false) {
+  public func updateFABVisibility() {
     // FAB not available on macOS/tvOS
   }
   #endif

--- a/packages/expo-dev-menu/ios/DevMenuWindow-default.swift
+++ b/packages/expo-dev-menu/ios/DevMenuWindow-default.swift
@@ -103,12 +103,11 @@ class DevMenuWindow: UIWindow, PresentationControllerDelegate {
       self.backgroundColor = .clear
     }
 
-    DevMenuManager.shared.updateFABVisibility(menuDismissing: true)
-
     devMenuViewController.dismiss(animated: true) {
       self.isDismissing = false
       self.isHidden = true
       self.backgroundColor = UIColor(white: 0, alpha: 0.4)
+      DevMenuManager.shared.updateFABVisibility()
       completion?()
     }
   }

--- a/packages/expo-dev-menu/ios/DevMenuWindow-macOS.swift
+++ b/packages/expo-dev-menu/ios/DevMenuWindow-macOS.swift
@@ -100,7 +100,7 @@ class DevMenuWindow: NSObject, AnyObject {
       ctx.duration = 0.3
       overlay.animator().alphaValue = 0.0
     }, completionHandler: { [weak self] in
-      guard let self = self else { return }
+      guard let self else { return }
       overlay.removeFromSuperview()
       self.overlayView = nil
       self.hostingView = nil

--- a/packages/expo-dev-menu/ios/FAB/DevMenuFABWindow.swift
+++ b/packages/expo-dev-menu/ios/FAB/DevMenuFABWindow.swift
@@ -10,6 +10,8 @@ class DevMenuFABWindow: UIWindow {
   private weak var manager: DevMenuManager?
   private var hostingController: UIHostingController<DevMenuFABView>?
   var fabFrame: CGRect = .zero
+  private var currentAnimator: UIViewPropertyAnimator?
+  private var targetVisibility: Bool?
 
   init(manager: DevMenuManager, windowScene: UIWindowScene) {
     self.manager = manager
@@ -51,44 +53,48 @@ class DevMenuFABWindow: UIWindow {
   }
 
   func setVisible(_ visible: Bool, animated: Bool = true) {
+    // Skip if already animating to the same state
+    if targetVisibility == visible {
+      return
+    }
+
+    // Cancel any in-progress animation and reset to clean state
+    if currentAnimator != nil {
+      currentAnimator?.stopAnimation(true)
+      currentAnimator = nil
+      transform = .identity
+    }
+
+    targetVisibility = visible
+
     if visible {
       isHidden = false
-      if animated {
-        alpha = 0
-        transform = edgeTranslation
-        UIView.animate(
-          withDuration: 0.5,
-          delay: 0,
-          usingSpringWithDamping: 0.6,
-          initialSpringVelocity: 0.8,
-          options: .curveEaseOut
-        ) {
-          self.alpha = 1
-          self.transform = .identity
-        }
-      } else {
-        alpha = 1
-        transform = .identity
+      alpha = 0
+      transform = edgeTranslation
+
+      let animator = UIViewPropertyAnimator(duration: animated ? 0.5 : 0, dampingRatio: 0.6) {
+        self.alpha = 1
+        self.transform = .identity
       }
+      animator.addCompletion { [weak self] _ in
+        self?.targetVisibility = nil
+      }
+      currentAnimator = animator
+      animator.startAnimation()
     } else {
-      if animated {
-        UIView.animate(
-          withDuration: 0.4,
-          delay: 0,
-          usingSpringWithDamping: 0.6,
-          initialSpringVelocity: 0.8,
-          options: .curveEaseIn
-        ) {
-          self.alpha = 0
-          self.transform = self.edgeTranslation
-        } completion: { _ in
-          self.isHidden = true
-          self.transform = .identity
-        }
-      } else {
-        alpha = 0
-        isHidden = true
+      let animator = UIViewPropertyAnimator(duration: animated ? 0.3 : 0, dampingRatio: 0.8) {
+        self.alpha = 0
+        self.transform = self.edgeTranslation
       }
+      animator.addCompletion { [weak self] position in
+        self?.targetVisibility = nil
+        if position == .end {
+          self?.isHidden = true
+          self?.transform = .identity
+        }
+      }
+      currentAnimator = animator
+      animator.startAnimation()
     }
   }
 

--- a/packages/expo-dev-menu/ios/Modules/DevMenuPreferences.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuPreferences.swift
@@ -42,7 +42,7 @@ public class DevMenuPreferences: Module {
       keyCommandsEnabledKey: true,
       showsAtLaunchKey: false,
       isOnboardingFinishedKey: false,
-      showFloatingActionButtonKey: false
+      showFloatingActionButtonKey: true
     ])
     #endif
 

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuAppInfo.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuAppInfo.swift
@@ -12,8 +12,6 @@ struct DevMenuAppInfo: View {
         .foregroundColor(.primary.opacity(0.6))
 
       VStack(spacing: 0) {
-        Divider()
-
         InfoRow(title: "Version", value: viewModel.appInfo?.appVersion ?? "Unknown")
 
         if let runtimeVersion = viewModel.appInfo?.runtimeVersion {
@@ -44,8 +42,7 @@ struct DevMenuAppInfo: View {
         }
       }
       .padding(.horizontal)
-      .background(Color.expoSystemBackground)
-      .cornerRadius(18)
+      .background(Color.expoSecondarySystemBackground, in: RoundedRectangle(cornerRadius: 18))
     }
   }
 }

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuButtons.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuButtons.swift
@@ -59,6 +59,8 @@ struct DevMenuToggleButton: View {
 
       Text(title)
         .foregroundColor(disabled ? .secondary : .primary)
+        .lineLimit(1)
+        .minimumScaleFactor(0.8)
 
       Spacer()
 

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuDeveloperTools.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuDeveloperTools.swift
@@ -79,15 +79,14 @@ struct DevMenuDeveloperTools: View {
         Divider()
 
         DevMenuToggleButton(
-          title: "Show dev menu button",
+          title: "Tools button",
           icon: "hand.tap",
           isEnabled: viewModel.showFloatingActionButton,
           action: viewModel.toggleFloatingActionButton
         )
         #endif
       }
-      .background(Color.expoSystemBackground)
-      .cornerRadius(18)
+      .background(Color.expoSecondarySystemBackground, in: RoundedRectangle(cornerRadius: 18))
     }
   }
 }


### PR DESCRIPTION
# Why
Brings over the look and feel improvements to the the tools button from sdk-55. 

# How
- Update the drag animation
- Allow button to move into the safe area and settle just outside it
- Change the label to "Tools button"
- Update the dev menus windows animation
- Show the button by default
- Persist last position to user defaults

# Test Plan
Bare expo

