### PR TITLE
 fix(image-picker): skip askForPermissions when camera permission already granted on Android

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixed `launchCameraAsync()` hanging indefinitely on Android 16 devices with the 2025-09-05 security patch when camera permission is already granted. ([#39480](https://github.com/expo/expo/issues/39480) by [@Mako-L](https://github.com/Mako-L))
+- [Android] Fixed `launchCameraAsync()` hanging indefinitely on Android 16 devices with the 2025-09-05 security patch when camera permission is already granted. ([#39480](https://github.com/expo/expo/issues/39480) by [@Mako-L](https://github.com/Mako-L)) ([#43438](https://github.com/expo/expo/pull/43438) by [@Mako-L](https://github.com/Mako-L))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed `launchCameraAsync()` hanging indefinitely on Android 16 devices with the 2025-09-05 security patch when camera permission is already granted. ([#39480](https://github.com/expo/expo/issues/39480) by [@Mako-L](https://github.com/Mako-L))
+
 ### 💡 Others
 
 ## 55.0.9 — 2026-02-25

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -273,6 +273,17 @@ class ImagePickerModule : Module() {
       return@suspendCancellableCoroutine
     }
 
+    // Workaround for Android 16 (2025-09-05 security patch) where askForPermissions()
+    // hangs forever when permissions are already granted. Check first with ContextCompat.
+    val cameraGranted = ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED
+    val storageGranted = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q ||
+      ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED
+
+    if (cameraGranted && storageGranted) {
+      continuation.resume(Unit)
+      return@suspendCancellableCoroutine
+    }
+
     permissions.askForPermissions(
       { permissionsResponse ->
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {


### PR DESCRIPTION
## Summary

Fixes #39480

On Android 16 devices with the 2025-09-05 security patch, `launchCameraAsync()` hangs indefinitely because `ensureCameraPermissionsAreGranted()` calls `permissions.askForPermissions()` which never resolves when the CAMERA permission is already granted.

This adds a guard check using `ContextCompat.checkSelfPermission()` before calling `askForPermissions()`. If permissions are already granted, the function resumes immediately without triggering the broken permission request flow.

## Why

On Android 16 devices with the 2025-09-05 security patch, a framework change in the Permission module causes `askForPermissions()` to never invoke its callback when the requested permissions are already granted. This results in `launchCameraAsync()` hanging indefinitely — the came$

## How

Added a guard in `ensureCameraPermissionsAreGranted()` that checks if CAMERA (and WRITE_EXTERNAL_STORAGE on pre-Q) permissions are already granted using `ContextCompat.checkSelfPermission()` before calling `askForPermissions()`. If all required permissions are already granted, the$

## Test Plan

- Tested on Android 16 device with 2025-09-05 security patch (Pixel 9a)
- Camera opens immediately after granting permission for the first time
- Camera opens immediately on subsequent launches (previously hung forever)
- Gallery picker still works correctly
- No behavior change on Android < 16
- No behavior change on iOS

## Related

- Android framework change: https://android.googlesource.com/platform/packages/modules/Permission/+/5dca0ccb26f2b99d706a1d3e9402f851e849c913
- Logcat message on hang: `"No requestable permission in the request."`

## Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)