### PR TITLE
fix(expo-sqlite): delete WAL and SHM sidecar files when deleting a database

### DIFF
--- a/apps/test-suite/tests/SQLite.ts
+++ b/apps/test-suite/tests/SQLite.ts
@@ -242,6 +242,42 @@ CREATE TABLE IF NOT EXISTS users (user_id INTEGER PRIMARY KEY NOT NULL, name VAR
       await db.closeAsync();
     });
 
+    nativeIt('should remove WAL and SHM files when deleting a database', async () => {
+      const dbName = 'test-wal-cleanup.db';
+      let db = await SQLite.openDatabaseAsync(dbName);
+
+      // Enable WAL mode to create sidecar files
+      await db.execAsync('PRAGMA journal_mode = WAL');
+      await db.execAsync(`
+DROP TABLE IF EXISTS data;
+CREATE TABLE IF NOT EXISTS data (id INTEGER PRIMARY KEY NOT NULL, value TEXT);
+INSERT INTO data (value) VALUES ('test');
+`);
+      await db.closeAsync();
+
+      // Verify the database and sidecar files exist
+      const dbPath = `${FS.documentDirectory}SQLite/${dbName}`;
+      const dbInfo = await FS.getInfoAsync(dbPath);
+      expect(dbInfo.exists).toBeTruthy();
+
+      // At least the WAL file should exist after WAL-mode writes
+      const walInfo = await FS.getInfoAsync(dbPath + '-wal');
+      const shmInfo = await FS.getInfoAsync(dbPath + '-shm');
+      // WAL and SHM files are typically created together
+      expect(walInfo.exists || shmInfo.exists).toBeTruthy();
+
+      // Delete the database
+      await SQLite.deleteDatabaseAsync(dbName);
+
+      // Verify all files are removed (main db + sidecars)
+      const dbInfoAfter = await FS.getInfoAsync(dbPath);
+      expect(dbInfoAfter.exists).toBeFalsy();
+      const walInfoAfter = await FS.getInfoAsync(dbPath + '-wal');
+      expect(walInfoAfter.exists).toBeFalsy();
+      const shmInfoAfter = await FS.getInfoAsync(dbPath + '-shm');
+      expect(shmInfoAfter.exists).toBeFalsy();
+    });
+
     nativeIt('should be able to recreate db from scratch by deleting file', async () => {
       let db = await SQLite.openDatabaseAsync('test.db');
       await db.execAsync(`

--- a/apps/test-suite/tests/SQLite.ts
+++ b/apps/test-suite/tests/SQLite.ts
@@ -244,7 +244,7 @@ CREATE TABLE IF NOT EXISTS users (user_id INTEGER PRIMARY KEY NOT NULL, name VAR
 
     nativeIt('should remove WAL and SHM files when deleting a database', async () => {
       const dbName = 'test-wal-cleanup.db';
-      let db = await SQLite.openDatabaseAsync(dbName);
+      const db = await SQLite.openDatabaseAsync(dbName);
 
       // Enable WAL mode to create sidecar files
       await db.execAsync('PRAGMA journal_mode = WAL');

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `deleteDatabaseSync` not removing WAL and SHM sidecar files on iOS and Android. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@jmalmo](https://github.com/jmalmo))
+
 ### 💡 Others
 
 ## 55.0.10 — 2026-02-25

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed `deleteDatabaseSync` not removing WAL and SHM sidecar files on iOS and Android. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@jmalmo](https://github.com/jmalmo))
+- Fixed `deleteDatabaseSync` not removing WAL and SHM sidecar files on iOS and Android. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@jmalmo](https://github.com/jmalmo)) ([#43442](https://github.com/expo/expo/pull/43442) by [@jmalmo](https://github.com/jmalmo))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed `deleteDatabaseSync` not removing WAL and SHM sidecar files on iOS and Android. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@jmalmo](https://github.com/jmalmo)) ([#43442](https://github.com/expo/expo/pull/43442) by [@jmalmo](https://github.com/jmalmo))
+- Fixed `deleteDatabaseSync` not removing WAL and SHM sidecar files on iOS and Android. ([#43442](https://github.com/expo/expo/pull/43442) by [@jmalmo](https://github.com/jmalmo))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
@@ -535,6 +535,11 @@ class SQLiteModule : Module() {
     if (!dbFile.delete()) {
       throw DeleteDatabaseFileException(databasePath)
     }
+
+    // Also remove WAL and SHM sidecar files if they exist.
+    // SQLite in WAL mode creates these alongside the main database file.
+    File(dbFile.path + "-wal").delete()
+    File(dbFile.path + "-shm").delete()
   }
 
   @Throws(AccessClosedResourceException::class, SQLiteErrorException::class)

--- a/packages/expo-sqlite/ios/SQLiteModule.swift
+++ b/packages/expo-sqlite/ios/SQLiteModule.swift
@@ -526,6 +526,15 @@ public final class SQLiteModule: Module {
     } catch {
       throw DeleteDatabaseFileException(path)
     }
+
+    // Also remove WAL and SHM sidecar files if they exist.
+    // SQLite in WAL mode creates these alongside the main database file.
+    for suffix in ["-wal", "-shm"] {
+      let sidecarPath = path + suffix
+      if FileManager.default.fileExists(atPath: sidecarPath) {
+        try? FileManager.default.removeItem(atPath: sidecarPath)
+      }
+    }
   }
 
   private func backupDatabase(destDatabase: NativeDatabase, destDatabaseName: String, sourceDatabase: NativeDatabase, sourceDatabaseName: String) throws {

--- a/packages/expo-sqlite/ios/SQLiteModuleLibSQL.swift
+++ b/packages/expo-sqlite/ios/SQLiteModuleLibSQL.swift
@@ -550,6 +550,15 @@ public final class SQLiteModule: Module {
     } catch {
       throw DeleteDatabaseFileException(path)
     }
+
+    // Also remove WAL and SHM sidecar files if they exist.
+    // SQLite in WAL mode creates these alongside the main database file.
+    for suffix in ["-wal", "-shm"] {
+      let sidecarPath = path + suffix
+      if FileManager.default.fileExists(atPath: sidecarPath) {
+        try? FileManager.default.removeItem(atPath: sidecarPath)
+      }
+    }
   }
 
   private func getColumnNames(statement: NativeStatement) throws -> SQLiteColumnNames {


### PR DESCRIPTION
## Summary

Fixes #43441

`deleteDatabaseSync` / `deleteDatabaseAsync` only remove the main database file, leaving behind `-wal` (Write-Ahead Log) and `-shm` (Shared Memory) sidecar files that SQLite creates in WAL mode.

After a crash or abnormal exit, these sidecar files persist on disk. If a new database is later created with the same name, SQLite may replay the orphaned WAL, leading to corruption or unexpected state.

## Changes

- **iOS** (`SQLiteModule.swift`): After removing the main database file, also remove `path + "-wal"` and `path + "-shm"`, ignoring not-found errors.
- **Android** (`SQLiteModule.kt`): After removing the main database file, also delete `File(dbFile.path + "-wal")` and `File(dbFile.path + "-shm")`.
- **E2E test** (`SQLite.ts`): Added test that enables WAL mode, closes the database, and verifies that `deleteDatabaseAsync` removes all sidecar files.
- **CHANGELOG**: Added bug fix entry.

This aligns with Android's built-in [`SQLiteDatabase.deleteDatabase()`](https://developer.android.com/reference/android/database/sqlite/SQLiteDatabase#deleteDatabase(java.io.File)), which explicitly removes `-wal`, `-shm`, and `-journal` files.

## Test plan

- [x] Added E2E test in `apps/test-suite/tests/SQLite.ts` that verifies WAL/SHM cleanup
- [x] Verified bug reproduces on iOS Simulator using [reproduction app](https://github.com/jmalmo/expo-sqlite-wal-repro)
- [x] Run existing SQLite test suite to ensure no regressions
