### PR TITLE
[CI][Nightly] - Fix expo-widgets bundling

### DIFF
--- a/packages/expo-widgets/metro.config.js
+++ b/packages/expo-widgets/metro.config.js
@@ -1,11 +1,14 @@
 const { getDefaultConfig } = require('expo/metro-config');
 const path = require('path');
 
-const config = getDefaultConfig(process.cwd());
+const appRoot = process.cwd();
+const config = getDefaultConfig(appRoot);
 
 const expoStubPath = path.resolve(__dirname, './bundle/expo-module-stub.ts');
 const reactStubPath = path.resolve(__dirname, './bundle/react-stub.ts');
 const jsxRuntimeStubPath = path.resolve(__dirname, './bundle/jsx-runtime-stub.ts');
+
+const appNodeModules = path.resolve(appRoot, 'node_modules');
 
 const buildConfig = {
   ...config,
@@ -13,9 +16,14 @@ const buildConfig = {
   watchFolders: [
     ...config.watchFolders,
     __dirname,
+    appNodeModules,
   ],
   resolver: {
     ...config.resolver,
+    nodeModulesPaths: [
+      ...(config.resolver.nodeModulesPaths ?? []),
+      appNodeModules,
+    ],
     resolveRequest(context, moduleName, platform) {
       const fileSpecifierRe = /^[\\/]|^\.\.?(?:$|[\\/])/i;
       if (fileSpecifierRe.test(moduleName)) {

--- a/packages/expo-widgets/metro.config.js
+++ b/packages/expo-widgets/metro.config.js
@@ -1,4 +1,5 @@
 const { getDefaultConfig } = require('expo/metro-config');
+const fs = require('fs');
 const path = require('path');
 
 const appRoot = process.cwd();
@@ -10,6 +11,13 @@ const jsxRuntimeStubPath = path.resolve(__dirname, './bundle/jsx-runtime-stub.ts
 
 const appNodeModules = path.resolve(appRoot, 'node_modules');
 
+let expoUiDir;
+try {
+  expoUiDir = fs.realpathSync(
+    path.dirname(require.resolve('@expo/ui/package.json', { paths: [appRoot, __dirname] }))
+  );
+} catch { }
+
 const buildConfig = {
   ...config,
   projectRoot: __dirname,
@@ -17,6 +25,7 @@ const buildConfig = {
     ...config.watchFolders,
     __dirname,
     appNodeModules,
+    ...(expoUiDir ? [expoUiDir] : []),
   ],
   resolver: {
     ...config.resolver,


### PR DESCRIPTION
# Why

On nightly build CI, expo-widgets bundler is not able to resolve `@expo/ui`. 
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
