### PR TITLE
fix(expo-widgets): Add missing project root to watchFolders since default doesn't apply

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add missing project root to `watchFolders` in `metro.config.js` ([#43449](https://github.com/expo/expo/pull/43449) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 55.0.1 — 2026-02-25

--- a/packages/expo-widgets/metro.config.js
+++ b/packages/expo-widgets/metro.config.js
@@ -1,19 +1,26 @@
 const { getDefaultConfig } = require('expo/metro-config');
 const path = require('path');
 
-const config = getDefaultConfig(process.cwd());
+const projectRoot = process.cwd();
+const config = getDefaultConfig(projectRoot);
 
 const expoStubPath = path.resolve(__dirname, './bundle/expo-module-stub.ts');
 const reactStubPath = path.resolve(__dirname, './bundle/react-stub.ts');
 const jsxRuntimeStubPath = path.resolve(__dirname, './bundle/jsx-runtime-stub.ts');
 
+// The `projectRoot` won't be included by default, since we alter it to be `__dirname`
+// to bundle from `expo-widgets` as the main module
+// NOTE: We check the `watchFolders` to start with `projectRoot`, since `expo/metro-config`
+// might add folders if we're in a monorepo
+const watchFolders = config.watchFolders;
+if (!watchFolders.some((entry) => !entry.startsWith(projectRoot))) {
+  watchFolders.push(projectRoot);
+}
+
 const buildConfig = {
   ...config,
-  projectRoot: __dirname,
-  watchFolders: [
-    ...config.watchFolders,
-    __dirname,
-  ],
+  projectRoot: __dirname, // Override root to be expo-widgets
+  watchFolders,
   resolver: {
     ...config.resolver,
     resolveRequest(context, moduleName, platform) {


### PR DESCRIPTION
# Why

The default `projectRoot` won't be applied to the Metro config in `expo-widgets`, since we alter `config.projectRoot` to be `__dirname`, hence, when this config is loaded only `__dirname` is added. We must add `projectRoot` manually if `@expo/metro-config` hasn't populated the `watchFolders` with a monorepo's `node_modules` folders.

# How

- Add missing `projectRoot` to `watchFolders` in `expo-widgets/metro.config.js`

# Test Plan

- Nightly RN build CI task should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
