### PR TITLE
fix(babel-preset-expo): Opt widget functions out of `react-compiler` changes

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Opt `"widget"` functions for `expo-widgets` out of react-compiler ([#43451](https://github.com/expo/expo/pull/43451) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 55.0.8 — 2026-02-25

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -81,6 +81,7 @@ function babelPresetExpo(api, options = {}) {
         !isServerEnv &&
         // Give users the ability to opt-out of the feature, per-platform.
         platformOptions['react-compiler'] !== false) {
+        const reactCompilerOptions = platformOptions['react-compiler'];
         extraPlugins.push([
             require('babel-plugin-react-compiler'),
             {
@@ -90,7 +91,10 @@ function babelPresetExpo(api, options = {}) {
                     ...(platformOptions['react-compiler']?.environment ?? {}),
                 },
                 panicThreshold: isDev ? undefined : 'NONE',
-                ...platformOptions['react-compiler'],
+                ...reactCompilerOptions,
+                // See: https://github.com/facebook/react/blob/074d96b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts#L160-L163
+                // We need to opt-out for our widgets, since they're stringified functions that output Swift UI JSX
+                customOptOutDirectives: [...(reactCompilerOptions?.customOptOutDirectives ?? []), 'widget'],
             },
         ]);
     }

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -173,6 +173,7 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
     // Give users the ability to opt-out of the feature, per-platform.
     platformOptions['react-compiler'] !== false
   ) {
+    const reactCompilerOptions = platformOptions['react-compiler'];
     extraPlugins.push([
       require('babel-plugin-react-compiler'),
       {
@@ -182,7 +183,10 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
           ...(platformOptions['react-compiler']?.environment ?? {}),
         },
         panicThreshold: isDev ? undefined : 'NONE',
-        ...platformOptions['react-compiler'],
+        ...reactCompilerOptions,
+        // See: https://github.com/facebook/react/blob/074d96b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts#L160-L163
+        // We need to opt-out for our widgets, since they're stringified functions that output Swift UI JSX
+        customOptOutDirectives: [...(reactCompilerOptions?.customOptOutDirectives ?? []), 'widget'],
       },
     ]);
   }


### PR DESCRIPTION
# Why

While the `customOptOutDirectives` are marked as unstable, they're the most reliable and simple way to opt us out of the react-compiler modifications for widget functions. It seems like a low-risk and optimal way to not modify the widget functions, and seems appropriate since they're not meant to be components, instead being just functions that return Swift UI JSX.

# How

- Add `customOptOutDirectives` override to `react-compiler` Babel plugin options opting out `widget` directive

# Test Plan

- Unit test checks that the compiler changes don't happen

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
