### PR TITLE
fix(expo-widgets): Remove extraneous dependencies

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Remove extraneous `@expo/config-plugins` dependency ([#43452](https://github.com/expo/expo/pull/43452) by [@kitten](https://github.com/kitten))
+
 ## 55.0.1 — 2026-02-25
 
 ### 🐛 Bug fixes

--- a/packages/expo-widgets/package.json
+++ b/packages/expo-widgets/package.json
@@ -32,10 +32,8 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/widgets/",
   "dependencies": {
-    "@expo/config-plugins": "~55.0.6",
-    "@expo/config-types": "^55.0.5",
     "@expo/plist": "^0.5.2",
-    "@expo/ui": "55.0.1"
+    "@expo/ui": "~55.0.1"
   },
   "devDependencies": {
     "expo-module-scripts": "^55.0.2"

--- a/packages/expo-widgets/plugin/build/withIosWarning.d.ts
+++ b/packages/expo-widgets/plugin/build/withIosWarning.d.ts
@@ -1,4 +1,4 @@
-import { ConfigPlugin } from '@expo/config-plugins';
+import { ConfigPlugin } from 'expo/config-plugins';
 type WithIosWarningProps = {
     property: string;
     warning: string;

--- a/packages/expo-widgets/plugin/build/withIosWarning.js
+++ b/packages/expo-widgets/plugin/build/withIosWarning.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const config_plugins_1 = require("@expo/config-plugins");
+const config_plugins_1 = require("expo/config-plugins");
 // Hack to display the warning only once
 const withIosWarning = (config, { property, warning }) => (0, config_plugins_1.withInfoPlist)(config, (config) => {
     config_plugins_1.WarningAggregator.addWarningIOS(property, warning);

--- a/packages/expo-widgets/plugin/src/withIosWarning.ts
+++ b/packages/expo-widgets/plugin/src/withIosWarning.ts
@@ -1,5 +1,5 @@
-import { ConfigPlugin, WarningAggregator, withInfoPlist } from '@expo/config-plugins';
-import { ExpoConfig } from '@expo/config-types';
+import type { ExpoConfig } from 'expo/config';
+import { ConfigPlugin, WarningAggregator, withInfoPlist } from 'expo/config-plugins';
 
 type WithIosWarningProps = { property: string; warning: string };
 


### PR DESCRIPTION
# Why

- `@expo/config-plugins` isn't a necessary import; replace with `expo/config-plugins` like the other files
- Remove `@expo/config-types` import; `expo/config` should be used
- Open up `@expo/ui` dependency range to include patch versions, since we can't guarantee alignment on the user's side

# Test Plan

- n/a; should build as expected

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
