### PR TITLE
chore(cli): Remove ws-tunnel test

### DIFF
--- a/packages/@expo/cli/e2e/__tests__/start-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/start-test.ts
@@ -215,31 +215,3 @@ describe('start - dev clients', () => {
     expect(response.ok).toBeTruthy();
   });
 });
-
-describe('start - webcontainer', () => {
-  const expo = createExpoStart({
-    cwd: getRouterE2ERoot(),
-    port: 8081, // Only port 8081 is supported with the ws-tunnel
-    env: {
-      NODE_ENV: 'development',
-      EXPO_USE_STATIC: 'server',
-      E2E_ROUTER_SRC: 'server',
-      E2E_ROUTER_ASYNC: 'development',
-      // Force webcontainer mode
-      CI: 'false',
-      EXPO_FORCE_WEBCONTAINER_ENV: 'true',
-    },
-  });
-
-  beforeEach(async () => {
-    await expo.startAsync();
-  });
-  afterAll(async () => {
-    await expo.stopAsync();
-  });
-
-  it('starts with ws-tunnel enabled by default', () => {
-    // Ensure dev server URL points to the ws tunnel by default
-    expect(expo.url.href).toContain('.boltexpo.dev:');
-  });
-});


### PR DESCRIPTION
# Why

Not a test we intended to keep, that's now causing sporadic failures. The test wasn't intended to be kept since this doesn't represent stable functionality and is for internal usage/testing.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
