### PR TITLE
[docs] Update Upgrade Expo SDK guide for SDK 55

### DIFF
--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
@@ -30,7 +30,7 @@ Install the new version of the Expo package:
   }}
 />
 
-Depending on which SDK you're upgrading to, substitute the `expo@^55.0.0` with the version range of the Expo SDK version you're targeting. For example, `expo@^55.0.0` stands for SDK 55.
+Depending on which SDK you're upgrading to, substitute `expo@^55.0.0` with the version range of the Expo SDK version you're targeting. For example, `expo@^55.0.0` stands for SDK 55.
 
 </Step>
 

--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
@@ -1,7 +1,6 @@
 ---
 title: Upgrade Expo SDK
 description: Learn how to incrementally upgrade the Expo SDK version in your project.
-hasVideoLink: false
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
@@ -1,24 +1,18 @@
 ---
 title: Upgrade Expo SDK
 description: Learn how to incrementally upgrade the Expo SDK version in your project.
-hasVideoLink: true
+hasVideoLink: false
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
-import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 > **info** We recommend upgrading SDK versions incrementally, one at a time. Doing so will help you pinpoint breakages and issues that arise during the upgrade process.
 
 With a new SDK release, the latest version enters the current release status. This applies to Expo Go as it only supports the latest SDK version and previous versions are no longer supported. We recommend using [development builds](/develop/development-builds/introduction/) for production apps as the backwards compatibility for older SDK versions on EAS services tends to be much longer, but not forever.
 
 If you are looking to install a specific version of Expo Go, visit [expo.dev/go](https://expo.dev/go). It supports downloads for Android devices/emulators and iOS simulators. However, due to iOS platform restrictions, only the latest version of Expo Go is available for installation on physical iOS devices.
-
-<VideoBoxLink
-  videoId="QuN63BRRhAM"
-  title="Watch: How to upgrade from Expo SDK 53 to SDK 54 in 5 minutes"
-/>
 
 ## How to upgrade to the latest SDK version
 
@@ -30,14 +24,14 @@ Install the new version of the Expo package:
 
 <Terminal
   cmd={{
-    npm: ['$ npm install expo@^54.0.0'],
-    yarn: ['$ yarn add expo@^54.0.0'],
-    pnpm: ['$ pnpm add expo@^54.0.0'],
-    bun: ['$ bun install expo@^54.0.0'],
+    npm: ['$ npm install expo@^55.0.0'],
+    yarn: ['$ yarn add expo@^55.0.0'],
+    pnpm: ['$ pnpm add expo@^55.0.0'],
+    bun: ['$ bun install expo@^55.0.0'],
   }}
 />
 
-Depending on which SDK you're upgrading to, substitute the `expo@^54.0.0` with the version range of the Expo SDK version you're targeting. For example, `expo@^54.0.0` stands for SDK 54.
+Depending on which SDK you're upgrading to, substitute the `expo@^55.0.0` with the version range of the Expo SDK version you're targeting. For example, `expo@^55.0.0` stands for SDK 55.
 
 </Step>
 
@@ -75,10 +69,9 @@ Read the [SDK changelogs](#sdk-changelogs) for the SDK version you are upgrading
 
 Each SDK announcement release notes post contains information deprecations, breaking changes, and anything else that might be unique to that particular SDK version. When upgrading, be sure to check these out to make sure you don't miss anything.
 
+- **SDK 55**: [Release notes](https://expo.dev/changelog/sdk-55)
 - **SDK 54**: [Release notes](https://expo.dev/changelog/sdk-54)
 - **SDK 53**: [Release notes](https://expo.dev/changelog/sdk-53)
-- **SDK 52**: [Release notes](https://expo.dev/changelog/2024-11-12-sdk-52)
-  - **React Native 0.77 is available with Expo SDK 52**. To upgrade, see these [Release notes](https://expo.dev/changelog/2025/01-21-react-native-0.77).
 
 ### Deprecated SDK Version Changelogs
 
@@ -86,6 +79,8 @@ The following blog posts may included outdated information, but they are still u
 
 <Collapsible summary="See a full list of deprecated SDK release changelogs">
 
+- **SDK 52**: [Release notes](https://expo.dev/changelog/2024-11-12-sdk-52)
+  - **React Native 0.77 is available with Expo SDK 52**. To upgrade, see these [Release notes](https://expo.dev/changelog/2025/01-21-react-native-0.77).
 - **SDK 51**: [Release notes](https://expo.dev/changelog/2024-05-07-sdk-51)
 - **SDK 50**: [Release notes](https://expo.dev/changelog/2024-01-18-sdk-50)
 - **SDK 49**: [Release notes](https://blog.expo.dev/expo-sdk-49-c6d398cdf740)


### PR DESCRIPTION
## Why

Resolves ENG-18819.

## How

- Add SDK 55 release notes link to the SDK Changelogs section.
- Move SDK 52 to the Deprecated SDK Version Changelogs collapsible.
- Update install command examples from `expo@^54.0.0` to `expo@^55.0.0`.
- Remove the SDK 53 to SDK 54 upgrade video link (outdated for the current release).

## Test Plan

Visit the Upgrade Expo SDK page in preview.
# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
