### PR TITLE
[sdk-56] Upgrade react-native-screens to 4.24.0

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2958,7 +2958,7 @@ PODS:
     - ReactNativeDependencies
     - RNWorklets
     - Yoga
-  - RNScreens (4.23.0):
+  - RNScreens (4.24.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2980,9 +2980,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNScreens/common (= 4.23.0)
+    - RNScreens/common (= 4.24.0)
     - Yoga
-  - RNScreens/common (4.23.0):
+  - RNScreens/common (4.24.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3995,7 +3995,7 @@ SPEC CHECKSUMS:
   RNDateTimePicker: 5e0666de98f1edfac67ee7dde6be8a5415e487a0
   RNGestureHandler: 6d378fd1aa991c7ab62a4215ee6cc417895a6954
   RNReanimated: 752b27ede7d3f8970d5adba71f10258cb7848150
-  RNScreens: fb11b7412bcbdc0ffafcaf9174938d998d4e2bc4
+  RNScreens: 088d923c4327c63c9f8c942cae17a9d038f47d97
   RNSVG: 13970bfde0ea9c9e10e01ab0d7b4a6cde11fca1b
   RNWorklets: 460112a8b250bcecd1b6b68d39a82fcdb6f8eb24
   SDWebImage: e9c98383c7572d713c1a0d7dd2783b10599b9838

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -76,7 +76,7 @@
     "react-native-reanimated": "4.2.2",
     "react-native-safe-area-context": "5.6.2",
     "react-native-svg": "15.15.3",
-    "react-native-screens": "4.23.0",
+    "react-native-screens": "4.24.0",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.16.0",
     "react-native-worklets": "0.7.4",

--- a/apps/brownfield-tester/expo-app/package.json
+++ b/apps/brownfield-tester/expo-app/package.json
@@ -35,7 +35,7 @@
     "react-native-worklets": "0.7.4",
     "react-native-reanimated": "~4.2.2",
     "react-native-safe-area-context": "~5.6.2",
-    "react-native-screens": "~4.23.0",
+    "react-native-screens": "~4.24.0",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3739,7 +3739,7 @@ PODS:
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNScreens (4.23.0):
+  - RNScreens (4.24.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3766,10 +3766,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.23.0)
+    - RNScreens/common (= 4.24.0)
     - SocketRocket
     - Yoga
-  - RNScreens/common (4.23.0):
+  - RNScreens/common (4.24.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -4868,7 +4868,7 @@ SPEC CHECKSUMS:
   RNDateTimePicker: e9e210197c267461f70f3f47bec705401ff72077
   RNGestureHandler: 0ac42879420bf5353c06174d14af11f6435f3294
   RNReanimated: f60cb180f1540dde5e14d1fdc09d20a3552ee3ff
-  RNScreens: ec8bdc9f024d5828e5adf4f5e8870d5260cff616
+  RNScreens: 7179cc1ba31b4e18ed29f10abf20c24a7961cf4c
   RNSVG: 15c97a81fe80139227609070b1c11a86dce5c9b6
   RNWorklets: 7f524b9625dc3d9f1014ae6529fdd25a0141c922
   SDWebImage: f29024626962457f3470184232766516dee8dfea

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -78,7 +78,7 @@
     "react-native-reanimated": "4.2.2",
     "react-native-safe-area-context": "5.6.2",
     "react-native-svg": "15.15.3",
-    "react-native-screens": "4.23.0",
+    "react-native-screens": "4.24.0",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.16.0",
     "react-native-worklets": "0.7.4",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -153,7 +153,7 @@
     "react-native-reanimated": "4.2.2",
     "react-native-safe-area-context": "5.6.2",
     "react-native-svg": "15.15.3",
-    "react-native-screens": "4.23.0",
+    "react-native-screens": "4.24.0",
     "react-native-view-shot": "4.0.3",
     "react-native-web": "~0.21.0",
     "react-native-webview": "13.16.0",

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -36,7 +36,7 @@
     "react": "19.2.3",
     "react-native": "0.84.1",
     "react-native-safe-area-context": "5.6.2",
-    "react-native-screens": "4.23.0"
+    "react-native-screens": "4.24.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -73,7 +73,7 @@
     "react": "19.2.3",
     "react-native": "0.84.1",
     "react-native-safe-area-context": "5.6.2",
-    "react-native-screens": "4.23.0",
+    "react-native-screens": "4.24.0",
     "react-native-webview": "13.16.0"
   },
   "devDependencies": {

--- a/packages/@expo/cli/e2e/fixtures/with-monorepo/apps/app-a/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-monorepo/apps/app-a/package.json
@@ -13,7 +13,7 @@
     "react-dom": "19.2.3",
     "react-native": "0.84.1",
     "react-native-safe-area-context": "~5.6.2",
-    "react-native-screens": "~4.23.0",
+    "react-native-screens": "~4.24.0",
     "react-native-web": "~0.21.0"
   }
 }

--- a/packages/@expo/cli/e2e/fixtures/with-monorepo/apps/app-b/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-monorepo/apps/app-b/package.json
@@ -13,7 +13,7 @@
     "react-dom": "19.2.3",
     "react-native": "0.84.1",
     "react-native-safe-area-context": "~5.6.2",
-    "react-native-screens": "~4.23.0",
+    "react-native-screens": "~4.24.0",
     "react-native-web": "~0.21.0"
   }
 }

--- a/packages/@expo/cli/e2e/fixtures/with-router-typed-routes/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-router-typed-routes/package.json
@@ -13,7 +13,7 @@
     "react-dom": "19.2.3",
     "react-native": "0.84.1",
     "react-native-safe-area-context": "~5.6.2",
-    "react-native-screens": "~4.23.0",
+    "react-native-screens": "~4.24.0",
     "react-native-web": "~0.21.0"
   }
 }

--- a/packages/@expo/cli/e2e/fixtures/with-router/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-router/package.json
@@ -12,7 +12,7 @@
     "react-dom": "19.2.3",
     "react-native": "0.84.1",
     "react-native-safe-area-context": "~5.6.2",
-    "react-native-screens": "~4.23.0",
+    "react-native-screens": "~4.24.0",
     "react-native-web": "~0.21.0"
   }
 }

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -38,6 +38,8 @@ _This version does not introduce any user-facing changes._
 
 ### 💡 Others
 
+- Pin screens to 4.24.0 ([#43379](https://github.com/expo/expo/pull/43379) by [@Ubax](https://github.com/Ubax))
+
 ## 55.0.0-preview.9 — 2026-02-20
 
 ### 🎉 New features

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -94,6 +94,7 @@
     "react-native-gesture-handler": "*",
     "react-native-reanimated": "*",
     "react-native-safe-area-context": ">= 5.4.0",
+    "react-native-screens": "~4.24.0",
     "react-native-web": "*",
     "react-server-dom-webpack": "~19.0.4 || ~19.1.5 || ~19.2.4"
   },
@@ -150,7 +151,7 @@
     "query-string": "^7.1.3",
     "react-fast-compare": "^3.2.2",
     "react-native-is-edge-to-edge": "^1.2.1",
-    "react-native-screens": "4.24.0",
+    "react-native-screens": "~4.24.0",
     "server-only": "^0.0.1",
     "sf-symbols-typescript": "^2.1.0",
     "shallowequal": "^1.1.0",

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -94,7 +94,6 @@
     "react-native-gesture-handler": "*",
     "react-native-reanimated": "*",
     "react-native-safe-area-context": ">= 5.4.0",
-    "react-native-screens": "*",
     "react-native-web": "*",
     "react-server-dom-webpack": "~19.0.4 || ~19.1.5 || ~19.2.4"
   },
@@ -151,6 +150,7 @@
     "query-string": "^7.1.3",
     "react-fast-compare": "^3.2.2",
     "react-native-is-edge-to-edge": "^1.2.1",
+    "react-native-screens": "4.24.0",
     "server-only": "^0.0.1",
     "sf-symbols-typescript": "^2.1.0",
     "shallowequal": "^1.1.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -105,7 +105,7 @@
   "react-native-pager-view": "8.0.0",
   "react-native-worklets": "0.7.4",
   "react-native-reanimated": "4.2.2",
-  "react-native-screens": "~4.23.0",
+  "react-native-screens": "~4.24.0",
   "react-native-safe-area-context": "~5.6.2",
   "react-native-svg": "15.15.3",
   "react-native-view-shot": "4.0.3",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -35,7 +35,7 @@
     "react-native-worklets": "0.7.4",
     "react-native-reanimated": "4.2.2",
     "react-native-safe-area-context": "~5.6.2",
-    "react-native-screens": "~4.23.0",
+    "react-native-screens": "~4.24.0",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -27,7 +27,7 @@
     "react-native-worklets": "0.7.4",
     "react-native-reanimated": "4.2.2",
     "react-native-safe-area-context": "~5.6.2",
-    "react-native-screens": "~4.23.0",
+    "react-native-screens": "~4.24.0",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13311,7 +13311,15 @@ react-native-safe-area-context@5.6.2, react-native-safe-area-context@~5.6.2:
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz#283e006f5b434fb247fcb4be0971ad7473d5c560"
   integrity sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==
 
-react-native-screens@4.23.0, react-native-screens@~4.23.0:
+react-native-screens@4.24.0, react-native-screens@~4.24.0:
+  version "4.24.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.24.0.tgz#dbe8f610b5d2e31f71425d2ea3caaff1b9a7e2de"
+  integrity sha512-SyoiGaDofiyGPFrUkn1oGsAzkRuX1JUvTD9YQQK3G1JGQ5VWkvHgYSsc1K9OrLsDQxN7NmV71O0sHCAh8cBetA==
+  dependencies:
+    react-freeze "^1.0.0"
+    warn-once "^0.1.0"
+
+react-native-screens@~4.23.0:
   version "4.23.0"
   resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.23.0.tgz#81574b1b0cc4ac6c9ed63e46eca7126f37affe86"
   integrity sha512-XhO3aK0UeLpBn4kLecd+J+EDeRRJlI/Ro9Fze06vo1q163VeYtzfU9QS09/VyDFMWR1qxDC1iazCArTPSFFiPw==


### PR DESCRIPTION
# Why

Reverts:
- https://github.com/expo/expo/commit/261916942287d8626a21cf035d98f161a74ada68
- https://github.com/expo/expo/commit/5b34e1db573af84d0503b1db169a181d5852c896

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

1. Clean repo `git clean -fdx`
2. Build expo-go & test it with latest SDK-55 example (with screens bumped to 4.24.0)
4. Build and test bare-expo 
5. Build router-e2e and test 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
