### PR TITLE
[expo-router] add claude settings to router

### DIFF
--- a/packages/expo-router/.claude/settings.json
+++ b/packages/expo-router/.claude/settings.json
@@ -1,0 +1,73 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(CI=1 yarn test:*)",
+      "Bash(yarn test:*)",
+      "Bash(yarn test:types)",
+      "Bash(yarn build:*)",
+      "Bash(yarn lint:*)",
+      "Bash(yarn clean && yarn build)",
+      "Bash(yarn test:rsc:*)",
+      "Bash(yarn)",
+
+      "Bash(cd ../../apps/router-e2e && yarn android:*)",
+      "Bash(cd ../../apps/router-e2e && yarn android:*)",
+      "Bash(cd ../../apps/router-e2e && yarn ios:*)",
+      "Bash(cd ../../apps/router-e2e && yarn start:*)",
+      "Bash(cd ../../apps/router-e2e && yarn export:*)",
+      "Bash(cd ../../apps/router-e2e && cat * | grep -E * | head *)",
+
+      "Bash(et generate-docs-api-data:*)",
+      "Bash(et check-packages:*)",
+      "Bash(et native-unit-tests *)",
+      "Bash(et native-unit-tests * 2>&1)",
+
+      "Bash(pod install)",
+
+      "Bash(gh issue view:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh release view:*)",
+      "Bash(gh release list:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh run list:*)",
+
+      "Bash(gt sync:*)",
+      "Bash(gt checkout:*)",
+      "Bash(gt parent:*)",
+
+      "Bash(git diff:*)",
+      "Bash(git -C * diff:*)",
+      "Bash(git log:*)",
+      "Bash(git -C * log:*)",
+
+      "Bash(adb *)",
+
+      "mcp__playwright__*",
+      "mcp__ide__getDiagnostics",
+
+      "Skill(android-e2e-testing)",
+
+      "Search(**)"
+    ],
+    "deny": [
+      "Bash(git push --force *)",
+      "Bash(rm -rf *)",
+
+      "Bash(npm ci *)",
+      "Bash(npm exec *)",
+      "Bash(npm install *)",
+      "Bash(npm run *)",
+      "Bash(npm start *)",
+      "Bash(npm test *)",
+      "Bash(npm build *)",
+
+      "Bash(npx tsc:*)",
+      "Bash(npx eslint:*)",
+
+      "Bash(cd /Users/* && *)",
+      "Bash(cd ~/* && *)"
+    ],
+    "additionalDirectories": ["../../"]
+  }
+}

--- a/packages/expo-router/.claude/skills/android-e2e-testing/SKILL.md
+++ b/packages/expo-router/.claude/skills/android-e2e-testing/SKILL.md
@@ -1,0 +1,312 @@
+---
+name: android-e2e-testing
+description: Test Expo Router features on Android emulators using ADB. Use after implementing native Android features or when verifying UI behavior on Android.
+user-invokable: true
+---
+
+# Android E2E Testing for Expo Router
+
+Use `adb` to manually test Expo Router screens and components on Android emulators.
+
+## When to Use
+
+- After implementing or modifying native Android UI components (toolbars, tabs, menus)
+- When verifying Jetpack Compose components (`@expo/ui/jetpack-compose`)
+- When running the `native-navigation` or other E2E apps on Android
+- Before opening a PR that touches Android-specific behavior
+
+## Prerequisites
+
+An Android emulator must be running. Prefer **Pixel emulators** over tablet ones for standard phone-sized testing.
+
+```bash
+# Verify emulator is connected
+adb devices
+
+# Check which emulator is running
+adb -s DEVICE_ID emu avd name
+
+# Check screen resolution (important for coordinate calculations)
+adb -s DEVICE_ID shell wm size
+```
+
+## Step 1: Build and Launch
+
+### Router E2E apps
+
+Package name: `dev.expo.routere2e`
+
+Each app in `apps/router-e2e/__e2e__/` has a corresponding `yarn android:<name>` script. Check `apps/router-e2e/package.json` for available scripts.
+
+```bash
+cd apps/router-e2e
+yarn android:[APP_NAME]   # e.g. yarn android:native-navigation
+```
+
+If the app is already built, relaunch it:
+
+```bash
+adb shell monkey -p dev.expo.routere2e -c android.intent.category.LAUNCHER 1
+```
+
+To find the package name of any installed app:
+
+```bash
+adb shell pm list packages | grep -i <keyword>
+```
+
+## Step 2: Navigate Using UI Dump
+
+**CRITICAL: Always use `uiautomator dump` for element coordinates.** Screenshot pixel coordinates have display scaling factors that make them unreliable for `adb shell input tap`. The UI dump provides actual device coordinates.
+
+### Dump the view hierarchy
+
+```bash
+adb shell uiautomator dump /sdcard/ui.xml && adb shell cat /sdcard/ui.xml
+```
+
+This returns XML with every UI element including:
+- `text` — displayed text
+- `content-desc` — accessibility description (useful for icon buttons)
+- `bounds` — position as `[left,top][right,bottom]`
+- `clickable` — whether the element responds to taps
+- `class` — Android view class
+
+### Find and tap an element
+
+1. Search the XML for your target element by `text` or `content-desc`
+2. Extract the `bounds` attribute: `bounds="[left,top][right,bottom]"`
+3. Calculate center: `x = (left + right) / 2`, `y = (top + bottom) / 2`
+4. Tap:
+
+```bash
+adb shell input tap <x> <y>
+```
+
+**Example:** For `bounds="[367,498][714,633]"`:
+- x = (367 + 714) / 2 = 540
+- y = (498 + 633) / 2 = 565
+
+```bash
+adb shell input tap 540 565
+```
+
+### Wait for navigation to settle
+
+After tapping a navigation element, wait before verifying:
+
+```bash
+sleep 1
+```
+
+For slow transitions or heavy screens, use `sleep 2`.
+
+## Step 3: Interact
+
+### Tap items
+
+```bash
+adb shell input tap <x> <y>
+```
+
+### Scroll
+
+```bash
+# Scroll down
+adb shell input swipe 540 1500 540 500 300
+
+# Scroll up
+adb shell input swipe 540 500 540 1500 300
+
+# Scroll further (larger distance)
+adb shell input swipe 540 1500 540 200 500
+```
+
+### Type text
+
+```bash
+adb shell input text "hello%sworld"   # %s = space
+```
+
+### Press hardware buttons
+
+```bash
+adb shell input keyevent 4    # Back
+adb shell input keyevent 3    # Home
+adb shell input keyevent 82   # Menu / React Native dev menu
+```
+
+### Long press
+
+```bash
+adb shell input swipe <x> <y> <x> <y> 1000
+```
+
+## Step 4: Verify
+
+### Visual verification via screenshot
+
+```bash
+adb shell screencap -p /sdcard/screenshot.png && adb pull /sdcard/screenshot.png /tmp/screenshot.png
+```
+
+Then use the `Read` tool to view `/tmp/screenshot.png`. Screenshots are useful for:
+- Confirming visual appearance (colors, layout, styling)
+- Verifying toolbar/tab positioning
+- Checking selection states and visual feedback
+
+**Note:** Use screenshots for *visual* verification only. For element positions and tapping, always use `uiautomator dump`.
+
+### Programmatic verification via UI dump
+
+```bash
+adb shell uiautomator dump /sdcard/ui.xml && adb shell cat /sdcard/ui.xml
+```
+
+Search the XML for expected content:
+- Verify text content appears
+- Check `content-desc` for accessibility labels
+- Confirm element presence after navigation
+- Verify selection states (look for checkmarks, content-desc changes)
+
+### Check for errors
+
+```bash
+# React Native JS errors
+adb logcat -d -s ReactNativeJS:E | tail -20
+
+# Crash logs
+adb logcat -b crash -d
+
+# All recent errors
+adb logcat -d *:E | tail -30
+```
+
+## Step 5: Report Results
+
+After testing, summarize results in a table:
+
+| Test | Result |
+|------|--------|
+| Navigation to screen | PASS/FAIL |
+| Component renders correctly | PASS/FAIL |
+| Interaction works | PASS/FAIL |
+| No JS errors in logcat | PASS/FAIL |
+
+Include details for any failures: what was expected vs what happened, relevant logcat output, and screenshots.
+
+Preferably attach screenshots for features you tested.
+
+## Testing Jetpack Compose Components
+
+Components from `@expo/ui/jetpack-compose` (like `HorizontalFloatingToolbar`, `IconButton`, `Host`) render as Compose views inside React Native. In UI dumps they appear as:
+
+- `androidx.compose.ui.platform.ComposeView` — the Compose container
+- `android.widget.HorizontalScrollView` — inside toolbar layouts
+- `android.widget.Button` — Compose buttons
+- `android.view.View` with `content-desc` — icon buttons with accessibility labels
+
+When testing Compose components:
+1. Look for `content-desc` attributes to identify buttons (e.g., `content-desc="Clear selection"`)
+2. The `ComposeView` wrapper may have different bounds than the inner interactive elements
+3. Tap the interactive element's bounds, not the container's
+
+## Troubleshooting
+
+### uiautomator dump fails or returns empty
+
+This can happen during animations or transitions. Wait and retry:
+
+```bash
+sleep 2 && adb shell uiautomator dump /sdcard/ui.xml && adb shell cat /sdcard/ui.xml
+```
+
+### Tap doesn't register
+
+- Recalculate coordinates from a fresh UI dump — the layout may have shifted
+- Ensure you're tapping a `clickable="true"` element
+- Try tapping the parent element if the child isn't clickable
+
+### App navigated to wrong screen or went to home
+
+- The Back button (`keyevent 4`) can exit the app entirely if on the root screen
+- Use `monkey` command to relaunch: `adb shell monkey -p dev.expo.routere2e -c android.intent.category.LAUNCHER 1`
+- Wait 2 seconds after launch before interacting
+
+### Metro bundler not connecting
+
+```bash
+adb reverse tcp:8081 tcp:8081
+```
+
+### App crashes on launch
+
+```bash
+# Check crash buffer
+adb logcat -b crash -d
+
+# Look for fatal exceptions
+adb logcat -d | grep -A 10 "FATAL EXCEPTION"
+```
+
+### Reload the app
+
+```bash
+# Open React Native dev menu and tap Reload
+adb shell input keyevent 82
+
+# Or force-stop and relaunch
+adb shell am force-stop dev.expo.routere2e && adb shell monkey -p dev.expo.routere2e -c android.intent.category.LAUNCHER 1
+```
+
+## Disable Animations (Recommended for Testing)
+
+Disabling animations prevents flaky UI dumps and makes testing more reliable:
+
+```bash
+adb shell settings put global window_animation_scale 0
+adb shell settings put global transition_animation_scale 0
+adb shell settings put global animator_duration_scale 0
+```
+
+Re-enable when done:
+
+```bash
+adb shell settings put global window_animation_scale 1
+adb shell settings put global transition_animation_scale 1
+adb shell settings put global animator_duration_scale 1
+```
+
+## Complete Example: Testing a Toolbar Screen
+
+```bash
+# 1. Launch app
+adb shell monkey -p dev.expo.routere2e -c android.intent.category.LAUNCHER 1
+sleep 2
+
+# 2. Dump UI to find navigation button
+adb shell uiautomator dump /sdcard/ui.xml && adb shell cat /sdcard/ui.xml
+# Find: content-desc="Android Toolbar" bounds="[367,498][714,633]"
+# Center: (540, 565)
+
+# 3. Navigate to screen
+adb shell input tap 540 565
+sleep 1
+
+# 4. Take screenshot to verify visual appearance
+adb shell screencap -p /sdcard/screenshot.png && adb pull /sdcard/screenshot.png /tmp/screenshot.png
+
+# 5. Dump UI to find toolbar buttons
+adb shell uiautomator dump /sdcard/ui.xml && adb shell cat /sdcard/ui.xml
+# Find buttons by content-desc: "Clear selection", "Select all", "Delete", "Add"
+
+# 6. Test toolbar interactions
+adb shell input tap 457 2233  # "Select all" button center
+sleep 1
+
+# 7. Verify state changed
+adb shell screencap -p /sdcard/screenshot.png && adb pull /sdcard/screenshot.png /tmp/screenshot.png
+
+# 8. Check for errors
+adb logcat -d -s ReactNativeJS:E | tail -20
+```

--- a/packages/expo-router/CLAUDE.md
+++ b/packages/expo-router/CLAUDE.md
@@ -275,13 +275,13 @@ Native tabs (`expo-router/unstable-native-tabs`) provide native bottom tab navig
 
 ### E2E Testing (router-e2e)
 
-The `apps/router-e2e` app contains end-to-end tests and examples for Expo Router. Different apps are in `__e2e__/` subdirectory.
-
 **Running tests/apps:**
 
 - From `packages/@expo/cli`: `yarn test:e2e <PROJECT_NAME>` or `yarn test:playwright <PROJECT_NAME>`
 - Maestro tests (native navigation): `yarn test:e2e` from `apps/router-e2e`
 - Some of the apps are only for manual testing
+
+**Manual Android testing:** Use the `/android-e2e-testing` skill for step-by-step guidance on testing Expo Router screens on Android emulators using ADB. This covers launching E2E apps, navigating via UI dumps, interacting with the app, and verifying results.
 
 ## Verification
 
@@ -291,6 +291,10 @@ After developing a feature, run these commands in `packages/expo-router`:
 2. `yarn build` - Build and verify TypeScript correctness. If you moved or deleted files, run `yarn clean` first.
 3. `yarn test:types` - Verify type correctness in tests
 4. `yarn lint` - Run last to find linting issues
+
+Then test the feature on the simulator using one of the `apps/router-e2e/__e2e__/` projects. For android, use the `/android-e2e-testing` skill for testing on emulators.
+
+Lastly, span a new fresh senior engineer agent to challenge the implementation, how it fits into general expo-router architecture and find edge cases.
 
 When adding dependencies or changing static/server rendering, run e2e tests in `packages/@expo/cli` (time-consuming, run only when necessary).
 


### PR DESCRIPTION
# Why

To improve the work in `expo-router` project

# How

1. Adds `settings.json`, so that agent asks less often
2. Adds skill for testing android features
3. Adds note about reviewing the code to the CLAUDE.md

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
