### PR TITLE
Revert "chore(expo): Re-add `@react-navigation/native` to `bundledNativeModules.json`"

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -11,8 +11,6 @@
   "@react-native-community/viewpager": "5.0.11",
   "@react-native-picker/picker": "2.11.4",
   "@react-native-segmented-control/segmented-control": "2.5.7",
-  "@react-navigation/native": "^7.1.28",
-  "@react-navigation/native-stack": "^7.10.1",
   "@stripe/stripe-react-native": "0.58.0",
   "eslint-config-expo": "~55.0.0",
   "expo-analytics-amplitude": "~11.3.0",


### PR DESCRIPTION
## Summary

Since we're not using `@react-navigation/*` anymore in `expo-go`, @brentvatne pointed out that this means we don't actually test any version of it independent of `expo-router` and can't issue a recommendation via `expo install` for it.

## Set of changes

Reverts expo/expo#43465