### PR TITLE
[android][core] Use `RuntimeSchedulerCallInvoker`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - `NativeArrayBuffer` and `JavaScriptArrayBuffer` arguments now also accept typed arrays. ([#43082](https://github.com/expo/expo/pull/43082) by [@barthap](https://github.com/barthap))
+- [Android] Use the `RuntimeScheduler` to schedule tasks on the JS thread.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - `NativeArrayBuffer` and `JavaScriptArrayBuffer` arguments now also accept typed arrays. ([#43082](https://github.com/expo/expo/pull/43082) by [@barthap](https://github.com/barthap))
-- [Android] Use the `RuntimeScheduler` to schedule tasks on the JS thread.
+- [Android] Use the `RuntimeScheduler` to schedule tasks on the JS thread. ([#43481](https://github.com/expo/expo/pull/43481) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIScheduleTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIScheduleTest.kt
@@ -1,0 +1,46 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package expo.modules.kotlin.jni
+
+import com.google.common.truth.Truth
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+
+class JSIScheduleTest {
+  @Test
+  fun scheduleOnJSThread_should_execute_runnable() = withJSIInterop {
+    evaluateScript("global.counter = 0")
+
+    scheduleOnJSThread {
+      evaluateScript("global.counter = global.counter + 1")
+    }
+
+    val result = evaluateScript("global.counter").getInt()
+    Truth.assertThat(result).isEqualTo(1)
+  }
+
+  @Test
+  fun scheduleOnJSThread_should_execute_multiple_runnables_in_order() = withJSIInterop {
+    evaluateScript("global.values = []")
+
+    scheduleOnJSThread {
+      evaluateScript("global.values.push(1)")
+    }
+    scheduleOnJSThread {
+      evaluateScript("global.values.push(2)")
+    }
+    scheduleOnJSThread {
+      evaluateScript("global.values.push(3)")
+    }
+
+    val result = evaluateScript("global.values.length").getInt()
+    Truth.assertThat(result).isEqualTo(3)
+
+    val first = evaluateScript("global.values[0]").getInt()
+    val second = evaluateScript("global.values[1]").getInt()
+    val third = evaluateScript("global.values[2]").getInt()
+    Truth.assertThat(first).isEqualTo(1)
+    Truth.assertThat(second).isEqualTo(2)
+    Truth.assertThat(third).isEqualTo(3)
+  }
+}

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
@@ -26,6 +26,7 @@ void JSIContext::registerNatives() {
                    makeNativeMethod("evaluateVoidScript", JSIContext::evaluateVoidScript),
                    makeNativeMethod("global", JSIContext::global),
                    makeNativeMethod("createObject", JSIContext::createObject),
+                   makeNativeMethod("scheduleOnJSThread", JSIContext::scheduleOnJSThread),
                    makeNativeMethod("drainJSEventLoop", JSIContext::drainJSEventLoop),
                    makeNativeMethod("setNativeStateForSharedObject",
                                     JSIContext::jniSetNativeStateForSharedObject),
@@ -148,6 +149,13 @@ jni::local_ref<JavaScriptObject::javaobject> JSIContext::global() noexcept {
 
 jni::local_ref<JavaScriptObject::javaobject> JSIContext::createObject() noexcept {
   return runtimeHolder->createObject();
+}
+
+void JSIContext::scheduleOnJSThread(jni::alias_ref<JSRunnable::javaobject> runnable) {
+  auto ref = jni::make_global(runnable);
+  runtimeHolder->jsInvoker->invokeAsync([ref = std::move(ref)](jsi::Runtime &) {
+    ref->run();
+  });
 }
 
 void JSIContext::drainJSEventLoop() {

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
@@ -10,6 +10,7 @@
 #include "JSReferencesCache.h"
 #include "JNIDeallocator.h"
 #include "ThreadSafeJNIGlobalRef.h"
+#include "javaclasses/JSRunnable.h"
 
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
@@ -113,6 +114,11 @@ public:
     jni::alias_ref<JSIContext::javaobject> javaObject,
     int objectId
   );
+
+  /**
+   * Schedules a lambda to run on the JS thread via the RuntimeScheduler.
+   */
+  void scheduleOnJSThread(jni::alias_ref<JSRunnable::javaobject> runnable);
 
   /**
    * Exposes a `JavaScriptRuntime::drainJSEventLoop` function to Kotlin

--- a/packages/expo-modules-core/android/src/main/cpp/installers/MainRuntimeInstaller.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/installers/MainRuntimeInstaller.cpp
@@ -8,6 +8,8 @@
 #if IS_NEW_ARCHITECTURE_ENABLED
 
 #include "BridgelessJSCallInvoker.h"
+#include <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
+#include <react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h>
 
 #endif
 
@@ -54,11 +56,23 @@ jni::local_ref<JSIContext::javaobject> MainRuntimeInstaller::install(
   jni::alias_ref<JNIDeallocator::javaobject> jniDeallocator,
   jni::alias_ref<react::JRuntimeExecutor::javaobject> runtimeExecutor
 ) noexcept {
+  auto *runtime = reinterpret_cast<jsi::Runtime *>(jsRuntimePointer);
+
+  std::shared_ptr<react::CallInvoker> callInvoker;
+  std::shared_ptr<react::RuntimeScheduler> runtimeScheduler;
+
+  if (auto binding = react::RuntimeSchedulerBinding::getBinding(*runtime)) {
+    runtimeScheduler = binding->getRuntimeScheduler();
+    callInvoker = std::make_shared<react::RuntimeSchedulerCallInvoker>(runtimeScheduler);
+  } else {
+    callInvoker = std::make_shared<BridgelessJSCallInvoker>(runtimeExecutor->cthis()->get());
+  }
+
   auto jsiContext = createJSIContext(
     runtimeContextHolder,
     jsRuntimePointer,
     jniDeallocator,
-    std::make_shared<BridgelessJSCallInvoker>(runtimeExecutor->cthis()->get())
+    callInvoker
   );
 
   prepareRuntime(

--- a/packages/expo-modules-core/android/src/main/cpp/javaclasses/JSRunnable.h
+++ b/packages/expo-modules-core/android/src/main/cpp/javaclasses/JSRunnable.h
@@ -1,0 +1,20 @@
+// Copyright © 2025-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+
+namespace jni = facebook::jni;
+
+namespace expo {
+
+struct JSRunnable : public jni::JavaClass<JSRunnable> {
+  constexpr static auto kJavaDescriptor = "Ljava/lang/Runnable;";
+
+  void run() const {
+    static auto method = javaClassStatic()->getMethod<void()>("run");
+    method(self());
+  }
+};
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
@@ -44,6 +44,11 @@ class JSIContext @DoNotStrip internal constructor(
   external fun createObject(): JavaScriptObject
 
   /**
+   * Schedules a block to run on the JS thread via the RuntimeScheduler.
+   */
+  external fun scheduleOnJSThread(runnable: Runnable)
+
+  /**
    * Drains the JavaScript VM internal Microtask (a.k.a. event loop) queue.
    */
   external fun drainJSEventLoop()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/runtime/MainRuntime.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/runtime/MainRuntime.kt
@@ -49,8 +49,11 @@ class MainRuntime(
    * Runs a code block on the JavaScript thread.
    */
   override fun schedule(block: () -> Unit) {
-    // TODO(@lukmccall): start using RuntimeScheduler
-    reactContext?.runOnJSQueueThread(block)
+    if (isJSIContextInitialized()) {
+      jsiContext.scheduleOnJSThread(block)
+    } else {
+      reactContext?.runOnJSQueueThread(block)
+    }
   }
 
   /**


### PR DESCRIPTION
# Why
Closes #43474
Follow up of #40473. 
We are currently still using `runOnJSQueueThread` on android which posts work directly to the JS thread, bypassing the scheduler. The causes the problem mentioned in the issue where react never flushes state updates because it is unaware of them. We should use `RuntimeSchedulerCallInvoker` instead of `BridgelessJSCallInvoker` to match the iOS behaviour. 

# How
- Add an new native method `scheduleOnJSThread`
- Expose `Runnable` to c++ 
- Create an instance of `RuntimeSchedulerCallInvoker` in `install` and pass that to the `jsiContext`
- Use it in the `MainRuntime`s `schedule` method

# Test Plan
Bare expo behaves as normal
Tested in the provided repro.
