### PR TITLE
[template-default] remove expo/vector-icons from package.json

### DIFF
--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -12,7 +12,6 @@
     "lint": "expo lint"
   },
   "dependencies": {
-    "@expo/vector-icons": "^15.0.2",
     "@react-navigation/bottom-tabs": "^7.7.3",
     "@react-navigation/elements": "^2.8.1",
     "@react-navigation/native": "^7.1.28",

--- a/templates/expo-template-default/src/components/app-tabs.web.tsx
+++ b/templates/expo-template-default/src/components/app-tabs.web.tsx
@@ -63,7 +63,7 @@ export function CustomTabList(props: TabListProps) {
 
         <ExternalLink href="https://docs.expo.dev" asChild>
           <Pressable style={styles.externalPressable}>
-            <ThemedText type="link">Doc</ThemedText>
+            <ThemedText type="link">Docs</ThemedText>
             <SymbolView
               tintColor={colors.text}
               name={{ ios: 'arrow.up.right.square', web: 'link' }}


### PR DESCRIPTION
# Why

the default template doesn't depend on `@expo/vector-icons` so it can be removed from package.json

# How

- remove the dep

# Test Plan

- create-expo-app with the template, run in on all 3 platforms

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
