### PR TITLE
fix(expo-router): update RNSBottomTabs* class names to RNSTabs* for react-native-screens

### DIFF
--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeNavigation.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeNavigation.swift
@@ -48,7 +48,7 @@ internal class LinkPreviewNativeNavigation {
     guard let stackOrTabView else {
       return
     }
-    if let tabView = stackOrTabView as? RNSBottomTabsScreenComponentView {
+    if let tabView = stackOrTabView as? RNSTabsScreenComponentView {
       let newTabKeys = tabPath?.path.map { $0.newTabKey } ?? []
       // The order is important here. findStackViewWithScreenIdInSubViews must be called
       // even if screenId is nil to compute the tabChangeCommands.
@@ -150,7 +150,7 @@ internal class LinkPreviewNativeNavigation {
     if let result =
       enumeratedViews
       .first(where: { _, view in
-        guard let tabView = view as? RNSBottomTabsScreenComponentView, let tabKey = tabView.tabKey
+        guard let tabView = view as? RNSTabsScreenComponentView, let tabKey = tabView.tabKey
         else {
           return false
         }
@@ -162,10 +162,10 @@ internal class LinkPreviewNativeNavigation {
   }
 
   private func getTabBarControllerFromTabView(view: UIView) -> UITabBarController? {
-    if let tabScreenView = view as? RNSBottomTabsScreenComponentView {
+    if let tabScreenView = view as? RNSTabsScreenComponentView {
       return tabScreenView.reactViewController()?.tabBarController as? UITabBarController
     }
-    if let tabHostView = view as? RNSBottomTabsHostComponentView {
+    if let tabHostView = view as? RNSTabsHostComponentView {
       return tabHostView.controller as? UITabBarController
     }
     return nil
@@ -182,7 +182,7 @@ internal class LinkPreviewNativeNavigation {
         if view.screenIds.contains(screenId) {
           return view
         }
-      } else if let tabView = nextResponder as? RNSBottomTabsScreenComponentView {
+      } else if let tabView = nextResponder as? RNSTabsScreenComponentView {
         if let tabKey = tabView.tabKey, tabKeys.contains(tabKey) {
           return tabView
         }


### PR DESCRIPTION
`LinkPreviewNativeNavigation.swift` casts to `RNSBottomTabsScreenComponentView` and `RNSBottomTabsHostComponentView` in four places. Both got renamed in react-native-screens [PR #3658](https://github.com/software-mansion/react-native-screens/pull/3658) to `RNSTabsScreenComponentView` and `RNSTabsHostComponentView`. Build fails with `cannot find type in scope`.

```swift
// before
if let tabView = stackOrTabView as? RNSBottomTabsScreenComponentView {
if let tabHostView = view as? RNSBottomTabsHostComponentView {

// after
if let tabView = stackOrTabView as? RNSTabsScreenComponentView {
if let tabHostView = view as? RNSTabsHostComponentView {
```

Rename landed in stable `4.24.0`, not just nightly. Tested on SDK 56 canary, builds clean.