### PR TITLE
Fix apps/expo-go build

### DIFF
--- a/apps/expo-go/android/app/build.gradle
+++ b/apps/expo-go/android/app/build.gradle
@@ -35,7 +35,6 @@ apply plugin: 'com.facebook.react'
 react {
   def projectRoot = rootDir.getAbsoluteFile().getParentFile().getAbsolutePath()
 
-  entryFile = file(["node", "-e", "require('expo/scripts/resolveAppEntry')", projectRoot, "android", "absolute"].execute(null, rootDir).text.trim())
   reactNativeDir = new File(projectRoot, "../../react-native-lab/react-native/packages/react-native")
   codegenDir = new File(projectRoot, "../../react-native-lab/react-native/packages/react-native-codegen")
 

--- a/apps/expo-go/app.json
+++ b/apps/expo-go/app.json
@@ -1,0 +1,38 @@
+{
+  "expo": {
+    "name": "expo-home",
+    "description": "",
+    "slug": "home",
+    "privacy": "unlisted",
+    "sdkVersion": "55.0.0",
+    "version": "55.0.0",
+    "platforms": ["ios", "android"],
+    "primaryColor": "#cccccc",
+    "icon": "https://s3.amazonaws.com/exp-brand-assets/ExponentEmptyManifest_192.png",
+    "updates": {
+      "checkAutomatically": "NEVER",
+      "fallbackToCacheTimeout": 0,
+      "url": "https://u.expo.dev/6b6c6660-df76-11e6-b9b4-59d1587e6774"
+    },
+    "userInterfaceStyle": "automatic",
+    "ios": {
+      "supportsTablet": true,
+      "bundleIdentifier": "host.exp.exponent"
+    },
+    "newArchEnabled": true,
+    "android": {
+      "package": "host.exp.exponent"
+    },
+    "androidStatusBar": {
+      "barStyle": "dark-content"
+    },
+    "scheme": "exp",
+    "jsEngine": "hermes",
+    "extra": {
+      "eas": {
+        "projectId": "6b6c6660-df76-11e6-b9b4-59d1587e6774"
+      }
+    },
+    "runtimeVersion": "55.0.0"
+  }
+}


### PR DESCRIPTION
# Why

Commit 810063b broke the `apps/expo-go` build by removing `app.json` (along with other files considered leftover).

# How

- Restored `apps/expo-go/app.json` with the correct configuration
- Removed the now-unnecessary `entryFile` line from `apps/expo-go/android/app/build.gradle`

# Test Plan

Verify that the `apps/expo-go` Android build completes successfully, following [this guide](https://github.com/expo/expo/tree/main/apps/expo-go).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
