### PR TITLE
[docs] Add FAQPage JSON-LD structured data across FAQ sections

### DIFF
--- a/docs/constants/structured-data.test.ts
+++ b/docs/constants/structured-data.test.ts
@@ -1,4 +1,4 @@
-import { buildBreadcrumbListSchema } from './structured-data';
+import { buildBreadcrumbListSchema, buildFAQPageSchema } from './structured-data';
 
 describe(buildBreadcrumbListSchema, () => {
   it('returns null for empty array', () => {
@@ -64,5 +64,51 @@ describe(buildBreadcrumbListSchema, () => {
 
     const positions = result?.itemListElement.map((el: { position: number }) => el.position);
     expect(positions).toEqual([1, 2, 3]);
+  });
+});
+
+describe(buildFAQPageSchema, () => {
+  it('returns null for empty array', () => {
+    expect(buildFAQPageSchema([])).toBeNull();
+  });
+
+  it('returns valid FAQPage for a single item', () => {
+    const result = buildFAQPageSchema([
+      { question: 'What is Expo?', answer: 'A framework for React Native.' },
+    ]);
+
+    expect(result).toEqual({
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: [
+        {
+          '@type': 'Question',
+          name: 'What is Expo?',
+          acceptedAnswer: { '@type': 'Answer', text: 'A framework for React Native.' },
+        },
+      ],
+    });
+  });
+
+  it('returns valid FAQPage for multiple items', () => {
+    const result = buildFAQPageSchema([
+      { question: 'Q1?', answer: 'A1' },
+      { question: 'Q2?', answer: 'A2' },
+      { question: 'Q3?', answer: 'A3' },
+    ]);
+
+    expect(result?.mainEntity).toHaveLength(3);
+    expect(result?.mainEntity[1]).toEqual({
+      '@type': 'Question',
+      name: 'Q2?',
+      acceptedAnswer: { '@type': 'Answer', text: 'A2' },
+    });
+  });
+
+  it('preserves answer text as-is', () => {
+    const answer = 'Use `npx expo install` to add packages.\nSee https://docs.expo.dev for more.';
+    const result = buildFAQPageSchema([{ question: 'How?', answer }]);
+
+    expect(result?.mainEntity[0].acceptedAnswer.text).toBe(answer);
   });
 });

--- a/docs/constants/structured-data.ts
+++ b/docs/constants/structured-data.ts
@@ -20,6 +20,24 @@ export function buildBreadcrumbListSchema(items: BreadcrumbItem[]) {
   };
 }
 
+type FAQItem = { question: string; answer: string };
+
+export function buildFAQPageSchema(items: FAQItem[]) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: items.map(item => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: { '@type': 'Answer', text: item.answer },
+    })),
+  };
+}
+
 export const websiteSchema = {
   '@context': 'https://schema.org',
   '@type': 'WebSite',

--- a/docs/pages/bare/overview.mdx
+++ b/docs/pages/bare/overview.mdx
@@ -14,6 +14,7 @@ import { Rocket02Icon } from '@expo/styleguide-icons/outline/Rocket02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
+import { FAQ } from '~/ui/components/FAQ';
 import { CODE } from '~/ui/components/Text';
 
 If you have a React Native app that doesn't use any Expo tools, you might be wondering what Expo can provide for you, why you might want to use Expo tools and services, and how to get started.
@@ -144,6 +145,8 @@ The following helps with your project's long term maintainability, native code m
 
 ## Common questions
 
+<FAQ>
+
 <Collapsible summary="How long will it take to adopt Expo in my existing React Native project?">
 
 Adopting Expo doesn't have to be done in one step. You can start with the _quick wins_ and then move on to more complex parts. You can also pick and choose which features you want to adopt based on what is most helpful for your project.
@@ -207,3 +210,5 @@ Yes, you can install and use third-party libraries that require native projects 
 You can continue using any navigation library in your project. However, we recommend using Expo Router for all the benefits [described here](/router/introduction).
 
 </Collapsible>
+
+</FAQ>

--- a/docs/pages/bare/using-expo-cli.mdx
+++ b/docs/pages/bare/using-expo-cli.mdx
@@ -9,6 +9,7 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
+import { FAQ } from '~/ui/components/FAQ';
 import { Terminal } from '~/ui/components/Snippet';
 import { DEMI } from '~/ui/components/Text';
 
@@ -71,6 +72,8 @@ When building your project, you can choose a device or simulator by using the `-
 
 ## Common questions
 
+<FAQ>
+
 <Collapsible summary="Can I use Expo CLI without installing the Expo Modules API?">
 
 Expo Modules API is also installed when you install the `expo` package with `npx install-expo-modules`. If you want to try out Expo CLI for now without installing Expo Modules API, install the `expo` package with `npm install` and then configure the **react-native.config.js** to exclude the package from autolinking:
@@ -98,6 +101,8 @@ module.exports = {
 Yes! Refer to the [Customized Prebuild Example repository](https://github.com/byCedric/custom-prebuild-example) for more information.
 
 </Collapsible>
+
+</FAQ>
 
 ## Next steps
 

--- a/docs/pages/build/introduction.mdx
+++ b/docs/pages/build/introduction.mdx
@@ -9,6 +9,7 @@ import { Cube01Icon } from '@expo/styleguide-icons/outline/Cube01Icon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
+import { FAQ } from '~/ui/components/FAQ';
 import { Terminal } from '~/ui/components/Snippet';
 
 **EAS Build** is a hosted Expo Application Services (EAS) service that builds app binaries (also called [standalone apps](/more/glossary-of-terms/#standalone-app)) for your Expo and React Native projects.
@@ -51,6 +52,8 @@ This command sends your project to EAS Build and produces installable binaries f
 | Debugging native code locally                                                        | <NoIcon />     |
 
 ## Frequently asked questions
+
+<FAQ>
 
 <Collapsible summary="How do I share builds with my team before submitting to app stores?">
 
@@ -110,6 +113,8 @@ EAS Build supports [builds from GitHub](/build/building-from-github/) and [build
 Android builds run on Linux runners hosted in Google Cloud Platform, and iOS builds run on macOS runners hosted in Expo's macOS cloud. See [Build server infrastructure](/build-reference/infrastructure/).
 
 </Collapsible>
+
+</FAQ>
 
 ## Get started
 

--- a/docs/pages/eas-update/codepush.mdx
+++ b/docs/pages/eas-update/codepush.mdx
@@ -4,6 +4,7 @@ description: A guide to help migrate from CodePush to EAS Update.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import { FAQ } from '~/ui/components/FAQ';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
@@ -69,6 +70,8 @@ After successfully submitting your app, users will be able to download and use t
 
 ## Common questions
 
+<FAQ>
+
 <Collapsible summary="How do I release mandatory/critical updates with EAS Update?">
 
 CodePush CLI has a `--mandatory` flag that allows you to release mandatory updates. You can build this functionality with EAS Update but there is no specific flag for it.
@@ -129,6 +132,8 @@ Yes, EAS Update supports end-to-end code signing. It is available for EAS Produc
 - Each update and build created with EAS is associated with a [fingerprint](/versions/latest/sdk/fingerprint/). You can diff these fingerprints through the website UI or with `eas fingerprint:compare` to see what changed in the native runtime of your app between your builds and updates, to understand build/update compatibility, and guide your decision about when to bump the [`runtimeVersion`](/eas-update/runtime-versions/).
 
 </Collapsible>
+
+</FAQ>
 
 ## Conceptual differences between CodePush and EAS Update
 

--- a/docs/pages/eas-update/integration-in-existing-native-apps.mdx
+++ b/docs/pages/eas-update/integration-in-existing-native-apps.mdx
@@ -5,6 +5,7 @@ description: Learn how to integrate EAS Update into your existing native Android
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import { FAQ } from '~/ui/components/FAQ';
 import { Terminal, DiffBlock } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
@@ -496,6 +497,8 @@ public class CustomViewController: UIViewController, AppControllerDelegate {
 
 ## Common questions
 
+<FAQ>
+
 <Collapsible summary="How long will this take to add to my app?">
 
 Assuming you are using the latest version of React Native supported by the Expo SDK, and you are comfortable with the React Native integration in your native projects, then you can likely integrate EAS Update in a similar amount of time as it would take you to integrate with a tool like CodePush or Sentry.
@@ -509,3 +512,5 @@ The most important factor is the React Native version that your app uses. If you
 To learn more, see [Migrating from CodePush](/eas-update/codepush/) guide.
 
 </Collapsible>
+
+</FAQ>

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -13,6 +13,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
+import { FAQ } from '~/ui/components/FAQ';
 import { Terminal } from '~/ui/components/Snippet';
 
 **EAS Update** is a cloud service from EAS (Expo Application Services) that serves updates for projects using the [`expo-updates`](/versions/latest/sdk/updates/) library.
@@ -89,6 +90,8 @@ If an update isn't performing as expected, you can [republish](/eas-update/eas-c
 For scenarios marked with <NoIcon />, use [EAS Build](/build/introduction/) to create and submit a new app binary.
 
 ## Frequently asked questions (FAQ)
+
+<FAQ>
 
 <Collapsible summary="What guidelines must I follow when publishing updates?" open>
 
@@ -167,6 +170,8 @@ The Classic Updates service was available before December 2021 and is now deprec
 We recommend transitioning to EAS Update or using a [self-hosted update service](/versions/latest/sdk/updates/).
 
 </Collapsible>
+
+</FAQ>
 
 ## Get started
 

--- a/docs/pages/eas/hosting/introduction.mdx
+++ b/docs/pages/eas/hosting/introduction.mdx
@@ -10,6 +10,7 @@ import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
+import { FAQ } from '~/ui/components/FAQ';
 import { Terminal } from '~/ui/components/Snippet';
 
 **EAS Hosting** is a service from EAS (Expo Application Services) for quickly deploying your web projects built using [Expo Router](/router/introduction/) and React Native web. It seamlessly integrates with the Expo CLI, allowing you to automate the deployment of API routes, server functions, and server-side assets.
@@ -56,6 +57,8 @@ EAS Hosting addresses these limitations by providing a unified deployment experi
 | Already have established web infrastructure that meets your needs                                                                                       | <NoIcon />     |
 
 ## Frequently asked questions (FAQ)
+
+<FAQ>
 
 <Collapsible summary="What web output modes can I use with EAS Hosting?">
 
@@ -133,6 +136,8 @@ jobs:
 For more information, see the [Web deployments with EAS Workflows](/eas/hosting/workflows/).
 
 </Collapsible>
+
+</FAQ>
 
 ## Get started
 

--- a/docs/pages/eas/metadata/index.mdx
+++ b/docs/pages/eas/metadata/index.mdx
@@ -9,6 +9,7 @@ import { EasMetadataIcon } from '@expo/styleguide-icons/custom/EasMetadataIcon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
+import { FAQ } from '~/ui/components/FAQ';
 import { Terminal } from '~/ui/components/Snippet';
 
 > **important** **EAS Metadata** is in beta and subject to breaking changes.
@@ -58,6 +59,8 @@ This dynamic store config allows you to gather information from other places lik
 
 ## Frequently asked questions (FAQ)
 
+<FAQ>
+
 <Collapsible summary="Can I use EAS Metadata with Google Play Store?" open>
 
 We are committed to EAS Metadata and will expand functionality over time. This also means that not all functionality is implemented in EAS Metadata. The Google Play Store is one of those features currently not implemented.
@@ -80,6 +83,8 @@ When using EAS Metadata and editing something in the app store dashboards, make 
 You'll need to authenticate with the app store before EAS Metadata can access the information. If you are working with a large corporate account, you might not have permission to use all functionality of EAS Metadata. While you can use EAS Metadata in these cases, it's often more challenging due to the security restrictions.
 
 </Collapsible>
+
+</FAQ>
 
 ## Get started
 

--- a/docs/pages/eas/workflows/introduction.mdx
+++ b/docs/pages/eas/workflows/introduction.mdx
@@ -11,6 +11,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { DownloadSlide } from '~/ui/components/DownloadSlide';
+import { FAQ } from '~/ui/components/FAQ';
 import { Terminal } from '~/ui/components/Snippet';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
@@ -81,6 +82,8 @@ Run on-demand using `eas workflow:run` command. Supports parameterized inputs fo
 
 ## Frequently asked questions (FAQ)
 
+<FAQ>
+
 <Collapsible summary="How do workflows compare to other CI services?" open>
 
 EAS Workflows are designed to help you and your team release your app. It comes preconfigured with pre-packaged job types that can build, submit, update, run Maestro tests, and more. All job types run on EAS, so you'll only have to manage one set of YAML files, and all the artifacts from your job runs will appear on [expo.dev](https://expo.dev/).
@@ -148,6 +151,8 @@ Share the following slide in your next team meeting to discuss what EAS Workflow
   imageUrl="/static/images/eas-workflows/eas-worfklows-slide.png"
 />
 </Collapsible>
+
+</FAQ>
 
 ## Get started
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -5,6 +5,7 @@ description: Learn how to set up and use pre-packaged jobs in EAS Workflows.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import { FAQ } from '~/ui/components/FAQ';
 
 Pre-packaged jobs are ready-to-use workflow jobs that help you automate common tasks like building, submitting, and testing your app. They provide a standardized way to handle these operations without having to write custom job configurations from scratch. This guide covers the available pre-packaged jobs and how to use them in your workflows.
 
@@ -1657,6 +1658,8 @@ jobs:
 
 ### Common questions
 
+<FAQ>
+
 <Collapsible summary="When to use and when not to use repack?">
 
 Repack job is suitable for the following use cases:
@@ -1670,6 +1673,8 @@ Repack job is not suitable for the following use cases:
 - Production builds that require builds to go through the complete pipeline for correct symbolication and app signing
 
 </Collapsible>
+
+</FAQ>
 
 #### Parameters
 

--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -517,16 +517,16 @@ While DOM components help with migration and moving quickly, we recommend using 
 
 <FAQ>
 
-### How to obtain a Secure Context in DOM components?
+<Collapsible summary="How to obtain a Secure Context in DOM components?">
 
 Some Web APIs require a [Secure Context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) function correctly. For example, the [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API) is only available in secure contexts. A secure context means that remote resources must be served over HTTPS. [Learn more about features restricted to secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts).
 
 To ensure your DOM components run within a secure context, follow these guidelines:
 
 - **Release builds**: DOM components served using the `file://` scheme are provided a secure context by default.
-- **Debug builds**: When using development servers (which default to the `http:// `protocol), you can use [tunneling](/more/expo-cli/#tunneling) to serve DOM components over HTTPS.
+- **Debug builds**: When using development servers (which default to the `http://` protocol), you can use [tunneling](/more/expo-cli/#tunneling) to serve DOM components over HTTPS.
 
-<Collapsible summary="Example commands to tunnel DOM components over HTTPS">
+**Example commands to tunnel DOM components over HTTPS:**
 
 <Terminal
   cmd={[

--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -5,6 +5,7 @@ description: Learn about rendering React DOM components in Expo native apps usin
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import { FAQ } from '~/ui/components/FAQ';
 import { Terminal } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
@@ -514,6 +515,8 @@ While DOM components help with migration and moving quickly, we recommend using 
 
 ## Common questions
 
+<FAQ>
+
 ### How to obtain a Secure Context in DOM components?
 
 Some Web APIs require a [Secure Context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) function correctly. For example, the [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API) is only available in secure contexts. A secure context means that remote resources must be served over HTTPS. [Learn more about features restricted to secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts).
@@ -543,3 +546,5 @@ To ensure your DOM components run within a secure context, follow these guidelin
 />
 
 </Collapsible>
+
+</FAQ>

--- a/docs/pages/guides/expo-ui-swift-ui/index.mdx
+++ b/docs/pages/guides/expo-ui-swift-ui/index.mdx
@@ -12,6 +12,7 @@ import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import { FAQ } from '~/ui/components/FAQ';
 import { Terminal } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { CODE } from '~/ui/components/Text';
@@ -461,6 +462,8 @@ Use `VStack` with `alignment="leading"` for list items with title and subtitle.
 
 ## Common questions
 
+<FAQ>
+
 <Collapsible summary="Can I use flexbox or other styles in SwiftUI components?">
 
 Flexbox styles can be applied to the `Host` component itself. Once you're inside the SwiftUI context, however, [`Yoga`](https://www.yogalayout.dev/) is not available &mdash; layouts should be defined using `<HStack>` and `<VStack>` instead.
@@ -503,6 +506,8 @@ We recommend keeping SwiftUI layouts self-contained. Interop is possible, but it
 Because React's promise of _"learn once, write anywhere"_, it now extends to SwiftUI and Jetpack Compose. With Expo UI, you can apply your SwiftUI knowledge to build apps that run in the React Native ecosystem, extend to the Web through [DOM components](/guides/dom-components/), and even integrate [2D](https://shopify.github.io/react-native-skia/) and [3D](https://github.com/wcandillon/react-native-webgpu) rendering. The system is flexible enough that different parts of your app can use different approaches &mdash; giving you seamless integration at the component level.
 
 </Collapsible>
+
+</FAQ>
 
 ## Additional resources
 

--- a/docs/pages/modules/overview.mdx
+++ b/docs/pages/modules/overview.mdx
@@ -9,6 +9,7 @@ import { Settings01Icon } from '@expo/styleguide-icons/outline/Settings01Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
+import { FAQ } from '~/ui/components/FAQ';
 
 ## What is the Expo Modules API
 
@@ -17,6 +18,8 @@ The Expo Modules API allows you to write Swift and Kotlin to add new capabilitie
 We believe that using the Expo Modules API makes building and maintaining nearly all kinds of React Native modules about as easy as it can be, and we think that the Expo Modules API is the best choice for the vast majority of developers building native modules for their apps.
 
 ### Common questions
+
+<FAQ>
 
 <Collapsible summary="Do I need to know the Expo Modules API to build an Expo / React Native app?">
 
@@ -79,6 +82,8 @@ The Expo Modules API has experimental support for macOS and tvOS. See [Additiona
 Learn more about this in the [Integrate an existing library](/modules/existing-library/) tutorial.
 
 </Collapsible>
+
+</FAQ>
 
 ## Next steps
 

--- a/docs/pages/router/advanced/custom-tabs.mdx
+++ b/docs/pages/router/advanced/custom-tabs.mdx
@@ -8,6 +8,7 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
+import { FAQ } from '~/ui/components/FAQ';
 import { FileTree } from '~/ui/components/FileTree';
 import { DiffBlock } from '~/ui/components/Snippet';
 
@@ -274,6 +275,8 @@ The `TabSlot` accepts a `renderFn` property. This function can be used to overri
 
 ## Common questions
 
+<FAQ>
+
 <Collapsible summary="How do I create multiple tabs for the same route?">
 
 <FileTree
@@ -312,3 +315,5 @@ You can provide a custom renderer to `TabSlot` to customize how it renders a scr
 A `TabTrigger` with a relative href is relative to the local path name `Tabs` was rendered on. This is different from normal relative hrefs which are relative to the current displayed route. For example, the `<TabTrigger href="./profile" />` will resolve to `/directory/profile`, even when the `/directory/page` route is showing. Expo recommends against using relative hrefs.
 
 </Collapsible>
+
+</FAQ>

--- a/docs/pages/router/introduction.mdx
+++ b/docs/pages/router/introduction.mdx
@@ -13,6 +13,7 @@ import { YoutubeIcon } from '@expo/styleguide-icons/outline/YoutubeIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
+import { FAQ } from '~/ui/components/FAQ';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
@@ -89,6 +90,8 @@ If you are looking to use [React Native Navigation by Wix](https://github.com/wi
 
 ## Common questions
 
+<FAQ>
+
 <Collapsible summary="Expo Router versus Expo versus React Native CLI">
 
 Historically, React Native has been non prescriptive about how apps should be built which is similar to using React without a modern web framework. Expo Router is an opinionated framework for React Native, similar to how Remix and Next.js are opinionated frameworks for web-only React.
@@ -132,6 +135,8 @@ If file-based routing isn't right for your project, you can drop down to React N
 Basic static rendering (SSG) is supported in Expo Router. Server-side rendering currently requires custom infrastructure to set up.
 
 </Collapsible>
+
+</FAQ>
 
 ## Next steps
 

--- a/docs/pages/router/web/data-loaders.mdx
+++ b/docs/pages/router/web/data-loaders.mdx
@@ -5,6 +5,7 @@ isAlpha: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import { FAQ } from '~/ui/components/FAQ';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
@@ -366,6 +367,8 @@ export default function Post() {
 
 ## Common questions
 
+<FAQ>
+
 <Collapsible summary="Can I use data loaders without server rendering?">
 
 Yes. Data loaders work with both static rendering (`web.output: 'static'`) and server rendering (`web.output: 'server'`).
@@ -377,3 +380,5 @@ Yes. Data loaders work with both static rendering (`web.output: 'static'`) and s
 No, `loader` exports are dropped from the client bundle. However, if another module contains server-side logic and is imported by client-side code outside of the **src/app** directory, it may be included in your client-side bundle.
 
 </Collapsible>
+
+</FAQ>

--- a/docs/pages/router/web/server-rendering.mdx
+++ b/docs/pages/router/web/server-rendering.mdx
@@ -5,6 +5,7 @@ isAlpha: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import { FAQ } from '~/ui/components/FAQ';
 import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
@@ -204,6 +205,8 @@ EAS Hosting supports server rendering out of the box. Export your app and deploy
 
 ## Common questions
 
+<FAQ>
+
 <Collapsible summary="Can I use data loaders with server rendering?">
 
 Yes. Server rendering works with [data loaders](/router/web/data-loaders) to fetch data on the server before rendering.
@@ -227,3 +230,5 @@ Caching is handled at the server or CDN level. Configure your deployment platfor
 Yes. [API routes](/router/web/api-routes/) work independently of the rendering mode. They are always executed on the server.
 
 </Collapsible>
+
+</FAQ>

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -11,6 +11,7 @@ import { Settings01Icon } from '@expo/styleguide-icons/outline/Settings01Icon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+import { FAQ } from '~/ui/components/FAQ';
 import { Terminal } from '~/ui/components/Snippet';
 
 **EAS Submit** is a hosted service from EAS (Expo Application Services) for submitting Android and iOS binaries directly to the Google Play Store and Apple App Store without opening the [Google Play Console](https://play.google.com/console), or downloading the [Transporter app](https://apps.apple.com/us/app/transporter/id1450874784).
@@ -69,6 +70,8 @@ Build and submit in one step:
 | Do not have a store listing configured yet for Google Play Store                                                                                           | <NoIcon />     |
 
 ## Frequently asked questions (FAQ)
+
+<FAQ>
 
 <Collapsible summary="Can I submit builds that were not built with EAS Build?">
 
@@ -148,6 +151,8 @@ To understand why your EAS Submit submission failed, open the submission details
 - Look for ["Build Annotations" bubble](https://expo.dev/changelog/2023-12-01-build-annotations) if there is one. These highlight common failure reasons and suggested fixes directly in the logs.
 
 </Collapsible>
+
+</FAQ>
 
 ## Get started
 

--- a/docs/pages/versions/unversioned/sdk/expo.mdx
+++ b/docs/pages/versions/unversioned/sdk/expo.mdx
@@ -10,6 +10,7 @@ platforms: ['android', 'ios', 'tvos', 'web', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { Collapsible } from '~/ui/components/Collapsible';
+import { FAQ } from '~/ui/components/FAQ';
 import { CODE } from '~/ui/components/Text';
 
 ## Installation
@@ -143,6 +144,8 @@ Remove any custom polyfills for `structuredClone` to prevent bloat. Refer to the
 
 Some common questions about using the `expo` package in your project.
 
+<FAQ>
+
 <Collapsible summary={<><CODE>rootRegisterComponent</CODE> setup for existing React Native projects</>}>
 
 If you are managing your React Native project's native directories (**android** and **ios**) manually, you need to follow the instructions below to set up the `registerRootComponent` function. This is necessary for the Expo modules to work correctly.
@@ -192,3 +195,5 @@ registerRootComponent(App);
 **For projects that use [Expo Router](/router/introduction/)**, you can create a custom entry point by following these steps from [Expo Router's installation guide](/router/installation/#custom-entry-point-to-initialize-and-load). To use the top-level **src** directory in your Expo Router project, see [src directory reference](/router/reference/src-directory/) for more information.
 
 </Collapsible>
+
+</FAQ>

--- a/docs/pages/versions/v53.0.0/sdk/expo.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/expo.mdx
@@ -10,6 +10,7 @@ platforms: ['android', 'ios', 'tvos', 'web', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { Collapsible } from '~/ui/components/Collapsible';
+import { FAQ } from '~/ui/components/FAQ';
 import { CODE } from '~/ui/components/Text';
 
 ## Installation
@@ -112,6 +113,8 @@ console.log(new URL('http://🥓').toString());
 
 Some common questions about using the `expo` package in your project.
 
+<FAQ>
+
 <Collapsible summary={<><CODE>rootRegisterComponent</CODE> setup for existing React Native projects</>}>
 
 If you are managing your React Native project's native directories (**android** and **ios**) manually, you need to follow the instructions below to set up the `registerRootComponent` function. This is necessary for the Expo modules to work correctly.
@@ -161,3 +164,5 @@ registerRootComponent(App);
 **For projects that use [Expo Router](/router/introduction/)**, you can create a custom entry point by following these steps from [Expo Router's installation guide](/router/installation/#custom-entry-point-to-initialize-and-load). To use the top-level **src** directory in your Expo Router project, see [src directory reference](/router/reference/src-directory/) for more information.
 
 </Collapsible>
+
+</FAQ>

--- a/docs/pages/versions/v54.0.0/sdk/expo.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/expo.mdx
@@ -10,6 +10,7 @@ platforms: ['android', 'ios', 'tvos', 'web', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { Collapsible } from '~/ui/components/Collapsible';
+import { FAQ } from '~/ui/components/FAQ';
 import { CODE } from '~/ui/components/Text';
 
 ## Installation
@@ -129,6 +130,8 @@ console.log(new URL('http://🥓').toString());
 
 Some common questions about using the `expo` package in your project.
 
+<FAQ>
+
 <Collapsible summary={<><CODE>rootRegisterComponent</CODE> setup for existing React Native projects</>}>
 
 If you are managing your React Native project's native directories (**android** and **ios**) manually, you need to follow the instructions below to set up the `registerRootComponent` function. This is necessary for the Expo modules to work correctly.
@@ -178,3 +181,5 @@ registerRootComponent(App);
 **For projects that use [Expo Router](/router/introduction/)**, you can create a custom entry point by following these steps from [Expo Router's installation guide](/router/installation/#custom-entry-point-to-initialize-and-load). To use the top-level **src** directory in your Expo Router project, see [src directory reference](/router/reference/src-directory/) for more information.
 
 </Collapsible>
+
+</FAQ>

--- a/docs/pages/versions/v55.0.0/sdk/expo.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/expo.mdx
@@ -10,6 +10,7 @@ platforms: ['android', 'ios', 'tvos', 'web', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { Collapsible } from '~/ui/components/Collapsible';
+import { FAQ } from '~/ui/components/FAQ';
 import { CODE } from '~/ui/components/Text';
 
 ## Installation
@@ -143,6 +144,8 @@ Remove any custom polyfills for `structuredClone` to prevent bloat. Refer to the
 
 Some common questions about using the `expo` package in your project.
 
+<FAQ>
+
 <Collapsible summary={<><CODE>rootRegisterComponent</CODE> setup for existing React Native projects</>}>
 
 If you are managing your React Native project's native directories (**android** and **ios**) manually, you need to follow the instructions below to set up the `registerRootComponent` function. This is necessary for the Expo modules to work correctly.
@@ -192,3 +195,5 @@ registerRootComponent(App);
 **For projects that use [Expo Router](/router/introduction/)**, you can create a custom entry point by following these steps from [Expo Router's installation guide](/router/installation/#custom-entry-point-to-initialize-and-load). To use the top-level **src** directory in your Expo Router project, see [src directory reference](/router/reference/src-directory/) for more information.
 
 </Collapsible>
+
+</FAQ>

--- a/docs/pages/workflow/continuous-native-generation.mdx
+++ b/docs/pages/workflow/continuous-native-generation.mdx
@@ -5,6 +5,7 @@ sidebar_title: Continuous Native Generation
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import { FAQ } from '~/ui/components/FAQ';
 import { Terminal, DiffBlock } from '~/ui/components/Snippet';
 
 A single native project on its own is complicated to maintain, scale, and update. In a cross-platform app, you have multiple native projects that you must maintain and keep up to date with the latest operating system releases to avoid falling too far behind in any third-party dependencies.
@@ -130,6 +131,8 @@ Prebuild is optional and works seamlessly with all Expo tools and services. For 
 Everything offered by Expo including [EAS](/eas/), Expo CLI, and the libraries in the Expo SDK are built to **fully support** bare React Native projects as this is a minimum requirement for supporting projects using `npx expo prebuild`. The only exception is the [Expo Go](https://expo.dev/go) app, which can load arbitrary React Native projects only if they include JavaScript fallbacks for native code absent in the Expo Go runtime.
 
 ## Common questions
+
+<FAQ>
 
 ### CNG
 
@@ -272,3 +275,5 @@ Other packages, such as [`react-native-ble-plx`](https://github.com/Polidea/reac
 Alternatively, we also have a repo for [out-of-tree config plugins](https://github.com/expo/config-plugins) which provides plugins for popular packages that haven't adopted the system yet. Think of this like [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) for TypeScript. We prefer packages ship their own config plugin, but if they haven't adopted the system yet, the community can use the packages listed in the repo.
 
 </Collapsible>
+
+</FAQ>

--- a/docs/ui/components/FAQ/FAQ.test.tsx
+++ b/docs/ui/components/FAQ/FAQ.test.tsx
@@ -1,0 +1,82 @@
+import { jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import { type PropsWithChildren, type ReactNode } from 'react';
+
+jest.unstable_mockModule('~/ui/components/StructuredData', () => ({
+  StructuredData: ({ data, id }: { data: Record<string, unknown>; id: string }) => (
+    <div data-testid={id}>{JSON.stringify(data)}</div>
+  ),
+}));
+
+const { FAQ } = await import('.');
+
+function FakeCollapsible({ summary, children }: PropsWithChildren<{ summary: ReactNode }>) {
+  return (
+    <details>
+      <summary>{summary}</summary>
+      <div>{children}</div>
+    </details>
+  );
+}
+
+describe('FAQ', () => {
+  it('renders children unchanged', () => {
+    render(
+      <FAQ>
+        <FakeCollapsible summary="Question one?">Answer one.</FakeCollapsible>
+      </FAQ>
+    );
+
+    expect(screen.getByText('Question one?')).toBeInTheDocument();
+    expect(screen.getByText('Answer one.')).toBeInTheDocument();
+  });
+
+  it('injects FAQPage JSON-LD from children with summary prop', () => {
+    render(
+      <FAQ>
+        <FakeCollapsible summary="What is Expo?">A React Native framework.</FakeCollapsible>
+        <FakeCollapsible summary="Is it free?">Yes.</FakeCollapsible>
+      </FAQ>
+    );
+
+    const el = screen.getByTestId('faq');
+    const data = JSON.parse(el.textContent!);
+
+    expect(data['@type']).toBe('FAQPage');
+    expect(data.mainEntity).toHaveLength(2);
+    expect(data.mainEntity[0].name).toBe('What is Expo?');
+    expect(data.mainEntity[0].acceptedAnswer.text).toBe('A React Native framework.');
+    expect(data.mainEntity[1].name).toBe('Is it free?');
+  });
+
+  it('handles JSX fragment summaries', () => {
+    render(
+      <FAQ>
+        <FakeCollapsible
+          summary={
+            <>
+              Can I use <code>expo-camera</code>?
+            </>
+          }>
+          Yes you can.
+        </FakeCollapsible>
+      </FAQ>
+    );
+
+    const el = screen.getByTestId('faq');
+    const data = JSON.parse(el.textContent!);
+
+    expect(data.mainEntity[0].name).toBe('Can I use expo-camera?');
+  });
+
+  it('does not render structured data when there are no children with summary prop', () => {
+    render(
+      <FAQ>
+        <p>Just a paragraph.</p>
+      </FAQ>
+    );
+
+    expect(screen.queryByTestId('faq')).not.toBeInTheDocument();
+    expect(screen.getByText('Just a paragraph.')).toBeInTheDocument();
+  });
+});

--- a/docs/ui/components/FAQ/index.tsx
+++ b/docs/ui/components/FAQ/index.tsx
@@ -1,0 +1,31 @@
+import { Children, type PropsWithChildren, type ReactElement, isValidElement } from 'react';
+
+import { toString } from '~/common/utilities';
+import { buildFAQPageSchema } from '~/constants/structured-data';
+import { StructuredData } from '~/ui/components/StructuredData';
+
+export function FAQ({ children }: PropsWithChildren) {
+  const items: { question: string; answer: string }[] = [];
+
+  Children.forEach(children, child => {
+    if (
+      isValidElement(child) &&
+      (child as ReactElement<{ summary?: unknown }>).props.summary !== undefined
+    ) {
+      const { summary, children: body } = child.props as { summary?: unknown; children?: unknown };
+      items.push({
+        question: toString(summary as React.ReactNode),
+        answer: toString(body as React.ReactNode),
+      });
+    }
+  });
+
+  const schema = buildFAQPageSchema(items);
+
+  return (
+    <>
+      {schema && <StructuredData data={schema} id="faq" />}
+      {children}
+    </>
+  );
+}


### PR DESCRIPTION
## Why

Fix ENG-19530

## How

- Add `buildFAQPageSchema()` following the same pattern as the existing `buildBreadcrumbListSchema`. Takes an array of `{ question, answer }` items and returns a `FAQPage` JSON-LD object.
- Add a new `FAQ` wrapper component.
- Wrap Collapsible blocks in FAQ sections with `<FAQ>...</FAQ>` across 6 "Frequently asked questions" pages and 17 "Common questions" pages.

## Test Plan

- Run yarn dev, open a page with a VideoBoxLink (for example, http://localhost:3002/build/introduction/), view page source in developer console, and search for `application/ld+json`.
- Copy and validate the JSON-LD snippet at [validator.schema.org](https://validator.schema.org/).

<img width="4098" height="2390" alt="CleanShot 2026-02-27 at 00 34 22@2x" src="https://github.com/user-attachments/assets/25fda1e0-6b91-4247-b910-5a2e04913021" />


<img width="1432" height="1082" alt="CleanShot 2026-02-27 at 00 34 00@2x" src="https://github.com/user-attachments/assets/e355f595-d147-4255-a2c5-f6d35579a5a7" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
