### PR TITLE
[expo-go][android][expo-module-template] Partial restore of legacy plugin removal

### DIFF
--- a/apps/expo-go/android/app/build.gradle
+++ b/apps/expo-go/android/app/build.gradle
@@ -24,12 +24,6 @@ buildscript {
 apply plugin: 'com.android.application'
 apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'com.google.firebase.crashlytics'
-
-def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
-apply from: expoModulesCorePlugin
-applyKotlinExpoModulesCorePlugin()
-useDefaultAndroidSdkVersions()
-
 apply plugin: 'com.facebook.react'
 
 react {
@@ -49,6 +43,11 @@ react {
 }
 
 android {
+  ndkVersion rootProject.ext.ndkVersion
+
+  buildToolsVersion rootProject.ext.buildToolsVersion
+  compileSdk rootProject.ext.compileSdkVersion
+
   namespace "host.exp.exponent"
 
   buildFeatures {
@@ -57,6 +56,8 @@ android {
 
   defaultConfig {
     applicationId 'host.exp.exponent'
+    minSdkVersion rootProject.ext.minSdkVersion
+    targetSdkVersion rootProject.ext.targetSdkVersion
     versionCode 229
     versionName '55.0.2'
 

--- a/apps/expo-go/android/expoview/build.gradle
+++ b/apps/expo-go/android/expoview/build.gradle
@@ -21,11 +21,15 @@ plugins {
   alias libs.plugins.download
   id("org.jetbrains.kotlin.plugin.compose") version "2.2.21"
   id("org.jetbrains.kotlin.plugin.serialization") version "2.2.21" // Use your Kotlin version
+  id 'expo-module-gradle-plugin'
 }
 apply plugin: 'kotlin-kapt'
 apply from: new File(rootDir, "versioning_linking.gradle")
 apply plugin: 'com.apollographql.apollo'
 
+expoModule {
+  canBePublished false
+}
 
 def reactProperties = new Properties()
 file("${project(':packages:react-native:ReactAndroid').projectDir}/gradle.properties").withInputStream { reactProperties.load(it) }
@@ -36,17 +40,10 @@ group = 'host.exp.exponent'
 version = '45.0.0'
 // WHEN_VERSIONING_REMOVE_TO_HERE
 
-def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
-apply from: expoModulesCorePlugin
-applyKotlinExpoModulesCorePlugin()
-useDefaultAndroidSdkVersions()
-useExpoPublishing()
-
 repositories {
   mavenCentral()
   maven { url "https://jitpack.io" }
 }
-
 
 apply plugin: 'com.facebook.react'
 apply plugin: 'org.jetbrains.kotlin.plugin.compose'

--- a/packages/expo-module-template-local/android/build.gradle
+++ b/packages/expo-module-template-local/android/build.gradle
@@ -1,35 +1,10 @@
-apply plugin: 'com.android.library'
+plugins {
+  id 'com.android.library'
+  id 'expo-module-gradle-plugin'
+}
 
 group = '<%- project.package %>'
 version = '0.7.8'
-
-def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
-apply from: expoModulesCorePlugin
-applyKotlinExpoModulesCorePlugin()
-useCoreDependencies()
-useExpoPublishing()
-
-// If you want to use the managed Android SDK versions from expo-modules-core, set this to true.
-// The Android SDK versions will be bumped from time to time in SDK releases and may introduce breaking changes in your module code.
-// Most of the time, you may like to manage the Android SDK versions yourself.
-def useManagedAndroidSdkVersions = false
-if (useManagedAndroidSdkVersions) {
-  useDefaultAndroidSdkVersions()
-} else {
-  buildscript {
-    // Simple helper that allows the root project to override versions declared by this library.
-    ext.safeExtGet = { prop, fallback ->
-      rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
-    }
-  }
-  project.android {
-    compileSdkVersion safeExtGet("compileSdkVersion", 36)
-    defaultConfig {
-      minSdkVersion safeExtGet("minSdkVersion", 24)
-      targetSdkVersion safeExtGet("targetSdkVersion", 36)
-    }
-  }
-}
 
 android {
   namespace "<%- project.package %>"

--- a/packages/expo-module-template/android/build.gradle
+++ b/packages/expo-module-template/android/build.gradle
@@ -1,35 +1,10 @@
-apply plugin: 'com.android.library'
+plugins {
+  id 'com.android.library'
+  id 'expo-module-gradle-plugin'
+}
 
 group = '<%- project.package %>'
 version = '<%- project.version %>'
-
-def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
-apply from: expoModulesCorePlugin
-applyKotlinExpoModulesCorePlugin()
-useCoreDependencies()
-useExpoPublishing()
-
-// If you want to use the managed Android SDK versions from expo-modules-core, set this to true.
-// The Android SDK versions will be bumped from time to time in SDK releases and may introduce breaking changes in your module code.
-// Most of the time, you may like to manage the Android SDK versions yourself.
-def useManagedAndroidSdkVersions = false
-if (useManagedAndroidSdkVersions) {
-  useDefaultAndroidSdkVersions()
-} else {
-  buildscript {
-    // Simple helper that allows the root project to override versions declared by this library.
-    ext.safeExtGet = { prop, fallback ->
-      rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
-    }
-  }
-  project.android {
-    compileSdkVersion safeExtGet("compileSdkVersion", 36)
-    defaultConfig {
-      minSdkVersion safeExtGet("minSdkVersion", 24)
-      targetSdkVersion safeExtGet("targetSdkVersion", 36)
-    }
-  }
-}
 
 android {
   namespace "<%- project.package %>"


### PR DESCRIPTION
# Why

PR #43312 removed the legacy Android plugin in expo-modules-core, and made associated changes to the Gradle scripts in expo-go and in the create-expo-module templates.

Because of the potential to break many existing native modules when a project was upgraded to SDK 55, that PR was reverted.

However, what we should be doing is reverting only the changes in expo-modules-core, but leaving in place the changes in expo-go and create-expo-module templates that move to the newer Gradle plugin. This way, Expo Go and any new native modules created in future, will correctly use the new plugin.

# How

Restored only changes in expo-go and in the module templates, leaving expo-modules-core unchanged.

# Test Plan

CI (including Expo Go CI) should pass

