### PR TITLE
fix(expo-updates): fix iOS build script failing silently on paths with spaces

### DIFF
--- a/packages/expo-updates/scripts/create-updates-resources-ios.sh
+++ b/packages/expo-updates/scripts/create-updates-resources-ios.sh
@@ -26,7 +26,7 @@ RCT_METRO_PORT=${RCT_METRO_PORT:=8081}
 # `$PROJECT_DIR` is passed by Xcode as the directory to the xcodeproj file.
 # in classic main project setup it is something like /path/to/app/ios
 # in new style pod project setup it is something like /path/to/app/ios/Pods
-PROJECT_DIR_BASENAME=$(basename $PROJECT_DIR)
+PROJECT_DIR_BASENAME=$(basename "$PROJECT_DIR")
 if [ "x$PROJECT_DIR_BASENAME" != "xPods" ]; then
   exit 0
 fi
@@ -41,6 +41,7 @@ PROJECT_ROOT="$(pwd -P)"
 
 if [ "$BUNDLE_FORMAT" == "shallow" ]; then
   RESOURCE_DEST="$DEST/$RESOURCE_BUNDLE_NAME"
+  mkdir -p "$RESOURCE_DEST"
 elif [ "$BUNDLE_FORMAT" == "deep" ]; then
   RESOURCE_DEST="$DEST/$RESOURCE_BUNDLE_NAME/Contents/Resources"
   mkdir -p "$RESOURCE_DEST"


### PR DESCRIPTION
Fixes #43500



## Why

When the Xcode project root lives in a path containing **spaces** (e.g. a USB volume mounted as `/Volumes/My Drive/MyApp`), the iOS build script `create-updates-resources-ios.sh` silently exits early and never generates `app.manifest`.

### Root cause

```bash
# Before – unquoted, triggers word-splitting in bash
PROJECT_DIR_BASENAME=$(basename $PROJECT_DIR)
if [ "x$PROJECT_DIR_BASENAME" != "xPods" ]; then
  exit 0     # ← always taken when PROJECT_DIR contains spaces
fi
```

`basename /Volumes/My Drive/App/ios/Pods` splits on the space, producing a multi-word token (e.g. `Drive/App/ios/Pods` as a separate word). The `[ … != xPods ]` check then always succeeds, causing the script to `exit 0` before generating any resources.

The result is that `EXUpdates.bundle` is built with only `Info.plist` and no `app.manifest`. The app then crashes on launch inside `EmbeddedAppLoader.cachedEmbeddedManifest` with:

```
Assertion failed: The embedded update is invalid …
```

### Fixes

1. **Quote `$PROJECT_DIR`** in the `basename` call so word-splitting cannot occur:
   ```bash
   PROJECT_DIR_BASENAME=$(basename "$PROJECT_DIR")
   ```

2. **`mkdir -p "$RESOURCE_DEST"`** for the `shallow` bundle format branch. The `deep` branch already had this; without it a clean build writes `app.manifest` into a directory that doesn't exist yet, producing an `ENOENT` from `createUpdatesResources.js`.

## Test plan

- Build an iOS archive with the project root on a volume/directory whose path contains spaces.
- Verify `EXUpdates.bundle/app.manifest` is present in the built `.app`.
- Confirm the app launches without crashing.