### PR TITLE
[ios][ui] Fix incorrect assignment on animation modifier

### DIFF
--- a/packages/expo-ui/ios/Modifiers/ViewModifierRegistry.swift
+++ b/packages/expo-ui/ios/Modifiers/ViewModifierRegistry.swift
@@ -711,12 +711,12 @@ internal struct AnimationModifier: ViewModifier, Record {
       let bounce = config.bounce
       let mass = config.mass
       let stiffness = config.stiffness
-      let damping = config.stiffness
+      let damping = config.damping
       let initialVelocity = config.initialVelocity
 
       if duration != nil || bounce != nil {
         animation = .interpolatingSpring(duration: duration ?? 0.5, bounce: bounce ?? 0.0, initialVelocity: initialVelocity ?? 0.0)
-      } else if let stiffness = stiffness, let damping = damping {
+      } else if let stiffness, let damping {
         animation = .interpolatingSpring(mass: mass ?? 1.0, stiffness: stiffness, damping: damping, initialVelocity: initialVelocity ?? 0.0)
       } else {
         animation = .interpolatingSpring


### PR DESCRIPTION
# Why
Fixes an incorrect assignment on animation modifier. We were using `config.stiffness` for both damping and stiffness

# How
Use the correct config property

# Test Plan
Bare expo

