### PR TITLE
[android][ui] Fix PickerView modifiers

### DIFF
--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/PickerView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/PickerView.kt
@@ -99,7 +99,7 @@ fun FunctionalComposableScope.PickerContent(
           onClick = {
             onOptionSelected(PickerOptionSelectedEvent(index, label))
           },
-          modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher),
+          modifier = ModifierRegistry.applyModifiers(props.buttonModifiers, appContext, composableScope, globalEventDispatcher),
           selected = index == selectedIndex,
           label = { Text(label) },
           colors = SegmentedButtonDefaults.colors(


### PR DESCRIPTION
# Why
Fixes `PickerView` modifiers. We're applying the parent modifiers to each button instead of the `buttonModifiers`

# How
Use the correct prop on the button

# Test Plan
Bare expo

