### PR TITLE
[templates] update tabs template

### DIFF
--- a/templates/expo-template-tabs/app/(tabs)/_layout.tsx
+++ b/templates/expo-template-tabs/app/(tabs)/_layout.tsx
@@ -1,19 +1,11 @@
 import React from 'react';
-import FontAwesome from '@expo/vector-icons/FontAwesome';
+import { SymbolView } from 'expo-symbols';
 import { Link, Tabs } from 'expo-router';
-import { Pressable } from 'react-native';
+import { Platform, Pressable } from 'react-native';
 
 import Colors from '@/constants/Colors';
 import { useColorScheme } from '@/components/useColorScheme';
 import { useClientOnlyValue } from '@/components/useClientOnlyValue';
-
-// You can explore the built-in icon families and icons on the web at https://icons.expo.fyi/
-function TabBarIcon(props: {
-  name: React.ComponentProps<typeof FontAwesome>['name'];
-  color: string;
-}) {
-  return <FontAwesome size={28} style={{ marginBottom: -3 }} {...props} />;
-}
 
 export default function TabLayout() {
   const colorScheme = useColorScheme();
@@ -21,7 +13,7 @@ export default function TabLayout() {
   return (
     <Tabs
       screenOptions={{
-        tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
+        tabBarActiveTintColor: Colors[colorScheme].tint,
         // Disable the static render of the header on web
         // to prevent a hydration error in React Navigation v6.
         headerShown: useClientOnlyValue(false, true),
@@ -30,16 +22,26 @@ export default function TabLayout() {
         name="index"
         options={{
           title: 'Tab One',
-          tabBarIcon: ({ color }) => <TabBarIcon name="code" color={color} />,
+          tabBarIcon: ({ color }) => (
+            <SymbolView
+              name={{
+                ios: 'chevron.left.forwardslash.chevron.right',
+                android: 'code',
+                web: 'code',
+              }}
+              tintColor={color}
+              size={28}
+            />
+          ),
           headerRight: () => (
             <Link href="/modal" asChild>
-              <Pressable>
+              <Pressable style={{ marginRight: 15 }}>
                 {({ pressed }) => (
-                  <FontAwesome
-                    name="info-circle"
+                  <SymbolView
+                    name={{ ios: 'info.circle', android: 'info', web: 'info' }}
                     size={25}
-                    color={Colors[colorScheme ?? 'light'].text}
-                    style={{ marginRight: 15, opacity: pressed ? 0.5 : 1 }}
+                    tintColor={Colors[colorScheme].text}
+                    style={{ opacity: pressed ? 0.5 : 1 }}
                   />
                 )}
               </Pressable>
@@ -51,7 +53,17 @@ export default function TabLayout() {
         name="two"
         options={{
           title: 'Tab Two',
-          tabBarIcon: ({ color }) => <TabBarIcon name="code" color={color} />,
+          tabBarIcon: ({ color }) => (
+            <SymbolView
+              name={{
+                ios: 'chevron.left.forwardslash.chevron.right',
+                android: 'code',
+                web: 'code',
+              }}
+              tintColor={color}
+              size={28}
+            />
+          ),
         }}
       />
     </Tabs>

--- a/templates/expo-template-tabs/app/_layout.tsx
+++ b/templates/expo-template-tabs/app/_layout.tsx
@@ -1,4 +1,3 @@
-import FontAwesome from '@expo/vector-icons/FontAwesome';
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
@@ -24,7 +23,6 @@ SplashScreen.preventAutoHideAsync();
 export default function RootLayout() {
   const [loaded, error] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
-    ...FontAwesome.font,
   });
 
   // Expo Router uses Error Boundaries to catch errors in the navigation tree.

--- a/templates/expo-template-tabs/components/Themed.tsx
+++ b/templates/expo-template-tabs/components/Themed.tsx
@@ -2,11 +2,11 @@
  * Learn more about Light and Dark modes:
  * https://docs.expo.io/guides/color-schemes/
  */
-
 import { Text as DefaultText, View as DefaultView } from 'react-native';
 
-import Colors from '@/constants/Colors';
 import { useColorScheme } from './useColorScheme';
+
+import Colors from '@/constants/Colors';
 
 type ThemeProps = {
   lightColor?: string;
@@ -20,7 +20,7 @@ export function useThemeColor(
   props: { light?: string; dark?: string },
   colorName: keyof typeof Colors.light & keyof typeof Colors.dark
 ) {
-  const theme = useColorScheme() ?? 'light';
+  const theme = useColorScheme();
   const colorFromProps = props[theme];
 
   if (colorFromProps) {

--- a/templates/expo-template-tabs/components/useColorScheme.ts
+++ b/templates/expo-template-tabs/components/useColorScheme.ts
@@ -1,1 +1,6 @@
-export { useColorScheme } from 'react-native';
+import { useColorScheme as useColorSchemeCore } from 'react-native';
+
+export const useColorScheme = () => {
+  const coreScheme = useColorSchemeCore();
+  return coreScheme === 'unspecified' ? 'light' : coreScheme;
+};

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -11,9 +11,9 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@expo/vector-icons": "^15.0.2",
     "@react-navigation/native": "^7.1.28",
     "expo": "~55.0.2",
+    "expo-symbols": "~55.0.4",
     "expo-constants": "~55.0.7",
     "expo-font": "~55.0.4",
     "expo-linking": "~55.0.7",


### PR DESCRIPTION
# Why

Replace FontAwesome icons with expo-symbols in the Expo tabs template.

# How

- Replaced `@expo/vector-icons/FontAwesome` with `expo-symbols` SymbolView component
- Removed the custom `TabBarIcon` wrapper function and implemented icons directly using SymbolView
- Added platform-specific icon names for iOS, Android, and web platforms
- Updated the `useColorScheme` hook to handle the 'unspecified' color scheme by defaulting to 'light' (`null` was changed to `unspecified`)
- Cleaned up null coalescing operators where the hook now guarantees a non-null return value

# Test Plan

- create a new app from template, verify it looks good on all platforms

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)