### PR TITLE
Enforce Android navigationBar / statusBar to transparent in Expo Go / Dev Launcher

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.kt
@@ -179,7 +179,7 @@ class ExponentManifest @Inject constructor(
 
     // NavigationBar
     const val MANIFEST_NAVIGATION_BAR_KEY = "androidNavigationBar"
-    const val MANIFEST_NAVIGATION_BAR_VISIBLILITY = "visible"
+    const val MANIFEST_NAVIGATION_BAR_VISIBILITY = "visible"
     const val MANIFEST_NAVIGATION_BAR_APPEARANCE = "barStyle"
     const val MANIFEST_NAVIGATION_BAR_BACKGROUND_COLOR = "backgroundColor"
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.kt
@@ -98,7 +98,6 @@ object ExperienceActivityUtils {
   fun configureStatusBar(manifest: Manifest, activity: Activity) {
     val statusBarOptions = manifest.getAndroidStatusBarOptions()
     val statusBarStyle = statusBarOptions?.getNullable<String>(ExponentManifest.MANIFEST_STATUS_BAR_APPEARANCE)
-    val statusBarBackgroundColor = statusBarOptions?.getNullable<String>(ExponentManifest.MANIFEST_STATUS_BAR_BACKGROUND_COLOR)
 
     val statusBarHidden = statusBarOptions != null && statusBarOptions.optBoolean(
       ExponentManifest.MANIFEST_STATUS_BAR_HIDDEN,
@@ -113,38 +112,9 @@ object ExperienceActivityUtils {
 
       setTranslucent(activity)
 
-      val appliedStatusBarStyle = setStyle(statusBarStyle, activity)
+      setStyle(statusBarStyle, activity)
 
-      // Color passed from manifest is in format '#RRGGBB(AA)' and Android uses '#AARRGGBB'
-      val normalizedStatusBarBackgroundColor = RGBAtoARGB(statusBarBackgroundColor)
-
-      if (normalizedStatusBarBackgroundColor == null || !ColorParser.isValid(normalizedStatusBarBackgroundColor)) {
-        // backgroundColor is invalid or not set
-        if (appliedStatusBarStyle == STATUS_BAR_STYLE_LIGHT_CONTENT) {
-          // appliedStatusBarStyle is "light-content" so background color should be semi transparent black
-          setColor(Color.parseColor("#88000000"), activity)
-        } else {
-          // otherwise it has to be transparent
-          setColor(Color.TRANSPARENT, activity)
-        }
-      } else {
-        setColor(Color.parseColor(normalizedStatusBarBackgroundColor), activity)
-      }
-    }
-  }
-
-  /**
-   * If the string conforms to the "#RRGGBBAA" format then it's converted into the "#AARRGGBB" format.
-   * Otherwise noop.
-   */
-  private fun RGBAtoARGB(rgba: String?): String? {
-    if (rgba == null) {
-      return null
-    }
-    return if (rgba.startsWith("#") && rgba.length == 9) {
-      "#" + rgba.substring(7, 9) + rgba.substring(1, 7)
-    } else {
-      rgba
+      setColor(Color.TRANSPARENT, activity)
     }
   }
 
@@ -178,28 +148,16 @@ object ExperienceActivityUtils {
    * @return Effective style that is actually applied to the status bar.
    */
   @UiThread
-  private fun setStyle(style: String?, activity: Activity): String {
-    var appliedStatusBarStyle = STATUS_BAR_STYLE_LIGHT_CONTENT
+  private fun setStyle(style: String?, activity: Activity) {
     val decorView = activity.window.decorView
-    var systemUiVisibilityFlags = decorView.systemUiVisibility
-    when (style) {
-      STATUS_BAR_STYLE_LIGHT_CONTENT -> {
-        systemUiVisibilityFlags =
-          systemUiVisibilityFlags and View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv()
-        appliedStatusBarStyle = STATUS_BAR_STYLE_LIGHT_CONTENT
-      }
-      STATUS_BAR_STYLE_DARK_CONTENT -> {
-        systemUiVisibilityFlags = systemUiVisibilityFlags or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
-        appliedStatusBarStyle = STATUS_BAR_STYLE_DARK_CONTENT
-      }
-      else -> {
-        systemUiVisibilityFlags = systemUiVisibilityFlags or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
-        appliedStatusBarStyle = STATUS_BAR_STYLE_DARK_CONTENT
-      }
+    decorView.systemUiVisibility = when (style) {
+      STATUS_BAR_STYLE_LIGHT_CONTENT ->
+        decorView.systemUiVisibility and View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv()
+      STATUS_BAR_STYLE_DARK_CONTENT ->
+        decorView.systemUiVisibility or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+      else ->
+        decorView.systemUiVisibility or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
     }
-    decorView.systemUiVisibility = systemUiVisibilityFlags
-
-    return appliedStatusBarStyle
   }
 
   @UiThread
@@ -245,17 +203,6 @@ object ExperienceActivityUtils {
 
   fun setNavigationBar(manifest: Manifest, activity: Activity) {
     val navBarOptions = manifest.getAndroidNavigationBarOptions() ?: return
-
-    // Set background color of navigation bar
-    val navBarColor = navBarOptions.getNullable<String>(ExponentManifest.MANIFEST_NAVIGATION_BAR_BACKGROUND_COLOR)
-    if (navBarColor != null && ColorParser.isValid(navBarColor)) {
-      try {
-        activity.window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION)
-        activity.window.navigationBarColor = Color.parseColor(navBarColor)
-      } catch (e: Throwable) {
-        EXL.e(TAG, e)
-      }
-    }
 
     // Set icon color of navigation bar
     val navBarAppearance = navBarOptions.getNullable<String>(ExponentManifest.MANIFEST_NAVIGATION_BAR_APPEARANCE)

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/utils/ExperienceActivityUtils.kt
@@ -275,7 +275,7 @@ object ExperienceActivityUtils {
     }
 
     // Set visibility of navigation bar
-    val navBarVisible = navBarOptions.getNullable<String>(ExponentManifest.MANIFEST_NAVIGATION_BAR_VISIBLILITY)
+    val navBarVisible = navBarOptions.getNullable<String>(ExponentManifest.MANIFEST_NAVIGATION_BAR_VISIBILITY)
     if (navBarVisible != null) {
       // Hide both the navigation bar and the status bar. The Android docs recommend, "you should
       // design your app to hide the status bar whenever you hide the navigation bar."

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Enforce transparent status bar and navigation bar on Android, remove unused `backgroundColor` / `translucent` options handling.
+
 ## 55.0.10 — 2026-02-25
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Enforce transparent status bar and navigation bar on Android, remove unused `backgroundColor` / `translucent` options handling.
+- Enforce transparent status bar and navigation bar on Android, remove unused `backgroundColor` / `translucent` options handling. ([#43518](https://github.com/expo/expo/pull/43518) by [@zoontek](https://github.com/zoontek))
 
 ## 55.0.10 — 2026-02-25
 


### PR DESCRIPTION
# Why

Following #43514 (removal of `expo_splash_screen_status_bar_translucent` attribute) and #43516 (deletion of `withAndroidSplashLegacyMainActivity`), this PR continues the cleanup by enforcing transparent status bar and navigation bar on Android in Expo Go and dev-launcher (it was already enforced by edge-to-edge, so it's more about removing `backgroundColor` / `translucent` related code).

# How

- **Expo Go** (`ExperienceActivityUtils.kt`):
  - Removed `statusBar` `backgroundColor` handling and return value from `setStyle`
  - Removed `navigationBar` `backgroundColor` handling
  - Simplified `setStyle` to directly assign `systemUiVisibility` flags without tracking / returning the applied style
  - Fixed `MANIFEST_NAVIGATION_BAR_VISIBLILITY` → `MANIFEST_NAVIGATION_BAR_VISIBILITY` typo in `ExponentManifest.kt`

- **Dev Launcher** (`DevLauncherExpoActivityConfigurator.kt`):
  - Removed `statusBar` `backgroundColor` / `translucent` handling and return value from `setStyle`
  - Removed `navigationBar` `backgroundColor` handling
  - `setTranslucent` no longer takes a `Boolean` parameter (always applies translucent insets)

# Test Plan

Open the Expo Go / the Bare apps on Android and verify:

- Status bar is transparent and respects `barStyle` (`light-content` / `dark-content`)
- Navigation bar is transparent
- Navigation bar visibility and appearance options still work as expected

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
