### PR TITLE
[ios][dev-launcher] Fix `fullScreenModal` issue

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix issue when using `fullScreenModal` with `expo-router`.
+- [iOS] Fix issue when using `fullScreenModal` with `expo-router`. ([#43520](https://github.com/expo/expo/pull/43520) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix issue when using `fullScreenModal` with `expo-router`.
+
 ### 💡 Others
 
 ## 55.0.10 — 2026-02-25

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -8,7 +8,11 @@ private class DevLauncherWrapperView: UIView {
   weak var devLauncherViewController: UIViewController?
 
   func setupDevLauncherView(_ viewController: UIViewController) {
+#if os(macOS)
+    viewController.view.autoresizingMask = [.width, .height]
+#else
     viewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+#endif
     viewController.view.frame = bounds
   }
 

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -6,48 +6,20 @@ import React
 
 private class DevLauncherWrapperView: UIView {
   weak var devLauncherViewController: UIViewController?
-  private var devLauncherConstraints: [NSLayoutConstraint] = []
 
-  #if os(iOS)
-  @objc
-  func orientationDidChange() {
-    if let controller = devLauncherViewController {
-      setDevLauncherViewControllerConstraints(controller)
-    }
-  }
-  #endif
-
-  func setDevLauncherViewControllerConstraints(_ viewController: UIViewController) {
-    viewController.view.translatesAutoresizingMaskIntoConstraints = false
-    if !devLauncherConstraints.isEmpty {
-      NSLayoutConstraint.deactivate(devLauncherConstraints)
-    }
-    devLauncherConstraints = [
-      viewController.view.topAnchor.constraint(equalTo: self.topAnchor),
-      viewController.view.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-      viewController.view.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-      viewController.view.bottomAnchor.constraint(equalTo: self.bottomAnchor)
-    ]
-    NSLayoutConstraint.activate(devLauncherConstraints)
+  func setupDevLauncherView(_ viewController: UIViewController) {
+    viewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    viewController.view.frame = bounds
   }
 
 #if !os(macOS)
-  override func didMoveToWindow() {
-    super.didMoveToWindow()
-    #if os(iOS)
-    if window != nil {
-      NotificationCenter.default.addObserver(self, selector: #selector(orientationDidChange), name: UIDevice.orientationDidChangeNotification, object: nil)
-      devLauncherViewController?.view.setNeedsLayout()
-      devLauncherViewController?.view.layoutIfNeeded()
-    } else {
-      NotificationCenter.default.removeObserver(self, name: UIDevice.orientationDidChangeNotification, object: nil)
-    }
-    #endif
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    devLauncherViewController?.view.frame = bounds
   }
 
   override func safeAreaInsetsDidChange() {
     super.safeAreaInsetsDidChange()
-    devLauncherViewController?.view.setNeedsLayout()
     devLauncherViewController?.view.layoutIfNeeded()
   }
 #endif
@@ -93,7 +65,7 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, EXDe
     let wrapperView = DevLauncherWrapperView()
     wrapperView.devLauncherViewController = viewController
     wrapperView.addSubview(viewController.view)
-    wrapperView.setDevLauncherViewControllerConstraints(viewController)
+    wrapperView.setupDevLauncherView(viewController)
     return wrapperView
   }
 

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -37,35 +37,18 @@ private class DevLauncherWrapperView: UIView {
     #if os(iOS)
     if window != nil {
       NotificationCenter.default.addObserver(self, selector: #selector(orientationDidChange), name: UIDevice.orientationDidChangeNotification, object: nil)
+      devLauncherViewController?.view.setNeedsLayout()
+      devLauncherViewController?.view.layoutIfNeeded()
+    } else {
+      NotificationCenter.default.removeObserver(self, name: UIDevice.orientationDidChangeNotification, object: nil)
     }
     #endif
-
-    guard let devLauncherViewController,
-      let window,
-      let rootViewController = window.rootViewController else {
-      return
-    }
-
-    let isSwiftUIController = NSStringFromClass(type(of: rootViewController)).contains("UIHostingController")
-    // TODO(pmleczek): Revisit this for a more reliable solution
-    let isBrownfield = NSStringFromClass(type(of: rootViewController)).contains("UINavigationController")
-    if !isSwiftUIController && !isBrownfield && devLauncherViewController.parent != rootViewController {
-      rootViewController.addChild(devLauncherViewController)
-      devLauncherViewController.didMove(toParent: rootViewController)
-      devLauncherViewController.view.setNeedsLayout()
-      devLauncherViewController.view.layoutIfNeeded()
-    }
   }
 
-  override func willMove(toWindow newWindow: UIWindow?) {
-    super.willMove(toWindow: newWindow)
-    if newWindow == nil {
-      devLauncherViewController?.willMove(toParent: nil)
-      devLauncherViewController?.removeFromParent()
-      #if os(iOS)
-      NotificationCenter.default.removeObserver(self, name: UIDevice.orientationDidChangeNotification, object: nil)
-      #endif
-    }
+  override func safeAreaInsetsDidChange() {
+    super.safeAreaInsetsDidChange()
+    devLauncherViewController?.view.setNeedsLayout()
+    devLauncherViewController?.view.layoutIfNeeded()
   }
 #endif
 }


### PR DESCRIPTION
# Why
There is a problem when using `fullScreenModal` in expo-router with dev-launcher where the view freezes when `router.back` is called. The issue is caused by the `DevLauncherWrapperView`. This was originally added to address an issue with the safe area on a physical device but it should not be handling view controller containment. It should be a dumb wrapper, the only thing we need to it to do is signal to the devLauncherViewController that it needs a layout pass when the safe area insets change.

# How
Simplify the view, remove orientation observers. This is handled by auto-layout. All we need to do is set the bounds and the autoresizingMask and override `safeAreaInsetsDidChange`

# Test Plan
Bare expo 
In the provided repro. The modal works as expected. The safe are is still handled correctly on a physical device

