### PR TITLE
fix(babel-preset-expo): Add missing default react-compiler opt-out directives

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Opt `"widget"` functions for `expo-widgets` out of react-compiler ([#43451](https://github.com/expo/expo/pull/43451) by [@kitten](https://github.com/kitten))
+- Fix `"use no memo"` and `"use no forget"` default opt-out directives being ineffective in react-compiler transform ([#43521](https://github.com/expo/expo/pull/43521) by [@Titozzz](https://github.com/Titozzz), [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -94,7 +94,7 @@ function babelPresetExpo(api, options = {}) {
                 ...reactCompilerOptions,
                 // See: https://github.com/facebook/react/blob/074d96b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts#L160-L163
                 // We need to opt-out for our widgets, since they're stringified functions that output Swift UI JSX
-                customOptOutDirectives: [...(reactCompilerOptions?.customOptOutDirectives ?? []), 'widget'],
+                customOptOutDirectives: [...(reactCompilerOptions?.customOptOutDirectives ?? []), 'widget', 'use no memo', 'use no forget'],
             },
         ]);
     }

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -82,6 +82,18 @@ function babelPresetExpo(api, options = {}) {
         // Give users the ability to opt-out of the feature, per-platform.
         platformOptions['react-compiler'] !== false) {
         const reactCompilerOptions = platformOptions['react-compiler'];
+        const reactCompilerOptOutDirectives = new Set([
+            // We need to opt-out for our widgets, since they're stringified functions that output Swift UI JSX
+            'widget',
+            // We need to manually include the default opt-out directives, since they get overridden
+            // See:
+            // - https://github.com/facebook/react/blob/e0cc720/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts#L48C1-L48C77
+            // - https://github.com/facebook/react/blob/e0cc720/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts#L69-L86
+            'use no memo',
+            'use no forget',
+            // Add the user's override but preserve defaults above to avoid the pitfall of them being removed
+            ...(reactCompilerOptions?.customOptOutDirectives ?? []),
+        ]);
         extraPlugins.push([
             require('babel-plugin-react-compiler'),
             {
@@ -93,8 +105,7 @@ function babelPresetExpo(api, options = {}) {
                 panicThreshold: isDev ? undefined : 'NONE',
                 ...reactCompilerOptions,
                 // See: https://github.com/facebook/react/blob/074d96b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts#L160-L163
-                // We need to opt-out for our widgets, since they're stringified functions that output Swift UI JSX
-                customOptOutDirectives: [...(reactCompilerOptions?.customOptOutDirectives ?? []), 'widget', 'use no memo', 'use no forget'],
+                customOptOutDirectives: [...reactCompilerOptOutDirectives],
             },
         ]);
     }

--- a/packages/babel-preset-expo/src/__tests__/compiler.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/compiler.test.ts
@@ -167,3 +167,30 @@ it(`skips memoizing in node modules`, () => {
   })!;
   expect(code).not.toContain('react.memo_cache_sentinel');
 });
+
+it.each(['widget', 'use no memo', 'use no forget'])(
+  `skips memoizing with opt-out directive "%s"`,
+  (directive) => {
+    const { code } = babel.transformSync(
+      `
+    export default function App() {
+      ${JSON.stringify(directive)};
+      return <div />;
+    }
+   `,
+      {
+        ...options,
+        filename: '/samples/Test.jsx',
+        caller: getCaller({
+          name: 'metro',
+          supportsReactCompiler: true,
+          engine: 'hermes',
+          platform: 'ios',
+          isDev: false,
+        }),
+      }
+    )!;
+    expect(code).not.toContain('import {');
+    expect(code).not.toContain('react.memo_cache_sentinel');
+  }
+);

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -186,7 +186,7 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
         ...reactCompilerOptions,
         // See: https://github.com/facebook/react/blob/074d96b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts#L160-L163
         // We need to opt-out for our widgets, since they're stringified functions that output Swift UI JSX
-        customOptOutDirectives: [...(reactCompilerOptions?.customOptOutDirectives ?? []), 'widget'],
+        customOptOutDirectives: [...(reactCompilerOptions?.customOptOutDirectives ?? []), 'widget', 'use no memo', 'use no forget'],
       },
     ]);
   }

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -174,6 +174,19 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
     platformOptions['react-compiler'] !== false
   ) {
     const reactCompilerOptions = platformOptions['react-compiler'];
+    const reactCompilerOptOutDirectives = new Set([
+      // We need to opt-out for our widgets, since they're stringified functions that output Swift UI JSX
+      'widget',
+      // We need to manually include the default opt-out directives, since they get overridden
+      // See:
+      // - https://github.com/facebook/react/blob/e0cc720/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts#L48C1-L48C77
+      // - https://github.com/facebook/react/blob/e0cc720/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts#L69-L86
+      'use no memo',
+      'use no forget',
+      // Add the user's override but preserve defaults above to avoid the pitfall of them being removed
+      ...(reactCompilerOptions?.customOptOutDirectives ?? []),
+    ]);
+
     extraPlugins.push([
       require('babel-plugin-react-compiler'),
       {
@@ -185,8 +198,7 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
         panicThreshold: isDev ? undefined : 'NONE',
         ...reactCompilerOptions,
         // See: https://github.com/facebook/react/blob/074d96b/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts#L160-L163
-        // We need to opt-out for our widgets, since they're stringified functions that output Swift UI JSX
-        customOptOutDirectives: [...(reactCompilerOptions?.customOptOutDirectives ?? []), 'widget', 'use no memo', 'use no forget'],
+        customOptOutDirectives: [...reactCompilerOptOutDirectives],
       },
     ]);
   }


### PR DESCRIPTION
# Why

Specifying opt-out directives overrides all defaults, and doesn't add them back. They'll instead have to be added manually; See: https://github.com/facebook/react/blob/e0cc7202e14418b453c69c4f06dc00c64151f202/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Program.ts#L69-L86

# How

- Add list of default directives

# Test Plan

- Tested manually against local test project
- Tested with unit test added in babel-preset-expo

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
