### PR TITLE
[docs] Fix previous /prebuild internal links

### DIFF
--- a/docs/pages/bare/using-expo-cli.mdx
+++ b/docs/pages/bare/using-expo-cli.mdx
@@ -32,7 +32,7 @@ Expo CLI commands provide several benefits over the similar commands in `@react-
 
 - Instant access to Hermes debugger with <kbd>j</kbd> keystroke.
 - The debugger ships with [React Native DevTools](/debugging/tools/#debugging-with-react-native-devtools).
-- [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/) support with [`expo prebuild`](/workflow/prebuild/) for upgrades, white-labeling, easy third-party package setup, and better maintainability of the codebase (by reducing the surface area).
+- [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/) support with [`expo prebuild`](/more/glossary-of-terms/#prebuild) for upgrades, white-labeling, easy third-party package setup, and better maintainability of the codebase (by reducing the surface area).
 - Support for file-based routing with [`expo-router`](/router/introduction/).
   - [Async bundling](/router/web/async-routes) in development.
 - Built-in [environment variable support](/guides/environment-variables) and **.env** file integration.

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -256,7 +256,7 @@ To disable using our CocoaPods cache server for your builds set the `EAS_BUILD_D
 }
 ```
 
-It is typical to not have your project **Podfile.lock** committed to source control when using [prebuild](/workflow/prebuild) to generate your **ios** directory [remotely at build time](/build-reference/ios-builds).
+It is typical to not have your project **Podfile.lock** committed to source control when using [prebuild](/more/glossary-of-terms/#prebuild) to generate your **ios** directory [remotely at build time](/build-reference/ios-builds).
 It can be useful to cache your **Podfile.lock** to have deterministic builds, but the tradeoff in this case is that, because you don't use the lockfile during local development, your ability to determine when a change is needed and to update specific dependencies is limited.
 If you cache this file, you may occasionally end up with build errors that require clearing the cache.
 To cache **Podfile.lock**, add **./ios/Podfile.lock** to the `cache.paths` list in your build profile in **eas.json**.

--- a/docs/pages/build-reference/easignore.mdx
+++ b/docs/pages/build-reference/easignore.mdx
@@ -37,7 +37,7 @@ Copy the content of the **.gitignore** file into the **.easignore** file. Then, 
 /coverage
 ```
 
-If your project does not contain **android** and **ios** directories, [EAS Build will run Prebuild](/workflow/prebuild/#usage-with-eas-build) to generate these native directories before compilation.
+If your project does not contain **android** and **ios** directories, [EAS Build will run Prebuild](/workflow/continuous-native-generation/#usage-with-eas-build) to generate these native directories before compilation.
 
 </Step>
 

--- a/docs/pages/build-reference/ios-capabilities.mdx
+++ b/docs/pages/build-reference/ios-capabilities.mdx
@@ -114,7 +114,7 @@ There are two ways to manually enable Apple capabilities, both systems will requ
 
 ### Xcode
 
-> Preferred method for projects that do **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the native **android** and **ios** directories.
+> Preferred method for projects that do **not** use [Expo Prebuild](/more/glossary-of-terms/#prebuild) to continuously generate the native **android** and **ios** directories.
 
 1. Open the **ios** directory in Xcode with `xed ios`. If you don't have an **ios** directory, run `npx expo prebuild -p ios` to generate one.
 2. Then follow the steps mentioned in [Add a capability][apple-enable-capability].

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -56,7 +56,7 @@ Some of the options available for cloud builds are not available locally. Limita
 
 ## App compilation for development and production builds locally
 
-To compile your app locally for development with Expo CLI, use `npx expo run:android` or `npx expo run:ios` commands instead. If you use [Continuous Native Generation](/workflow/continuous-native-generation), you can also run [prebuild](/workflow/prebuild) to generate your **android** and **ios** directories and then proceed to open the projects in the respective IDEs and build them like any native project. For more details, see:
+To compile your app locally for development with Expo CLI, use `npx expo run:android` or `npx expo run:ios` commands instead. If you use [Continuous Native Generation](/workflow/continuous-native-generation), you can also run [prebuild](/more/glossary-of-terms/#prebuild) to generate your **android** and **ios** directories and then proceed to open the projects in the respective IDEs and build them like any native project. For more details, see:
 
 <BoxLink
   title="Local app development"

--- a/docs/pages/core-concepts.mdx
+++ b/docs/pages/core-concepts.mdx
@@ -38,7 +38,7 @@ The `expo` npm package enables a suite of incredible features for React Native a
 <BoxLink
   title="Prebuild"
   description="Separate React from Native to develop from any computer, upgrade easily, white label apps, and maintain larger projects."
-  href="/workflow/prebuild/"
+  href="/workflow/continuous-native-generation/"
   Icon={BookOpen02Icon}
 />
 <BoxLink

--- a/docs/pages/deploy/build-project.mdx
+++ b/docs/pages/deploy/build-project.mdx
@@ -129,7 +129,7 @@ Learn more about common patterns with the [workflows examples guide](/eas/workfl
 
 To create a release (also known as production) build locally, see the following React Native guides for more information on the necessary steps for Android and iOS.
 
-These guides assume your project has **android** and/or **ios** directories containing the respective native projects. If you use [Continuous Native Generation](/workflow/continuous-native-generation) then you will need to run [prebuild](/workflow/prebuild) to generate the directories before following the guides.
+These guides assume your project has **android** and/or **ios** directories containing the respective native projects. If you use [Continuous Native Generation](/workflow/continuous-native-generation) then you will need to run [prebuild](/more/glossary-of-terms/#prebuild) to generate the directories before following the guides.
 
 > **Note**: Following the guide below, in step four, when you build the release **.aab** for Android, run `./gradlew app:bundleRelease` from the **android** directory instead of `npx react-native build-android --mode=release`.
 

--- a/docs/pages/develop/tools.mdx
+++ b/docs/pages/develop/tools.mdx
@@ -25,7 +25,7 @@ The following is a list of common commands that you will use with Expo CLI while
 | Command                         | Description                                                                                                                                                      |
 | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `npx expo start`                | Starts the development server (whether you are using a development build or Expo Go).                                                                            |
-| `npx expo prebuild`             | Generates native Android and iOS directories using [Prebuild](/workflow/prebuild/).                                                                              |
+| `npx expo prebuild`             | Generates native Android and iOS directories using [Prebuild](/workflow/continuous-native-generation/).                                                                              |
 | `npx expo run:android`          | Compiles native Android app locally.                                                                                                                             |
 | `npx expo run:ios`              | Compiles native iOS app locally.                                                                                                                                 |
 | `npx expo install package-name` | Used to install a new library or validate and update specific libraries in your project by adding `--fix` option to this command.                                |

--- a/docs/pages/develop/tools.mdx
+++ b/docs/pages/develop/tools.mdx
@@ -25,7 +25,7 @@ The following is a list of common commands that you will use with Expo CLI while
 | Command                         | Description                                                                                                                                                      |
 | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `npx expo start`                | Starts the development server (whether you are using a development build or Expo Go).                                                                            |
-| `npx expo prebuild`             | Generates native Android and iOS directories using [Prebuild](/workflow/continuous-native-generation/).                                                                              |
+| `npx expo prebuild`             | Generates native Android and iOS directories using [Prebuild](/workflow/continuous-native-generation/).                                                          |
 | `npx expo run:android`          | Compiles native Android app locally.                                                                                                                             |
 | `npx expo run:ios`              | Compiles native iOS app locally.                                                                                                                                 |
 | `npx expo install package-name` | Used to install a new library or validate and update specific libraries in your project by adding `--fix` option to this command.                                |

--- a/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
+++ b/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
@@ -135,7 +135,7 @@ To test your new splash screen, build your app for [internal distribution](/tuto
 
 <Collapsible summary="Not using prebuild?">
 
-If your app does not use [Expo Prebuild](/workflow/prebuild) (formerly the _managed workflow_) to generate the native **android** and **ios** directories, then changes in the app config will have no effect. For more information, see [how you can customize the configuration manually](https://github.com/expo/expo/tree/main/packages/expo-splash-screen#-installation-in-bare-react-native-projects).
+If your app does not use [Expo Prebuild](/more/glossary-of-terms/#prebuild) (formerly the _managed workflow_) to generate the native **android** and **ios** directories, then changes in the app config will have no effect. For more information, see [how you can customize the configuration manually](https://github.com/expo/expo/tree/main/packages/expo-splash-screen#-installation-in-bare-react-native-projects).
 
 </Collapsible>
 

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -121,7 +121,7 @@ Source: [3.3.1 APIs and Functionality - B. Executable Code](https://developer.ap
 
 ## Should I use Expo CLI or React Native Community CLI?
 
-Expo CLI offers the same core functionality as React Native Community CLI (also known as "React Native CLI") with additional features such as automatic [TypeScript setup](/guides/typescript), [web support](/workflow/web), [auto installing compatible libraries](/more/expo-cli/#install), [improved native build commands](/more/expo-cli#compiling), [tunneling](/more/expo-cli#tunneling), [Prebuild](/workflow/prebuild), and [more](/more/expo-cli).
+Expo CLI offers the same core functionality as React Native Community CLI (also known as "React Native CLI") with additional features such as automatic [TypeScript setup](/guides/typescript), [web support](/workflow/web), [auto installing compatible libraries](/more/expo-cli/#install), [improved native build commands](/more/expo-cli#compiling), [tunneling](/more/expo-cli#tunneling), [Prebuild](/more/glossary-of-terms/#prebuild), and [more](/more/expo-cli).
 
 It can be used simultaneously with React Native Community. Regardless of which CLI you use, you can use any part of the [Expo SDK](/versions/latest/) and [Expo Application Services](/eas) with your project. For more information, see:
 
@@ -145,6 +145,6 @@ Expo Go cannot use third-party libraries that require custom native code and you
 
 ## Is ejecting deprecated?
 
-Yes, eject is a deprecated term and is no longer necessary. When Expo was first released, apps had larger native binary sizes and didn't support custom native code without "ejecting". This changed in December 2020 with the release of [EAS Build](/build/introduction) which supports any React Native app. The concept of "ejecting" was replaced by the [`npx expo prebuild`](/workflow/prebuild) command in SDK 41 (April 2021), which continuously generates native projects based on the libraries in your project and the app config (**app.json**). The `expo eject` command was fully deprecated in SDK 46 (August 2022).
+Yes, eject is a deprecated term and is no longer necessary. When Expo was first released, apps had larger native binary sizes and didn't support custom native code without "ejecting". This changed in December 2020 with the release of [EAS Build](/build/introduction) which supports any React Native app. The concept of "ejecting" was replaced by the [`npx expo prebuild`](/more/glossary-of-terms/#prebuild) command in SDK 41 (April 2021), which continuously generates native projects based on the libraries in your project and the app config (**app.json**). The `expo eject` command was fully deprecated in SDK 46 (August 2022).
 
-Unlike the previous eject workflow, authors can configure their libraries to work with Expo Prebuild by creating a [config plugin](/config-plugins/introduction/). This means you can use any library with Expo Prebuild. You can also use any custom native code with Expo Prebuild by creating a [development build](/develop/development-builds/introduction/). Learn more in the [Expo Prebuild documentation](/workflow/prebuild).
+Unlike the previous eject workflow, authors can configure their libraries to work with Expo Prebuild by creating a [config plugin](/config-plugins/introduction/). This means you can use any library with Expo Prebuild. You can also use any custom native code with Expo Prebuild by creating a [development build](/develop/development-builds/introduction/). Learn more in the [Expo Prebuild documentation](/workflow/continuous-native-generation).

--- a/docs/pages/guides/adopting-prebuild.mdx
+++ b/docs/pages/guides/adopting-prebuild.mdx
@@ -5,7 +5,7 @@ description: Learn how to adopt Expo Prebuild in a project that was bootstrapped
 
 import { DiffBlock, Terminal } from '~/ui/components/Snippet';
 
-There are [many advantages](/workflow/prebuild#pitch) of using [Expo Prebuild][prebuild] to [continuously generate your native projects](/workflow/continuous-native-generation). This guide will show you how to adopt Expo Prebuild in a project that was bootstrapped with `npx @react-native-community/cli@latest init`. The amount of time it will take to convert your project depends on the amount of custom native changes that you have made to your Android and iOS native projects. This may take a minute or two on a brand new project, and on a large project, it will be much longer.
+There are [many advantages](/workflow/continuous-native-generation) of using [Expo Prebuild][prebuild] to [continuously generate your native projects](/workflow/continuous-native-generation). This guide will show you how to adopt Expo Prebuild in a project that was bootstrapped with `npx @react-native-community/cli@latest init`. The amount of time it will take to convert your project depends on the amount of custom native changes that you have made to your Android and iOS native projects. This may take a minute or two on a brand new project, and on a large project, it will be much longer.
 
 Adopting prebuild will automatically add support for developing modules with the [Expo native module API][expo-modules-core] by linking `expo-modules-core` natively. You can also use any command from [Expo CLI][cli] in your project.
 
@@ -13,7 +13,7 @@ Adopting prebuild will automatically add support for developing modules with the
 
 ## Install the `expo` package
 
-The `expo` package contains the [`npx expo prebuild`](/more/expo-cli/#prebuild) command and indicates which [prebuild template](/workflow/prebuild#templates) to use:
+The `expo` package contains the [`npx expo prebuild`](/more/expo-cli/#prebuild) command and indicates which [prebuild template](/workflow/continuous-native-generation#templates) to use:
 
 <Terminal cmd={['$ npm install expo']} />
 
@@ -140,5 +140,5 @@ Prebuild is the tip of the automation iceberg, here are some features you can ad
 [expo-modules-core]: /modules/module-api/
 [dev-client]: /develop/development-builds/introduction/
 [config-plugins]: /config-plugins/introduction/
-[prebuild]: /workflow/prebuild
+[prebuild]: /workflow/continuous-native-generation
 [cli]: /more/expo-cli/

--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -19,7 +19,7 @@ Using the React Native TV library as the `react-native` dependency in an Expo pr
 
 ## Prerequisites
 
-The necessary changes to the native Android and iOS files are minimal and can be automated with a [config plugin](https://github.com/react-native-tvos/config-tv/tree/main/packages/config-tv) if you use [prebuild](/workflow/prebuild/). Below is a list of changes made by the config plugins, which you can alternatively apply manually:
+The necessary changes to the native Android and iOS files are minimal and can be automated with a [config plugin](https://github.com/react-native-tvos/config-tv/tree/main/packages/config-tv) if you use [prebuild](/more/glossary-of-terms/#prebuild). Below is a list of changes made by the config plugins, which you can alternatively apply manually:
 
 ### Android
 

--- a/docs/pages/guides/permissions.mdx
+++ b/docs/pages/guides/permissions.mdx
@@ -35,7 +35,7 @@ The only way to remove permissions that are added by package-level **AndroidMani
 }
 ```
 
-- See [`android.permissions`](/versions/latest/config/app/#permissions) to learn about which permissions are included in the default [prebuild template](/workflow/prebuild#templates).
+- See [`android.permissions`](/versions/latest/config/app/#permissions) to learn about which permissions are included in the default [prebuild template](/workflow/continuous-native-generation#templates).
 - Apps using _dangerous_ or _signature_ permissions without valid reasons **may be rejected by Google**. Ensure you follow the [Android permissions best practices](https://developer.android.com/training/permissions/usage-notes) when submitting your app.
 - [All available Android `Manifest.permissions`](https://developer.android.com/reference/android/Manifest.permission).
 

--- a/docs/pages/linking/into-your-app.mdx
+++ b/docs/pages/linking/into-your-app.mdx
@@ -27,7 +27,7 @@ To provide a link to your app, add a custom string to the [`scheme`](/versions/l
 
 After adding a custom scheme to your app, you need to [create a new development build](/develop/development-builds/create-a-build/). Once the app is installed on a device, you can open links within your app using `myapp://`.
 
-If the **custom scheme is not defined**, the app will use `android.package` and `ios.bundleIdentifier` as the default schemes in both development and production builds. This is because [Expo Prebuild](/workflow/prebuild/) automatically adds these properties as custom schemes for Android and iOS.
+If the **custom scheme is not defined**, the app will use `android.package` and `ios.bundleIdentifier` as the default schemes in both development and production builds. This is because [Expo Prebuild](/more/glossary-of-terms/#prebuild) automatically adds these properties as custom schemes for Android and iOS.
 
 ## Test the deep link
 

--- a/docs/pages/more/create-expo.mdx
+++ b/docs/pages/more/create-expo.mdx
@@ -53,7 +53,7 @@ You can use the `--template` option to select one of the following templates or 
 | [`blank`](https://github.com/expo/expo/tree/main/templates/expo-template-blank)                       | Installs minimum required npm dependencies without configuring navigation.                                                                                                            |
 | [`blank-typescript`](https://github.com/expo/expo/tree/main/templates/expo-template-blank-typescript) | A Blank template with TypeScript enabled.                                                                                                                                             |
 | [`tabs`](https://github.com/expo/expo/tree/main/templates/expo-template-tabs)                         | Installs and configures file-based routing with Expo Router and TypeScript enabled.                                                                                                   |
-| [`bare-minimum`](https://github.com/expo/expo/tree/main/templates/expo-template-bare-minimum)         | A Blank template with native directories (**android** and **ios**) generated. Runs [`npx expo prebuild`](/workflow/continuous-native-generation) during the setup.                                       |
+| [`bare-minimum`](https://github.com/expo/expo/tree/main/templates/expo-template-bare-minimum)         | A Blank template with native directories (**android** and **ios**) generated. Runs [`npx expo prebuild`](/workflow/continuous-native-generation) during the setup.                    |
 
 ### `--example`
 

--- a/docs/pages/more/create-expo.mdx
+++ b/docs/pages/more/create-expo.mdx
@@ -53,7 +53,7 @@ You can use the `--template` option to select one of the following templates or 
 | [`blank`](https://github.com/expo/expo/tree/main/templates/expo-template-blank)                       | Installs minimum required npm dependencies without configuring navigation.                                                                                                            |
 | [`blank-typescript`](https://github.com/expo/expo/tree/main/templates/expo-template-blank-typescript) | A Blank template with TypeScript enabled.                                                                                                                                             |
 | [`tabs`](https://github.com/expo/expo/tree/main/templates/expo-template-tabs)                         | Installs and configures file-based routing with Expo Router and TypeScript enabled.                                                                                                   |
-| [`bare-minimum`](https://github.com/expo/expo/tree/main/templates/expo-template-bare-minimum)         | A Blank template with native directories (**android** and **ios**) generated. Runs [`npx expo prebuild`](/workflow/prebuild/) during the setup.                                       |
+| [`bare-minimum`](https://github.com/expo/expo/tree/main/templates/expo-template-bare-minimum)         | A Blank template with native directories (**android** and **ios**) generated. Runs [`npx expo prebuild`](/workflow/continuous-native-generation) during the setup.                                       |
 
 ### `--example`
 

--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -179,7 +179,7 @@ Building locally is useful for developing native modules and [debugging complex 
 
 If your project does not have the corresponding native directories, the `npx expo prebuild` command will run once to generate the respective directory before building.
 
-For example, if your project does not have an **ios** directory in the root of your project, then `npx expo run:ios` will first run `npx expo prebuild -p ios` before compiling your app. For more information on this process, see [Expo Prebuild](/workflow/prebuild).
+For example, if your project does not have an **ios** directory in the root of your project, then `npx expo run:ios` will first run `npx expo prebuild -p ios` before compiling your app. For more information on this process, see [Expo Prebuild](/workflow/continuous-native-generation).
 
 **Cross-platform arguments**
 
@@ -364,7 +364,7 @@ This command will be disabled if your project is configured to use `metro` for b
 
 <Terminal cmd={['$ npx expo prebuild']} />
 
-Native source code must be generated before a native app can compile. Expo CLI provides a unique and powerful system called _prebuild_, that generates the native code for your project. To learn more, read the [Expo Prebuild docs](/workflow/prebuild/).
+Native source code must be generated before a native app can compile. Expo CLI provides a unique and powerful system called _prebuild_, that generates the native code for your project. To learn more, read the [Expo Prebuild docs](/workflow/continuous-native-generation/).
 
 ## Lint
 
@@ -406,7 +406,7 @@ Evaluate the app config (**app.json**, or **app.config.js**) by running:
 There are three different config types that are generated from the app config:
 
 - `public`: The manifest file to use with OTA updates. Think of this like an `index.html` file's `<head />` element but for native apps.
-- `prebuild`: The config that is used for [Expo Prebuild](/workflow/prebuild) including async modifiers. This is the only time the config is not serializable.
+- `prebuild`: The config that is used for [Expo Prebuild](/workflow/continuous-native-generation) including async modifiers. This is the only time the config is not serializable.
 - `introspect`: A subset of the `prebuild` config that only shows in-memory modifications like `Info.plist` or **AndroidManifest.xml** changes. Learn more about [introspection](/config-plugins/development-and-debugging/#introspection).
 
 ## Install

--- a/docs/pages/more/glossary-of-terms.mdx
+++ b/docs/pages/more/glossary-of-terms.mdx
@@ -54,7 +54,7 @@ Projects can configure how Babel is used by modifying the [**babel.config.js**](
 
 Describes the approach when the native projects (in the **android** and **ios** directories) are versioned in Git and maintained manually. It's typical for **existing "bare" React Native apps** where you manually make changes to the native projects. There is freedom to customize them but also high maintenance overhead.
 
-This is in contrast to using [app config and prebuild](/workflow/prebuild), where the native projects are not versioned. Instead, they are generated on demand using the `npx expo prebuild`, which is the [recommended approach](/workflow/prebuild/#pitch).
+This is in contrast to using [app config and prebuild](/workflow/continuous-native-generation), where the native projects are not versioned. Instead, they are generated on demand using the `npx expo prebuild`, which is the [recommended approach](/workflow/continuous-native-generation).
 
 ### Bun
 
@@ -82,7 +82,7 @@ A JavaScript function that is used to append [config mods](#config-mods) to the 
 
 ### Continuous Native Generation (CNG)
 
-An abstract concept that describes the process of generating native projects from a set of inputs. In the context of Expo, CNG is implemented via the [`prebuild`](#prebuild) command. See [CNG](/workflow/continuous-native-generation/) and [Expo Prebuild](/workflow/prebuild/) for more information.
+An abstract concept that describes the process of generating native projects from a set of inputs. In the context of Expo, CNG is implemented via the [`prebuild`](#prebuild) command. See [Continuous Native Generation](/workflow/continuous-native-generation/) for more information.
 
 ### create-expo-app
 

--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -635,9 +635,9 @@ Using a variable in the `Worker` constructor is not supported for bundling. To i
 
 ## Bare workflow setup
 
-> This guide is versioned and will need to be revisited when upgrading/downgrading Expo. Alternatively, use [Expo Prebuild](/workflow/prebuild) for fully automated setup.
+> This guide is versioned and will need to be revisited when upgrading/downgrading Expo. Alternatively, use [Expo Prebuild](/more/glossary-of-terms/#prebuild) for fully automated setup.
 
-Projects that don't use [Expo Prebuild](/workflow/prebuild) must configure native files to ensure the Expo Metro config is always used to bundle the project.
+Projects that don't use [Expo Prebuild](/more/glossary-of-terms/#prebuild) must configure native files to ensure the Expo Metro config is always used to bundle the project.
 
 {/* If this isn't done, then features like [aliases](/guides/typescript/#path-aliases-optional), [absolute imports](/guides/typescript/#absolute-imports-optional), asset hashing, and more will not work. */}
 

--- a/docs/pages/versions/unversioned/config/package-json.mdx
+++ b/docs/pages/versions/unversioned/config/package-json.mdx
@@ -82,7 +82,7 @@ By default, the check is enabled and unknown packages are listed.
 
 ### `appConfigFieldsNotSyncedCheck`
 
-Expo Doctor checks if your project includes native project directories such as **android** or **ios**. If these directories exist but are not listed in your **.gitignore** or [**.easignore**](/build-reference/easignore) files, Expo Doctor verifies the presence of an app config file. If this file exists, it means your project is configured to use [Prebuild](/workflow/prebuild).
+Expo Doctor checks if your project includes native project directories such as **android** or **ios**. If these directories exist but are not listed in your **.gitignore** or [**.easignore**](/build-reference/easignore) files, Expo Doctor verifies the presence of an app config file. If this file exists, it means your project is configured to use [Prebuild](/more/glossary-of-terms/#prebuild).
 
 When the **android** or **ios** directories are present, EAS Build does not sync app config properties to the native projects. Expo Doctor throws a warning if these conditions are true.
 

--- a/docs/pages/versions/unversioned/sdk/build-properties.mdx
+++ b/docs/pages/versions/unversioned/sdk/build-properties.mdx
@@ -12,9 +12,9 @@ import { ConfigPluginExample } from '~/ui/components/ConfigSection';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
 `expo-build-properties` is a [config plugin](/config-plugins/introduction/) configuring the native build properties
-of your **android/gradle.properties** and **ios/Podfile.properties.json** directories during [Prebuild](/workflow/prebuild).
+of your **android/gradle.properties** and **ios/Podfile.properties.json** directories during [Prebuild](/workflow/continuous-native-generation).
 
-> **info** This config plugin configures how [Prebuild command](/workflow/prebuild) generates the native **android** and **ios** directories
+> **info** This config plugin configures how [Prebuild command](/workflow/continuous-native-generation/#usage) generates the native **android** and **ios** directories
 > and therefore cannot be used with projects that don't run `npx expo prebuild` (bare projects).
 
 ## Installation

--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -643,7 +643,7 @@ We encourage you to always ensure appropriate channels with informative names ar
 
 ### Custom notification icon and colors&ensp;<PlatformTags platforms={['android']} />
 
-You can configure the `icon` and `color` keys for notification in the project by using the [`expo-notifications` config plugin](#configurable-properties) with [Expo Prebuild](/workflow/prebuild). These are build-time settings, so you'll need to recompile your native Android app with `eas build -p android` or `npx expo run:android` to see the changes.
+You can configure the `icon` and `color` keys for notification in the project by using the [`expo-notifications` config plugin](#configurable-properties) with [Expo Prebuild](/workflow/continuous-native-generation). These are build-time settings, so you'll need to recompile your native Android app with `eas build -p android` or `npx expo run:android` to see the changes.
 
 For your notification icon, make sure you follow [Google's design guidelines](https://material.io/design/iconography/product-icons.html#design-principles)
 (the icon must be all white with a transparent background) or else it may not be displayed as intended.

--- a/docs/pages/versions/v53.0.0/config/metro.mdx
+++ b/docs/pages/versions/v53.0.0/config/metro.mdx
@@ -623,9 +623,9 @@ Using a variable in the `Worker` constructor is not supported for bundling. To i
 
 ## Bare workflow setup
 
-> This guide is versioned and will need to be revisited when upgrading/downgrading Expo. Alternatively, use [Expo Prebuild](/workflow/prebuild) for fully automated setup.
+> This guide is versioned and will need to be revisited when upgrading/downgrading Expo. Alternatively, use [Expo Prebuild](/more/glossary-of-terms/#prebuild) for fully automated setup.
 
-Projects that don't use [Expo Prebuild](/workflow/prebuild) must configure native files to ensure the Expo Metro config is always used to bundle the project.
+Projects that don't use [Expo Prebuild](/more/glossary-of-terms/#prebuild) must configure native files to ensure the Expo Metro config is always used to bundle the project.
 
 {/* If this isn't done, then features like [aliases](/guides/typescript/#path-aliases-optional), [absolute imports](/guides/typescript/#absolute-imports-optional), asset hashing, and more will not work. */}
 

--- a/docs/pages/versions/v53.0.0/config/package-json.mdx
+++ b/docs/pages/versions/v53.0.0/config/package-json.mdx
@@ -82,7 +82,7 @@ By default, the check is enabled and unknown packages are listed.
 
 ### `appConfigFieldsNotSyncedCheck`
 
-Expo Doctor checks if your project includes native project directories such as **android** or **ios**. If these directories exist but are not listed in your **.gitignore** or [**.easignore**](/build-reference/easignore) files, Expo Doctor verifies the presence of an app config file. If this file exists, it means your project is configured to use [Prebuild](/workflow/prebuild).
+Expo Doctor checks if your project includes native project directories such as **android** or **ios**. If these directories exist but are not listed in your **.gitignore** or [**.easignore**](/build-reference/easignore) files, Expo Doctor verifies the presence of an app config file. If this file exists, it means your project is configured to use [Prebuild](/more/glossary-of-terms/#prebuild).
 
 When the **android** or **ios** directories are present, EAS Build does not sync app config properties to the native projects. Expo Doctor throws a warning if these conditions are true.
 

--- a/docs/pages/versions/v53.0.0/sdk/build-properties.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/build-properties.mdx
@@ -12,9 +12,9 @@ import { ConfigPluginExample } from '~/ui/components/ConfigSection';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
 `expo-build-properties` is a [config plugin](/config-plugins/introduction/) configuring the native build properties
-of your **android/gradle.properties** and **ios/Podfile.properties.json** directories during [Prebuild](/workflow/prebuild).
+of your **android/gradle.properties** and **ios/Podfile.properties.json** directories during [Prebuild](/workflow/continuous-native-generation).
 
-> **info** This config plugin configures how [Prebuild command](/workflow/prebuild) generates the native **android** and **ios** directories
+> **info** This config plugin configures how [Prebuild command](/workflow/continuous-native-generation/#usage) generates the native **android** and **ios** directories
 > and therefore cannot be used with projects that don't run `npx expo prebuild` (bare projects).
 
 ## Installation

--- a/docs/pages/versions/v53.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/notifications.mdx
@@ -639,7 +639,7 @@ We encourage you to always ensure appropriate channels with informative names ar
 
 ### Custom notification icon and colors&ensp;<PlatformTags platforms={['android']} />
 
-You can configure the [`notification.icon`](../config/app/#notification) and [`notification.color`](../config/app/#notification) keys in the project's **app.json** if you are using [Expo Prebuild](/workflow/prebuild) or by using the [`expo-notifications` config plugin directly](#configurable-properties). These are build-time settings, so you'll need to recompile your native Android app with `eas build -p android` or `npx expo run:android` to see the changes.
+You can configure the [`notification.icon`](../config/app/#notification) and [`notification.color`](../config/app/#notification) keys in the project's **app.json** if you are using [Expo Prebuild](/workflow/continuous-native-generation) or by using the [`expo-notifications` config plugin directly](#configurable-properties). These are build-time settings, so you'll need to recompile your native Android app with `eas build -p android` or `npx expo run:android` to see the changes.
 
 For your notification icon, make sure you follow [Google's design guidelines](https://material.io/design/iconography/product-icons.html#design-principles)
 (the icon must be all white with a transparent background) or else it may not be displayed as intended.

--- a/docs/pages/versions/v53.0.0/sdk/sharing.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/sharing.mdx
@@ -23,7 +23,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 #### Sharing to your app from other apps
 
-Currently `expo-sharing` only supports sharing _from your app to other apps_ and you cannot register to your app to have content shared to it through the native share dialog on native platforms. You can read more [in the related feature request](https://expo.canny.io/feature-requests/p/share-extension-ios-share-intent-android). You can setup this functionality manually in Xcode and Android Studio and create an [Expo Config Plugin](/config-plugins/introduction/) to continue using [Expo Prebuild](/workflow/prebuild).
+Currently `expo-sharing` only supports sharing _from your app to other apps_ and you cannot register to your app to have content shared to it through the native share dialog on native platforms. You can read more [in the related feature request](https://expo.canny.io/feature-requests/p/share-extension-ios-share-intent-android). You can setup this functionality manually in Xcode and Android Studio and create an [Expo Config Plugin](/config-plugins/introduction/) to continue using [Expo Prebuild](/workflow/continuous-native-generation).
 
 ## Installation
 

--- a/docs/pages/versions/v54.0.0/config/metro.mdx
+++ b/docs/pages/versions/v54.0.0/config/metro.mdx
@@ -635,9 +635,9 @@ Using a variable in the `Worker` constructor is not supported for bundling. To i
 
 ## Bare workflow setup
 
-> This guide is versioned and will need to be revisited when upgrading/downgrading Expo. Alternatively, use [Expo Prebuild](/workflow/prebuild) for fully automated setup.
+> This guide is versioned and will need to be revisited when upgrading/downgrading Expo. Alternatively, use [Expo Prebuild](/more/glossary-of-terms/#prebuild) for fully automated setup.
 
-Projects that don't use [Expo Prebuild](/workflow/prebuild) must configure native files to ensure the Expo Metro config is always used to bundle the project.
+Projects that don't use [Expo Prebuild](/more/glossary-of-terms/#prebuild) must configure native files to ensure the Expo Metro config is always used to bundle the project.
 
 {/* If this isn't done, then features like [aliases](/guides/typescript/#path-aliases-optional), [absolute imports](/guides/typescript/#absolute-imports-optional), asset hashing, and more will not work. */}
 

--- a/docs/pages/versions/v54.0.0/config/package-json.mdx
+++ b/docs/pages/versions/v54.0.0/config/package-json.mdx
@@ -82,7 +82,7 @@ By default, the check is enabled and unknown packages are listed.
 
 ### `appConfigFieldsNotSyncedCheck`
 
-Expo Doctor checks if your project includes native project directories such as **android** or **ios**. If these directories exist but are not listed in your **.gitignore** or [**.easignore**](/build-reference/easignore) files, Expo Doctor verifies the presence of an app config file. If this file exists, it means your project is configured to use [Prebuild](/workflow/prebuild).
+Expo Doctor checks if your project includes native project directories such as **android** or **ios**. If these directories exist but are not listed in your **.gitignore** or [**.easignore**](/build-reference/easignore) files, Expo Doctor verifies the presence of an app config file. If this file exists, it means your project is configured to use [Prebuild](/more/glossary-of-terms/#prebuild).
 
 When the **android** or **ios** directories are present, EAS Build does not sync app config properties to the native projects. Expo Doctor throws a warning if these conditions are true.
 

--- a/docs/pages/versions/v54.0.0/sdk/build-properties.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/build-properties.mdx
@@ -12,9 +12,9 @@ import { ConfigPluginExample } from '~/ui/components/ConfigSection';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
 `expo-build-properties` is a [config plugin](/config-plugins/introduction/) configuring the native build properties
-of your **android/gradle.properties** and **ios/Podfile.properties.json** directories during [Prebuild](/workflow/prebuild).
+of your **android/gradle.properties** and **ios/Podfile.properties.json** directories during [Prebuild](/workflow/continuous-native-generation).
 
-> **info** This config plugin configures how [Prebuild command](/workflow/prebuild) generates the native **android** and **ios** directories
+> **info** This config plugin configures how [Prebuild command](/workflow/continuous-native-generation/#usage) generates the native **android** and **ios** directories
 > and therefore cannot be used with projects that don't run `npx expo prebuild` (bare projects).
 
 ## Installation

--- a/docs/pages/versions/v54.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/notifications.mdx
@@ -643,7 +643,7 @@ We encourage you to always ensure appropriate channels with informative names ar
 
 ### Custom notification icon and colors&ensp;<PlatformTags platforms={['android']} />
 
-You can configure the [`notification.icon`](../config/app/#notification) and [`notification.color`](../config/app/#notification) keys in the project's **app.json** if you are using [Expo Prebuild](/workflow/prebuild) or by using the [`expo-notifications` config plugin directly](#configurable-properties). These are build-time settings, so you'll need to recompile your native Android app with `eas build -p android` or `npx expo run:android` to see the changes.
+You can configure the [`notification.icon`](../config/app/#notification) and [`notification.color`](../config/app/#notification) keys in the project's **app.json** if you are using [Expo Prebuild](/workflow/continuous-native-generation) or by using the [`expo-notifications` config plugin directly](#configurable-properties). These are build-time settings, so you'll need to recompile your native Android app with `eas build -p android` or `npx expo run:android` to see the changes.
 
 For your notification icon, make sure you follow [Google's design guidelines](https://material.io/design/iconography/product-icons.html#design-principles)
 (the icon must be all white with a transparent background) or else it may not be displayed as intended.

--- a/docs/pages/versions/v54.0.0/sdk/sharing.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/sharing.mdx
@@ -23,7 +23,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 #### Sharing to your app from other apps
 
-Currently `expo-sharing` only supports sharing _from your app to other apps_ and you cannot register to your app to have content shared to it through the native share dialog on native platforms. You can read more [in the related feature request](https://expo.canny.io/feature-requests/p/share-extension-ios-share-intent-android). You can setup this functionality manually in Xcode and Android Studio and create an [Expo Config Plugin](/config-plugins/introduction/) to continue using [Expo Prebuild](/workflow/prebuild).
+Currently `expo-sharing` only supports sharing _from your app to other apps_ and you cannot register to your app to have content shared to it through the native share dialog on native platforms. You can read more [in the related feature request](https://expo.canny.io/feature-requests/p/share-extension-ios-share-intent-android). You can setup this functionality manually in Xcode and Android Studio and create an [Expo Config Plugin](/config-plugins/introduction/) to continue using [Expo Prebuild](/workflow/continuous-native-generation).
 
 ## Installation
 

--- a/docs/pages/versions/v55.0.0/config/metro.mdx
+++ b/docs/pages/versions/v55.0.0/config/metro.mdx
@@ -635,9 +635,9 @@ Using a variable in the `Worker` constructor is not supported for bundling. To i
 
 ## Bare workflow setup
 
-> This guide is versioned and will need to be revisited when upgrading/downgrading Expo. Alternatively, use [Expo Prebuild](/workflow/prebuild) for fully automated setup.
+> This guide is versioned and will need to be revisited when upgrading/downgrading Expo. Alternatively, use [Expo Prebuild](/more/glossary-of-terms/#prebuild) for fully automated setup.
 
-Projects that don't use [Expo Prebuild](/workflow/prebuild) must configure native files to ensure the Expo Metro config is always used to bundle the project.
+Projects that don't use [Expo Prebuild](/more/glossary-of-terms/#prebuild) must configure native files to ensure the Expo Metro config is always used to bundle the project.
 
 {/* If this isn't done, then features like [aliases](/guides/typescript/#path-aliases-optional), [absolute imports](/guides/typescript/#absolute-imports-optional), asset hashing, and more will not work. */}
 

--- a/docs/pages/versions/v55.0.0/config/package-json.mdx
+++ b/docs/pages/versions/v55.0.0/config/package-json.mdx
@@ -82,7 +82,7 @@ By default, the check is enabled and unknown packages are listed.
 
 ### `appConfigFieldsNotSyncedCheck`
 
-Expo Doctor checks if your project includes native project directories such as **android** or **ios**. If these directories exist but are not listed in your **.gitignore** or [**.easignore**](/build-reference/easignore) files, Expo Doctor verifies the presence of an app config file. If this file exists, it means your project is configured to use [Prebuild](/workflow/prebuild).
+Expo Doctor checks if your project includes native project directories such as **android** or **ios**. If these directories exist but are not listed in your **.gitignore** or [**.easignore**](/build-reference/easignore) files, Expo Doctor verifies the presence of an app config file. If this file exists, it means your project is configured to use [Prebuild](/more/glossary-of-terms/#prebuild).
 
 When the **android** or **ios** directories are present, EAS Build does not sync app config properties to the native projects. Expo Doctor throws a warning if these conditions are true.
 

--- a/docs/pages/versions/v55.0.0/sdk/build-properties.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/build-properties.mdx
@@ -12,9 +12,9 @@ import { ConfigPluginExample } from '~/ui/components/ConfigSection';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
 `expo-build-properties` is a [config plugin](/config-plugins/introduction/) configuring the native build properties
-of your **android/gradle.properties** and **ios/Podfile.properties.json** directories during [Prebuild](/workflow/prebuild).
+of your **android/gradle.properties** and **ios/Podfile.properties.json** directories during [Prebuild](/workflow/continuous-native-generation).
 
-> **info** This config plugin configures how [Prebuild command](/workflow/prebuild) generates the native **android** and **ios** directories
+> **info** This config plugin configures how [Prebuild command](/workflow/continuous-native-generation/#usage) generates the native **android** and **ios** directories
 > and therefore cannot be used with projects that don't run `npx expo prebuild` (bare projects).
 
 ## Installation

--- a/docs/pages/versions/v55.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/notifications.mdx
@@ -643,7 +643,7 @@ We encourage you to always ensure appropriate channels with informative names ar
 
 ### Custom notification icon and colors&ensp;<PlatformTags platforms={['android']} />
 
-You can configure the `icon` and `color` keys for notification in the project by using the [`expo-notifications` config plugin](#configurable-properties) with [Expo Prebuild](/workflow/prebuild). These are build-time settings, so you'll need to recompile your native Android app with `eas build -p android` or `npx expo run:android` to see the changes.
+You can configure the `icon` and `color` keys for notification in the project by using the [`expo-notifications` config plugin](#configurable-properties) with [Expo Prebuild](/workflow/continuous-native-generation). These are build-time settings, so you'll need to recompile your native Android app with `eas build -p android` or `npx expo run:android` to see the changes.
 
 For your notification icon, make sure you follow [Google's design guidelines](https://material.io/design/iconography/product-icons.html#design-principles)
 (the icon must be all white with a transparent background) or else it may not be displayed as intended.

--- a/docs/pages/workflow/configuration.mdx
+++ b/docs/pages/workflow/configuration.mdx
@@ -12,7 +12,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 <PossibleRedirectNotification newUrl="/versions/latest/config/app/" />
 
-The app config (**app.json**, **app.config.js**, **app.config.ts**) is used for configuring [Expo Prebuild](/workflow/prebuild) generation, how a project loads in [Expo Go](/get-started/expo-go/), and the OTA update manifest.
+The app config (**app.json**, **app.config.js**, **app.config.ts**) is used for configuring [Expo Prebuild](/more/glossary-of-terms/#prebuild) generation, how a project loads in [Expo Go](/get-started/expo-go/), and the OTA update manifest.
 
 It must be located at the root of your project, next to the **package.json**. Here is a minimal example:
 
@@ -62,7 +62,7 @@ The following fields are filtered out of the public app config (and not accessib
 
 Library authors can extend the app config by using [Expo Config plugins](/config-plugins/introduction/).
 
-> **info** Config plugins are mostly used to configure the [`npx expo prebuild`](/workflow/prebuild) command.
+> **info** Config plugins are mostly used to configure the [`npx expo prebuild`](/more/glossary-of-terms/#prebuild) command.
 
 ## Dynamic configuration
 

--- a/docs/pages/workflow/overview.mdx
+++ b/docs/pages/workflow/overview.mdx
@@ -94,7 +94,7 @@ Android and Xcode projects that bundle the JavaScript app, serve as the launchpa
 
 Like any mobile app, the application that is distributed to users is created by compiling ("building") the Android Studio or Xcode project.
 
-When you initialize a new app with `npx create-expo-app`, you will not see any **android** or **ios** directories. You can [generate the native projects by running `npx expo prebuild`](/workflow/prebuild/), which will initialize the native projects and then apply the project Expo app config (**app.json/app.config.js**) to them.
+When you initialize a new app with `npx create-expo-app`, you will not see any **android** or **ios** directories. You can [generate the native projects by running `npx expo prebuild`](/workflow/continuous-native-generation/), which will initialize the native projects and then apply the project Expo app config (**app.json/app.config.js**) to them.
 
 If you use a cloud-based development workflow, you may never need to run prebuild or install Android Studio or Xcode on your own machine (although you may find this useful). This is explained below in the [Local and cloud-based development workflows](#cloud-based-and-local-development-workflows).
 

--- a/docs/pages/workflow/using-libraries.mdx
+++ b/docs/pages/workflow/using-libraries.mdx
@@ -113,7 +113,7 @@ If the module needs additional native configuration, you can do so using [config
 
 <ConfigReactNative>
 
-If your project does not support [Expo Prebuild](/workflow/prebuild) then you won't be able to use [config plugins](/config-plugins/introduction/). You can either [adopt Expo Prebuild](/guides/adopting-prebuild) or set up and configure each library manually by following any additional setup guides from the respective module's website or README.
+If your project does not support [Expo Prebuild](/workflow/continuous-native-generation) then you won't be able to use [config plugins](/config-plugins/introduction/). You can either [adopt Expo Prebuild](/guides/adopting-prebuild) or set up and configure each library manually by following any additional setup guides from the respective module's website or README.
 
 </ConfigReactNative>
 


### PR DESCRIPTION
# Why

All internal links pointing to `/workflow/prebuild` are hitting a 301 redirect since the page was renamed to `/workflow/continuous-native-generation`. This adds unnecessary redirect hops for readers and shows stale URLs in the browser.

# How

- Replace `/workflow/prebuild` links across 38 files with the correct destination, using context-appropriate targets:
  - **CNG page**: used in SDK reference pages, guides, and "learn more" contexts where readers need the full explanation of how prebuild works.
  - **Glossary**: used for casual "if you use prebuild" mentions in config reference pages and non-SDK docs.
- Consolidate a redundant double-link in `more/glossary-of-terms.mdx` where both "CNG" and "Expo Prebuild" linked to the same destination.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Verify that no remaining references to `/workflow/prebuild` exist in the docs/pages/ directory.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
