### PR TITLE
[docs] Fix internal links to Expo Router hooks API reference

### DIFF
--- a/docs/pages/router/migrate/from-react-navigation.mdx
+++ b/docs/pages/router/migrate/from-react-navigation.mdx
@@ -201,11 +201,11 @@ Instead, migrate `navigation` to the `useRouter` hook.
 
 <DiffBlock source="/static/diffs/router/migrate-from-react-navigation/use-router-hook.diff" />
 
-Similarly, migrate from the `route` prop to the [`useLocalSearchParams`](/router/reference/hooks/#uselocalsearchparams) hook.
+Similarly, migrate from the `route` prop to the [`useLocalSearchParams`](/versions/latest/sdk/router/#uselocalsearchparams) hook.
 
 <DiffBlock source="/static/diffs/router/migrate-from-react-navigation/use-local-search-params.diff" />
 
-To access the [`navigation.navigate`](https://reactnavigation.org/docs/navigation-object/#navigate), import the `navigation` prop from [`useNavigation`](/router/reference/hooks/#usenavigation) hook.
+To access the [`navigation.navigate`](https://reactnavigation.org/docs/navigation-object/#navigate), import the `navigation` prop from [`useNavigation`](/versions/latest/sdk/router/#usenavigation) hook.
 
 <DiffBlock source="/static/diffs/router/migrate-from-react-navigation/use-navigation-hook.diff" />
 
@@ -277,11 +277,11 @@ Use `useRootNavigationState()`.
 
 #### `getCurrentRoute`
 
-Unlike React Navigation, Expo Router can reliably represent any route with a string. Use the [`usePathname()`](/router/reference/hooks/#usepathname) or [`useSegments()`](/router/reference/hooks/#usesegments) hooks to identify the current route.
+Unlike React Navigation, Expo Router can reliably represent any route with a string. Use the [`usePathname()`](/versions/latest/sdk/router/#usepathname) or [`useSegments()`](/versions/latest/sdk/router/#usesegments) hooks to identify the current route.
 
 #### `getCurrentOptions`
 
-Use the [`useLocalSearchParams()`](/router/reference/hooks/#uselocalsearchparams) hook to get the current route's query parameters.
+Use the [`useLocalSearchParams()`](/versions/latest/sdk/router/#uselocalsearchparams) hook to get the current route's query parameters.
 
 #### `addListener`
 
@@ -289,11 +289,11 @@ The following events can be migrated:
 
 #### `state`
 
-Use the [`usePathname()`](/router/reference/hooks/#usepathname) or [`useSegments()`](/router/reference/hooks/#usesegments) hooks to identify the current route. Use in conjunction with `useEffect(() => {}, [...])` to observe changes.
+Use the [`usePathname()`](/versions/latest/sdk/router/#usepathname) or [`useSegments()`](/versions/latest/sdk/router/#usesegments) hooks to identify the current route. Use in conjunction with `useEffect(() => {}, [...])` to observe changes.
 
 #### `options`
 
-Use the [`useLocalSearchParams()`](/router/reference/hooks/#uselocalsearchparams) hook to get the current route's query parameters. Use in conjunction with `useEffect(() => {}, [...])` to observe changes.
+Use the [`useLocalSearchParams()`](/versions/latest/sdk/router/#uselocalsearchparams) hook to get the current route's query parameters. Use in conjunction with `useEffect(() => {}, [...])` to observe changes.
 
 ### props
 
@@ -307,7 +307,7 @@ Avoid using this pattern in favor of deep linking (for example, a user opens you
 
 #### `onStateChange`
 
-Use the [`usePathname()`](/router/reference/hooks/#usepathname), [`useSegments()`](/router/reference/hooks/#usesegments), and [`useGlobalSearchParams()`](/router/reference/hooks/#useglobalsearchparams) hooks to identify the current route state. Use in conjunction with `useEffect(() => {}, [...])` to observe changes.
+Use the [`usePathname()`](/versions/latest/sdk/router/#usepathname), [`useSegments()`](/versions/latest/sdk/router/#usesegments), and [`useGlobalSearchParams()`](/versions/latest/sdk/router/#useglobalsearchparams) hooks to identify the current route state. Use in conjunction with `useEffect(() => {}, [...])` to observe changes.
 
 - If you're attempting to track screen changes, follow the [Screen Tracking guide](/router/reference/screen-tracking/).
 - React Navigation recommends avoiding [`onStateChange`](https://reactnavigation.org/docs/navigation-container/#onstatechange).
@@ -434,7 +434,7 @@ Expo Router wraps `expo-splash-screen` and adds special handling to ensure it's 
 
 ### Navigation state observation
 
-If you're observing the navigation state directly, migrate to the [`usePathname`](/router/reference/hooks/#usepathname), [`useSegments`](/router/reference/hooks/#usesegments), and [`useGlobalSearchParams`](/router/reference/hooks/#useglobalsearchparams) hooks.
+If you're observing the navigation state directly, migrate to the [`usePathname`](/versions/latest/sdk/router/#usepathname), [`useSegments`](/versions/latest/sdk/router/#usesegments), and [`useGlobalSearchParams`](/versions/latest/sdk/router/#useglobalsearchparams) hooks.
 
 ### Pass params to nested screens
 
@@ -457,7 +457,7 @@ In React Navigation, you can use the `initialRouteName` property of the linking 
 
 ### Reset navigation state
 
-You can use the [`reset`](https://reactnavigation.org/docs/navigation-actions/#reset) action from the React Navigation library to reset the navigation state. It is dispatched using the [`useNavigation`](/router/reference/hooks/#usenavigation) hook from Expo Router to access the `navigation` prop.
+You can use the [`reset`](https://reactnavigation.org/docs/navigation-actions/#reset) action from the React Navigation library to reset the navigation state. It is dispatched using the [`useNavigation`](/versions/latest/sdk/router/#usenavigation) hook from Expo Router to access the `navigation` prop.
 
 In the below example, the `navigation` prop is accessible from the `useNavigation` hook and the `CommonActions.reset` action from `@react-navigation/native`. The object specified in the `reset` action replaces the existing navigation state with the new one.
 

--- a/docs/pages/router/reference/testing.mdx
+++ b/docs/pages/router/reference/testing.mdx
@@ -117,7 +117,7 @@ The following matches have been added to `expect` and can be used to assert valu
 
 <PaddedAPIBox header="toHavePathname()">
 
-Assert the current pathname against a given string. The matcher uses the value of the [`usePathname`](/router/reference/hooks/#usepathname) hook on the current `screen`.
+Assert the current pathname against a given string. The matcher uses the value of the [`usePathname`](/versions/latest/sdk/router/#usepathname) hook on the current `screen`.
 
 ```tsx app.test.tsx
 expect(screen).toHavePathname('/my-router');
@@ -137,7 +137,7 @@ expect(screen).toHavePathnameWithParams('/my-router?hello=world');
 
 <PaddedAPIBox header="toHaveSegments()">
 
-Assert the current segments against an array of strings. The matcher uses the value of the [`useSegments`](/router/reference/hooks/#usesegments) hook on the current `screen`.
+Assert the current segments against an array of strings. The matcher uses the value of the [`useSegments`](/versions/latest/sdk/router/#usesegments) hook on the current `screen`.
 
 ```tsx app.test.tsx
 expect(screen).toHaveSegments(['[id]']);
@@ -146,7 +146,7 @@ expect(screen).toHaveSegments(['[id]']);
 </PaddedAPIBox>
 <PaddedAPIBox header="useLocalSearchParams()">
 
-Assert the current local URL parameters against an object. The matcher uses the value of the [`useLocalSearchParams`](/router/reference/hooks/#uselocalsearchparams) hook on the current `screen`.
+Assert the current local URL parameters against an object. The matcher uses the value of the [`useLocalSearchParams`](/versions/latest/sdk/router/#uselocalsearchparams) hook on the current `screen`.
 
 ```tsx app.test.tsx
 expect(screen).useLocalSearchParams({ first: 'abc' });
@@ -155,9 +155,9 @@ expect(screen).useLocalSearchParams({ first: 'abc' });
 </PaddedAPIBox>
 <PaddedAPIBox header="useGlobalSearchParams()">
 
-Assert the current screen's pathname that matches a value. Compares using the value of [`useGlobalSearchParams`](/router/reference/hooks/#useglobalsearchparams) hook.
+Assert the current screen's pathname that matches a value. Compares using the value of [`useGlobalSearchParams`](/versions/latest/sdk/router/#useglobalsearchparams) hook.
 
-Assert the current global URL parameters against an object. The matcher uses the value of the [`useGlobalSearchParams`](/router/reference/hooks/#useglobalsearchparams) hook on the current `screen`.
+Assert the current global URL parameters against an object. The matcher uses the value of the [`useGlobalSearchParams`](/versions/latest/sdk/router/#useglobalsearchparams) hook on the current `screen`.
 
 ```tsx app.test.tsx
 expect(screen).useGlobalSearchParams({ first: 'abc' });

--- a/docs/pages/router/reference/typed-routes.mdx
+++ b/docs/pages/router/reference/typed-routes.mdx
@@ -7,7 +7,7 @@ import { FileTree } from '~/ui/components/FileTree';
 
 > Available when using TypeScript in your project. Expo Router supports standard TypeScript out of the box. See the [TypeScript](/guides/typescript/) guide for more information on how to set it up.
 
-Expo Router supports generating TypeScript types automatically with Expo CLI. This enables `<Link>`, and the [hooks API](/router/reference/hooks) to be statically typed. This feature is currently in beta and is not enabled by default.
+Expo Router supports generating TypeScript types automatically with Expo CLI. This enables `<Link>`, and the [hooks API](/versions/latest/sdk/router/#hooks) to be statically typed. This feature is currently in beta and is not enabled by default.
 
 ## Get started
 


### PR DESCRIPTION
# Why

Links to `/router/reference/hooks/#<hookname>` across 3 docs pages point to a page that no longer exists. The hooks API reference has moved to `/versions/latest/sdk/router/`.

# How

- Update 15 hook reference links across `from-react-navigation.mdx`, `testing.mdx`, and `typed-routes.mdx` to point directly to `/versions/latest/sdk/router/#<hookname>`.

# Test Plan

Visit the following pages on the docs preview and confirm all hook links (`usePathname`, `useSegments`, `useLocalSearchParams`, `useGlobalSearchParams`, `useNavigation`) navigate to the correct anchor on the Router API reference page:
- `/router/migrate/from-react-navigation/`
- `/router/reference/testing/`
- `/router/reference/typed-routes/`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
