### PR TITLE
[docs] Fix broken internal links for EAS environment variables

### DIFF
--- a/docs/pages/build-reference/git-submodules.mdx
+++ b/docs/pages/build-reference/git-submodules.mdx
@@ -15,7 +15,7 @@ To initialize a submodule on EAS Build builder:
 
 <Step label="1">
 
-Create a [secret](/build-reference/variables/#using-secrets-in-environment-variables) with a base64 encoded private SSH key that has permission to access submodule repositories.
+Create a [secret](/eas/environment-variables/#visibility-settings-for-environment-variables) with a base64 encoded private SSH key that has permission to access submodule repositories.
 
 </Step>
 

--- a/docs/pages/build-reference/private-npm-packages.mdx
+++ b/docs/pages/build-reference/private-npm-packages.mdx
@@ -37,7 +37,7 @@ The recommended way is to add the `NPM_TOKEN` secret to your account or project'
   src="/static/images/eas-build/environment-secrets/secrets-create-filled.png"
 />
 
-For more information on how to do that, see [secret environment variables](/build-reference/variables/#secrets-on-the-expo-website).
+For more information on how to do that, see [secret environment variables](/eas/environment-variables/manage/#create-variables-in-the-dashboard).
 
 When EAS detects that the `NPM_TOKEN` environment variable is available during a build, it automatically creates the following **.npmrc**:
 

--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -101,7 +101,7 @@ If your project imports a file listed in **.gitignore**, the build will fail wit
 
 - Encode the file with `base64`, save that string as secrets, and create the file in an EAS Build hook. See [How can I upload files to EAS Build if they are gitignored?](https://expo.fyi/eas-build-archive.md#how-can-i-upload-files-to-eas-build-if-they-are-gitignored) for more information.
 
-- Refactor your source code to avoid importing sensitive files on the client side. If a file is an auto-generated code from a third-party provider and that provider has automatically listed files in your **.gitignore**, then that file probably contains sensitive information. You should not include it on the client side. During app development, ensure you follow secure practices, such as using environment variables or serving them through your backend. See [Using secrets in environment variables](/build-reference/variables/#using-secrets-in-environment-variables) for more information.
+- Refactor your source code to avoid importing sensitive files on the client side. If a file is an auto-generated code from a third-party provider and that provider has automatically listed files in your **.gitignore**, then that file probably contains sensitive information. You should not include it on the client side. During app development, ensure you follow secure practices, such as using environment variables or serving them through your backend. See [Using secrets in environment variables](/eas/environment-variables/#visibility-settings-for-environment-variables) for more information.
 
 </Collapsible>
 
@@ -149,7 +149,7 @@ You can build the production bundle locally by running `npx expo export` to bypa
 If the logs weren't enough to immediately help you understand and fix the root cause, it's time to try to reproduce the issue locally. If your project builds and runs locally in release mode then it will also build on EAS Build, provided that the following are all true:
 
 - Relevant [Build tool versions](/build/eas-json#configuring-your-build-tools) (for example, Xcode, Node.js, npm, Yarn) are the same in both environments.
-- Relevant [environment variables](/build-reference/variables) are the same in both environments.
+- Relevant [environment variables](/eas/environment-variables) are the same in both environments.
 - The [archive](https://expo.fyi/eas-build-archive) that is uploaded to EAS Build includes the same relevant source files.
 
 You can verify that your project builds on your local machine with the `npx expo run:android` and `npx expo run:ios` commands, with variant/configuration flags set to release to most faithfully reproduce what executes on EAS Build. For more information, see [Android build process](/build-reference/android-builds) and [iOS build process](/build-reference/ios-builds).

--- a/docs/pages/build/eas-json.mdx
+++ b/docs/pages/build/eas-json.mdx
@@ -381,7 +381,7 @@ You can configure environment variables on your build profiles using the `"env"`
 }
 ```
 
-The [Environment variables and secrets](/build-reference/variables) reference explains this topic in greater detail, and the [Use EAS Update](/build/updates) guide provides considerations when using this feature alongside `expo-updates`.
+The [Environment variables and secrets](/eas/environment-variables) reference explains this topic in greater detail, and the [Use EAS Update](/build/updates) guide provides considerations when using this feature alongside `expo-updates`.
 
 ## More
 

--- a/docs/pages/build/setup.mdx
+++ b/docs/pages/build/setup.mdx
@@ -78,7 +78,7 @@ For development, we recommend creating a [development build](/develop/developmen
 
 Additional configuration may be required for some scenarios:
 
-- Does your app code depend on environment variables? [Add them to your build configuration](/build-reference/variables).
+- Does your app code depend on environment variables? [Add them to your build configuration](/eas/environment-variables).
 - Is your project inside of a monorepo? [Follow these instructions](/build-reference/build-with-monorepos).
 - Do you use private npm packages? [Add your npm token](/build-reference/private-npm-packages).
 - Does your app depend on specific versions of tools like Node, Yarn, npm, CocoaPods, or Xcode? [Specify these versions in your build configuration](/build/eas-json).

--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -85,7 +85,7 @@ If you're experiencing issues with environment variables, you can try disabling 
 
 ### EAS Build
 
-[EAS Build](/build/introduction/) uses Metro Bundler to build the JavaScript bundle embedded within your app binary, so it will use **.env** files uploaded with your build job to inline `EXPO_PUBLIC_` variables into your code. EAS Build also lets you define environment variables within build profiles in **eas.json** and via EAS Secrets. Check out the EAS Build documentation on [environment variables and build secrets](/build-reference/variables/) for more information.
+[EAS Build](/build/introduction/) uses Metro Bundler to build the JavaScript bundle embedded within your app binary, so it will use **.env** files uploaded with your build job to inline `EXPO_PUBLIC_` variables into your code. EAS Build also lets you define environment variables within build profiles in **eas.json** and via EAS Secrets. Check out the EAS Build documentation on [environment variables and build secrets](/eas/environment-variables) for more information.
 
 ### EAS Update
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The `/build-reference/variables` page no longer exists. All 7 internal links pointing to it are broken (they only work because of a redirect rule). This PR updates them to point directly to the correct pages under `/eas/environment-variables/`.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update 3 links that referenced secret/visibility anchors (`#using-secrets-in-environment-variables`, `#secrets-on-the-expo-website`) to point to `/eas/environment-variables/#visibility-settings-for-environment-variables` or
  `/eas/environment-variables/manage/#create-variables-in-the-dashboard` depending on context.
- Update 4 general references to `/build-reference/variables` to point to `/eas/environment-variables`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Verify that no remaining references to `/build-reference/variables` exist in the `docs/pages/` directory.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
