### PR TITLE
[docs] Add --environment flag to eas update:configure commands

### DIFF
--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -37,11 +37,11 @@ Apply the changes from the diffs from the following sections to configure `expo-
 
 Run `eas update:configure` to set the `updates` URL and `projectId` in **app.json**.
 
-<Terminal cmd={['$ eas update:configure']} />
+<Terminal cmd={['$ eas update:configure --environment production']} />
 
 Modify the `expo` section of **app.json**. If you created your project using `npx @react-native-community/cli@latest init`, you will need to add the following changes including the [`updates` URL](/versions/latest/config/app/#url).
 
-> The example `updates` URL and `projectId` shown below are used with EAS Update. The EAS CLI sets this URL correctly for the EAS Update service when running `eas update:configure`.
+> The example `updates` URL and `projectId` shown below are used with EAS Update. The EAS CLI sets this URL correctly for the EAS Update service when running `eas update:configure --environment production`.
 
 <DiffBlock source="/static/diffs/expo-updates-app-json.diff" />
 

--- a/docs/pages/deploy/send-over-the-air-updates.mdx
+++ b/docs/pages/deploy/send-over-the-air-updates.mdx
@@ -13,7 +13,7 @@ You can send over-the-air updates containing critical bug fixes and improvements
 
 To set up updates, run the following [EAS CLI](/develop/tools/#eas-cli) command:
 
-<Terminal cmd={['$ eas update:configure']} />
+<Terminal cmd={['$ eas update:configure --environment production']} />
 
 After the command completes, you'll need to make new builds before continuing to the next section.
 

--- a/docs/pages/eas-update/debug.mdx
+++ b/docs/pages/eas-update/debug.mdx
@@ -205,7 +205,7 @@ The `expo-updates` library runs inside an end-user's app and makes requests to a
 
 #### Verifying app configuration
 
-When we set up EAS Update, we likely ran `eas update:configure` to configure expo-updates to work with EAS Update. This command makes changes to our app config (**app.json**/**app.config.js**). Here are the fields we'd expect to see:
+When we set up EAS Update, we likely ran `eas update:configure --environment production` to configure expo-updates to work with EAS Update. This command makes changes to our app config (**app.json**/**app.config.js**). Here are the fields we'd expect to see:
 
 - `runtimeVersion` should be set. By default, it is `{ "policy": "appVersion" }`. If our project has **android** and **ios** directories, we'll have to set the `runtimeVersion` manually.
 - `updates.url` should be a value like `https://u.expo.dev/your-project-id`, where `your-project-id` matches the ID of our project. We can see this ID on [our website](https://expo.dev/accounts/[account]/projects/[project]).

--- a/docs/pages/eas-update/deployment.mdx
+++ b/docs/pages/eas-update/deployment.mdx
@@ -36,13 +36,13 @@ Channels will indicate which environment the update targets (such as "production
 
 ### Channel configuration
 
-Run `eas update:configure` in your project if you haven't already.
+Run `eas update:configure --environment production` in your project if you haven't already.
 
 **If you use EAS Build**, the default configuration that will be applied by the configure command, which is almost what we want to use here: each profile will point to a channel of the same name, so our production release of our app will point to the "production" channel. We only need to add a "staging" profile that points to the "staging" channel.
 
 <Collapsible summary="Example eas.json configuration">
 
-The following configuration is approximately what `eas update:configure` will generate for you if you haven't already configured your project.
+The following configuration is approximately what `eas update:configure --environment production` will generate for you if you haven't already configured your project.
 
 ```json
 {

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -106,7 +106,10 @@ You can check whether you are logged in by running `eas whoami`.
 Navigate to your project directory in your terminal and run the following command:
 
 <Terminal
-  cmd={['# Initialize your project with EAS Update', '$ eas update:configure --environment production']}
+  cmd={[
+    '# Initialize your project with EAS Update',
+    '$ eas update:configure --environment production',
+  ]}
   cmdCopy="eas update:configure --environment production"
 />
 

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -106,9 +106,11 @@ You can check whether you are logged in by running `eas whoami`.
 Navigate to your project directory in your terminal and run the following command:
 
 <Terminal
-  cmd={['# Initialize your project with EAS Update', '$ eas update:configure']}
-  cmdCopy="eas update:configure"
+  cmd={['# Initialize your project with EAS Update', '$ eas update:configure --environment production']}
+  cmdCopy="eas update:configure --environment production"
 />
+
+The `--environment` flag specifies which [EAS environment variables](/eas/environment-variables/) to use during the command. Replace `production` with the appropriate environment for your project (for example, `development` or `preview`).
 
 <Collapsible summary="What does this command do?">
 
@@ -155,7 +157,7 @@ The `EXUpdatesURL` value should contain your project's ID.
 
 The channel property on a build allows you to point updates at specific types of builds. For example, it allows you to publish updates to a preview build without impacting your production deployment.
 
-**If you are using EAS Build**, `eas update:configure` will set the update `channel` property on the `preview` and `production` profiles in **eas.json**. Set them manually if you use different profile names.
+**If you are using EAS Build**, `eas update:configure --environment production` will set the update `channel` property on the `preview` and `production` profiles in **eas.json**. Set them manually if you use different profile names.
 
 <Collapsible summary="Example channel configuration in eas.json">
 

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -26,8 +26,8 @@ EAS Update makes fixing small bugs and pushing quick fixes a snap in between app
 Install the `expo-updates` library and configure EAS Update:
 
 <Terminal
-  cmd={['$ npx expo install expo-updates', '', '$ eas update:configure']}
-  cmdCopy="npx expo install expo-updates && eas update:configure"
+  cmd={['$ npx expo install expo-updates', '', '$ eas update:configure --environment production']}
+  cmdCopy="npx expo install expo-updates && eas update:configure --environment production"
 />
 
 You need to create a new build for Android or iOS to include the `expo-updates` library in your build. After that, you can push an update to the production channel:

--- a/docs/pages/eas-update/migrate-from-classic-updates.mdx
+++ b/docs/pages/eas-update/migrate-from-classic-updates.mdx
@@ -43,7 +43,7 @@ You'll need to make the following changes to your project:
 <Step label="1">
 Initialize your project with EAS Update:
 
-<Terminal cmd={['$ eas update:configure']} />
+<Terminal cmd={['$ eas update:configure --environment production']} />
 
 After this command, you should have two new fields in your app config at `expo.updates.url` and `expo.runtimeVersion`.
 

--- a/docs/pages/eas-update/request-proxying.mdx
+++ b/docs/pages/eas-update/request-proxying.mdx
@@ -35,7 +35,7 @@ EAS Update supports request proxying, which allows you to proxy requests to the 
    ```
 
 1. Run the following command to apply the changes:
-   <Terminal cmd={['$ eas update:configure']} />
+   <Terminal cmd={['$ eas update:configure --environment production']} />
 1. Publish an update to test the proxying:
    <Terminal cmd={['$ eas update']} />
 1. Verify by navigating to the update group on the [EAS Update dashboard](https://expo.dev/accounts/[account]/projects/[project]/updates) and clicking "View Metadata" for one of the platforms.

--- a/docs/pages/eas/workflows/examples/deploy-to-production.mdx
+++ b/docs/pages/eas/workflows/examples/deploy-to-production.mdx
@@ -61,7 +61,7 @@ When you're ready to deliver changes to your users, you can build and submit to 
   <Requirement number={3} title="Set up EAS Update">
   And finally, you'll need to set up EAS Update, which you can do with:
 
-<Terminal cmd={['$ eas update:configure']} />
+<Terminal cmd={['$ eas update:configure --environment production']} />
   </Requirement>
 </Prerequisites>
 

--- a/docs/pages/eas/workflows/examples/publish-preview-update.mdx
+++ b/docs/pages/eas/workflows/examples/publish-preview-update.mdx
@@ -31,7 +31,7 @@ You can access preview updates in the development build UI and through scannable
   <Requirement number={1} title="Set up EAS Update">
     Your project needs to have [EAS Update](/eas-update/introduction/) setup to publish preview updates. You can set up your project with:
 
-    <Terminal cmd={['$ eas update:configure']} />
+    <Terminal cmd={['$ eas update:configure --environment production']} />
 
   </Requirement>
   <Requirement number={2} title="Create new development builds">

--- a/docs/pages/tutorial/eas/team-development.mdx
+++ b/docs/pages/tutorial/eas/team-development.mdx
@@ -38,7 +38,9 @@ To initialize our project with EAS Update, we need to follow these steps:
 
 - Since we are using dynamic **app.config.js** for our app's configuration, adding [`updates`](/versions/latest/config/app/#updates) and [`runtimeVersion`](/eas-update/runtime-versions/#setting-runtimeversion) properties are required to make our project compatible with EAS Update. Run the following command to obtain these properties and their values from EAS and manually copy them to **app.config.js**:
 
-<Terminal cmd={['$ eas update:configure']} />
+<Terminal cmd={['$ eas update:configure --environment development']} />
+
+The `--environment` flag specifies which [EAS environment variables](/eas/environment-variables/) to use during the command. Since we're working with a development build in this tutorial, we use `development`. For other build profiles, replace it with the appropriate environment (for example, `preview` or `production`).
 
 <Collapsible summary="What about non-dynamic (app.json) projects?">
 
@@ -46,7 +48,7 @@ If a project doesn't use dynamic app config (uses **app.json** instead of **app.
 
 </Collapsible>
 
-- Re-run `eas update:configure` to continue with the setup process. A [`channel`](/eas/json/#channel) should be added to every build profile in **eas.json**:
+- Re-run `eas update:configure --environment development` to continue with the setup process. A [`channel`](/eas/json/#channel) should be added to every build profile in **eas.json**:
 
 {/* prettier-ignore */}
 ```json eas.json
@@ -78,7 +80,7 @@ If a project doesn't use dynamic app config (uses **app.json** instead of **app.
 }
 ```
 
-> **info** Notice that the `eas update:configure` command adds the `channel` to every build profile in **eas.json**. However, our `ios-simulator` profile extends the `development` profile and having a separate `channel` doesn't make sense. We can safely remove `ios-simulator.channel` from the above configuration.
+> **info** Notice that the `eas update:configure --environment development` command adds the `channel` to every build profile in **eas.json**. However, our `ios-simulator` profile extends the `development` profile and having a separate `channel` doesn't make sense. We can safely remove `ios-simulator.channel` from the above configuration.
 
 <Collapsible summary="What is a channel?">
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-19899


# How

- Add `--environment production` to all `eas update:configure` Terminal commands and inline code references across 11 docs pages.
- Use `--environment development` in the EAS tutorial (`tutorial/eas/team-development.mdx`) since that page uses a development build profile.
- Add a brief explanation of the `--environment` flag on the two primary setup pages (`eas-update/getting-started.mdx` and `tutorial/eas/team-development.mdx`) so users understand what the flag does and how to pick the right value.

# Test Plan

Visit each updated page on the local dev server and confirm the Terminal commands render correctly with the `--environment` flag.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
