### PR TITLE
[docs] Bump EAS CLI version in reference

### DIFF
--- a/docs/pages/eas/cli.mdx
+++ b/docs/pages/eas/cli.mdx
@@ -2,7 +2,7 @@
 title: EAS CLI reference
 sidebar_title: EAS CLI
 description: EAS CLI is a command-line tool that allows you to interact with Expo Application Services (EAS) from your terminal.
-cliVersion: 18.0.5
+cliVersion: 18.0.6
 ---
 
 import { EASCLIReference } from '~/ui/components/EASCLIReference';

--- a/docs/ui/components/EASCLIReference/data/eas-cli-commands.json
+++ b/docs/ui/components/EASCLIReference/data/eas-cli-commands.json
@@ -1,8 +1,8 @@
 {
   "source": {
     "url": "https://raw.githubusercontent.com/expo/eas-cli/main/packages/eas-cli/README.md",
-    "fetchedAt": "2026-02-25T17:06:26.787Z",
-    "cliVersion": "18.0.5"
+    "fetchedAt": "2026-02-28T06:56:56.329Z",
+    "cliVersion": "18.0.6"
   },
   "totalCommands": 102,
   "commands": [


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Bump EAS CLI version in reference to 18.0.6.


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
