### PR TITLE
jest-expo support Jest v30

### DIFF
--- a/packages/expo/build/winter/structuredClone.d.ts
+++ b/packages/expo/build/winter/structuredClone.d.ts
@@ -1,0 +1,6 @@
+declare const clone: (any: any, options?: {
+    json?: boolean;
+    lossy?: boolean;
+}) => any;
+export default clone;
+//# sourceMappingURL=structuredClone.d.ts.map

--- a/packages/expo/build/winter/structuredClone.d.ts.map
+++ b/packages/expo/build/winter/structuredClone.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"structuredClone.d.ts","sourceRoot":"","sources":["../../src/winter/structuredClone.ts"],"names":[],"mappings":"AAGA,QAAA,MAAM,KAAK,GAAI,KAAK,GAAG,EAAE,UAAU;IAAE,IAAI,CAAC,EAAE,OAAO,CAAC;IAAC,KAAK,CAAC,EAAE,OAAO,CAAA;CAAE,QAChC,CAAC;AAEvC,eAAe,KAAK,CAAC"}

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -103,6 +103,7 @@
   "devDependencies": {
     "@expo/dom-webview": "^55.0.3",
     "@expo/metro-runtime": "^55.0.6",
+    "@types/ungap__structured-clone": "^1.2.0",
     "@types/node": "^22.14.0",
     "@types/react": "~19.2.0",
     "@types/react-test-renderer": "~19.1.0",

--- a/packages/expo/src/winter/runtime.native.ts
+++ b/packages/expo/src/winter/runtime.native.ts
@@ -1,11 +1,10 @@
 // This file configures the runtime environment to increase compatibility with WinterCG.
 // https://wintercg.org/
 
-import structuredClone from '@ungap/structured-clone';
-
 import { installFormDataPatch } from './FormData';
 import { ImportMetaRegistry } from './ImportMetaRegistry';
 import { installGlobal as install } from './installGlobal';
+import clone from './structuredClone';
 
 // https://encoding.spec.whatwg.org/#textdecoder
 install('TextDecoder', () => require('./TextDecoder').TextDecoder);
@@ -23,7 +22,7 @@ install('URLSearchParams', () => require('./url').URLSearchParams);
 install('__ExpoImportMetaRegistry', () => ImportMetaRegistry);
 
 // https://html.spec.whatwg.org/multipage/structured-data.html#structuredclone
-install('structuredClone', () => structuredClone);
+install('structuredClone', () => clone);
 
 installFormDataPatch(FormData);
 

--- a/packages/expo/src/winter/runtime.native.ts
+++ b/packages/expo/src/winter/runtime.native.ts
@@ -1,7 +1,10 @@
 // This file configures the runtime environment to increase compatibility with WinterCG.
 // https://wintercg.org/
 
+import structuredClone from '@ungap/structured-clone';
+
 import { installFormDataPatch } from './FormData';
+import { ImportMetaRegistry } from './ImportMetaRegistry';
 import { installGlobal as install } from './installGlobal';
 
 // https://encoding.spec.whatwg.org/#textdecoder
@@ -17,10 +20,10 @@ install('URLSearchParams', () => require('./url').URLSearchParams);
 // https://streams.spec.whatwg.org/#rs
 // ReadableStream is injected by Metro as a global
 
-install('__ExpoImportMetaRegistry', () => require('./ImportMetaRegistry').ImportMetaRegistry);
+install('__ExpoImportMetaRegistry', () => ImportMetaRegistry);
 
 // https://html.spec.whatwg.org/multipage/structured-data.html#structuredclone
-install('structuredClone', () => require('@ungap/structured-clone').default);
+install('structuredClone', () => structuredClone);
 
 installFormDataPatch(FormData);
 

--- a/packages/expo/src/winter/structuredClone.ts
+++ b/packages/expo/src/winter/structuredClone.ts
@@ -1,0 +1,7 @@
+import { serialize, deserialize } from '@ungap/structured-clone';
+
+// if structuredClone is already declared if used directly it will run into an infinite loop
+const clone = (any: any, options?: { json?: boolean; lossy?: boolean }) =>
+  deserialize(serialize(any, options));
+
+export default clone;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4785,6 +4785,11 @@
   dependencies:
     source-map "^0.6.1"
 
+"@types/ungap__structured-clone@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/ungap__structured-clone/-/ungap__structured-clone-1.2.0.tgz#12b9fd4ab3e6a82292d60048492b05eb75b4a48f"
+  integrity sha512-ZoaihZNLeZSxESbk9PUAPZOlSpcKx81I1+4emtULDVmBLkYutTcMlCj2K9VNlf9EWODxdO6gkAqEaLorXwZQVA==
+
 "@types/webgl2@^0.0.6":
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/@types/webgl2/-/webgl2-0.0.6.tgz#1ea2db791362bd8521548d664dbd3c5311cdf4b6"


### PR DESCRIPTION
# Why

The goal of this PR is to add support for jest version 30. Currently the setup errors with the following message:

```
ReferenceError: You are trying to `import` a file outside of the scope of the test code.
```

here is a minimal reproducible repository:
[https://github.com/netconomy-stephan-dum/jest-expo-with-jest-30](https://github.com/netconomy-stephan-dum/jest-expo-with-jest-30)

this is related to:
https://github.com/expo/expo/pull/37394
closes:
https://github.com/expo/expo/issues/36831

# How

Instead of using require, import is used. This seams to solve the problem. Not sure why only two require statements are affected.

added types for `@ungap/structured-clone` to prevent typescript errors.

## up for discussion
remove `@ungap/structured-clone` polyfill as its included since node v17
:warning: this could result in a breaking change as the API is different
as alternative a feature detection could be added

# Test Plan

Tested by linking to the minimal reproducible repository. Now the test passes without error.
The linked version can be found in the linked branch:
[https://github.com/netconomy-stephan-dum/jest-expo-with-jest-30/tree/linked](https://github.com/netconomy-stephan-dum/jest-expo-with-jest-30/tree/linked)

<img width="325" height="154" alt="image" src="https://github.com/user-attachments/assets/3e59f1b5-b56e-49a0-8f84-873b5ec0e6c5" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
