### PR TITLE
[notifications] fix ios permission response shape

### DIFF
--- a/packages/expo-modules-core/ios/Legacy/Services/Permissions/EXPermissionsService.h
+++ b/packages/expo-modules-core/ios/Legacy/Services/Permissions/EXPermissionsService.h
@@ -9,6 +9,8 @@
 
 + (NSString *)permissionStringForStatus:(EXPermissionStatus)status;
 
++ (NSDictionary *)parsePermissionFromRequester:(NSDictionary *)permission;
+
 - (void)askForGlobalPermissionUsingRequesterClass:(Class)requesterClass
                                     withResolver:(EXPromiseResolveBlock)resolver
                                     withRejecter:(EXPromiseRejectBlock)reject;

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [ios] Fixed `requestPermissionsAsync` returning raw permission result without several documented fields
+- [ios] Fixed `requestPermissionsAsync` returning raw permission result without several documented fields ([#43555](https://github.com/expo/expo/pull/43555) by [@vonovak](https://github.com/vonovak))
 
 ### 💡 Others
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Fixed `requestPermissionsAsync` returning raw permission result without several documented fields
+
 ### 💡 Others
 
 ## 55.0.10 — 2026-02-25

--- a/packages/expo-notifications/ios/ExpoNotifications/Permissions/PermissionsModule.swift
+++ b/packages/expo-notifications/ios/ExpoNotifications/Permissions/PermissionsModule.swift
@@ -37,7 +37,14 @@ public class PermissionsModule: Module {
       // forwarded to the OS, even if notifications were previously granted.
       // iOS safely handles repeated calls to `requestAuthorization(options:)`.
       // Expo Go notifications permissions are not scoped
-      requester.requestAuthorizationOptions(options, resolver: promise.resolver, rejecter: promise.legacyRejecter)
+      let resolver: EXPromiseResolveBlock = { result in
+        if let permission = result as? [AnyHashable: Any] {
+          promise.resolver(EXPermissionsService.parsePermission(fromRequester: permission))
+        } else {
+          promise.legacyRejecter("ERR_PERMISSIONS_REQUEST_NOTIFICATIONS", "Unexpected permission result type", nil)
+        }
+      }
+      requester.requestAuthorizationOptions(options, resolver: resolver, rejecter: promise.legacyRejecter)
     }
   }
 }


### PR DESCRIPTION
# Why

The notifications permissions module was not properly parsing permission results from the requester. I missed that in https://github.com/expo/expo/commit/796c7098c2e32c898c1cf91dc647be926c543a3a

closes #43530

# How

Exposed `parsePermissionFromRequester:` method in `EXPermissionsService` and updated the notifications permissions module to use this parser. 

# Test Plan

- verified the returned data matches the `NotificationPermissionsStatus` TS type

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)