### PR TITLE
fix(cli): Fix missing waiting period for bundler

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### 🐛 Bug fixes
 
-- Correctly handle JavaScript assets when `asyncRoutes: true` in SSR ([#43446](https://github.com/expo/expo/pull/43446) by [@hassankhan](https://github.com/hassankhan))`
+- Correctly handle JavaScript assets when `asyncRoutes: true` in SSR ([#43446](https://github.com/expo/expo/pull/43446) by [@hassankhan](https://github.com/hassankhan))
+- Fix server being started before Metro is ready, or, if it's started, status middleware responding too soon ([#43557](https://github.com/expo/expo/pull/43557) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/utils.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/utils.ts
@@ -14,7 +14,16 @@ export function withMetroServer(projectRoot = '/project'): {
     connect: (url: string) => WebSocket;
   };
 } {
-  const metro = createMetroMiddleware({ projectRoot });
+  const metro = createMetroMiddleware(
+    { projectRoot },
+    {
+      getMetroBundler: () =>
+        ({
+          ready: () => Promise.resolve(),
+        }) as any,
+    }
+  );
+
   const server = createServer(metro.middleware);
 
   const closeServer = promisify(server.close.bind(server));

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
@@ -1,4 +1,5 @@
 import type { MetroConfig } from '@expo/metro/metro';
+import type MetroBundler from '@expo/metro/metro/Bundler';
 import connect from 'connect';
 import { Body } from 'fetch-nodeshim';
 
@@ -8,7 +9,14 @@ import { createMessagesSocket } from './createMessageSocket';
 import { Log } from '../../../../log';
 import { openInEditorAsync } from '../../../../utils/editor';
 
-export function createMetroMiddleware(metroConfig: Pick<MetroConfig, 'projectRoot'>) {
+interface MetroMiddlewareOptions {
+  getMetroBundler(): MetroBundler;
+}
+
+export function createMetroMiddleware(
+  metroConfig: Pick<MetroConfig, 'projectRoot'>,
+  options: MetroMiddlewareOptions
+) {
   const messages = createMessagesSocket({ logger: Log });
   const events = createEventsSocket(messages);
 
@@ -18,7 +26,7 @@ export function createMetroMiddleware(metroConfig: Pick<MetroConfig, 'projectRoo
     // Support opening stack frames from clients directly in the editor
     .use('/open-stack-frame', metroOpenStackFrameMiddleware)
     // Support status check to detect if the packager needs to be started from the native side
-    .use('/status', createMetroStatusMiddleware(metroConfig));
+    .use('/status', createMetroStatusMiddleware(metroConfig, options));
 
   return {
     middleware,
@@ -54,10 +62,13 @@ const metroOpenStackFrameMiddleware: connect.NextHandleFunction = async (req, re
 };
 
 function createMetroStatusMiddleware(
-  metroConfig: Pick<MetroConfig, 'projectRoot'>
+  metroConfig: Pick<MetroConfig, 'projectRoot'>,
+  options: MetroMiddlewareOptions
 ): connect.NextHandleFunction {
-  return (_req, res) => {
+  return async (_req, res) => {
     res.setHeader('X-React-Native-Project-Root', encodeURI(metroConfig.projectRoot!));
+    res.flushHeaders();
+    await options.getMetroBundler().ready();
     res.end('packager-status:running');
   };
 }

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -295,6 +295,7 @@ export async function instantiateMetroAsync(
   messageSocket: MessageSocket;
 }> {
   const projectRoot = metroBundler.projectRoot;
+  const getMetroBundler = () => metro.getBundler().getBundler();
 
   const {
     config: metroConfig,
@@ -303,14 +304,14 @@ export async function instantiateMetroAsync(
   } = await loadMetroConfigAsync(projectRoot, options, {
     exp,
     isExporting,
-    getMetroBundler() {
-      return metro.getBundler().getBundler();
-    },
+    getMetroBundler,
   });
 
   // Create the core middleware stack for Metro, including websocket listeners
-  const { middleware, messagesSocket, eventsSocket, websocketEndpoints } =
-    createMetroMiddleware(metroConfig);
+  const { middleware, messagesSocket, eventsSocket, websocketEndpoints } = createMetroMiddleware(
+    metroConfig,
+    { getMetroBundler }
+  );
 
   // Get local URL to Metro bundler server (typically configured as 127.0.0.1:8081)
   const serverBaseUrl = metroBundler

--- a/packages/@expo/cli/src/start/server/metro/runServer-fork.ts
+++ b/packages/@expo/cli/src/start/server/metro/runServer-fork.ts
@@ -48,9 +48,9 @@ export const runServer = async (
     onError,
     onReady,
     secureServerOptions,
-    waitForBundler = false,
     websocketEndpoints = {},
     watch,
+    waitForBundler = !!watch,
   }: RunServerOptionsFork,
   {
     mockServer,


### PR DESCRIPTION
# Why

In most cases, it doesn't make sense for us to start the server when Metro isn't ready. Readiness depends on the file tree scanning, which is the initial `metro-file-map` crawl phase. When this isn't done, Metro will wait for this to finish itself upon request, which is done eagerly even without a request. However, without this finishing no headers can even be sent, which means requests with a low timeout tolerance may fail.

Not waiting for the bundler is often non-sensical since no request can really be ready without it, and we should prolong the initial startup phase by that time. This is done by `waitForBundler`, which we now activate when we're not exporting and watch mode is active, as a heuristic.

Failing `waitForBundler` being set we shouldn't respond to `/status` requests with `packager-status:running` until the bundler is ready.

# How

- Default `waitForBundler: true` when not exporting / in watch mode
- Delay `/status` response by `bundler.ready()` promise but send headers early

# Test Plan

- Start up CLI and observe requests waiting properly without timeouts

We can either check `/` or `/status`. Behaviour changes according to the two middlewares used.

```bash
while ! curl -f -i -m 30 --connect-timeout 30 http://localhost:8081/status; do
  sleep 0.5
done
```

- Tested manually against a development build starting up on Android (`expo start --android -d`)
- Tested manually against a development build starting up on iOS (`expo start --ios -d`)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
