### PR TITLE
[docs] Fix internal links for EAS Workflows examples introduction

### DIFF
--- a/docs/pages/deploy/build-project.mdx
+++ b/docs/pages/deploy/build-project.mdx
@@ -123,7 +123,7 @@ The workflow above will create Android and iOS builds on every commit to your pr
 
 <Terminal cmd={['$ eas workflow:run create-builds.yml']} />
 
-Learn more about common patterns with the [workflows examples guide](/eas/workflows/examples).
+Learn more about common patterns with the [workflows examples guide](/eas/workflows/examples/introduction).
 
 ## Release builds locally
 

--- a/docs/pages/deploy/send-over-the-air-updates.mdx
+++ b/docs/pages/deploy/send-over-the-air-updates.mdx
@@ -50,7 +50,7 @@ The workflow above will send an over-the-air update for the `production` update 
 
 <Terminal cmd={['$ eas workflow:run send-updates.yml']} />
 
-Learn more about common patterns with the [workflows examples guide](/eas/workflows/examples).
+Learn more about common patterns with the [workflows examples guide](/eas/workflows/examples/introduction).
 
 ## Learn more
 

--- a/docs/pages/deploy/submit-to-app-stores.mdx
+++ b/docs/pages/deploy/submit-to-app-stores.mdx
@@ -159,7 +159,7 @@ The workflow above will create Android and iOS builds on every commit to your pr
 
 <Terminal cmd={['$ eas workflow:run build-and-submit.yml']} />
 
-Learn more about common patterns with the [workflows examples guide](/eas/workflows/examples).
+Learn more about common patterns with the [workflows examples guide](/eas/workflows/examples/introduction).
 
 ## Manual submission to app stores
 

--- a/docs/pages/deploy/web.mdx
+++ b/docs/pages/deploy/web.mdx
@@ -61,7 +61,7 @@ The workflow above will create a web deployment on every commit to your project'
 
 <Terminal cmd={['$ eas workflow:run deploy-web.yml']} />
 
-Learn more about common patterns with the [workflows examples guide](/eas/workflows/examples).
+Learn more about common patterns with the [workflows examples guide](/eas/workflows/examples/introduction).
 
 ## Learn more
 

--- a/docs/pages/eas/workflows/automating-eas-cli.mdx
+++ b/docs/pages/eas/workflows/automating-eas-cli.mdx
@@ -119,7 +119,7 @@ You can provide parameters to update specific branches or channels, and configur
 Workflows are a powerful way to automate your development and release processes. Learn how to create development builds, publish preview updates, and create production builds with the workflows examples guide:
 
 <BoxLink
-  href="/eas/workflows/examples"
+  href="/eas/workflows/examples/introduction"
   title="Workflow examples"
   description="Learn how to use workflows to create development builds, publish preview updates, and create production builds."
   Icon={Dataflow03Icon}

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -13,7 +13,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 A workflow is a configurable automated process made up of one or more jobs. You must create a YAML file to define your workflow configuration.
 
-To get started with workflows, see [Get Started with EAS Workflows](/eas/workflows/get-started) or see [Examples](/eas/workflows/examples) for complete workflow configurations.
+To get started with workflows, see [Get Started with EAS Workflows](/eas/workflows/get-started) or see [Examples](/eas/workflows/examples/introduction) for complete workflow configurations.
 
 ## Workflow files
 

--- a/docs/pages/review/share-previews-with-your-team.mdx
+++ b/docs/pages/review/share-previews-with-your-team.mdx
@@ -64,7 +64,7 @@ The workflow above will publish an update on every commit to every branch. You c
 
 <Terminal cmd={['$ eas workflow:run publish-preview-update.yml']} />
 
-Learn more about common patterns with the [workflows examples guide](/eas/workflows/examples).
+Learn more about common patterns with the [workflows examples guide](/eas/workflows/examples/introduction).
 
 ## Learn more
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix internal links for the EAS Workflows examples introduction in multiple docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Navigate to each updated page and confirm the "workflows examples guide" link goes directly to `/eas/workflows/examples/introduction` without a redirect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
