### PR TITLE
[ios][audio] Fix crash during seek

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix crash during seek.
+
 ### 💡 Others
 
 ## 55.0.8 — 2026-02-25

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix crash during seek.
+- [iOS] Fix crash during seek. ([#43564](https://github.com/expo/expo/pull/43564) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/ios/AudioPlayer.swift
+++ b/packages/expo-audio/ios/AudioPlayer.swift
@@ -143,10 +143,16 @@ public class AudioPlayer: SharedRef<AVPlayer> {
       CMTime(seconds: $0 / 1000.0, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
     } ?? CMTime.positiveInfinity
 
-    await ref.currentItem?.seek(to: time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter	)
-    updateStatus(with: [
-      "currentTime": currentTime
-    ])
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+      ref.seek(to: time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter) { [weak self] _ in
+        if let self {
+          self.updateStatus(with: [
+            "currentTime": self.currentTime
+          ])
+        }
+        continuation.resume()
+      }
+    }
   }
 
   private func setupPublisher() {
@@ -402,6 +408,7 @@ public class AudioPlayer: SharedRef<AVPlayer> {
   }
 
   public override func sharedObjectWillRelease() {
+    ref.currentItem?.cancelPendingSeeks()
     owningRegistry?.remove(self)
 
     if isActiveForLockScreen {

--- a/packages/expo-audio/ios/AudioPlaylist.swift
+++ b/packages/expo-audio/ios/AudioPlaylist.swift
@@ -123,8 +123,14 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer> {
 
   func seekTo(seconds: Double) async {
     let time = CMTime(seconds: seconds, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
-    await ref.currentItem?.seek(to: time)
-    updateStatus(with: ["currentTime": currentTime])
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+      ref.seek(to: time) { [weak self] _ in
+        if let self {
+          self.updateStatus(with: ["currentTime": self.currentTime])
+        }
+        continuation.resume()
+      }
+    }
   }
 
   func add(source: AudioSource) {
@@ -357,6 +363,7 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer> {
   }
 
   public override func sharedObjectWillRelease() {
+    ref.currentItem?.cancelPendingSeeks()
     owningRegistry?.remove(self)
     cancellables.removeAll()
 


### PR DESCRIPTION
# Why
Closes #38550
Because `seek` is async, `sharedObjectWillRelease` could be called before the seek completes. When this happens, we will try updating the status but the module is now nil, causing a hard crash

# How
Switch to using the completion handler based seek. We can check if `self` is nil before attempting to update the status. Also, we should call `cancelPendingSeeks` in `sharedObjectWillRelease`. 

# Test Plan
Bare expo. Hard to reproduce but this should fix the issue.