### PR TITLE
[widgets][plugin] Fix reading undefined when config is not provided

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Add missing project root to `watchFolders` in `metro.config.js` ([#43449](https://github.com/expo/expo/pull/43449) by [@kitten](https://github.com/kitten))
+- [plugin] Fix reading undefined when config is not provided.
 
 ### 💡 Others
 

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - Add missing project root to `watchFolders` in `metro.config.js` ([#43449](https://github.com/expo/expo/pull/43449) by [@kitten](https://github.com/kitten))
-- [plugin] Fix reading undefined when config is not provided.
+- [plugin] Fix reading undefined when config is not provided. ([#43568](https://github.com/expo/expo/pull/43568) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-widgets/plugin/build/index.d.ts
+++ b/packages/expo-widgets/plugin/build/index.d.ts
@@ -7,5 +7,5 @@ type ExpoWidgetsConfigPluginProps = {
     frequentUpdates?: boolean;
     widgets?: WidgetConfig[];
 };
-declare const _default: ConfigPlugin<ExpoWidgetsConfigPluginProps>;
+declare const _default: ConfigPlugin<ExpoWidgetsConfigPluginProps | undefined>;
 export default _default;

--- a/packages/expo-widgets/plugin/build/index.js
+++ b/packages/expo-widgets/plugin/build/index.js
@@ -17,7 +17,7 @@ const withWidgets = (config, props) => {
     let plugins = [];
     const deploymentTarget = '16.2';
     const targetName = 'ExpoWidgetsTarget';
-    let bundleIdentifier = props.bundleIdentifier;
+    let bundleIdentifier = props?.bundleIdentifier;
     if (!bundleIdentifier) {
         bundleIdentifier = `${config.ios?.bundleIdentifier}.${targetName}`;
         plugins.push([
@@ -28,7 +28,7 @@ const withWidgets = (config, props) => {
             },
         ]);
     }
-    let groupIdentifier = props.groupIdentifier;
+    let groupIdentifier = props?.groupIdentifier;
     if (!groupIdentifier) {
         if (!config.ios?.bundleIdentifier) {
             throw new Error('iOS bundle identifier is required. Please set `ios.bundleIdentifier` in `app.json` or `app.config.js`');
@@ -42,9 +42,9 @@ const withWidgets = (config, props) => {
             },
         ]);
     }
-    const widgets = props.widgets ?? [];
-    const enablePushNotifications = props.enablePushNotifications ?? false;
-    const frequentUpdates = props.frequentUpdates ?? false;
+    const widgets = props?.widgets ?? [];
+    const enablePushNotifications = props?.enablePushNotifications ?? false;
+    const frequentUpdates = props?.frequentUpdates ?? false;
     let sharedFiles = [];
     const setFiles = (files) => {
         sharedFiles = [...sharedFiles, ...files];

--- a/packages/expo-widgets/plugin/src/index.ts
+++ b/packages/expo-widgets/plugin/src/index.ts
@@ -24,12 +24,12 @@ type ExpoWidgetsConfigPluginProps = {
   widgets?: WidgetConfig[];
 };
 
-const withWidgets: ConfigPlugin<ExpoWidgetsConfigPluginProps> = (config, props) => {
+const withWidgets: ConfigPlugin<ExpoWidgetsConfigPluginProps | undefined> = (config, props) => {
   let plugins: (StaticPlugin | ConfigPlugin | string)[] = [];
   const deploymentTarget = '16.2';
   const targetName = 'ExpoWidgetsTarget';
 
-  let bundleIdentifier = props.bundleIdentifier;
+  let bundleIdentifier = props?.bundleIdentifier;
   if (!bundleIdentifier) {
     bundleIdentifier = `${config.ios?.bundleIdentifier}.${targetName}`;
     plugins.push([
@@ -41,7 +41,7 @@ const withWidgets: ConfigPlugin<ExpoWidgetsConfigPluginProps> = (config, props) 
     ]);
   }
 
-  let groupIdentifier = props.groupIdentifier;
+  let groupIdentifier = props?.groupIdentifier;
   if (!groupIdentifier) {
     if (!config.ios?.bundleIdentifier) {
       throw new Error(
@@ -58,9 +58,9 @@ const withWidgets: ConfigPlugin<ExpoWidgetsConfigPluginProps> = (config, props) 
     ]);
   }
 
-  const widgets = props.widgets ?? [];
-  const enablePushNotifications = props.enablePushNotifications ?? false;
-  const frequentUpdates = props.frequentUpdates ?? false;
+  const widgets = props?.widgets ?? [];
+  const enablePushNotifications = props?.enablePushNotifications ?? false;
+  const frequentUpdates = props?.frequentUpdates ?? false;
 
   let sharedFiles: string[] = [];
   const setFiles = (files: string[]) => {


### PR DESCRIPTION
# Why

When config is not provided, reading `bundleIdentifier` will throw an error (props are `undefined`):
```
TypeError: Cannot read properties of undefined (reading 'bundleIdentifier')
```

# How

Fix types and use optional chaining.

# Test Plan

Create empty app, add `expo-widgets` to plugins in `app.json` without config:
```json
    "plugins": [
      "expo-widgets"
    ],
```
and run `expo prebuild -p ios`.

## Before
```
$ node_modules/.bin/expo prebuild -p ios --no-install --clean
TypeError: Cannot read properties of undefined (reading 'bundleIdentifier')
```

## After
```
$ node_modules/.bin/expo prebuild -p ios --no-install --clean
✔ Created native directory
✔ Updated package.json | no changes
» ios: groupIdentifier: Expo Widgets: No group identifier provided, using fallback: group.com.jakex7.widgets-plugin-repro.
» ios: bundleIdentifier: Expo Widgets: No bundle identifier provided, using fallback: com.jakex7.widgets-plugin-repro.ExpoWidgetsTarget.
✔ Finished prebuild
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
