### PR TITLE
[@expo/cli] Use RCT_METRO_PORT env in `expo run` when Metro is already running

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Use `RCT_METRO_PORT` environment variable in `expo run` when Metro is already running ([#43446](https://github.com/expo/expo/pull/43446) by [@robingullo](https://github.com/robingullo))
 - Correctly handle JavaScript assets when `asyncRoutes: true` in SSR ([#43446](https://github.com/expo/expo/pull/43446) by [@hassankhan](https://github.com/hassankhan))`
 
 ### 💡 Others

--- a/packages/@expo/cli/src/run/__tests__/resolveBundlerProps-test.ts
+++ b/packages/@expo/cli/src/run/__tests__/resolveBundlerProps-test.ts
@@ -4,6 +4,9 @@ import { resolvePortAsync } from '../../utils/port';
 import { resolveBundlerPropsAsync } from '../resolveBundlerProps';
 
 jest.mock('../../utils/port');
+jest.mock('../../utils/env', () => ({
+  env: {},
+}));
 
 describe(resolveBundlerPropsAsync, () => {
   afterEach(() => vol.reset());
@@ -42,5 +45,25 @@ describe(resolveBundlerPropsAsync, () => {
       port: 19006,
       shouldStartBundler: true,
     });
+  });
+  it(`uses RCT_METRO_PORT env when bundler is skipped`, async () => {
+    jest.mocked(resolvePortAsync).mockResolvedValueOnce(null);
+
+    const { env } = require('../../utils/env');
+    const originalRCT_METRO_PORT = env.RCT_METRO_PORT;
+    env.RCT_METRO_PORT = 8082;
+
+    try {
+      expect(
+        await resolveBundlerPropsAsync('/', {
+          bundler: true,
+        })
+      ).toEqual({
+        port: 8082,
+        shouldStartBundler: false,
+      });
+    } finally {
+      env.RCT_METRO_PORT = originalRCT_METRO_PORT;
+    }
   });
 });

--- a/packages/@expo/cli/src/run/resolveBundlerProps.ts
+++ b/packages/@expo/cli/src/run/resolveBundlerProps.ts
@@ -1,4 +1,5 @@
 import { Log } from '../log';
+import { env } from '../utils/env';
 import { CommandError } from '../utils/errors';
 import { resolvePortAsync } from '../utils/port';
 
@@ -34,8 +35,8 @@ export async function resolveBundlerPropsAsync(
   // Skip bundling if the port is null -- meaning skip the bundler if the port is already running the app.
   options.bundler = !!port;
   if (!port) {
-    // Use explicit user-provided port, or the default port
-    port = options.port ?? 8081;
+    // Use explicit user-provided port, RCT_METRO_PORT env, or the default port
+    port = options.port ?? (env.RCT_METRO_PORT || 8081);
   }
   Log.debug(`Resolved port: ${port}, start dev server: ${options.bundler}`);
 


### PR DESCRIPTION
# Why

When running `expo run:ios` or `expo run:android` with `RCT_METRO_PORT` environment variable set and the Metro bundler already running, the CLI was ignoring the `RCT_METRO_PORT` value and using the hardcoded default port 8081 in the deeplink URL.

This makes it impractical to use with multiple worktree setup e.g. where each worktree has its own `RCT_METRO_PORT` in `.env.local`

# How

Modified `resolveBundlerProps.ts` to check `RCT_METRO_PORT` environment variable as a fallback when the bundler is skipped (i.e., when Metro is already running). The logic is now the same as in `resolvePortAsync`.

# Test Plan

Successfully used as a patch in my project.

- Run Metro on port 8082: `RCT_METRO_PORT=8082 expo start`
- Run `RCT_METRO_PORT=8082 expo run:ios`
- Verify the deeplink URL uses port 8082: `exp://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8082`

# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
