### PR TITLE
[docs] Fix internal link in Extending with SwiftUI

### DIFF
--- a/docs/pages/guides/expo-ui-swift-ui/extending.mdx
+++ b/docs/pages/guides/expo-ui-swift-ui/extending.mdx
@@ -14,7 +14,7 @@ This guide explains how to create custom SwiftUI components and modifiers that i
 
 Before you begin, make sure you have:
 
-- `@expo/ui` installed in your project. See [Building SwiftUI apps with Expo UI](/expo-ui-swift-ui/) for more information.
+- `@expo/ui` installed in your project. See [Building SwiftUI apps with Expo UI](/guides/expo-ui-swift-ui/) for more information.
 - A [development build](/develop/development-builds/introduction/) of your app (Expo UI is not available in Expo Go)
 - Basic familiarity with [Expo Modules API](/modules/overview/) and [SwiftUI](https://developer.apple.com/swiftui/)
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-19911

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix the internal link in Extending with SwiftUI.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
