### PR TITLE
[expo-router][sdk-55] use KVC to provide native API compatible with both react-native-screens 4.24.0 and 4.23.0

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -532,6 +532,9 @@ PODS:
   - ExpoRouter (55.0.2):
     - ExpoModulesCore
     - RNScreens
+  - ExpoRouter/Tests (55.0.2):
+    - ExpoModulesCore
+    - RNScreens
   - ExpoScreenCapture (55.0.8):
     - ExpoModulesCore
   - ExpoScreenOrientation (55.0.8):
@@ -3234,6 +3237,7 @@ DEPENDENCIES:
   - ExpoNotifications/Tests (from `../../../packages/expo-notifications/ios`)
   - ExpoPrint (from `../../../packages/expo-print/ios`)
   - ExpoRouter (from `../../../packages/expo-router/ios`)
+  - ExpoRouter/Tests (from `../../../packages/expo-router/ios`)
   - ExpoScreenCapture (from `../../../packages/expo-screen-capture/ios`)
   - ExpoScreenOrientation (from `../../../packages/expo-screen-orientation/ios`)
   - ExpoSecureStore (from `../../../packages/expo-secure-store/ios`)
@@ -3867,7 +3871,7 @@ SPEC CHECKSUMS:
   ExpoNetwork: 018e4e16afdaff30c5002fadf64daab55bc20de0
   ExpoNotifications: 0293112699b35aa26f6e9e1fcecee0323f3187dc
   ExpoPrint: 744a2ca8033698b749389290d96f4ec836027aed
-  ExpoRouter: 98f1ec6dfbde5edb827aa411681c1fcbee07786f
+  ExpoRouter: d770a57784f2cf06d0d5496913857ab79727dc99
   ExpoScreenCapture: a4b2159b48fd2514a99f426778da31d1f0a9736f
   ExpoScreenOrientation: e042b7f121c3b3463f9486189785d568ff57739e
   ExpoSecureStore: 7837b892a89ad8d28b64d9302b657e8b6ebae250

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -336,6 +336,9 @@ PODS:
   - ExpoRouter (55.0.2):
     - ExpoModulesCore
     - RNScreens
+  - ExpoRouter/Tests (55.0.2):
+    - ExpoModulesCore
+    - RNScreens
   - ExpoScreenCapture (55.0.8):
     - ExpoModulesCore
   - ExpoScreenOrientation (55.0.8):
@@ -4151,6 +4154,7 @@ DEPENDENCIES:
   - ExpoNotifications/Tests (from `../../../packages/expo-notifications/ios`)
   - ExpoPrint (from `../../../packages/expo-print/ios`)
   - ExpoRouter (from `../../../packages/expo-router/ios`)
+  - ExpoRouter/Tests (from `../../../packages/expo-router/ios`)
   - ExpoScreenCapture (from `../../../packages/expo-screen-capture/ios`)
   - ExpoScreenOrientation (from `../../../packages/expo-screen-orientation/ios`)
   - ExpoSecureStore (from `../../../packages/expo-secure-store/ios`)
@@ -4725,7 +4729,7 @@ SPEC CHECKSUMS:
   ExpoNetwork: 018e4e16afdaff30c5002fadf64daab55bc20de0
   ExpoNotifications: 0293112699b35aa26f6e9e1fcecee0323f3187dc
   ExpoPrint: 744a2ca8033698b749389290d96f4ec836027aed
-  ExpoRouter: 98f1ec6dfbde5edb827aa411681c1fcbee07786f
+  ExpoRouter: d770a57784f2cf06d0d5496913857ab79727dc99
   ExpoScreenCapture: a4b2159b48fd2514a99f426778da31d1f0a9736f
   ExpoScreenOrientation: ba181744c7ac781952da30c3c2b8d7661df21446
   ExpoSecureStore: 7837b892a89ad8d28b64d9302b657e8b6ebae250

--- a/apps/native-tests/ios/Podfile.lock
+++ b/apps/native-tests/ios/Podfile.lock
@@ -385,6 +385,12 @@ PODS:
   - ExpoNotifications/Tests (55.0.6):
     - ExpoModulesCore
     - ExpoModulesTestCore
+  - ExpoRouter (55.0.2):
+    - ExpoModulesCore
+    - RNScreens
+  - ExpoRouter/Tests (55.0.2):
+    - ExpoModulesCore
+    - RNScreens
   - EXStructuredHeaders (55.0.0)
   - EXStructuredHeaders/Tests (55.0.0)
   - EXUpdates (55.0.7):
@@ -2265,6 +2271,53 @@ PODS:
     - React-utils (= 0.84.0)
     - ReactNativeDependencies
   - ReactNativeDependencies (0.84.0)
+  - RNScreens (4.24.0):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-RCTImage
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - RNScreens/common (= 4.24.0)
+    - Yoga
+  - RNScreens/common (4.24.0):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-RCTImage
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
   - SDWebImage (5.21.0):
     - SDWebImage/Core (= 5.21.0)
   - SDWebImage/Core (5.21.0)
@@ -2306,6 +2359,8 @@ DEPENDENCIES:
   - ExpoModulesTestCore (from `../../../packages/expo-modules-test-core/ios`)
   - ExpoNotifications (from `../../../packages/expo-notifications/ios`)
   - ExpoNotifications/Tests (from `../../../packages/expo-notifications/ios`)
+  - ExpoRouter (from `../../../packages/expo-router/ios`)
+  - ExpoRouter/Tests (from `../../../packages/expo-router/ios`)
   - EXStructuredHeaders (from `../../../packages/expo-structured-headers/ios`)
   - EXStructuredHeaders/Tests (from `../../../packages/expo-structured-headers/ios`)
   - EXUpdates (from `../../../packages/expo-updates/ios`)
@@ -2384,6 +2439,7 @@ DEPENDENCIES:
   - ReactCodegen (from `build/generated/ios/ReactCodegen`)
   - ReactCommon/turbomodule/core (from `../../../node_modules/react-native/ReactCommon`)
   - ReactNativeDependencies (from `../../../node_modules/react-native/third-party-podspecs/ReactNativeDependencies.podspec`)
+  - RNScreens (from `../../../node_modules/react-native-screens`)
   - Yoga (from `../../../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -2440,6 +2496,9 @@ EXTERNAL SOURCES:
   ExpoNotifications:
     inhibit_warnings: false
     :path: "../../../packages/expo-notifications/ios"
+  ExpoRouter:
+    inhibit_warnings: false
+    :path: "../../../packages/expo-router/ios"
   EXStructuredHeaders:
     inhibit_warnings: false
     :path: "../../../packages/expo-structured-headers/ios"
@@ -2594,6 +2653,8 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon"
   ReactNativeDependencies:
     :podspec: "../../../node_modules/react-native/third-party-podspecs/ReactNativeDependencies.podspec"
+  RNScreens:
+    :path: "../../../node_modules/react-native-screens"
   Yoga:
     :path: "../../../node_modules/react-native/ReactCommon/yoga"
 
@@ -2611,7 +2672,7 @@ SPEC CHECKSUMS:
   ExpoModulesCore: 5f6eec9c900eede33fb4c1b3e546f9a640ec7ee6
   ExpoModulesJSI: 1416a6a3f0511a7a354f9e47cc45e353b50d5fda
   ExpoModulesTestCore: 382d7b11f61dd661215fbe33d8ce6c95d6c09e99
-  ExpoNotifications: ae80bb85a37cc15f3c671a14978854e405c33a26
+  ExpoRouter: d770a57784f2cf06d0d5496913857ab79727dc99
   EXStructuredHeaders: aa49a5557fa24aa61dda4ac665f3987bf3e9e35d
   EXUpdates: e1fd76387b4ab5a13d7e0206bcb0c2b88a6edafd
   EXUpdatesInterface: 48272cb8995e613f0843fe531347e2f783e1df5f
@@ -2693,7 +2754,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 625d2f6d9d5ef01acc9dfe2b5385504bbffd2ad0
   ReactCodegen: e6f176b40e56d6fa6d441baf3bc2e351172a41a6
   ReactCommon: cc0e38600f82487c5fe5d29150abb6fa9d981986
-  ReactNativeDependencies: e4649f4c1481999f5bcaca9c43343eb6f0017028
+  RNScreens: 088d923c4327c63c9f8c942cae17a9d038f47d97
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c

--- a/apps/native-tests/package.json
+++ b/apps/native-tests/package.json
@@ -12,6 +12,7 @@
     "expo": "~55.0.2",
     "expo-clipboard": "55.0.8",
     "expo-dev-client": "~55.0.9",
+    "expo-router": "~55.0.2",
     "expo-image": "~55.0.5",
     "expo-media-library": "55.0.9",
     "expo-notifications": "~55.0.10",

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Remove `expo-router/doctor` since this is covered by `expo-doctor`'s duplicates check now ([#43461](https://github.com/expo/expo/pull/43461) by [@kitten](https://github.com/kitten))
+- use KVC to provide native API compatible with both react-native-screens 4.24.0 and 4.23.0 ([#43576](https://github.com/expo/expo/pull/43576) by [@Ubax](https://github.com/Ubax))
 
 ## 55.0.2 — 2026-02-25
 

--- a/packages/expo-router/CLAUDE.md
+++ b/packages/expo-router/CLAUDE.md
@@ -128,6 +128,25 @@ To verify if the types used in tests are correct, run:
 yarn test:types
 ```
 
+### Swift Tests (iOS)
+
+Native Swift tests live in `ios/Tests/` and use Apple's Swift Testing framework (`import Testing`).
+
+Run from the `packages/expo-router` directory:
+
+```bash
+et native-unit-tests --packages expo-router -p ios
+```
+
+> Pods must be installed in `apps/native-tests/ios` first (`pod install`).
+
+**Conventions:**
+
+- Use `@Test` / `@Suite` from Swift Testing (not XCTest)
+- Backtick-quoted test names for readability (e.g., `` @Test func `converts options correctly`() ``)
+- Inner structs for grouping related tests within a `@Suite`
+- `#expect` / `#require` for assertions
+
 ### Testing Patterns
 
 Tests use the custom `renderRouter` testing utility:

--- a/packages/expo-router/ios/ExpoRouter.podspec
+++ b/packages/expo-router/ios/ExpoRouter.podspec
@@ -36,10 +36,16 @@ Pod::Spec.new do |s|
     'OTHER_SWIFT_FLAGS' => "$(inherited) #{compiler_flags}",
   }
 
+  s.exclude_files = 'Tests/**/*'
+
   if !$ExpoUseSources&.include?(package['name']) && ENV['EXPO_USE_SOURCE'].to_i == 0 && File.exist?("#{s.name}.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
     s.source_files = "**/*.h"
     s.vendored_frameworks = "#{s.name}.xcframework"
   else
     s.source_files = "**/*.{h,m,swift,mm,cpp}"
+  end
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'Tests/**/*.{m,swift}'
   end
 end

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeNavigation.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeNavigation.swift
@@ -48,12 +48,12 @@ internal class LinkPreviewNativeNavigation {
     guard let stackOrTabView else {
       return
     }
-    if let tabView = stackOrTabView as? RNSBottomTabsScreenComponentView {
+    if RNScreensTabCompat.isTabScreen(stackOrTabView) {
       let newTabKeys = tabPath?.path.map { $0.newTabKey } ?? []
       // The order is important here. findStackViewWithScreenIdInSubViews must be called
       // even if screenId is nil to compute the tabChangeCommands.
       if let stackView = findStackViewWithScreenIdInSubViews(
-        screenId: screenId, tabKeys: newTabKeys, rootView: tabView), let screenId {
+        screenId: screenId, tabKeys: newTabKeys, rootView: stackOrTabView), let screenId {
         setPreloadedView(stackView: stackView, screenId: screenId)
       }
     } else if let stackView = stackOrTabView as? RNSScreenStackView, let screenId {
@@ -150,8 +150,7 @@ internal class LinkPreviewNativeNavigation {
     if let result =
       enumeratedViews
       .first(where: { _, view in
-        guard let tabView = view as? RNSBottomTabsScreenComponentView, let tabKey = tabView.tabKey
-        else {
+        guard let tabKey = RNScreensTabCompat.tabKey(from: view) else {
           return false
         }
         return tabKeys.contains(tabKey)
@@ -162,13 +161,10 @@ internal class LinkPreviewNativeNavigation {
   }
 
   private func getTabBarControllerFromTabView(view: UIView) -> UITabBarController? {
-    if let tabScreenView = view as? RNSBottomTabsScreenComponentView {
-      return tabScreenView.reactViewController()?.tabBarController as? UITabBarController
+    if let tabBarController = RNScreensTabCompat.tabBarController(fromTabScreen: view) {
+      return tabBarController
     }
-    if let tabHostView = view as? RNSBottomTabsHostComponentView {
-      return tabHostView.controller as? UITabBarController
-    }
-    return nil
+    return RNScreensTabCompat.tabBarController(fromTabHost: view)
   }
 
   private func findStackViewWithScreenIdOrTabBarController(
@@ -182,10 +178,10 @@ internal class LinkPreviewNativeNavigation {
         if view.screenIds.contains(screenId) {
           return view
         }
-      } else if let tabView = nextResponder as? RNSBottomTabsScreenComponentView {
-        if let tabKey = tabView.tabKey, tabKeys.contains(tabKey) {
-          return tabView
-        }
+      } else if let nextView = nextResponder as? UIView,
+        let tabKey = RNScreensTabCompat.tabKey(from: nextView),
+        tabKeys.contains(tabKey) {
+          return nextView
       }
       currentResponder = nextResponder
     }

--- a/packages/expo-router/ios/LinkPreview/RNScreensTabCompat.swift
+++ b/packages/expo-router/ios/LinkPreview/RNScreensTabCompat.swift
@@ -1,0 +1,42 @@
+import UIKit
+
+/// Instead of casting to concrete class names (which break on renames),
+/// we detect tab views by checking `responds(to:)` for expected selectors
+/// and read properties via KVC.
+enum RNScreensTabCompat {
+  private static let tabKeyName = "tabKey"
+  private static let controllerName = "controller"
+  private static let reactViewControllerName = "reactViewController"
+
+  private static let tabKeySelector = NSSelectorFromString(tabKeyName)
+  private static let controllerSelector = NSSelectorFromString(controllerName)
+  private static let reactViewControllerSelector = NSSelectorFromString(reactViewControllerName)
+
+  // MARK: - Type check
+
+  /// A view is a tab screen if it has a `tabKey` property — specific to RNScreens tab views.
+  static func isTabScreen(_ view: UIView) -> Bool {
+    view.responds(to: tabKeySelector)
+  }
+
+  // MARK: - Property access via KVC
+
+  static func tabKey(from view: UIView) -> String? {
+    guard view.responds(to: tabKeySelector) else { return nil }
+    return view.value(forKey: tabKeyName) as? String
+  }
+
+  /// Calls `reactViewController()` dynamically via `perform(_:)`, then returns `.tabBarController`.
+  static func tabBarController(fromTabScreen view: UIView) -> UITabBarController? {
+    guard isTabScreen(view),
+      view.responds(to: reactViewControllerSelector)
+    else { return nil }
+    let vc = view.perform(reactViewControllerSelector)?.takeUnretainedValue() as? UIViewController
+    return vc?.tabBarController
+  }
+
+  static func tabBarController(fromTabHost view: UIView) -> UITabBarController? {
+    guard view.responds(to: controllerSelector) else { return nil }
+    return view.value(forKey: controllerName) as? UITabBarController
+  }
+}

--- a/packages/expo-router/ios/Tests/RNScreensTabCompatTests.swift
+++ b/packages/expo-router/ios/Tests/RNScreensTabCompatTests.swift
@@ -1,0 +1,218 @@
+import Testing
+import UIKit
+
+@testable import ExpoRouter
+
+// MARK: - Mock views
+
+/// Mock tab screen: has @objc tabKey property, mimicking RNScreens tab screen views.
+private class MockTabScreenView: UIView {
+  @objc var tabKey: String?
+}
+
+/// Mock tab host: has @objc controller property, mimicking RNScreens tab host views.
+private class MockTabHostView: UIView {
+  @objc var controller: UIViewController?
+}
+
+/// Mock tab host with a non-UIViewController controller property.
+private class MockTabHostWithBadController: UIView {
+  @objc var controller: NSObject? = NSObject()
+}
+
+/// Mock view with a reactViewController() method that returns a UIViewController.
+private class MockTabScreenWithReactVC: UIView {
+  @objc var tabKey: String?
+  private var _reactViewController: UIViewController?
+
+  func configure(reactViewController: UIViewController) {
+    _reactViewController = reactViewController
+  }
+
+  @objc override func reactViewController() -> UIViewController? {
+    return _reactViewController
+  }
+}
+
+// MARK: - Unit tests
+
+@Suite("RNScreensTabCompat unit tests")
+struct RNScreensTabCompatUnitTests {
+
+  @Suite("isTabScreen")
+  struct IsTabScreen {
+    @Test
+    func `detects mock tab screen`() {
+      let tabScreen = MockTabScreenView()
+      #expect(RNScreensTabCompat.isTabScreen(tabScreen))
+    }
+
+    @Test
+    func `rejects plain UIView`() {
+      let plainView = UIView()
+      #expect(!RNScreensTabCompat.isTabScreen(plainView))
+    }
+
+    @Test
+    func `rejects mock tab host`() {
+      let tabHost = MockTabHostView()
+      #expect(!RNScreensTabCompat.isTabScreen(tabHost))
+    }
+  }
+
+  @Suite("tabKey")
+  struct TabKey {
+    @Test
+    func `reads value`() {
+      let tabScreen = MockTabScreenView()
+      tabScreen.tabKey = "home"
+      #expect(RNScreensTabCompat.tabKey(from: tabScreen) == "home")
+    }
+
+    @Test
+    func `returns nil for nil tab key`() {
+      let tabScreen = MockTabScreenView()
+      tabScreen.tabKey = nil
+      #expect(RNScreensTabCompat.tabKey(from: tabScreen) == nil)
+    }
+
+    @Test
+    func `returns nil for plain UIView`() {
+      let plainView = UIView()
+      #expect(RNScreensTabCompat.tabKey(from: plainView) == nil)
+    }
+  }
+
+  @Suite("tabBarController(fromTabHost:)")
+  struct TabBarControllerFromTabHost {
+    @Test
+    func `returns tab bar controller`() {
+      let tabHost = MockTabHostView()
+      let tabBarController = UITabBarController()
+      tabHost.controller = tabBarController
+      #expect(RNScreensTabCompat.tabBarController(fromTabHost: tabHost) === tabBarController)
+    }
+
+    @Test
+    func `returns nil for non-tab bar controller`() {
+      let tabHost = MockTabHostView()
+      tabHost.controller = UIViewController()
+      #expect(RNScreensTabCompat.tabBarController(fromTabHost: tabHost) == nil)
+    }
+
+    @Test
+    func `returns nil for nil controller`() {
+      let tabHost = MockTabHostView()
+      tabHost.controller = nil
+      #expect(RNScreensTabCompat.tabBarController(fromTabHost: tabHost) == nil)
+    }
+
+    @Test
+    func `returns nil for non-UIViewController type`() {
+      let tabHost = MockTabHostWithBadController()
+      #expect(RNScreensTabCompat.tabBarController(fromTabHost: tabHost) == nil)
+    }
+
+    @Test
+    func `returns nil for plain UIView`() {
+      let plainView = UIView()
+      #expect(RNScreensTabCompat.tabBarController(fromTabHost: plainView) == nil)
+    }
+  }
+
+  @Suite("tabBarController(fromTabScreen:)")
+  struct TabBarControllerFromTabScreen {
+    @Test
+    func `returns tab bar controller via reactViewController`() {
+      let tabBarController = UITabBarController()
+      let childVC = UIViewController()
+      tabBarController.viewControllers = [childVC]
+
+      let mockView = MockTabScreenWithReactVC()
+      mockView.tabKey = "tab1"
+      mockView.configure(reactViewController: childVC)
+      childVC.view.addSubview(mockView)
+
+      let result = RNScreensTabCompat.tabBarController(fromTabScreen: mockView)
+      #expect(result === tabBarController)
+    }
+
+    @Test
+    func `returns nil when reactViewController returns nil`() {
+      let mockView = MockTabScreenWithReactVC()
+      mockView.tabKey = "tab1"
+      // Don't configure — reactViewController() returns nil
+      #expect(RNScreensTabCompat.tabBarController(fromTabScreen: mockView) == nil)
+    }
+
+    @Test
+    func `returns nil when no reactViewController method`() {
+      // MockTabScreenView has tabKey but no reactViewController() method
+      let mockView = MockTabScreenView()
+      mockView.tabKey = "tab1"
+      #expect(RNScreensTabCompat.tabBarController(fromTabScreen: mockView) == nil)
+    }
+
+    @Test
+    func `returns nil for plain UIView`() {
+      let plainView = UIView()
+      #expect(RNScreensTabCompat.tabBarController(fromTabScreen: plainView) == nil)
+    }
+
+    @Test
+    func `returns nil when not in tab bar controller`() {
+      let navController = UINavigationController()
+      let childVC = UIViewController()
+      navController.viewControllers = [childVC]
+
+      let mockView = MockTabScreenWithReactVC()
+      mockView.tabKey = "tab1"
+      mockView.configure(reactViewController: childVC)
+      childVC.view.addSubview(mockView)
+
+      #expect(RNScreensTabCompat.tabBarController(fromTabScreen: mockView) == nil)
+    }
+  }
+}
+
+// MARK: - Integration tests (RNScreens API contract)
+
+@Suite("RNScreens API contract")
+struct RNScreensAPIContractTests {
+
+  @Test
+  func `tab screen class responds to tabKey`() throws {
+    let cls = NSClassFromString("RNSTabsScreenComponentView")
+      ?? NSClassFromString("RNSBottomTabsScreenComponentView")
+    guard let cls else {
+      Issue.record("No tab screen class found — neither RNSTabsScreenComponentView nor RNSBottomTabsScreenComponentView")
+      return
+    }
+    let view = try #require((cls as? UIView.Type)?.init(), "Failed to instantiate tab screen class")
+    #expect(view.responds(to: NSSelectorFromString("tabKey")))
+  }
+
+  @Test
+  func `tab host class responds to controller`() throws {
+    let cls = NSClassFromString("RNSTabsHostComponentView")
+      ?? NSClassFromString("RNSBottomTabsHostComponentView")
+    guard let cls else {
+      Issue.record("No tab host class found — neither RNSTabsHostComponentView nor RNSBottomTabsHostComponentView")
+      return
+    }
+    let view = try #require((cls as? UIView.Type)?.init(), "Failed to instantiate tab host class")
+    #expect(view.responds(to: NSSelectorFromString("controller")))
+  }
+
+  @Test
+  func `tab screen class responds to reactViewController`() throws {
+    let cls = NSClassFromString("RNSTabsScreenComponentView")
+      ?? NSClassFromString("RNSBottomTabsScreenComponentView")
+    guard let cls else {
+      Issue.record("No tab screen class found")
+      return
+    }
+    let view = try #require((cls as? UIView.Type)?.init(), "Failed to instantiate tab screen class")
+    #expect(view.responds(to: NSSelectorFromString("reactViewController")))
+  }
+}


### PR DESCRIPTION
# Why

react-native-screens changed the tab class names in version `4.24.0`. Since we want to support both `4.23.0` and `4.24.0`, we need a way Link.Preview navigation code to detect screens classes. 

This change should be cherry-picked to sdk-55 as well.

# How

I chose to use `responds` with `KVC` in order to support any future changes in this API. When the API is marked as stable in `react-native-screens` we can change the API back to use compile time `as?`

# Test Plan

1. Unit tests
2. Link preview in stack (link preview app in router-e2e)
3. Link preview inside native tabs (native-navigation app in router-e2e)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
