### PR TITLE
[core] POC for modules C++ API

### DIFF
--- a/packages/expo-modules-core/android/CMakeLists.txt
+++ b/packages/expo-modules-core/android/CMakeLists.txt
@@ -10,5 +10,11 @@ include(${CMAKE_SOURCE_DIR}/cmake/common.cmake)
 # defines expo-modules-jsi target
 include(${CMAKE_SOURCE_DIR}/cmake/jsi.cmake)
 
+# defines expo-modules-common
+include(${CMAKE_SOURCE_DIR}/cmake/common_source.cmake)
+
+# defines expo-modules-cpp-api target
+include(${CMAKE_SOURCE_DIR}/cmake/cpp_api.cmake)
+
 # defines expo-modules-core target
 include(${CMAKE_SOURCE_DIR}/cmake/main.cmake)

--- a/packages/expo-modules-core/android/cmake/common_source.cmake
+++ b/packages/expo-modules-core/android/cmake/common_source.cmake
@@ -1,0 +1,27 @@
+file(
+  GLOB
+  common_sources
+  "${COMMON_DIR}/*.cpp"
+  "${COMMON_DIR}/fabric/*.cpp"
+)
+
+add_library(
+  expo-modules-common
+  STATIC
+  ${common_sources}
+)
+
+use_expo_common(expo-modules-common)
+
+target_include_directories(
+  expo-modules-common
+  PUBLIC
+  "${COMMON_DIR}"
+  "${COMMON_DIR}/fabric"
+)
+
+target_link_libraries(
+  expo-modules-common
+  PUBLIC
+  expo-modules-jsi
+)

--- a/packages/expo-modules-core/android/cmake/cpp_api.cmake
+++ b/packages/expo-modules-core/android/cmake/cpp_api.cmake
@@ -1,0 +1,22 @@
+set(main_dir "${ANDROID_SRC_DIR}/cpp-api")
+file(GLOB cpp_api "${main_dir}/*.cpp")
+
+add_library(
+  expo-modules-cpp-api
+  STATIC
+  ${cpp_api}
+)
+
+use_expo_common(expo-modules-cpp-api)
+
+target_include_directories(
+  expo-modules-cpp-api
+  PUBLIC
+  "${main_dir}"
+)
+
+target_link_libraries(
+  expo-modules-cpp-api
+  PRIVATE
+  expo-modules-common
+)

--- a/packages/expo-modules-core/android/cmake/main.cmake
+++ b/packages/expo-modules-core/android/cmake/main.cmake
@@ -1,10 +1,3 @@
-file(
-  GLOB
-  common_sources
-  "${COMMON_DIR}/*.cpp"
-  "${COMMON_DIR}/fabric/*.cpp"
-)
-
 set(main_dir ${ANDROID_SRC_DIR}/main/cpp)
 file(
   GLOB
@@ -22,7 +15,6 @@ file(GLOB fabric_andorid_sources "${ANDROID_SRC_DIR}/fabric/*.cpp")
 add_library(
   expo-modules-core
   SHARED
-  ${common_sources}
   ${sources_android}
   ${fabric_andorid_sources}
 )
@@ -37,8 +29,6 @@ target_include_directories(
   # header only imports from turbomodule, e.g. CallInvokerHolder.h
   "${REACT_NATIVE_DIR}/ReactAndroid/src/main/jni/react/turbomodule"
   "${ANDROID_SRC_DIR}/fabric"
-  "${COMMON_DIR}"
-  "${COMMON_DIR}/fabric"
 )
 
 target_compile_options(
@@ -65,7 +55,9 @@ target_link_libraries(
   android
   ${JSEXECUTOR_LIB}
   ${NEW_ARCHITECTURE_DEPENDENCIES}
+  expo-modules-common
   expo-modules-jsi
+  expo-modules-cpp-api
 )
 
 if (REACT_NATIVE_WORKLETS_DIR)

--- a/packages/expo-modules-core/android/src/cpp-api/CppModule.cpp
+++ b/packages/expo-modules-core/android/src/cpp-api/CppModule.cpp
@@ -1,0 +1,19 @@
+#include "CppModule.h"
+
+namespace expo {
+
+void CppModule::install(jsi::Runtime &rt, jsi::Object &parent) {
+  auto def = definition();
+
+  moduleObject_ = std::make_shared<jsi::Object>(rt);
+
+  def.decorate(rt, *moduleObject_);
+
+  parent.setProperty(
+    rt,
+    def.name().data(),
+    *moduleObject_
+  );
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/cpp-api/CppModule.h
+++ b/packages/expo-modules-core/android/src/cpp-api/CppModule.h
@@ -1,0 +1,41 @@
+// Copyright © 2026-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include <memory>
+
+#include "NativeModule.h"
+#include "EventEmitter.h"
+#include "jsi_function_binding.h"
+#include "ModuleDefinition.h"
+#include "ModuleDefinitionData.h"
+
+namespace jsi = facebook::jsi;
+
+namespace expo {
+
+ModuleDefinitionData ModuleDefinition(std::function<void(const ModuleDefinition &> block) {
+  ModuleDefinition builder;
+  block(builder);
+  return builder.build();
+}
+
+class CppModule {
+public:
+  virtual ~CppModule() = default;
+
+  /**
+   * Override this to provide your module definition using the DSL.
+   */
+  virtual ModuleDefinitionData definition() = 0;
+
+  /**
+   * Build the definition once and cache it, then install onto the given parent object.
+   */
+  void install(jsi::Runtime &rt, jsi::Object &parent);
+
+private:
+  std::shared_ptr<jsi::Object> moduleObject_;
+};
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/cpp-api/ModuleDefinition.cpp
+++ b/packages/expo-modules-core/android/src/cpp-api/ModuleDefinition.cpp
@@ -1,0 +1,12 @@
+#include "ModuleDefinition.h"
+
+namespace expo {
+void ModuleDefinition::Name(std::string name) {
+  data_.name_ = std::move(name);
+}
+
+ModuleDefinitionData ModuleDefinition::build() {
+  return std::move(data_);
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/cpp-api/ModuleDefinition.h
+++ b/packages/expo-modules-core/android/src/cpp-api/ModuleDefinition.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <functional>
+#include <memory>
+
+#include <jsi/jsi.h>
+
+#include "ModuleDefinitionData.h"
+
+namespace jsi = facebook::jsi;
+
+namespace expo {
+
+class ModuleDefinition {
+public:
+  void Name(std::string name);
+
+  template<typename F>
+  void Function(std::string name, F &&fn) {
+    auto binding = make_jsi_function_binding(std::forward<F>(fn));
+
+    details::FunctionEntry entry{
+      .name = std::move(name),
+      .paramCount = binding->arity,
+      .hostFn = [binding = std::move(binding)](
+        jsi::Runtime &rt,
+        const jsi::Value &,
+        const jsi::Value *args,
+        std::size_t count
+      ) -> jsi::Value {
+        return binding->call(rt, args, count);
+      }
+    };
+
+    data_.functions_.push_back(std::move(entry));
+  }
+
+  template<typename Getter>
+  void Property(
+    std::string name,
+    Getter &&getter
+  ) {
+    Property(std::move(name), std::forward<Getter>(getter), nullptr);
+  }
+
+  template<typename Getter, typename Setter>
+  void Property(
+    std::string name,
+    Getter &&getter,
+    Setter &&setter
+  ) {
+    auto getBinding = make_jsi_function_binding(std::forward<Getter>(getter));
+    auto setBinding = make_jsi_function_binding(std::forward<Setter>(setter));
+
+    details::PropertyEntry entry{
+      .name = std::move(name),
+      .getter = [getBinding = std::move(getBinding)](
+        jsi::Runtime &rt,
+        const jsi::Value &,
+        const jsi::Value *,
+        std::size_t
+      ) -> jsi::Value {
+        return getBinding->call(rt, nullptr, 0);
+      },
+      .setter = [setBinding = std::move(setBinding)](
+        jsi::Runtime &rt,
+        const jsi::Value &,
+        const jsi::Value *args,
+        std::size_t count
+      ) -> jsi::Value {
+        setBinding->call(rt, args, count);
+        return jsi::Value::undefined();
+      }
+    };
+
+    data_.properties_.push_back(std::move(entry));
+  }
+
+  ModuleDefinitionData build();
+
+private:
+  ModuleDefinitionData data_;
+};
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/cpp-api/ModuleDefinitionData.cpp
+++ b/packages/expo-modules-core/android/src/cpp-api/ModuleDefinitionData.cpp
@@ -1,0 +1,64 @@
+#include "ModuleDefinitionData.h"
+
+namespace expo {
+
+std::string_view ModuleDefinitionData::name() const {
+  return name_;
+}
+
+void ModuleDefinitionData::decorate(jsi::Runtime &rt, jsi::Object &obj) const {
+  for (auto &entry: functions_) {
+    auto fn = jsi::Function::createFromHostFunction(
+      rt,
+      jsi::PropNameID::forAscii(rt, entry.name),
+      entry.paramCount,
+      entry.hostFn
+    );
+
+    obj.setProperty(rt, entry.name.c_str(), std::move(fn));
+  }
+
+  for (auto &prop: properties_) {
+    jsi::Object descriptor(rt);
+
+    if (prop.getter) {
+      descriptor.setProperty(
+        rt,
+        "get",
+        jsi::Function::createFromHostFunction(
+          rt,
+          jsi::PropNameID::forAscii(rt, prop.name),
+          0,
+          prop.getter
+        )
+      );
+    }
+    if (prop.setter) {
+      descriptor.setProperty(
+        rt,
+        "set",
+        jsi::Function::createFromHostFunction(
+          rt,
+          jsi::PropNameID::forAscii(rt, prop.name),
+          1,
+          prop.setter
+        )
+      );
+    }
+    descriptor.setProperty(rt, "enumerable", true);
+    descriptor.setProperty(rt, "configurable", true);
+
+    auto defineProperty = rt.global()
+      .getPropertyAsObject(rt, "Object")
+      .getPropertyAsFunction(rt, "defineProperty");
+
+    defineProperty.call(
+      rt,
+      obj,
+      jsi::String::createFromAscii(rt, prop.name),
+      std::move(descriptor)
+    );
+  }
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/cpp-api/ModuleDefinitionData.h
+++ b/packages/expo-modules-core/android/src/cpp-api/ModuleDefinitionData.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <functional>
+#include <memory>
+
+#include <jsi/jsi.h>
+
+namespace jsi = facebook::jsi;
+
+namespace expo {
+
+class ModuleDefinition;
+
+namespace details {
+
+struct FunctionEntry {
+  std::string name;
+  std::size_t paramCount;
+  jsi::HostFunctionType hostFn;
+  bool enumerable = true;
+};
+
+struct PropertyEntry {
+  std::string name;
+  jsi::HostFunctionType getter;
+  jsi::HostFunctionType setter;
+};
+
+} // namespace details
+
+class ModuleDefinitionData {
+public:
+  [[nodiscard]] std::string_view name() const;
+
+  void decorate(jsi::Runtime &rt, jsi::Object &object) const;
+
+private:
+  friend class ModuleDefinition;
+
+  std::string name_;
+  std::vector<details::FunctionEntry> functions_;
+  std::vector<details::PropertyEntry> properties_;
+};
+
+
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/cpp-api/callable_traits.h
+++ b/packages/expo-modules-core/android/src/cpp-api/callable_traits.h
@@ -1,0 +1,72 @@
+// Copyright © 2026-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include <tuple>
+#include <type_traits>
+
+namespace expo {
+
+template<typename T>
+struct callable_traits;
+
+template<typename Ret, typename... Args>
+struct callable_traits<Ret(*)(Args...)> {
+  using return_type = Ret;
+  using args_tuple = std::tuple<Args...>;
+
+  static constexpr std::size_t arity = sizeof...(Args);
+
+  template<std::size_t I>
+  using arg_type = std::tuple_element_t<I, args_tuple>;
+};
+
+// member-function pointers
+template<typename Ret, typename C, typename... Args>
+struct callable_traits<Ret(C::*)(Args...)> {
+  using return_type = Ret;
+  using args_tuple = std::tuple<Args...>;
+
+  static constexpr std::size_t arity = sizeof...(Args);
+
+  template<std::size_t I>
+  using arg_type = std::tuple_element_t<I, args_tuple>;
+};
+
+// const member-function pointers
+template<typename Ret, typename C, typename... Args>
+struct callable_traits<Ret(C::*)(Args...) const> {
+  using return_type = Ret;
+  using args_tuple = std::tuple<Args...>;
+
+  static constexpr std::size_t arity = sizeof...(Args);
+
+  template<std::size_t I>
+  using arg_type = std::tuple_element_t<I, args_tuple>;
+};
+
+// noexcept function pointer
+template<typename Ret, typename... Args>
+struct callable_traits<Ret(*)(Args...) noexcept>
+  : callable_traits<Ret(*)(Args...)> {
+};
+
+// noexcept member-function pointers
+template<typename Ret, typename C, typename... Args>
+struct callable_traits<Ret(C::*)(Args...) noexcept>
+  : callable_traits<Ret(C::*)(Args...)> {
+};
+
+// noexcept const member-function pointers
+template<typename Ret, typename C, typename... Args>
+struct callable_traits<Ret(C::*)(Args...) const noexcept>
+  : callable_traits<Ret(C::*)(Args...) const> {
+};
+
+// functors and lambdas (with ::operator())
+template<typename T> requires requires { &T::operator(); }
+struct callable_traits<T>
+  : callable_traits<decltype(&T::operator())> {
+};
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/cpp-api/convert_args.h
+++ b/packages/expo-modules-core/android/src/cpp-api/convert_args.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <jsi/jsi.h>
+
+#include "convert_from_jsi.h"
+
+namespace jsi = facebook::jsi;
+
+namespace expo {
+
+namespace details {
+
+template<typename T>
+T convert_arg(
+  jsi::Runtime &rt,
+  const jsi::Value *args,
+  std::size_t index
+) {
+  return convert_from_jsi<T>::convert(rt, args[index]);
+}
+
+template<typename... Args, std::size_t... Is>
+std::tuple<Args...> convert_args_impl(
+  jsi::Runtime &rt,
+  const jsi::Value *args,
+  std::index_sequence<Is...>
+) {
+  return std::tuple<Args...>{
+    convert_arg<Args>(rt, args, Is)...
+  };
+}
+
+} // namespace details
+
+/**
+ * Convert raw JSI arguments to a tuple of C++ values according to the specified types.
+ * The number of provided arguments must be at least the number of expected arguments.
+ */
+template<typename... Args>
+std::tuple<Args...> convert_args(
+  jsi::Runtime &rt,
+  const jsi::Value *args,
+  std::size_t count
+) {
+  constexpr std::size_t expectedArgs = sizeof...(Args);
+  if (count < expectedArgs) {
+    throw jsi::JSError(
+      rt,
+      "Expected at least " + std::to_string(expectedArgs) +
+      " argument(s), got " + std::to_string(count)
+    );
+  }
+
+  return details::convert_args_impl<Args...>(rt, args, std::index_sequence_for<Args...>{});
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/cpp-api/convert_from_jsi.cpp
+++ b/packages/expo-modules-core/android/src/cpp-api/convert_from_jsi.cpp
@@ -1,0 +1,53 @@
+#include "convert_from_jsi.h"
+
+namespace expo {
+
+bool convert_from_jsi<bool>::convert(jsi::Runtime &, const jsi::Value &value) {
+  return value.asBool();
+}
+
+int convert_from_jsi<int>::convert(jsi::Runtime &, const jsi::Value &value) {
+  return static_cast<int>(value.asNumber());
+}
+
+long convert_from_jsi<long>::convert(jsi::Runtime &, const jsi::Value &value) {
+  return static_cast<long>(value.asNumber());
+}
+
+long long convert_from_jsi<long long>::convert(jsi::Runtime &, const jsi::Value &value) {
+  return static_cast<long long>(value.asNumber());
+}
+
+float convert_from_jsi<float>::convert(jsi::Runtime &, const jsi::Value &value) {
+  return static_cast<float>(value.asNumber());
+}
+
+double convert_from_jsi<double>::convert(jsi::Runtime &, const jsi::Value &value) {
+  return static_cast<double>(value.asNumber());
+}
+
+std::string convert_from_jsi<std::string>::convert(jsi::Runtime &rt, const jsi::Value &value) {
+  return value.asString(rt).utf8(rt);
+}
+
+jsi::String convert_from_jsi<jsi::String>::convert(jsi::Runtime &rt, const jsi::Value &value) {
+  return value.asString(rt);
+}
+
+jsi::Object convert_from_jsi<jsi::Object>::convert(jsi::Runtime &rt, const jsi::Value &value) {
+  return value.asObject(rt);
+}
+
+jsi::Function convert_from_jsi<jsi::Function>::convert(jsi::Runtime &rt, const jsi::Value &value) {
+  return value.asObject(rt).asFunction(rt);
+}
+
+jsi::Array convert_from_jsi<jsi::Array>::convert(jsi::Runtime &rt, const jsi::Value &value) {
+  return value.asObject(rt).asArray(rt);
+}
+
+jsi::Value convert_from_jsi<jsi::Value>::convert(jsi::Runtime &rt, const jsi::Value &value) {
+  return {rt, value};
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/cpp-api/convert_from_jsi.h
+++ b/packages/expo-modules-core/android/src/cpp-api/convert_from_jsi.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <jsi/jsi.h>
+
+namespace jsi = facebook::jsi;
+
+namespace expo {
+
+template<typename T>
+struct convert_from_jsi {
+  static T convert(jsi::Runtime &, const jsi::Value &) {
+    static_assert(false && "No convert_from_jsi specialization for this type");
+  }
+};
+
+#define DECLARE_CONVERTER_FOR(Type) \
+  template<> \
+  struct convert_from_jsi<Type> { \
+    static Type convert(jsi::Runtime &, const jsi::Value &value); \
+  };
+
+DECLARE_CONVERTER_FOR(bool)
+DECLARE_CONVERTER_FOR(int)
+DECLARE_CONVERTER_FOR(long)
+DECLARE_CONVERTER_FOR(long long)
+DECLARE_CONVERTER_FOR(float)
+DECLARE_CONVERTER_FOR(double)
+DECLARE_CONVERTER_FOR(std::string)
+
+DECLARE_CONVERTER_FOR(jsi::String)
+DECLARE_CONVERTER_FOR(jsi::Object)
+DECLARE_CONVERTER_FOR(jsi::Function)
+DECLARE_CONVERTER_FOR(jsi::Array)
+DECLARE_CONVERTER_FOR(jsi::Value)
+
+#undef DECLARE_CONVERTER_FOR
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/cpp-api/convert_to_jsi.cpp
+++ b/packages/expo-modules-core/android/src/cpp-api/convert_to_jsi.cpp
@@ -1,0 +1,57 @@
+#include "convert_to_jsi.h"
+
+namespace expo {
+
+jsi::Value convert_to_jsi<bool>::convert(jsi::Runtime &, bool v) {
+  return {v};
+}
+
+jsi::Value convert_to_jsi<int>::convert(jsi::Runtime &, int v) {
+  return {v};
+}
+
+jsi::Value convert_to_jsi<long>::convert(jsi::Runtime &, long v) {
+  return {static_cast<double>(v)};
+}
+
+jsi::Value convert_to_jsi<long long>::convert(jsi::Runtime &, long long v) {
+  return {static_cast<double>(v)};
+}
+
+jsi::Value convert_to_jsi<float>::convert(jsi::Runtime &, float v) {
+  return {v};
+}
+
+jsi::Value convert_to_jsi<double>::convert(jsi::Runtime &, double v) {
+  return {v};
+}
+
+jsi::Value convert_to_jsi<std::string>::convert(jsi::Runtime &rt, const std::string &v) {
+  return {rt, jsi::String::createFromUtf8(rt, v)};
+}
+
+jsi::Value convert_to_jsi<char *>::convert(jsi::Runtime &rt, char *v) {
+  return {rt, jsi::String::createFromUtf8(rt, v)};
+}
+
+jsi::Value convert_to_jsi<jsi::String>::convert(jsi::Runtime &rt, const jsi::String &v) {
+  return {rt, v};
+}
+
+jsi::Value convert_to_jsi<jsi::Object>::convert(jsi::Runtime &rt, const jsi::Object &v) {
+  return {rt, v};
+}
+
+jsi::Value convert_to_jsi<jsi::Array>::convert(jsi::Runtime &rt, const jsi::Array &v) {
+  return {rt, v};
+}
+
+jsi::Value convert_to_jsi<jsi::Function>::convert(jsi::Runtime &rt, const jsi::Function &v) {
+  return {rt, v};
+}
+
+jsi::Value convert_to_jsi<jsi::Value>::convert(jsi::Runtime &rt, const jsi::Value &v) {
+  return {rt, v};
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/cpp-api/convert_to_jsi.h
+++ b/packages/expo-modules-core/android/src/cpp-api/convert_to_jsi.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <string>
+#include <type_traits>
+
+#include <jsi/jsi.h>
+
+namespace jsi = facebook::jsi;
+
+namespace expo {
+
+template<typename T>
+struct convert_to_jsi {
+  static jsi::Value convert(jsi::Runtime &, T value) {
+    static_assert(false && "No convert_to_jsi specialization for this type");
+  }
+};
+
+#define DECLARE_CONVERTER_FOR(Type, Arg) \
+  template<> \
+  struct convert_to_jsi<Type> { \
+    static jsi::Value convert(jsi::Runtime &, Arg value); \
+  };
+
+DECLARE_CONVERTER_FOR(bool, bool)
+DECLARE_CONVERTER_FOR(int, int)
+DECLARE_CONVERTER_FOR(long, long)
+DECLARE_CONVERTER_FOR(long long, long long)
+DECLARE_CONVERTER_FOR(float, float)
+DECLARE_CONVERTER_FOR(double, double)
+DECLARE_CONVERTER_FOR(std::string, const std::string&)
+DECLARE_CONVERTER_FOR(char *, char *)
+
+DECLARE_CONVERTER_FOR(jsi::String, const jsi::String&)
+DECLARE_CONVERTER_FOR(jsi::Object, const jsi::Object&)
+DECLARE_CONVERTER_FOR(jsi::Array, const jsi::Array&)
+DECLARE_CONVERTER_FOR(jsi::Function, const jsi::Function&)
+DECLARE_CONVERTER_FOR(jsi::Value, const jsi::Value&)
+
+#undef DECLARE_CONVERTER_FOR
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/cpp-api/jsi_function_binding.h
+++ b/packages/expo-modules-core/android/src/cpp-api/jsi_function_binding.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <memory>
+
+#include <jsi/jsi.h>
+
+#include "callable_traits.h"
+#include "convert_to_jsi.h"
+#include "convert_args.h"
+
+namespace jsi = facebook::jsi;
+
+namespace expo {
+
+template<typename F>
+class jsi_function_binding {
+public:
+  using Callable = callable_traits<std::remove_cvref_t<F>>;
+  using ReturnType = typename Callable::return_type;
+  using ArgsTuple = typename Callable::args_tuple;
+
+  explicit jsi_function_binding(F fn) : fn_(std::move(fn)) {}
+
+  static constexpr std::size_t arity = Callable::arity;
+
+  /**
+   * Convert raw JSI arguments, invoke the stored callable, and return
+   * the result as a jsi::Value.
+   */
+  jsi::Value call(
+    jsi::Runtime &rt,
+    const jsi::Value *args,
+    std::size_t count
+  ) {
+    return dispatcher<ArgsTuple>::call(*this, rt, args, count);
+  }
+
+  /**
+   * Produce a jsi::Function (host function) that can be installed on a
+   * JavaScript object. Calling it from JS will automatically convert
+   * the arguments, invoke the C++ lambda, and return the result.
+   */
+  jsi::Function toJSFunction(jsi::Runtime &rt, const char *name) {
+    return jsi::Function::createFromHostFunction(
+      rt,
+      jsi::PropNameID::forAscii(rt, name),
+      arity,
+      [this](
+        jsi::Runtime &rt,
+        const jsi::Value &self,
+        const jsi::Value *args,
+        std::size_t count
+      ) -> jsi::Value {
+        return this->call(rt, args, count);
+      }
+    );
+  }
+
+private:
+  F fn_;
+
+  template<typename... Args>
+  jsi::Value dispatch(
+    jsi::Runtime &rt,
+    std::tuple<Args...> &args
+  ) {
+    constexpr bool isVoid = std::is_void<ReturnType>::value;
+
+    if constexpr (!isVoid) {
+      ReturnType result = std::apply(fn_, args);
+      return convert_to_jsi<ReturnType>::convert(rt, std::move(result));
+    } else {
+      std::apply(fn_, args);
+      return jsi::Value::undefined();
+    }
+  }
+
+  template<typename Tuple>
+  struct dispatcher;
+
+  template<typename... Args>
+  struct dispatcher<std::tuple<Args...>> {
+    static jsi::Value call(
+      jsi_function_binding &binding,
+      jsi::Runtime &rt,
+      const jsi::Value *args,
+      std::size_t count
+    ) {
+      auto converted = convert_args<Args...>(rt, args, count);
+      return binding.dispatch(
+        rt,
+        converted
+      );
+    }
+  };
+};
+
+template<typename F>
+using jsi_function_binding_t = jsi_function_binding<std::remove_cvref_t<F>>;
+
+template<typename F>
+std::shared_ptr<jsi_function_binding_t<F>> make_jsi_function_binding(F &&fn) {
+  return std::make_shared<jsi_function_binding_t<F>>(std::forward<F>(fn));
+}
+
+} // namespace expo


### PR DESCRIPTION
# Why

It's a POC for the modules API in C++. 

# How

I wanted to check if it's possible to achieve a similar DSL syntax in C++. I was able to unpack, convert, and pass all arguments. I've also implemented it for records in C++, but I'll add that as a separate PR. 

Also, this API is added to Android for now, but it's cross-platform. I didn't want to interrupt the iOS precompilation work. 

# Test Plan

- bare expo ✅ 

Example usage:

```c++
class MyCppModule : public CppModule {
public:
  ModuleDefinitionData definition() override {
    return ModuleDefinition([](auto &m) {
      m.Name("MyCppModule");

      m.Function("add", [](int a, int b) {
        return a + b;
      });

      m.Function("greet", [](std::string name) {
        return "Hello, " + name + "!";
      });
    });
  }
};
```