### PR TITLE
[docs] Fix internal links for EAS Update docs

### DIFF
--- a/docs/pages/eas-update/debug.mdx
+++ b/docs/pages/eas-update/debug.mdx
@@ -19,7 +19,7 @@ This guide shows how to verify our configuration so that we can find the source 
 
 <br />
 
-> If we are not using EAS Build, our Deployments page will be empty. Follow the guide on [debugging configuration without EAS Build](/eas-update/debug-advanced/#configuration-without-eas-build) instead.
+> If we are not using EAS Build, our Deployments page will be empty. Follow the guide on [debugging configuration without EAS Build](/eas-update/debug/#configuration-without-eas-build) instead.
 
 ## Go to the Deployments page
 
@@ -89,7 +89,7 @@ The displayed deployment has the correct channel, but it is not linked to a bran
 
 ### Missing deployment
 
-If our deployment is not displayed, it means our build is not configured properly for EAS Update. To fix this, [configure our channel](/#configure-channel), [configure our runtime version](/#configure-runtime-version) and verify our [general configuration](/eas-update/debug-advanced/#verifying-app-configuration). We'll need to rebuild our app after making these changes.
+If our deployment is not displayed, it means our build is not configured properly for EAS Update. To fix this, [configure our channel](/#configure-channel), [configure our runtime version](/#configure-runtime-version) and verify our [general configuration](/eas-update/debug/#verifying-app-configuration). We'll need to rebuild our app after making these changes.
 
 ### Automatic roll back when an update crashes
 
@@ -247,7 +247,7 @@ If we aren't using EAS Build, this section will walk through debugging the state
 
 #### Verify build configuration
 
-Follow the [Building Locally guide](/eas-update/standalone-service/) to configure our app's channel and runtime version. We'll also need to make sure our [general configuration](/eas-update/debug-advanced/#expo-updates-configuration) is correct.
+Follow the [Building Locally guide](/eas-update/standalone-service/) to configure our app's channel and runtime version. We'll also need to make sure our [general configuration](/eas-update/debug/#expo-updates-configuration) is correct.
 
 #### Verify the channel
 

--- a/docs/pages/eas-update/deployment.mdx
+++ b/docs/pages/eas-update/deployment.mdx
@@ -26,7 +26,7 @@ In this guide, we'll describe a simple but powerful release process that uses **
 
 The most simple way to use EAS Update is to ignore the concept of "branches" and focus on "channels". Branches will still exist, but you will not have to interact with them directly to manage deployments. You can keep your channels pointed at a branch with the same name as the channel and think of them as a singular concept.
 
-EAS Update branches were meant to map to Git branches and enable teams to publish changes from a Git branch directly to an EAS Update branch of the same name. This can be helpful for [previewing updates](/eas-update/develop-faster/), but for many apps, this level of integration with Git is not required. Often, developers are only interested in being able to release hotfixes to a staging or production version of their app manually, and can run `eas update --channel staging` or `eas update --channel production`, when needed rather than managing branches to accomplish the same result.
+EAS Update branches were meant to map to Git branches and enable teams to publish changes from a Git branch directly to an EAS Update branch of the same name. This can be helpful for [previewing updates](/eas-update/preview/), but for many apps, this level of integration with Git is not required. Often, developers are only interested in being able to release hotfixes to a staging or production version of their app manually, and can run `eas update --channel staging` or `eas update --channel production`, when needed rather than managing branches to accomplish the same result.
 
 </Collapsible>
 
@@ -99,7 +99,7 @@ As explained above, preview builds will point to the "preview" channel. If you w
 
 ### Preview in development builds
 
-Development builds can load updates from any channel, provided the runtime version is compatible. Learn more about this in [Previewing updates](/eas-update/develop-faster/).
+Development builds can load updates from any channel, provided the runtime version is compatible. Learn more about this in [Previewing updates](/eas-update/preview/).
 
 ## Deploying to staging
 
@@ -144,4 +144,4 @@ Learn more in [Rollbacks](/eas-update/rollbacks/).
 ## Next steps
 
 - [Learn more about the Persistent staging release process](/eas-update/deployment-patterns/#persistent-staging-flow), which is very similar to what is described here.
-- [Explore using preview updates in development builds](/eas-update/develop-faster/).
+- [Explore using preview updates in development builds](/eas-update/preview/).

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -306,7 +306,7 @@ If your app is not updating as expected, see the [debugging guide](/eas-update/d
 <BoxLink
   title="Previewing updates"
   description="Learn how to iterate quickly by sharing updates for QA and testing."
-  href="/eas-update/develop-faster/"
+  href="/eas-update/preview/"
   Icon={LayersTwo02Icon}
 />
 

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -192,7 +192,7 @@ We recommend transitioning to EAS Update or using a [self-hosted update service]
 <BoxLink
   title="Preview updates"
   description="View your teammate's changes with EAS Update."
-  href="/eas-update/develop-faster/"
+  href="/eas-update/preview/"
   Icon={LayersTwo02Icon}
 />
 

--- a/docs/pages/troubleshooting/overview.mdx
+++ b/docs/pages/troubleshooting/overview.mdx
@@ -140,7 +140,7 @@ This page lists a collection of various troubleshooting guides for Expo and EAS.
 <BoxLink
   title="EAS Update: Advanced debugging"
   description="Learn advanced strategies on how to debug EAS Update."
-  href="/eas-update/debug-advanced/"
+  href="/eas-update/debug/"
   Icon={LayersTwo02Icon}
 />
 

--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -259,7 +259,7 @@ You can configure your app to check for updates manually by doing the following 
 
 ## Testing
 
-Most of the methods and constants in this library can be used or tested only in release builds. In debug builds, the default behavior is to always load the latest JavaScript from a development server. It is possible to [build a debug version of your app with the same updates behavior as a release build](/eas-update/debug-advanced/#debugging-of-native-code-while-loading-the-app-through-expo-updates). Such an app will not open the latest JavaScript from your development server &mdash; it will load published updates just as a release build does. This may be useful for debugging the behavior of your app when it is not connected to a development server.
+Most of the methods and constants in this library can be used or tested only in release builds. In debug builds, the default behavior is to always load the latest JavaScript from a development server. It is possible to [build a debug version of your app with the same updates behavior as a release build](/eas-update/debug/#debugging-of-native-code-while-loading-the-app-through-expo-updates). Such an app will not open the latest JavaScript from your development server &mdash; it will load published updates just as a release build does. This may be useful for debugging the behavior of your app when it is not connected to a development server.
 
 **To test the content of an update in a development build**, run [`eas update`](/eas-update/getting-started/) and then browse to the update in your development build. Note that this only simulates what an update will look like in your app, and most of the [Updates API](#api) is unavailable when running in a development build.
 

--- a/docs/pages/versions/v53.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/updates.mdx
@@ -258,7 +258,7 @@ You can configure your app to check for updates manually by doing the following 
 
 ## Testing
 
-Most of the methods and constants in this library can be used or tested only in release builds. In debug builds, the default behavior is to always load the latest JavaScript from a development server. It is possible to [build a debug version of your app with the same updates behavior as a release build](/eas-update/debug-advanced/#debugging-of-native-code-while-loading-the-app-through-expo-updates). Such an app will not open the latest JavaScript from your development server &mdash; it will load published updates just as a release build does. This may be useful for debugging the behavior of your app when it is not connected to a development server.
+Most of the methods and constants in this library can be used or tested only in release builds. In debug builds, the default behavior is to always load the latest JavaScript from a development server. It is possible to [build a debug version of your app with the same updates behavior as a release build](/eas-update/debug/#debugging-of-native-code-while-loading-the-app-through-expo-updates). Such an app will not open the latest JavaScript from your development server &mdash; it will load published updates just as a release build does. This may be useful for debugging the behavior of your app when it is not connected to a development server.
 
 **To test the content of an update in a development build**, run [`eas update`](/eas-update/getting-started/) and then browse to the update in your development build. Note that this only simulates what an update will look like in your app, and most of the [Updates API](#api) is unavailable when running in a development build.
 

--- a/docs/pages/versions/v54.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/updates.mdx
@@ -258,7 +258,7 @@ You can configure your app to check for updates manually by doing the following 
 
 ## Testing
 
-Most of the methods and constants in this library can be used or tested only in release builds. In debug builds, the default behavior is to always load the latest JavaScript from a development server. It is possible to [build a debug version of your app with the same updates behavior as a release build](/eas-update/debug-advanced/#debugging-of-native-code-while-loading-the-app-through-expo-updates). Such an app will not open the latest JavaScript from your development server &mdash; it will load published updates just as a release build does. This may be useful for debugging the behavior of your app when it is not connected to a development server.
+Most of the methods and constants in this library can be used or tested only in release builds. In debug builds, the default behavior is to always load the latest JavaScript from a development server. It is possible to [build a debug version of your app with the same updates behavior as a release build](/eas-update/debug/#debugging-of-native-code-while-loading-the-app-through-expo-updates). Such an app will not open the latest JavaScript from your development server &mdash; it will load published updates just as a release build does. This may be useful for debugging the behavior of your app when it is not connected to a development server.
 
 **To test the content of an update in a development build**, run [`eas update`](/eas-update/getting-started/) and then browse to the update in your development build. Note that this only simulates what an update will look like in your app, and most of the [Updates API](#api) is unavailable when running in a development build.
 

--- a/docs/pages/versions/v55.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/updates.mdx
@@ -259,7 +259,7 @@ You can configure your app to check for updates manually by doing the following 
 
 ## Testing
 
-Most of the methods and constants in this library can be used or tested only in release builds. In debug builds, the default behavior is to always load the latest JavaScript from a development server. It is possible to [build a debug version of your app with the same updates behavior as a release build](/eas-update/debug-advanced/#debugging-of-native-code-while-loading-the-app-through-expo-updates). Such an app will not open the latest JavaScript from your development server &mdash; it will load published updates just as a release build does. This may be useful for debugging the behavior of your app when it is not connected to a development server.
+Most of the methods and constants in this library can be used or tested only in release builds. In debug builds, the default behavior is to always load the latest JavaScript from a development server. It is possible to [build a debug version of your app with the same updates behavior as a release build](/eas-update/debug/#debugging-of-native-code-while-loading-the-app-through-expo-updates). Such an app will not open the latest JavaScript from your development server &mdash; it will load published updates just as a release build does. This may be useful for debugging the behavior of your app when it is not connected to a development server.
 
 **To test the content of an update in a development build**, run [`eas update`](/eas-update/getting-started/) and then browse to the update in your development build. Note that this only simulates what an update will look like in your app, and most of the [Updates API](#api) is unavailable when running in a development build.
 

--- a/docs/pages/workflow/overview.mdx
+++ b/docs/pages/workflow/overview.mdx
@@ -249,4 +249,4 @@ Analytics allows you to track how users interact with your app. See [analytics o
 
 The `expo-updates` library allows you to programmatically make instant updates to your app's JavaScript available to your production app.
 
-You can use [EAS Update](/eas-update/introduction/) which provides first-class support for instant updates in a React Native app. It serves updates from the edge of a global CDN and uses modern networking protocols such as HTTP/3 for clients that support them. It is also [tailored for developers](/eas-update/develop-faster/) who use EAS Build. You can also use it for builds you have created [locally](/eas-update/standalone-service/).
+You can use [EAS Update](/eas-update/introduction/) which provides first-class support for instant updates in a React Native app. It serves updates from the edge of a global CDN and uses modern networking protocols such as HTTP/3 for clients that support them. It is also [tailored for developers](/eas-update/preview/) who use EAS Build. You can also use it for builds you have created [locally](/eas-update/standalone-service/).


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Several EAS Update pages were renamed (for example, `debug-advanced` became `debug`, and `develop-faster` became `preview`), but internal links across the docs still pointed to the old paths. These broken links lead to 404s or redirects.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
