### PR TITLE
[docs] Fix internal links in multiple pages

### DIFF
--- a/docs/pages/archive/classic-updates/offline-support.mdx
+++ b/docs/pages/archive/classic-updates/offline-support.mdx
@@ -14,7 +14,7 @@ To force JS updates to run in the background (rather than synchronously checking
 
 ## Cache your assets after downloading
 
-By default, all of your assets (images, fonts, and so on) are [uploaded to Expo's CDN](/guides/assets/) when you publish updates to your app. Once they're downloaded, you can [cache them](/archive/classic-updates/preloading-and-caching-assets) so you don't need to download them a second time. If you publish changes, the cache will be invalidated and the changed version will be downloaded.
+By default, all of your assets (images, fonts, and so on) are [uploaded to Expo's CDN](/develop/user-interface/assets/) when you publish updates to your app. Once they're downloaded, you can [cache them](/archive/classic-updates/preloading-and-caching-assets) so you don't need to download them a second time. If you publish changes, the cache will be invalidated and the changed version will be downloaded.
 
 ## Bundle your assets inside your standalone binary
 

--- a/docs/pages/archive/glossary.mdx
+++ b/docs/pages/archive/glossary.mdx
@@ -12,12 +12,12 @@ The term "detach" was previously used in Expo to mean [ejecting](#eject) your ap
 
 The term "eject" was popularized by [create-react-app](https://github.com/facebook/create-react-app), and it is used in Expo to describe leaving the cozy comfort of the standard Expo development environment, where you do not have to deal with build configuration or native code. When you "eject" from Expo, you have two choices:
 
-- _Eject to bare workflow_, where you jump between [workflows](/archive/managed-vs-bare/) and move into the bare workflow, where you can continue to use Expo APIs but have access and full control over your native Android and iOS projects.
+- _Eject to bare workflow_, where you jump between [workflows](/workflow/overview/) and move into the bare workflow, where you can continue to use Expo APIs but have access and full control over your native Android and iOS projects.
 - _Eject to ExpoKit_, where you get the native projects along with [ExpoKit](#expokit). This option is deprecated and support for ExpoKit was removed after SDK 38.
 
 ### ExpoKit
 
-ExpoKit is an Objective-C and Java library that allows you to use the [Expo SDK](/more/glossary-of-terms/#expo-sdk) and platform and your existing Expo project as part of a larger standard native project — one that you would normally create using Xcode, Android Studio, or `react-native init`. For more information, see [Ejecting to ExpoKit](/archive/expokit/eject/).
+ExpoKit is an Objective-C and Java library that allows you to use the [Expo SDK](/more/glossary-of-terms/#expo-sdk) and platform and your existing Expo project as part of a larger standard native project — one that you would normally create using Xcode, Android Studio, or `react-native init`. For more information, see [Ejecting to ExpoKit](#eject).
 
 **Support for ExpoKit ended after SDK 38. Expo modules can implement support for custom native configuration, and projects that need even more custom native code can [expose their Android Studio and Xcode projects with `npx expo prebuild`](/workflow/customizing/).**
 

--- a/docs/pages/archive/push-notifications/sending-notifications-custom-fcm-legacy.mdx
+++ b/docs/pages/archive/push-notifications/sending-notifications-custom-fcm-legacy.mdx
@@ -8,7 +8,7 @@ description: Learn how to send notifications with FCM legacy server.
 
 > **info** For documentation on communicating with the newer FCMv1 service, see [Send notifications with FCMv1 and APNs](/push-notifications/sending-notifications-custom/). This guide is based on [Google's documentation](https://firebase.google.com/docs/cloud-messaging/http-server-ref), and this section covers the basics to get you started.
 >
-> Before sending a notification directly through FCM, you will need to [obtain a device token](/push-notifications/obtaining-a-device-token-for-fcm-or-apns).
+> Before sending a notification directly through FCM, you will need to [obtain a device token](/push-notifications/sending-notifications-custom/).
 
 Communicating with FCM is done by sending a POST request. However, before sending or receiving any notifications, you'll need to follow the steps to [configure FCM](/push-notifications/push-notifications-setup/#android) to configure FCM and get your `FCM-SERVER-KEY`.
 

--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -46,7 +46,7 @@ For example, you might see something like this on your Android builds:
   ]}
 />
 
-While you may or may not be interested in following up on that warning, it is not the cause of your failed build. So how do you know which logs are truly responsible? If you are building a bare project, you will already be good at this. If you are building a [managed project](/archive/managed-vs-bare/), it may be tricky because you don't directly interact with the native code, only write JavaScript.
+While you may or may not be interested in following up on that warning, it is not the cause of your failed build. So how do you know which logs are truly responsible? If you are building a bare project, you will already be good at this. If you are building a [managed project](/workflow/overview/), it may be tricky because you don't directly interact with the native code, only write JavaScript.
 
 A good path forward is to **determine if the build failed due to a native or JavaScript error**. When your build fails due to a JavaScript build error, you will usually see something like this:
 

--- a/docs/pages/build/updates.mdx
+++ b/docs/pages/build/updates.mdx
@@ -31,7 +31,7 @@ The following example demonstrates how you might use the `"production"` channel 
 
 Your native runtime may change on each build, depending on whether you modify the code in a way that changes the API contract with JavaScript. If you publish a JavaScript bundle to a binary with an incompatible native runtime (for example, a function that the JavaScript bundle expects to exist does not exist) then your app may not work as expected, or it may crash.
 
-We recommend using a different [runtime version](/distribution/runtime-versions/) for each binary version of your app. Any time you change the native runtime (in managed apps, this happens when you add or remove a native library, or modify **app.json**), you should increment the runtime version.
+We recommend using a different [runtime version](/eas-update/runtime-versions/) for each binary version of your app. Any time you change the native runtime (in managed apps, this happens when you add or remove a native library, or modify **app.json**), you should increment the runtime version.
 
 ## Previewing updates in development builds
 
@@ -39,4 +39,4 @@ Updates published with the `runtimeVersion` field can't be loaded in Expo Go. In
 
 ## Environment variables and `eas update`
 
-Environment variables set on the `env` field in build profiles are not available when you run `eas update`. Learn more about using [environment variables with EAS Update](/eas-update/environment-variables).
+Environment variables set on the `env` field in build profiles are not available when you run `eas update`. Learn more about using [environment variables with EAS Update](/eas/environment-variables).

--- a/docs/pages/build/updates.mdx
+++ b/docs/pages/build/updates.mdx
@@ -39,4 +39,4 @@ Updates published with the `runtimeVersion` field can't be loaded in Expo Go. In
 
 ## Environment variables and `eas update`
 
-Environment variables set on the `env` field in build profiles are not available when you run `eas update`. Learn more about using [environment variables with EAS Update](/eas/environment-variables).
+Environment variables set on the `env` field in build profiles are not available when you run `eas update`. Learn more about using [environment variables with EAS Update](/eas/environment-variables/usage/#using-environment-variables-with-eas-update).

--- a/docs/pages/develop/development-builds/share-with-your-team.mdx
+++ b/docs/pages/develop/development-builds/share-with-your-team.mdx
@@ -66,6 +66,6 @@ You can use `eas build:resign` to codesign an existing **.ipa** for iOS to a new
 <BoxLink
   title="Sharing pre-release versions of your app"
   description="Learn more about sharing pre-release versions of your app."
-  href="/guides/sharing-preview-releases"
+  href="/build/internal-distribution"
   Icon={BookOpen02Icon}
 />

--- a/docs/pages/eas-update/integration-in-existing-native-apps.mdx
+++ b/docs/pages/eas-update/integration-in-existing-native-apps.mdx
@@ -23,7 +23,7 @@ You should have a brownfield native project with React Native installed and conf
 
 - Your app must be using the [latest Expo SDK version and its supported React Native version](/versions/latest/#each-expo-sdk-version-depends-on-a-react-native-version).
 - Remove any other update library integration from your app, such as react-native-code-push, and ensure that your app compiles and runs successfully in both debug and release on your supported platforms.
-- Support for Expo modules (through the `expo` package) must be installed and configured in your project. [Learn more](/brownfield/installing-expo-modules/).
+- Support for Expo modules (through the `expo` package) must be installed and configured in your project. [Learn more](/brownfield/overview/).
 - Your **metro.config.js** [must extend `expo/metro-config`](/guides/customizing-metro/#customizing) .
 - Your **babel.config.js** [must extend `babel-preset-expo`](/versions/latest/config/babel/).
 - The command `npx expo export -p android` must run successfully in your project if it supports Android, and `npx expo export -p ios` if it supports iOS.

--- a/docs/pages/eas/hosting/introduction.mdx
+++ b/docs/pages/eas/hosting/introduction.mdx
@@ -158,7 +158,7 @@ For more information, see the [Web deployments with EAS Workflows](/eas/hosting/
 <BoxLink
   title="Configure environment variables"
   description="Use environment variables in your web and server code."
-  href="/eas/hosting/environment-variables"
+  href="/eas/environment-variables/usage/#using-environment-variables-with-eas-hosting"
   Icon={Cloud01Icon}
 />
 

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -21,7 +21,7 @@ When Expo was first created, React Native had yet to be publicly released. This 
 
 The Expo SDK is well-tested, written in TypeScript, documented, and built for Android, iOS, and the web. Every module in the Expo SDK works together to ensure versioning always matches. This creates a nice upgrading experience.
 
-The Expo SDK is also written with the [Expo Modules API](/modules) to make contributing, maintaining, and understanding easier.
+The Expo SDK is also written with the [Expo Modules API](/modules/overview/) to make contributing, maintaining, and understanding easier.
 
 ## What is the difference between Expo and React Native?
 
@@ -43,7 +43,7 @@ Expo supports adding custom native code and customizing that native code (Androi
 
 ## Can I use Expo in the app that is created with React Native CLI?
 
-Yes! All Expo tools and services work great in any React Native app. For example, you can use any part of the [Expo SDK](/versions/latest), [`expo-dev-client`](/develop/development-builds/installation/) and EAS Build, Submit, and Update &mdash; they work great! Learn more about [installing `expo` in your project](/bare/installing-expo-modules), [adopting prebuild](/guides/adopting-prebuild), and [setting up EAS Build](/build/introduction).
+Yes! All Expo tools and services work great in any React Native app. For example, you can use any part of the [Expo SDK](/versions/latest), [`expo-dev-client`](/develop/development-builds/create-a-build/) and EAS Build, Submit, and Update &mdash; they work great! Learn more about [installing `expo` in your project](/bare/installing-expo-modules), [adopting prebuild](/guides/adopting-prebuild), and [setting up EAS Build](/build/introduction).
 
 ## How do I share my Expo project? Can I submit it to the app stores?
 
@@ -69,7 +69,7 @@ If the `expo` package is included in your app, it only adds 1 MB one time to the
 
 ## Can I use Expo with my native library?
 
-You can use native Android and iOS libraries with Expo by creating a [custom native module](/modules) with Swift and Kotlin. Many popular libraries already have custom native modules. Check out our [React Native directory](https://reactnative.directory) to find popular libraries for your use case.
+You can use native Android and iOS libraries with Expo by creating a [custom native module](/modules/overview/) with Swift and Kotlin. Many popular libraries already have custom native modules. Check out our [React Native directory](https://reactnative.directory) to find popular libraries for your use case.
 
 ## Can I use Expo with this web library?
 

--- a/docs/pages/guides/expo-ui-swift-ui/extending.mdx
+++ b/docs/pages/guides/expo-ui-swift-ui/extending.mdx
@@ -14,7 +14,7 @@ This guide explains how to create custom SwiftUI components and modifiers that i
 
 Before you begin, make sure you have:
 
-- `@expo/ui` installed in your project. See [Building SwiftUI apps with Expo UI](/expo-ui-swift-ui/) for more information.
+- `@expo/ui` installed in your project. See [Building SwiftUI apps with Expo UI](/guides/expo-ui-swift-ui/) for more information.
 - A [development build](/develop/development-builds/introduction/) of your app (Expo UI is not available in Expo Go)
 - Basic familiarity with [Expo Modules API](/modules/overview/) and [SwiftUI](https://developer.apple.com/swiftui/)
 

--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -181,7 +181,7 @@ React Native Firebase requires [custom native code and cannot be used with Expo 
 Since React Native Firebase requires custom native code, you need to install the `expo-dev-client` library in your project.
 It allows configuring any native code required by React Native Firebase using [Config plugins](/config-plugins/introduction/) without writing native code yourself.
 
-To install [`expo-dev-client`](/development/getting-started/#installing--expo-dev-client--in-your-project), run the following command in your project:
+To install [`expo-dev-client`](/develop/development-builds/create-a-build/), run the following command in your project:
 
 <Terminal cmd={['$ npx expo install expo-dev-client']} />
 </Step>

--- a/docs/pages/guides/using-vexo.mdx
+++ b/docs/pages/guides/using-vexo.mdx
@@ -59,7 +59,7 @@ With a two-line integration, Vexo starts collecting data automatically, giving y
 
 ## Compatibility
 
-- Expo: Vexo is compatible with [Development builds](/development/introduction/) and does not require additional configuration plugins.
+- Expo: Vexo is compatible with [Development builds](/develop/development-builds/introduction/) and does not require additional configuration plugins.
 - Expo Go: Not supported, as Vexo requires custom native code.
 
 ## Learn more about Vexo

--- a/docs/pages/guides/why-metro.mdx
+++ b/docs/pages/guides/why-metro.mdx
@@ -23,7 +23,7 @@ New and upcoming features that are planned to come to Metro include:
 - Compiling Flow code to native machine code with Static Hermes. Learn more in the [Static Hermes](https://www.youtube.com/watch?v=GUM64b-gAGg) talk by Tzvetan Mikov.
 - Data fetching, streaming, React Suspense, server rendering, and build-time static rendering with universal React Server Components for all platforms. Learn more in the [Universal React Server Components](https://www.youtube.com/watch?v=djhEgxQf3Kw) talk at React Conf 2024.
 
-The Expo team collaborates with Meta to develop Metro for Expo Router, adding features like [file-based routing](/develop/file-based-routing/), [web support](/guides/customizing-metro/#web-support), [bundle splitting](/guides/customizing-metro/#bundle-splitting), [tree shaking](/guides/tree-shaking/), [CSS](/versions/latest/config/metro/#css), [DOM components](/guides/dom-components/), server components, and [API routes](/router/web/api-routes/).
+The Expo team collaborates with Meta to develop Metro for Expo Router, adding features like [file-based routing](/develop/app-navigation/), [web support](/guides/customizing-metro/#web-support), [bundle splitting](/guides/customizing-metro/#bundle-splitting), [tree shaking](/guides/tree-shaking/), [CSS](/versions/latest/config/metro/#css), [DOM components](/guides/dom-components/), server components, and [API routes](/router/web/api-routes/).
 
 ## Battle-tested at scale
 

--- a/docs/pages/linking/into-other-apps.mdx
+++ b/docs/pages/linking/into-other-apps.mdx
@@ -10,7 +10,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 Handling linking into other apps from your app is achieved by using the target app's URL. There are two methods you can use to open such URLs from your app:
 
 - Using the [`expo-linking`](/versions/latest/sdk/linking) API
-- Using Expo Router's [`Link` component](/develop/file-based-routing/#how-does-link-work)
+- Using Expo Router's [`Link` component](/develop/app-navigation/)
 
 ## Using expo-linking API
 

--- a/docs/pages/router/advanced/modals.mdx
+++ b/docs/pages/router/advanced/modals.mdx
@@ -132,7 +132,7 @@ A modal loses its previous context when it is the current screen in the navigato
 
 - On Android, the modal slides on top of the current screen. To dismiss it, use the back button to navigate back to the previous screen.
 - On iOS, the modal slides from the bottom of the current screen. To dismiss it, swipe it down from the top.
-- On web, the modal is presented as a separate route, and the dismiss behavior has to be provided manually using [`router.canGoBack()`](/router/navigating-pages/#imperative-navigation). Here's an example of how to dismiss the modal:
+- On web, the modal is presented as a separate route, and the dismiss behavior has to be provided manually using [`router.canGoBack()`](/router/basics/navigation/). Here's an example of how to dismiss the modal:
 
 {/* prettier-ignore */}
 ```tsx src/app/modal.tsx

--- a/docs/pages/router/advanced/redirects.mdx
+++ b/docs/pages/router/advanced/redirects.mdx
@@ -82,7 +82,7 @@ Unlike routes within the **app** directory, you do not need to add the `/index` 
 
 ### Dynamic routes
 
-The `source` and `destination` routes can use the [dynamic route syntax](/develop/dynamic-routes/) to create redirects for dynamic routes. You can define them in **app.json** using the `expo-router` config plugin.
+The `source` and `destination` routes can use the [dynamic route syntax](/develop/app-navigation/) to create redirects for dynamic routes. You can define them in **app.json** using the `expo-router` config plugin.
 
 ```json app.json
 {

--- a/docs/pages/submit/android.mdx
+++ b/docs/pages/submit/android.mdx
@@ -151,7 +151,7 @@ Once you have completed all the prerequisites, you can set up a CI/CD pipeline t
 
 ### Use EAS Workflows CI/CD
 
-You can use [EAS Workflows](/eas-workflows/get-started/) to build and submit your app automatically.
+You can use [EAS Workflows](/eas/workflows/get-started/) to build and submit your app automatically.
 
 1. Create a workflow file named **.eas/workflows/submit-android.yml** at the root of your project.
 2. Inside **submit-android.yml**, you can use the following workflow to kick off a job that submits an Android app:

--- a/docs/pages/submit/ios.mdx
+++ b/docs/pages/submit/ios.mdx
@@ -172,7 +172,7 @@ Once you have completed all the prerequisites, you can set up a CI/CD pipeline t
 
 ### Use EAS Workflows CI/CD
 
-You can use [EAS Workflows](/eas-workflows/get-started/) to build and submit your app automatically.
+You can use [EAS Workflows](/eas/workflows/get-started/) to build and submit your app automatically.
 
 1. Create a workflow file named **.eas/workflows/submit-ios.yml** at the root of your project.
 2. Inside **submit-ios.yml**, you can use the following workflow to kick off a job that submits an iOS app:

--- a/docs/pages/troubleshooting/overview.mdx
+++ b/docs/pages/troubleshooting/overview.mdx
@@ -108,7 +108,7 @@ This page lists a collection of various troubleshooting guides for Expo and EAS.
 <BoxLink
   title="Expo Router FAQ"
   description="A list of common questions about Expo Router."
-  href="/router/reference/faq/"
+  href="/router/introduction/"
   Icon={RouterLogo}
 />
 

--- a/docs/pages/tutorial/eas/configure-development-build.mdx
+++ b/docs/pages/tutorial/eas/configure-development-build.mdx
@@ -27,7 +27,7 @@ A [development build](/develop/development-builds/introduction/) is a debug vers
 
 ### Key highlights
 
-> **Note:** If you are familiar with [Expo Go](/get-started/expo-go/), think of a development build as a customizable version of Expo Go that is unique to the requirements of a project.
+> **Note:** If you are familiar with [Expo Go](/get-started/set-up-your-environment/), think of a development build as a customizable version of Expo Go that is unique to the requirements of a project.
 
 | Feature                           | Development Builds                                                                                                                             | Expo Go                                                                                              |
 | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |

--- a/docs/pages/workflow/configuration.mdx
+++ b/docs/pages/workflow/configuration.mdx
@@ -12,7 +12,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 <PossibleRedirectNotification newUrl="/versions/latest/config/app/" />
 
-The app config (**app.json**, **app.config.js**, **app.config.ts**) is used for configuring [Expo Prebuild](/more/glossary-of-terms/#prebuild) generation, how a project loads in [Expo Go](/get-started/expo-go/), and the OTA update manifest.
+The app config (**app.json**, **app.config.js**, **app.config.ts**) is used for configuring [Expo Prebuild](/more/glossary-of-terms/#prebuild) generation, how a project loads in [Expo Go](/get-started/set-up-your-environment/), and the OTA update manifest.
 
 It must be located at the root of your project, next to the **package.json**. Here is a minimal example:
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Several doc pages contain internal links pointing to paths that have been moved or renamed. These broken links lead to 404s or unexpected redirects.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
