### PR TITLE
[docs] Fix internal links for Config plugins docs

### DIFF
--- a/docs/pages/guides/permissions.mdx
+++ b/docs/pages/guides/permissions.mdx
@@ -15,7 +15,7 @@ Permissions in standalone and [development builds](/develop/development-builds/i
 
 Permissions are configured with the [`android.permissions`](/versions/latest/config/app/#permissions) and [`android.blockedPermissions`](/versions/latest/config/app/#blockedpermissions) keys in your [app config](/workflow/configuration/).
 
-Most permissions are added automatically by libraries that you use in your app either with [config plugins](/config-plugins/plugins-and-mods/#create-a-plugin) or with a package-level **AndroidManifest.xml**. You only need to use `android.permissions` to add additional permissions that are not included by default in a library.
+Most permissions are added automatically by libraries that you use in your app either with [config plugins](/config-plugins/plugins/#creating-a-config-plugin) or with a package-level **AndroidManifest.xml**. You only need to use `android.permissions` to add additional permissions that are not included by default in a library.
 
 ```json app.json
 {

--- a/docs/pages/linking/into-other-apps.mdx
+++ b/docs/pages/linking/into-other-apps.mdx
@@ -79,7 +79,7 @@ There are built-in URL schemes that provide access to core functionality on all 
 
 <Collapsible summary="Specify Android intents to handle common URL schemes">
 
-For Android 11 (API level 30) and above, you must specify the intents your app will handle in the **AndroidManifest.xml** file. You can accomplish this by [creating a config plugin](/config-plugins/plugins-and-mods/#create-a-plugin).
+For Android 11 (API level 30) and above, you must specify the intents your app will handle in the **AndroidManifest.xml** file. You can accomplish this by [creating a config plugin](/config-plugins/plugins/#creating-a-config-plugin).
 
 The following config plugin example enables linking to email and phone apps by defining the intents:
 
@@ -109,7 +109,7 @@ const withAndroidQueries: ConfigPlugin = config => {
 module.exports = withAndroidQueries;
 ```
 
-After creating the config plugin, [import the custom config plugin](/config-plugins/plugins-and-mods/#import-a-plugin) under the `plugins` property:
+After creating the config plugin, [import the custom config plugin](/config-plugins/plugins/#call-the-config-plugin-from-your-dynamic-app-config) under the `plugins` property:
 
 ```json app.json
 {

--- a/docs/pages/modules/config-plugin-and-native-module-tutorial.mdx
+++ b/docs/pages/modules/config-plugin-and-native-module-tutorial.mdx
@@ -245,7 +245,7 @@ When you run the `npx expo prebuild` command inside your **example** directory, 
   cmdCopy="$ cd example && npx expo prebuild --clean"
 />
 
-To inject your custom API keys into **AndroidManifest.xml** and **Info.plist**, use helper [`mods` provided by `expo/config-plugins`](/config-plugins/plugins-and-mods/#what-are-mods). These make it easy to modify native files. For this example, use `withAndroidManifest` and `withInfoPlist`.
+To inject your custom API keys into **AndroidManifest.xml** and **Info.plist**, use helper [`mods` provided by `expo/config-plugins`](/config-plugins/mods/). These make it easy to modify native files. For this example, use `withAndroidManifest` and `withInfoPlist`.
 
 As the name suggests, `withAndroidManifest` allows you to read and modify the **AndroidManifest.xml** file. Use `AndroidConfig` helpers to add a metadata item to the main application, as shown below:
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

 The Config plugins docs were restructured, splitting `plugins-and-mods` into separate `plugins` and `mods` pages with new heading anchors. Several pages still link to the old paths, resulting in broken links or unnecessary redirects.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
