### PR TITLE
[gha] bump sdk branch for template sync workflow

### DIFF
--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -3,7 +3,7 @@ name: Sync App Template Repository
 on:
   workflow_dispatch: {}
   push:
-    branches: [sdk-54]
+    branches: [sdk-55]
     paths:
       - .github/workflows/sync-template.yml
       - templates/expo-template-default/**


### PR DESCRIPTION
## Summary
- Update `sync-template.yml` to trigger on `sdk-55` instead of `sdk-54`

The workflow evaluates its `branches:` filter from the file on the branch being pushed to. The bump to `sdk-54` on `main` never got propagated to the actual SDK branches, so only `sdk-53` (which correctly had `branches: [sdk-53]`) was triggering syncs. #43589 is the critical PR (it'll ensure the correct version is synced); this is just for hygiene. 
