### PR TITLE
[gha] bump sdk branch for template sync workflow

### DIFF
--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -3,7 +3,7 @@ name: Sync App Template Repository
 on:
   workflow_dispatch: {}
   push:
-    branches: [sdk-54]
+    branches: [sdk-55]
     paths:
       - .github/workflows/sync-template.yml
       - templates/expo-template-default/**


### PR DESCRIPTION
## Summary
- Update `sync-template.yml` to trigger on `sdk-55` instead of `sdk-54`
- This is the critical fix — the workflow file on the `sdk-55` branch itself must reference `sdk-55` in its `branches:` filter, otherwise pushes to sdk-55 never trigger the sync
- `expo/expo-template-default` has been stuck on SDK 53 content because this bump was missed

Companion PR into `main`: #43588

## Test plan
- After this merges, trigger `workflow_dispatch` on sdk-55 to do an immediate sync to `expo/expo-template-default`, or wait for the next push to `templates/expo-template-default/` on sdk-55