### PR TITLE
[docs] update expo-brownfield docs to include new features

### DIFF
--- a/docs/pages/versions/unversioned/sdk/brownfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/brownfield.mdx
@@ -186,8 +186,9 @@ The `expo-brownfield` package provides a [config plugin](/config-plugins/introdu
     {
       name: 'ios.buildReactNativeFromSource',
       platform: 'ios',
-      description: 'Build React Native from source instead of using prebuilt frameworks. Turning this on significantly increases the build times.',
-      default: 'true'
+      description:
+        'Build React Native from source instead of using prebuilt frameworks. Turning this on significantly increases the build times.',
+      default: 'true',
     },
     {
       name: 'android.group',
@@ -262,7 +263,7 @@ Builds the brownfield XCFramework and copies the Hermes XCFramework to the artif
 | `-a, --artifacts`   | Path to the artifacts directory (default: `./artifacts`) |
 | `-s, --scheme`      | Xcode scheme to build                                    |
 | `-x, --xcworkspace` | Xcode workspace path                                     |
-| `-p, --package`     | Ship artifacts as Swift Package (with optional name)  |
+| `-p, --package`     | Ship artifacts as Swift Package (with optional name)     |
 | `--verbose`         | Include all logs from subprocesses                       |
 
 #### `tasks:android`

--- a/docs/pages/versions/unversioned/sdk/brownfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/brownfield.mdx
@@ -184,6 +184,12 @@ The `expo-brownfield` package provides a [config plugin](/config-plugins/introdu
       default: '"<ios.bundleIdentifier base>.<targetName>" or "com.example.<targetName>"',
     },
     {
+      name: 'ios.buildReactNativeFromSource',
+      platform: 'ios',
+      description: 'Build React Native from source instead of using prebuilt frameworks. Turning this on significantly increases the build times.',
+      default: 'true'
+    },
+    {
       name: 'android.group',
       platform: 'android',
       description:
@@ -256,6 +262,7 @@ Builds the brownfield XCFramework and copies the Hermes XCFramework to the artif
 | `-a, --artifacts`   | Path to the artifacts directory (default: `./artifacts`) |
 | `-s, --scheme`      | Xcode scheme to build                                    |
 | `-x, --xcworkspace` | Xcode workspace path                                     |
+| `-p, --package`     | Ship artifacts as Swift Package (with optional name)  |
 | `--verbose`         | Include all logs from subprocesses                       |
 
 #### `tasks:android`

--- a/docs/pages/versions/v55.0.0/sdk/brownfield.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/brownfield.mdx
@@ -184,6 +184,12 @@ The `expo-brownfield` package provides a [config plugin](/config-plugins/introdu
       default: '"<ios.bundleIdentifier base>.<targetName>" or "com.example.<targetName>"',
     },
     {
+      name: 'ios.buildReactNativeFromSource',
+      platform: 'ios',
+      description: 'Build React Native from source instead of using prebuilt frameworks. Turning this on significantly increases the build times.',
+      default: 'true'
+    },
+    {
       name: 'android.group',
       platform: 'android',
       description:
@@ -256,6 +262,7 @@ Builds the brownfield XCFramework and copies the Hermes XCFramework to the artif
 | `-a, --artifacts`   | Path to the artifacts directory (default: `./artifacts`) |
 | `-s, --scheme`      | Xcode scheme to build                                    |
 | `-x, --xcworkspace` | Xcode workspace path                                     |
+| `-p, --package`     | Ship artifacts as Swift Package (accepts optional name)  |
 | `--verbose`         | Include all logs from subprocesses                       |
 
 #### `tasks:android`

--- a/docs/pages/versions/v55.0.0/sdk/brownfield.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/brownfield.mdx
@@ -186,8 +186,9 @@ The `expo-brownfield` package provides a [config plugin](/config-plugins/introdu
     {
       name: 'ios.buildReactNativeFromSource',
       platform: 'ios',
-      description: 'Build React Native from source instead of using prebuilt frameworks. Turning this on significantly increases the build times.',
-      default: 'true'
+      description:
+        'Build React Native from source instead of using prebuilt frameworks. Turning this on significantly increases the build times.',
+      default: 'true',
     },
     {
       name: 'android.group',


### PR DESCRIPTION
# Why

We introduced shipping Swift packages and plugin option `buildReactNativeFromSource` (yet to be renamed in https://github.com/expo/expo/pull/43574) and docs should include those new features

# How

- Added entry for `-p`/`--package` flag to `build:ios` specifications
- Added `ios.buildReactNativeFromSource` plugin prop to the appropriate table

(I also plan to cherrypick this to SDK 55 branch along with the appropriate changes later on)

# Test Plan

Ran:

- `yarn prettier`
- `yarn test`
- `yarn lint`
- `yarn run lint-prose`

# Checklist

- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)