### PR TITLE
[ui][android] - Fix `IconButton` not opening context menu

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix `ContextMenu` not expanding when triggered by `IconButton`. ([#43613](https://github.com/expo/expo/pull/43592) by [@nishan](https://github.com/intergalacticspacehighway))
+- [Android] Fix `ContextMenu` not expanding when triggered by `IconButton`. ([#43592](https://github.com/expo/expo/pull/43592) by [@nishan](https://github.com/intergalacticspacehighway))
 
 ### 💡 Others
 

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `ContextMenu` not expanding when triggered by `IconButton`. ([#43613](https://github.com/expo/expo/pull/43592) by [@nishan](https://github.com/intergalacticspacehighway))
+
 ### 💡 Others
 
 ## 55.0.1 — 2026-02-25

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/button/IconButton.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/button/IconButton.kt
@@ -16,6 +16,7 @@ import expo.modules.ui.ModifierList
 import expo.modules.ui.ModifierRegistry
 import expo.modules.ui.ShapeRecord
 import expo.modules.ui.compose
+import expo.modules.ui.menu.LocalContextMenuExpanded
 import expo.modules.ui.shapeFromShapeRecord
 
 enum class IconButtonVariant(val value: String) : Enumerable {
@@ -95,11 +96,16 @@ fun FunctionalComposableScope.IconButtonContent(
   val colors = props.elementColors
   val disabled = props.disabled
 
+  val contextMenuExpanded = LocalContextMenuExpanded.current
+
   StyledIconButton(
     variant ?: IconButtonVariant.DEFAULT,
     colors,
     disabled ?: false,
-    onPress = { onButtonPressed(ButtonPressedEvent()) },
+    onPress = {
+      contextMenuExpanded?.let { it.value = true }
+      onButtonPressed(ButtonPressedEvent())
+    },
     modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher),
     shape = shapeFromShapeRecord(props.shape)
   ) {


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/43571
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

It uses the `LocalContextMenuExpanded` to trigger menu state, similar to `Button.kt`. 

I think we should handle the menu expanded state via react state instead of compose state. This will also allow us to use non Expo UI components to trigger the menu - https://github.com/expo/expo/issues/40488. I just tested and it works. We can pick this up when refactoring some components.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested in the original repro.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
