### PR TITLE
[android][expo-blur]: forward child ops to avoid Fabric removeViewAt mismatch

### DIFF
--- a/packages/expo-blur/CHANGELOG.md
+++ b/packages/expo-blur/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix Fabric mount/detach mismatch in `BlurTargetView` that could trigger `view already removed from parent` errors during root tree transitions. ([#43595](https://github.com/expo/expo/pull/43595) by [@stathis](https://github.com/efstathiosntonas))
+
 ### 💡 Others
 
 ## 55.0.8 — 2026-02-25

--- a/packages/expo-blur/android/src/main/java/expo/modules/blur/ExpoBlurTargetView.kt
+++ b/packages/expo-blur/android/src/main/java/expo/modules/blur/ExpoBlurTargetView.kt
@@ -2,6 +2,7 @@ package expo.modules.blur
 
 import android.content.Context
 import android.view.View
+import android.view.View.MeasureSpec
 import android.view.ViewGroup
 import eightbitlab.com.blurview.BlurTarget
 import expo.modules.kotlin.AppContext
@@ -11,66 +12,107 @@ class ExpoBlurTargetView(context: Context, appContext: AppContext) : ExpoView(co
   internal val blurTargetView: BlurTarget = UIManagerCompatibleBlurTarget(appContext, context)
 
   init {
-    addView(
+    super.addView(
       blurTargetView,
-      ViewGroup.LayoutParams(
-        LayoutParams.MATCH_PARENT,
-        LayoutParams.MATCH_PARENT
+      LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT
       )
     )
   }
 
+  /**
+   * When adding a child to this view, we want to actually add it to the blur target view.
+   * Because of this we need to override add, remove and measurement methods.
+   */
   override fun addView(child: View?) {
+    if (child === blurTargetView) {
+      super.addView(child)
+      return
+    }
     blurTargetView.addView(child)
   }
 
   override fun addView(child: View?, index: Int) {
+    if (child === blurTargetView) {
+      super.addView(child, index)
+      return
+    }
     blurTargetView.addView(child, index)
   }
 
   override fun addView(child: View?, params: ViewGroup.LayoutParams?) {
+    if (child === blurTargetView) {
+      super.addView(child, toHostLayoutParams(params))
+      return
+    }
     blurTargetView.addView(child, params)
   }
 
   override fun addView(child: View?, index: Int, params: ViewGroup.LayoutParams?) {
+    if (child === blurTargetView) {
+      super.addView(child, index, toHostLayoutParams(params))
+      return
+    }
     blurTargetView.addView(child, index, params)
   }
 
   override fun addView(child: View?, width: Int, height: Int) {
+    if (child === blurTargetView) {
+      super.addView(child, width, height)
+      return
+    }
     blurTargetView.addView(child, width, height)
   }
 
   override fun updateViewLayout(view: View?, params: ViewGroup.LayoutParams?) {
+    if (view === blurTargetView) {
+      super.updateViewLayout(view, toHostLayoutParams(params))
+      return
+    }
     blurTargetView.updateViewLayout(view, params)
   }
 
   override fun removeView(view: View?) {
+    if (view === blurTargetView) {
+      super.removeView(view)
+      return
+    }
     blurTargetView.removeView(view)
   }
 
-  override fun removeViewAt(index: Int) {
-    blurTargetView.removeViewAt(index)
-  }
+  override fun removeViewAt(index: Int) = blurTargetView.removeViewAt(index)
 
-  override fun removeViews(start: Int, count: Int) {
-    blurTargetView.removeViews(start, count)
-  }
+  override fun removeViews(start: Int, count: Int) = blurTargetView.removeViews(start, count)
 
-  override fun removeViewsInLayout(start: Int, count: Int) {
-    blurTargetView.removeViewsInLayout(start, count)
-  }
+  override fun removeViewsInLayout(start: Int, count: Int) = blurTargetView.removeViewsInLayout(start, count)
 
-  override fun removeAllViews() {
-    blurTargetView.removeAllViews()
-  }
+  override fun removeAllViews() = blurTargetView.removeAllViews()
 
-  override fun removeAllViewsInLayout() {
-    blurTargetView.removeAllViewsInLayout()
-  }
+  override fun removeAllViewsInLayout() = blurTargetView.removeAllViewsInLayout()
 
   override fun getChildCount(): Int = blurTargetView.childCount
 
   override fun getChildAt(index: Int): View? = blurTargetView.getChildAt(index)
 
   override fun indexOfChild(child: View?): Int = blurTargetView.indexOfChild(child)
+
+  override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+    val width = MeasureSpec.getSize(widthMeasureSpec)
+    val height = MeasureSpec.getSize(heightMeasureSpec)
+    setMeasuredDimension(width, height)
+
+    blurTargetView.measure(
+      MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+      MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
+    )
+  }
+
+  override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+    blurTargetView.layout(0, 0, right - left, bottom - top)
+  }
+
+  private fun toHostLayoutParams(params: ViewGroup.LayoutParams?): LayoutParams = when (params) {
+    null -> LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+    is LayoutParams -> params
+    else -> LayoutParams(params)
+  }
 }

--- a/packages/expo-blur/android/src/main/java/expo/modules/blur/ExpoBlurTargetView.kt
+++ b/packages/expo-blur/android/src/main/java/expo/modules/blur/ExpoBlurTargetView.kt
@@ -28,11 +28,49 @@ class ExpoBlurTargetView(context: Context, appContext: AppContext) : ExpoView(co
     blurTargetView.addView(child, index)
   }
 
+  override fun addView(child: View?, params: ViewGroup.LayoutParams?) {
+    blurTargetView.addView(child, params)
+  }
+
+  override fun addView(child: View?, index: Int, params: ViewGroup.LayoutParams?) {
+    blurTargetView.addView(child, index, params)
+  }
+
   override fun addView(child: View?, width: Int, height: Int) {
     blurTargetView.addView(child, width, height)
+  }
+
+  override fun updateViewLayout(view: View?, params: ViewGroup.LayoutParams?) {
+    blurTargetView.updateViewLayout(view, params)
   }
 
   override fun removeView(view: View?) {
     blurTargetView.removeView(view)
   }
+
+  override fun removeViewAt(index: Int) {
+    blurTargetView.removeViewAt(index)
+  }
+
+  override fun removeViews(start: Int, count: Int) {
+    blurTargetView.removeViews(start, count)
+  }
+
+  override fun removeViewsInLayout(start: Int, count: Int) {
+    blurTargetView.removeViewsInLayout(start, count)
+  }
+
+  override fun removeAllViews() {
+    blurTargetView.removeAllViews()
+  }
+
+  override fun removeAllViewsInLayout() {
+    blurTargetView.removeAllViewsInLayout()
+  }
+
+  override fun getChildCount(): Int = blurTargetView.childCount
+
+  override fun getChildAt(index: Int): View? = blurTargetView.getChildAt(index)
+
+  override fun indexOfChild(child: View?): Int = blurTargetView.indexOfChild(child)
 }

--- a/packages/expo-blur/android/src/main/java/expo/modules/blur/ExpoBlurTargetView.kt
+++ b/packages/expo-blur/android/src/main/java/expo/modules/blur/ExpoBlurTargetView.kt
@@ -14,7 +14,9 @@ class ExpoBlurTargetView(context: Context, appContext: AppContext) : ExpoView(co
   init {
     super.addView(
       blurTargetView,
-      LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT
+      LayoutParams(
+        LayoutParams.MATCH_PARENT,
+        LayoutParams.MATCH_PARENT
       )
     )
   }

--- a/packages/expo-blur/android/src/main/java/expo/modules/blur/ExpoBlurView.kt
+++ b/packages/expo-blur/android/src/main/java/expo/modules/blur/ExpoBlurView.kt
@@ -149,7 +149,7 @@ class ExpoBlurView(context: Context, appContext: AppContext) : ExpoView(context,
   private fun configureBlurView() {
     if (blurTarget == null || blurMethod == BlurMethod.NONE) {
       blurView.setBlurEnabled(false)
-      blurConfiguration == BlurViewConfiguration.NONE
+      blurConfiguration = BlurViewConfiguration.NONE
       return
     }
 


### PR DESCRIPTION
# Why

  On Android, `expo-blur` can hit a native mounting mismatch during aggressive tree transitions
  (for example auth/login/logout root swaps).

  The failure signature is:

  `removeViewAt: ... view already removed from parent! Children in parent: 1`

   The app UI becomes unresponsive until app kill and then cold boot.

  # How

  The fix updates `ExpoBlurTargetView` to consistently forward child management and layout operations to its internal
  blur target view.

  Added forwarding overrides for:
  - `addView(child, params)`
  - `addView(child, index, params)`
  - `updateViewLayout(view, params)`
  - `removeViewAt(index)`
  - `removeViews(start, count)`
  - `removeViewsInLayout(start, count)`
  - `removeAllViews()`
  - `removeAllViewsInLayout()`
  - `getChildCount()`
  - `getChildAt(index)`
  - `indexOfChild(child)`

  Why this approach:
  - Under Fabric, parent/child bookkeeping is strict.
  - If `ExpoBlurTargetView` and its internal target diverge, detach/mount commands can be applied to already removed children.
  - Forwarding all relevant operations keeps React/Fabric and native hierarchy in sync.

  # Test Plan

  Environment:
  - Android device (Pixel 7a), Expo SDK 55.
  - `BlurTargetView` + `BlurView` present in both unauthenticated and authenticated trees.
  - Tree transition path: login -> authenticated root, logout -> onboarding root.

  Notes:
  - This change is Android-only.
  - No API changes.

  # Checklist

  - [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://
  github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
  - [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
  - [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/
  Expo%20Documentation%20Writing%20Style%20Guide.md)