### PR TITLE
[docs] Add cross-links between llms-*.txt files

### DIFF
--- a/docs/scripts/generate-llms/llms-eas-txt.js
+++ b/docs/scripts/generate-llms/llms-eas-txt.js
@@ -23,7 +23,12 @@ function generateFullMarkdown({ title, description }) {
   const markdownPaths = allHrefs.map(href => getMarkdownPathFromHref(buildDir, href));
   const contentChunks = readUniqueMarkdownContent(markdownPaths, { warnOnMissing: true });
 
-  return composeMarkdownDocument({ title, description, contentChunks });
+  return composeMarkdownDocument({
+    title,
+    description,
+    contentChunks,
+    currentFilename: OUTPUT_FILENAME_EAS_DOCS,
+  });
 }
 
 export async function generateLlmsEasTxt() {

--- a/docs/scripts/generate-llms/llms-full-txt.js
+++ b/docs/scripts/generate-llms/llms-full-txt.js
@@ -23,7 +23,12 @@ function generateFullMarkdown({ title, description }) {
   const markdownPaths = allHrefs.map(href => getMarkdownPathFromHref(buildDir, href));
   const contentChunks = readUniqueMarkdownContent(markdownPaths, { warnOnMissing: true });
 
-  return composeMarkdownDocument({ title, description, contentChunks });
+  return composeMarkdownDocument({
+    title,
+    description,
+    contentChunks,
+    currentFilename: OUTPUT_FILENAME_EXPO_DOCS,
+  });
 }
 
 export async function generateLlmsFullTxt() {

--- a/docs/scripts/generate-llms/llms-sdk.js
+++ b/docs/scripts/generate-llms/llms-sdk.js
@@ -31,7 +31,12 @@ function generateFullMarkdown() {
     });
   const contentChunks = readUniqueMarkdownContent(matchingFiles);
 
-  return composeMarkdownDocument({ title: TITLE, description: DESCRIPTION, contentChunks });
+  return composeMarkdownDocument({
+    title: TITLE,
+    description: DESCRIPTION,
+    contentChunks,
+    currentFilename: OUTPUT_FILENAME,
+  });
 }
 
 export async function generateLlmsSdkTxt() {

--- a/docs/scripts/generate-llms/llms-txt.js
+++ b/docs/scripts/generate-llms/llms-txt.js
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import ts from 'typescript';
 
+import { generateCrossLinksSection } from './shared.js';
 import { home, learn, general, eas, reference } from '../../constants/navigation.js';
 
 const OUTPUT_DIRECTORY_NAME = 'public';
@@ -53,7 +54,10 @@ function generateFullMarkdown({ title, description, sections }) {
   });
 
   return (
-    `# ${title}\n\n${description}\n\n` + filteredSections.map(generateSectionMarkdown).join('')
+    `# ${title}\n\n${description}\n\n` +
+    filteredSections.map(generateSectionMarkdown).join('') +
+    '\n' +
+    generateCrossLinksSection(OUTPUT_FILENAME_LLMS_TXT)
   );
 }
 

--- a/docs/scripts/generate-llms/shared.js
+++ b/docs/scripts/generate-llms/shared.js
@@ -3,6 +3,24 @@ import path from 'node:path';
 
 export const OUTPUT_DIRECTORY_NAME = 'public';
 export const BUILD_OUTPUT_DIR = 'out';
+export const DOCS_BASE_URL = 'https://docs.expo.dev';
+
+const LLMS_FILES = [
+  { filename: 'llms.txt', description: 'A list of all available documentation files' },
+  {
+    filename: 'llms-full.txt',
+    description:
+      'Complete documentation for Expo, including Expo Router, Expo Modules API, development process, and more',
+  },
+  {
+    filename: 'llms-eas.txt',
+    description: 'Complete documentation for Expo Application Services (EAS)',
+  },
+  {
+    filename: 'llms-sdk.txt',
+    description: 'Complete documentation for the latest Expo SDK',
+  },
+];
 
 const CONTENT_SEPARATOR = '\n\n---\n\n';
 
@@ -100,11 +118,26 @@ export function readUniqueMarkdownContent(markdownPaths, { warnOnMissing = false
   return contentChunks;
 }
 
-export function composeMarkdownDocument({ title, description, contentChunks }) {
+export function generateCrossLinksSection(currentFilename) {
+  const otherFiles = LLMS_FILES.filter(f => f.filename !== currentFilename);
+  let section = '## Other Expo documentation files\n\n';
+
+  for (const file of otherFiles) {
+    section += `- [/${file.filename}](${DOCS_BASE_URL}/${file.filename}): ${file.description}\n`;
+  }
+
+  return section;
+}
+
+export function composeMarkdownDocument({ title, description, contentChunks, currentFilename }) {
   let fullContent = `# ${title}\n\n${description}\n\n`;
 
   for (const content of contentChunks) {
     fullContent += content + CONTENT_SEPARATOR;
+  }
+
+  if (currentFilename) {
+    fullContent += generateCrossLinksSection(currentFilename);
   }
 
   return fullContent;


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-19898


# How

- Add a centralized `LLMS_FILES` array and `generateCrossLinksSection(currentFilename)` helper in `shared.js` that generates a markdown section linking to all other llms files, excluding the current file to avoid self-references.
- Update `composeMarkdownDocument` in `shared.js` to accept an optional `currentFilename` parameter. When provided, it appends the cross-links as a separate section at the end of the generated file.
- Use full URLs (`https://docs.expo.dev/llms-sdk.txt`) instead of relative paths so AI agents can directly fetch the linked files.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2884" height="192" alt="CleanShot 2026-03-03 at 16 45 13@2x" src="https://github.com/user-attachments/assets/05ed49b6-605c-4b40-9285-76094e80bd4b" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
