### PR TITLE
[ios][audio] Improve looping support

### DIFF
--- a/apps/native-component-list/src/screens/Audio/AudioEventsScreen.tsx
+++ b/apps/native-component-list/src/screens/Audio/AudioEventsScreen.tsx
@@ -115,6 +115,7 @@ function AudioEvents() {
           highlight={status.didJustFinish}
         />
         <StatusRow label="isLoaded" value={status.isLoaded} />
+        <StatusRow label="loop" value={status.loop} />
         <StatusRow label="currentTime" value={status.currentTime.toFixed(2)} />
         <StatusRow label="duration" value={status.duration.toFixed(2)} />
       </View>
@@ -128,6 +129,12 @@ function AudioEvents() {
         </View>
         <View style={styles.controlsRow}>
           <Button title="Seek Near End (-2s)" onPress={seekToEnd} />
+          <Button
+            title={`Loop: ${player.loop ? 'ON' : 'OFF'}`}
+            onPress={() => {
+              player.loop = !player.loop;
+            }}
+          />
           <Button title="Clear Log" onPress={clearLog} />
         </View>
       </View>

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix crash during seek. ([#43564](https://github.com/expo/expo/pull/43564) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Improve looping support.
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix crash during seek. ([#43564](https://github.com/expo/expo/pull/43564) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Improve looping support.
+- [iOS] Improve looping support. ([#43600](https://github.com/expo/expo/pull/43600) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -656,7 +656,7 @@ public class AudioModule: Module {
             player.ref.volume = originalVolume
           }
         case .doNotMix, .mixWithOthers:
-          player.ref.play()
+          player.play(at: player.currentRate > 0 ? player.currentRate : 1.0)
         }
       }
     }
@@ -705,7 +705,7 @@ public class AudioModule: Module {
   private func resumeAllPlayers() {
     registry.allPlayers.values.forEach { player in
       if player.wasPlaying {
-        player.ref.play()
+        player.play(at: player.currentRate > 0 ? player.currentRate : 1.0)
         player.wasPlaying = false
       }
     }

--- a/packages/expo-audio/ios/AudioPlayer.swift
+++ b/packages/expo-audio/ios/AudioPlayer.swift
@@ -8,7 +8,6 @@ private enum AudioConstants {
 
 public class AudioPlayer: SharedRef<AVPlayer> {
   let id = UUID().uuidString
-  var isLooping = false
   var shouldCorrectPitch = true
   var pitchCorrectionQuality: AVAudioTimePitchAlgorithm = .timeDomain
   var isActiveForLockScreen = false
@@ -21,6 +20,22 @@ public class AudioPlayer: SharedRef<AVPlayer> {
   }
   var samplingEnabled = false
   var keepAudioSessionActive = false
+
+  var isLooping = false {
+    didSet {
+      guard isLooping != oldValue else {
+        return
+      }
+      if isLooping {
+        ref.actionAtItemEnd = .advance
+        enqueueNextLoopItem()
+      } else {
+        removeQueuedLoopItems()
+        ref.actionAtItemEnd = .pause
+      }
+      updateStatus(with: [:])
+    }
+  }
 
   private var source: AudioSource?
 
@@ -65,7 +80,15 @@ public class AudioPlayer: SharedRef<AVPlayer> {
     playerIsBuffering()
   }
 
+  private var effectiveRate: Float {
+    currentRate > 0 ? currentRate : 1.0
+  }
+
   func play(at rate: Float) {
+    ref.actionAtItemEnd = isLooping ? .advance : .pause
+    if isLooping {
+      enqueueNextLoopItem()
+    }
     addPlaybackEndNotification()
     registerTimeObserver()
     ref.playImmediately(atRate: rate)
@@ -165,6 +188,9 @@ public class AudioPlayer: SharedRef<AVPlayer> {
           self.updateStatus(with: [
             "isLoaded": true
           ])
+          if self.isLooping {
+            self.enqueueNextLoopItem()
+          }
           if shouldInstallAudioTap || samplingEnabled {
             installTap()
             shouldInstallAudioTap = false
@@ -178,7 +204,12 @@ public class AudioPlayer: SharedRef<AVPlayer> {
         guard let self else {
           return
         }
+        if self.isLooping {
+          self.enqueueNextLoopItem()
+          self.addPlaybackEndNotification()
+        }
         if self.samplingEnabled && self.isLoaded {
+          self.uninstallTap()
           self.installTap()
         }
       }
@@ -188,19 +219,20 @@ public class AudioPlayer: SharedRef<AVPlayer> {
   func replaceWithPreloadedItem(_ item: AVPlayerItem?) {
     let wasPlaying = ref.timeControlStatus == .playing
     let wasSamplingEnabled = samplingEnabled
+    removeQueuedLoopItems()
     ref.pause()
 
     if samplingEnabled {
       uninstallTap()
     }
-    ref.replaceCurrentItem(with: item)
+    replacePlayerItem(with: item)
 
     if wasSamplingEnabled {
       shouldInstallAudioTap = true
     }
 
     if wasPlaying {
-      ref.play()
+      play(at: effectiveRate)
     }
   }
 
@@ -208,13 +240,14 @@ public class AudioPlayer: SharedRef<AVPlayer> {
     self.source = source
     let wasPlaying = ref.timeControlStatus == .playing
     let wasSamplingEnabled = samplingEnabled
+    removeQueuedLoopItems()
     ref.pause()
 
     if samplingEnabled {
       uninstallTap()
     }
     let item = AudioUtils.createAVPlayerItem(from: source)
-    ref.replaceCurrentItem(with: item)
+    replacePlayerItem(with: item)
 
     if wasSamplingEnabled {
       shouldInstallAudioTap = true
@@ -222,7 +255,8 @@ public class AudioPlayer: SharedRef<AVPlayer> {
 
     if wasPlaying {
       onReady { [weak self] in
-        self?.ref.play()
+        guard let self else { return }
+        self.play(at: self.effectiveRate)
       }
     }
   }
@@ -261,6 +295,7 @@ public class AudioPlayer: SharedRef<AVPlayer> {
   }
 
   private func teardownPlayer() {
+    removeQueuedLoopItems()
     if samplingEnabled {
       uninstallTap()
     }
@@ -360,6 +395,41 @@ public class AudioPlayer: SharedRef<AVPlayer> {
     audioProcessor?.sampleBufferCallback = nil
   }
 
+  private func replacePlayerItem(with item: AVPlayerItem?) {
+    if let queuePlayer = ref as? AVQueuePlayer {
+      queuePlayer.removeAllItems()
+      if let item {
+        queuePlayer.insert(item, after: nil)
+      }
+    } else {
+      ref.replaceCurrentItem(with: item)
+    }
+  }
+
+  private func enqueueNextLoopItem() {
+    guard let queuePlayer = ref as? AVQueuePlayer,
+      let currentItem = queuePlayer.currentItem else {
+      return
+    }
+
+    guard queuePlayer.items().count <= 1 else {
+      return
+    }
+    let nextItem = AVPlayerItem(asset: currentItem.asset)
+    nextItem.audioTimePitchAlgorithm = currentItem.audioTimePitchAlgorithm
+    queuePlayer.insert(nextItem, after: currentItem)
+  }
+
+  private func removeQueuedLoopItems() {
+    guard let queuePlayer = ref as? AVQueuePlayer else {
+      return
+    }
+
+    for item in queuePlayer.items() where item != queuePlayer.currentItem {
+      queuePlayer.remove(item)
+    }
+  }
+
   private func addPlaybackEndNotification() {
     if let endObserver {
       NotificationCenter.default.removeObserver(endObserver)
@@ -367,20 +437,24 @@ public class AudioPlayer: SharedRef<AVPlayer> {
 
     endObserver = NotificationCenter.default.addObserver(
       forName: .AVPlayerItemDidPlayToEndTime,
-      object: ref.currentItem,
+      object: nil,
       queue: nil
-    ) { [weak self] _ in
-      guard let self else {
+    ) { [weak self] notification in
+      guard let self,
+        let finishedItem = notification.object as? AVPlayerItem else {
         return
       }
 
-      if self.isLooping {
-        self.ref.seek(to: CMTime.zero)
-        self.ref.play()
-      } else {
+      guard let queuePlayer = self.ref as? AVQueuePlayer,
+        finishedItem == queuePlayer.currentItem || queuePlayer.items().contains(finishedItem) else {
+        return
+      }
+
+      if !self.isLooping {
+        let currentTime = finishedItem.duration.seconds
         self.updateStatus(with: [
           "playing": false,
-          "currentTime": self.duration,
+          "currentTime": currentTime.isNaN ? 0.0 : currentTime,
           "didJustFinish": true
         ])
         self.onPlaybackComplete?()

--- a/packages/expo-audio/ios/AudioPlayer.swift
+++ b/packages/expo-audio/ios/AudioPlayer.swift
@@ -12,7 +12,11 @@ public class AudioPlayer: SharedRef<AVPlayer> {
   var pitchCorrectionQuality: AVAudioTimePitchAlgorithm = .timeDomain
   var isActiveForLockScreen = false
   var metadata: Metadata?
-  var currentRate: Float = 0.0
+  var currentRate: Float = 1.0 {
+    didSet {
+      currentRate = max(0, currentRate)
+    }
+  }
   let interval: Double
   var wasPlaying = false
   var isPaused: Bool {

--- a/packages/expo-audio/ios/AudioUtils.swift
+++ b/packages/expo-audio/ios/AudioUtils.swift
@@ -87,9 +87,9 @@ struct AudioUtils {
 
   static func createAVPlayer(from source: AudioSource?) -> AVPlayer {
     if let item = createAVPlayerItem(from: source) {
-      return AVPlayer(playerItem: item)
+      return AVQueuePlayer(items: [item])
     }
-    return AVPlayer()
+    return AVQueuePlayer()
   }
 
   static func createAVPlayerItem(from source: AudioSource?) -> AVPlayerItem? {


### PR DESCRIPTION
# Why
Closes #42880
When the player is set to `loop` it is not seamless. When the current item ends, we seek to the beginning and start again. This causes an event where `playing` is false briefly before starting again.

# How
`AVPlayer` does not have built-in support for gapless looping. For that ideally we would use `AVPlayerLooper` but that means switching out the entire player. If the user enables looping during playback, it will restart from the beginning. This is inconsistent with androids behaviour. Instead, because `AVQueuePlayer` is a subclass of `AVPlayer` we can use that, treat it like a `AVPlayer` in the rest of the module so nothing else needs to change but handle looping correctly. 

It's a bit of a hack but when looping is enabled, we enqueue a copy of the same item so playback can continue seamlessly. It means management of sampling, notifications etc is a bit more complicated but it's the only way I could match android behaviour.  

# Test Plan
Bare expo
