### PR TITLE
[expo-ui][android] detect FAB in HorizontalFloatingToolbar

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - [iOS] Added `ControlGroup` component. ([#43581](https://github.com/expo/expo/pull/43581) by [@nishan](https://github.com/intergalacticspacehighway))
+- [android] detect FAB in HorizontalFloatingToolbar ([#43601](https://github.com/expo/expo/pull/43601) by [@Ubax](https://github.com/Ubax))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/HorizontalFloatingToolbarView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/HorizontalFloatingToolbarView.kt
@@ -51,13 +51,26 @@ fun FunctionalComposableScope.HorizontalFloatingToolbarContent(props: Horizontal
   }
 
   val scrollBehavior = composableScope.nestedScrollConnection as? FloatingToolbarScrollBehavior
-  HorizontalFloatingToolbar(
-    expanded = true,
-    colors = colors,
-    scrollBehavior = scrollBehavior,
-    modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher),
-    floatingActionButton = floatingActionButton
-  ) {
-    Children(ComposableScope(), filter = { !isSlotView(it) })
+  val modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
+
+  if (fabSlotView != null) {
+    HorizontalFloatingToolbar(
+      expanded = true,
+      floatingActionButton = floatingActionButton,
+      colors = colors,
+      scrollBehavior = scrollBehavior,
+      modifier = modifier,
+    ) {
+      Children(ComposableScope(), filter = { !isSlotView(it) })
+    }
+  } else {
+    HorizontalFloatingToolbar(
+      expanded = true,
+      colors = colors,
+      scrollBehavior = scrollBehavior,
+      modifier = modifier,
+    ) {
+      Children(ComposableScope(), filter = { !isSlotView(it) })
+    }
   }
 }


### PR DESCRIPTION
# Why

When no FAB is passed to toolbar, it tries to render it anyway.

# How

Based on wether FAB is passed or not use different version of `HorizontalFloatingToolbar`

# Test Plan


![Screenshot 2026-03-03 at 13.28.26.png](https://app.graphite.com/user-attachments/assets/c79c3b42-cede-4c42-af19-3cb0b090bdcf.png)


![Screenshot 2026-03-03 at 13.29.50.png](https://app.graphite.com/user-attachments/assets/604297a6-a41d-4eb7-9534-6247cd16afdf.png)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
