### PR TITLE
fix(widgets,cli): Add internal flag to `export:embed` to disable API routes bundling

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add `@react-navigation/core` and `@react-navigation/native` to autolinking resolution ([#43456](https://github.com/expo/expo/pull/43456) by [@kitten](https://github.com/kitten))
 - Drop `expo-router/doctor` install check ([#43461](https://github.com/expo/expo/pull/43461) by [@kitten](https://github.com/kitten))
 - Pass on `tls` options from Metro config to Metro `runServer` fork ([#43186](https://github.com/expo/expo/pull/43186) by [@cortinico](https://github.com/cortinico))
+- Add internal `--no-server` flag to skip server bundling in `export:embed` ([#43602](https://github.com/expo/expo/pull/43602) by [@kitten](https://github.com/kitten))
 
 ## 55.0.12 — 2026-02-25
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Add `@react-navigation/core` and `@react-navigation/native` to autolinking resolution ([#43456](https://github.com/expo/expo/pull/43456) by [@kitten](https://github.com/kitten))
 - Drop `expo-router/doctor` install check ([#43461](https://github.com/expo/expo/pull/43461) by [@kitten](https://github.com/kitten))
 - Pass on `tls` options from Metro config to Metro `runServer` fork ([#43186](https://github.com/expo/expo/pull/43186) by [@cortinico](https://github.com/cortinico))
-- Add internal `--no-server` flag to skip server bundling in `export:embed` ([#43602](https://github.com/expo/expo/pull/43602) by [@kitten](https://github.com/kitten))
+- Add internal `--skip-server` flag to skip server bundling in `export:embed` ([#43602](https://github.com/expo/expo/pull/43602) by [@kitten](https://github.com/kitten))
 
 ## 55.0.12 — 2026-02-25
 

--- a/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
+++ b/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
@@ -215,10 +215,12 @@ export async function exportEmbedBundleAndAssetsAsync(
       }
     );
 
+    // We optimistically build the server-side API routes code here, to ensure they're
+    // valid or to enable parallel deployment in the future (TBD). This is disabled using
+    // the explicit `--skip-server` flag.
     const apiRoutesEnabled =
       devServer.isReactServerComponentsEnabled || exp.web?.output === 'server';
-
-    if (apiRoutesEnabled) {
+    if (!options.skipServer && apiRoutesEnabled) {
       await exportStandaloneServerAsync(projectRoot, devServer, {
         exp,
         pkg,

--- a/packages/@expo/cli/src/export/embed/index.ts
+++ b/packages/@expo/cli/src/export/embed/index.ts
@@ -22,6 +22,12 @@ export const expoExportEmbed: Command = async (argv) => {
     '--unstable-transform-profile': String,
     '--config': String,
 
+    // By default we also export a standalone server, which is mostly done
+    // during the `export:embed` native build to ensure that the server is
+    // valid, or to deploy it later (TBD). This can be skipped using this
+    // flag explicitly
+    '--skip-server': Boolean,
+
     // Hack: This is added because react-native-xcode.sh script always includes this value.
     // If supplied, we'll do nothing with the value, but at least the process won't crash.
     // Note that we also don't show this value in the `--help` prompt since we don't want people to use it.

--- a/packages/@expo/cli/src/export/embed/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/embed/resolveOptions.ts
@@ -30,6 +30,7 @@ export interface Options {
   unstableTransformProfile?: string;
   eager?: boolean;
   bytecode?: boolean;
+  skipServer?: boolean;
 }
 
 function assertIsBoolean(val: any): asserts val is boolean {
@@ -81,6 +82,7 @@ export function resolveOptions(
     minify: parsed.args['--minify'] as boolean | undefined,
     eager: !!parsed.args['--eager'],
     bytecode: parsed.args['--bytecode'] as boolean | undefined,
+    skipServer: !!parsed.args['--skip-server'],
   };
 
   if (commonOptions.eager) {

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Add missing project root to `watchFolders` in `metro.config.js` ([#43449](https://github.com/expo/expo/pull/43449) by [@kitten](https://github.com/kitten))
 - [plugin] Fix reading undefined when config is not provided. ([#43568](https://github.com/expo/expo/pull/43568) by [@jakex7](https://github.com/jakex7))
+- Skip server bundling in `export:embed` call for `expo-widgets` bundle ([#43602](https://github.com/expo/expo/pull/43602) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/expo-widgets/scripts/build-bundle.mjs
+++ b/packages/expo-widgets/scripts/build-bundle.mjs
@@ -49,7 +49,8 @@ const result = await spawn(
     '--entry-file',
     path.join(__dirname, '../bundle/index.ts'),
     '--dev',
-    false,
+    'false',
+    '--skip-server',
     ...argv.slice(2),
   ],
   {


### PR DESCRIPTION
# Why

When the `expo-widgets` bundle is built, we'd like to skip the API Routes output being built, since it's not going to have any effect on the `expo-widgets` bundle. This was only necessary to prepare for parallel deployment and to ensure that API routes output is valid, and has no relevance for the `expo-widgets` bundle.

Skipping this means we don't let the build fail on assertions that aren't relevant for the `expo-widgets` bundle (such as no routes being present)

# How

- Add `--skip-server` flag to `export:embed` command
- Use `--skip-server` flag in `expo-widget` bundle build script

# Test Plan

- Manually invoke `export:embed --skip-server [...]` on a project

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
