### PR TITLE
docs(sqlite): document that withExclusiveTransactionAsync opens a new connection

### DIFF
--- a/docs/pages/versions/unversioned/sdk/sqlite.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite.mdx
@@ -417,6 +417,15 @@ Promise.all([
 
 The [`withExclusiveTransactionAsync()`](#withexclusivetransactionasynctask) function addresses this. Only queries that run within the scope function passed to `withExclusiveTransactionAsync()` will run within the actual SQL transaction.
 
+> **warning** `withExclusiveTransactionAsync()` opens a **new database connection** internally. Any per-connection state — such as `PRAGMA foreign_keys = ON` — set on your original database instance will **not** carry over to the transaction. If you rely on connection-specific PRAGMAs, you must re-execute them on the `txn` object at the beginning of your task callback:
+>
+> ```ts
+> await db.withExclusiveTransactionAsync(async (txn) => {
+>   await txn.execAsync('PRAGMA foreign_keys = ON');
+>   // ... your queries here
+> });
+> ```
+
 ### Executing PRAGMA queries
 
 ```js Executing PRAGMA queries

--- a/packages/expo-sqlite/src/SQLiteDatabase.ts
+++ b/packages/expo-sqlite/src/SQLiteDatabase.ts
@@ -157,6 +157,12 @@ export class SQLiteDatabase {
    *
    * > **Note:** This function is not supported on web.
    *
+   * > **Note:** This method opens a **new, separate database connection** internally for the transaction.
+   * Any per-connection state — such as PRAGMAs set on your original database instance (for example,
+   * `PRAGMA foreign_keys = ON`) — will **not** carry over to the transaction connection. If you rely on
+   * connection-specific PRAGMAs, you must re-execute them on the `txn` object at the beginning of your
+   * task callback.
+   *
    * @param task An async function to execute within a transaction. Any queries inside the transaction must be executed on the `txn` object.
    * The `txn` object has the same interfaces as the [`SQLiteDatabase`](#sqlitedatabase) object. You can use `txn` like a [`SQLiteDatabase`](#sqlitedatabase) object.
    *
@@ -168,6 +174,8 @@ export class SQLiteDatabase {
    * @example
    * ```ts
    * db.withExclusiveTransactionAsync(async (txn) => {
+   *   // Re-apply any PRAGMAs needed for the transaction connection
+   *   await txn.execAsync('PRAGMA foreign_keys = ON');
    *   await txn.execAsync('UPDATE test SET name = "aaa"');
    * });
    * ```


### PR DESCRIPTION
## Summary

`withExclusiveTransactionAsync()` internally opens a new database connection (via `Transaction.createAsync` with `useNewConnection: true`). Per-connection state — such as `PRAGMA foreign_keys = ON` — set on the original database instance does **not** carry over to the transaction connection. This can cause silent data integrity issues (e.g., foreign key constraints not enforced).

This PR:
- Adds a warning callout to the SQLite docs page explaining this behavior
- Updates the JSDoc on `withExclusiveTransactionAsync` with a note and example showing how to re-apply PRAGMAs on the `txn` object

## Test plan
- Documentation-only change
- Verified the warning callout renders correctly in MDX format

Fixes #41986