### PR TITLE
docs(audio): clarify allowsBackgroundRecording requirement in release notes

### DIFF
--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -169,6 +169,9 @@ export default function App() {
       setAudioModeAsync({
         playsInSilentMode: true,
         allowsRecording: true,
+        // To record in the background, also set allowsBackgroundRecording: true
+        // and enable the enableBackgroundRecording config plugin option.
+        // See "Recording audio in the background" below.
       });
     })();
   }, []);

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -72,7 +72,7 @@ _This version does not introduce any user-facing changes._
 ### 🎉 New features
 
 - [iOS/Android] Add showSeekForward and showSeekBackward options to AudioLockScreenOptions to control visibility of seek buttons on lock screen. ([#40124](https://github.com/expo/expo/pull/40124) by [@chrfalch](https://github.com/chrfalch))
-- [iOS/Android] Add support background recording. ([#41134](https://github.com/expo/expo/pull/41134) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS/Android] Add support for background recording. Apps that need to record audio in the background must now explicitly set `allowsBackgroundRecording: true` via `setAudioModeAsync()` in addition to the `enableBackgroundRecording` config plugin option. See the [background recording docs](https://docs.expo.dev/versions/latest/sdk/audio/#recording-audio-in-the-background) for details. ([#41134](https://github.com/expo/expo/pull/41134) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Support `mixWithOthers` interruption mode. ([#41670](https://github.com/expo/expo/pull/41670) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes


### PR DESCRIPTION
## Summary

After PR #41134 added background recording support in SDK 55, apps that previously recorded audio in the background silently break unless they explicitly set `allowsBackgroundRecording: true` via `setAudioModeAsync()`. This two-step requirement (config plugin + runtime flag) was not clearly communicated in the release notes.

This PR:
- Updates the v55.0.0 CHANGELOG entry to explicitly mention the `allowsBackgroundRecording` runtime requirement
- Adds a comment to the basic recording example pointing users to the background recording docs section

## Test plan
- Documentation-only change
- Verified CHANGELOG formatting matches existing entries

Fixes #42003