### PR TITLE
Docs/add network note remote image uri

### DIFF
--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -64,6 +64,8 @@ We'll use `expo-image` library to display the image in the app. It provides a cr
 
 The Image component takes the source of an image as its value. The source can be either a [static asset](https://reactnative.dev/docs/images#static-image-resources) or a URL. For example, the source required from **assets/images** directory is static. It can also come from [Network](https://reactnative.dev/docs/images#network-images) as a `uri` property.
 
+> **Note:** When using a remote `uri` (for example, `https://...`) as the image source, ensure the device running the app has an active internet connection. This is especially important when testing on a physical device or emulator that relies on your local network. If the device is offline or cannot access the network, the image request will fail.
+
 <ContentSpotlight
   alt="Background image that we are going to use as a placeholder for the tutorial."
   src="/static/images/tutorial/background-image.png"

--- a/docs/pages/versions/unversioned/sdk/image.mdx
+++ b/docs/pages/versions/unversioned/sdk/image.mdx
@@ -130,6 +130,8 @@ const styles = StyleSheet.create({
 });
 ```
 
+> **Note:** When using a remote `uri` (for example, `https://...`) as the image source, ensure the device running the app has an active internet connection. This is especially important when testing on a physical device or emulator that relies on your local network. If the device is offline or cannot access the network, the image request will fail.
+
 ## API
 
 ```js


### PR DESCRIPTION
# Why                                                                                                                                                                                                                                                       
                                                                
  When using a remote `uri` as an image source, the device must have an active internet connection for the image to load. This requirement isn't documented, which can lead to confusion, especially when testing on a physical device or emulator without network access.                                               

  # How

  Added an informational note in two places:
  - **Tutorial** (`docs/pages/tutorial/build-a-screen.mdx`): In Step 2 ("Display the image"), right after the paragraph introducing remote `uri` as an image source option.
  - **SDK reference** (`docs/pages/versions/unversioned/sdk/image.mdx`): After the usage example that demonstrates loading a remote image (`https://picsum.photos/...`).

  # Test Plan

  - [ ] Verify the note renders correctly on both pages
  - [ ] Confirm placement is contextually appropriate in each file

  # Checklist

  - [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
  - [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
