### PR TITLE
test(autolinking): Add test coverage for more isolated dependencies edge cases

### DIFF
--- a/packages/expo-modules-autolinking/src/dependencies/__tests__/resolution-test.ts
+++ b/packages/expo-modules-autolinking/src/dependencies/__tests__/resolution-test.ts
@@ -475,6 +475,264 @@ describe(scanDependenciesRecursively, () => {
     `);
   });
 
+  it('resolves isolated duplicates with stable version regardless of dependency ordering', async () => {
+    const runWithOrder = async (first: string, second: string) => {
+      const result = await createMemoizer().withMemoizer(async () => {
+        vol.fromNestedJSON(
+          {
+            ...mockedNodeModule('root', {
+              pkgDependencies: { [first]: '*', [second]: '*' },
+            }),
+            node_modules: {
+              '.pnpm': {
+                'parent-a@1.0.0/node_modules': {
+                  'parent-a': mockedNodeModule('parent-a', {
+                    pkgVersion: '1.0.0',
+                    pkgDependencies: { dep: '*' },
+                  }),
+                },
+                'parent-b@1.0.0/node_modules': {
+                  'parent-b': mockedNodeModule('parent-b', {
+                    pkgVersion: '1.0.0',
+                    pkgDependencies: { dep: '*' },
+                  }),
+                },
+                'dep@2.0.0/node_modules': {
+                  dep: mockedNodeModule('dep', { pkgVersion: '2.0.0' }),
+                },
+              },
+            },
+          },
+          projectRoot
+        );
+        symlinkMany({
+          'node_modules/parent-a': 'node_modules/.pnpm/parent-a@1.0.0/node_modules/parent-a',
+          'node_modules/parent-b': 'node_modules/.pnpm/parent-b@1.0.0/node_modules/parent-b',
+          'node_modules/.pnpm/parent-a@1.0.0/node_modules/dep':
+            'node_modules/.pnpm/dep@2.0.0/node_modules/dep',
+          'node_modules/.pnpm/parent-b@1.0.0/node_modules/dep':
+            'node_modules/.pnpm/dep@2.0.0/node_modules/dep',
+        });
+        return await scanDependenciesRecursively(projectRoot);
+      });
+      expect(_verifyMemoizerFreed()).toBe(true);
+      return result;
+    };
+
+    const resultAB = await runWithOrder('parent-a', 'parent-b');
+    vol.reset();
+    const resultBA = await runWithOrder('parent-b', 'parent-a');
+
+    for (const key of Object.keys(resultAB)) {
+      expect(resultAB[key]?.path).toBe(resultBA[key]?.path);
+      expect(resultAB[key]?.version).toBe(resultBA[key]?.version);
+    }
+    expect(resultAB['dep']?.version).toBe('2.0.0');
+  });
+
+  it('resolves multi-level isolated duplicates with stable path and version, unstable originPath', async () => {
+    const runWithOrder = async (first: string, second: string) => {
+      const result = await createMemoizer().withMemoizer(async () => {
+        vol.fromNestedJSON(
+          {
+            ...mockedNodeModule('root', {
+              pkgDependencies: { [first]: '*', [second]: '*' },
+            }),
+            node_modules: {
+              '.pnpm': {
+                'parent-a@1.0.0/node_modules': {
+                  'parent-a': mockedNodeModule('parent-a', {
+                    pkgVersion: '1.0.0',
+                    pkgDependencies: { 'shared-dep': '*' },
+                  }),
+                },
+                'parent-b@1.0.0/node_modules': {
+                  'parent-b': mockedNodeModule('parent-b', {
+                    pkgVersion: '1.0.0',
+                    pkgDependencies: { 'shared-dep': '*' },
+                  }),
+                },
+                'shared-dep@2.0.0/node_modules': {
+                  'shared-dep': mockedNodeModule('shared-dep', {
+                    pkgVersion: '2.0.0',
+                    pkgDependencies: { grandchild: '*' },
+                  }),
+                },
+                'grandchild@3.0.0/node_modules': {
+                  grandchild: mockedNodeModule('grandchild', { pkgVersion: '3.0.0' }),
+                },
+              },
+            },
+          },
+          projectRoot
+        );
+        symlinkMany({
+          'node_modules/parent-a': 'node_modules/.pnpm/parent-a@1.0.0/node_modules/parent-a',
+          'node_modules/parent-b': 'node_modules/.pnpm/parent-b@1.0.0/node_modules/parent-b',
+          'node_modules/.pnpm/parent-a@1.0.0/node_modules/shared-dep':
+            'node_modules/.pnpm/shared-dep@2.0.0/node_modules/shared-dep',
+          'node_modules/.pnpm/parent-b@1.0.0/node_modules/shared-dep':
+            'node_modules/.pnpm/shared-dep@2.0.0/node_modules/shared-dep',
+          'node_modules/.pnpm/shared-dep@2.0.0/node_modules/grandchild':
+            'node_modules/.pnpm/grandchild@3.0.0/node_modules/grandchild',
+        });
+        return await scanDependenciesRecursively(projectRoot);
+      });
+      expect(_verifyMemoizerFreed()).toBe(true);
+      return result;
+    };
+
+    const resultAB = await runWithOrder('parent-a', 'parent-b');
+    vol.reset();
+    const resultBA = await runWithOrder('parent-b', 'parent-a');
+
+    for (const key of Object.keys(resultAB)) {
+      expect(resultAB[key]?.path).toBe(resultBA[key]?.path);
+      expect(resultAB[key]?.version).toBe(resultBA[key]?.version);
+      expect(resultAB[key]?.depth).toBe(resultBA[key]?.depth);
+      expect(resultAB[key]?.source).toBe(resultBA[key]?.source);
+      expect(resultAB[key]?.name).toBe(resultBA[key]?.name);
+    }
+    expect(resultAB['shared-dep']?.version).toBe('2.0.0');
+    expect(resultAB['grandchild']?.version).toBe('3.0.0');
+    expect(resultAB['shared-dep']?.originPath).not.toBe(resultBA['shared-dep']?.originPath);
+  });
+
+  it('resolves mixed-depth diamond with stable path and version', async () => {
+    const runWithOrder = async (first: string, second: string) => {
+      const result = await createMemoizer().withMemoizer(async () => {
+        vol.fromNestedJSON(
+          {
+            ...mockedNodeModule('root', {
+              pkgDependencies: { [first]: '*', [second]: '*' },
+            }),
+            node_modules: {
+              '.pnpm': {
+                'parent-a@1.0.0/node_modules': {
+                  'parent-a': mockedNodeModule('parent-a', {
+                    pkgVersion: '1.0.0',
+                    pkgDependencies: { 'shared-dep': '*' },
+                  }),
+                },
+                'parent-b@1.0.0/node_modules': {
+                  'parent-b': mockedNodeModule('parent-b', {
+                    pkgVersion: '1.0.0',
+                    pkgDependencies: { 'mid-b': '*' },
+                  }),
+                },
+                'mid-b@1.5.0/node_modules': {
+                  'mid-b': mockedNodeModule('mid-b', {
+                    pkgVersion: '1.5.0',
+                    pkgDependencies: { 'shared-dep': '*' },
+                  }),
+                },
+                'shared-dep@2.0.0/node_modules': {
+                  'shared-dep': mockedNodeModule('shared-dep', {
+                    pkgVersion: '2.0.0',
+                    pkgDependencies: { grandchild: '*' },
+                  }),
+                },
+                'grandchild@3.0.0/node_modules': {
+                  grandchild: mockedNodeModule('grandchild', { pkgVersion: '3.0.0' }),
+                },
+              },
+            },
+          },
+          projectRoot
+        );
+        symlinkMany({
+          'node_modules/parent-a': 'node_modules/.pnpm/parent-a@1.0.0/node_modules/parent-a',
+          'node_modules/parent-b': 'node_modules/.pnpm/parent-b@1.0.0/node_modules/parent-b',
+          'node_modules/.pnpm/parent-b@1.0.0/node_modules/mid-b':
+            'node_modules/.pnpm/mid-b@1.5.0/node_modules/mid-b',
+          'node_modules/.pnpm/parent-a@1.0.0/node_modules/shared-dep':
+            'node_modules/.pnpm/shared-dep@2.0.0/node_modules/shared-dep',
+          'node_modules/.pnpm/mid-b@1.5.0/node_modules/shared-dep':
+            'node_modules/.pnpm/shared-dep@2.0.0/node_modules/shared-dep',
+          'node_modules/.pnpm/shared-dep@2.0.0/node_modules/grandchild':
+            'node_modules/.pnpm/grandchild@3.0.0/node_modules/grandchild',
+        });
+        return await scanDependenciesRecursively(projectRoot);
+      });
+      expect(_verifyMemoizerFreed()).toBe(true);
+      return result;
+    };
+
+    const resultAB = await runWithOrder('parent-a', 'parent-b');
+    vol.reset();
+    const resultBA = await runWithOrder('parent-b', 'parent-a');
+
+    for (const key of Object.keys(resultAB)) {
+      expect(resultAB[key]?.path).toBe(resultBA[key]?.path);
+      expect(resultAB[key]?.version).toBe(resultBA[key]?.version);
+    }
+    expect(resultAB['shared-dep']?.depth).toBe(1);
+  });
+
+  it('resolves isolated duplicates with stable version when three parents share a dependency', async () => {
+    const runWithOrder = async (first: string, second: string) => {
+      const result = await createMemoizer().withMemoizer(async () => {
+        vol.fromNestedJSON(
+          {
+            ...mockedNodeModule('root', {
+              pkgDependencies: { [first]: '*', [second]: '*', 'parent-c': '*' },
+            }),
+            node_modules: {
+              '.pnpm': {
+                'parent-a@1.0.0/node_modules': {
+                  'parent-a': mockedNodeModule('parent-a', {
+                    pkgVersion: '1.0.0',
+                    pkgDependencies: { dep: '*' },
+                  }),
+                },
+                'parent-b@1.0.0/node_modules': {
+                  'parent-b': mockedNodeModule('parent-b', {
+                    pkgVersion: '1.0.0',
+                    pkgDependencies: { dep: '*' },
+                  }),
+                },
+                'parent-c@1.0.0/node_modules': {
+                  'parent-c': mockedNodeModule('parent-c', {
+                    pkgVersion: '1.0.0',
+                    pkgDependencies: { dep: '*' },
+                  }),
+                },
+                'dep@2.0.0/node_modules': {
+                  dep: mockedNodeModule('dep', { pkgVersion: '2.0.0' }),
+                },
+              },
+            },
+          },
+          projectRoot
+        );
+        symlinkMany({
+          'node_modules/parent-a': 'node_modules/.pnpm/parent-a@1.0.0/node_modules/parent-a',
+          'node_modules/parent-b': 'node_modules/.pnpm/parent-b@1.0.0/node_modules/parent-b',
+          'node_modules/parent-c': 'node_modules/.pnpm/parent-c@1.0.0/node_modules/parent-c',
+          'node_modules/.pnpm/parent-a@1.0.0/node_modules/dep':
+            'node_modules/.pnpm/dep@2.0.0/node_modules/dep',
+          'node_modules/.pnpm/parent-b@1.0.0/node_modules/dep':
+            'node_modules/.pnpm/dep@2.0.0/node_modules/dep',
+          'node_modules/.pnpm/parent-c@1.0.0/node_modules/dep':
+            'node_modules/.pnpm/dep@2.0.0/node_modules/dep',
+        });
+        return await scanDependenciesRecursively(projectRoot);
+      });
+      expect(_verifyMemoizerFreed()).toBe(true);
+      return result;
+    };
+
+    const resultAB = await runWithOrder('parent-a', 'parent-b');
+    vol.reset();
+    const resultBA = await runWithOrder('parent-b', 'parent-a');
+
+    for (const key of Object.keys(resultAB)) {
+      expect(resultAB[key]?.path).toBe(resultBA[key]?.path);
+      expect(resultAB[key]?.version).toBe(resultBA[key]?.version);
+    }
+    expect(resultAB['dep']?.version).toBe('2.0.0');
+  });
+
   itWithMemoize('ignores transitive optional peer dependencies', async () => {
     vol.fromNestedJSON(
       {


### PR DESCRIPTION
# Why

Adding tests demonstrating that `path` and `version` are stable across dependency orderings when multiple parents share a pnpm-isolated dependency. The `_visitedPackagePaths` race in `scanDependenciesRecursively` determines which parent sets the version, but `mergeWithDuplicate` correctly transfers it in all cases. The sole non-deterministic field is `originPath`, which is internal and unused outside diagnostics.

This is based on tests in an issue to validate that the output is deterministic for (non-corrupted) isolated dependency installations

Related #43517

# How

- Add a few more tests from issue analysis

# Test Plan

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
