### PR TITLE
[docs] Fix Prerequisites anchor link scroll

### DIFF
--- a/docs/ui/components/Prerequisites/index.tsx
+++ b/docs/ui/components/Prerequisites/index.tsx
@@ -58,7 +58,7 @@ const Prerequisites: ComponentType<PrerequisitesProps> = withHeadingManager(
     }, [open]);
     return (
       <details
-        id={anchorId}
+        id={heading.current.slug}
         className={mergeClasses(
           'mb-3 scroll-m-4 rounded-md border border-default p-0',
           '[&[open]]:shadow-xs',


### PR DESCRIPTION

# Why
When a page has multiple `<Prerequisites>` components (e.g., https://docs.expo.dev/submit/ios/ or https://docs.expo.dev/deploy/submit-to-app-stores), navigating to the anchor link of any instance other than the first does not scroll to the correct position. 

The anchor link URL itself was correct (e.g., #prerequisites-1), but the `<details>` element's id was hardcoded to "prerequisites" for every instance. Since no DOM element had the matching id, the browser couldn't scroll to it and the hash-based auto-expansion didn't trigger.

# How

Changed the id attribute on the `<details>` element in `ui/components/Prerequisites/index.tsx` from the hardcoded `anchorId` ("prerequisites") to heading.current.slug, which is the unique slug already used by the anchor link href.

# Test Plan

Tested on a few pages locally to see that it works as intended.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
