### PR TITLE
ci: Disable `EXPO_DEBUG` flag

### DIFF
--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -64,7 +64,7 @@ jobs:
         run: ./scripts/start-ios-e2e-test.ts --build
         working-directory: apps/bare-expo
         env:
-          EXPO_DEBUG: 1
+          EXPO_UNSTABLE_HEADLESS: 1
           NODE_ENV: production
       - name: 📸 Upload builds
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -201,7 +201,7 @@ jobs:
         uses: expo/actions/repack-app-artifact@main
         timeout-minutes: 55
         env:
-          EXPO_DEBUG: 1
+          EXPO_UNSTABLE_HEADLESS: 1
           NODE_ENV: production
           RCT_USE_PREBUILT_RNCORE: 1
           RCT_USE_RN_DEP: 1
@@ -401,7 +401,7 @@ jobs:
         uses: expo/actions/repack-app-artifact@main
         timeout-minutes: 35
         env:
-          EXPO_DEBUG: 1
+          EXPO_UNSTABLE_HEADLESS: 1
           NODE_ENV: production
         with:
           platform: android


### PR DESCRIPTION
# Why

> [!NOTE]
> Test to see how this affects CI run time of the `test-suite`

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
