### PR TITLE
fix(cli): prevent hanging when launching iOS apps on physical devices

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Prevent hanging when installing iOS apps on device.
 - Correctly handle JavaScript assets when `asyncRoutes: true` in SSR ([#43446](https://github.com/expo/expo/pull/43446) by [@hassankhan](https://github.com/hassankhan))
 - Fix server being started before Metro is ready, or, if it's started, status middleware responding too soon ([#43557](https://github.com/expo/expo/pull/43557) by [@kitten](https://github.com/kitten))
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Prevent hanging when installing iOS apps on device.
+- Prevent hanging when installing iOS apps on device. ([#43618](https://github.com/expo/expo/pull/43618) by [@EvanBacon](https://github.com/EvanBacon))
 - Correctly handle JavaScript assets when `asyncRoutes: true` in SSR ([#43446](https://github.com/expo/expo/pull/43446) by [@hassankhan](https://github.com/hassankhan))
 - Fix server being started before Metro is ready, or, if it's started, status middleware responding too soon ([#43557](https://github.com/expo/expo/pull/43557) by [@kitten](https://github.com/kitten))
 

--- a/packages/@expo/cli/src/start/platforms/ios/devicectl.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/devicectl.ts
@@ -332,7 +332,15 @@ async function installAppWithDeviceCtlInternalAsync(
 }
 
 export async function launchAppWithDeviceCtl(deviceId: string, bundleId: string) {
-  await devicectlAsync(['device', 'process', 'launch', '--device', deviceId, bundleId]);
+  await devicectlAsync([
+    'device',
+    'process',
+    'launch',
+    '--terminate-existing',
+    '--device',
+    deviceId,
+    bundleId,
+  ]);
 }
 
 /** Find all error codes from the output log */


### PR DESCRIPTION
## Summary

Fixes `expo run:ios -d` hanging indefinitely at "Connecting to: <device name>" when launching on physical devices.

The `xcrun devicectl device process launch` command was hanging when the app was already running on the device. Adding the `--terminate-existing` flag terminates any running instances before launching, preventing the hang.

**Root cause:** Without `--terminate-existing`, the devicectl launch command would wait indefinitely if the app was already running.

**The fix:** Add `--terminate-existing` to the devicectl launch command arguments.

This only affects the devicectl code path (used for iOS 17+ and network-connected devices). The usbmuxd path has its own mechanism for handling already-running apps.

## Test plan

- [x] Run `yarn test src/start/platforms/ios/__tests__/devicectl.test.ts` - tests pass
- [ ] Run `npx expo run:ios -d` on a physical device with the app already running
- [ ] Verify app terminates and relaunches successfully
- [ ] Verify launching works when app is not already running

🤖 Generated with [Claude Code](https://claude.ai/code)