### PR TITLE
fix(cli): Add missing try-catch for dependency validation in `expo start`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Correctly handle JavaScript assets when `asyncRoutes: true` in SSR ([#43446](https://github.com/expo/expo/pull/43446) by [@hassankhan](https://github.com/hassankhan))
 - Fix server being started before Metro is ready, or, if it's started, status middleware responding too soon ([#43557](https://github.com/expo/expo/pull/43557) by [@kitten](https://github.com/kitten))
+- Don't let `expo start`'s dependency validation fail the `start` command ([#43619](https://github.com/expo/expo/pull/43619) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -111,7 +111,12 @@ export async function startAsync(
   }
 
   if (!env.EXPO_NO_DEPENDENCY_VALIDATION && !settings.webOnly && !options.devClient) {
-    await profile(validateDependenciesVersionsAsync)(projectRoot, exp, pkg);
+    try {
+      await profile(validateDependenciesVersionsAsync)(projectRoot, exp, pkg);
+    } catch {
+      // We don't show the dependency validation error, since it's non-essential
+      // for the user to know it ran or failed
+    }
   }
 
   // Open project on devices.


### PR DESCRIPTION
# Why

This is only a slight annoyance, but there's no point for us to fail `expo start` when dependency validation fails. There isn't even any real point to show the error, since it's a non-essential task. I saw this failing for someone on Discord and it's really confusing to see

# How

- Add empty try-catch to dependency validation in `expo start`

# Test Plan

- n/a

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)