### PR TITLE
[docs] Migrate to TailwindCSS v4 and upgrade styleguide libraries

### DIFF
--- a/docs/components/DocumentationNestedScrollLayout.tsx
+++ b/docs/components/DocumentationNestedScrollLayout.tsx
@@ -84,7 +84,7 @@ export default function DocumentationNestedScrollLayout({
     <div className="mx-auto flex h-dvh w-full flex-col overflow-hidden">
       <div className="max-lg-gutters:sticky">{header}</div>
       <div className="mx-auto flex h-[calc(100dvh-60px)] w-full items-center justify-between">
-        <div className="relative h-full max-lg-gutters:hidden">
+        <div className="max-lg-gutters:hidden relative h-full">
           {onSidebarToggle ? (
             <div
               className={mergeClasses(
@@ -99,12 +99,12 @@ export default function DocumentationNestedScrollLayout({
                     theme="quaternary"
                     size="xs"
                     className={mergeClasses(
-                      'inline-flex size-9 items-center justify-center rounded-full border !p-0 transition-colors duration-150 ease-out',
+                      'inline-flex size-9 items-center justify-center rounded-full border p-0! transition-colors duration-150 ease-out',
                       'shadow-sm',
                       isSidebarCollapsed
                         ? 'border-palette-gray5 bg-palette-gray4 text-icon-secondary dark:border-palette-gray6 dark:bg-palette-gray5'
                         : 'border-default bg-default text-icon-secondary',
-                      'hover:bg-element focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-palette-blue9'
+                      'hover:bg-element focus-visible:ring-palette-blue9 focus-visible:ring-2 focus-visible:outline-none'
                     )}
                     aria-label={isSidebarCollapsed ? 'Show navigation' : 'Hide navigation'}
                     title={isSidebarCollapsed ? 'Show navigation' : 'Hide navigation'}
@@ -128,7 +128,7 @@ export default function DocumentationNestedScrollLayout({
           ) : null}
           <div
             className={mergeClasses(
-              'flex h-full max-w-[280px] flex-col overflow-hidden border-r border-r-default transition-[max-width,opacity,width] duration-200 ease-out will-change-[max-width,width,opacity]',
+              'border-r-default flex h-full max-w-[280px] flex-col overflow-hidden border-r transition-[max-width,opacity,width] duration-200 ease-out will-change-[max-width,width,opacity]',
               isSidebarCollapsed
                 ? 'w-0 max-w-0 border-r-0 opacity-0'
                 : 'w-[280px] max-w-[280px] opacity-100'
@@ -158,7 +158,7 @@ export default function DocumentationNestedScrollLayout({
               className={mergeClasses(
                 'mx-auto max-w-screen-xl transition-[padding,max-width,margin] duration-200 ease-out will-change-[padding,max-width,margin]',
                 isChatExpanded &&
-                  'lg:pr-[360px] lg:pl-8 lg:max-w-[calc(100%-360px)] max-lg-gutters:max-w-screen-xl max-lg-gutters:pl-0 max-lg-gutters:pr-0'
+                  'max-lg-gutters:max-w-screen-xl max-lg-gutters:pl-0 max-lg-gutters:pr-0'
               )}>
               {children}
             </div>
@@ -167,7 +167,7 @@ export default function DocumentationNestedScrollLayout({
         {!hideTOC && (
           <div
             className={mergeClasses(
-              'flex h-[calc(100dvh-60px)] max-w-[280px] shrink-0 flex-col overflow-hidden border-l border-l-default',
+              'border-l-default flex h-[calc(100dvh-60px)] max-w-[280px] shrink-0 flex-col overflow-hidden border-l',
               'max-xl-gutters:hidden'
             )}>
             <ScrollContainer ref={sidebarRightRef}>

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -341,7 +341,7 @@ export default function DocumentationPage({
         <div
           className={mergeClasses(
             'pointer-events-none absolute z-10 h-8 w-[calc(100%-6px)] max-w-screen-xl',
-            'bg-gradient-to-b from-default to-transparent opacity-90'
+            'from-default bg-linear-to-b to-transparent opacity-90'
           )}
         />
         <main
@@ -350,7 +350,7 @@ export default function DocumentationPage({
             'max-lg-gutters:px-4 max-lg-gutters:pt-5'
           )}>
           {version && version === 'unversioned' && (
-            <InlineHelp type="default" size="sm" className="!mb-5 !inline-flex w-full">
+            <InlineHelp type="default" size="sm" className="mb-5! inline-flex! w-full">
               This is documentation for the next SDK version. For up-to-date documentation, see the{' '}
               <A href={pathname.replace('unversioned', 'latest')}>latest version</A> (
               {versionToText(LATEST_VERSION)}).

--- a/docs/components/ScrollContainer.tsx
+++ b/docs/components/ScrollContainer.tsx
@@ -41,7 +41,7 @@ export const ScrollContainer = forwardRef<ScrollContainerHandle, ScrollContainer
     return (
       <div
         className={mergeClasses(
-          'size-full transform-gpu overflow-y-auto overflow-x-hidden',
+          'size-full transform-gpu overflow-x-hidden overflow-y-auto',
           className
         )}
         ref={scrollRef}

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -93,8 +93,8 @@ export function Code({ className, children, title }: CodeProps) {
   }
 
   const commonClasses = mergeClasses(
-    wordWrap && '!break-words !whitespace-pre-wrap',
-    showExpand && !isExpanded && `!overflow-y-hidden [&::-webkit-scrollbar-track]:!bg-default`
+    wordWrap && 'break-words! whitespace-pre-wrap!',
+    showExpand && !isExpanded && `[&::-webkit-scrollbar-track]:bg-default! overflow-y-hidden!`
   );
 
   return codeBlockTitle ? (
@@ -130,7 +130,7 @@ export function Code({ className, children, title }: CodeProps) {
         maxHeight: collapseBound,
       }}
       className={mergeClasses(
-        'relative my-4 overflow-x-auto whitespace-pre rounded-md border border-secondary bg-subtle',
+        'border-secondary bg-subtle relative my-4 overflow-x-auto rounded-md border whitespace-pre',
         preferredTheme === Themes.DARK && 'dark-theme',
         commonClasses,
         '[p+&]:mt-0'
@@ -157,12 +157,12 @@ export const CodeBlock = ({ children, theme, className, inline = false }: CodeBl
   const Element = inline ? 'span' : 'pre';
   return (
     <Element
-      className={mergeClasses('m-0 whitespace-pre px-1 py-1.5', inline && 'inline-flex !p-0')}
+      className={mergeClasses('m-0 px-1 py-1.5 whitespace-pre', inline && 'inline-flex p-0!')}
       {...attributes}>
       <CODE
         className={mergeClasses(
-          '!text-3xs text-default',
-          inline && 'block w-full !p-1.5',
+          'text-3xs! text-default',
+          inline && 'block w-full p-1.5!',
           className
         )}
         theme={theme}>

--- a/docs/components/plugins/APIBox.tsx
+++ b/docs/components/plugins/APIBox.tsx
@@ -33,7 +33,7 @@ export const APIBox = ({
         STYLES_APIBOX_WRAPPER,
         headerNestingLevel > 3 && STYLES_APIBOX_NESTED,
         className,
-        '!pb-4 last:[&>*]:!mb-1'
+        'pb-4! [&>*:last-child]:mb-1!'
       )}>
       {header && (
         <HeadingElement tags={platforms}>

--- a/docs/components/plugins/CodeBlocksTable.tsx
+++ b/docs/components/plugins/CodeBlocksTable.tsx
@@ -41,14 +41,14 @@ export function CodeBlocksTable({ children, tabs, connected = true, ...rest }: P
         'grid grid-cols-2 gap-4',
         connected && 'lg-gutters:mb-4 lg-gutters:gap-0',
         connected &&
-          '[&>div:nth-child(odd)>div]:lg-gutters:!rounded-r-none [&>div:nth-child(odd)>div]:lg-gutters:border-r-0',
-        connected && '[&>div:nth-child(even)>div]:lg-gutters:!rounded-l-none',
+          '[&>div:nth-child(odd)>div]:lg-gutters:rounded-r-none! [&>div:nth-child(odd)>div]:lg-gutters:border-r-0',
+        connected && '[&>div:nth-child(even)>div]:lg-gutters:rounded-l-none!',
         '[&_pre]:m-0 [&_pre]:border-0',
         'max-lg-gutters:grid-cols-1'
       )}
       {...rest}>
       {codeBlocks.map((codeBlock, index) => (
-        <Snippet key={index} className="mb-0 last:max-lg-gutters:mb-4">
+        <Snippet key={index} className="last:max-lg-gutters:mb-4 mb-0">
           <SnippetHeader title={tabNames[index]} Icon={FileCode01Icon}>
             <CopyAction text={cleanCopyValue(codeBlock.props.children.props.children)} />
           </SnippetHeader>

--- a/docs/components/plugins/EasMetadataTable.tsx
+++ b/docs/components/plugins/EasMetadataTable.tsx
@@ -31,7 +31,7 @@ export function MetadataTable({
   const id = useId();
 
   return (
-    <div className="mb-2 mt-1">
+    <div className="mt-1 mb-2">
       <Table headers={headers}>
         {children.map(property => (
           <TableRow key={`${id}-${property.name}`}>

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -3,13 +3,13 @@
 exports[`APISection expo-apple-authentication 1`] = `
 <div>
   <h2
-    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mb-3.5 mt-8 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group flex gap-1 scroll-m-5"
+    class="text-inherit text-[25px] leading-[1.4] font-bold tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group flex gap-1 scroll-m-5"
     data-heading="true"
     id="component"
   >
     Component
     <a
-      class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[25px] min-w-[25px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100"
+      class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex size-[25px] min-w-[25px] justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100"
       href="#component"
     >
       <span
@@ -43,24 +43,24 @@ exports[`APISection expo-apple-authentication 1`] = `
     </a>
   </h2>
   <div
-    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none !shadow-none"
+    class="border-palette-gray4 mb-5 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none shadow-none!"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="appleauthenticationbutton"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           AppleAuthenticationButton
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#appleauthenticationbutton"
         >
           <span
@@ -95,18 +95,18 @@ exports[`APISection expo-apple-authentication 1`] = `
       </h3>
     </div>
     <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0 mx-4"
+      class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0 mx-4"
       data-text="true"
     >
       <span
-        class="text-xs font-medium text-tertiary"
+        class="text-tertiary text-xs font-medium"
         data-text="true"
       >
         Type:
       </span>
        
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+        class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
         data-text="true"
       >
         React.Element
@@ -116,7 +116,7 @@ exports[`APISection expo-apple-authentication 1`] = `
           &lt;
         </span>
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationbuttonprops"
         >
           AppleAuthenticationButtonProps
@@ -129,10 +129,10 @@ exports[`APISection expo-apple-authentication 1`] = `
       </code>
     </p>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         This component displays the proprietary "Sign In with Apple" / "Continue with Apple" button on
@@ -143,16 +143,16 @@ available via the provided properties.
       
 
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         You should only attempt to render this if 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationisavailableasync"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
             data-text="true"
           >
             AppleAuthentication.isAvailableAsync()
@@ -161,7 +161,7 @@ available via the provided properties.
         
 resolves to 
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
           data-text="true"
         >
           true
@@ -169,7 +169,7 @@ resolves to
         . This component will render nothing if it is not available, and you will get
 a warning in development mode (
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
           data-text="true"
         >
           __DEV__ === true
@@ -179,12 +179,12 @@ a warning in development mode (
       
 
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         The properties of this component extend from 
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
           data-text="true"
         >
           View
@@ -192,21 +192,21 @@ a warning in development mode (
         ; however, you should not attempt to set
 
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
           data-text="true"
         >
           backgroundColor
         </code>
          or 
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
           data-text="true"
         >
           borderRadius
         </code>
          with the 
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
           data-text="true"
         >
           style
@@ -214,7 +214,7 @@ a warning in development mode (
          property. This will not work and is against
 the App Store Guidelines. Instead, you should use the 
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
           data-text="true"
         >
           buttonStyle
@@ -222,7 +222,7 @@ the App Store Guidelines. Instead, you should use the
          property to choose one of the
 predefined color styles and the 
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
           data-text="true"
         >
           cornerRadius
@@ -233,14 +233,14 @@ button.
       
 
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         Make sure to attach height and width via the style props as without these styles, the button will
 not appear on the screen.
       </p>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0 [table_&]:mt-2"
+        class="border-default mb-4 flex rounded-md border gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
         data-md="callout"
         data-testid="callout-container"
       >
@@ -270,21 +270,21 @@ not appear on the screen.
           </g>
         </svg>
         <div
-          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+          class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             <span
-              class="leading-[1.6154] text-default font-semibold"
+              class="leading-[1.6154] text-inherit font-semibold"
               data-text="true"
             >
               See:
             </span>
              
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidbutton"
               rel="noopener noreferrer"
               target="_blank"
@@ -300,7 +300,7 @@ for more details.
     </div>
     <div>
       <p
-        class="tracking-[-0.006rem] flex border-y border-palette-gray4 bg-subtle px-4 py-2 text-2xs font-medium text-tertiary"
+        class="tracking-[-0.006rem] border-palette-gray4 bg-subtle text-2xs text-tertiary flex border-y px-4 py-2 font-medium"
         data-text="true"
       >
         <span
@@ -310,7 +310,7 @@ for more details.
         >
           AppleAuthenticationButtonProps
           <a
-            class="border border-solid rounded-full whitespace-nowrap border-button-quaternary bg-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] flex flex-row items-center gap-2 text-2xs font-medium text-tertiary"
+            class="border border-solid rounded-full whitespace-nowrap border-button-quaternary bg-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] text-2xs text-tertiary flex flex-row items-center gap-2 font-medium"
             href="#appleauthenticationbuttonprops"
           >
             <span
@@ -346,27 +346,27 @@ for more details.
       </p>
     </div>
     <div
-      class="[&>*]:last:!mb-0"
+      class="[&>*]:last:mb-0!"
     >
       <div
-        class="border-t border-palette-gray4 first:border-t-0"
+        class="border-palette-gray4 border-t first:border-t-0"
       >
         <div
-          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
         >
           <h3
-            class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+            class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
             data-heading="true"
             id="buttonstyle"
           >
             <code
-              class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+              class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
               data-text="true"
             >
               buttonStyle
             </code>
             <a
-              class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+              class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
               href="#buttonstyle"
             >
               <span
@@ -401,17 +401,17 @@ for more details.
           </h3>
         </div>
         <div
-          class="text-xs font-medium text-tertiary mx-4 mb-2.5"
+          class="text-tertiary text-xs font-medium mx-4 mb-2.5"
         >
           Type:
            
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
             data-md="type-sig"
             data-text="true"
           >
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="#appleauthenticationbuttonstyle"
             >
               AppleAuthenticationButtonStyle
@@ -419,10 +419,10 @@ for more details.
           </code>
         </div>
         <div
-          class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+          class="px-4 [table_&]:mb-0! [table_&]:px-0"
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             The Apple-defined color scheme to use to display the button.
@@ -430,24 +430,24 @@ for more details.
         </div>
       </div>
       <div
-        class="border-t border-palette-gray4 first:border-t-0"
+        class="border-palette-gray4 border-t first:border-t-0"
       >
         <div
-          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
         >
           <h3
-            class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+            class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
             data-heading="true"
             id="buttontype"
           >
             <code
-              class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+              class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
               data-text="true"
             >
               buttonType
             </code>
             <a
-              class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+              class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
               href="#buttontype"
             >
               <span
@@ -482,17 +482,17 @@ for more details.
           </h3>
         </div>
         <div
-          class="text-xs font-medium text-tertiary mx-4 mb-2.5"
+          class="text-tertiary text-xs font-medium mx-4 mb-2.5"
         >
           Type:
            
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
             data-md="type-sig"
             data-text="true"
           >
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="#appleauthenticationbuttontype"
             >
               AppleAuthenticationButtonType
@@ -500,10 +500,10 @@ for more details.
           </code>
         </div>
         <div
-          class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+          class="px-4 [table_&]:mb-0! [table_&]:px-0"
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             The type of button text to display ("Sign In with Apple" vs. "Continue with Apple").
@@ -511,24 +511,24 @@ for more details.
         </div>
       </div>
       <div
-        class="border-t border-palette-gray4 first:border-t-0"
+        class="border-palette-gray4 border-t first:border-t-0"
       >
         <div
-          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
         >
           <h3
-            class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+            class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
             data-heading="true"
             id="cornerradius"
           >
             <code
-              class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+              class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
               data-text="true"
             >
               cornerRadius
             </code>
             <a
-              class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+              class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
               href="#cornerradius"
             >
               <span
@@ -563,13 +563,13 @@ for more details.
           </h3>
         </div>
         <div
-          class="text-xs font-medium text-tertiary mx-4 mb-2.5"
+          class="text-tertiary text-xs font-medium mx-4 mb-2.5"
         >
           Optional • 
           Type:
            
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
             data-md="type-sig"
             data-text="true"
           >
@@ -577,16 +577,16 @@ for more details.
           </code>
         </div>
         <div
-          class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+          class="px-4 [table_&]:mb-0! [table_&]:px-0"
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             The border radius to use when rendering the button. This works similarly to
 
             <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
               data-text="true"
             >
               style.borderRadius
@@ -596,24 +596,24 @@ for more details.
         </div>
       </div>
       <div
-        class="border-t border-palette-gray4 first:border-t-0"
+        class="border-palette-gray4 border-t first:border-t-0"
       >
         <div
-          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
         >
           <h3
-            class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+            class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
             data-heading="true"
             id="onpress"
           >
             <code
-              class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+              class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
               data-text="true"
             >
               onPress
             </code>
             <a
-              class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+              class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
               href="#onpress"
             >
               <span
@@ -648,12 +648,12 @@ for more details.
           </h3>
         </div>
         <div
-          class="text-xs font-medium text-tertiary mx-4 mb-2.5"
+          class="text-tertiary text-xs font-medium mx-4 mb-2.5"
         >
           Type:
            
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
             data-md="type-sig"
             data-text="true"
           >
@@ -672,19 +672,19 @@ for more details.
           </code>
         </div>
         <div
-          class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+          class="px-4 [table_&]:mb-0! [table_&]:px-0"
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             The method to call when the user presses the button. You should call 
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="#appleauthenticationisavailableasync"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                 data-text="true"
               >
                 AppleAuthentication.signInAsync
@@ -696,24 +696,24 @@ in here.
         </div>
       </div>
       <div
-        class="border-t border-palette-gray4 first:border-t-0"
+        class="border-palette-gray4 border-t first:border-t-0"
       >
         <div
-          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+          class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
         >
           <h3
-            class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+            class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
             data-heading="true"
             id="style"
           >
             <code
-              class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+              class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
               data-text="true"
             >
               style
             </code>
             <a
-              class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+              class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
               href="#style"
             >
               <span
@@ -748,13 +748,13 @@ in here.
           </h3>
         </div>
         <div
-          class="text-xs font-medium text-tertiary mx-4 mb-2.5"
+          class="text-tertiary text-xs font-medium mx-4 mb-2.5"
         >
           Optional • 
           Type:
            
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
             data-md="type-sig"
             data-text="true"
           >
@@ -766,7 +766,7 @@ in here.
             </span>
             <span>
               <a
-                class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                 href="https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -780,7 +780,7 @@ in here.
               </span>
               <span>
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="https://reactnative.dev/docs/view-style-props"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -820,22 +820,22 @@ in here.
           </code>
         </div>
         <div
-          class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+          class="px-4 [table_&]:mb-0! [table_&]:px-0"
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             The custom style to apply to the button. Should not include 
             <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
               data-text="true"
             >
               backgroundColor
             </code>
              or 
             <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
               data-text="true"
             >
               borderRadius
@@ -846,16 +846,16 @@ properties.
         </div>
       </div>
       <div
-        class="border-t border-palette-gray4 px-4 py-3"
+        class="border-palette-gray4 border-t px-4 py-3"
       >
         <h4
-          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
+          class="text-inherit text-[16px] leading-relaxed font-semibold tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
           data-heading="true"
           id="inherited-props"
         >
           Inherited Props
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
             href="#inherited-props"
           >
             <span
@@ -889,18 +889,18 @@ properties.
           </a>
         </h4>
         <ul
-          class="leading-[1.6154] text-default list-disc ml-6 [&_ol]:mt-2 [&_ol]:mb-4 [&_ul]:mt-2 [&_ul]:mb-4"
+          class="leading-[1.6154] text-inherit list-disc ml-6 [&_ol]:mt-2 [&_ol]:mb-4 [&_ul]:mt-2 [&_ul]:mb-4"
         >
           <li
-            class="text-default text-base font-normal leading-relaxed mb-2"
+            class="text-inherit text-base leading-relaxed font-normal mb-2"
             data-text="true"
           >
             <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
               data-text="true"
             >
               <a
-                class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                 href="https://reactnative.dev/docs/view#props"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -914,13 +914,13 @@ properties.
     </div>
   </div>
   <h2
-    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mb-3.5 mt-8 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group flex gap-1 scroll-m-5"
+    class="text-inherit text-[25px] leading-[1.4] font-bold tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group flex gap-1 scroll-m-5"
     data-heading="true"
     id="methods"
   >
     Methods
     <a
-      class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[25px] min-w-[25px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100"
+      class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex size-[25px] min-w-[25px] justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100"
       href="#methods"
     >
       <span
@@ -954,24 +954,24 @@ properties.
     </a>
   </h2>
   <div
-    class="overflow-hidden rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
+    class="border-palette-gray4 overflow-hidden rounded-lg border [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="formatfullnamefullname-formatstyle"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           formatFullName(fullName, formatStyle)
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#formatfullnamefullname-formatstyle"
         >
           <span
@@ -1006,29 +1006,29 @@ properties.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
+      class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
     >
       <table
-        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="border-b border-b-default bg-subtle"
+          class="border-b-default bg-subtle border-b"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -1036,13 +1036,13 @@ properties.
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-md="api-param-name"
                 data-text="true"
               >
@@ -1050,14 +1050,14 @@ properties.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="#appleauthenticationfullname"
                 >
                   AppleAuthenticationFullName
@@ -1065,13 +1065,13 @@ properties.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:!mb-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   The full name object with the tokenized portions
@@ -1080,33 +1080,33 @@ properties.
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-md="api-param-name"
                 data-text="true"
               >
                 formatStyle
               </span>
               <span
-                class="flex !text-3xs text-tertiary"
+                class="text-3xs! text-tertiary flex"
               >
                 (optional)
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="#appleauthenticationfullnameformatstyle"
                 >
                   AppleAuthenticationFullNameFormatStyle
@@ -1114,13 +1114,13 @@ properties.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:!mb-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   The style in which the name should be formatted
@@ -1133,10 +1133,10 @@ properties.
     </div>
     <br />
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         Creates a locale-aware string representation of a person's name from an object representing the tokenized portions of a user's full name
@@ -1149,7 +1149,7 @@ properties.
           class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            class="translate-z shrink-0 icon-sm text-icon-tertiary relative -mt-0.5 inline-block"
             fill="none"
             role="img"
             stroke="currentColor"
@@ -1168,26 +1168,26 @@ properties.
             </g>
           </svg>
           <span
-            class="text-xs font-medium text-tertiary"
+            class="text-tertiary text-xs font-medium"
           >
             Returns:
           </span>
         </div>
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           string
         </code>
       </div>
       <div
-        class="mb-1 mt-1.5 flex flex-col pl-6"
+        class="mt-1.5 mb-1 flex flex-col pl-6"
       >
         <div
           class=""
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             A locale-aware string representation of a person's name
@@ -1197,24 +1197,24 @@ properties.
     </div>
   </div>
   <div
-    class="overflow-hidden rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
+    class="border-palette-gray4 overflow-hidden rounded-lg border [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="getcredentialstateasyncuser"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           getCredentialStateAsync(user)
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#getcredentialstateasyncuser"
         >
           <span
@@ -1249,29 +1249,29 @@ properties.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
+      class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
     >
       <table
-        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="border-b border-b-default bg-subtle"
+          class="border-b-default bg-subtle border-b"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -1279,13 +1279,13 @@ properties.
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-md="api-param-name"
                 data-text="true"
               >
@@ -1293,33 +1293,33 @@ properties.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 string
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:!mb-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   The unique identifier for the user whose credential state you'd like to check.
 This should come from the user field of an 
                   <a
-                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                     href="#appleauthenticationcredentialstate"
                   >
                     <code
-                      class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                      class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                       data-text="true"
                     >
                       AppleAuthenticationCredential
@@ -1335,10 +1335,10 @@ This should come from the user field of an
     </div>
     <br />
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         Queries the current state of a user credential, to determine if it is still valid or if it has been revoked.
@@ -1346,7 +1346,7 @@ This should come from the user field of an
       
 
       <blockquote
-        class="flex rounded-md border border-default bg-subtle gap-2 px-3 py-2.5 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-2.5 [table_&]:last:mb-0"
+        class="border-default bg-subtle flex rounded-md border gap-2 px-3 py-2.5 [&_code]:bg-element [&_p]:mb-0! shadow-none mb-2.5 [table_&]:last:mb-0"
         data-md="callout"
         data-testid="callout-container"
       >
@@ -1376,16 +1376,16 @@ This should come from the user field of an
           </g>
         </svg>
         <div
-          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+          class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
           
 
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             <span
-              class="leading-[1.6154] text-default font-semibold"
+              class="leading-[1.6154] text-inherit font-semibold"
               data-text="true"
             >
               Note:
@@ -1404,7 +1404,7 @@ This should come from the user field of an
           class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            class="translate-z shrink-0 icon-sm text-icon-tertiary relative -mt-0.5 inline-block"
             fill="none"
             role="img"
             stroke="currentColor"
@@ -1423,17 +1423,17 @@ This should come from the user field of an
             </g>
           </svg>
           <span
-            class="text-xs font-medium text-tertiary"
+            class="text-tertiary text-xs font-medium"
           >
             Returns:
           </span>
         </div>
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+            class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -1447,7 +1447,7 @@ This should come from the user field of an
           </span>
           <span>
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="#appleauthenticationcredentialstate"
             >
               AppleAuthenticationCredentialState
@@ -1461,22 +1461,22 @@ This should come from the user field of an
         </code>
       </div>
       <div
-        class="mb-1 mt-1.5 flex flex-col pl-6"
+        class="mt-1.5 mb-1 flex flex-col pl-6"
       >
         <div
           class=""
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             A promise that fulfills with an 
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="#appleauthenticationcredentialstate"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                 data-text="true"
               >
                 AppleAuthenticationCredentialState
@@ -1490,24 +1490,24 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="overflow-hidden rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
+    class="border-palette-gray4 overflow-hidden rounded-lg border [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="isavailableasync"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           isAvailableAsync()
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#isavailableasync"
         >
           <span
@@ -1542,10 +1542,10 @@ value depending on the state of the credential.
       </h3>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         Determine if the current device's operating system supports Apple authentication.
@@ -1558,7 +1558,7 @@ value depending on the state of the credential.
           class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            class="translate-z shrink-0 icon-sm text-icon-tertiary relative -mt-0.5 inline-block"
             fill="none"
             role="img"
             stroke="currentColor"
@@ -1577,17 +1577,17 @@ value depending on the state of the credential.
             </g>
           </svg>
           <span
-            class="text-xs font-medium text-tertiary"
+            class="text-tertiary text-xs font-medium"
           >
             Returns:
           </span>
         </div>
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+            class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -1610,25 +1610,25 @@ value depending on the state of the credential.
         </code>
       </div>
       <div
-        class="mb-1 mt-1.5 flex flex-col pl-6"
+        class="mt-1.5 mb-1 flex flex-col pl-6"
       >
         <div
           class=""
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             A promise that fulfills with 
             <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
               data-text="true"
             >
               true
             </code>
              if the system supports Apple authentication, and 
             <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
               data-text="true"
             >
               false
@@ -1640,24 +1640,24 @@ value depending on the state of the credential.
     </div>
   </div>
   <div
-    class="overflow-hidden rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
+    class="border-palette-gray4 overflow-hidden rounded-lg border [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="refreshasyncoptions"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           refreshAsync(options)
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#refreshasyncoptions"
         >
           <span
@@ -1692,29 +1692,29 @@ value depending on the state of the credential.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
+      class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
     >
       <table
-        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="border-b border-b-default bg-subtle"
+          class="border-b-default bg-subtle border-b"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -1722,13 +1722,13 @@ value depending on the state of the credential.
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-md="api-param-name"
                 data-text="true"
               >
@@ -1736,14 +1736,14 @@ value depending on the state of the credential.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="#appleauthenticationrefreshoptions"
                 >
                   AppleAuthenticationRefreshOptions
@@ -1751,22 +1751,22 @@ value depending on the state of the credential.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:!mb-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   An 
                   <a
-                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                     href="#appleauthenticationrefreshoptions"
                   >
                     <code
-                      class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                      class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                       data-text="true"
                     >
                       AppleAuthenticationRefreshOptions
@@ -1782,10 +1782,10 @@ value depending on the state of the credential.
     </div>
     <br />
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         An operation that refreshes the logged-in user’s credentials.
@@ -1799,7 +1799,7 @@ Calling this method will show the sign in modal before actually refreshing the u
           class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            class="translate-z shrink-0 icon-sm text-icon-tertiary relative -mt-0.5 inline-block"
             fill="none"
             role="img"
             stroke="currentColor"
@@ -1818,17 +1818,17 @@ Calling this method will show the sign in modal before actually refreshing the u
             </g>
           </svg>
           <span
-            class="text-xs font-medium text-tertiary"
+            class="text-tertiary text-xs font-medium"
           >
             Returns:
           </span>
         </div>
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+            class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -1842,7 +1842,7 @@ Calling this method will show the sign in modal before actually refreshing the u
           </span>
           <span>
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="#appleauthenticationcredential"
             >
               AppleAuthenticationCredential
@@ -1856,22 +1856,22 @@ Calling this method will show the sign in modal before actually refreshing the u
         </code>
       </div>
       <div
-        class="mb-1 mt-1.5 flex flex-col pl-6"
+        class="mt-1.5 mb-1 flex flex-col pl-6"
       >
         <div
           class=""
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             A promise that fulfills with an 
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="#appleauthenticationcredential"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                 data-text="true"
               >
                 AppleAuthenticationCredential
@@ -1880,7 +1880,7 @@ Calling this method will show the sign in modal before actually refreshing the u
             
 object after a successful authentication, and rejects with 
             <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
               data-text="true"
             >
               ERR_REQUEST_CANCELED
@@ -1893,24 +1893,24 @@ refresh operation.
     </div>
   </div>
   <div
-    class="overflow-hidden rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
+    class="border-palette-gray4 overflow-hidden rounded-lg border [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="signinasyncoptions"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           signInAsync(options)
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#signinasyncoptions"
         >
           <span
@@ -1945,29 +1945,29 @@ refresh operation.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
+      class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
     >
       <table
-        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="border-b border-b-default bg-subtle"
+          class="border-b-default bg-subtle border-b"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -1975,33 +1975,33 @@ refresh operation.
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-md="api-param-name"
                 data-text="true"
               >
                 options
               </span>
               <span
-                class="flex !text-3xs text-tertiary"
+                class="text-3xs! text-tertiary flex"
               >
                 (optional)
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="#appleauthenticationsigninoptions"
                 >
                   AppleAuthenticationSignInOptions
@@ -2009,22 +2009,22 @@ refresh operation.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:!mb-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   An optional 
                   <a
-                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                     href="#appleauthenticationsigninoptions"
                   >
                     <code
-                      class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                      class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                       data-text="true"
                     >
                       AppleAuthenticationSignInOptions
@@ -2040,10 +2040,10 @@ refresh operation.
     </div>
     <br />
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         Sends a request to the operating system to initiate the Apple authentication flow, which will
@@ -2052,7 +2052,7 @@ present a modal to the user over your app and allow them to sign in.
       
 
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         You can request access to the user's full name and email address in this method, which allows you
@@ -2062,14 +2062,14 @@ of these options at runtime.
       
 
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         Additionally, you will only receive Apple Authentication Credentials the first time users sign
 into your app, so you must store it for later use. It's best to store this information either
 server-side, or using 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="./securestore"
         >
           SecureStore
@@ -2077,11 +2077,11 @@ server-side, or using
         , so that the data persists across app installs.
 You can use 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationcredential"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
             data-text="true"
           >
             AppleAuthenticationCredential.user
@@ -2098,7 +2098,7 @@ the user, since this remains the same for apps released by the same developer.
           class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            class="translate-z shrink-0 icon-sm text-icon-tertiary relative -mt-0.5 inline-block"
             fill="none"
             role="img"
             stroke="currentColor"
@@ -2117,17 +2117,17 @@ the user, since this remains the same for apps released by the same developer.
             </g>
           </svg>
           <span
-            class="text-xs font-medium text-tertiary"
+            class="text-tertiary text-xs font-medium"
           >
             Returns:
           </span>
         </div>
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+            class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -2141,7 +2141,7 @@ the user, since this remains the same for apps released by the same developer.
           </span>
           <span>
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="#appleauthenticationcredential"
             >
               AppleAuthenticationCredential
@@ -2155,22 +2155,22 @@ the user, since this remains the same for apps released by the same developer.
         </code>
       </div>
       <div
-        class="mb-1 mt-1.5 flex flex-col pl-6"
+        class="mt-1.5 mb-1 flex flex-col pl-6"
       >
         <div
           class=""
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             A promise that fulfills with an 
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="#appleauthenticationcredential"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                 data-text="true"
               >
                 AppleAuthenticationCredential
@@ -2179,7 +2179,7 @@ the user, since this remains the same for apps released by the same developer.
             
 object after a successful authentication, and rejects with 
             <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
               data-text="true"
             >
               ERR_REQUEST_CANCELED
@@ -2192,24 +2192,24 @@ sign-in operation.
     </div>
   </div>
   <div
-    class="overflow-hidden rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
+    class="border-palette-gray4 overflow-hidden rounded-lg border [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="signoutasyncoptions"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           signOutAsync(options)
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#signoutasyncoptions"
         >
           <span
@@ -2244,29 +2244,29 @@ sign-in operation.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
+      class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
     >
       <table
-        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="border-b border-b-default bg-subtle"
+          class="border-b-default bg-subtle border-b"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -2274,13 +2274,13 @@ sign-in operation.
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-md="api-param-name"
                 data-text="true"
               >
@@ -2288,14 +2288,14 @@ sign-in operation.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="#appleauthenticationsignoutoptions"
                 >
                   AppleAuthenticationSignOutOptions
@@ -2303,22 +2303,22 @@ sign-in operation.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:!mb-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   An 
                   <a
-                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                     href="#appleauthenticationsignoutoptions"
                   >
                     <code
-                      class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                      class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                       data-text="true"
                     >
                       AppleAuthenticationSignOutOptions
@@ -2334,10 +2334,10 @@ sign-in operation.
     </div>
     <br />
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         An operation that ends the authenticated session.
@@ -2346,18 +2346,18 @@ Calling this method will show the sign in modal before actually signing the user
       
 
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         It is not recommended to use this method to sign out the user as it works counterintuitively.
 Instead of using this method it is recommended to simply clear all the user's data collected
 from using 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationsigninasyncoptions"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
             data-text="true"
           >
             signInAsync
@@ -2365,11 +2365,11 @@ from using
         </a>
          or 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationrefreshasyncoptions"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
             data-text="true"
           >
             refreshAsync
@@ -2385,7 +2385,7 @@ from using
           class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            class="translate-z shrink-0 icon-sm text-icon-tertiary relative -mt-0.5 inline-block"
             fill="none"
             role="img"
             stroke="currentColor"
@@ -2404,17 +2404,17 @@ from using
             </g>
           </svg>
           <span
-            class="text-xs font-medium text-tertiary"
+            class="text-tertiary text-xs font-medium"
           >
             Returns:
           </span>
         </div>
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+            class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -2428,7 +2428,7 @@ from using
           </span>
           <span>
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="#appleauthenticationcredential"
             >
               AppleAuthenticationCredential
@@ -2442,22 +2442,22 @@ from using
         </code>
       </div>
       <div
-        class="mb-1 mt-1.5 flex flex-col pl-6"
+        class="mt-1.5 mb-1 flex flex-col pl-6"
       >
         <div
           class=""
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             A promise that fulfills with an 
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="#appleauthenticationcredential"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                 data-text="true"
               >
                 AppleAuthenticationCredential
@@ -2466,7 +2466,7 @@ from using
             
 object after a successful authentication, and rejects with 
             <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
               data-text="true"
             >
               ERR_REQUEST_CANCELED
@@ -2479,13 +2479,13 @@ sign-out operation.
     </div>
   </div>
   <h2
-    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mb-3.5 mt-8 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group flex gap-1 scroll-m-5"
+    class="text-inherit text-[25px] leading-[1.4] font-bold tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group flex gap-1 scroll-m-5"
     data-heading="true"
     id="event-subscriptions"
   >
     Event Subscriptions
     <a
-      class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[25px] min-w-[25px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100"
+      class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex size-[25px] min-w-[25px] justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100"
       href="#event-subscriptions"
     >
       <span
@@ -2519,24 +2519,24 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="overflow-hidden rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
+    class="border-palette-gray4 overflow-hidden rounded-lg border [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="addrevokelistenerlistener"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           addRevokeListener(listener)
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#addrevokelistenerlistener"
         >
           <span
@@ -2571,24 +2571,24 @@ sign-out operation.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
+      class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
     >
       <table
-        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="border-b border-b-default bg-subtle"
+          class="border-b-default bg-subtle border-b"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
@@ -2596,13 +2596,13 @@ sign-out operation.
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-md="api-param-name"
                 data-text="true"
               >
@@ -2610,10 +2610,10 @@ sign-out operation.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <span
@@ -2631,7 +2631,7 @@ sign-out operation.
     </div>
     <br />
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <div
         class="flex flex-row items-start gap-2 mb-2.5 [table_&]:last:mb-0"
@@ -2641,7 +2641,7 @@ sign-out operation.
           class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            class="translate-z shrink-0 icon-sm text-icon-tertiary relative -mt-0.5 inline-block"
             fill="none"
             role="img"
             stroke="currentColor"
@@ -2660,13 +2660,13 @@ sign-out operation.
             </g>
           </svg>
           <span
-            class="text-xs font-medium text-tertiary"
+            class="text-tertiary text-xs font-medium"
           >
             Returns:
           </span>
         </div>
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           EventSubscription
@@ -2675,13 +2675,13 @@ sign-out operation.
     </div>
   </div>
   <h2
-    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mb-3.5 mt-8 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group flex gap-1 scroll-m-5"
+    class="text-inherit text-[25px] leading-[1.4] font-bold tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group flex gap-1 scroll-m-5"
     data-heading="true"
     id="interfaces"
   >
     Interfaces
     <a
-      class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[25px] min-w-[25px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100"
+      class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex size-[25px] min-w-[25px] justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100"
       href="#interfaces"
     >
       <span
@@ -2715,24 +2715,24 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0 overflow-hidden"
+    class="border-palette-gray4 rounded-lg border [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0 overflow-hidden"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="subscription"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           Subscription
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#subscription"
         >
           <span
@@ -2767,17 +2767,17 @@ sign-out operation.
       </h3>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         A subscription object that allows to conveniently remove an event listener from the emitter.
       </p>
     </div>
     <p
-      class="tracking-[-0.006rem] flex border-y border-palette-gray4 bg-subtle px-4 py-2 text-2xs font-medium text-tertiary"
+      class="tracking-[-0.006rem] border-palette-gray4 bg-subtle text-2xs text-tertiary flex border-y px-4 py-2 font-medium"
       data-text="true"
     >
       <span
@@ -2787,7 +2787,7 @@ sign-out operation.
       >
         Subscription Methods
         <a
-          class="border border-solid rounded-full whitespace-nowrap border-button-quaternary bg-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] flex flex-row items-center gap-2 text-2xs font-medium text-tertiary"
+          class="border border-solid rounded-full whitespace-nowrap border-button-quaternary bg-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] text-2xs text-tertiary flex flex-row items-center gap-2 font-medium"
           href="#subscription-methods"
         >
           <span
@@ -2822,24 +2822,24 @@ sign-out operation.
       </span>
     </p>
     <div
-      class="border-b border-palette-gray4 last:border-b-0"
+      class="border-palette-gray4 border-b last:border-b-0"
     >
       <div
-        class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+        class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
       >
         <h3
-          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+          class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
           data-heading="true"
           id="remove"
         >
           <code
-            class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+            class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
             data-text="true"
           >
             remove()
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
             href="#remove"
           >
             <span
@@ -2874,10 +2874,10 @@ sign-out operation.
         </h3>
       </div>
       <div
-        class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+        class="px-4 [table_&]:mb-0! [table_&]:px-0"
       >
         <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
           data-text="true"
         >
           Removes an event listener for which the subscription has been created.
@@ -2891,7 +2891,7 @@ After calling this function, the listener will no longer receive any events from
             class="flex flex-row items-center gap-2"
           >
             <svg
-              class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+              class="translate-z shrink-0 icon-sm text-icon-tertiary relative -mt-0.5 inline-block"
               fill="none"
               role="img"
               stroke="currentColor"
@@ -2910,13 +2910,13 @@ After calling this function, the listener will no longer receive any events from
               </g>
             </svg>
             <span
-              class="text-xs font-medium text-tertiary"
+              class="text-tertiary text-xs font-medium"
             >
               Returns:
             </span>
           </div>
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
             data-text="true"
           >
             void
@@ -2926,13 +2926,13 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <h2
-    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mb-3.5 mt-8 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group flex gap-1 scroll-m-5"
+    class="text-inherit text-[25px] leading-[1.4] font-bold tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group flex gap-1 scroll-m-5"
     data-heading="true"
     id="types"
   >
     Types
     <a
-      class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[25px] min-w-[25px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100"
+      class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex size-[25px] min-w-[25px] justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100"
       href="#types"
     >
       <span
@@ -2966,24 +2966,24 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
+    class="border-palette-gray4 mb-5 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="appleauthenticationcredential"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           AppleAuthenticationCredential
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#appleauthenticationcredential"
         >
           <span
@@ -3018,19 +3018,19 @@ After calling this function, the listener will no longer receive any events from
       </h3>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         The object type returned from a successful call to 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationsigninasyncoptions"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
             data-text="true"
           >
             AppleAuthentication.signInAsync()
@@ -3039,11 +3039,11 @@ After calling this function, the listener will no longer receive any events from
         ,
 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationrefreshasyncoptions"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
             data-text="true"
           >
             AppleAuthentication.refreshAsync()
@@ -3051,11 +3051,11 @@ After calling this function, the listener will no longer receive any events from
         </a>
         , or 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationsignoutasyncoptions"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
             data-text="true"
           >
             AppleAuthentication.signOutAsync()
@@ -3065,7 +3065,7 @@ After calling this function, the listener will no longer receive any events from
 which contains all of the pertinent user and credential information.
       </p>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0 [table_&]:mt-2"
+        class="border-default mb-4 flex rounded-md border gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
         data-md="callout"
         data-testid="callout-container"
       >
@@ -3095,21 +3095,21 @@ which contains all of the pertinent user and credential information.
           </g>
         </svg>
         <div
-          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+          class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             <span
-              class="leading-[1.6154] text-default font-semibold"
+              class="leading-[1.6154] text-inherit font-semibold"
               data-text="true"
             >
               See:
             </span>
              
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidcredential"
               rel="noopener noreferrer"
               target="_blank"
@@ -3127,29 +3127,29 @@ for more details.
       class=""
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
+      class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
-        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="border-b border-b-default bg-subtle"
+          class="border-b-default bg-subtle border-b"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Property
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -3157,23 +3157,23 @@ for more details.
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 authorizationCode
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <span>
@@ -3190,19 +3190,19 @@ for more details.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   A short-lived session token used by your app for proof of authorization when interacting with
 the app's server counterpart. Unlike 
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                     data-text="true"
                   >
                     user
@@ -3213,23 +3213,23 @@ the app's server counterpart. Unlike
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 email
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <span>
@@ -3246,18 +3246,18 @@ the app's server counterpart. Unlike
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   The user's email address. Might not be present if you didn't request the 
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                     data-text="true"
                   >
                     EMAIL
@@ -3271,28 +3271,28 @@ an Apple domain.
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 fullName
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <span>
                   <a
-                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                     href="#appleauthenticationfullname"
                   >
                     AppleAuthenticationFullName
@@ -3309,32 +3309,32 @@ an Apple domain.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   The user's name. May be 
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                     data-text="true"
                   >
                     null
                   </code>
                    or contain 
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                     data-text="true"
                   >
                     null
                   </code>
                    values if you didn't request the 
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                     data-text="true"
                   >
                     FULL_NAME
@@ -3347,23 +3347,23 @@ your app.
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 identityToken
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <span>
@@ -3380,13 +3380,13 @@ your app.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   A JSON Web Token (JWT) that securely communicates information about the user to your app.
@@ -3395,27 +3395,27 @@ your app.
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 realUserStatus
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="#appleauthenticationuserdetectionstatus"
                 >
                   AppleAuthenticationUserDetectionStatus
@@ -3423,13 +3423,13 @@ your app.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   A value that indicates whether the user appears to the system to be a real person.
@@ -3438,23 +3438,23 @@ your app.
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 state
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <span>
@@ -3471,18 +3471,18 @@ your app.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   An arbitrary string that your app provided as 
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                     data-text="true"
                   >
                     state
@@ -3491,7 +3491,7 @@ your app.
 credential. Used to verify that the response was from the request you made. Can be used to
 avoid replay attacks. If you did not provide 
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                     data-text="true"
                   >
                     state
@@ -3499,7 +3499,7 @@ avoid replay attacks. If you did not provide
                    when making the sign-in request, this field
 will be 
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                     data-text="true"
                   >
                     null
@@ -3510,36 +3510,36 @@ will be
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 user
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 string
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   An identifier associated with the authenticated user. You can use this to check if the user is
@@ -3555,24 +3555,24 @@ developers.
     </div>
   </div>
   <div
-    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
+    class="border-palette-gray4 mb-5 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="appleauthenticationfullname"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           AppleAuthenticationFullName
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#appleauthenticationfullname"
         >
           <span
@@ -3607,16 +3607,16 @@ developers.
       </h3>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         An object representing the tokenized portions of the user's full name. Any of all of the fields
 may be 
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
           data-text="true"
         >
           null
@@ -3628,29 +3628,29 @@ may be
       class=""
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
+      class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
-        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="border-b border-b-default bg-subtle"
+          class="border-b-default bg-subtle border-b"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Property
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -3658,23 +3658,23 @@ may be
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 familyName
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <span>
@@ -3691,7 +3691,7 @@ may be
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
                 class="text-quaternary"
@@ -3701,23 +3701,23 @@ may be
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 givenName
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <span>
@@ -3734,7 +3734,7 @@ may be
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
                 class="text-quaternary"
@@ -3744,23 +3744,23 @@ may be
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 middleName
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <span>
@@ -3777,7 +3777,7 @@ may be
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
                 class="text-quaternary"
@@ -3787,23 +3787,23 @@ may be
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 namePrefix
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <span>
@@ -3820,7 +3820,7 @@ may be
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
                 class="text-quaternary"
@@ -3830,23 +3830,23 @@ may be
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 nameSuffix
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <span>
@@ -3863,7 +3863,7 @@ may be
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
                 class="text-quaternary"
@@ -3873,23 +3873,23 @@ may be
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 nickname
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <span>
@@ -3906,7 +3906,7 @@ may be
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
                 class="text-quaternary"
@@ -3920,24 +3920,24 @@ may be
     </div>
   </div>
   <div
-    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
+    class="border-palette-gray4 mb-5 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="appleauthenticationfullnameformatstyle"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           AppleAuthenticationFullNameFormatStyle
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#appleauthenticationfullnameformatstyle"
         >
           <span
@@ -3972,32 +3972,32 @@ may be
       </h3>
     </div>
     <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mx-4 mb-1.5"
+      class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mx-4 mb-1.5"
       data-text="true"
     >
       <span
-        class="text-xs font-medium text-tertiary"
+        class="text-tertiary text-xs font-medium"
       >
         Literal Type: 
       </span>
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+        class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
         data-text="true"
       >
         string
       </code>
     </p>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         A value to specify the style for formatting a name.
       </p>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0 [table_&]:mt-2"
+        class="border-default mb-4 flex rounded-md border gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
         data-md="callout"
         data-testid="callout-container"
       >
@@ -4027,21 +4027,21 @@ may be
           </g>
         </svg>
         <div
-          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+          class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             <span
-              class="leading-[1.6154] text-default font-semibold"
+              class="leading-[1.6154] text-inherit font-semibold"
               data-text="true"
             >
               See:
             </span>
              
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="https://developer.apple.com/documentation/foundation/personnamecomponentsformatter"
               rel="noopener noreferrer"
               target="_blank"
@@ -4056,13 +4056,13 @@ for more details.
       </blockquote>
     </div>
     <p
-      class="tracking-[-0.006rem] text-xs font-medium text-tertiary mx-4 mb-2.5 [table_&]:last:mb-0"
+      class="tracking-[-0.006rem] text-tertiary text-xs font-medium mx-4 mb-2.5 [table_&]:last:mb-0"
       data-text="true"
     >
       Acceptable values are:
        
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 mb-px"
+        class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 mb-px"
         data-text="true"
       >
         'default'
@@ -4073,7 +4073,7 @@ for more details.
          | 
       </span>
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 mb-px"
+        class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 mb-px"
         data-text="true"
       >
         'short'
@@ -4084,7 +4084,7 @@ for more details.
          | 
       </span>
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 mb-px"
+        class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 mb-px"
         data-text="true"
       >
         'medium'
@@ -4095,7 +4095,7 @@ for more details.
          | 
       </span>
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 mb-px"
+        class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 mb-px"
         data-text="true"
       >
         'long'
@@ -4106,7 +4106,7 @@ for more details.
          | 
       </span>
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 mb-px"
+        class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 mb-px"
         data-text="true"
       >
         'abbreviated'
@@ -4114,24 +4114,24 @@ for more details.
     </p>
   </div>
   <div
-    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
+    class="border-palette-gray4 mb-5 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="appleauthenticationrefreshoptions"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           AppleAuthenticationRefreshOptions
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#appleauthenticationrefreshoptions"
         >
           <span
@@ -4166,19 +4166,19 @@ for more details.
       </h3>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         The options you can supply when making a call to 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationrefreshasyncoptions"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
             data-text="true"
           >
             AppleAuthentication.refreshAsync()
@@ -4188,7 +4188,7 @@ for more details.
 You must include the ID string of the user whose credentials you'd like to refresh.
       </p>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0 [table_&]:mt-2"
+        class="border-default mb-4 flex rounded-md border gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
         data-md="callout"
         data-testid="callout-container"
       >
@@ -4218,21 +4218,21 @@ You must include the ID string of the user whose credentials you'd like to refre
           </g>
         </svg>
         <div
-          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+          class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             <span
-              class="leading-[1.6154] text-default font-semibold"
+              class="leading-[1.6154] text-inherit font-semibold"
               data-text="true"
             >
               See:
             </span>
              
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest"
               rel="noopener noreferrer"
               target="_blank"
@@ -4250,29 +4250,29 @@ for more details.
       class=""
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
+      class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
-        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="border-b border-b-default bg-subtle"
+          class="border-b-default bg-subtle border-b"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Property
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -4280,32 +4280,32 @@ for more details.
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 requestedScopes
               </span>
               <span
-                class="flex !text-3xs text-tertiary"
+                class="text-3xs! text-tertiary flex"
               >
                 (optional)
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="#appleauthenticationscope"
                 >
                   AppleAuthenticationScope
@@ -4314,20 +4314,20 @@ for more details.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   Array of user information scopes to which your app is requesting access. Note that the user can
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                     data-text="true"
                   >
                     null
@@ -4336,14 +4336,14 @@ handle
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                     data-text="true"
                   >
                     null
                   </code>
                   . Defaults to 
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                     data-text="true"
                   >
                     []
@@ -4354,41 +4354,41 @@ requests they will be
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 state
               </span>
               <span
-                class="flex !text-3xs text-tertiary"
+                class="text-3xs! text-tertiary flex"
               >
                 (optional)
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 string
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   An arbitrary string that is returned unmodified in the corresponding credential after a
@@ -4396,7 +4396,7 @@ successful authentication. This can be used to verify that the response was from
 you made and avoid replay attacks. More information on this property is available in the
 OAuth 2.0 protocol 
                   <a
-                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                     href="https://tools.ietf.org/html/rfc6749#section-10.12"
                     rel="noopener noreferrer"
                     target="_blank"
@@ -4409,30 +4409,30 @@ OAuth 2.0 protocol
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 user
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 string
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
                 class="text-quaternary"
@@ -4446,24 +4446,24 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
+    class="border-palette-gray4 mb-5 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="appleauthenticationsigninoptions"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           AppleAuthenticationSignInOptions
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#appleauthenticationsigninoptions"
         >
           <span
@@ -4498,19 +4498,19 @@ OAuth 2.0 protocol
       </h3>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         The options you can supply when making a call to 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationsigninasyncoptions"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
             data-text="true"
           >
             AppleAuthentication.signInAsync()
@@ -4520,7 +4520,7 @@ OAuth 2.0 protocol
 None of these options are required.
       </p>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0 [table_&]:mt-2"
+        class="border-default mb-4 flex rounded-md border gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
         data-md="callout"
         data-testid="callout-container"
       >
@@ -4550,21 +4550,21 @@ None of these options are required.
           </g>
         </svg>
         <div
-          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+          class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             <span
-              class="leading-[1.6154] text-default font-semibold"
+              class="leading-[1.6154] text-inherit font-semibold"
               data-text="true"
             >
               See:
             </span>
              
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest"
               rel="noopener noreferrer"
               target="_blank"
@@ -4582,29 +4582,29 @@ for more details.
       class=""
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
+      class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
-        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="border-b border-b-default bg-subtle"
+          class="border-b-default bg-subtle border-b"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Property
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -4612,47 +4612,47 @@ for more details.
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 nonce
               </span>
               <span
-                class="flex !text-3xs text-tertiary"
+                class="text-3xs! text-tertiary flex"
               >
                 (optional)
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 string
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   An arbitrary string that is used to prevent replay attacks. See more information on this in the
 
                   <a
-                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                     href="https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps"
                     rel="noopener noreferrer"
                     target="_blank"
@@ -4665,32 +4665,32 @@ for more details.
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 requestedScopes
               </span>
               <span
-                class="flex !text-3xs text-tertiary"
+                class="text-3xs! text-tertiary flex"
               >
                 (optional)
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="#appleauthenticationscope"
                 >
                   AppleAuthenticationScope
@@ -4699,20 +4699,20 @@ for more details.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   Array of user information scopes to which your app is requesting access. Note that the user can
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                     data-text="true"
                   >
                     null
@@ -4721,14 +4721,14 @@ handle
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                     data-text="true"
                   >
                     null
                   </code>
                   . Defaults to 
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                     data-text="true"
                   >
                     []
@@ -4739,41 +4739,41 @@ requests they will be
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 state
               </span>
               <span
-                class="flex !text-3xs text-tertiary"
+                class="text-3xs! text-tertiary flex"
               >
                 (optional)
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 string
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   An arbitrary string that is returned unmodified in the corresponding credential after a
@@ -4781,7 +4781,7 @@ successful authentication. This can be used to verify that the response was from
 you made and avoid replay attacks. More information on this property is available in the
 OAuth 2.0 protocol 
                   <a
-                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                     href="https://tools.ietf.org/html/rfc6749#section-10.12"
                     rel="noopener noreferrer"
                     target="_blank"
@@ -4798,24 +4798,24 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
+    class="border-palette-gray4 mb-5 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="appleauthenticationsignoutoptions"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           AppleAuthenticationSignOutOptions
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#appleauthenticationsignoutoptions"
         >
           <span
@@ -4850,19 +4850,19 @@ OAuth 2.0 protocol
       </h3>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         The options you can supply when making a call to 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationsignoutasyncoptions"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
             data-text="true"
           >
             AppleAuthentication.signOutAsync()
@@ -4872,7 +4872,7 @@ OAuth 2.0 protocol
 You must include the ID string of the user to sign out.
       </p>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0 [table_&]:mt-2"
+        class="border-default mb-4 flex rounded-md border gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
         data-md="callout"
         data-testid="callout-container"
       >
@@ -4902,21 +4902,21 @@ You must include the ID string of the user to sign out.
           </g>
         </svg>
         <div
-          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+          class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             <span
-              class="leading-[1.6154] text-default font-semibold"
+              class="leading-[1.6154] text-inherit font-semibold"
               data-text="true"
             >
               See:
             </span>
              
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest"
               rel="noopener noreferrer"
               target="_blank"
@@ -4934,29 +4934,29 @@ for more details.
       class=""
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
+      class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
-        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="border-b border-b-default bg-subtle"
+          class="border-b-default bg-subtle border-b"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Property
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -4964,41 +4964,41 @@ for more details.
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 state
               </span>
               <span
-                class="flex !text-3xs text-tertiary"
+                class="text-3xs! text-tertiary flex"
               >
                 (optional)
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 string
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   An arbitrary string that is returned unmodified in the corresponding credential after a
@@ -5006,7 +5006,7 @@ successful authentication. This can be used to verify that the response was from
 you made and avoid replay attacks. More information on this property is available in the
 OAuth 2.0 protocol 
                   <a
-                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                     href="https://tools.ietf.org/html/rfc6749#section-10.12"
                     rel="noopener noreferrer"
                     target="_blank"
@@ -5019,30 +5019,30 @@ OAuth 2.0 protocol
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 user
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 string
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
                 class="text-quaternary"
@@ -5056,13 +5056,13 @@ OAuth 2.0 protocol
     </div>
   </div>
   <h2
-    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mb-3.5 mt-8 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group flex gap-1 scroll-m-5"
+    class="text-inherit text-[25px] leading-[1.4] font-bold tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group flex gap-1 scroll-m-5"
     data-heading="true"
     id="enums"
   >
     Enums
     <a
-      class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[25px] min-w-[25px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100"
+      class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex size-[25px] min-w-[25px] justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100"
       href="#enums"
     >
       <span
@@ -5096,24 +5096,24 @@ OAuth 2.0 protocol
     </a>
   </h2>
   <div
-    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
+    class="border-palette-gray4 mb-5 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="appleauthenticationbuttonstyle"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           AppleAuthenticationButtonStyle
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#appleauthenticationbuttonstyle"
         >
           <span
@@ -5148,19 +5148,19 @@ OAuth 2.0 protocol
       </h3>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         An enum whose values control which pre-defined color scheme to use when rendering an 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationbutton"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
             data-text="true"
           >
             AppleAuthenticationButton
@@ -5170,24 +5170,24 @@ OAuth 2.0 protocol
       </p>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t-palette-gray4 border-t px-4 pt-3 pb-0 [&_h4]:mb-0.5"
     >
       <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+        class="max-md-gutters:flex-col flex flex-wrap justify-between"
       >
         <h4
-          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
+          class="text-inherit text-[16px] leading-relaxed font-semibold tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
           data-heading="true"
           id="white"
         >
           <code
-            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
+            class="leading-[1.6154] text-inherit text-sm! font-medium! wrap-anywhere!"
             data-text="true"
           >
             WHITE
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] !font-medium"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] font-medium!"
             href="#white"
           >
             <span
@@ -5222,7 +5222,7 @@ OAuth 2.0 protocol
         </h4>
       </div>
       <code
-        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
+        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.WHITE ＝ 0
@@ -5231,7 +5231,7 @@ OAuth 2.0 protocol
         class=""
       >
         <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
           data-text="true"
         >
           White button with black text.
@@ -5239,24 +5239,24 @@ OAuth 2.0 protocol
       </div>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t-palette-gray4 border-t px-4 pt-3 pb-0 [&_h4]:mb-0.5"
     >
       <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+        class="max-md-gutters:flex-col flex flex-wrap justify-between"
       >
         <h4
-          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
+          class="text-inherit text-[16px] leading-relaxed font-semibold tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
           data-heading="true"
           id="white_outline"
         >
           <code
-            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
+            class="leading-[1.6154] text-inherit text-sm! font-medium! wrap-anywhere!"
             data-text="true"
           >
             WHITE_OUTLINE
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] !font-medium"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] font-medium!"
             href="#white_outline"
           >
             <span
@@ -5291,7 +5291,7 @@ OAuth 2.0 protocol
         </h4>
       </div>
       <code
-        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
+        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.WHITE_OUTLINE ＝ 1
@@ -5300,7 +5300,7 @@ OAuth 2.0 protocol
         class=""
       >
         <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
           data-text="true"
         >
           White button with a black outline and black text.
@@ -5308,24 +5308,24 @@ OAuth 2.0 protocol
       </div>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t-palette-gray4 border-t px-4 pt-3 pb-0 [&_h4]:mb-0.5"
     >
       <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+        class="max-md-gutters:flex-col flex flex-wrap justify-between"
       >
         <h4
-          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
+          class="text-inherit text-[16px] leading-relaxed font-semibold tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
           data-heading="true"
           id="black"
         >
           <code
-            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
+            class="leading-[1.6154] text-inherit text-sm! font-medium! wrap-anywhere!"
             data-text="true"
           >
             BLACK
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] !font-medium"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] font-medium!"
             href="#black"
           >
             <span
@@ -5360,7 +5360,7 @@ OAuth 2.0 protocol
         </h4>
       </div>
       <code
-        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
+        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.BLACK ＝ 2
@@ -5369,7 +5369,7 @@ OAuth 2.0 protocol
         class=""
       >
         <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
           data-text="true"
         >
           Black button with white text.
@@ -5378,24 +5378,24 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
+    class="border-palette-gray4 mb-5 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="appleauthenticationbuttontype"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           AppleAuthenticationButtonType
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#appleauthenticationbuttontype"
         >
           <span
@@ -5430,19 +5430,19 @@ OAuth 2.0 protocol
       </h3>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         An enum whose values control which pre-defined text to use when rendering an 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationbutton"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
             data-text="true"
           >
             AppleAuthenticationButton
@@ -5452,24 +5452,24 @@ OAuth 2.0 protocol
       </p>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t-palette-gray4 border-t px-4 pt-3 pb-0 [&_h4]:mb-0.5"
     >
       <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+        class="max-md-gutters:flex-col flex flex-wrap justify-between"
       >
         <h4
-          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
+          class="text-inherit text-[16px] leading-relaxed font-semibold tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
           data-heading="true"
           id="sign_in"
         >
           <code
-            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
+            class="leading-[1.6154] text-inherit text-sm! font-medium! wrap-anywhere!"
             data-text="true"
           >
             SIGN_IN
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] !font-medium"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] font-medium!"
             href="#sign_in"
           >
             <span
@@ -5504,7 +5504,7 @@ OAuth 2.0 protocol
         </h4>
       </div>
       <code
-        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
+        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationButtonType.SIGN_IN ＝ 0
@@ -5513,7 +5513,7 @@ OAuth 2.0 protocol
         class=""
       >
         <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
           data-text="true"
         >
           "Sign in with Apple"
@@ -5521,24 +5521,24 @@ OAuth 2.0 protocol
       </div>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t-palette-gray4 border-t px-4 pt-3 pb-0 [&_h4]:mb-0.5"
     >
       <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+        class="max-md-gutters:flex-col flex flex-wrap justify-between"
       >
         <h4
-          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
+          class="text-inherit text-[16px] leading-relaxed font-semibold tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
           data-heading="true"
           id="continue"
         >
           <code
-            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
+            class="leading-[1.6154] text-inherit text-sm! font-medium! wrap-anywhere!"
             data-text="true"
           >
             CONTINUE
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] !font-medium"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] font-medium!"
             href="#continue"
           >
             <span
@@ -5573,7 +5573,7 @@ OAuth 2.0 protocol
         </h4>
       </div>
       <code
-        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
+        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationButtonType.CONTINUE ＝ 1
@@ -5582,7 +5582,7 @@ OAuth 2.0 protocol
         class=""
       >
         <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
           data-text="true"
         >
           "Continue with Apple"
@@ -5590,24 +5590,24 @@ OAuth 2.0 protocol
       </div>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t-palette-gray4 border-t px-4 pt-3 pb-0 [&_h4]:mb-0.5"
     >
       <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+        class="max-md-gutters:flex-col flex flex-wrap justify-between"
       >
         <h4
-          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
+          class="text-inherit text-[16px] leading-relaxed font-semibold tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
           data-heading="true"
           id="sign_up"
         >
           <code
-            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
+            class="leading-[1.6154] text-inherit text-sm! font-medium! wrap-anywhere!"
             data-text="true"
           >
             SIGN_UP
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] !font-medium"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] font-medium!"
             href="#sign_up"
           >
             <span
@@ -5645,15 +5645,15 @@ OAuth 2.0 protocol
           data-md="api-platforms"
         >
           <span
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
             data-text="true"
           >
             <div
-              class="mr-2 inline-flex min-h-[21px] select-none items-center gap-1 rounded-full border px-[7px] py-0.5 last:mr-0 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-blue3 text-palette-blue12 border-palette-blue4"
+              class="mr-2 inline-flex min-h-[21px] items-center gap-1 rounded-full border px-[7px] py-0.5 select-none last:mr-0 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-blue3 text-palette-blue12 border-palette-blue4"
               data-md="platform-badge"
             >
               <svg
-                class="translate-z icon-2xs mt-[-0.5px] shrink-0 text-palette-blue12 opacity-80"
+                class="translate-z icon-2xs text-palette-blue12 mt-[-0.5px] shrink-0 opacity-80"
                 fill="none"
                 role="img"
                 viewBox="0 0 24 24"
@@ -5669,7 +5669,7 @@ OAuth 2.0 protocol
                 </g>
               </svg>
               <span
-                class="whitespace-nowrap !text-3xs font-normal !leading-none"
+                class="text-3xs! leading-none! font-normal whitespace-nowrap"
               >
                 iOS 13.2+
               </span>
@@ -5678,7 +5678,7 @@ OAuth 2.0 protocol
         </div>
       </div>
       <code
-        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
+        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationButtonType.SIGN_UP ＝ 2
@@ -5687,7 +5687,7 @@ OAuth 2.0 protocol
         class=""
       >
         <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
           data-text="true"
         >
           "Sign up with Apple"
@@ -5696,24 +5696,24 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
+    class="border-palette-gray4 mb-5 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="appleauthenticationcredentialstate"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           AppleAuthenticationCredentialState
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#appleauthenticationcredentialstate"
         >
           <span
@@ -5748,19 +5748,19 @@ OAuth 2.0 protocol
       </h3>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         An enum whose values specify state of the credential when checked with 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationgetcredentialstateasyncuser"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
             data-text="true"
           >
             AppleAuthentication.getCredentialStateAsync()
@@ -5769,7 +5769,7 @@ OAuth 2.0 protocol
         .
       </p>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0 [table_&]:mt-2"
+        class="border-default mb-4 flex rounded-md border gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
         data-md="callout"
         data-testid="callout-container"
       >
@@ -5799,21 +5799,21 @@ OAuth 2.0 protocol
           </g>
         </svg>
         <div
-          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+          class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             <span
-              class="leading-[1.6154] text-default font-semibold"
+              class="leading-[1.6154] text-inherit font-semibold"
               data-text="true"
             >
               See:
             </span>
              
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidprovidercredentialstate"
               rel="noopener noreferrer"
               target="_blank"
@@ -5828,24 +5828,24 @@ for more details.
       </blockquote>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t-palette-gray4 border-t px-4 pt-3 pb-0 [&_h4]:mb-0.5"
     >
       <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+        class="max-md-gutters:flex-col flex flex-wrap justify-between"
       >
         <h4
-          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
+          class="text-inherit text-[16px] leading-relaxed font-semibold tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
           data-heading="true"
           id="revoked"
         >
           <code
-            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
+            class="leading-[1.6154] text-inherit text-sm! font-medium! wrap-anywhere!"
             data-text="true"
           >
             REVOKED
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] !font-medium"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] font-medium!"
             href="#revoked"
           >
             <span
@@ -5880,7 +5880,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
+        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationCredentialState.REVOKED ＝ 0
@@ -5890,24 +5890,24 @@ for more details.
       />
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t-palette-gray4 border-t px-4 pt-3 pb-0 [&_h4]:mb-0.5"
     >
       <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+        class="max-md-gutters:flex-col flex flex-wrap justify-between"
       >
         <h4
-          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
+          class="text-inherit text-[16px] leading-relaxed font-semibold tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
           data-heading="true"
           id="authorized"
         >
           <code
-            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
+            class="leading-[1.6154] text-inherit text-sm! font-medium! wrap-anywhere!"
             data-text="true"
           >
             AUTHORIZED
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] !font-medium"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] font-medium!"
             href="#authorized"
           >
             <span
@@ -5942,7 +5942,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
+        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationCredentialState.AUTHORIZED ＝ 1
@@ -5952,24 +5952,24 @@ for more details.
       />
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t-palette-gray4 border-t px-4 pt-3 pb-0 [&_h4]:mb-0.5"
     >
       <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+        class="max-md-gutters:flex-col flex flex-wrap justify-between"
       >
         <h4
-          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
+          class="text-inherit text-[16px] leading-relaxed font-semibold tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
           data-heading="true"
           id="not_found"
         >
           <code
-            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
+            class="leading-[1.6154] text-inherit text-sm! font-medium! wrap-anywhere!"
             data-text="true"
           >
             NOT_FOUND
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] !font-medium"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] font-medium!"
             href="#not_found"
           >
             <span
@@ -6004,7 +6004,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
+        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationCredentialState.NOT_FOUND ＝ 2
@@ -6014,24 +6014,24 @@ for more details.
       />
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t-palette-gray4 border-t px-4 pt-3 pb-0 [&_h4]:mb-0.5"
     >
       <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+        class="max-md-gutters:flex-col flex flex-wrap justify-between"
       >
         <h4
-          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
+          class="text-inherit text-[16px] leading-relaxed font-semibold tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
           data-heading="true"
           id="transferred"
         >
           <code
-            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
+            class="leading-[1.6154] text-inherit text-sm! font-medium! wrap-anywhere!"
             data-text="true"
           >
             TRANSFERRED
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] !font-medium"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] font-medium!"
             href="#transferred"
           >
             <span
@@ -6066,7 +6066,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
+        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationCredentialState.TRANSFERRED ＝ 3
@@ -6077,24 +6077,24 @@ for more details.
     </div>
   </div>
   <div
-    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
+    class="border-palette-gray4 mb-5 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="appleauthenticationoperation"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           AppleAuthenticationOperation
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#appleauthenticationoperation"
         >
           <span
@@ -6132,24 +6132,24 @@ for more details.
       class=""
     />
     <div
-      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t-palette-gray4 border-t px-4 pt-3 pb-0 [&_h4]:mb-0.5"
     >
       <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+        class="max-md-gutters:flex-col flex flex-wrap justify-between"
       >
         <h4
-          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
+          class="text-inherit text-[16px] leading-relaxed font-semibold tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
           data-heading="true"
           id="implicit"
         >
           <code
-            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
+            class="leading-[1.6154] text-inherit text-sm! font-medium! wrap-anywhere!"
             data-text="true"
           >
             IMPLICIT
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] !font-medium"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] font-medium!"
             href="#implicit"
           >
             <span
@@ -6184,7 +6184,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
+        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationOperation.IMPLICIT ＝ 0
@@ -6193,7 +6193,7 @@ for more details.
         class=""
       >
         <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
           data-text="true"
         >
           An operation that depends on the particular kind of credential provider.
@@ -6201,24 +6201,24 @@ for more details.
       </div>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t-palette-gray4 border-t px-4 pt-3 pb-0 [&_h4]:mb-0.5"
     >
       <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+        class="max-md-gutters:flex-col flex flex-wrap justify-between"
       >
         <h4
-          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
+          class="text-inherit text-[16px] leading-relaxed font-semibold tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
           data-heading="true"
           id="login"
         >
           <code
-            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
+            class="leading-[1.6154] text-inherit text-sm! font-medium! wrap-anywhere!"
             data-text="true"
           >
             LOGIN
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] !font-medium"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] font-medium!"
             href="#login"
           >
             <span
@@ -6253,7 +6253,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
+        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationOperation.LOGIN ＝ 1
@@ -6263,24 +6263,24 @@ for more details.
       />
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t-palette-gray4 border-t px-4 pt-3 pb-0 [&_h4]:mb-0.5"
     >
       <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+        class="max-md-gutters:flex-col flex flex-wrap justify-between"
       >
         <h4
-          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
+          class="text-inherit text-[16px] leading-relaxed font-semibold tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
           data-heading="true"
           id="refresh"
         >
           <code
-            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
+            class="leading-[1.6154] text-inherit text-sm! font-medium! wrap-anywhere!"
             data-text="true"
           >
             REFRESH
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] !font-medium"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] font-medium!"
             href="#refresh"
           >
             <span
@@ -6315,7 +6315,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
+        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationOperation.REFRESH ＝ 2
@@ -6325,24 +6325,24 @@ for more details.
       />
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t-palette-gray4 border-t px-4 pt-3 pb-0 [&_h4]:mb-0.5"
     >
       <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+        class="max-md-gutters:flex-col flex flex-wrap justify-between"
       >
         <h4
-          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
+          class="text-inherit text-[16px] leading-relaxed font-semibold tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
           data-heading="true"
           id="logout"
         >
           <code
-            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
+            class="leading-[1.6154] text-inherit text-sm! font-medium! wrap-anywhere!"
             data-text="true"
           >
             LOGOUT
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] !font-medium"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] font-medium!"
             href="#logout"
           >
             <span
@@ -6377,7 +6377,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
+        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationOperation.LOGOUT ＝ 3
@@ -6388,24 +6388,24 @@ for more details.
     </div>
   </div>
   <div
-    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
+    class="border-palette-gray4 mb-5 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="appleauthenticationscope"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           AppleAuthenticationScope
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#appleauthenticationscope"
         >
           <span
@@ -6440,19 +6440,19 @@ for more details.
       </h3>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         An enum whose values specify scopes you can request when calling 
         <a
-          class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+          class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationsigninasyncoptions"
         >
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
             data-text="true"
           >
             AppleAuthentication.signInAsync()
@@ -6463,7 +6463,7 @@ for more details.
       
 
       <blockquote
-        class="flex rounded-md border border-default bg-subtle gap-2 px-3 py-2.5 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-2.5 [table_&]:last:mb-0"
+        class="border-default bg-subtle flex rounded-md border gap-2 px-3 py-2.5 [&_code]:bg-element [&_p]:mb-0! shadow-none mb-2.5 [table_&]:last:mb-0"
         data-md="callout"
         data-testid="callout-container"
       >
@@ -6493,12 +6493,12 @@ for more details.
           </g>
         </svg>
         <div
-          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+          class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
           
 
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             Note that it is possible that you will not be granted all of the scopes which you request.
@@ -6509,7 +6509,7 @@ You will still need to handle null values for any fields you request.
         </div>
       </blockquote>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0 [table_&]:mt-2"
+        class="border-default mb-4 flex rounded-md border gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
         data-md="callout"
         data-testid="callout-container"
       >
@@ -6539,21 +6539,21 @@ You will still need to handle null values for any fields you request.
           </g>
         </svg>
         <div
-          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+          class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             <span
-              class="leading-[1.6154] text-default font-semibold"
+              class="leading-[1.6154] text-inherit font-semibold"
               data-text="true"
             >
               See:
             </span>
              
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="https://developer.apple.com/documentation/authenticationservices/asauthorizationscope"
               rel="noopener noreferrer"
               target="_blank"
@@ -6568,24 +6568,24 @@ for more details.
       </blockquote>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t-palette-gray4 border-t px-4 pt-3 pb-0 [&_h4]:mb-0.5"
     >
       <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+        class="max-md-gutters:flex-col flex flex-wrap justify-between"
       >
         <h4
-          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
+          class="text-inherit text-[16px] leading-relaxed font-semibold tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
           data-heading="true"
           id="full_name"
         >
           <code
-            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
+            class="leading-[1.6154] text-inherit text-sm! font-medium! wrap-anywhere!"
             data-text="true"
           >
             FULL_NAME
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] !font-medium"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] font-medium!"
             href="#full_name"
           >
             <span
@@ -6620,7 +6620,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
+        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationScope.FULL_NAME ＝ 0
@@ -6630,24 +6630,24 @@ for more details.
       />
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t-palette-gray4 border-t px-4 pt-3 pb-0 [&_h4]:mb-0.5"
     >
       <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+        class="max-md-gutters:flex-col flex flex-wrap justify-between"
       >
         <h4
-          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
+          class="text-inherit text-[16px] leading-relaxed font-semibold tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
           data-heading="true"
           id="email"
         >
           <code
-            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
+            class="leading-[1.6154] text-inherit text-sm! font-medium! wrap-anywhere!"
             data-text="true"
           >
             EMAIL
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] !font-medium"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] font-medium!"
             href="#email"
           >
             <span
@@ -6682,7 +6682,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
+        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationScope.EMAIL ＝ 1
@@ -6693,24 +6693,24 @@ for more details.
     </div>
   </div>
   <div
-    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
+    class="border-palette-gray4 mb-5 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="appleauthenticationuserdetectionstatus"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           AppleAuthenticationUserDetectionStatus
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#appleauthenticationuserdetectionstatus"
         >
           <span
@@ -6745,16 +6745,16 @@ for more details.
       </h3>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         An enum whose values specify the system's best guess for how likely the current user is a real person.
       </p>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0 [table_&]:mt-2"
+        class="border-default mb-4 flex rounded-md border gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
         data-md="callout"
         data-testid="callout-container"
       >
@@ -6784,21 +6784,21 @@ for more details.
           </g>
         </svg>
         <div
-          class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+          class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             <span
-              class="leading-[1.6154] text-default font-semibold"
+              class="leading-[1.6154] text-inherit font-semibold"
               data-text="true"
             >
               See:
             </span>
              
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="https://developer.apple.com/documentation/authenticationservices/asuserdetectionstatus"
               rel="noopener noreferrer"
               target="_blank"
@@ -6813,24 +6813,24 @@ for more details.
       </blockquote>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t-palette-gray4 border-t px-4 pt-3 pb-0 [&_h4]:mb-0.5"
     >
       <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+        class="max-md-gutters:flex-col flex flex-wrap justify-between"
       >
         <h4
-          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
+          class="text-inherit text-[16px] leading-relaxed font-semibold tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
           data-heading="true"
           id="unsupported"
         >
           <code
-            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
+            class="leading-[1.6154] text-inherit text-sm! font-medium! wrap-anywhere!"
             data-text="true"
           >
             UNSUPPORTED
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] !font-medium"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] font-medium!"
             href="#unsupported"
           >
             <span
@@ -6865,7 +6865,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
+        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.UNSUPPORTED ＝ 0
@@ -6874,7 +6874,7 @@ for more details.
         class=""
       >
         <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
           data-text="true"
         >
           The system does not support this determination and there is no data.
@@ -6882,24 +6882,24 @@ for more details.
       </div>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t-palette-gray4 border-t px-4 pt-3 pb-0 [&_h4]:mb-0.5"
     >
       <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+        class="max-md-gutters:flex-col flex flex-wrap justify-between"
       >
         <h4
-          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
+          class="text-inherit text-[16px] leading-relaxed font-semibold tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
           data-heading="true"
           id="unknown"
         >
           <code
-            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
+            class="leading-[1.6154] text-inherit text-sm! font-medium! wrap-anywhere!"
             data-text="true"
           >
             UNKNOWN
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] !font-medium"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] font-medium!"
             href="#unknown"
           >
             <span
@@ -6934,7 +6934,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
+        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.UNKNOWN ＝ 1
@@ -6943,7 +6943,7 @@ for more details.
         class=""
       >
         <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
           data-text="true"
         >
           The system has not determined whether the user might be a real person.
@@ -6951,24 +6951,24 @@ for more details.
       </div>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t-palette-gray4 border-t px-4 pt-3 pb-0 [&_h4]:mb-0.5"
     >
       <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+        class="max-md-gutters:flex-col flex flex-wrap justify-between"
       >
         <h4
-          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
+          class="text-inherit text-[16px] leading-relaxed font-semibold tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
           data-heading="true"
           id="likely_real"
         >
           <code
-            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
+            class="leading-[1.6154] text-inherit text-sm! font-medium! wrap-anywhere!"
             data-text="true"
           >
             LIKELY_REAL
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] !font-medium"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] font-medium!"
             href="#likely_real"
           >
             <span
@@ -7003,7 +7003,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
+        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.LIKELY_REAL ＝ 2
@@ -7012,7 +7012,7 @@ for more details.
         class=""
       >
         <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
           data-text="true"
         >
           The user appears to be a real person.
@@ -7026,13 +7026,13 @@ for more details.
 exports[`APISection expo-pedometer 1`] = `
 <div>
   <h2
-    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mb-3.5 mt-8 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group flex gap-1 scroll-m-5"
+    class="text-inherit text-[25px] leading-[1.4] font-bold tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group flex gap-1 scroll-m-5"
     data-heading="true"
     id="methods"
   >
     Methods
     <a
-      class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[25px] min-w-[25px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100"
+      class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex size-[25px] min-w-[25px] justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100"
       href="#methods"
     >
       <span
@@ -7066,24 +7066,24 @@ exports[`APISection expo-pedometer 1`] = `
     </a>
   </h2>
   <div
-    class="overflow-hidden rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
+    class="border-palette-gray4 overflow-hidden rounded-lg border [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="getpermissionsasync"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           getPermissionsAsync()
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#getpermissionsasync"
         >
           <span
@@ -7118,10 +7118,10 @@ exports[`APISection expo-pedometer 1`] = `
       </h3>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         Checks user's permissions for accessing pedometer.
@@ -7134,7 +7134,7 @@ exports[`APISection expo-pedometer 1`] = `
           class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            class="translate-z shrink-0 icon-sm text-icon-tertiary relative -mt-0.5 inline-block"
             fill="none"
             role="img"
             stroke="currentColor"
@@ -7153,17 +7153,17 @@ exports[`APISection expo-pedometer 1`] = `
             </g>
           </svg>
           <span
-            class="text-xs font-medium text-tertiary"
+            class="text-tertiary text-xs font-medium"
           >
             Returns:
           </span>
         </div>
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+            class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -7188,24 +7188,24 @@ exports[`APISection expo-pedometer 1`] = `
     </div>
   </div>
   <div
-    class="overflow-hidden rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
+    class="border-palette-gray4 overflow-hidden rounded-lg border [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="getstepcountasyncstart-end"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           getStepCountAsync(start, end)
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#getstepcountasyncstart-end"
         >
           <span
@@ -7243,15 +7243,15 @@ exports[`APISection expo-pedometer 1`] = `
         data-md="api-platforms"
       >
         <span
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
+          class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
           data-text="true"
         >
           <div
-            class="mr-2 inline-flex min-h-[21px] select-none items-center gap-1 rounded-full border px-[7px] py-0.5 last:mr-0 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-blue3 text-palette-blue12 border-palette-blue4"
+            class="mr-2 inline-flex min-h-[21px] items-center gap-1 rounded-full border px-[7px] py-0.5 select-none last:mr-0 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-blue3 text-palette-blue12 border-palette-blue4"
             data-md="platform-badge"
           >
             <svg
-              class="translate-z icon-2xs mt-[-0.5px] shrink-0 text-palette-blue12 opacity-80"
+              class="translate-z icon-2xs text-palette-blue12 mt-[-0.5px] shrink-0 opacity-80"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
@@ -7267,7 +7267,7 @@ exports[`APISection expo-pedometer 1`] = `
               </g>
             </svg>
             <span
-              class="whitespace-nowrap !text-3xs font-normal !leading-none"
+              class="text-3xs! leading-none! font-normal whitespace-nowrap"
             >
               iOS
             </span>
@@ -7276,29 +7276,29 @@ exports[`APISection expo-pedometer 1`] = `
       </div>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
+      class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
     >
       <table
-        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="border-b border-b-default bg-subtle"
+          class="border-b-default bg-subtle border-b"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -7306,13 +7306,13 @@ exports[`APISection expo-pedometer 1`] = `
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-md="api-param-name"
                 data-text="true"
               >
@@ -7320,14 +7320,14 @@ exports[`APISection expo-pedometer 1`] = `
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -7337,13 +7337,13 @@ exports[`APISection expo-pedometer 1`] = `
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:!mb-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   A date indicating the start of the range over which to measure steps.
@@ -7352,13 +7352,13 @@ exports[`APISection expo-pedometer 1`] = `
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-md="api-param-name"
                 data-text="true"
               >
@@ -7366,14 +7366,14 @@ exports[`APISection expo-pedometer 1`] = `
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date"
                   rel="noopener noreferrer"
                   target="_blank"
@@ -7383,13 +7383,13 @@ exports[`APISection expo-pedometer 1`] = `
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:!mb-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   A date indicating the end of the range over which to measure steps.
@@ -7402,10 +7402,10 @@ exports[`APISection expo-pedometer 1`] = `
     </div>
     <br />
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         Get the step count between two dates.
@@ -7418,7 +7418,7 @@ exports[`APISection expo-pedometer 1`] = `
           class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            class="translate-z shrink-0 icon-sm text-icon-tertiary relative -mt-0.5 inline-block"
             fill="none"
             role="img"
             stroke="currentColor"
@@ -7437,17 +7437,17 @@ exports[`APISection expo-pedometer 1`] = `
             </g>
           </svg>
           <span
-            class="text-xs font-medium text-tertiary"
+            class="text-tertiary text-xs font-medium"
           >
             Returns:
           </span>
         </div>
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+            class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -7461,7 +7461,7 @@ exports[`APISection expo-pedometer 1`] = `
           </span>
           <span>
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="#pedometerresult"
             >
               PedometerResult
@@ -7475,22 +7475,22 @@ exports[`APISection expo-pedometer 1`] = `
         </code>
       </div>
       <div
-        class="mb-1 mt-1.5 flex flex-col pl-6"
+        class="mt-1.5 mb-1 flex flex-col pl-6"
       >
         <div
           class=""
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             Returns a promise that fulfills with a 
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="#pedometerresult"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                 data-text="true"
               >
                 PedometerResult
@@ -7501,12 +7501,12 @@ exports[`APISection expo-pedometer 1`] = `
           
 
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             As 
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="https://developer.apple.com/documentation/coremotion/cmpedometer/1613946-querypedometerdatafromdate?language=objc"
               rel="noopener noreferrer"
               target="_blank"
@@ -7518,7 +7518,7 @@ exports[`APISection expo-pedometer 1`] = `
           
 
           <blockquote
-            class="flex rounded-md border border-default bg-subtle gap-2 px-3 py-2.5 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-2.5 [table_&]:last:mb-0"
+            class="border-default bg-subtle flex rounded-md border gap-2 px-3 py-2.5 [&_code]:bg-element [&_p]:mb-0! shadow-none mb-2.5 [table_&]:last:mb-0"
             data-md="callout"
             data-testid="callout-container"
           >
@@ -7548,12 +7548,12 @@ exports[`APISection expo-pedometer 1`] = `
               </g>
             </svg>
             <div
-              class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+              class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
             >
               
 
               <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                 data-text="true"
               >
                 Only the past seven days worth of data is stored and available for you to retrieve. Specifying
@@ -7568,24 +7568,24 @@ a start date that is more than seven days in the past returns only the available
     </div>
   </div>
   <div
-    class="overflow-hidden rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
+    class="border-palette-gray4 overflow-hidden rounded-lg border [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="isavailableasync"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           isAvailableAsync()
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#isavailableasync"
         >
           <span
@@ -7620,10 +7620,10 @@ a start date that is more than seven days in the past returns only the available
       </h3>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         Returns whether the pedometer is enabled on the device.
@@ -7636,7 +7636,7 @@ a start date that is more than seven days in the past returns only the available
           class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            class="translate-z shrink-0 icon-sm text-icon-tertiary relative -mt-0.5 inline-block"
             fill="none"
             role="img"
             stroke="currentColor"
@@ -7655,17 +7655,17 @@ a start date that is more than seven days in the past returns only the available
             </g>
           </svg>
           <span
-            class="text-xs font-medium text-tertiary"
+            class="text-tertiary text-xs font-medium"
           >
             Returns:
           </span>
         </div>
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+            class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -7688,18 +7688,18 @@ a start date that is more than seven days in the past returns only the available
         </code>
       </div>
       <div
-        class="mb-1 mt-1.5 flex flex-col pl-6"
+        class="mt-1.5 mb-1 flex flex-col pl-6"
       >
         <div
           class=""
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             Returns a promise that fulfills with a 
             <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
               data-text="true"
             >
               boolean
@@ -7712,24 +7712,24 @@ available on this device.
     </div>
   </div>
   <div
-    class="overflow-hidden rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
+    class="border-palette-gray4 overflow-hidden rounded-lg border [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="requestpermissionsasync"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           requestPermissionsAsync()
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#requestpermissionsasync"
         >
           <span
@@ -7764,10 +7764,10 @@ available on this device.
       </h3>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         Asks the user to grant permissions for accessing pedometer.
@@ -7780,7 +7780,7 @@ available on this device.
           class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            class="translate-z shrink-0 icon-sm text-icon-tertiary relative -mt-0.5 inline-block"
             fill="none"
             role="img"
             stroke="currentColor"
@@ -7799,17 +7799,17 @@ available on this device.
             </g>
           </svg>
           <span
-            class="text-xs font-medium text-tertiary"
+            class="text-tertiary text-xs font-medium"
           >
             Returns:
           </span>
         </div>
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           <a
-            class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+            class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
             rel="noopener noreferrer"
             target="_blank"
@@ -7834,24 +7834,24 @@ available on this device.
     </div>
   </div>
   <div
-    class="overflow-hidden rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
+    class="border-palette-gray4 overflow-hidden rounded-lg border [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="watchstepcountcallback"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           watchStepCount(callback)
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#watchstepcountcallback"
         >
           <span
@@ -7886,29 +7886,29 @@ available on this device.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
+      class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
     >
       <table
-        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="border-b border-b-default bg-subtle"
+          class="border-b-default bg-subtle border-b"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -7916,13 +7916,13 @@ available on this device.
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-md="api-param-name"
                 data-text="true"
               >
@@ -7930,14 +7930,14 @@ available on this device.
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="#pedometerupdatecallback"
                 >
                   PedometerUpdateCallback
@@ -7945,23 +7945,23 @@ available on this device.
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:!mb-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   A callback that is invoked when new step count data is available. The callback is
 provided with a single argument that is 
                   <a
-                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                     href="#pedometerresult"
                   >
                     <code
-                      class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                      class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                       data-text="true"
                     >
                       PedometerResult
@@ -7977,10 +7977,10 @@ provided with a single argument that is
     </div>
     <br />
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         Subscribe to pedometer updates.
@@ -7993,7 +7993,7 @@ provided with a single argument that is
           class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            class="translate-z shrink-0 icon-sm text-icon-tertiary relative -mt-0.5 inline-block"
             fill="none"
             role="img"
             stroke="currentColor"
@@ -8012,35 +8012,35 @@ provided with a single argument that is
             </g>
           </svg>
           <span
-            class="text-xs font-medium text-tertiary"
+            class="text-tertiary text-xs font-medium"
           >
             Returns:
           </span>
         </div>
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           EventSubscription
         </code>
       </div>
       <div
-        class="mb-1 mt-1.5 flex flex-col pl-6"
+        class="mt-1.5 mb-1 flex flex-col pl-6"
       >
         <div
           class=""
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             Returns a 
             <a
-              class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+              class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
               href="#subscription"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                 data-text="true"
               >
                 Subscription
@@ -8049,7 +8049,7 @@ provided with a single argument that is
              that enables you to call
 
             <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
               data-text="true"
             >
               remove()
@@ -8059,7 +8059,7 @@ provided with a single argument that is
           
 
           <blockquote
-            class="flex rounded-md border border-default bg-subtle gap-2 px-3 py-2.5 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-2.5 [table_&]:last:mb-0"
+            class="border-default bg-subtle flex rounded-md border gap-2 px-3 py-2.5 [&_code]:bg-element [&_p]:mb-0! shadow-none mb-2.5 [table_&]:last:mb-0"
             data-md="callout"
             data-testid="callout-container"
           >
@@ -8089,24 +8089,24 @@ provided with a single argument that is
               </g>
             </svg>
             <div
-              class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+              class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
             >
               
 
               <p
-                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                 data-text="true"
               >
                 Pedometer updates will not be delivered while the app is in the background. As an alternative, on Android, use another solution based on
 
                 <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                  class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                   href="https://developer.android.com/health-and-fitness/guides/health-connect"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
                   <code
-                    class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                     data-text="true"
                   >
                     Health Connect API
@@ -8115,7 +8115,7 @@ provided with a single argument that is
                 .
 On iOS, the 
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+                  class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
                   data-text="true"
                 >
                   getStepCountAsync
@@ -8131,13 +8131,13 @@ On iOS, the
     </div>
   </div>
   <h2
-    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mb-3.5 mt-8 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group flex gap-1 scroll-m-5"
+    class="text-inherit text-[25px] leading-[1.4] font-bold tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group flex gap-1 scroll-m-5"
     data-heading="true"
     id="interfaces"
   >
     Interfaces
     <a
-      class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[25px] min-w-[25px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100"
+      class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex size-[25px] min-w-[25px] justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100"
       href="#interfaces"
     >
       <span
@@ -8171,24 +8171,24 @@ On iOS, the
     </a>
   </h2>
   <div
-    class="rounded-lg border border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0 overflow-hidden"
+    class="border-palette-gray4 rounded-lg border [&_h2]:mt-0 [&_h3]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-4 shadow-none [&_h4]:mt-0 overflow-hidden"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="subscription"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           Subscription
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#subscription"
         >
           <span
@@ -8223,17 +8223,17 @@ On iOS, the
       </h3>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         A subscription object that allows to conveniently remove an event listener from the emitter.
       </p>
     </div>
     <p
-      class="tracking-[-0.006rem] flex border-y border-palette-gray4 bg-subtle px-4 py-2 text-2xs font-medium text-tertiary"
+      class="tracking-[-0.006rem] border-palette-gray4 bg-subtle text-2xs text-tertiary flex border-y px-4 py-2 font-medium"
       data-text="true"
     >
       <span
@@ -8243,7 +8243,7 @@ On iOS, the
       >
         Subscription Methods
         <a
-          class="border border-solid rounded-full whitespace-nowrap border-button-quaternary bg-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] flex flex-row items-center gap-2 text-2xs font-medium text-tertiary"
+          class="border border-solid rounded-full whitespace-nowrap border-button-quaternary bg-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] text-2xs text-tertiary flex flex-row items-center gap-2 font-medium"
           href="#subscription-methods"
         >
           <span
@@ -8278,24 +8278,24 @@ On iOS, the
       </span>
     </p>
     <div
-      class="border-b border-palette-gray4 last:border-b-0"
+      class="border-palette-gray4 border-b last:border-b-0"
     >
       <div
-        class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+        class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
       >
         <h3
-          class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+          class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
           data-heading="true"
           id="remove"
         >
           <code
-            class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+            class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
             data-text="true"
           >
             remove()
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
             href="#remove"
           >
             <span
@@ -8330,10 +8330,10 @@ On iOS, the
         </h3>
       </div>
       <div
-        class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+        class="px-4 [table_&]:mb-0! [table_&]:px-0"
       >
         <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
           data-text="true"
         >
           Removes an event listener for which the subscription has been created.
@@ -8347,7 +8347,7 @@ After calling this function, the listener will no longer receive any events from
             class="flex flex-row items-center gap-2"
           >
             <svg
-              class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+              class="translate-z shrink-0 icon-sm text-icon-tertiary relative -mt-0.5 inline-block"
               fill="none"
               role="img"
               stroke="currentColor"
@@ -8366,13 +8366,13 @@ After calling this function, the listener will no longer receive any events from
               </g>
             </svg>
             <span
-              class="text-xs font-medium text-tertiary"
+              class="text-tertiary text-xs font-medium"
             >
               Returns:
             </span>
           </div>
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
             data-text="true"
           >
             void
@@ -8382,13 +8382,13 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <h2
-    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mb-3.5 mt-8 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group flex gap-1 scroll-m-5"
+    class="text-inherit text-[25px] leading-[1.4] font-bold tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group flex gap-1 scroll-m-5"
     data-heading="true"
     id="types"
   >
     Types
     <a
-      class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[25px] min-w-[25px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100"
+      class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex size-[25px] min-w-[25px] justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100"
       href="#types"
     >
       <span
@@ -8422,24 +8422,24 @@ After calling this function, the listener will no longer receive any events from
     </a>
   </h2>
   <div
-    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
+    class="border-palette-gray4 mb-5 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="pedometerresult"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           PedometerResult
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#pedometerresult"
         >
           <span
@@ -8480,29 +8480,29 @@ After calling this function, the listener will no longer receive any events from
       class=""
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
+      class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
-        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="border-b border-b-default bg-subtle"
+          class="border-b-default bg-subtle border-b"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Property
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -8510,36 +8510,36 @@ After calling this function, the listener will no longer receive any events from
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 steps
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 number
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   Number of steps taken between the given dates.
@@ -8552,24 +8552,24 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
+    class="border-palette-gray4 mb-5 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="pedometerupdatecallbackresult"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           PedometerUpdateCallback(result)
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#pedometerupdatecallbackresult"
         >
           <span
@@ -8604,10 +8604,10 @@ After calling this function, the listener will no longer receive any events from
       </h3>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         Callback function providing event result as an argument.
@@ -8618,24 +8618,24 @@ After calling this function, the listener will no longer receive any events from
         class=""
       />
       <div
-        class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
+        class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
       >
         <table
-          class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+          class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
         >
           <thead
-            class="border-b border-b-default bg-subtle"
+            class="border-b-default bg-subtle border-b"
           >
             <tr
-              class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+              class="even:bg-subtle"
             >
               <th
-                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+                class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
               >
                 Parameter
               </th>
               <th
-                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+                class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
               >
                 Type
               </th>
@@ -8643,13 +8643,13 @@ After calling this function, the listener will no longer receive any events from
           </thead>
           <tbody>
             <tr
-              class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+              class="even:bg-subtle"
             >
               <td
-                class="border-r border-secondary p-4 text-left last:border-r-0"
+                class="border-secondary border-r p-4 text-left last:border-r-0"
               >
                 <span
-                  class="leading-[1.6154] text-default font-medium"
+                  class="leading-[1.6154] text-inherit font-medium"
                   data-md="api-param-name"
                   data-text="true"
                 >
@@ -8657,14 +8657,14 @@ After calling this function, the listener will no longer receive any events from
                 </span>
               </td>
               <td
-                class="border-r border-secondary p-4 text-left last:border-r-0"
+                class="border-secondary border-r p-4 text-left last:border-r-0"
               >
                 <code
-                  class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                  class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                   data-text="true"
                 >
                   <a
-                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                     href="#pedometerresult"
                   >
                     PedometerResult
@@ -8683,7 +8683,7 @@ After calling this function, the listener will no longer receive any events from
         class="flex flex-row items-center gap-2"
       >
         <svg
-          class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+          class="translate-z shrink-0 icon-sm text-icon-tertiary relative -mt-0.5 inline-block"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -8702,17 +8702,17 @@ After calling this function, the listener will no longer receive any events from
           </g>
         </svg>
         <span
-          class="text-xs font-medium text-tertiary"
+          class="text-tertiary text-xs font-medium"
         >
           Returns:
         </span>
       </div>
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]"
         data-text="true"
       >
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           void
@@ -8721,24 +8721,24 @@ After calling this function, the listener will no longer receive any events from
     </div>
   </div>
   <div
-    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
+    class="border-palette-gray4 mb-5 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="permissionexpiration"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           PermissionExpiration
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#permissionexpiration"
         >
           <span
@@ -8773,39 +8773,39 @@ After calling this function, the listener will no longer receive any events from
       </h3>
     </div>
     <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mx-4 mb-1.5"
+      class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mx-4 mb-1.5"
       data-text="true"
     >
       <span
-        class="text-xs font-medium text-tertiary"
+        class="text-tertiary text-xs font-medium"
       >
         Literal Type: 
       </span>
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+        class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
         data-text="true"
       >
         union
       </code>
     </p>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         Permission expiration time. Currently, all permissions are granted permanently.
       </p>
     </div>
     <p
-      class="tracking-[-0.006rem] text-xs font-medium text-tertiary mx-4 mb-2.5 [table_&]:last:mb-0"
+      class="tracking-[-0.006rem] text-tertiary text-xs font-medium mx-4 mb-2.5 [table_&]:last:mb-0"
       data-text="true"
     >
       Acceptable values are:
        
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 mb-px"
+        class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 mb-px"
         data-text="true"
       >
         'never'
@@ -8816,7 +8816,7 @@ After calling this function, the listener will no longer receive any events from
          | 
       </span>
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 mb-px"
+        class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 mb-px"
         data-text="true"
       >
         number
@@ -8824,24 +8824,24 @@ After calling this function, the listener will no longer receive any events from
     </p>
   </div>
   <div
-    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
+    class="border-palette-gray4 mb-5 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="permissionresponse"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           PermissionResponse
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#permissionresponse"
         >
           <span
@@ -8876,10 +8876,10 @@ After calling this function, the listener will no longer receive any events from
       </h3>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class="px-4 [table_&]:mb-0! [table_&]:px-0"
     >
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         An object obtained by permissions get and request functions.
@@ -8889,29 +8889,29 @@ After calling this function, the listener will no longer receive any events from
       class=""
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
+      class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
-        class="w-full rounded-none border-0 text-xs text-default [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
-          class="border-b border-b-default bg-subtle"
+          class="border-b-default bg-subtle border-b"
         >
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Property
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-3xs [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
             >
               Description
             </th>
@@ -8919,36 +8919,36 @@ After calling this function, the listener will no longer receive any events from
         </thead>
         <tbody>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 canAskAgain
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 boolean
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   Indicates if user can be asked again for specific permission.
@@ -8959,36 +8959,36 @@ in order to enable/disable the permission.
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 expires
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 PermissionExpiration
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   Determines time when the permission expires.
@@ -8997,36 +8997,36 @@ in order to enable/disable the permission.
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 granted
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 boolean
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   A convenience boolean that indicates if the permission is granted.
@@ -9035,36 +9035,36 @@ in order to enable/disable the permission.
             </td>
           </tr>
           <tr
-            class="even:bg-subtle even:[&_summary]:bg-element even:[&_blockquote]:bg-default"
+            class="even:bg-subtle"
           >
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <span
-                class="leading-[1.6154] text-default font-medium"
+                class="leading-[1.6154] text-inherit font-medium"
                 data-text="true"
               >
                 status
               </span>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:!text-inherit"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 PermissionStatus
               </code>
             </td>
             <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+              class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <div
-                class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+                class="px-4 [table_&]:mb-0! [table_&]:px-0"
               >
                 <p
-                  class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                   data-text="true"
                 >
                   Determines the status of the permission.
@@ -9077,13 +9077,13 @@ in order to enable/disable the permission.
     </div>
   </div>
   <h2
-    class="text-default text-[25px] font-bold leading-[1.4] tracking-[-0.021rem] mb-3.5 mt-8 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group flex gap-1 scroll-m-5"
+    class="text-inherit text-[25px] leading-[1.4] font-bold tracking-[-0.021rem] mt-8 mb-3.5 [&_code]:text-[90%] max-md-gutters:text-[22px] max-md-gutters:leading-[1.409] max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263] group flex gap-1 scroll-m-5"
     data-heading="true"
     id="enums"
   >
     Enums
     <a
-      class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex size-[25px] min-w-[25px] justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100"
+      class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex size-[25px] min-w-[25px] justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100"
       href="#enums"
     >
       <span
@@ -9117,24 +9117,24 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none"
+    class="border-palette-gray4 mb-5 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none"
   >
     <div
-      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:!mb-0"
+      class="mb-2.5 flex flex-wrap justify-between px-4 pt-3 max-md-gutters:flex-col max-md-gutters:gap-y-1.5 [&_h3]:mb-0!"
     >
       <h3
-        class="text-default text-[20px] font-semibold leading-normal tracking-[-0.017rem] mb-3 mt-7 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
+        class="text-inherit text-[20px] leading-normal font-semibold tracking-[-0.017rem] mt-7 mb-3 [&_code]:text-[90%] max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555] max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed group flex gap-1 scroll-m-8"
         data-heading="true"
         id="permissionstatus"
       >
         <code
-          class="leading-[1.6154] text-default font-medium !wrap-anywhere !text-base !leading-snug"
+          class="leading-[1.6154] text-inherit font-medium text-base! leading-snug! wrap-anywhere!"
           data-text="true"
         >
           PermissionStatus
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#permissionstatus"
         >
           <span
@@ -9172,24 +9172,24 @@ in order to enable/disable the permission.
       class=""
     />
     <div
-      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t-palette-gray4 border-t px-4 pt-3 pb-0 [&_h4]:mb-0.5"
     >
       <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+        class="max-md-gutters:flex-col flex flex-wrap justify-between"
       >
         <h4
-          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
+          class="text-inherit text-[16px] leading-relaxed font-semibold tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
           data-heading="true"
           id="denied"
         >
           <code
-            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
+            class="leading-[1.6154] text-inherit text-sm! font-medium! wrap-anywhere!"
             data-text="true"
           >
             DENIED
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] !font-medium"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] font-medium!"
             href="#denied"
           >
             <span
@@ -9224,7 +9224,7 @@ in order to enable/disable the permission.
         </h4>
       </div>
       <code
-        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
+        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
         data-text="true"
       >
         PermissionStatus.DENIED ＝ "denied"
@@ -9233,7 +9233,7 @@ in order to enable/disable the permission.
         class=""
       >
         <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
           data-text="true"
         >
           User has denied the permission.
@@ -9241,24 +9241,24 @@ in order to enable/disable the permission.
       </div>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t-palette-gray4 border-t px-4 pt-3 pb-0 [&_h4]:mb-0.5"
     >
       <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+        class="max-md-gutters:flex-col flex flex-wrap justify-between"
       >
         <h4
-          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
+          class="text-inherit text-[16px] leading-relaxed font-semibold tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
           data-heading="true"
           id="granted"
         >
           <code
-            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
+            class="leading-[1.6154] text-inherit text-sm! font-medium! wrap-anywhere!"
             data-text="true"
           >
             GRANTED
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] !font-medium"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] font-medium!"
             href="#granted"
           >
             <span
@@ -9293,7 +9293,7 @@ in order to enable/disable the permission.
         </h4>
       </div>
       <code
-        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
+        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
         data-text="true"
       >
         PermissionStatus.GRANTED ＝ "granted"
@@ -9302,7 +9302,7 @@ in order to enable/disable the permission.
         class=""
       >
         <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
           data-text="true"
         >
           User has granted the permission.
@@ -9310,24 +9310,24 @@ in order to enable/disable the permission.
       </div>
     </div>
     <div
-      class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
+      class="border-t-palette-gray4 border-t px-4 pt-3 pb-0 [&_h4]:mb-0.5"
     >
       <div
-        class="flex flex-wrap justify-between max-md-gutters:flex-col"
+        class="max-md-gutters:flex-col flex flex-wrap justify-between"
       >
         <h4
-          class="text-default text-[16px] font-semibold leading-relaxed tracking-[-0.011rem] mb-2 mt-6 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
+          class="text-inherit text-[16px] leading-relaxed font-semibold tracking-[-0.011rem] mt-6 mb-2 [&_code]:text-[90%] group flex gap-1 scroll-m-5"
           data-heading="true"
           id="undetermined"
         >
           <code
-            class="leading-[1.6154] text-default !wrap-anywhere !text-sm !font-medium"
+            class="leading-[1.6154] text-inherit text-sm! font-medium! wrap-anywhere!"
             data-text="true"
           >
             UNDETERMINED
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] !font-medium"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] font-medium!"
             href="#undetermined"
           >
             <span
@@ -9362,7 +9362,7 @@ in order to enable/disable the permission.
         </h4>
       </div>
       <code
-        class="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary"
+        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
         data-text="true"
       >
         PermissionStatus.UNDETERMINED ＝ "undetermined"
@@ -9371,7 +9371,7 @@ in order to enable/disable the permission.
         class=""
       >
         <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
           data-text="true"
         >
           User hasn't granted or denied the permission yet.
@@ -9385,7 +9385,7 @@ in order to enable/disable the permission.
 exports[`APISection no data 1`] = `
 <div>
   <p
-    class="text-default font-normal text-base [&_strong]:break-words"
+    class="text-inherit font-normal text-base [&_strong]:break-words"
     data-text="true"
   >
     No API data file found, sorry!

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -117,7 +117,7 @@ const renderClass = (
       <APISectionDeprecationNote comment={comment} sticky />
       <APIBoxHeader name={name} comment={comment} />
       {(extendedTypes?.length || implementedTypes?.length) && (
-        <CALLOUT className={mergeClasses('mb-3 !font-normal', STYLES_SECONDARY, VERTICAL_SPACING)}>
+        <CALLOUT className={mergeClasses('mb-3 font-normal!', STYLES_SECONDARY, VERTICAL_SPACING)}>
           <span className="font-medium">Type: </span>
           {type ? <CODE>{resolveTypeName(type, sdkVersion)}</CODE> : <span>Class</span>}
           {extendedTypes?.length && (
@@ -149,10 +149,10 @@ const renderClass = (
           returnComment && (
             <div className="flex flex-col items-start">
               <div className="flex flex-row items-center gap-2">
-                <CornerDownRightIcon className="icon-sm relative -mt-0.5 inline-block text-icon-tertiary" />
+                <CornerDownRightIcon className="icon-sm text-icon-tertiary relative -mt-0.5 inline-block" />
                 <span className={STYLES_SECONDARY}>Returns</span>
               </div>
-              <div className="mb-1 mt-1.5 flex flex-col pl-6">
+              <div className="mt-1.5 mb-1 flex flex-col pl-6">
                 <APICommentTextBlock
                   comment={{ summary: returnComment.content }}
                   includeSpacing={false}

--- a/docs/components/plugins/api/APISectionComponents.tsx
+++ b/docs/components/plugins/api/APISectionComponents.tsx
@@ -108,7 +108,7 @@ const renderComponent = (
   return (
     <div
       key={`component-definition-${resolvedName}`}
-      className={mergeClasses(STYLES_APIBOX, '!shadow-none')}>
+      className={mergeClasses(STYLES_APIBOX, 'shadow-none!')}>
       <APISectionDeprecationNote comment={extractedComment} sticky />
       <APIBoxHeader name={resolvedName} comment={extractedComment} />
       {resolvedType && resolvedTypeParameters && !hideType && (

--- a/docs/components/plugins/api/APISectionDeprecationNote.tsx
+++ b/docs/components/plugins/api/APISectionDeprecationNote.tsx
@@ -35,7 +35,7 @@ export const APISectionDeprecationNote = ({ comment, className, sticky = false }
         className={mergeClasses(
           'border-palette-yellow5',
           '[table_&]:last-of-type:mb-2.5',
-          sticky && 'mb-0 rounded-b-none rounded-t-lg px-4 shadow-none max-md-gutters:px-4',
+          sticky && 'max-md-gutters:px-4 mb-0 rounded-t-lg rounded-b-none px-4 shadow-none',
           className
         )}>
         {content.length > 0 ? (

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -35,18 +35,18 @@ function APISectionEnum({ data: { name, children, comment } }: { data: EnumDefin
       <APICommentTextBlock comment={comment} includePlatforms={false} />
       {children.sort(sortByValue).map((enumValue: EnumValueData) => (
         <div
-          className="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
+          className="border-t-palette-gray4 border-t px-4 pt-3 pb-0 [&_h4]:mb-0.5"
           key={enumValue.name}>
           <APISectionDeprecationNote comment={enumValue.comment} />
-          <div className="flex flex-wrap justify-between max-md-gutters:flex-col">
-            <H4 hideInSidebar className="!font-medium">
-              <MONOSPACE className="!wrap-anywhere !text-sm !font-medium">
+          <div className="max-md-gutters:flex-col flex flex-wrap justify-between">
+            <H4 hideInSidebar className="font-medium!">
+              <MONOSPACE className="text-sm! font-medium! wrap-anywhere!">
                 {enumValue.name}
               </MONOSPACE>
             </H4>
             <APISectionPlatformTags comment={enumValue.comment} disableFallback className="mb-1" />
           </div>
-          <MONOSPACE className="wrap-anywhere mb-2 inline-flex text-2xs text-tertiary">
+          <MONOSPACE className="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere">
             {`${name}.${enumValue.name} ＝ ${renderEnumValue(
               enumValue.type.value,
               enumValue.type.name

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -141,9 +141,9 @@ export const renderMethod = (
         className={mergeClasses(
           !nested && STYLES_APIBOX,
           !nested && STYLES_APIBOX_NESTED,
-          nested && 'border-b border-palette-gray4 last:border-b-0'
+          nested && 'border-palette-gray4 border-b last:border-b-0'
         )}>
-        <APISectionDeprecationNote comment={comment} sticky className="!rounded-t-none" />
+        <APISectionDeprecationNote comment={comment} sticky className="rounded-t-none!" />
         <APIBoxHeader
           name={getMethodName(
             method as MethodDefinitionData,
@@ -160,7 +160,7 @@ export const renderMethod = (
           tags={hasOverloads ? ['overload'] : undefined}
         />
         {hasOverloads && (
-          <div className="px-4 pb-2 text-tertiary">
+          <div className="text-tertiary px-4 pb-2">
             <BracketsEllipsesDuotoneIcon className="icon-xs mr-1 inline shrink-0" />
             <span className="text-3xs">Overload #{overloadIndex + 1}</span>
           </div>
@@ -184,13 +184,13 @@ export const renderMethod = (
                     !returnComment && getAllTagData('example', comment) && ELEMENT_SPACING
                   )}>
                   <div className="flex flex-row items-center gap-2">
-                    <CornerDownRightIcon className="icon-sm relative -mt-0.5 inline-block text-icon-tertiary" />
+                    <CornerDownRightIcon className="icon-sm text-icon-tertiary relative -mt-0.5 inline-block" />
                     <span className={STYLES_SECONDARY}>Returns:</span>
                   </div>
                   <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />
                 </div>
                 {returnComment ? (
-                  <div className="mb-1 mt-1.5 flex flex-col pl-6">
+                  <div className="mt-1.5 mb-1 flex flex-col pl-6">
                     <APICommentTextBlock
                       comment={{ summary: returnComment.content }}
                       includeSpacing={false}

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -79,7 +79,7 @@ const renderInheritedProps = (
     inheritedData.filter((ip: TypeDefinitionData) => ip.type === 'reference') ?? [];
   if (inheritedProps.length > 0) {
     return (
-      <div className={mergeClasses('border-t border-palette-gray4 px-4 py-3')}>
+      <div className={mergeClasses('border-palette-gray4 border-t px-4 py-3')}>
         {exposeInSidebar ? <H3>Inherited Props</H3> : <H4>Inherited Props</H4>}
         <UL>{inheritedProps.map(prop => renderInheritedProp(prop, sdkVersion))}</UL>
       </div>
@@ -115,7 +115,7 @@ const renderProps = (
     .filter((dec, i, arr) => arr.findIndex(t => t?.name === dec?.name) === i);
 
   return (
-    <div key={`props-definition-${def.name}`} className="[&>*]:last:!mb-0">
+    <div key={`props-definition-${def.name}`} className="[&>*]:last:mb-0!">
       {propsDeclarations?.map(prop =>
         prop
           ? renderProp(
@@ -158,8 +158,8 @@ export const renderProp = (
   return (
     <div
       key={`prop-entry-${name}`}
-      className={mergeClasses('border-t border-palette-gray4 first:border-t-0')}>
-      <APISectionDeprecationNote comment={extractedComment} className="mx-4 mb-0 mt-3" />
+      className={mergeClasses('border-palette-gray4 border-t first:border-t-0')}>
+      <APISectionDeprecationNote comment={extractedComment} className="mx-4 mt-3 mb-0" />
       <APIBoxHeader
         name={name}
         comment={extractedComment}

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -50,7 +50,7 @@ const renderTypeDeclarationTable = (
   <Fragment key={`type-declaration-table-${children?.map(child => child.name).join('-')}`}>
     {index && index > 0 ? (
       <CALLOUT
-        className={mergeClasses(STYLES_SECONDARY, 'border-t border-palette-gray4 px-4 py-3')}>
+        className={mergeClasses(STYLES_SECONDARY, 'border-palette-gray4 border-t px-4 py-3')}>
         Or <CODE className="text-default">object</CODE> shaped as below:
       </CALLOUT>
     ) : undefined}
@@ -78,7 +78,7 @@ const renderTypeMethodEntry = (
 
   const content = (
     <>
-      <RawH4 className="!mb-3">
+      <RawH4 className="mb-3!">
         <MONOSPACE>
           {`(${baseSignature.parameters ? listParams(baseSignature?.parameters) : ''})`}
           {` => `}
@@ -96,12 +96,12 @@ const renderTypeMethodEntry = (
   );
 
   if (inline) {
-    return <div className="border-t border-secondary p-4 pt-2.5">{content}</div>;
+    return <div className="border-secondary border-t p-4 pt-2.5">{content}</div>;
   } else {
     return (
       <APIBox
         key={`type-declaration-table-${children?.map(child => child.name).join('-')}`}
-        className="!mb-0">
+        className="mb-0!">
         {content}
       </APIBox>
     );
@@ -174,7 +174,7 @@ const renderType = (
   const defaultValueElement = defaultValue ? (
     <CALLOUT className="flex items-start gap-1">
       <span className={STYLES_SECONDARY}>Default:</span>
-      <CODE className="!text-[90%]">{defaultValue}</CODE>
+      <CODE className="text-[90!%]">{defaultValue}</CODE>
     </CALLOUT>
   ) : undefined;
 
@@ -210,7 +210,7 @@ const renderType = (
               'mt-3.5 flex flex-row items-start gap-2'
             )}>
             <div className="flex flex-row items-center gap-2">
-              <CornerDownRightIcon className="icon-sm relative -mt-0.5 inline-block text-icon-tertiary" />
+              <CornerDownRightIcon className="icon-sm text-icon-tertiary relative -mt-0.5 inline-block" />
               <span className={STYLES_SECONDARY}>Returns:</span>
             </div>
             <CALLOUT>

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -66,7 +66,7 @@ export const mdComponents: Components = {
         {children}
       </PrismCodeBlock>
     ) : (
-      <CODE className="break-words !inline py-0">{children}</CODE>
+      <CODE className="inline! py-0 break-words">{children}</CODE>
     );
   },
   pre: ({ children }) => <>{children}</>,
@@ -425,7 +425,7 @@ export const renderDefaultValue = (defaultValue?: string) =>
   defaultValue && defaultValue !== '...' ? (
     <div className="flex items-start gap-1">
       <span className={STYLES_SECONDARY}>Default:</span>
-      <CODE className="!text-[90%]">{defaultValue}</CODE>
+      <CODE className="text-[90!%]">{defaultValue}</CODE>
     </div>
   ) : undefined;
 

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`APISectionUtils.resolveTypeName Promise 1`] = `
 <div>
   <a
-    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+    class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
     href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
     rel="noopener noreferrer"
     target="_blank"
@@ -29,7 +29,7 @@ exports[`APISectionUtils.resolveTypeName Promise 1`] = `
 exports[`APISectionUtils.resolveTypeName Promise with custom type 1`] = `
 <div>
   <a
-    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+    class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
     href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
     rel="noopener noreferrer"
     target="_blank"
@@ -43,7 +43,7 @@ exports[`APISectionUtils.resolveTypeName Promise with custom type 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="#appleauthenticationcredential"
     >
       AppleAuthenticationCredential
@@ -148,7 +148,7 @@ exports[`APISectionUtils.resolveTypeName alternative generic object notation 1`]
 exports[`APISectionUtils.resolveTypeName custom type 1`] = `
 <div>
   <a
-    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+    class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
     href="https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesisEvent"
     rel="noopener noreferrer"
     target="_blank"
@@ -161,7 +161,7 @@ exports[`APISectionUtils.resolveTypeName custom type 1`] = `
 exports[`APISectionUtils.resolveTypeName custom type array 1`] = `
 <div>
   <a
-    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+    class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
     href="#appleauthenticationscope"
   >
     AppleAuthenticationScope
@@ -179,7 +179,7 @@ exports[`APISectionUtils.resolveTypeName custom type non-linkable array 1`] = `
 exports[`APISectionUtils.resolveTypeName custom type with single pick 1`] = `
 <div>
   <a
-    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+    class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
     href="https://www.typescriptlang.org/docs/handbook/utility-types.html#picktype-keys"
     rel="noopener noreferrer"
     target="_blank"
@@ -193,7 +193,7 @@ exports[`APISectionUtils.resolveTypeName custom type with single pick 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="#fontresource"
     >
       FontResource
@@ -233,7 +233,7 @@ exports[`APISectionUtils.resolveTypeName function 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="/versions/latest/sdk/speech#speecheventcallback"
     >
       SpeechEventCallback
@@ -258,7 +258,7 @@ exports[`APISectionUtils.resolveTypeName function with arguments 1`] = `
     </span>
      
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error"
       rel="noopener noreferrer"
       target="_blank"
@@ -282,7 +282,7 @@ exports[`APISectionUtils.resolveTypeName function with arguments 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="/versions/latest/sdk/speech#speecheventcallback"
     >
       SpeechEventCallback
@@ -307,7 +307,7 @@ exports[`APISectionUtils.resolveTypeName function with non-linkable custom type 
     </span>
      
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error"
       rel="noopener noreferrer"
       target="_blank"
@@ -334,7 +334,7 @@ exports[`APISectionUtils.resolveTypeName generic type 1`] = `
 exports[`APISectionUtils.resolveTypeName generic type 2`] = `
 <div>
   <a
-    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+    class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
     href="#pagedinfo"
   >
     PagedInfo
@@ -346,7 +346,7 @@ exports[`APISectionUtils.resolveTypeName generic type 2`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="/versions/latest/sdk/asset#asset"
     >
       Asset
@@ -363,7 +363,7 @@ exports[`APISectionUtils.resolveTypeName generic type 2`] = `
 exports[`APISectionUtils.resolveTypeName generic type in Promise 1`] = `
 <div>
   <a
-    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+    class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
     href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise"
     rel="noopener noreferrer"
     target="_blank"
@@ -377,7 +377,7 @@ exports[`APISectionUtils.resolveTypeName generic type in Promise 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="#pagedinfo"
     >
       PagedInfo
@@ -389,7 +389,7 @@ exports[`APISectionUtils.resolveTypeName generic type in Promise 1`] = `
     </span>
     <span>
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+        class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
         href="/versions/latest/sdk/asset#asset"
       >
         Asset
@@ -450,7 +450,7 @@ exports[`APISectionUtils.resolveTypeName props with multiple omits 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys"
       rel="noopener noreferrer"
       target="_blank"
@@ -464,7 +464,7 @@ exports[`APISectionUtils.resolveTypeName props with multiple omits 1`] = `
     </span>
     <span>
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+        class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
         href="https://reactnative.dev/docs/view-style-props"
         rel="noopener noreferrer"
         target="_blank"
@@ -532,7 +532,7 @@ exports[`APISectionUtils.resolveTypeName tuple type 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="#sortbykey"
     >
       SortByKey
@@ -558,7 +558,7 @@ exports[`APISectionUtils.resolveTypeName union 1`] = `
 <div>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="/versions/latest/sdk/speech#speecheventcallback"
     >
       SpeechEventCallback
@@ -584,7 +584,7 @@ exports[`APISectionUtils.resolveTypeName union of array values 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="#resultseterror"
     >
       ResultSetError
@@ -597,7 +597,7 @@ exports[`APISectionUtils.resolveTypeName union of array values 1`] = `
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="#resultset"
     >
       ResultSet
@@ -637,7 +637,7 @@ exports[`APISectionUtils.resolveTypeName union with custom type and array 1`] = 
 <div>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="#assetref"
     >
       AssetRef
@@ -651,7 +651,7 @@ exports[`APISectionUtils.resolveTypeName union with custom type and array 1`] = 
   </span>
   <span>
     <a
-      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+      class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
       href="#assetref"
     >
       AssetRef

--- a/docs/components/plugins/api/components/APIBoxHeader.tsx
+++ b/docs/components/plugins/api/components/APIBoxHeader.tsx
@@ -30,14 +30,14 @@ export function APIBoxHeader({
       className={mergeClasses(
         'mb-2.5 flex flex-wrap justify-between px-4 pt-3',
         'max-md-gutters:flex-col max-md-gutters:gap-y-1.5',
-        '[&_h3]:!mb-0'
+        '[&_h3]:mb-0!'
       )}>
       <HeaderComponent {...additionalProps} tags={tags}>
         <MONOSPACE
           weight="medium"
           className={mergeClasses(
-            '!wrap-anywhere !text-base !leading-snug',
-            deprecated && 'text-secondary line-through decoration-quaternary decoration-[0.5px]'
+            'text-base! leading-snug! wrap-anywhere!',
+            deprecated && 'text-secondary decoration-quaternary line-through decoration-[0.5px]'
           )}>
           {name}
         </MONOSPACE>

--- a/docs/components/plugins/api/components/APIBoxSectionHeader.tsx
+++ b/docs/components/plugins/api/components/APIBoxSectionHeader.tsx
@@ -28,10 +28,10 @@ export const APIBoxSectionHeader = ({
   return (
     <CALLOUT
       className={mergeClasses(
-        'flex border-y border-palette-gray4 bg-subtle px-4 py-2 text-2xs font-medium text-tertiary',
+        'border-palette-gray4 bg-subtle text-2xs text-tertiary flex border-y px-4 py-2 font-medium',
         className
       )}>
-      <TextWrapper className="flex flex-row items-center gap-2 text-2xs font-medium text-tertiary">
+      <TextWrapper className="text-2xs text-tertiary flex flex-row items-center gap-2 font-medium">
         {Icon && <Icon className="icon-sm text-icon-secondary" />}
         {text}
       </TextWrapper>

--- a/docs/components/plugins/api/components/APICommentTextBlock.tsx
+++ b/docs/components/plugins/api/components/APICommentTextBlock.tsx
@@ -63,19 +63,19 @@ export const APICommentTextBlock = ({
         className={mergeClasses(
           ELEMENT_SPACING,
           !isMultiline && 'flex items-center gap-1.5',
-          'last:[&>*]:!mb-0'
+          '[&>*:last-child]:mb-0!'
         )}>
         {inlineHeaders ? (
           <CALLOUT
             className={mergeClasses(
-              'my-1.5 flex flex-row items-center gap-1.5 font-medium text-tertiary',
+              'text-tertiary my-1.5 flex flex-row items-center gap-1.5 font-medium',
               !isMultiline && 'my-0'
             )}>
-            <CodeSquare01Icon className="icon-sm -mt-px text-icon-tertiary" />
+            <CodeSquare01Icon className="icon-sm text-icon-tertiary -mt-px" />
             Example
           </CALLOUT>
         ) : (
-          <APIBoxSectionHeader text="Example" className="-mx-4 mb-3 mt-1" Icon={CodeSquare01Icon} />
+          <APIBoxSectionHeader text="Example" className="-mx-4 mt-1 mb-3" Icon={CodeSquare01Icon} />
         )}
         <ReactMarkdown components={mdComponents} remarkPlugins={[remarkGfm, remarkSupsub]}>
           {exampleText}
@@ -87,7 +87,7 @@ export const APICommentTextBlock = ({
   const see = getTagData('see', comment);
   const seeContent = see && (
     <InlineHelp
-      className={mergeClasses('shadow-none', `!${ELEMENT_SPACING}`, '[table_&]:mt-2')}
+      className={mergeClasses('shadow-none', 'mb-2.5! [table_&]:last:mb-0!', '[table_&]:mt-2')}
       size="sm"
       type="info-light">
       <ReactMarkdown components={mdComponents} remarkPlugins={[remarkGfm, remarkSupsub]}>
@@ -101,7 +101,7 @@ export const APICommentTextBlock = ({
   return (
     <div
       className={mergeClasses(
-        includeSpacing && hasContent && 'px-4 [table_&]:!mb-0 [table_&]:px-0',
+        includeSpacing && hasContent && 'px-4 [table_&]:mb-0! [table_&]:px-0',
         emptyCommentFallback && !hasContent && 'text-quaternary'
       )}>
       {includePlatforms && hasPlatforms && (

--- a/docs/components/plugins/api/components/APIDataType.tsx
+++ b/docs/components/plugins/api/components/APIDataType.tsx
@@ -32,7 +32,7 @@ export const APIDataType = ({ typeDefinition, sdkVersion, inline = true }: APIDa
       {resolveTypeName(typeDefinition, sdkVersion)}
     </CodeBlock>
   ) : (
-    <CODE key={typeDefinition.name} className="[&>span]:!text-inherit">
+    <CODE key={typeDefinition.name} className="[&>span]:text-inherit!">
       {resolveTypeName(typeDefinition, sdkVersion)}
     </CODE>
   );

--- a/docs/components/plugins/api/components/APIParamDetailsBlock.tsx
+++ b/docs/components/plugins/api/components/APIParamDetailsBlock.tsx
@@ -19,7 +19,7 @@ export function APIParamDetailsBlock({ param, sdkVersion, className }: Props) {
   return (
     <div
       className={mergeClasses(
-        'flex flex-col gap-0.5 border-l-2 border-secondary pl-2.5 text-xs text-secondary',
+        'border-secondary text-secondary flex flex-col gap-0.5 border-l-2 pl-2.5 text-xs',
         className
       )}
       key={param.name}>

--- a/docs/components/plugins/api/components/APIParamRow.tsx
+++ b/docs/components/plugins/api/components/APIParamRow.tsx
@@ -40,7 +40,7 @@ export function APIParamRow({
         <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />
       </Cell>
       {showDescription && (
-        <Cell className="[&>*]:last:!mb-0">
+        <Cell className="[&>*]:last:mb-0!">
           <APICommentTextBlock
             comment={comment}
             afterContent={renderDefaultValue(initValue)}

--- a/docs/components/plugins/api/components/APISectionPlatformTags.tsx
+++ b/docs/components/plugins/api/components/APISectionPlatformTags.tsx
@@ -57,7 +57,7 @@ export const APISectionPlatformTags = ({
       className={mergeClasses('mb-3 flex flex-row items-start [table_&]:mb-2.5', className)}>
       {experimentalData.length > 0 && (
         <div className="inline-flex flex-row">
-          <StatusTag status="experimental" className="!mr-0" />
+          <StatusTag status="experimental" className="mr-0!" />
           {!!platformNames?.length && (
             <span className={mergeClasses(STYLES_SECONDARY)}>&ensp;&bull;&ensp;</span>
           )}

--- a/docs/components/plugins/api/components/__snapshots__/APICommentTextBlock.test.tsx.snap
+++ b/docs/components/plugins/api/components/__snapshots__/APICommentTextBlock.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`APICommentTextBlock basic comment 1`] = `
 <div>
   <div
-    class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+    class="px-4 [table_&]:mb-0! [table_&]:px-0"
   >
     <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+      class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
       data-text="true"
     >
       This is the basic comment.
@@ -18,22 +18,22 @@ exports[`APICommentTextBlock basic comment 1`] = `
 exports[`APICommentTextBlock comment with example 1`] = `
 <div>
   <div
-    class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+    class="px-4 [table_&]:mb-0! [table_&]:px-0"
   >
     <div
       class="mb-3 flex flex-row items-start [table_&]:mb-2.5"
       data-md="api-platforms"
     >
       <span
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] inline-flex items-center"
         data-text="true"
       >
         <div
-          class="mr-2 inline-flex min-h-[21px] select-none items-center gap-1 rounded-full border px-[7px] py-0.5 last:mr-0 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-green3 text-palette-green12 border-palette-green4"
+          class="mr-2 inline-flex min-h-[21px] items-center gap-1 rounded-full border px-[7px] py-0.5 select-none last:mr-0 [table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5 [h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0 bg-palette-green3 text-palette-green12 border-palette-green4"
           data-md="platform-badge"
         >
           <svg
-            class="translate-z icon-2xs mt-[-0.5px] shrink-0 text-palette-green12 opacity-80"
+            class="translate-z icon-2xs text-palette-green12 mt-[-0.5px] shrink-0 opacity-80"
             fill="none"
             role="img"
             viewBox="0 0 24 24"
@@ -49,7 +49,7 @@ exports[`APICommentTextBlock comment with example 1`] = `
             </g>
           </svg>
           <span
-            class="whitespace-nowrap !text-3xs font-normal !leading-none"
+            class="text-3xs! leading-none! font-normal whitespace-nowrap"
           >
             Android
           </span>
@@ -57,18 +57,18 @@ exports[`APICommentTextBlock comment with example 1`] = `
       </span>
     </div>
     <p
-      class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+      class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
       data-text="true"
     >
       Gets the referrer URL of the installed app with the 
       <a
-        class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+        class="cursor-pointer decoration-0 hocus:opacity-80 text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
         href="https://developer.android.com/google/play/installreferrer"
         rel="noopener noreferrer"
         target="_blank"
       >
         <code
-          class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
           data-text="true"
         >
           Install Referrer API
@@ -78,14 +78,14 @@ exports[`APICommentTextBlock comment with example 1`] = `
 from the Google Play Store. In practice, the referrer URL may not be a complete, absolute URL.
     </p>
     <div
-      class="mb-2.5 [table_&]:last:mb-0 last:[&>*]:!mb-0"
+      class="mb-2.5 [table_&]:last:mb-0 [&>*:last-child]:mb-0!"
     >
       <p
-        class="tracking-[-0.006rem] flex border-y border-palette-gray4 bg-subtle px-4 py-2 text-2xs font-medium text-tertiary -mx-4 mb-3 mt-1"
+        class="tracking-[-0.006rem] border-palette-gray4 bg-subtle text-2xs text-tertiary flex border-y px-4 py-2 font-medium -mx-4 mt-1 mb-3"
         data-text="true"
       >
         <span
-          class="tracking-[-0.006rem] flex flex-row items-center gap-2 text-2xs font-medium text-tertiary"
+          class="tracking-[-0.006rem] text-2xs text-tertiary flex flex-row items-center gap-2 font-medium"
           data-text="true"
         >
           <svg
@@ -111,7 +111,7 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
         </span>
       </p>
       <pre
-        class="relative my-4 overflow-x-auto whitespace-pre rounded-md border border-secondary bg-subtle [p+&]:mt-0"
+        class="border-secondary bg-subtle relative my-4 overflow-x-auto rounded-md border whitespace-pre [p+&]:mt-0"
         data-md-lang="ts"
         data-text="true"
       >

--- a/docs/components/plugins/api/styles.tsx
+++ b/docs/components/plugins/api/styles.tsx
@@ -3,20 +3,20 @@ import { mergeClasses } from '@expo/styleguide';
 export const ELEMENT_SPACING = mergeClasses('mb-2.5 [table_&]:last:mb-0');
 export const VERTICAL_SPACING = mergeClasses('mx-4');
 
-export const STYLES_SECONDARY = mergeClasses('text-xs font-medium text-tertiary');
+export const STYLES_SECONDARY = mergeClasses('text-tertiary text-xs font-medium');
 
-export const STYLES_OPTIONAL = mergeClasses('flex !text-3xs text-tertiary');
+export const STYLES_OPTIONAL = mergeClasses('text-3xs! text-tertiary flex');
 
 export const STYLES_APIBOX = mergeClasses(
-  'mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs',
+  'border-palette-gray4 mb-5 overflow-hidden rounded-lg border shadow-xs',
   '[&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0',
   '[&_h3]:mb-1.5',
   '[&_h4]:mb-0',
   '[&_li]:mb-0',
   '[&_thead]:border-palette-gray4',
-  '[&_th]:px-4 [&_th]:text-tertiary',
+  '[&_th]:text-tertiary [&_th]:px-4',
   '[&_td]:border-palette-gray4 [&_td]:py-3',
-  '[&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none'
+  '[&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none'
 );
 
 export const STYLES_APIBOX_NESTED = mergeClasses('mb-4 shadow-none [&_h4]:mt-0');

--- a/docs/components/plugins/permissions/AndroidPermissions.tsx
+++ b/docs/components/plugins/permissions/AndroidPermissions.tsx
@@ -60,15 +60,15 @@ function AndroidPermissionRow({
       {/* <Cell>{getPermissionGranter(permission)}</Cell> */}
       <Cell>
         {!!description && (
-          <P className={mergeClasses((warning || explanation) && '!mb-4')}>{description}</P>
+          <P className={mergeClasses((warning || explanation) && 'mb-4!')}>{description}</P>
         )}
         {!!warning && (
-          <InlineHelp className="mb-0 mt-1.5" type="warning">
+          <InlineHelp className="mt-1.5 mb-0" type="warning">
             {warning}
           </InlineHelp>
         )}
         {explanation && !warning && (
-          <InlineHelp className="mb-0 mt-1.5">
+          <InlineHelp className="mt-1.5 mb-0">
             <span dangerouslySetInnerHTML={{ __html: explanation }} />
           </InlineHelp>
         )}

--- a/docs/eslint.config.mjs
+++ b/docs/eslint.config.mjs
@@ -3,15 +3,15 @@ import { defineConfig, globalIgnores } from 'eslint/config';
 import universeNodeConfig from 'eslint-config-universe/flat/node.js';
 import universeTypescriptAnalysisConfig from 'eslint-config-universe/flat/shared/typescript-analysis.js';
 import universeWebConfig from 'eslint-config-universe/flat/web.js';
+import betterTailwindcss from 'eslint-plugin-better-tailwindcss';
 import lodash from 'eslint-plugin-lodash';
 import * as mdx from 'eslint-plugin-mdx';
-import tailwind from 'eslint-plugin-tailwindcss';
 import testingLibrary from 'eslint-plugin-testing-library';
 import unicorn from 'eslint-plugin-unicorn'; // eslint-disable-line
 
-const TAILWIND_DEFAULTS = {
+const TAILWIND_SETTINGS = {
+  entryPoint: 'styles/global.css',
   callees: ['mergeClasses'],
-  classRegex: '^(confirmation|container|icon)?(c|C)lass(Name)?$',
 };
 
 const CORE_RULES = {
@@ -109,11 +109,13 @@ export default defineConfig([
     files: ['**/*.ts', '**/*.tsx', '**/*.d.ts'],
     plugins: {
       '@next/next': nextPlugin,
-      tailwind,
+      'better-tailwindcss': betterTailwindcss,
       lodash,
       unicorn,
     },
-    extends: ['tailwind/flat/recommended'],
+    settings: {
+      'better-tailwindcss': TAILWIND_SETTINGS,
+    },
     rules: {
       ...nextPlugin.configs.recommended.rules,
       ...nextPlugin.configs['core-web-vitals'].rules,
@@ -208,15 +210,13 @@ export default defineConfig([
           warnOnDuplicates: true,
         },
       ],
-      'tailwindcss/classnames-order': 'off',
-      'tailwindcss/enforces-negative-arbitrary-values': 'error',
-      'tailwindcss/enforces-shorthand': 'error',
-      'tailwindcss/no-arbitrary-value': 'off',
-      'tailwindcss/no-custom-classname': [
+      'better-tailwindcss/enforce-consistent-class-order': 'off',
+      'better-tailwindcss/enforce-consistent-line-wrapping': 'off',
+      'better-tailwindcss/enforce-shorthand-classes': 'error',
+      'better-tailwindcss/no-unknown-classes': [
         'error',
         {
-          cssFiles: ['node_modules/@expo/styleguide/dist/global.css'],
-          whitelist: [
+          ignore: [
             'diff-.+',
             'react-player',
             'dark-theme',
@@ -224,11 +224,14 @@ export default defineConfig([
             'terminal-snippet',
             'table-wrapper',
             'tutorial-code-annotation',
+            'max-sm:.+',
+            'max-medium:.+',
+            'max-md-gutters:.+',
+            '\\[table_&\\]:.+',
+            '\\[table_&\\]',
           ],
-          ...TAILWIND_DEFAULTS,
         },
       ],
-      'tailwindcss/no-unnecessary-arbitrary-value': ['error', TAILWIND_DEFAULTS],
       'no-restricted-properties': [
         'warn',
         {

--- a/docs/eslint.config.mjs
+++ b/docs/eslint.config.mjs
@@ -9,9 +9,14 @@ import * as mdx from 'eslint-plugin-mdx';
 import testingLibrary from 'eslint-plugin-testing-library';
 import unicorn from 'eslint-plugin-unicorn'; // eslint-disable-line
 
+const CLASS_NAME_PREFIXES = ['container', 'icon', 'text'];
+
+const CLASS_NAME_PATTERN = '(c|C)lass(Name)?$';
+
 const TAILWIND_SETTINGS = {
   entryPoint: 'styles/global.css',
   callees: ['mergeClasses'],
+  attributes: [`^(${CLASS_NAME_PREFIXES.join('|')})?${CLASS_NAME_PATTERN}`],
 };
 
 const CORE_RULES = {

--- a/docs/package.json
+++ b/docs/package.json
@@ -32,11 +32,11 @@
   },
   "packageManager": "yarn@4.9.1",
   "dependencies": {
-    "@expo/styleguide": "^9.3.1",
+    "@expo/styleguide": "^10.0.1",
     "@expo/styleguide-base": "^2.0.5",
     "@expo/styleguide-cookie-consent": "^0.1.13",
-    "@expo/styleguide-icons": "^2.3.4",
-    "@expo/styleguide-search-ui": "^3.3.3",
+    "@expo/styleguide-icons": "^3.0.0",
+    "@expo/styleguide-search-ui": "^4.0.0",
     "@kapaai/react-sdk": "^0.9.0",
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/mdx": "^3.1.1",
@@ -80,6 +80,7 @@
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.9.3",
     "@expo/spawn-async": "^1.7.2",
+    "@tailwindcss/postcss": "^4.0.0",
     "@tailwindcss/typography": "^0.5.19",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
@@ -99,15 +100,14 @@
     "@types/turndown": "^5.0.6",
     "@vvago/vale": "3.12.0",
     "acorn": "^8.15.0",
-    "autoprefixer": "^10.4.21",
     "axios": "^1.12.2",
     "cheerio": "^1.2.0",
     "eslint": "^9.39.2",
     "eslint-config-next": "^16.1.6",
     "eslint-config-universe": "^15.0.3",
+    "eslint-plugin-better-tailwindcss": "^4.0.0",
     "eslint-plugin-lodash": "^8.0.0",
     "eslint-plugin-mdx": "^3.6.2",
-    "eslint-plugin-tailwindcss": "^3.18.2",
     "eslint-plugin-testing-library": "^7.13.4",
     "eslint-plugin-unicorn": "^62.0.0",
     "fs-extra": "^11.3.2",
@@ -116,7 +116,6 @@
     "jest-environment-jsdom": "^29.7.0",
     "next-router-mock": "^0.9.13",
     "postcss": "^8.5.6",
-    "postcss-import": "^16.1.1",
     "prettier": "^3.8.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "react-test-renderer": "^19.2.4",
@@ -126,7 +125,7 @@
     "remark-validate-links": "^13.1.0",
     "semver": "^7.7.3",
     "sitemap": "^8.0.2",
-    "tailwindcss": "^3.4.18",
+    "tailwindcss": "^4.0.0",
     "turndown": "^7.2.2",
     "turndown-plugin-gfm": "^1.0.2",
     "typescript": "~5.8.3",
@@ -156,9 +155,7 @@
   ],
   "postcss": {
     "plugins": {
-      "postcss-import": {},
-      "tailwindcss": {},
-      "autoprefixer": {}
+      "@tailwindcss/postcss": {}
     }
   },
   "resolutions": {

--- a/docs/pages/_error.tsx
+++ b/docs/pages/_error.tsx
@@ -51,12 +51,12 @@ const Error = () => {
   }, [redirectPath]);
 
   return (
-    <Layout className="flex flex-col items-center justify-center !pb-20">
+    <Layout className="flex flex-col items-center justify-center pb-20!">
       {redirectPath && (
         <>
           <DocumentationHead title="Redirecting" />
           <RedirectImage />
-          <H1 className="!mt-8">Redirecting</H1>
+          <H1 className="mt-8!">Redirecting</H1>
           {/* note(simek): "redirect-link" ID is needed for test-links script */}
           <P theme="secondary" className="mb-8 max-w-[450px] text-center" id="redirect-link">
             Just a moment…
@@ -67,7 +67,7 @@ const Error = () => {
         <>
           <DocumentationHead title="Not Found" />
           {redirectFailed ? <ServerErrorImage /> : <NotFoundImage />}
-          <H1 className="!mt-8">404: Not Found</H1>
+          <H1 className="mt-8!">404: Not Found</H1>
           {redirectFailed ? (
             <P theme="secondary" className="mb-8 max-w-[450px] text-center" id="__redirect_failed">
               We took an educated guess and tried to direct you to the right page, but it seems that

--- a/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
@@ -107,7 +107,7 @@ function HookComponent() {
 
 <APIBoxSectionHeader text="Returns" />
 
-<CornerDownRightIcon className="icon-sm mr-2 inline-block align-middle text-icon-secondary" />
+<CornerDownRightIcon className="icon-sm text-icon-secondary mr-2 inline-block align-middle" />
 [`EdgeInsets`](#edgeinsets)
 
 </PaddedAPIBox>

--- a/docs/pages/versions/v53.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/safe-area-context.mdx
@@ -107,7 +107,7 @@ function HookComponent() {
 
 <APIBoxSectionHeader text="Returns" />
 
-<CornerDownRightIcon className="icon-sm mr-2 inline-block align-middle text-icon-secondary" />
+<CornerDownRightIcon className="icon-sm text-icon-secondary mr-2 inline-block align-middle" />
 [`EdgeInsets`](#edgeinsets)
 
 </PaddedAPIBox>

--- a/docs/pages/versions/v54.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/safe-area-context.mdx
@@ -107,7 +107,7 @@ function HookComponent() {
 
 <APIBoxSectionHeader text="Returns" />
 
-<CornerDownRightIcon className="icon-sm mr-2 inline-block align-middle text-icon-secondary" />
+<CornerDownRightIcon className="icon-sm text-icon-secondary mr-2 inline-block align-middle" />
 [`EdgeInsets`](#edgeinsets)
 
 </PaddedAPIBox>

--- a/docs/pages/versions/v55.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/safe-area-context.mdx
@@ -107,7 +107,7 @@ function HookComponent() {
 
 <APIBoxSectionHeader text="Returns" />
 
-<CornerDownRightIcon className="icon-sm mr-2 inline-block align-middle text-icon-secondary" />
+<CornerDownRightIcon className="icon-sm text-icon-secondary mr-2 inline-block align-middle" />
 [`EdgeInsets`](#edgeinsets)
 
 </PaddedAPIBox>

--- a/docs/scenes/get-started/set-up-your-environment/BuildEnvironmentSwitch.tsx
+++ b/docs/scenes/get-started/set-up-your-environment/BuildEnvironmentSwitch.tsx
@@ -50,7 +50,7 @@ export function BuildEnvironmentSwitch() {
   }
 
   return (
-    <div className="flex items-start gap-3 rounded-lg border border-default bg-subtle px-4 py-3">
+    <div className="border-default bg-subtle flex items-start gap-3 rounded-lg border px-4 py-3">
       <div className="mt-1">
         <Switch onChange={onSwitchChange} value={!buildEnv} />{' '}
       </div>

--- a/docs/scenes/get-started/set-up-your-environment/SelectCard.tsx
+++ b/docs/scenes/get-started/set-up-your-environment/SelectCard.tsx
@@ -27,13 +27,13 @@ export function SelectCard({
     <ButtonBase onClick={onClick}>
       <div
         className={mergeClasses(
-          'flex w-[250px] flex-col overflow-hidden rounded-lg border border-default shadow-xs transition-all',
+          'border-default flex w-[250px] flex-col overflow-hidden rounded-lg border shadow-xs transition-all',
           'hocus:scale-[102%] hocus:shadow-sm'
         )}>
         <div
           className={mergeClasses(
-            'border-b border-default',
-            isSelected ? 'bg-gradient-to-b from-palette-blue3 to-palette-blue4' : 'bg-subtle'
+            'border-default border-b',
+            isSelected ? 'from-palette-blue3 to-palette-blue4 bg-linear-to-b' : 'bg-subtle'
           )}>
           <picture className="relative flex h-full w-auto items-end">
             {themeName !== 'light' && (
@@ -55,13 +55,13 @@ export function SelectCard({
             <div className="relative">
               <div
                 className={mergeClasses(
-                  'size-5 rounded-full border bg-default',
+                  'bg-default size-5 rounded-full border',
                   isSelected ? 'border-palette-blue9' : 'border-default'
                 )}
               />
               <div
                 className={mergeClasses(
-                  'absolute right-1 top-1 size-3 rounded-full',
+                  'absolute top-1 right-1 size-3 rounded-full',
                   isSelected ? 'border-palette-blue9 bg-palette-blue9' : 'bg-transparent'
                 )}
               />

--- a/docs/scenes/get-started/set-up-your-environment/instructions/androidPhysicalExpoGo.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/androidPhysicalExpoGo.mdx
@@ -4,7 +4,7 @@ import QRCodeReact from 'react-qr-code';
 
 Scan the QR code to download the app from the Google Play Store, or visit the Expo Go page on the [Google Play Store](https://play.google.com/store/apps/details?id=host.exp.exponent&referrer=docs).
 
-<div className="inline-block rounded-lg border border-default bg-palette-white p-4">
+<div className="border-default bg-palette-white inline-block rounded-lg border p-4">
   <QRCodeReact
     value="https://play.google.com/store/apps/details?id=host.exp.exponent&referrer=docs"
     size={228}

--- a/docs/scenes/get-started/start-developing/ProjectStructure/Tab.tsx
+++ b/docs/scenes/get-started/start-developing/ProjectStructure/Tab.tsx
@@ -17,8 +17,8 @@ export function Tab({ title, onClick, isSelected, type }: Props) {
     <ButtonBase
       onClick={onClick}
       className={mergeClasses(
-        'items-center gap-1.5 rounded-md border border-transparent px-3 py-1.5 text-left hocus:bg-hover',
-        isSelected && 'border border-default bg-default shadow-xs'
+        'hocus:bg-hover items-center gap-1.5 rounded-md border border-transparent px-3 py-1.5 text-left',
+        isSelected && 'border-default bg-default border shadow-xs'
       )}>
       {type === 'directory' ? <FolderIcon className="icon-sm text-icon-tertiary" /> : null}
       {type === 'file' ? <FileCode01Icon className="icon-sm text-icon-tertiary" /> : null}

--- a/docs/scenes/get-started/start-developing/ProjectStructure/index.tsx
+++ b/docs/scenes/get-started/start-developing/ProjectStructure/index.tsx
@@ -18,14 +18,14 @@ export function ProjectStructure() {
   const [selected, setSelected] = useState('app');
 
   return (
-    <div className="overflow-hidden rounded-md border border-default text-default">
-      <div className="flex border-b border-default bg-subtle p-3 pl-4">
+    <div className="border-default text-default overflow-hidden rounded-md border">
+      <div className="border-default bg-subtle flex border-b p-3 pl-4">
         <HEADLINE>Files</HEADLINE>
       </div>
-      <div className="grid grid-cols-[250px_minmax(0,_1fr)] max-md-gutters:grid-cols-1">
+      <div className="max-md-gutters:grid-cols-1 grid grid-cols-[250px_minmax(0,_1fr)]">
         <div
           className={mergeClasses(
-            'flex flex-col gap-1 border-r border-default p-3',
+            'border-default flex flex-col gap-1 border-r p-3',
             'max-md-gutters:border-b max-md-gutters:border-r-0'
           )}>
           <Tab

--- a/docs/scenes/get-started/start-developing/TemplateFeatures/Content.tsx
+++ b/docs/scenes/get-started/start-developing/TemplateFeatures/Content.tsx
@@ -25,13 +25,13 @@ export function Content({ imgSrc, darkImgSrc, alt, href, content }: Props) {
 
   return (
     <div>
-      <div className="flex items-center justify-center bg-screen">
+      <div className="bg-screen flex items-center justify-center">
         <picture className="relative">
           {isDarkMode && <source srcSet={darkImgSrc} type="image/png" />}
           <img src={imgSrc} alt={alt} className="size-[300px]" />
         </picture>
       </div>
-      <div className="flex flex-col items-start gap-3 border-t border-default bg-default px-6 pb-6">
+      <div className="border-default bg-default flex flex-col items-start gap-3 border-t px-6 pb-6">
         <div>
           {content}
           {href && (

--- a/docs/scenes/get-started/start-developing/TemplateFeatures/Tab.tsx
+++ b/docs/scenes/get-started/start-developing/TemplateFeatures/Tab.tsx
@@ -14,8 +14,8 @@ export function Tab({ title, onClick, isSelected }: Props) {
     <ButtonBase
       onClick={onClick}
       className={mergeClasses(
-        'rounded-md border border-transparent px-3 py-1.5 text-left hocus:bg-hover',
-        isSelected && 'border border-default bg-default shadow-xs'
+        'hocus:bg-hover rounded-md border border-transparent px-3 py-1.5 text-left',
+        isSelected && 'border-default bg-default border shadow-xs'
       )}>
       <CALLOUT theme={isSelected ? 'default' : 'secondary'}>{title}</CALLOUT>
     </ButtonBase>

--- a/docs/scenes/get-started/start-developing/TemplateFeatures/index.tsx
+++ b/docs/scenes/get-started/start-developing/TemplateFeatures/index.tsx
@@ -15,14 +15,14 @@ export function TemplateFeatures() {
   const [selected, setSelected] = useState('navigation');
 
   return (
-    <div className="overflow-hidden rounded-md border border-default text-default">
-      <div className="flex border-b border-default bg-subtle p-3 pl-4">
+    <div className="border-default text-default overflow-hidden rounded-md border">
+      <div className="border-default bg-subtle flex border-b p-3 pl-4">
         <HEADLINE>Default project</HEADLINE>
       </div>
-      <div className="grid grid-cols-[250px_minmax(0,_1fr)] max-md-gutters:grid-cols-1">
+      <div className="max-md-gutters:grid-cols-1 grid grid-cols-[250px_minmax(0,_1fr)]">
         <div
           className={mergeClasses(
-            'flex flex-col gap-1 border-r border-default p-3',
+            'border-default flex flex-col gap-1 border-r p-3',
             'max-md-gutters:border-b max-md-gutters:border-r-0'
           )}>
           <Tab

--- a/docs/styles/global.css
+++ b/docs/styles/global.css
@@ -1,31 +1,32 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
+@config "../tailwind.config.cjs";
 
-html {
-  @apply bg-default;
-}
+@layer base {
+  html {
+    @apply bg-default;
+  }
 
-body {
-  text-rendering: optimizeLegibility;
-  line-height: 1;
-}
+  body {
+    text-rendering: optimizeLegibility;
+    line-height: 1;
+  }
 
-input {
-  appearance: unset;
-}
+  input {
+    appearance: unset;
+  }
 
-#__next[aria-hidden] {
-  filter: none !important;
-}
+  #__next[aria-hidden] {
+    filter: none !important;
+  }
 
-img {
-  max-width: 768px;
-  width: 100%;
-}
+  img {
+    max-width: 768px;
+    width: 100%;
+  }
 
-img.wide-image {
-  max-width: 900px;
+  img.wide-image {
+    max-width: 900px;
+  }
 }
 
 code {

--- a/docs/tailwind.config.cjs
+++ b/docs/tailwind.config.cjs
@@ -29,12 +29,12 @@ module.exports = {
     borderColor: {
       'palette-orange3.5': 'hsl(from var(--orange-4) h calc(s - 5) calc(l + 5));',
     },
-    backgroundImage: () => ({
+    backgroundImage: {
       'cell-quickstart-pattern': "url('/static/images/home/QuickStartPattern.svg')",
       'cell-tutorial-pattern': "url('/static/images/home/TutorialPattern.svg')",
       'launch-party-banner': "url('/static/images/launch-party-banner-bg.svg')",
       'launch-party-banner-mobile': "url('/static/images/launch-party-banner-bg.svg') 200px",
-    }),
+    },
     keyframes: {
       wave: {
         '0%, 100%': {

--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -4,10 +4,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
 <div>
   <div>
     <div
-      class="overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default px-4 py-3 !pb-4 last:[&>*]:!mb-1"
+      class="border-palette-gray4 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 mb-0! rounded-none! border-b-0! shadow-none! [&]:first-of-type:rounded-t-md! [&]:last-of-type:border-default! [&]:last-of-type:rounded-b-md! [&]:last-of-type:border-b! px-4 py-3 pb-4! [&>*:last-child]:mb-1!"
     >
       <h3
-        class="text-default font-normal text-base [&_strong]:break-words group flex gap-1 scroll-m-8"
+        class="text-inherit font-normal text-base [&_strong]:break-words group flex gap-1 scroll-m-8"
         data-heading="true"
         id="name"
       >
@@ -17,7 +17,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           name
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#name"
         >
           <span
@@ -60,7 +60,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         >
           Type: 
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
             data-text="true"
           >
             string
@@ -68,21 +68,21 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </span>
       </div>
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         Name of your app.
       </p>
       <details
-        class="mb-3 scroll-m-4 rounded-md border border-default bg-default p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
+        class="border-default bg-default mb-3 scroll-m-4 rounded-md border p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
         data-md="collapsible"
         id="existing-react-native-app"
       >
         <summary
-          class="group m-0 grid cursor-pointer grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3 [details[open]>&]:rounded-b-none [&_h4]:my-0 [&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
+          class="group bg-subtle m-0 grid cursor-pointer grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md p-1.5 pr-3 [details[open]>&]:rounded-b-none [&_h4]:my-0 [&_code]:bg-element [&_code]:mt-px [&_code]:inline [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
         >
           <div
-            class="ml-1.5 mr-2 mt-[5px] self-baseline"
+            class="mt-[5px] mr-2 ml-1.5 self-baseline"
           >
             <svg
               class="translate-z shrink-0 icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
@@ -102,14 +102,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </svg>
           </div>
           <span
-            class="leading-[1.6154] text-default font-medium relative mr-1 inline scroll-m-5 items-center gap-1.5 group-hover:text-secondary group-hover:[&_code]:text-secondary"
+            class="leading-[1.6154] text-inherit font-medium relative mr-1 inline scroll-m-5 items-center gap-1.5 group-hover:text-secondary group-hover:[&_code]:text-secondary"
             data-text="true"
           >
             Existing React Native app?
           </span>
           <a
             aria-label="Permalink"
-            class="ml-auto inline rounded-md p-1 hocus:bg-element"
+            class="hocus:bg-element ml-auto inline rounded-md p-1"
             href="#existing-react-native-app"
           >
             <svg
@@ -144,10 +144,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           style="height: 0px;"
         >
           <div
-            class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
+            class="px-5 py-4 [&_p]:ml-0 [&_pre>pre]:mt-0 [&>*:last-child]:mb-1!"
           >
             <p
-              class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+              class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
               data-text="true"
             >
               Edit the 'Display Name' field in Xcode
@@ -157,10 +157,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </details>
     </div>
     <div
-      class="overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default px-4 py-3 !pb-4 last:[&>*]:!mb-1"
+      class="border-palette-gray4 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 mb-0! rounded-none! border-b-0! shadow-none! [&]:first-of-type:rounded-t-md! [&]:last-of-type:border-default! [&]:last-of-type:rounded-b-md! [&]:last-of-type:border-b! px-4 py-3 pb-4! [&>*:last-child]:mb-1!"
     >
       <h3
-        class="text-default font-normal text-base [&_strong]:break-words group flex gap-1 scroll-m-8"
+        class="text-inherit font-normal text-base [&_strong]:break-words group flex gap-1 scroll-m-8"
         data-heading="true"
         id="androidnavigationbar"
       >
@@ -170,7 +170,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           androidNavigationBar
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#androidnavigationbar"
         >
           <span
@@ -213,7 +213,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         >
           Type: 
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
             data-text="true"
           >
             object
@@ -221,21 +221,21 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </span>
       </div>
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         Configuration for the bottom navigation bar on Android.
       </p>
       <details
-        class="mb-3 scroll-m-4 rounded-md border border-default bg-default p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
+        class="border-default bg-default mb-3 scroll-m-4 rounded-md border p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
         data-md="collapsible"
         id="existing-react-native-app-1"
       >
         <summary
-          class="group m-0 grid cursor-pointer grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3 [details[open]>&]:rounded-b-none [&_h4]:my-0 [&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
+          class="group bg-subtle m-0 grid cursor-pointer grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md p-1.5 pr-3 [details[open]>&]:rounded-b-none [&_h4]:my-0 [&_code]:bg-element [&_code]:mt-px [&_code]:inline [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
         >
           <div
-            class="ml-1.5 mr-2 mt-[5px] self-baseline"
+            class="mt-[5px] mr-2 ml-1.5 self-baseline"
           >
             <svg
               class="translate-z shrink-0 icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
@@ -255,14 +255,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </svg>
           </div>
           <span
-            class="leading-[1.6154] text-default font-medium relative mr-1 inline scroll-m-5 items-center gap-1.5 group-hover:text-secondary group-hover:[&_code]:text-secondary"
+            class="leading-[1.6154] text-inherit font-medium relative mr-1 inline scroll-m-5 items-center gap-1.5 group-hover:text-secondary group-hover:[&_code]:text-secondary"
             data-text="true"
           >
             Existing React Native app?
           </span>
           <a
             aria-label="Permalink"
-            class="ml-auto inline rounded-md p-1 hocus:bg-element"
+            class="hocus:bg-element ml-auto inline rounded-md p-1"
             href="#existing-react-native-app-1"
           >
             <svg
@@ -297,10 +297,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           style="height: 0px;"
         >
           <div
-            class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
+            class="px-5 py-4 [&_p]:ml-0 [&_pre>pre]:mt-0 [&>*:last-child]:mb-1!"
           >
             <p
-              class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+              class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
               data-text="true"
             >
               Set this property using just Xcode
@@ -309,10 +309,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </details>
       <div
-        class="overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default px-4 py-3 !pb-4 last:[&>*]:!mb-1"
+        class="border-palette-gray4 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 mb-0! rounded-none! border-b-0! shadow-none! [&]:first-of-type:rounded-t-md! [&]:last-of-type:border-default! [&]:last-of-type:rounded-b-md! [&]:last-of-type:border-b! px-4 py-3 pb-4! [&>*:last-child]:mb-1!"
       >
         <h4
-          class="text-default font-normal text-base [&_strong]:break-words group flex gap-1 scroll-m-8"
+          class="text-inherit font-normal text-base [&_strong]:break-words group flex gap-1 scroll-m-8"
           data-heading="true"
           id="visible"
         >
@@ -322,7 +322,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             visible
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
             href="#visible"
           >
             <span
@@ -365,7 +365,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           >
             Type: 
             <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
               data-text="true"
             >
               enum
@@ -378,7 +378,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
              • Path:
              
             <code
-              class="break-words px-1 text-secondary"
+              class="text-secondary px-1 break-words"
             >
               androidNavigationBar
               .
@@ -387,16 +387,16 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
         </div>
         <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
           data-text="true"
         >
           Determines how and when the navigation bar is shown.
         </p>
         <div
-          class="overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default px-4 py-3 !pb-4 last:[&>*]:!mb-1"
+          class="border-palette-gray4 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 mb-0! rounded-none! border-b-0! shadow-none! [&]:first-of-type:rounded-t-md! [&]:last-of-type:border-default! [&]:last-of-type:rounded-b-md! [&]:last-of-type:border-b! px-4 py-3 pb-4! [&>*:last-child]:mb-1!"
         >
           <h5
-            class="text-default font-normal text-base [&_strong]:break-words group flex gap-1 scroll-m-8"
+            class="text-inherit font-normal text-base [&_strong]:break-words group flex gap-1 scroll-m-8"
             data-heading="true"
             id="always"
           >
@@ -406,7 +406,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               always
             </code>
             <a
-              class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+              class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
               href="#always"
             >
               <span
@@ -449,7 +449,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             >
               Type: 
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
                 data-text="true"
               >
                 boolean
@@ -462,7 +462,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                • Path:
                
               <code
-                class="break-words px-1 text-secondary"
+                class="text-secondary px-1 break-words"
               >
                 androidNavigationBar.visible
                 .
@@ -471,7 +471,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </span>
           </div>
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
             data-text="true"
           >
             Test sub-sub-property
@@ -479,10 +479,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </div>
       <div
-        class="overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default px-4 py-3 !pb-4 last:[&>*]:!mb-1"
+        class="border-palette-gray4 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 mb-0! rounded-none! border-b-0! shadow-none! [&]:first-of-type:rounded-t-md! [&]:last-of-type:border-default! [&]:last-of-type:rounded-b-md! [&]:last-of-type:border-b! px-4 py-3 pb-4! [&>*:last-child]:mb-1!"
       >
         <h4
-          class="text-default font-normal text-base [&_strong]:break-words group flex gap-1 scroll-m-8"
+          class="text-inherit font-normal text-base [&_strong]:break-words group flex gap-1 scroll-m-8"
           data-heading="true"
           id="backgroundcolor"
         >
@@ -492,7 +492,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             backgroundColor
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
             href="#backgroundcolor"
           >
             <span
@@ -535,7 +535,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           >
             Type: 
             <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
               data-text="true"
             >
               string
@@ -548,7 +548,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
              • Path:
              
             <code
-              class="break-words px-1 text-secondary"
+              class="text-secondary px-1 break-words"
             >
               androidNavigationBar
               .
@@ -557,7 +557,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
         </div>
         <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
           data-text="true"
         >
           Specifies the background color of the navigation bar.
@@ -565,12 +565,12 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         
 
         <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
           data-text="true"
         >
           6 character long hex color string, eg: 
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 break-words !inline py-0"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 break-words"
             data-text="true"
           >
             '#000000'
@@ -579,10 +579,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </div>
     </div>
     <div
-      class="overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default px-4 py-3 !pb-4 last:[&>*]:!mb-1"
+      class="border-palette-gray4 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 mb-0! rounded-none! border-b-0! shadow-none! [&]:first-of-type:rounded-t-md! [&]:last-of-type:border-default! [&]:last-of-type:rounded-b-md! [&]:last-of-type:border-b! px-4 py-3 pb-4! [&>*:last-child]:mb-1!"
     >
       <h3
-        class="text-default font-normal text-base [&_strong]:break-words group flex gap-1 scroll-m-8"
+        class="text-inherit font-normal text-base [&_strong]:break-words group flex gap-1 scroll-m-8"
         data-heading="true"
         id="intentfilters"
       >
@@ -592,7 +592,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           intentFilters
         </code>
         <a
-          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+          class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
           href="#intentfilters"
         >
           <span
@@ -635,7 +635,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         >
           Type: 
           <code
-            class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
             data-text="true"
           >
             array
@@ -643,21 +643,21 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </span>
       </div>
       <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+        class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
         data-text="true"
       >
         Configuration for setting an array of custom intent filters in Android manifest.
       </p>
       <details
-        class="mb-3 scroll-m-4 rounded-md border border-default bg-default p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
+        class="border-default bg-default mb-3 scroll-m-4 rounded-md border p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
         data-md="collapsible"
         id="existing-react-native-app-2"
       >
         <summary
-          class="group m-0 grid cursor-pointer grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3 [details[open]>&]:rounded-b-none [&_h4]:my-0 [&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
+          class="group bg-subtle m-0 grid cursor-pointer grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md p-1.5 pr-3 [details[open]>&]:rounded-b-none [&_h4]:my-0 [&_code]:bg-element [&_code]:mt-px [&_code]:inline [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
         >
           <div
-            class="ml-1.5 mr-2 mt-[5px] self-baseline"
+            class="mt-[5px] mr-2 ml-1.5 self-baseline"
           >
             <svg
               class="translate-z shrink-0 icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
@@ -677,14 +677,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </svg>
           </div>
           <span
-            class="leading-[1.6154] text-default font-medium relative mr-1 inline scroll-m-5 items-center gap-1.5 group-hover:text-secondary group-hover:[&_code]:text-secondary"
+            class="leading-[1.6154] text-inherit font-medium relative mr-1 inline scroll-m-5 items-center gap-1.5 group-hover:text-secondary group-hover:[&_code]:text-secondary"
             data-text="true"
           >
             Existing React Native app?
           </span>
           <a
             aria-label="Permalink"
-            class="ml-auto inline rounded-md p-1 hocus:bg-element"
+            class="hocus:bg-element ml-auto inline rounded-md p-1"
             href="#existing-react-native-app-2"
           >
             <svg
@@ -719,10 +719,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           style="height: 0px;"
         >
           <div
-            class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
+            class="px-5 py-4 [&_p]:ml-0 [&_pre>pre]:mt-0 [&>*:last-child]:mb-1!"
           >
             <p
-              class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+              class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
               data-text="true"
             >
               This is set in AndroidManifest.xml directly.
@@ -740,11 +740,11 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           Example
         </p>
         <span
-          class="m-0 whitespace-pre px-1 py-1.5 inline-flex !p-0"
+          class="m-0 px-1 py-1.5 whitespace-pre inline-flex p-0!"
           data-text="true"
         >
           <code
-            class="text-[13px] font-normal leading-[130%] tracking-[-0.003rem] rounded-md border border-secondary bg-subtle px-1 py-0.5 !text-3xs text-default block w-full !p-1.5"
+            class="text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle rounded-md border px-1 py-0.5 text-3xs! text-default block w-full p-1.5!"
             data-text="true"
           >
             [
@@ -759,10 +759,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </span>
       </span>
       <div
-        class="overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default px-4 py-3 !pb-4 last:[&>*]:!mb-1"
+        class="border-palette-gray4 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 mb-0! rounded-none! border-b-0! shadow-none! [&]:first-of-type:rounded-t-md! [&]:last-of-type:border-default! [&]:last-of-type:rounded-b-md! [&]:last-of-type:border-b! px-4 py-3 pb-4! [&>*:last-child]:mb-1!"
       >
         <h4
-          class="text-default font-normal text-base [&_strong]:break-words group flex gap-1 scroll-m-8"
+          class="text-inherit font-normal text-base [&_strong]:break-words group flex gap-1 scroll-m-8"
           data-heading="true"
           id="autoverify"
         >
@@ -772,7 +772,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             autoVerify
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
             href="#autoverify"
           >
             <span
@@ -815,7 +815,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           >
             Type: 
             <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
               data-text="true"
             >
               boolean
@@ -828,7 +828,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
              • Path:
              
             <code
-              class="break-words px-1 text-secondary"
+              class="text-secondary px-1 break-words"
             >
               intentFilters
               .
@@ -837,17 +837,17 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
         </div>
         <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+          class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
           data-text="true"
         >
           You may also use an intent filter to set your app as the default handler for links
         </p>
       </div>
       <div
-        class="overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default px-4 py-3 !pb-4 last:[&>*]:!mb-1"
+        class="border-palette-gray4 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 mb-0! rounded-none! border-b-0! shadow-none! [&]:first-of-type:rounded-t-md! [&]:last-of-type:border-default! [&]:last-of-type:rounded-b-md! [&]:last-of-type:border-b! px-4 py-3 pb-4! [&>*:last-child]:mb-1!"
       >
         <h4
-          class="text-default font-normal text-base [&_strong]:break-words group flex gap-1 scroll-m-8"
+          class="text-inherit font-normal text-base [&_strong]:break-words group flex gap-1 scroll-m-8"
           data-heading="true"
           id="data"
         >
@@ -857,7 +857,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             data
           </code>
           <a
-            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+            class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
             href="#data"
           >
             <span
@@ -900,7 +900,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           >
             Type: 
             <code
-              class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
               data-text="true"
             >
               array || object
@@ -913,7 +913,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
              • Path:
              
             <code
-              class="break-words px-1 text-secondary"
+              class="text-secondary px-1 break-words"
             >
               intentFilters
               .
@@ -922,10 +922,10 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </span>
         </div>
         <div
-          class="overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 !mb-0 !rounded-none !border-b-0 !shadow-none [&]:first-of-type:!rounded-t-md [&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default px-4 py-3 !pb-4 last:[&>*]:!mb-1"
+          class="border-palette-gray4 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none mb-3.5 [&_.table-wrapper]:last:mb-4 mb-0! rounded-none! border-b-0! shadow-none! [&]:first-of-type:rounded-t-md! [&]:last-of-type:border-default! [&]:last-of-type:rounded-b-md! [&]:last-of-type:border-b! px-4 py-3 pb-4! [&>*:last-child]:mb-1!"
         >
           <h5
-            class="text-default font-normal text-base [&_strong]:break-words group flex gap-1 scroll-m-8"
+            class="text-inherit font-normal text-base [&_strong]:break-words group flex gap-1 scroll-m-8"
             data-heading="true"
             id="host"
           >
@@ -935,7 +935,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               host
             </code>
             <a
-              class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 relative my-auto inline-flex justify-center p-0 transition-all duration-default invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
+              class="border border-solid rounded-full font-medium items-center whitespace-nowrap gap-2 text-xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto inline-flex justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px]"
               href="#host"
             >
               <span
@@ -978,7 +978,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             >
               Type: 
               <code
-                class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
                 data-text="true"
               >
                 string
@@ -991,7 +991,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                • Path:
                
               <code
-                class="break-words px-1 text-secondary"
+                class="text-secondary px-1 break-words"
               >
                 intentFilters.data
                 .

--- a/docs/ui/components/AppConfigSchemaTable/index.tsx
+++ b/docs/ui/components/AppConfigSchemaTable/index.tsx
@@ -84,9 +84,9 @@ function AppConfigProperty({
   return (
     <APIBox
       className={mergeClasses(
-        '!mb-0 !rounded-none !border-b-0 !shadow-none',
-        '[&]:first-of-type:!rounded-t-md',
-        '[&]:last-of-type:!rounded-b-md [&]:last-of-type:!border-b [&]:last-of-type:!border-default',
+        'mb-0! rounded-none! border-b-0! shadow-none!',
+        '[&]:first-of-type:rounded-t-md!',
+        '[&]:last-of-type:border-default! [&]:last-of-type:rounded-b-md! [&]:last-of-type:border-b!',
         'px-4 py-3'
       )}>
       <PropertyName name={name} nestingLevel={nestingLevel} />
@@ -106,7 +106,7 @@ function AppConfigProperty({
                       {typeData.pattern ? (
                         <>
                           <CODE>string</CODE> matching the following pattern:{' '}
-                          <code className="text-sm text-default">{typeData.pattern}</code>
+                          <code className="text-default text-sm">{typeData.pattern}</code>
                         </>
                       ) : (
                         <CODE>string</CODE>
@@ -147,7 +147,7 @@ function AppConfigProperty({
                 } else {
                   return (
                     <CodeBlock
-                      className="text-balance text-secondary"
+                      className="text-secondary text-balance"
                       inline
                       key={`${name}-${index}`}>
                       {oneOfType}
@@ -165,7 +165,7 @@ function AppConfigProperty({
         {!canHaveMultipleValues && nestingLevel > 0 && (
           <CALLOUT theme="secondary" tag="span">
             &emsp;&bull;&emsp;Path:{' '}
-            <code className="break-words px-1 text-secondary">
+            <code className="text-secondary px-1 break-words">
               {parent}.{name}
             </code>
           </CALLOUT>

--- a/docs/ui/components/AppJSBanner/index.tsx
+++ b/docs/ui/components/AppJSBanner/index.tsx
@@ -35,9 +35,9 @@ export function AppJSBanner() {
         'max-md-gutters:flex-wrap'
       )}>
       <div className="flex items-center gap-4">
-        <div className="relative z-10 p-2 max-sm-gutters:hidden">
+        <div className="max-sm-gutters:hidden relative z-10 p-2">
           <div className="asset-sm-shadow absolute inset-0 rounded-md bg-[#494CFC]" />
-          <AppJSIcon className="icon-lg relative z-10 text-palette-white" />
+          <AppJSIcon className="icon-lg text-palette-white relative z-10" />
         </div>
         <div className="relative grid grid-cols-1">
           <p className="text-base font-medium text-[#494CFC] dark:text-[#a0b9ff]">
@@ -55,7 +55,7 @@ export function AppJSBanner() {
           openInNewTab
           rightSlot={<ArrowUpRightIcon className="icon-xs text-palette-white opacity-75" />}
           className={mergeClasses(
-            'gap-1.5 border-[#494CFC] bg-[#494CFC] text-palette-white shadow-none',
+            'text-palette-white gap-1.5 border-[#494CFC] bg-[#494CFC] shadow-none',
             'dark:hocus:border-[#23257b] dark:hocus:bg-[#23257b]',
             'hocus:border-[#7189ff] hocus:bg-[#7189ff]'
           )}>
@@ -68,7 +68,7 @@ export function AppJSBanner() {
           onClick={() => {
             setIsAppJSBannerVisible(false);
           }}
-          className="bg-transparent text-palette-white shadow-none hocus:bg-[#ccd8ff] dark:hocus:bg-[#23257b]"
+          className="text-palette-white hocus:bg-[#ccd8ff] dark:hocus:bg-[#23257b] bg-transparent shadow-none"
           leftSlot={<XIcon className="text-[#494CFC]" />}
         />
       </div>

--- a/docs/ui/components/AskPageAI/AskPageAIChat.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChat.tsx
@@ -407,7 +407,7 @@ export function AskPageAIChat({
   );
 
   return (
-    <div className="flex h-full flex-col overflow-hidden bg-default">
+    <div className="bg-default flex h-full flex-col overflow-hidden">
       <AskPageAIChatHeader
         displayContextLabel={displayContextLabel}
         contextScope={contextScope}

--- a/docs/ui/components/AskPageAI/AskPageAIChatHeader.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChatHeader.tsx
@@ -42,17 +42,17 @@ export function AskPageAIChatHeader({
   const headerAccentBackground = useMemo(() => ({ backgroundColor: 'rgba(255,255,255,0.1)' }), []);
 
   return (
-    <div className="flex flex-col gap-3 border-b border-default bg-palette-black px-4 py-2.5 text-palette-white">
+    <div className="border-default bg-palette-black text-palette-white flex flex-col gap-3 border-b px-4 py-2.5">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <span
             className={mergeClasses(
-              'inline-flex size-8 items-center justify-center rounded-full bg-palette-white shadow-xs'
+              'bg-palette-white inline-flex size-8 items-center justify-center rounded-full shadow-xs'
             )}
             style={headerAccentBackground}>
             <Star06Icon className="icon-sm text-palette-white" />
           </span>
-          <span className="text-sm font-medium leading-tight text-palette-white">
+          <span className="text-palette-white text-sm leading-tight font-medium">
             Expo AI Assistant
           </span>
         </div>
@@ -63,7 +63,7 @@ export function AskPageAIChatHeader({
               aria-label={isExpanded ? 'Restore Ask AI assistant size' : 'Expand Ask AI assistant'}
               theme="quaternary"
               size="xs"
-              className="px-2 !text-palette-white hover:!text-palette-white focus:!text-palette-white"
+              className="text-palette-white! hover:text-palette-white! focus:text-palette-white! px-2"
               style={closeButtonThemeOverrides}
               aria-pressed={isExpanded}
               onClick={onToggleExpand}>
@@ -79,7 +79,7 @@ export function AskPageAIChatHeader({
             aria-label="Reset conversation"
             theme="quaternary"
             size="xs"
-            className="px-2 !text-palette-white hover:!text-palette-white focus:!text-palette-white"
+            className="text-palette-white! hover:text-palette-white! focus:text-palette-white! px-2"
             style={closeButtonThemeOverrides}
             onClick={onReset}>
             <RefreshCcw02Icon className="icon-xs text-palette-white" />
@@ -88,7 +88,7 @@ export function AskPageAIChatHeader({
             aria-label="Close Ask AI assistant"
             theme="quaternary"
             size="xs"
-            className="px-2 !text-palette-white hover:!text-palette-white focus:!text-palette-white"
+            className="text-palette-white! hover:text-palette-white! focus:text-palette-white! px-2"
             style={closeButtonThemeOverrides}
             onClick={onClose}>
             <XIcon className="icon-xs text-palette-white" />
@@ -108,10 +108,10 @@ export function AskPageAIChatHeader({
             type="button"
             theme="quaternary"
             size="xs"
-            className="inline-flex items-center self-start px-2 py-1.5 !text-palette-white hover:!text-palette-white focus:!text-palette-white"
+            className="text-palette-white! hover:text-palette-white! focus:text-palette-white! inline-flex items-center self-start px-2 py-1.5"
             style={closeButtonThemeOverrides}
             onClick={onSwitchToPageContext}>
-            <SwitchHorizontal01Icon className="icon-xs mr-2 self-center text-palette-white" />
+            <SwitchHorizontal01Icon className="icon-xs text-palette-white mr-2 self-center" />
             <span className="leading-snug">Switch back to {displayContextLabel} docs</span>
           </Button>
         ) : null}

--- a/docs/ui/components/AskPageAI/AskPageAIChatInput.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChatInput.tsx
@@ -18,15 +18,15 @@ export function AskPageAIChatInput({
   conversationLength,
 }: AskPageAIChatInputProps) {
   return (
-    <div className="mt-auto border-t border-default px-5 pb-6 pt-4">
+    <div className="border-default mt-auto border-t px-5 pt-4 pb-6">
       <form
-        className="flex items-center gap-1 rounded-md border border-default bg-default px-2 py-1.5"
+        className="border-default bg-default flex items-center gap-1 rounded-md border px-2 py-1.5"
         onSubmit={onSubmit}
         aria-label="Ask AI form">
         <textarea
           aria-label="Ask AI about this page"
           placeholder="Ask about this page (Shift+Enter for newline)"
-          className="max-h-[160px] min-h-[64px] flex-1 resize-none overflow-y-auto rounded-md border border-transparent bg-subtle px-3 py-2 text-sm leading-relaxed outline-none placeholder:text-tertiary focus:!shadow-none focus:!outline-none focus:ring-0 focus-visible:!shadow-none focus-visible:!outline-none focus-visible:ring-0"
+          className="bg-subtle placeholder:text-tertiary max-h-[160px] min-h-[64px] flex-1 resize-none overflow-y-auto rounded-md border border-transparent px-3 py-2 text-sm leading-relaxed outline-none focus:shadow-none! focus:ring-0 focus:outline-none! focus-visible:shadow-none! focus-visible:ring-0 focus-visible:outline-none!"
           rows={2}
           value={question}
           onChange={event => {
@@ -44,7 +44,7 @@ export function AskPageAIChatInput({
           type="submit"
           theme="quaternary"
           size="sm"
-          className="flex size-6 items-center justify-center rounded-full !p-0"
+          className="flex size-6 items-center justify-center rounded-full p-0!"
           disabled={isBusy || question.trim().length === 0}>
           <ArrowCircleUpDuotoneIcon className="icon-md text-icon-default" />
         </Button>

--- a/docs/ui/components/AskPageAI/AskPageAIChatMessages.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChatMessages.tsx
@@ -58,11 +58,11 @@ export function AskPageAIChatMessages({
 }: AskPageAIChatMessagesProps) {
   if (conversation.length === 0) {
     return (
-      <div className="rounded-md border border-default bg-subtle px-3 py-2 shadow-xs">
-        <FOOTNOTE className="font-medium text-default">AI Assistant</FOOTNOTE>
-        <div className="mt-1 space-y-3 text-xs text-secondary">
+      <div className="border-default bg-subtle rounded-md border px-3 py-2 shadow-xs">
+        <FOOTNOTE className="text-default font-medium">AI Assistant</FOOTNOTE>
+        <div className="text-secondary mt-1 space-y-3 text-xs">
           I'm an SDK AI assistant — ask me a question about the{' '}
-          <span className="font-medium text-default">
+          <span className="text-default font-medium">
             {contextScope === 'page' ? 'current page' : 'Expo docs'}
           </span>
           .
@@ -118,19 +118,19 @@ export function AskPageAIChatMessages({
               <div key={`marker-${marker.id}`} className="flex justify-center">
                 <FOOTNOTE
                   theme="secondary"
-                  className="inline-block rounded-md border border-default bg-subtle px-2 py-1">
-                  Switched to <span className="font-medium text-default">{marker.label}.</span>
+                  className="border-default bg-subtle inline-block rounded-md border px-2 py-1">
+                  Switched to <span className="text-default font-medium">{marker.label}.</span>
                 </FOOTNOTE>
               </div>
             ))}
             <div className="flex justify-end pr-1">
-              <div className="ml-auto max-w-[85%] rounded-md border border-default bg-subtle px-3 py-1.5 text-right text-sm leading-snug text-secondary shadow-xs">
+              <div className="border-default bg-subtle text-secondary ml-auto max-w-[85%] rounded-md border px-3 py-1.5 text-right text-sm leading-snug shadow-xs">
                 {displayQuestion}
               </div>
             </div>
             <div className="px-0">
-              <FOOTNOTE className="font-medium text-default">AI Assistant</FOOTNOTE>
-              <div className="mt-1 space-y-3 text-xs text-secondary">
+              <FOOTNOTE className="text-default font-medium">AI Assistant</FOOTNOTE>
+              <div className="text-secondary mt-1 space-y-3 text-xs">
                 {answerForDisplay ? (
                   <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
                     {answerForDisplay}
@@ -147,12 +147,12 @@ export function AskPageAIChatMessages({
                     type="button"
                     theme="quaternary"
                     size="xs"
-                    className="inline-flex items-center gap-2 rounded-md border border-default bg-subtle px-3 py-1 text-xs font-medium text-default shadow-xs transition-colors hover:bg-element focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-palette-blue9 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+                    className="border-default bg-subtle text-default hover:bg-element focus-visible:ring-palette-blue9 inline-flex items-center gap-2 rounded-md border px-3 py-1 text-xs font-medium shadow-xs transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
                     disabled={isBusy || hasTriggeredGlobalSearch || isPendingGlobal}
                     onClick={() => {
                       onSearchAcrossDocs(displayQuestion);
                     }}>
-                    <FileSearch02Icon className="icon-xs mr-2 text-icon-secondary" />
+                    <FileSearch02Icon className="icon-xs text-icon-secondary mr-2" />
                     {hasTriggeredGlobalSearch || isPendingGlobal
                       ? 'Searching Expo docs…'
                       : 'Search Expo docs'}
@@ -165,14 +165,14 @@ export function AskPageAIChatMessages({
                 </div>
               ) : null}
               {canSubmitFeedback ? (
-                <div className="mt-3 flex items-center gap-1 text-xs text-secondary">
+                <div className="text-secondary mt-3 flex items-center gap-1 text-xs">
                   <span className="text-secondary">Was this helpful?</span>
                   <div className="flex items-center gap-1">
                     <Button
                       type="button"
                       theme="quaternary"
                       size="xs"
-                      className="px-2 !text-secondary hover:!text-default focus:!text-default disabled:cursor-not-allowed disabled:opacity-60"
+                      className="text-secondary! hover:text-default! focus:text-default! px-2 disabled:cursor-not-allowed disabled:opacity-60"
                       aria-label="Upvote answer"
                       aria-pressed={isUpvoted}
                       disabled={disableUpvote}
@@ -193,7 +193,7 @@ export function AskPageAIChatMessages({
                       type="button"
                       theme="quaternary"
                       size="xs"
-                      className="px-2 !text-secondary hover:!text-default focus:!text-default disabled:cursor-not-allowed disabled:opacity-60"
+                      className="text-secondary! hover:text-default! focus:text-default! px-2 disabled:cursor-not-allowed disabled:opacity-60"
                       aria-label="Downvote answer"
                       aria-pressed={isDownvoted}
                       disabled={disableDownvote}
@@ -239,8 +239,8 @@ export function AskPageAIChatMessages({
         <div key={`marker-${marker.id}`} className="flex justify-center">
           <FOOTNOTE
             theme="secondary"
-            className="inline-block rounded-md border border-default bg-subtle px-2 py-1">
-            Switched to <span className="font-medium text-default">{marker.label}.</span>
+            className="border-default bg-subtle inline-block rounded-md border px-2 py-1">
+            Switched to <span className="text-default font-medium">{marker.label}.</span>
           </FOOTNOTE>
         </div>
       ))}

--- a/docs/ui/components/AskPageAI/AskPageAIOverlay.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIOverlay.tsx
@@ -80,11 +80,10 @@ export function AskPageAIOverlay({
     <div className="pointer-events-none fixed inset-0 z-[120]">
       <div
         className={mergeClasses(
-          'fixed bottom-4 right-4 flex h-full flex-col overflow-hidden rounded-2xl border border-default bg-default transition-all duration-200 ease-out',
-          'max-sm:left-4 sm:bottom-8',
+          'border-default bg-default fixed right-4 bottom-4 flex h-full flex-col overflow-hidden rounded-2xl border transition-all duration-200 ease-out',
           shouldShowExpandedLayout
-            ? 'sm:top-8 sm:bottom-8 sm:right-12 bottom-4 top-4 h-auto w-[min(600px,calc(100vw-72px))] max-w-[min(600px,calc(100vw-72px))]'
-            : 'sm:right-8 max-h-[min(85vh,600px)] w-[min(420px,calc(100vw-24px))]',
+            ? 'top-4 bottom-4 h-auto w-[min(600px,calc(100vw-72px))] max-w-[min(600px,calc(100vw-72px))]'
+            : 'max-h-[min(85vh,600px)] w-[min(420px,calc(100vw-24px))]',
           isVisible
             ? 'pointer-events-auto translate-y-0 opacity-100 shadow-xl'
             : 'pointer-events-none translate-y-3 opacity-0 shadow-none'

--- a/docs/ui/components/AskPageAI/useChatMarkdownComponents.tsx
+++ b/docs/ui/components/AskPageAI/useChatMarkdownComponents.tsx
@@ -62,7 +62,7 @@ export function useChatMarkdownComponents({ onNavigate }: UseChatMarkdownCompone
             type="button"
             theme="quaternary"
             size="xs"
-            className="pointer-events-auto absolute right-2 top-2 z-10 flex size-7 items-center justify-center rounded-full !border !border-default !bg-default !p-0 shadow-sm"
+            className="border-default! bg-default! pointer-events-auto absolute top-2 right-2 z-10 flex size-7 items-center justify-center rounded-full border! p-0! shadow-sm"
             onClick={handleCopy}
             aria-label="Copy code block">
             {copied ? (
@@ -80,31 +80,31 @@ export function useChatMarkdownComponents({ onNavigate }: UseChatMarkdownCompone
       h1: props => (
         <Heading1Component
           {...props}
-          className={mergeClasses('!text-[14px] font-semibold text-default', props.className)}
+          className={mergeClasses('text-default text-[14px]! font-semibold', props.className)}
         />
       ),
       h2: props => (
         <Heading2Component
           {...props}
-          className={mergeClasses('!text-[14px] font-semibold text-default', props.className)}
+          className={mergeClasses('text-default text-[14px]! font-semibold', props.className)}
         />
       ),
       h3: props => (
         <Heading3Component
           {...props}
-          className={mergeClasses('!text-[12px] font-semibold text-default', props.className)}
+          className={mergeClasses('text-default text-[12px]! font-semibold', props.className)}
         />
       ),
       h4: props => (
         <Heading4Component
           {...props}
-          className={mergeClasses('!text-[12px] font-semibold text-default', props.className)}
+          className={mergeClasses('text-default text-[12px]! font-semibold', props.className)}
         />
       ),
       h5: props => (
         <Heading5Component
           {...props}
-          className={mergeClasses('!text-[10px] font-semibold text-default', props.className)}
+          className={mergeClasses('text-default text-[10px]! font-semibold', props.className)}
         />
       ),
       p: ({ className, style, ...rest }) => (
@@ -112,9 +112,9 @@ export function useChatMarkdownComponents({ onNavigate }: UseChatMarkdownCompone
           {...rest}
           style={{ ...(style ?? {}), fontSize: '14px', lineHeight: '1.5' }}
           className={mergeClasses(
-            '!mb-2 text-secondary',
+            'text-secondary mb-2!',
             className,
-            '!text-[10px] !leading-[1.55]'
+            'text-[10px]! leading-[1.55]!'
           )}
         />
       ),
@@ -122,21 +122,21 @@ export function useChatMarkdownComponents({ onNavigate }: UseChatMarkdownCompone
         <OrderedListComponent
           {...rest}
           style={{ ...(style ?? {}), fontSize: '14px', lineHeight: '1.5' }}
-          className={mergeClasses('text-secondary', className, '!text-[10px] leading-normal')}
+          className={mergeClasses('text-secondary', className, 'text-[10px]! leading-normal')}
         />
       ),
       ul: ({ className, style, ...rest }) => (
         <UnorderedListComponent
           {...rest}
           style={{ ...(style ?? {}), fontSize: '14px', lineHeight: '1.5' }}
-          className={mergeClasses('text-secondary', className, '!text-[10px] leading-normal')}
+          className={mergeClasses('text-secondary', className, 'text-[10px]! leading-normal')}
         />
       ),
       li: ({ className, style, ...rest }) => (
         <ListItemComponent
           {...rest}
           style={{ ...(style ?? {}), fontSize: '14px', lineHeight: '1.45' }}
-          className={mergeClasses('text-secondary', className, '!text-[10px] !leading-[1.45]')}
+          className={mergeClasses('text-secondary', className, 'text-[10px]! leading-[1.45]!')}
         />
       ),
       sup: () => null,

--- a/docs/ui/components/Authentication/Box.tsx
+++ b/docs/ui/components/Authentication/Box.tsx
@@ -16,7 +16,7 @@ type BoxProps = PropsWithChildren<{
 export const Box = ({ name, image, createUrl, children }: BoxProps) => (
   <APIBox className={mergeClasses('mt-6 px-4 pt-3', '[&_.table-wrapper]:mb-4')}>
     <div className="max-md-gutters::gap-3 max-md-gutters::flex-col inline-flex w-full flex-row items-center gap-4 pb-4">
-      <div className="flex w-[inherit] flex-row items-center gap-3 [&>h3]:!mb-0">
+      <div className="flex w-[inherit] flex-row items-center gap-3 [&>h3]:mb-0!">
         <Icon title={name} image={image} className="size-12" />
         <H3>{name}</H3>
       </div>

--- a/docs/ui/components/Authentication/GridItem.tsx
+++ b/docs/ui/components/Authentication/GridItem.tsx
@@ -20,12 +20,12 @@ export const GridItem = ({
   <A
     href={href}
     className={mergeClasses(
-      'group flex flex-col items-center justify-center gap-1.5 rounded-md border border-default p-6 shadow-xs transition-all',
+      'group border-default flex flex-col items-center justify-center gap-1.5 rounded-md border p-6 shadow-xs transition-all',
       'hocus:scale-105 hocus:shadow-md'
     )}
     isStyled>
     <Icon title={title} image={image} />
-    <RawH4 className="!mt-1 text-center">{title}</RawH4>
+    <RawH4 className="mt-1! text-center">{title}</RawH4>
     {(protocol || []).length > 0 && (
       <CALLOUT
         theme="secondary"

--- a/docs/ui/components/Authentication/Icon.tsx
+++ b/docs/ui/components/Authentication/Icon.tsx
@@ -9,7 +9,7 @@ type IconProps = {
 
 export const Icon = ({ title, image, className }: IconProps) => (
   <img
-    className={mergeClasses('size-16 rounded-full bg-element p-1', className)}
+    className={mergeClasses('bg-element size-16 rounded-full p-1', className)}
     alt={title}
     src={image}
   />

--- a/docs/ui/components/BoxLink/index.tsx
+++ b/docs/ui/components/BoxLink/index.tsx
@@ -22,24 +22,24 @@ export function BoxLink({ title, description, href, testID, Icon, imageUrl }: Bo
       // Used by scripts/generate-markdown-pages-utils.js to extract card link title/description
       data-md="card-link"
       className={mergeClasses(
-        'group mb-3 flex flex-row justify-between rounded-md border border-solid border-default px-4 py-3 transition',
+        'group border-default mb-3 flex flex-row justify-between rounded-md border border-solid px-4 py-3 transition',
         'hocus:bg-subtle hocus:shadow-xs'
       )}
       data-testid={testID}
       openInNewTab={isExternal}>
       <div className="flex flex-row gap-4">
         {Icon && (
-          <div className="flex h-9 min-w-[36px] items-center justify-center self-center rounded-md bg-element transition group-hover:bg-hover">
+          <div className="bg-element group-hover:bg-hover flex h-9 min-w-[36px] items-center justify-center self-center rounded-md transition">
             <Icon className="icon-lg text-icon-default" />
           </div>
         )}
-        {imageUrl && <img className="!h-9 !w-9 self-center" src={imageUrl} alt="Icon" />}
+        {imageUrl && <img className="size-9! self-center" src={imageUrl} alt="Icon" />}
         <div className="flex flex-col self-center">
           <DEMI>{title}</DEMI>
           {description && <CALLOUT theme="secondary">{description}</CALLOUT>}
         </div>
       </div>
-      <ArrowIcon className="ml-3 min-w-[20px] content-end self-center text-icon-secondary" />
+      <ArrowIcon className="text-icon-secondary ml-3 min-w-[20px] content-end self-center" />
     </LinkBase>
   );
 }

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -65,7 +65,7 @@ const Collapsible: ComponentType<CollapsibleProps> = withHeadingManager(
           setIsOpen(event.currentTarget.open);
         }}
         className={mergeClasses(
-          'mb-3 scroll-m-4 rounded-md border border-default bg-default p-0',
+          'border-default bg-default mb-3 scroll-m-4 rounded-md border p-0',
           '[&[open]]:shadow-xs',
           '[h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3',
           className
@@ -75,12 +75,12 @@ const Collapsible: ComponentType<CollapsibleProps> = withHeadingManager(
         data-md="collapsible">
         <summary
           className={mergeClasses(
-            'group m-0 grid cursor-pointer grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3',
+            'group bg-subtle m-0 grid cursor-pointer grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md p-1.5 pr-3',
             '[details[open]>&]:rounded-b-none',
             '[&_h4]:my-0',
-            '[&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug'
+            '[&_code]:bg-element [&_code]:mt-px [&_code]:inline [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug'
           )}>
-          <div className="ml-1.5 mr-2 mt-[5px] self-baseline">
+          <div className="mt-[5px] mr-2 ml-1.5 self-baseline">
             <TriangleDownIcon
               className={mergeClasses(
                 'icon-sm text-icon-default',
@@ -102,7 +102,7 @@ const Collapsible: ComponentType<CollapsibleProps> = withHeadingManager(
             onClick={() => {
               detailsRef?.current?.setAttribute('open', '');
             }}
-            className="ml-auto inline rounded-md p-1 hocus:bg-element"
+            className="hocus:bg-element ml-auto inline rounded-md p-1"
             aria-label="Permalink">
             <PermalinkIcon className="icon-sm invisible inline-flex group-hover:visible group-focus-visible:visible" />
           </LinkBase>
@@ -116,7 +116,10 @@ const Collapsible: ComponentType<CollapsibleProps> = withHeadingManager(
           }}
           className="overflow-hidden">
           <div
-            className={mergeClasses('px-5 py-4', 'last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0')}>
+            className={mergeClasses(
+              'px-5 py-4',
+              '[&_p]:ml-0 [&_pre>pre]:mt-0 [&>*:last-child]:mb-1!'
+            )}>
             {children}
           </div>
         </motion.div>

--- a/docs/ui/components/ConfigPluginHierarchy/index.tsx
+++ b/docs/ui/components/ConfigPluginHierarchy/index.tsx
@@ -80,8 +80,8 @@ const getNodeStyles = (isHighlighted: boolean) => ({
     ? 'bg-palette-green9 text-palette-white'
     : 'bg-palette-blue9 text-palette-white',
   container: isHighlighted
-    ? 'bg-palette-green3 border-palette-green9 border-2 dark:bg-palette-green4 dark:border-palette-green8 !border-palette-green9 dark:!border-palette-green8 !bg-palette-green3 dark:!bg-palette-green4'
-    : 'bg-palette-blue3 border-palette-blue9 border-2 dark:bg-palette-blue4 dark:border-palette-blue8 !border-palette-blue9 dark:!border-palette-blue8 !bg-palette-blue3 dark:!bg-palette-blue4',
+    ? 'bg-palette-green3 border-palette-green9 border-2 dark:bg-palette-green4 dark:border-palette-green8 border-palette-green9! dark:border-palette-green8! bg-palette-green3! dark:bg-palette-green4!'
+    : 'bg-palette-blue3 border-palette-blue9 border-2 dark:bg-palette-blue4 dark:border-palette-blue8 border-palette-blue9! dark:border-palette-blue8! bg-palette-blue3! dark:bg-palette-blue4!',
 });
 
 const createNodeLabel = (data: NodeData, isHighlighted: boolean) => {
@@ -171,7 +171,7 @@ export const ConfigPluginHierarchy: React.FC<ConfigPluginHierarchyProps> = ({
 
   return (
     <div
-      className="mb-4 h-[300px] w-full overflow-hidden rounded-lg border border-default bg-default"
+      className="border-default bg-default mb-4 h-[300px] w-full overflow-hidden rounded-lg border"
       data-md="diagram"
       data-md-alt={diagramAlt}>
       <style dangerouslySetInnerHTML={{ __html: nodeHandleStyles }} />

--- a/docs/ui/components/ConfigSection/ConfigPluginProperties.tsx
+++ b/docs/ui/components/ConfigSection/ConfigPluginProperties.tsx
@@ -38,7 +38,7 @@ export const ConfigPluginProperties = ({ children, properties }: Props) => (
                   <div className="inline-flex flex-row flex-wrap">
                     {property.deprecated && (
                       <>
-                        <StatusTag status="deprecated" className="!mr-0" />
+                        <StatusTag status="deprecated" className="mr-0!" />
                         {(property.experimental || property.platform) && (
                           <span className={mergeClasses(STYLES_SECONDARY)}>&ensp;&bull;&ensp;</span>
                         )}
@@ -46,7 +46,7 @@ export const ConfigPluginProperties = ({ children, properties }: Props) => (
                     )}
                     {property.experimental && (
                       <>
-                        <StatusTag status="experimental" className="!mr-0" />
+                        <StatusTag status="experimental" className="mr-0!" />
                         {!!property.platform && (
                           <span className={mergeClasses(STYLES_SECONDARY)}>&ensp;&bull;&ensp;</span>
                         )}

--- a/docs/ui/components/ContentSpotlight/index.tsx
+++ b/docs/ui/components/ContentSpotlight/index.tsx
@@ -71,14 +71,14 @@ export function ContentSpotlight({
           src={src}
           alt={alt}
           className={mergeClasses(
-            'inline rounded-md transition-opacity duration-default ease-in-out hover:opacity-80',
+            'duration-default inline rounded-md transition-opacity ease-in-out hover:opacity-80',
             className
           )}
         />
       ) : isVideo ? (
         <div
           className={mergeClasses(
-            'relative overflow-hidden rounded-lg bg-palette-black',
+            'bg-palette-black relative overflow-hidden rounded-lg',
             hasCustomPlayerSize ? 'mx-auto' : 'aspect-video'
           )}
           ref={playerRef}
@@ -103,7 +103,7 @@ export function ContentSpotlight({
           />
           <div
             className={mergeClasses(
-              'pointer-events-none absolute inset-0 transition-opacity duration-500 max-md-gutters:hidden',
+              'max-md-gutters:hidden pointer-events-none absolute inset-0 transition-opacity duration-500',
               isInView ? 'opacity-0' : 'opacity-70'
             )}
           />
@@ -112,7 +112,7 @@ export function ContentSpotlight({
       {caption && (
         <figcaption
           className={mergeClasses(
-            'mt-3.5 cursor-text px-8 py-2 text-center text-xs text-secondary',
+            'text-secondary mt-3.5 cursor-text px-8 py-2 text-center text-xs',
             isVideo && 'bg-transparent'
           )}>
           {caption}

--- a/docs/ui/components/CopyableText/index.tsx
+++ b/docs/ui/components/CopyableText/index.tsx
@@ -49,9 +49,9 @@ export function CopyTextButton({ children, copyText, className }: CopyTextButton
         type="button"
         onClick={handleCopyAsync}
         className={mergeClasses(
-          'rounded inline-flex items-center justify-center p-1 transition-colors',
+          'inline-flex items-center justify-center rounded-sm p-1 transition-colors',
           'hover:bg-element focus-visible:bg-element',
-          'focus:outline-none focus-visible:ring-2 focus-visible:ring-link',
+          'focus-visible:ring-link focus:outline-none focus-visible:ring-2',
           copied && 'opacity-100'
         )}
         aria-label="Copy to clipboard"

--- a/docs/ui/components/Diagram/Diagram.tsx
+++ b/docs/ui/components/Diagram/Diagram.tsx
@@ -26,7 +26,7 @@ export const Diagram = ({ source, darkSource, disableSrcSet, alt }: Props) => {
 
   if (!source.endsWith('.png')) {
     return (
-      <div className="relative m-auto my-6 max-w-[750px] overflow-hidden rounded-md border border-default bg-default">
+      <div className="border-default bg-default relative m-auto my-6 max-w-[750px] overflow-hidden rounded-md border">
         <DotGrid />
         <picture className="relative">
           {isDark && darkSource && <source srcSet={darkSource} />}
@@ -37,7 +37,7 @@ export const Diagram = ({ source, darkSource, disableSrcSet, alt }: Props) => {
   }
 
   return (
-    <div className="relative m-auto my-6 max-w-[750px] overflow-hidden rounded-md border border-default bg-default">
+    <div className="border-default bg-default relative m-auto my-6 max-w-[750px] overflow-hidden rounded-md border">
       <DotGrid />
       <picture className="relative">
         {!isDark && !disableSrcSet && (

--- a/docs/ui/components/DownloadSlide/index.tsx
+++ b/docs/ui/components/DownloadSlide/index.tsx
@@ -15,16 +15,16 @@ export function DownloadSlide({ title, description, imageUrl, className }: Props
       download
       href={imageUrl}
       className={mergeClasses(
-        'relative flex items-stretch overflow-hidden rounded-lg border border-default bg-default shadow-xs transition',
+        'border-default bg-default relative flex items-stretch overflow-hidden rounded-lg border shadow-xs transition',
         'hocus:opacity-80 hocus:shadow-sm',
         'max-sm-gutters:flex-col',
-        '[&+hr]:!mt-6',
+        '[&+hr]:mt-6!',
         className
       )}
       aria-label="Download slide">
       <div
         className={mergeClasses(
-          'relative flex max-w-[200px] items-center justify-center border-r border-secondary bg-element',
+          'border-secondary bg-element relative flex max-w-[200px] items-center justify-center border-r',
           'max-sm-gutters:max-w-full max-sm-gutters:border-b max-sm-gutters:border-r-0'
         )}>
         <img
@@ -34,14 +34,14 @@ export function DownloadSlide({ title, description, imageUrl, className }: Props
           aria-label={`Download slide: ${title}`}
         />
       </div>
-      <div className="flex flex-col justify-center gap-1 bg-default px-4 py-2">
-        <p className="flex items-center gap-1.5 text-sm font-medium leading-normal">{title}</p>
+      <div className="bg-default flex flex-col justify-center gap-1 px-4 py-2">
+        <p className="flex items-center gap-1.5 text-sm leading-normal font-medium">{title}</p>
         {description && (
-          <p className="flex items-center gap-2 text-xs text-secondary">{description}</p>
+          <p className="text-secondary flex items-center gap-2 text-xs">{description}</p>
         )}
       </div>
       <Download03Icon
-        className="icon-md my-auto ml-auto mr-4 shrink-0 text-icon-secondary max-sm-gutters:hidden"
+        className="icon-md text-icon-secondary max-sm-gutters:hidden my-auto mr-4 ml-auto shrink-0"
         aria-hidden="true"
       />
     </a>

--- a/docs/ui/components/Dropdown/Item.tsx
+++ b/docs/ui/components/Dropdown/Item.tsx
@@ -33,9 +33,9 @@ export function Item({
     <DropdownMenu.Item
       aria-disabled={disabled}
       className={mergeClasses(
-        'group relative z-40 flex cursor-pointer select-none items-center justify-between rounded-sm px-2 py-1 transition-colors',
-        'hover:outline-0 hocus:bg-hover',
-        disabled && 'cursor-default opacity-60 hocus:bg-default'
+        'group relative z-40 flex cursor-pointer items-center justify-between rounded-sm px-2 py-1 transition-colors select-none',
+        'hocus:bg-hover hover:outline-0',
+        disabled && 'hocus:bg-default cursor-default opacity-60'
       )}
       onSelect={event => {
         // prevent default behavior of closing the menu without using pointer-events-none on the
@@ -90,7 +90,7 @@ export function Item({
           )}
         </div>
         {description && typeof description === 'string' ? (
-          <FOOTNOTE theme="tertiary" className="!leading-[18px]">
+          <FOOTNOTE theme="tertiary" className="leading-[18px]!">
             {description}
           </FOOTNOTE>
         ) : null}

--- a/docs/ui/components/Dropdown/index.tsx
+++ b/docs/ui/components/Dropdown/index.tsx
@@ -29,8 +29,8 @@ export function Dropdown({
         <div className="bg-danger">
           <Content
             className={mergeClasses(
-              'flex min-w-[180px] flex-col gap-0.5 rounded-md border border-default bg-default p-1 shadow-md',
-              'will-change-[opacity,transform] data-[side=bottom]:animate-slideUpAndFadeIn',
+              'border-default bg-default flex min-w-[180px] flex-col gap-0.5 rounded-md border p-1 shadow-md',
+              'data-[side=bottom]:animate-slideUpAndFadeIn will-change-[opacity,transform]',
               className
             )}
             side={side}
@@ -38,7 +38,7 @@ export function Dropdown({
             collisionPadding={collisionPadding}
             {...rest}>
             <Arrow asChild>
-              <div className="relative -top-1 size-2.5 rotate-45 border-b border-r border-default bg-default" />
+              <div className="border-default bg-default relative -top-1 size-2.5 rotate-45 border-r border-b" />
             </Arrow>
             {children}
           </Content>

--- a/docs/ui/components/EASCLIReference/index.tsx
+++ b/docs/ui/components/EASCLIReference/index.tsx
@@ -73,22 +73,22 @@ const CommandSection = ({ command }: { command: CommandData }) => {
   const flagsList = sections.flags ? parseListEntries(sections.flags) : [];
 
   return (
-    <section className="border-b border-secondary pb-8 last:border-0 last:pb-0">
+    <section className="border-secondary border-b pb-8 last:border-0 last:pb-0">
       <H3 id={slug} className="translate-y-[2px] self-center">
         <CODE className="font-mono text-[inherit]">{command.command}</CODE>
       </H3>
-      <P className="mb-5 mt-2">{renderInlineContent(description)}</P>
+      <P className="mt-2 mb-5">{renderInlineContent(description)}</P>
 
       {sections.usage && (
         <div className="mb-6">
-          <H4 className="mb-2 mt-0 translate-y-[2px] self-center">Usage</H4>
+          <H4 className="mt-0 mb-2 translate-y-[2px] self-center">Usage</H4>
           <Terminal cmd={toTerminalLines(sections.usage)} />
         </div>
       )}
 
       {argumentsList.length > 0 && (
         <div className="mb-6">
-          <H4 className="mb-2 mt-0 translate-y-[2px] self-center">
+          <H4 className="mt-0 mb-2 translate-y-[2px] self-center">
             {argumentsList.length === 1 ? 'Argument' : 'Arguments'}
           </H4>
           <ListSection entries={argumentsList} />
@@ -97,7 +97,7 @@ const CommandSection = ({ command }: { command: CommandData }) => {
 
       {flagsList.length > 0 && (
         <div className="mb-6">
-          <H4 className="mb-2 mt-0 translate-y-[2px] self-center">
+          <H4 className="mt-0 mb-2 translate-y-[2px] self-center">
             {flagsList.length === 1 ? 'Flag' : 'Flags'}
           </H4>
           <ListSection entries={flagsList} />
@@ -106,7 +106,7 @@ const CommandSection = ({ command }: { command: CommandData }) => {
 
       {sections.aliases && (
         <div className="mb-6">
-          <H4 className="mb-2 mt-0 translate-y-[2px] self-center">
+          <H4 className="mt-0 mb-2 translate-y-[2px] self-center">
             {countNonEmptyLines(sections.aliases) === 1 ? 'Alias' : 'Aliases'}
           </H4>
           <Terminal cmd={toTerminalLines(sections.aliases)} />
@@ -115,7 +115,7 @@ const CommandSection = ({ command }: { command: CommandData }) => {
 
       {sections.examples && (
         <div className="mb-4">
-          <H4 className="mb-2 mt-0 translate-y-[2px] self-center">Examples</H4>
+          <H4 className="mt-0 mb-2 translate-y-[2px] self-center">Examples</H4>
           <Terminal cmd={toTerminalLines(sections.examples)} />
         </div>
       )}

--- a/docs/ui/components/EASHostingShoutoutBanner.tsx
+++ b/docs/ui/components/EASHostingShoutoutBanner.tsx
@@ -24,7 +24,7 @@ export function EASHostingShoutoutBanner() {
   return (
     <div
       className={mergeClasses(
-        'relative mb-6 flex items-center justify-between gap-3 overflow-hidden rounded-lg border border-success bg-palette-green2 px-6 py-4 shadow-xs',
+        'border-success bg-palette-green2 relative mb-6 flex items-center justify-between gap-3 overflow-hidden rounded-lg border px-6 py-4 shadow-xs',
         'max-md-gutters:flex-wrap'
       )}>
       <svg
@@ -64,18 +64,18 @@ export function EASHostingShoutoutBanner() {
         />
       </svg>
       <div className="flex items-center gap-4">
-        <div className="relative z-10 p-2 max-sm-gutters:hidden">
+        <div className="max-sm-gutters:hidden relative z-10 p-2">
           <div
             className={mergeClasses(
-              'asset-sm-shadow absolute inset-0 rounded-md bg-palette-green10',
+              'asset-sm-shadow bg-palette-green10 absolute inset-0 rounded-md',
               'dark:bg-palette-green6'
             )}
           />
-          <Cloud01Icon className="icon-lg relative z-10 text-palette-white" />
+          <Cloud01Icon className="icon-lg text-palette-white relative z-10" />
         </div>
         <div className="relative grid grid-cols-1">
-          <p className="text-base font-medium text-success">EAS Hosting</p>
-          <p className="text-sm text-success">
+          <p className="text-success text-base font-medium">EAS Hosting</p>
+          <p className="text-success text-sm">
             Try the first end-to-end deployment solution for universal app development.
           </p>
         </div>
@@ -88,7 +88,7 @@ export function EASHostingShoutoutBanner() {
           theme="secondary"
           rightSlot={<ArrowUpRightIcon className="icon-xs text-icon-success" />}
           className={mergeClasses(
-            'gap-1.5 border-success text-icon-success hocus:bg-palette-green2',
+            'border-success text-icon-success hocus:bg-palette-green2 gap-1.5',
             'dark:border-palette-green8 dark:bg-palette-green4 dark:text-default dark:hocus:bg-palette-green5'
           )}>
           Learn More

--- a/docs/ui/components/FileTree/TextWithNote.tsx
+++ b/docs/ui/components/FileTree/TextWithNote.tsx
@@ -14,7 +14,7 @@ export function TextWithNote({
       {note && (
         <>
           {/* divider pushing  */}
-          <span className="mx-3 min-w-8 flex-1 border-b border-default opacity-60 max-md-gutters:mx-2" />
+          <span className="border-default max-md-gutters:mx-2 mx-3 min-w-8 flex-1 border-b opacity-60" />
           {/* Optional note */}
           <code className="text-default">{note}</code>
         </>

--- a/docs/ui/components/FileTree/index.tsx
+++ b/docs/ui/components/FileTree/index.tsx
@@ -19,7 +19,7 @@ type FileObject = {
 export function FileTree({ files = [], ...rest }: FileTreeProps) {
   return (
     <div
-      className="mb-4 overflow-x-auto whitespace-nowrap rounded-md border border-default bg-default p-2 pb-4 pr-4 text-xs"
+      className="border-default bg-default mb-4 overflow-x-auto rounded-md border p-2 pr-4 pb-4 text-xs whitespace-nowrap"
       {...rest}>
       {renderStructure(generateStructure(files))}
     </div>
@@ -72,10 +72,10 @@ function renderStructure(structure: FileObject[], level = 0): ReactNode {
 
     if (files.length > 0) {
       return (
-        <div key={name + '_' + index} className="mt-1 flex flex-col rounded-sm pl-2 pt-1">
+        <div key={name + '_' + index} className="mt-1 flex flex-col rounded-sm pt-1 pl-2">
           <div className="flex items-center">
             {' '.repeat(level)}
-            <FolderIcon className="mr-2 min-w-[20px] text-icon-tertiary opacity-60" />
+            <FolderIcon className="text-icon-tertiary mr-2 min-w-[20px] opacity-60" />
             <TextWithNote name={name} note={note} className="text-secondary" />
           </div>
           {renderStructure(files, level + 1)}
@@ -85,9 +85,9 @@ function renderStructure(structure: FileObject[], level = 0): ReactNode {
 
     if (name.length > 0) {
       return (
-        <div key={name + '_' + index} className="mt-1 flex items-center rounded-sm pl-2 pt-1">
+        <div key={name + '_' + index} className="mt-1 flex items-center rounded-sm pt-1 pl-2">
           {' '.repeat(Math.max(level, 0))}
-          <FileIcon className="mr-2 min-w-[20px] text-icon-tertiary" />
+          <FileIcon className="text-icon-tertiary mr-2 min-w-[20px]" />
           <TextWithNote name={name} note={note} className="text-default" />
         </div>
       );

--- a/docs/ui/components/Footer/FeedbackDialog.tsx
+++ b/docs/ui/components/Footer/FeedbackDialog.tsx
@@ -60,26 +60,26 @@ export const FeedbackDialog = ({ pathname }: Props) => {
           )}>
           <div className="fixed inset-0 bg-[#00000080]" />
         </Dialog.Overlay>
-        <div className="fixed left-0 top-0 z-[1000] flex h-dvh w-dvw items-center justify-center">
+        <div className="fixed top-0 left-0 z-[1000] flex h-dvh w-dvw items-center justify-center">
           <Dialog.Content
             className={mergeClasses(
               'dialog-content',
-              'break-words backface-hidden left-0 top-0 max-h-[90vh] w-[90vw] max-w-[500px] overflow-hidden rounded-lg border border-default bg-default shadow-md outline-0',
+              'border-default bg-default top-0 left-0 max-h-[90vh] w-[90vw] max-w-[500px] overflow-hidden rounded-lg border break-words shadow-md outline-0 backface-hidden',
               'data-[state=open]:animate-slideUpAndFadeIn',
               'data-[state=closed]:animate-fadeOut'
             )}>
             {isSuccess ? (
               <>
                 <div className="flex flex-col items-center px-6 py-12">
-                  <div className="flex size-[72px] items-center justify-center rounded-full border-2 border-success bg-success">
+                  <div className="border-success bg-success flex size-[72px] items-center justify-center rounded-full border-2">
                     <CheckIcon className="icon-2xl text-icon-success" />
                   </div>
-                  <RawH2 className="!mb-2 !mt-5">Feedback received</RawH2>
+                  <RawH2 className="mt-5! mb-2!">Feedback received</RawH2>
                   <CALLOUT theme="secondary">
                     Your feedback will help us make our docs better. Thanks for sharing!
                   </CALLOUT>
                 </div>
-                <div className="flex min-h-[56px] items-center justify-end gap-2 bg-subtle px-3">
+                <div className="bg-subtle flex min-h-[56px] items-center justify-end gap-2 px-3">
                   <Dialog.Close asChild>
                     <Button type="submit">Done</Button>
                   </Dialog.Close>
@@ -93,7 +93,7 @@ export const FeedbackDialog = ({ pathname }: Props) => {
                 }}>
                 <div className="px-6 py-5">
                   <div className="flex justify-between">
-                    <RawH2 className="!my-0">Share your feedback</RawH2>
+                    <RawH2 className="my-0!">Share your feedback</RawH2>
                     <Dialog.Close asChild>
                       <Button theme="quaternary" leftSlot={<XIcon className="icon-md" />} />
                     </Dialog.Close>
@@ -140,7 +140,7 @@ export const FeedbackDialog = ({ pathname }: Props) => {
                     </InlineHelp>
                   )}
                 </div>
-                <div className="flex min-h-[56px] items-center justify-end gap-2 bg-subtle px-3">
+                <div className="bg-subtle flex min-h-[56px] items-center justify-end gap-2 px-3">
                   <Dialog.Close asChild>
                     <Button theme="quaternary">No Thanks</Button>
                   </Dialog.Close>

--- a/docs/ui/components/Footer/Footer.tsx
+++ b/docs/ui/components/Footer/Footer.tsx
@@ -72,10 +72,10 @@ export const Footer = ({
             <LinkBase
               href={previousPage.href}
               className={mergeClasses(
-                'flex w-full items-center gap-3 rounded-md border border-solid border-default px-4 py-3 transition',
+                'border-default flex w-full items-center gap-3 rounded-md border border-solid px-4 py-3 transition',
                 'hocus:bg-subtle hocus:shadow-xs'
               )}>
-              <ArrowLeftIcon className="shrink-0 text-icon-secondary" />
+              <ArrowLeftIcon className="text-icon-secondary shrink-0" />
               <div>
                 <FOOTNOTE theme="secondary">
                   Previous{previousPage.section ? ` (${previousPage.section})` : ''}
@@ -90,7 +90,7 @@ export const Footer = ({
             <LinkBase
               href={nextPage.href}
               className={mergeClasses(
-                'flex w-full items-center justify-between gap-3 rounded-md border border-solid border-default px-4 py-3 transition',
+                'border-default flex w-full items-center justify-between gap-3 rounded-md border border-solid px-4 py-3 transition',
                 'hocus:bg-subtle hocus:shadow-xs'
               )}>
               <div>
@@ -99,7 +99,7 @@ export const Footer = ({
                 </FOOTNOTE>
                 <P weight="medium">{nextPage.sidebarTitle ?? nextPage.name}</P>
               </div>
-              <ArrowRightIcon className="shrink-0 text-icon-secondary" />
+              <ArrowRightIcon className="text-icon-secondary shrink-0" />
             </LinkBase>
           ) : (
             <div className="w-full" />
@@ -110,7 +110,7 @@ export const Footer = ({
         className={mergeClasses('flex flex-row justify-between gap-4', 'max-md-gutters:flex-col')}>
         <div>
           <PageVote />
-          <UL className="!ml-0 !mt-0 flex-1 !list-none">
+          <UL className="mt-0! ml-0! flex-1 list-none!">
             <ShareFeedbackLink pathname={router?.pathname} />
             {title && <ForumsLink isAPIPage={isAPIPage} title={title} />}
             {title && isAPIPage && (
@@ -119,12 +119,12 @@ export const Footer = ({
             {title && router?.pathname && <EditPageLink pathname={router.pathname} />}
             <LlmsTxtLink fullVersionHref={llmsFullHref} fullVersionLabel={llmsFullLabel} />
             {!isDev && shouldShowModifiedDate && modificationDate && (
-              <LI className="!mt-4 !text-2xs !text-quaternary">
+              <LI className="text-2xs! text-quaternary! mt-4!">
                 Last updated on <time dateTime={modificationDate}>{modificationDate}</time>
               </LI>
             )}
             {isDev && shouldShowModifiedDate && (
-              <LI className="!mt-4 !text-2xs !text-quaternary">
+              <LI className="text-2xs! text-quaternary! mt-4!">
                 Last updated data is not available in dev mode
               </LI>
             )}

--- a/docs/ui/components/Footer/NewsletterSignUp.tsx
+++ b/docs/ui/components/Footer/NewsletterSignUp.tsx
@@ -63,9 +63,9 @@ export const NewsletterSignUp = () => {
   }
 
   return (
-    <div className="max-w-[350px] flex-1 max-md-gutters:max-w-full">
-      <CALLOUT className="flex items-center gap-2 font-medium text-secondary" id="newsletter-label">
-        <Mail01Icon className="shrink-0 text-icon-tertiary" />
+    <div className="max-md-gutters:max-w-full max-w-[350px] flex-1">
+      <CALLOUT className="text-secondary flex items-center gap-2 font-medium" id="newsletter-label">
+        <Mail01Icon className="text-icon-tertiary shrink-0" />
         Sign up for the Expo Newsletter
       </CALLOUT>
       <form
@@ -95,7 +95,7 @@ export const NewsletterSignUp = () => {
           <Button
             size="xs"
             theme={userSignedUp ? 'quaternary' : 'secondary'}
-            className="absolute right-2.5 top-2 min-w-[68px]"
+            className="absolute top-2 right-2.5 min-w-[68px]"
             disabled={userSignedUp || email.length === 0}
             onClick={signUpAsync}>
             {userSignedUp ? 'Done!' : 'Sign Up'}

--- a/docs/ui/components/Footer/PageVote.tsx
+++ b/docs/ui/components/Footer/PageVote.tsx
@@ -21,7 +21,7 @@ export const PageVote = () => {
       {userVoted ? (
         <CALLOUT theme="secondary">Thank you for your vote! 💙</CALLOUT>
       ) : (
-        <div className="flex flex-row items-center gap-2 max-md-gutters:flex-col">
+        <div className="max-md-gutters:flex-col flex flex-row items-center gap-2">
           <CALLOUT theme="secondary" weight="medium">
             Was this doc helpful?
           </CALLOUT>
@@ -34,7 +34,7 @@ export const PageVote = () => {
               leftSlot={
                 <>
                   <ThumbsUpIcon className="icon-sm group-hover:hidden group-focus-visible:hidden" />
-                  <ThumbsUpDuotoneIcon className="icon-sm hidden text-icon-success group-hover:flex group-focus-visible:flex" />
+                  <ThumbsUpDuotoneIcon className="icon-sm text-icon-success hidden group-hover:flex group-focus-visible:flex" />
                 </>
               }
               onClick={() => {
@@ -50,7 +50,7 @@ export const PageVote = () => {
               leftSlot={
                 <>
                   <ThumbsDownIcon className="icon-sm group-hover:hidden group-focus-visible:hidden" />
-                  <ThumbsDownDuotoneIcon className="icon-sm hidden text-icon-danger group-hover:flex group-focus-visible:flex" />
+                  <ThumbsDownDuotoneIcon className="icon-sm text-icon-danger hidden group-hover:flex group-focus-visible:flex" />
                 </>
               }
               onClick={() => {

--- a/docs/ui/components/Form/Checkbox.tsx
+++ b/docs/ui/components/Form/Checkbox.tsx
@@ -15,7 +15,7 @@ export const Checkbox = forwardRef(function Checkbox(
   return (
     <div className={mergeClasses('relative flex items-center gap-2', className)}>
       {checked && (
-        <CheckIcon className="pointer-events-none absolute w-4 px-0.5 text-palette-white [&_path]:!stroke-[3px]" />
+        <CheckIcon className="text-palette-white pointer-events-none absolute w-4 px-0.5 [&_path]:stroke-[3px]!" />
       )}
       <input
         type="checkbox"
@@ -25,7 +25,7 @@ export const Checkbox = forwardRef(function Checkbox(
         data-label={label}
         disabled={disabled}
         className={mergeClasses(
-          'size-4 rounded-sm border border-palette-gray8 bg-default transition-colors',
+          'border-palette-gray8 bg-default size-4 rounded-sm border transition-colors',
           !disabled &&
             'focus-within:ring-palette-blue10 hocus:cursor-pointer hocus:border-palette-blue10 hocus:bg-palette-blue3',
           !disabled && 'dark:focus:ring-palette-blue8 dark:hocus:border-palette-blue8',
@@ -37,7 +37,7 @@ export const Checkbox = forwardRef(function Checkbox(
       {label && (
         <label
           htmlFor={id}
-          className={mergeClasses('select-none text-default', !disabled && 'hocus:cursor-pointer')}>
+          className={mergeClasses('text-default select-none', !disabled && 'hocus:cursor-pointer')}>
           {typeof label === 'string' ? <P>{label}</P> : label}
         </label>
       )}

--- a/docs/ui/components/Form/Input.tsx
+++ b/docs/ui/components/Form/Input.tsx
@@ -7,7 +7,7 @@ export function Input({ className, ...rest }: Props) {
   return (
     <input
       className={mergeClasses(
-        'my-2.5 block h-12 w-full rounded-md border border-default bg-default px-4 text-default shadow-xs placeholder:text-icon-quaternary',
+        'border-default bg-default text-default placeholder:text-icon-quaternary my-2.5 block h-12 w-full rounded-md border px-4 shadow-xs',
         className
       )}
       {...rest}

--- a/docs/ui/components/Form/Textarea.tsx
+++ b/docs/ui/components/Form/Textarea.tsx
@@ -20,7 +20,7 @@ export function Textarea({ characterLimit, className, onChange, ...rest }: Props
           }
         }}
         className={mergeClasses(
-          'my-2.5 block h-12 w-full rounded-sm border border-default bg-default p-4 leading-5 text-default shadow-xs placeholder:text-icon-tertiary',
+          'border-default bg-default text-default placeholder:text-icon-tertiary my-2.5 block h-12 w-full rounded-sm border p-4 leading-5 shadow-xs',
           className
         )}
         {...rest}
@@ -29,7 +29,7 @@ export function Textarea({ characterLimit, className, onChange, ...rest }: Props
         <CAPTION
           theme={characterCount > characterLimit ? 'danger' : 'secondary'}
           tag="code"
-          className="absolute bottom-1.5 right-3 z-10">
+          className="absolute right-3 bottom-1.5 z-10">
           {characterLimit - characterCount}
         </CAPTION>
       )}

--- a/docs/ui/components/Header/Header.tsx
+++ b/docs/ui/components/Header/Header.tsx
@@ -28,7 +28,7 @@ export const Header = ({
   const isArchive = sidebarActiveGroup === 'archive';
   return (
     <>
-      <header className="relative z-10 mx-auto flex h-[60px] items-center justify-between gap-2 border-b border-default bg-default p-0 px-4">
+      <header className="border-default bg-default relative z-10 mx-auto flex h-[60px] items-center justify-between gap-2 border-b p-0 px-4">
         <div className="flex items-center gap-8">
           <Logo subgroup={isArchive ? 'Archive' : undefined} />
         </div>
@@ -36,25 +36,25 @@ export const Header = ({
           <Button
             openInNewTab
             theme="quaternary"
-            className={mergeClasses('px-2 text-secondary', 'max-sm-gutters:hidden')}
+            className={mergeClasses('text-secondary px-2', 'max-sm-gutters:hidden')}
             href="https://expo.dev/blog">
             Blog
           </Button>
           <Button
             openInNewTab
             theme="quaternary"
-            className={mergeClasses('px-2 text-secondary', 'max-sm-gutters:hidden')}
+            className={mergeClasses('text-secondary px-2', 'max-sm-gutters:hidden')}
             href="https://expo.dev/changelog">
             Changelog
           </Button>
           <Button
             openInNewTab
             theme="quaternary"
-            className={mergeClasses('group px-2 text-secondary', 'max-lg-gutters:hidden')}
+            className={mergeClasses('group text-secondary px-2', 'max-lg-gutters:hidden')}
             leftSlot={
               <>
                 <Star01Icon className="icon-sm group-hover:hidden group-focus-visible:hidden" />
-                <Star01DuotoneIcon className="icon-sm hidden text-icon-warning group-hover:flex group-focus-visible:flex" />
+                <Star01DuotoneIcon className="icon-sm text-icon-warning hidden group-hover:flex group-focus-visible:flex" />
               </>
             }
             href="https://github.com/expo/expo">
@@ -91,7 +91,7 @@ export const Header = ({
       {isMobileMenuVisible && (
         <nav
           className={mergeClasses(
-            'relative z-10 mx-auto hidden h-[60px] items-center justify-between border-b border-default bg-default p-0 px-4',
+            'border-default bg-default relative z-10 mx-auto hidden h-[60px] items-center justify-between border-b p-0 px-4',
             'max-lg-gutters:flex'
           )}>
           <div className="flex items-center">
@@ -103,7 +103,7 @@ export const Header = ({
         </nav>
       )}
       {isMobileMenuVisible && (
-        <div className="h-[calc(100dvh-(60px*2))] overflow-y-auto overflow-x-hidden bg-subtle">
+        <div className="bg-subtle h-[calc(100dvh-(60px*2))] overflow-x-hidden overflow-y-auto">
           <SidebarHead sidebarActiveGroup={sidebarActiveGroup} />
           {sidebar}
           <SidebarFooter isMobileMenuVisible={isMobileMenuVisible} />

--- a/docs/ui/components/Header/Logo.tsx
+++ b/docs/ui/components/Header/Logo.tsx
@@ -10,26 +10,26 @@ type Props = {
 export const Logo = ({ subgroup }: Props) => (
   <div className="flex items-center gap-4">
     <LinkBase
-      className="flex select-none flex-row items-center gap-2 decoration-0 outline-offset-1"
+      className="flex flex-row items-center gap-2 decoration-0 outline-offset-1 select-none"
       href="https://expo.dev">
       <WordMarkLogo
-        className={mergeClasses('mt-px h-5 w-[72px] text-default', 'max-md-gutters:hidden')}
+        className={mergeClasses('text-default mt-px h-5 w-[72px]', 'max-md-gutters:hidden')}
         title="Expo"
       />
       <LogoIcon
-        className={mergeClasses('icon-lg mr-1.5 hidden text-default', 'max-md-gutters:flex')}
+        className={mergeClasses('icon-lg text-default mr-1.5 hidden', 'max-md-gutters:flex')}
         title="Expo"
       />
     </LinkBase>
     <LinkBase
-      className="flex select-none flex-row items-center gap-2 decoration-0 outline-offset-1"
+      className="flex flex-row items-center gap-2 decoration-0 outline-offset-1 select-none"
       href="/">
-      <div className="flex size-6 items-center justify-center rounded-sm bg-palette-blue4">
+      <div className="bg-palette-blue4 flex size-6 items-center justify-center rounded-sm">
         <DocumentationIcon className="icon-sm" />
       </div>
       <span
         className={mergeClasses(
-          'select-none text-lg font-medium text-default',
+          'text-default text-lg font-medium select-none',
           subgroup && 'max-md-gutters:hidden'
         )}>
         Docs
@@ -38,9 +38,9 @@ export const Logo = ({ subgroup }: Props) => (
     {subgroup && (
       <>
         <ChevronRightIcon
-          className={mergeClasses('-mx-2 text-icon-secondary', 'max-md-gutters:hidden')}
+          className={mergeClasses('text-icon-secondary -mx-2', 'max-md-gutters:hidden')}
         />
-        <span className="select-none text-lg font-medium text-default">{subgroup}</span>
+        <span className="text-default text-lg font-medium select-none">{subgroup}</span>
       </>
     )}
   </div>

--- a/docs/ui/components/Home/components/GridBox.tsx
+++ b/docs/ui/components/Home/components/GridBox.tsx
@@ -18,8 +18,8 @@ export function GridBox({ icon, title, link, className }: GridBoxProps) {
     <A
       href={link}
       className={mergeClasses(
-        'group relative flex min-h-[200px] flex-col overflow-hidden rounded-lg border border-default bg-subtle shadow-xs transition',
-        '[&_h2]:!my-0 [&_h3]:!mt-0',
+        'group border-default bg-subtle relative flex min-h-[200px] flex-col overflow-hidden rounded-lg border shadow-xs transition',
+        '[&_h2]:my-0! [&_h3]:mt-0!',
         'hocus:shadow-sm',
         className
       )}
@@ -27,7 +27,7 @@ export function GridBox({ icon, title, link, className }: GridBoxProps) {
       <div className="flex min-h-[142px] items-center justify-center transition-transform group-hover:scale-105">
         {icon}
       </div>
-      <LABEL className="flex h-full min-h-[30px] items-center justify-between gap-3 bg-default p-4">
+      <LABEL className="bg-default flex h-full min-h-[30px] items-center justify-between gap-3 p-4">
         {title}
         <Icon className="text-icon-secondary" />
       </LABEL>

--- a/docs/ui/components/Home/components/GridCell.tsx
+++ b/docs/ui/components/Home/components/GridCell.tsx
@@ -8,8 +8,8 @@ type GridCellProps = PropsWithChildren<{
 export const GridCell = ({ children, className }: GridCellProps) => (
   <div
     className={mergeClasses(
-      'relative min-h-[186px] overflow-hidden rounded-lg border border-default px-6 py-5 shadow-xs',
-      '[&_h2]:!my-0 [&_h3]:!mt-0',
+      'border-default relative min-h-[186px] overflow-hidden rounded-lg border px-6 py-5 shadow-xs',
+      '[&_h2]:my-0! [&_h3]:mt-0!',
       className
     )}>
     {children}

--- a/docs/ui/components/Home/components/Header.tsx
+++ b/docs/ui/components/Home/components/Header.tsx
@@ -10,8 +10,8 @@ type Props = {
 
 export function Header({ title, description, className }: Props) {
   return (
-    <div className={mergeClasses('mb-1.5 mt-5 flex flex-col gap-1', className)}>
-      <h3 className="font-semibold heading-lg max-md-gutters:heading-xl">{title}</h3>
+    <div className={mergeClasses('mt-5 mb-1.5 flex flex-col gap-1', className)}>
+      <h3 className="heading-lg max-md-gutters:heading-xl font-semibold">{title}</h3>
       <P className="text-secondary">{description}</P>
     </div>
   );

--- a/docs/ui/components/Home/resources/CodecademyImage.tsx
+++ b/docs/ui/components/Home/resources/CodecademyImage.tsx
@@ -2,7 +2,7 @@ import { theme } from '@expo/styleguide';
 
 export const CodecademyImage = () => (
   <svg
-    className="absolute bottom-5 right-5"
+    className="absolute right-5 bottom-5"
     width="126"
     height="154"
     viewBox="0 0 126 154"

--- a/docs/ui/components/Home/resources/DevicesImage.tsx
+++ b/docs/ui/components/Home/resources/DevicesImage.tsx
@@ -4,7 +4,7 @@ import { palette } from '@expo/styleguide-base';
 export const DevicesImage = () => (
   <svg
     className={mergeClasses(
-      'asset-shadow absolute bottom-0 right-0 z-1 max-w-[60%]',
+      'asset-shadow absolute right-0 bottom-0 z-1 max-w-[60%]',
       'max-lg-gutters:-bottom-4',
       'max-sm-gutters:-bottom-8'
     )}

--- a/docs/ui/components/Home/resources/QuickStartIcon.tsx
+++ b/docs/ui/components/Home/resources/QuickStartIcon.tsx
@@ -1,6 +1,6 @@
 export const QuickStartIcon = () => (
   <svg
-    className="float-left mr-3 mt-1.5"
+    className="float-left mt-1.5 mr-3"
     width="18"
     height="23"
     viewBox="0 0 18 23"

--- a/docs/ui/components/Home/resources/SnackImage.tsx
+++ b/docs/ui/components/Home/resources/SnackImage.tsx
@@ -2,7 +2,7 @@ import { palette } from '@expo/styleguide-base';
 
 export const SnackImage = () => (
   <svg
-    className="absolute bottom-6 right-5"
+    className="absolute right-5 bottom-6"
     width="80"
     height="81"
     viewBox="0 0 80 81"

--- a/docs/ui/components/Home/sections/CommandLineTools.tsx
+++ b/docs/ui/components/Home/sections/CommandLineTools.tsx
@@ -16,12 +16,12 @@ export function CommandLineTools() {
       <GridContainer>
         <GridCell
           className={mergeClasses(
-            'min-h-[192px] bg-subtle bg-gradient-to-br from-subtle from-15% to-palette-purple3',
+            'bg-subtle from-subtle to-palette-purple3 min-h-[192px] bg-linear-to-br from-15%',
             'selection:bg-palette-purple5'
           )}>
-          <AppleAppStoreIcon className="absolute -bottom-16 -right-10 size-72 text-palette-purple10 opacity-10" />
+          <AppleAppStoreIcon className="text-palette-purple10 absolute -right-10 -bottom-16 size-72! opacity-10" />
           <div className="relative z-10 flex flex-col gap-4">
-            <h2 className="flex items-center gap-2 !font-bold !text-palette-purple10 heading-lg">
+            <h2 className="text-palette-purple10! heading-lg flex items-center gap-2 font-bold!">
               <AppleAppStoreIcon className="icon-lg text-palette-purple10" /> Deploy to TestFlight
             </h2>
             <div>
@@ -34,12 +34,12 @@ export function CommandLineTools() {
         </GridCell>
         <GridCell
           className={mergeClasses(
-            'min-h-[192px] bg-subtle bg-gradient-to-br from-subtle from-15% to-palette-green3',
+            'bg-subtle from-subtle to-palette-green3 min-h-[192px] bg-linear-to-br from-15%',
             'selection:bg-palette-green4'
           )}>
-          <Cloud01DuotoneIcon className="absolute -bottom-20 -right-8 size-80 text-[#1e8a5f] opacity-10 dark:text-[#4eca8c]" />
+          <Cloud01DuotoneIcon className="absolute -right-8 -bottom-20 size-80! text-[#1e8a5f] opacity-10 dark:text-[#4eca8c]" />
           <div className="relative z-10 flex flex-col gap-4">
-            <h2 className="flex items-center gap-2 !font-bold !text-[#1e8a5f] heading-lg dark:!text-[#4eca8c]">
+            <h2 className="heading-lg flex items-center gap-2 font-bold! text-[#1e8a5f]! dark:text-[#4eca8c]!">
               <Cloud01DuotoneIcon className="icon-lg text-[#1e8a5f] dark:text-[#4eca8c]" /> Deploy
               your web app
             </h2>

--- a/docs/ui/components/Home/sections/DiscoverMore.tsx
+++ b/docs/ui/components/Home/sections/DiscoverMore.tsx
@@ -18,23 +18,23 @@ export function DiscoverMore() {
       <GridContainer>
         <GridCell
           className={mergeClasses(
-            'relative z-0 min-h-[158px] bg-subtle bg-gradient-to-br from-subtle from-30% to-palette-green3 selection:bg-palette-green5',
+            'bg-subtle from-subtle to-palette-green3 selection:bg-palette-green5 relative z-0 min-h-[158px] bg-linear-to-br from-30%',
             'selection:bg-palette-green5',
             'max-md-gutters:min-h-[200px]'
           )}>
           <PlanEnterpriseIcon
             className={mergeClasses(
-              'absolute -bottom-12 -left-20 size-[350px] rotate-[40deg] opacity-[0.12]',
+              'absolute -bottom-12 -left-20 size-[350px]! rotate-[40deg] opacity-[0.12]',
               'text-palette-green7'
             )}
           />
           <PlanEnterpriseIcon
             className={mergeClasses(
-              'absolute bottom-6 right-6 size-[72px] rounded-xl border-[6px] p-2',
+              'absolute right-6 bottom-6 size-[72px]! rounded-xl border-[6px] p-2',
               'border-palette-green5 bg-palette-green4 text-palette-green8'
             )}
           />
-          <RawH2 className="relative z-10 max-w-[22ch] !text-lg !text-palette-green11">
+          <RawH2 className="text-palette-green11! relative z-10 max-w-[22ch] text-lg!">
             Speed up your development with Expo Application Services
           </RawH2>
           <HomeButton
@@ -47,23 +47,23 @@ export function DiscoverMore() {
         </GridCell>
         <GridCell
           className={mergeClasses(
-            'relative z-0 min-h-[158px] bg-subtle bg-gradient-to-br from-subtle from-30% to-palette-pink3',
+            'bg-subtle from-subtle to-palette-pink3 relative z-0 min-h-[158px] bg-linear-to-br from-30%',
             'selection:bg-palette-pink5',
             'max-md-gutters:min-h-[200px]'
           )}>
           <RouterLogo
             className={mergeClasses(
-              'absolute -bottom-20 -left-24 size-[340px] rotate-[20deg] opacity-[0.12]',
-              'stroke-palette-pink7 stroke-[0.01rem] text-palette-pink7'
+              'absolute -bottom-20 -left-24 size-[340px]! rotate-[20deg] opacity-[0.12]',
+              'stroke-palette-pink7 text-palette-pink7 stroke-[0.01rem]'
             )}
           />
           <RouterLogo
             className={mergeClasses(
-              'absolute bottom-6 right-6 size-[72px] rounded-xl border-[6px] p-3',
-              'border-palette-pink5 bg-palette-pink4 stroke-palette-pink8 stroke-[0.01rem] text-palette-pink8'
+              'absolute right-6 bottom-6 size-[72px]! rounded-xl border-[6px] p-3',
+              'border-palette-pink5 bg-palette-pink4 stroke-palette-pink8 text-palette-pink8 stroke-[0.01rem]'
             )}
           />
-          <RawH2 className="relative z-10 max-w-[32ch] !text-lg !text-palette-pink11">
+          <RawH2 className="text-palette-pink11! relative z-10 max-w-[32ch] text-lg!">
             Discover the benefits of file-based routing with Expo Router
           </RawH2>
           <HomeButton
@@ -74,10 +74,10 @@ export function DiscoverMore() {
             Learn more
           </HomeButton>
         </GridCell>
-        <GridCell className="bg-gradient-to-br from-subtle from-30% to-palette-orange3 selection:bg-palette-orange4 dark:selection:bg-palette-orange6">
+        <GridCell className="from-subtle to-palette-orange3 selection:bg-palette-orange4 dark:selection:bg-palette-orange6 bg-linear-to-br from-30%">
           <SnackImage />
-          <RawH3 className="!font-bold !text-palette-orange11">Try Expo in your browser</RawH3>
-          <P className="max-w-[24ch] !text-xs !text-palette-orange11">
+          <RawH3 className="text-palette-orange11! font-bold!">Try Expo in your browser</RawH3>
+          <P className="text-palette-orange11! max-w-[24ch] text-xs!">
             Expo's Snack lets you try Expo with zero local setup.
           </P>
           <HomeButton
@@ -91,12 +91,12 @@ export function DiscoverMore() {
             Create a Snack
           </HomeButton>
         </GridCell>
-        <GridCell className="bg-gradient-to-br from-subtle from-30% to-palette-blue3 selection:bg-palette-blue5">
-          <div className="absolute bottom-6 right-6 rounded-full bg-palette-blue5 p-4">
-            <DiscordIcon className="size-12 text-palette-blue9 dark:text-palette-blue9" />
+        <GridCell className="from-subtle to-palette-blue3 selection:bg-palette-blue5 bg-linear-to-br from-30%">
+          <div className="bg-palette-blue5 absolute right-6 bottom-6 rounded-full p-4">
+            <DiscordIcon className="text-palette-blue9 dark:text-palette-blue9 size-12!" />
           </div>
-          <RawH3 className="!font-bold !text-palette-blue11">Chat with the community</RawH3>
-          <P className="max-w-[32ch] !text-xs !text-palette-blue11">
+          <RawH3 className="text-palette-blue11! font-bold!">Chat with the community</RawH3>
+          <P className="text-palette-blue11! max-w-[32ch] text-xs!">
             Join over 60,000 other developers
             <br />
             on the Expo Community Discord.

--- a/docs/ui/components/Home/sections/ExploreAPIs.tsx
+++ b/docs/ui/components/Home/sections/ExploreAPIs.tsx
@@ -26,22 +26,22 @@ export function ExploreAPIs() {
         <APIGridCell
           title="Image"
           link="/versions/latest/sdk/image/"
-          icon={<Image03DuotoneIcon className="size-16" />}
+          icon={<Image03DuotoneIcon className="size-16!" />}
         />
         <APIGridCell
           title="Camera"
           link="/versions/latest/sdk/camera"
-          icon={<CameraPlusDuotoneIcon className="size-16" />}
+          icon={<CameraPlusDuotoneIcon className="size-16!" />}
         />
         <APIGridCell
           title="Notifications"
           link="/versions/latest/sdk/notifications"
-          icon={<NotificationMessageDuotoneIcon className="size-16" />}
+          icon={<NotificationMessageDuotoneIcon className="size-16!" />}
         />
         <APIGridCell
           title="View all APIs"
           link="/versions/latest/"
-          icon={<DocsLogo className="size-16" />}
+          icon={<DocsLogo className="size-16!" />}
         />
       </div>
     </>
@@ -60,8 +60,8 @@ function APIGridCell({ icon, title, link, className }: APIGridCellProps) {
     <A
       href={link}
       className={mergeClasses(
-        'group relative block min-h-[200px] overflow-hidden rounded-lg border border-default bg-subtle shadow-xs transition',
-        '[&_h2]:!my-0 [&_h3]:!mt-0',
+        'group border-default bg-subtle relative block min-h-[200px] overflow-hidden rounded-lg border shadow-xs transition',
+        '[&_h2]:my-0! [&_h3]:mt-0!',
         'hocus:shadow-sm',
         className
       )}
@@ -69,7 +69,7 @@ function APIGridCell({ icon, title, link, className }: APIGridCellProps) {
       <div className="flex min-h-[142px] items-center justify-center transition-transform group-hover:scale-105">
         {icon}
       </div>
-      <LABEL className="flex min-h-[30px] items-center justify-between bg-default p-4">
+      <LABEL className="bg-default flex min-h-[30px] items-center justify-between p-4">
         {title}
         <ArrowRightIcon className="text-icon-secondary" />
       </LABEL>

--- a/docs/ui/components/Home/sections/ExploreExamples.tsx
+++ b/docs/ui/components/Home/sections/ExploreExamples.tsx
@@ -25,22 +25,22 @@ export function ExploreExamples() {
         <GridBox
           title="StickerSmash"
           link="https://github.com/expo/examples/tree/master/stickersmash"
-          icon={<StickerCircleDuotoneIcon className="size-16" />}
+          icon={<StickerCircleDuotoneIcon className="size-16!" />}
         />
         <GridBox
           title="Router + menus"
           link="https://github.com/expo/examples/tree/master/with-router-menus"
-          icon={<Rows03DuotoneIcon className="size-16" />}
+          icon={<Rows03DuotoneIcon className="size-16!" />}
         />
         <GridBox
           title="API Routes + Open AI"
           link="https://github.com/expo/examples/tree/master/with-openai"
-          icon={<MessageChatSquareDuotoneIcon className="size-16" />}
+          icon={<MessageChatSquareDuotoneIcon className="size-16!" />}
         />
         <GridBox
           title="View all examples"
           link="https://github.com/expo/examples"
-          icon={<GithubIcon className="size-16" />}
+          icon={<GithubIcon className="size-16!" />}
         />
       </div>
     </>

--- a/docs/ui/components/Home/sections/JoinTheCommunity.tsx
+++ b/docs/ui/components/Home/sections/JoinTheCommunity.tsx
@@ -23,7 +23,7 @@ export function JoinTheCommunity() {
       <div
         className={mergeClasses(
           'my-4 inline-grid w-full grid-cols-2 gap-x-8 gap-y-1.5',
-          'rounded-lg border border-default p-3 shadow-xs',
+          'border-default rounded-lg border p-3 shadow-xs',
           'max-xl-gutters:grid-cols-1',
           'max-lg-gutters:grid-cols-2',
           'max-md-gutters:grid-cols-1'
@@ -68,7 +68,7 @@ export function JoinTheCommunity() {
           title="X"
           description="Follow Expo on X for news and updates."
           link="https://x.com/expo"
-          icon={<XLogoIcon className="size-7 text-palette-white" />}
+          icon={<XLogoIcon className="text-palette-white size-7!" />}
           iconClassName="bg-[#000000]"
         />
         <CommunityGridCell
@@ -113,7 +113,7 @@ function CommunityGridCell({
     <A
       href={link}
       className={mergeClasses(
-        'relative flex min-h-[30px] items-center justify-between gap-3 overflow-hidden rounded-lg bg-default p-2 pr-3 transition',
+        'bg-default relative flex min-h-[30px] items-center justify-between gap-3 overflow-hidden rounded-lg p-2 pr-3 transition',
         'hocus:bg-element hocus:opacity-100',
         className
       )}
@@ -134,7 +134,7 @@ function CommunityGridCell({
           {description}
         </CALLOUT>
       </div>
-      <ArrowUpRightIcon className="shrink-0 self-center text-icon-tertiary" />
+      <ArrowUpRightIcon className="text-icon-tertiary shrink-0 self-center" />
     </A>
   );
 }

--- a/docs/ui/components/Home/sections/QuickStart.tsx
+++ b/docs/ui/components/Home/sections/QuickStart.tsx
@@ -11,25 +11,25 @@ import { H1, CALLOUT, A, P } from '~/ui/components/Text';
 export function QuickStart() {
   return (
     <>
-      <H1 className="mt-1 border-0 pb-0 !font-extrabold">
+      <H1 className="mt-1 border-0 pb-0 font-extrabold!">
         Create amazing apps that run everywhere
       </H1>
-      <P className="mb-2 text-secondary">
+      <P className="text-secondary mb-2">
         Build one JavaScript/TypeScript project that runs natively on all your users' devices.
       </P>
       <GridContainer>
         <GridCell
           className={mergeClasses(
-            'min-h-[192px] bg-element !bg-cell-quickstart-pattern bg-blend-multiply'
+            'bg-element bg-cell-quickstart-pattern! min-h-[192px] bg-blend-multiply'
           )}>
           <div
             className={mergeClasses(
-              'absolute inset-0 size-full rounded-lg bg-gradient-to-b from-subtle from-15% to-[#21262d00]',
+              'from-subtle absolute inset-0 size-full rounded-lg bg-linear-to-b from-15% to-[#21262d00]',
               'dark:from-[#181a1b]'
             )}
           />
           <div className="relative z-10 flex flex-col gap-4">
-            <h2 className="font-bold heading-xl">
+            <h2 className="heading-xl font-bold">
               <QuickStartIcon /> Quick Start
             </h2>
             <div>
@@ -46,17 +46,17 @@ export function QuickStart() {
         </GridCell>
         <GridCell
           className={mergeClasses(
-            'relative z-0 min-h-[192px] border-palette-blue6 bg-palette-blue4 !bg-cell-tutorial-pattern bg-blend-multiply',
+            'border-palette-blue6 bg-palette-blue4 bg-cell-tutorial-pattern! relative z-0 min-h-[192px] bg-blend-multiply',
             'dark:bg-palette-blue3 dark:bg-blend-color-burn'
           )}>
           <div
             className={mergeClasses(
-              'absolute inset-0 size-full rounded-lg bg-gradient-to-b from-palette-blue3 from-15% to-[#201d5200]',
+              'from-palette-blue3 absolute inset-0 size-full rounded-lg bg-linear-to-b from-15% to-[#201d5200]',
               'dark:from-palette-blue3 dark:to-transparent'
             )}
           />
           <DevicesImage />
-          <h2 className="relative z-10 max-w-[24ch] font-bold text-palette-blue12 heading-xl">
+          <h2 className="text-palette-blue12 heading-xl relative z-10 max-w-[24ch] font-bold">
             Create a universal Android, iOS, and web app
           </h2>
           <HomeButton
@@ -68,8 +68,8 @@ export function QuickStart() {
         </GridCell>
         <GridCell
           className={mergeClasses(
-            'col-span-2 min-h-[192px] overflow-hidden bg-gradient-to-br from-[#F3E5F5] via-[#E3F2FD] to-[#E3F2FD]',
-            'border border-palette-gray7 selection:bg-palette-blue8',
+            'col-span-2 min-h-[192px] overflow-hidden bg-linear-to-br from-[#F3E5F5] via-[#E3F2FD] to-[#E3F2FD]',
+            'border-palette-gray7 selection:bg-palette-blue8 border',
             'dark:border-[#2d3748] dark:from-[#0a0a0a] dark:via-[#1a1a2e] dark:to-[#16213e]',
             'max-xl-gutters:col-span-1',
             'max-lg-gutters:col-span-2',
@@ -77,33 +77,33 @@ export function QuickStart() {
           )}>
           <div
             className={mergeClasses(
-              'absolute inset-0 size-full rounded-lg bg-gradient-to-br from-palette-blue3 via-palette-purple3 to-palette-blue3 opacity-5',
+              'from-palette-blue3 via-palette-purple3 to-palette-blue3 absolute inset-0 size-full rounded-lg bg-linear-to-br opacity-5',
               'dark:from-palette-blue3 dark:via-palette-purple3 dark:to-palette-blue3 dark:opacity-20'
             )}
           />
           <div className="absolute inset-0 opacity-30">
-            <div className="absolute left-12 top-8 size-1 animate-pulse rounded-full bg-palette-blue9 dark:bg-palette-white" />
-            <div className="absolute right-20 top-16 size-0.5 animate-pulse rounded-full bg-palette-purple8 delay-1000 dark:bg-palette-blue8" />
-            <div className="absolute bottom-12 left-24 size-0.5 animate-pulse rounded-full bg-palette-blue9 delay-500 dark:bg-palette-white" />
-            <div className="absolute right-8 top-24 size-1 animate-pulse rounded-full bg-palette-purple7 delay-75 dark:bg-palette-blue7" />
-            <div className="absolute bottom-8 right-32 size-0.5 animate-pulse rounded-full bg-palette-blue9 delay-300 dark:bg-palette-white" />
+            <div className="bg-palette-blue9 dark:bg-palette-white absolute top-8 left-12 size-1 animate-pulse rounded-full" />
+            <div className="bg-palette-purple8 dark:bg-palette-blue8 absolute top-16 right-20 size-0.5 animate-pulse rounded-full delay-1000" />
+            <div className="bg-palette-blue9 dark:bg-palette-white absolute bottom-12 left-24 size-0.5 animate-pulse rounded-full delay-500" />
+            <div className="bg-palette-purple7 dark:bg-palette-blue7 absolute top-24 right-8 size-1 animate-pulse rounded-full delay-75" />
+            <div className="bg-palette-blue9 dark:bg-palette-white absolute right-32 bottom-8 size-0.5 animate-pulse rounded-full delay-300" />
           </div>
-          <Rocket02Icon className="absolute -bottom-20 -right-12 size-80 rotate-12 text-palette-blue9 opacity-[0.08] dark:opacity-[0.03]" />
+          <Rocket02Icon className="text-palette-blue9 absolute -right-12 -bottom-20 size-80! rotate-12 opacity-[0.08] dark:opacity-[0.03]" />
 
           <div className="relative z-10 flex flex-col gap-4">
-            <h2 className="flex items-center gap-3 !font-bold !text-palette-gray12 heading-lg dark:!text-palette-white">
-              <div className="rounded-lg bg-gradient-to-br from-palette-blue9 to-palette-purple9 p-2 shadow-lg">
+            <h2 className="text-palette-gray12! heading-lg dark:text-palette-white! flex items-center gap-3 font-bold!">
+              <div className="from-palette-blue9 to-palette-purple9 rounded-lg bg-linear-to-br p-2 shadow-lg">
                 <Rocket02Icon className="icon-lg text-palette-white" />
               </div>
               Launch to app stores
             </h2>
             <div>
-              <P className="mb-4 max-w-[80ch] !text-sm leading-relaxed !text-palette-gray11 dark:!text-palette-blue11">
+              <P className="text-palette-gray11! dark:text-palette-blue11! mb-4 max-w-[80ch] text-sm! leading-relaxed">
                 Ship apps with zero config or no prior experience. Launch easily guides you through
                 the technical stuff, directly from GitHub. No config or prior knowledge needed.
               </P>
               <HomeButton
-                className="!relative !bottom-auto border-2 border-palette-white bg-palette-white font-semibold text-palette-black shadow-md hocus:border-palette-gray1 hocus:bg-palette-gray1 hocus:text-palette-black dark:hocus:border-palette-gray11 dark:hocus:bg-palette-gray11 dark:hocus:text-palette-black"
+                className="border-palette-white bg-palette-white text-palette-black hocus:border-palette-gray1 hocus:bg-palette-gray1 hocus:text-palette-black dark:hocus:border-palette-gray11 dark:hocus:bg-palette-gray11 dark:hocus:text-palette-black relative! bottom-auto! border-2 font-semibold shadow-md"
                 href="https://launch.expo.dev/"
                 target="_blank"
                 rightSlot={<ArrowUpRightIcon className="icon-md text-palette-black" />}>

--- a/docs/ui/components/Home/sections/Talks.tsx
+++ b/docs/ui/components/Home/sections/Talks.tsx
@@ -67,8 +67,8 @@ export function TalkGridCell({
       openInNewTab
       href={link ?? `https://www.youtube.com/watch?v=${videoId}`}
       className={mergeClasses(
-        'relative flex h-full min-h-[266px] flex-col justify-between overflow-hidden rounded-lg border border-default bg-default shadow-xs transition',
-        '[&_h2]:!my-0 [&_h3]:!mt-0',
+        'border-default bg-default relative flex h-full min-h-[266px] flex-col justify-between overflow-hidden rounded-lg border shadow-xs transition',
+        '[&_h2]:my-0! [&_h3]:mt-0!',
         'hocus:shadow-sm',
         className
       )}
@@ -82,22 +82,22 @@ export function TalkGridCell({
                 : `https://i3.ytimg.com/vi/${videoId}/maxresdefault.jpg`
             })`,
           }}
-          className="h-[138px] border-b border-b-default bg-cover bg-center max-sm-gutters:h-[168px]"
+          className="border-b-default max-sm-gutters:h-[168px] h-[138px] border-b bg-cover bg-center"
         />
-        <div className="flex min-h-[30px] items-start justify-between gap-1 bg-default px-4 py-3">
+        <div className="bg-default flex min-h-[30px] items-start justify-between gap-1 px-4 py-3">
           <LABEL className="block leading-normal">{title}</LABEL>
-          <ArrowUpRightIcon className="icon-sm mt-1 shrink-0 text-icon-secondary" />
+          <ArrowUpRightIcon className="icon-sm text-icon-secondary mt-1 shrink-0" />
         </div>
       </div>
-      <div className="flex flex-col gap-0.5 bg-default px-4 pb-2">
+      <div className="bg-default flex flex-col gap-0.5 px-4 pb-2">
         {description && (
           <CALLOUT theme="secondary" className="flex items-center gap-2">
-            <Users02Icon className="icon-xs shrink-0 text-icon-tertiary" />
+            <Users02Icon className="icon-xs text-icon-tertiary shrink-0" />
             {description}
           </CALLOUT>
         )}
         <CALLOUT theme="secondary" className="flex items-center gap-2">
-          <AtSignIcon className="icon-xs shrink-0 text-icon-tertiary" />
+          <AtSignIcon className="icon-xs text-icon-tertiary shrink-0" />
           {event}
         </CALLOUT>
       </div>

--- a/docs/ui/components/InlineHelp/index.tsx
+++ b/docs/ui/components/InlineHelp/index.tsx
@@ -52,13 +52,13 @@ export const InlineHelp = ({ type = 'default', size = 'md', icon, children, clas
   return (
     <blockquote
       className={mergeClasses(
-        'mb-4 flex gap-2.5 rounded-md border border-default bg-subtle py-3 pl-3.5 pr-4 shadow-xs',
+        'border-default bg-subtle mb-4 flex gap-2.5 rounded-md border py-3 pr-4 pl-3.5 shadow-xs',
         size === 'sm' && 'gap-2 px-3 py-2.5',
         '[table_&]:last:mb-0',
         '[&_code]:bg-element',
         getCalloutColor(finalType),
         // TODO(simek): remove after migration to new components is completed
-        '[&_p]:!mb-0',
+        '[&_p]:mb-0!',
         className
       )}
       data-testid="callout-container"
@@ -72,7 +72,7 @@ export const InlineHelp = ({ type = 'default', size = 'md', icon, children, clas
       />
       <div
         className={mergeClasses(
-          'w-full leading-normal text-default',
+          'text-default w-full leading-normal',
           'last:mb-0',
           size === 'sm' && 'text-xs [&_code]:text-[90%] [&_p]:text-xs'
         )}>

--- a/docs/ui/components/LaunchPartyBanner/ConfettiPopper.tsx
+++ b/docs/ui/components/LaunchPartyBanner/ConfettiPopper.tsx
@@ -39,7 +39,7 @@ export function ConfettiPopper() {
         🎉
       </div>
       {confettiShown && (
-        <div className="absolute left-1/2 top-1/2">
+        <div className="absolute top-1/2 left-1/2">
           <ConfettiExplosionComponent
             zIndex={10}
             duration={CONFETTI_DURATION}

--- a/docs/ui/components/LaunchPartyBanner/index.tsx
+++ b/docs/ui/components/LaunchPartyBanner/index.tsx
@@ -36,19 +36,19 @@ export function LaunchPartyBanner({ currentDateAsString }: Props) {
     <div
       className={mergeClasses(
         'asset-shadow relative mb-6 flex justify-between overflow-hidden rounded-lg',
-        'border-2 border-palette-black bg-palette-white dark:border-palette-white dark:bg-palette-black',
+        'border-palette-black bg-palette-white dark:border-palette-white dark:bg-palette-black border-2',
         'max-md-gutters:flex-col max-md-gutters:items-start max-md-gutters:gap-2 max-md-gutters:bg-launch-party-banner-mobile'
       )}>
       <div
         className={mergeClasses(
-          'absolute bottom-0 hidden h-[60px] w-full bg-launch-party-banner bg-left-bottom',
+          'bg-launch-party-banner absolute bottom-0 hidden h-[60px] w-full bg-left-bottom',
           'max-md-gutters:flex'
         )}
       />
       <div className="flex items-center gap-4 p-5">
         <div
           className={mergeClasses(
-            'relative z-10 flex size-[44px] shrink-0 select-none justify-center rounded-md border-2 border-default bg-hover text-[24px] leading-[42px] shadow-xs',
+            'border-default bg-hover relative z-10 flex size-[44px] shrink-0 justify-center rounded-md border-2 text-[24px] leading-[42px] shadow-xs select-none',
             'max-sm-gutters:hidden'
           )}>
           <ConfettiPopper />
@@ -62,7 +62,7 @@ export function LaunchPartyBanner({ currentDateAsString }: Props) {
       </div>
       <div
         className={mergeClasses(
-          'z-10 flex min-w-[39.5%] shrink-0 items-center justify-end gap-3 bg-launch-party-banner bg-left bg-no-repeat pr-5',
+          'bg-launch-party-banner z-10 flex min-w-[39.5%] shrink-0 items-center justify-end gap-3 bg-left bg-no-repeat pr-5',
           'max-md-gutters:mb-4 max-md-gutters:h-[unset] max-md-gutters:min-w-[unset] max-md-gutters:bg-none max-md-gutters:px-5'
         )}>
         <Button
@@ -71,8 +71,8 @@ export function LaunchPartyBanner({ currentDateAsString }: Props) {
           openInNewTab
           rightSlot={<ArrowUpRightIcon className="icon-xs text-palette-black opacity-75" />}
           className={mergeClasses(
-            'gap-1.5 border-2 border-palette-white bg-launch-party-yellow text-palette-black',
-            'hocus:bg-launch-party-yellow hocus:bg-opacity-80 hocus:backdrop-blur-sm'
+            'border-palette-white bg-launch-party-yellow text-palette-black gap-1.5 border-2',
+            'hocus:bg-launch-party-yellow/80 hocus:backdrop-blur-sm'
           )}>
           Learn More
         </Button>
@@ -82,8 +82,8 @@ export function LaunchPartyBanner({ currentDateAsString }: Props) {
             setLaunchPartyBannerVisible(false);
           }}
           className={mergeClasses(
-            'border-2 border-palette-white bg-launch-party-red text-palette-white',
-            'hocus:bg-launch-party-red hocus:bg-opacity-80 hocus:backdrop-blur-sm'
+            'border-palette-white bg-launch-party-red text-palette-white border-2',
+            'hocus:bg-launch-party-red/80 hocus:backdrop-blur-sm'
           )}
           leftSlot={<XIcon />}
         />

--- a/docs/ui/components/Layout/Layout.tsx
+++ b/docs/ui/components/Layout/Layout.tsx
@@ -45,7 +45,7 @@ export function Layout({
       <header className="fixed top-0 z-[100] h-[60px] w-full">{header}</header>
       <main
         className={mergeClasses('mt-[60px] flex items-stretch', 'max-md-gutters:max-h-[unset]')}>
-        {navigation && <nav className="basis-[256px] max-md-gutters:hidden">{navigation}</nav>}
+        {navigation && <nav className="max-md-gutters:hidden basis-[256px]">{navigation}</nav>}
         <LayoutScroll>
           <article
             className={mergeClasses(
@@ -55,7 +55,7 @@ export function Layout({
             {children}
           </article>
         </LayoutScroll>
-        {sidebar && <aside className="basis-[288px] max-md-gutters:hidden">{sidebar}</aside>}
+        {sidebar && <aside className="max-md-gutters:hidden basis-[288px]">{sidebar}</aside>}
       </main>
     </>
   );

--- a/docs/ui/components/Layout/LayoutScroll.tsx
+++ b/docs/ui/components/Layout/LayoutScroll.tsx
@@ -18,7 +18,7 @@ export const LayoutScroll = forwardRef<HTMLDivElement, LayoutScrollProps>(
   ({ smoothScroll = true, disableOverscroll = true, children, ...rest }, ref) => (
     <div
       className={mergeClasses(
-        'flex flex-1 overflow-y-auto overflow-x-hidden',
+        'flex flex-1 overflow-x-hidden overflow-y-auto',
         smoothScroll && 'scroll-smooth',
         disableOverscroll && 'overscroll-contain'
       )}

--- a/docs/ui/components/MarkdownActions/MarkdownActionsDropdown.tsx
+++ b/docs/ui/components/MarkdownActions/MarkdownActionsDropdown.tsx
@@ -138,7 +138,7 @@ export function MarkdownActionsDropdown() {
   const dropdownTrigger = (
     <Button
       theme="quaternary"
-      className="justify-center pl-2.5 pr-2"
+      className="justify-center pr-2 pl-2.5"
       aria-haspopup="menu"
       aria-label="Copy page actions">
       <div className="flex flex-row items-center gap-1.5">

--- a/docs/ui/components/Navigation/GroupList.tsx
+++ b/docs/ui/components/Navigation/GroupList.tsx
@@ -13,7 +13,7 @@ export function GroupList({ route, children }: GroupListProps) {
 
   return (
     <>
-      <CALLOUT className="mb-2 ml-4 border-b border-default p-1 pl-[5.5] font-semibold">
+      <CALLOUT className="border-default mb-2 ml-4 border-b p-1 pl-[5.5] font-semibold">
         {route.name}
       </CALLOUT>
       {children}

--- a/docs/ui/components/Navigation/Navigation.tsx
+++ b/docs/ui/components/Navigation/Navigation.tsx
@@ -19,7 +19,7 @@ export function Navigation({ routes }: NavigationProps) {
   const persistScroll = usePersistScroll('navigation');
 
   return (
-    <nav className="h-full w-[280px] bg-subtle dark:bg-default">
+    <nav className="bg-subtle dark:bg-default h-full w-[280px]">
       <LayoutScroll {...persistScroll}>
         {routes.map(route => navigationRenderer(route, activeRoutes))}
       </LayoutScroll>

--- a/docs/ui/components/Navigation/PageLink.tsx
+++ b/docs/ui/components/Navigation/PageLink.tsx
@@ -12,18 +12,18 @@ export function PageLink({ route, isActive }: NavigationRenderProps) {
   return (
     <A
       className={mergeClasses(
-        'mx-1 my-4 flex items-center rounded-md bg-default px-1.5 py-2 shadow-xs',
+        'bg-default mx-1 my-4 flex items-center rounded-md px-1.5 py-2 shadow-xs',
         'dark:bg-element'
       )}
       href={route.href}>
       <i
         className={mergeClasses(
-          'invisible mr-2 size-1 shrink-0 rounded-full text-icon-secondary',
+          'text-icon-secondary invisible mr-2 size-1 shrink-0 rounded-full',
           isActive && 'visible'
         )}
       />
       <CALLOUT
-        className={mergeClasses('text-secondary', isActive && 'font-medium text-default')}
+        className={mergeClasses('text-secondary', isActive && 'text-default font-medium')}
         tag="span">
         {route.sidebarTitle ?? route.name}
       </CALLOUT>

--- a/docs/ui/components/Navigation/SectionList.tsx
+++ b/docs/ui/components/Navigation/SectionList.tsx
@@ -19,10 +19,10 @@ export function SectionList({ route, isActive, children }: SectionListProps) {
       className="mb-3 pt-3"
       open={isActive ?? route.expanded}
       summary={
-        <div className="mx-4 flex select-none items-center">
+        <div className="mx-4 flex items-center select-none">
           <ChevronDownIcon
             className={mergeClasses(
-              'icon-sm shrink-0 -rotate-90 text-icon-default transition-transform duration-150',
+              'icon-sm text-icon-default shrink-0 -rotate-90 transition-transform duration-150',
               '[details[open]>summary_&]:rotate-0'
             )}
           />

--- a/docs/ui/components/PageHeader/PageCliVersion.tsx
+++ b/docs/ui/components/PageHeader/PageCliVersion.tsx
@@ -16,7 +16,7 @@ export function PageCliVersion({ cliVersion, className }: Props) {
   return (
     <div className={mergeClasses('flex items-center gap-2', className)}>
       <div
-        className="flex items-center justify-center gap-1.5 text-xs text-secondary"
+        className="text-secondary flex items-center justify-center gap-1.5 text-xs"
         aria-hidden="true">
         <TerminalSquareDuotoneIcon className="icon-sm text-icon-secondary" />
         CLI version:

--- a/docs/ui/components/PageHeader/PageHeader.tsx
+++ b/docs/ui/components/PageHeader/PageHeader.tsx
@@ -66,7 +66,7 @@ export function PageHeader({
     return (
       <>
         <div className="mt-2 flex flex-col">
-          <H1 className="!my-0">
+          <H1 className="my-0!">
             {iconUrl && (
               <img
                 src={iconUrl}
@@ -95,12 +95,7 @@ export function PageHeader({
               'flex flex-wrap items-center gap-2',
               'max-md-gutters:w-full max-md-gutters:items-center max-md-gutters:justify-between max-md-gutters:border-b max-md-gutters:border-default max-md-gutters:py-3'
             )}>
-            <div className="flex flex-wrap items-center">
-              {renderAskAIButton()}
-              {hasAskAIButton && (sourceCodeUrl || packageName) && (
-                <div className="max-sm:hidden bg-secondary mx-1 h-5 w-px" />
-              )}
-            </div>
+            <div className="flex flex-wrap items-center">{renderAskAIButton()}</div>
             <div className="flex items-center gap-1.5">
               <PageTitleButtons packageName={packageName} sourceCodeUrl={sourceCodeUrl} />
             </div>
@@ -129,7 +124,7 @@ export function PageHeader({
           'mt-2 flex items-start justify-between gap-4',
           'max-xl-gutters:flex-col max-xl-gutters:items-start'
         )}>
-        <H1 className="!my-0">
+        <H1 className="my-0!">
           {iconUrl && (
             <img
               src={iconUrl}
@@ -140,7 +135,7 @@ export function PageHeader({
           {packageName && packageName.startsWith('expo-') && 'Expo '}
           {title}
         </H1>
-        <span className="-mt-0.5 flex items-center gap-1 max-xl-gutters:hidden">
+        <span className="max-xl-gutters:hidden -mt-0.5 flex items-center gap-1">
           <PageTitleButtons packageName={packageName} sourceCodeUrl={sourceCodeUrl} />
           {(showMarkdownActions || hasAskAIButton) && (
             <span className="flex items-center gap-1">
@@ -161,9 +156,9 @@ export function PageHeader({
         </P>
       )}
       {cliVersion && (
-        <PageCliVersion cliVersion={cliVersion} className="mt-3 max-xl-gutters:mt-2" />
+        <PageCliVersion cliVersion={cliVersion} className="max-xl-gutters:mt-2 mt-3" />
       )}
-      <span className="mb-1 mt-3 hidden items-center gap-1 max-xl-gutters:flex">
+      <span className="max-xl-gutters:flex mt-3 mb-1 hidden items-center gap-1">
         <PageTitleButtons packageName={packageName} sourceCodeUrl={sourceCodeUrl} />
         {(showMarkdownActions || hasAskAIButton) && (
           <span className="ml-1 flex items-center gap-1">

--- a/docs/ui/components/PageHeader/PagePackageVersion.tsx
+++ b/docs/ui/components/PageHeader/PagePackageVersion.tsx
@@ -48,7 +48,7 @@ export function PagePackageVersion({
       {versionRange && (
         <div
           data-md="skip"
-          className="flex items-center justify-center gap-1.5 text-xs text-secondary">
+          className="text-secondary flex items-center justify-center gap-1.5 text-xs">
           <PackageIcon className="icon-sm text-icon-secondary" />
           Bundled version:
           <Tag name={versionRange} className="select-auto" />

--- a/docs/ui/components/PageHeader/PagePlatformTags.tsx
+++ b/docs/ui/components/PageHeader/PagePlatformTags.tsx
@@ -31,7 +31,7 @@ export function PagePlatformTags({ platforms, className }: Props) {
             key={text}
             platform="expo-go"
             label="Included in Expo Go"
-            className="rounded-full border-palette-gray4 bg-palette-gray3 px-2.5 py-1.5 text-palette-gray12 dark:border-palette-gray4 dark:bg-palette-gray4"
+            className="border-palette-gray4 bg-palette-gray3 text-palette-gray12 dark:border-palette-gray4 dark:bg-palette-gray4 rounded-full px-2.5 py-1.5"
           />
         );
       })}

--- a/docs/ui/components/PageHeader/PageTitleButtons.tsx
+++ b/docs/ui/components/PageHeader/PageTitleButtons.tsx
@@ -24,7 +24,7 @@ export function PageTitleButtons({ packageName, sourceCodeUrl }: Props) {
       {showEditButton && (
         <Button
           theme="quaternary"
-          className="justify-center pl-2.5 pr-2"
+          className="justify-center pr-2 pl-2.5"
           openInNewTab
           href={githubUrl(router.pathname)}
           aria-label="Edit content of this page on GitHub">
@@ -48,9 +48,6 @@ export function PageTitleButtons({ packageName, sourceCodeUrl }: Props) {
                 href={sourceCodeUrl}
                 tooltip="View source code on GitHub"
               />
-              {(packageName || sourceCodeUrl?.startsWith('https://github.com/expo/expo')) && (
-                <div className="max-sm:hidden bg-secondary h-5 w-px" />
-              )}
             </>
           )}
           {packageName && (
@@ -61,9 +58,6 @@ export function PageTitleButtons({ packageName, sourceCodeUrl }: Props) {
                 href={`https://www.npmjs.com/package/${packageName}`}
                 tooltip="View library in npm registry"
               />
-              {sourceCodeUrl?.startsWith('https://github.com/expo/expo') && (
-                <div className="max-sm:hidden bg-secondary h-5 w-px" />
-              )}
             </>
           )}
           {sourceCodeUrl?.startsWith('https://github.com/expo/expo') && (

--- a/docs/ui/components/Permalink/Permalink.tsx
+++ b/docs/ui/components/Permalink/Permalink.tsx
@@ -52,7 +52,7 @@ const Permalink = withHeadingManager((props: Props & HeadingManagerProps) => {
       <Button
         theme="quaternary"
         className={mergeClasses(
-          'relative my-auto inline-flex size-[25px] min-w-[25px] justify-center p-0 transition-all duration-default',
+          'duration-default relative my-auto inline-flex size-[25px] min-w-[25px] justify-center p-0 transition-all',
           'invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100',
           isDeepNested && 'size-[22px] min-w-[22px]',
           props.additionalProps?.className

--- a/docs/ui/components/PossibleRedirectNotification.tsx
+++ b/docs/ui/components/PossibleRedirectNotification.tsx
@@ -19,7 +19,7 @@ export default function PossibleRedirectNotification({ newUrl }: Props) {
 
   if (targetId) {
     return (
-      <div className="mt-1 rounded-sm border border-solid border-warning bg-warning p-4">
+      <div className="border-warning bg-warning mt-1 rounded-sm border border-solid p-4">
         <P className="mb-0">
           ⚠️ The information you are looking for (addressed by <em>"{targetId}"</em>) has moved.{' '}
           <A href={`${newUrl}#${targetId}`}>Continue to the new location.</A>

--- a/docs/ui/components/Prerequisites/Requirement.tsx
+++ b/docs/ui/components/Prerequisites/Requirement.tsx
@@ -8,11 +8,11 @@ type RequirementProps = PropsWithChildren<{
 
 export function Requirement({ title, number, children }: RequirementProps) {
   return (
-    <div className={mergeClasses('flex gap-1.5 border-t border-default p-5')}>
+    <div className={mergeClasses('border-default flex gap-1.5 border-t p-5')}>
       <p className="mb-2 text-right font-medium">{number}.</p>
       <div className="flex-1 overflow-hidden">
         <p className="mb-2 font-medium">{title}</p>
-        <div className={mergeClasses('last:[&>*]:!mb-0 [&_p]:ml-0 [&_pre>pre]:mt-0')}>
+        <div className={mergeClasses('[&_p]:ml-0 [&_pre>pre]:mt-0 [&>*:last-child]:mb-0!')}>
           {children}
         </div>
       </div>

--- a/docs/ui/components/Prerequisites/index.tsx
+++ b/docs/ui/components/Prerequisites/index.tsx
@@ -60,7 +60,7 @@ const Prerequisites: ComponentType<PrerequisitesProps> = withHeadingManager(
       <details
         id={heading.current.slug}
         className={mergeClasses(
-          'mb-3 scroll-m-4 rounded-md border border-default p-0',
+          'border-default mb-3 scroll-m-4 rounded-md border p-0',
           '[&[open]]:shadow-xs',
           '[h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3',
           className
@@ -77,7 +77,7 @@ const Prerequisites: ComponentType<PrerequisitesProps> = withHeadingManager(
             'hocus:bg-subtle'
           )}>
           <div className="flex items-center">
-            <div className="ml-1.5 mr-2 mt-[5px] self-baseline">
+            <div className="mt-[5px] mr-2 ml-1.5 self-baseline">
               <TriangleDownIcon
                 className={mergeClasses(
                   'icon-sm text-icon-default',
@@ -102,13 +102,13 @@ const Prerequisites: ComponentType<PrerequisitesProps> = withHeadingManager(
               onClick={() => {
                 setIsOpen(true);
               }}
-              className="ml-1 inline rounded-md p-1 hocus:bg-element"
+              className="hocus:bg-element ml-1 inline rounded-md p-1"
               aria-label="Permalink">
               <PermalinkIcon className="icon-sm invisible inline-flex group-hover:visible group-focus-visible:visible" />
             </LinkBase>
           </div>
           <div>
-            <p className="text-xs text-secondary">
+            <p className="text-secondary text-xs">
               {numberOfRequirements} requirement{numberOfRequirements === 1 ? '' : 's'}
             </p>
           </div>

--- a/docs/ui/components/ProgressTracker/SuccessCheckmark.tsx
+++ b/docs/ui/components/ProgressTracker/SuccessCheckmark.tsx
@@ -10,7 +10,7 @@ export function SuccessCheckmark({ size = 'md', className }: Props) {
   return (
     <div
       className={mergeClasses(
-        'flex items-center justify-center rounded-full border-2 border-success bg-success',
+        'border-success bg-success flex items-center justify-center rounded-full border-2',
         size === 'md' && 'size-20',
         size === 'sm' && 'size-15',
         className

--- a/docs/ui/components/ProgressTracker/index.tsx
+++ b/docs/ui/components/ProgressTracker/index.tsx
@@ -91,7 +91,7 @@ export function ProgressTracker({
 
   return (
     <>
-      <div className="mx-auto flex w-full flex-col gap-4 rounded-lg border-2 border-palette-gray4 px-4 py-5">
+      <div className="border-palette-gray4 mx-auto flex w-full flex-col gap-4 rounded-lg border-2 px-4 py-5">
         <SuccessCheckmark
           size="sm"
           className={mergeClasses(
@@ -100,11 +100,11 @@ export function ProgressTracker({
           )}
         />
         <div className="flex flex-col items-center justify-center gap-2">
-          <p className="flex items-center text-center font-semibold text-default heading-lg">
-            <BookOpen02Icon className="mr-2 size-6 text-icon-secondary max-md-gutters:hidden" />{' '}
+          <p className="text-default heading-lg flex items-center text-center font-semibold">
+            <BookOpen02Icon className="text-icon-secondary max-md-gutters:hidden mr-2 size-6!" />{' '}
             {currentChapter.title}
           </p>
-          <p className="max-w-[60ch] pb-2 text-center leading-normal text-secondary">{summary}</p>
+          <p className="text-secondary max-w-[60ch] pb-2 text-center leading-normal">{summary}</p>
         </div>
         <div className="flex items-center justify-center">
           <Checkbox

--- a/docs/ui/components/ReactNavigationOptions/index.tsx
+++ b/docs/ui/components/ReactNavigationOptions/index.tsx
@@ -83,7 +83,7 @@ export const ReactNavigationOptions = ({
   const sortedOptions = filteredOptions.sort((a, b) => a.name.localeCompare(b.name));
 
   if (category && sortedOptions.length === 0) {
-    return <div className="text-sm text-secondary">No options found for category: {category}</div>;
+    return <div className="text-secondary text-sm">No options found for category: {category}</div>;
   }
 
   const categoryTitles: Record<string, string> = {

--- a/docs/ui/components/RouteUrl/RuntimePopup.tsx
+++ b/docs/ui/components/RouteUrl/RuntimePopup.tsx
@@ -30,7 +30,7 @@ export function RuntimePopup<T extends string>({
         aria-label="Runtime URL format selector"
         title="Select runtime URL format"
         className={mergeClasses(
-          'm-0 flex h-10 min-w-[100px] appearance-none items-center justify-center rounded-none border-l border-l-default bg-default px-10 indent-0 text-sm text-default shadow-xs',
+          'border-l-default bg-default text-default m-0 flex h-10 min-w-[100px] appearance-none items-center justify-center rounded-none border-l px-10 indent-0 text-sm shadow-xs',
           'hocus:bg-subtle hocus:shadow-none',
           'focus-visible:-outline-offset-2',
           'max-md-gutters:min-w-[unset] max-md-gutters:max-w-[60px] max-md-gutters:px-6 max-md-gutters:indent-[-9999px]'
@@ -46,9 +46,9 @@ export function RuntimePopup<T extends string>({
         ))}
       </select>
       {isLoaded && (
-        <div className="pointer-events-none absolute inset-x-3 inset-y-0 flex select-none items-center justify-between gap-2 text-icon-secondary">
+        <div className="text-icon-secondary pointer-events-none absolute inset-x-3 inset-y-0 flex items-center justify-between gap-2 select-none">
           <Icon className={ICON_CLASSES} />
-          <ChevronDownIcon className="icon-xs pointer-events-none text-icon-secondary" />
+          <ChevronDownIcon className="icon-xs text-icon-secondary pointer-events-none" />
         </div>
       )}
     </div>

--- a/docs/ui/components/SDKTables/ReactNativeCompatibilityTable.tsx
+++ b/docs/ui/components/SDKTables/ReactNativeCompatibilityTable.tsx
@@ -40,7 +40,7 @@ export const ReactNativeCompatibilityTable = () => {
                     onClick={() => {
                       setIsTooltipOpen(!isTooltipOpen);
                     }}
-                    className="inline-flex items-center justify-center rounded-full p-1 text-icon-secondary hover:text-icon-default focus:outline-none focus:ring-2 focus:ring-link focus:ring-offset-1 active:text-icon-default">
+                    className="text-icon-secondary hover:text-icon-default focus:ring-link active:text-icon-default inline-flex items-center justify-center rounded-full p-1 focus:ring-2 focus:ring-offset-1 focus:outline-none">
                     <InfoCircleDuotoneIcon className="icon-xs" />
                   </button>
                 </Tooltip.Trigger>

--- a/docs/ui/components/Search/Search.tsx
+++ b/docs/ui/components/Search/Search.tsx
@@ -49,7 +49,7 @@ export const Search = ({ mainSection }: SearchProps) => {
       />
       <CommandMenuTrigger
         setOpen={setOpen}
-        className="mb-2.5 hocus:bg-element hocus:dark:bg-subtle"
+        className="hocus:bg-element hocus:dark:bg-subtle mb-2.5"
       />
     </>
   );

--- a/docs/ui/components/Select.tsx
+++ b/docs/ui/components/Select.tsx
@@ -70,7 +70,7 @@ export function Select({
           {...{ 'data-testid': testID }}>
           <SelectPrimitive.Value
             placeholder={
-              <div className="whitespace-pre-wrap text-left text-sm leading-tight text-quaternary">
+              <div className="text-quaternary text-left text-sm leading-tight whitespace-pre-wrap">
                 {placeholder}
               </div>
             }
@@ -82,17 +82,17 @@ export function Select({
         <SelectPrimitive.Content
           // z-[605] to be above the dialogs (601)
           className={mergeClasses(
-            'relative z-[605] max-w-[87.5vw] overflow-hidden rounded-md border border-default bg-overlay shadow-md',
+            'border-default bg-overlay relative z-[605] max-w-[87.5vw] overflow-hidden rounded-md border shadow-md',
             'max-md-gutters:max-w-[unset]'
           )}
           data-orientation="horizontal">
-          <SelectPrimitive.ScrollUpButton className="flex h-7 items-center justify-center rounded-t-md bg-element">
+          <SelectPrimitive.ScrollUpButton className="bg-element flex h-7 items-center justify-center rounded-t-md">
             <ChevronUpIcon className="icon-sm text-icon-secondary" />
           </SelectPrimitive.ScrollUpButton>
           <SelectPrimitive.Viewport>
             <SelectPrimitive.Group>
               {optionsLabel && (
-                <SelectPrimitive.Label className="cursor-default px-3 pb-1 pt-2 text-2xs text-tertiary">
+                <SelectPrimitive.Label className="text-2xs text-tertiary cursor-default px-3 pt-2 pb-1">
                   {optionsLabel}
                 </SelectPrimitive.Label>
               )}
@@ -101,14 +101,14 @@ export function Select({
                   key={id}
                   value={id}
                   className={mergeClasses(
-                    'flex h-9 cursor-pointer items-center justify-between !rounded-none px-3 py-2',
+                    'flex h-9 cursor-pointer items-center justify-between rounded-none! px-3 py-2',
                     'hocus:bg-hover hocus:outline-0',
                     size === 'lg' && 'h-[56px]'
                   )}>
                   <SelectPrimitive.ItemText>
                     <div
                       className={mergeClasses(
-                        'flex items-center gap-2 whitespace-pre-wrap text-left text-xs font-normal leading-tight text-default',
+                        'text-default flex items-center gap-2 text-left text-xs leading-tight font-normal whitespace-pre-wrap',
                         size === 'lg' && 'text-lg'
                       )}>
                       {leftSlot}
@@ -127,7 +127,7 @@ export function Select({
                   <SelectPrimitive.ItemIndicator>
                     <CheckIcon
                       className={mergeClasses(
-                        'icon-sm shrink-0 text-icon-secondary',
+                        'icon-sm text-icon-secondary shrink-0',
                         size === 'lg' && 'icon-md'
                       )}
                     />
@@ -136,7 +136,7 @@ export function Select({
               ))}
             </SelectPrimitive.Group>
           </SelectPrimitive.Viewport>
-          <SelectPrimitive.ScrollDownButton className="flex h-7 items-center justify-center rounded-b-md bg-element">
+          <SelectPrimitive.ScrollDownButton className="bg-element flex h-7 items-center justify-center rounded-b-md">
             <ChevronDownIcon className="icon-sm text-icon-secondary" />
           </SelectPrimitive.ScrollDownButton>
         </SelectPrimitive.Content>
@@ -148,7 +148,7 @@ export function Select({
     return (
       <div className="flex flex-col gap-1">
         {typeof caption === 'string' ? (
-          <p className="text-xs font-medium text-tertiary">{caption}</p>
+          <p className="text-tertiary text-xs font-medium">{caption}</p>
         ) : (
           caption
         )}

--- a/docs/ui/components/Separator.tsx
+++ b/docs/ui/components/Separator.tsx
@@ -6,8 +6,8 @@ export function Separator() {
   const isSdkPage = currentPath.includes('/sdk/');
 
   if (isSdkPage) {
-    return <hr className="mb-6 h-[0.05rem] border-0 bg-palette-gray6 max-md-gutters:hidden" />;
+    return <hr className="bg-palette-gray6 max-md-gutters:hidden mb-6 h-[0.05rem] border-0" />;
   }
 
-  return <hr className="mb-6 mt-4 h-[0.05rem] border-0 bg-palette-gray6" />;
+  return <hr className="bg-palette-gray6 mt-4 mb-6 h-[0.05rem] border-0" />;
 }

--- a/docs/ui/components/Sidebar/ApiVersionSelect.tsx
+++ b/docs/ui/components/Sidebar/ApiVersionSelect.tsx
@@ -19,7 +19,7 @@ export function ApiVersionSelect() {
   return (
     <div
       className={mergeClasses(
-        'flex flex-col gap-1 border-b border-b-default bg-default px-4 pb-4 pt-3',
+        'border-b-default bg-default flex flex-col gap-1 border-b px-4 pt-3 pb-4',
         'max-lg-gutters:sticky max-lg-gutters:top-0 max-lg-gutters:z-10'
       )}>
       <FOOTNOTE theme="tertiary">Reference version</FOOTNOTE>

--- a/docs/ui/components/Sidebar/Sidebar.tsx
+++ b/docs/ui/components/Sidebar/Sidebar.tsx
@@ -19,11 +19,11 @@ export const Sidebar = ({ routes = [] }: SidebarProps) => {
   };
 
   return (
-    <nav className="relative w-[280px] bg-default p-4 max-lg-gutters:w-full" data-sidebar>
+    <nav className="bg-default max-lg-gutters:w-full relative w-[280px] p-4" data-sidebar>
       <div
         className={mergeClasses(
           'pointer-events-none fixed left-0 z-10 mt-[-22px] h-8 w-[273px]',
-          'bg-gradient-to-b from-default to-transparent opacity-90',
+          'from-default bg-linear-to-b to-transparent opacity-90',
           'max-lg-gutters:hidden'
         )}
       />

--- a/docs/ui/components/Sidebar/SidebarCollapsible.tsx
+++ b/docs/ui/components/Sidebar/SidebarCollapsible.tsx
@@ -76,13 +76,13 @@ export function SidebarCollapsible({ info, children }: Props) {
       <ButtonBase
         ref={ref}
         className={mergeClasses(
-          'relative flex w-full cursor-pointer select-none items-center gap-2 rounded-md px-3 py-1.5 transition duration-150',
+          'relative flex w-full cursor-pointer items-center gap-2 rounded-md px-3 py-1.5 transition duration-150 select-none',
           'hocus:bg-element'
         )}
         aria-expanded={isOpen ? 'true' : 'false'}
         onClick={toggleIsOpen}
         {...customDataAttributes}>
-        <div className="flex size-4 items-center justify-center rounded-sm border border-default bg-default shadow-xs">
+        <div className="border-default bg-default flex size-4 items-center justify-center rounded-sm border shadow-xs">
           <ChevronDownIcon
             className={mergeClasses(
               'icon-xs text-icon-secondary transition-transform duration-150',

--- a/docs/ui/components/Sidebar/SidebarFooter.tsx
+++ b/docs/ui/components/Sidebar/SidebarFooter.tsx
@@ -17,7 +17,7 @@ export const SidebarFooter = ({ isMobileMenuVisible }: SideBarFooterProps) => {
   const router = useRouter();
   const isArchive = router?.pathname ? getPageSection(router.pathname) === 'archive' : false;
   return (
-    <div className="flex flex-col gap-0.5 border-t border-t-default bg-default p-4">
+    <div className="border-t-default bg-default flex flex-col gap-0.5 border-t p-4">
       <SidebarSingleEntry
         secondary
         href="/archive"

--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -72,7 +72,7 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
             </SidebarTitle>
             <div className="flex flex-row items-center pb-1">
               <CircularProgressBar progress={progressPercentage} />{' '}
-              <p className="ml-2 text-xs text-tertiary">{`${completedChaptersCount} of ${totalChapters}`}</p>
+              <p className="text-tertiary ml-2 text-xs">{`${completedChaptersCount} of ${totalChapters}`}</p>
             </div>
           </div>
         )}
@@ -90,9 +90,9 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
                 {child.sidebarTitle ?? child.name}
                 {child.hasVideoLink &&
                   (!isSelected ? (
-                    <PlaySquareIcon className="icon-xs ml-1 inline text-icon-secondary" />
+                    <PlaySquareIcon className="icon-xs text-icon-secondary ml-1 inline" />
                   ) : (
-                    <PlaySquareDuotoneIcon className="icon-xs ml-1 inline text-palette-blue11" />
+                    <PlaySquareDuotoneIcon className="icon-xs text-palette-blue11 ml-1 inline" />
                   ))}
               </span>
               {completed && <CheckIcon className="icon-sm ml-auto" />}
@@ -144,7 +144,7 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
             </SidebarTitle>
             <div className="flex flex-row items-center pb-1">
               <CircularProgressBar progress={progressPercentageForGetStarted} />{' '}
-              <p className="ml-2 text-xs text-tertiary">{`${completedGetStartedChaptersCount} of ${totalGetStartedChapters}`}</p>
+              <p className="text-tertiary ml-2 text-xs">{`${completedGetStartedChaptersCount} of ${totalGetStartedChapters}`}</p>
             </div>
           </div>
         )}
@@ -162,9 +162,9 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
                 {child.sidebarTitle ?? child.name}
                 {child.hasVideoLink &&
                   (!isSelected ? (
-                    <PlaySquareIcon className="icon-xs ml-1 inline text-icon-secondary" />
+                    <PlaySquareIcon className="icon-xs text-icon-secondary ml-1 inline" />
                   ) : (
-                    <PlaySquareDuotoneIcon className="icon-xs ml-1 inline text-palette-blue11" />
+                    <PlaySquareDuotoneIcon className="icon-xs text-palette-blue11 ml-1 inline" />
                   ))}
               </span>
               {completed && <CheckIcon className="icon-sm ml-auto" />}

--- a/docs/ui/components/Sidebar/SidebarHead.tsx
+++ b/docs/ui/components/Sidebar/SidebarHead.tsx
@@ -29,10 +29,10 @@ export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
 
   if (sidebarActiveGroup === 'archive') {
     return (
-      <div className="flex flex-col gap-0.5 border-b border-default bg-default p-1.5">
+      <div className="border-default bg-default flex flex-col gap-0.5 border-b p-1.5">
         <LinkBase
           href="/"
-          className="flex items-center gap-3 rounded-md p-2.5 text-secondary hocus:bg-element">
+          className="text-secondary hocus:bg-element flex items-center gap-3 rounded-md p-2.5">
           <ArrowLeftIcon className="text-icon-secondary" />
           Back
         </LinkBase>
@@ -42,7 +42,7 @@ export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
 
   return (
     <>
-      <div className="flex flex-col gap-0.5 border-b border-default bg-default p-4 compact-height:pb-3">
+      <div className="border-default bg-default compact-height:pb-3 flex flex-col gap-0.5 border-b p-4">
         <Search mainSection={mainSection} />
         <div
           className={mergeClasses(

--- a/docs/ui/components/Sidebar/SidebarLink.tsx
+++ b/docs/ui/components/Sidebar/SidebarLink.tsx
@@ -57,7 +57,7 @@ export const SidebarLink = ({ info, className, children }: SidebarLinkProps) => 
       href={info.href}
       ref={ref}
       className={mergeClasses(
-        'group -ml-2.5 flex w-full scroll-m-[60px] items-center p-1 pr-0 text-xs text-secondary decoration-0',
+        'group text-secondary -ml-2.5 flex w-full scroll-m-[60px] items-center p-1 pr-0 text-xs decoration-0',
         'hocus:text-link [&_svg]:hocus:text-icon-info',
         isSelected && 'text-link [&_svg]:text-icon-info',
         info.isDeprecated && 'line-through',
@@ -73,24 +73,24 @@ export const SidebarLink = ({ info, className, children }: SidebarLinkProps) => 
       {children}
       {info.isDeprecated && <span className="sr-only">Deprecated</span>}
       {info.hasVideoLink && !isSelected && (
-        <PlaySquareIcon className="icon-xs ml-1.5 text-icon-secondary" aria-hidden="true" />
+        <PlaySquareIcon className="icon-xs text-icon-secondary ml-1.5" aria-hidden="true" />
       )}
       {info.hasVideoLink && isSelected && (
-        <PlaySquareDuotoneIcon className="icon-xs ml-1.5 text-palette-blue11" aria-hidden="true" />
+        <PlaySquareDuotoneIcon className="icon-xs text-palette-blue11 ml-1.5" aria-hidden="true" />
       )}
       {info.isDeprecated && !isSelected && (
-        <AlertTriangleIcon className="icon-xs ml-1.5 !text-icon-warning" aria-hidden="true" />
+        <AlertTriangleIcon className="icon-xs text-icon-warning! ml-1.5" aria-hidden="true" />
       )}
       {info.isDeprecated && isSelected && (
-        <AlertTriangleSolidIcon className="icon-xs ml-1.5 !text-icon-warning" aria-hidden="true" />
+        <AlertTriangleSolidIcon className="icon-xs text-icon-warning! ml-1.5" aria-hidden="true" />
       )}
       {info.isNew && (
         <div
           className={mergeClasses(
-            '-mt-px ml-2 inline-flex h-[17px] items-center rounded-full border border-palette-blue10 px-[5px] text-[10px] font-semibold leading-none text-palette-white',
+            'border-palette-blue10 text-palette-white -mt-px ml-2 inline-flex h-[17px] items-center rounded-full border px-[5px] text-[10px] leading-none font-semibold',
             isSelected
               ? 'bg-palette-blue10 text-palette-white dark:text-palette-black'
-              : 'border-palette-blue10 bg-none text-palette-blue10 dark:border-palette-blue9 dark:text-palette-blue9'
+              : 'border-palette-blue10 text-palette-blue10 dark:border-palette-blue9 dark:text-palette-blue9 bg-none'
           )}>
           NEW
         </div>
@@ -98,10 +98,10 @@ export const SidebarLink = ({ info, className, children }: SidebarLinkProps) => 
       {info.isAlpha && (
         <div
           className={mergeClasses(
-            '-mt-px ml-2 inline-flex h-[17px] items-center rounded-full border border-palette-purple10 px-[5px] text-[10px] font-semibold leading-none text-palette-white',
+            'border-palette-purple10 text-palette-white -mt-px ml-2 inline-flex h-[17px] items-center rounded-full border px-[5px] text-[10px] leading-none font-semibold',
             isSelected
               ? 'bg-palette-purple10 text-palette-white dark:text-palette-black'
-              : 'border-palette-purple10 bg-none text-palette-purple11 dark:border-palette-purple9 dark:text-palette-purple10'
+              : 'border-palette-purple10 text-palette-purple11 dark:border-palette-purple9 dark:text-palette-purple10 bg-none'
           )}>
           ALPHA
         </div>
@@ -109,10 +109,10 @@ export const SidebarLink = ({ info, className, children }: SidebarLinkProps) => 
       {info.isBeta && (
         <div
           className={mergeClasses(
-            '-mt-px ml-2 inline-flex h-[17px] items-center rounded-full border border-palette-purple10 px-[5px] text-[10px] font-semibold leading-none text-palette-white',
+            'border-palette-purple10 text-palette-white -mt-px ml-2 inline-flex h-[17px] items-center rounded-full border px-[5px] text-[10px] leading-none font-semibold',
             isSelected
               ? 'bg-palette-purple10 text-palette-white dark:text-palette-black'
-              : 'border-palette-purple10 bg-none text-palette-purple11 dark:border-palette-purple9 dark:text-palette-purple10'
+              : 'border-palette-purple10 text-palette-purple11 dark:border-palette-purple9 dark:text-palette-purple10 bg-none'
           )}>
           BETA
         </div>
@@ -120,16 +120,16 @@ export const SidebarLink = ({ info, className, children }: SidebarLinkProps) => 
       {info.isPreview && (
         <div
           className={mergeClasses(
-            '-mt-px ml-2 inline-flex h-[17px] items-center rounded-full border border-palette-purple10 px-[5px] text-[10px] font-semibold leading-none text-palette-white',
+            'border-palette-purple10 text-palette-white -mt-px ml-2 inline-flex h-[17px] items-center rounded-full border px-[5px] text-[10px] leading-none font-semibold',
             isSelected
               ? 'bg-palette-purple10 text-palette-white dark:text-palette-black'
-              : 'border-palette-purple10 bg-none text-palette-purple11 dark:border-palette-purple9 dark:text-palette-purple10'
+              : 'border-palette-purple10 text-palette-purple11 dark:border-palette-purple9 dark:text-palette-purple10 bg-none'
           )}>
           PREVIEW
         </div>
       )}
       {isExternal && (
-        <ArrowUpRightIcon className="icon-sm ml-auto text-icon-secondary group-hover:text-icon-info" />
+        <ArrowUpRightIcon className="icon-sm text-icon-secondary group-hover:text-icon-info ml-auto" />
       )}
     </LinkBase>
   );

--- a/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
+++ b/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
@@ -33,13 +33,13 @@ export const SidebarSingleEntry = ({
         <LinkBase
           href={href}
           className={mergeClasses(
-            'flex min-h-[32px] items-center gap-3 rounded-md px-2 py-1 text-sm !leading-[100%] text-secondary',
+            'text-secondary flex min-h-[32px] items-center gap-3 rounded-md px-2 py-1 text-sm leading-[100!%]',
             'hocus:bg-element',
             'focus-visible:relative focus-visible:z-10',
             allowCompactDisplay && 'compact-height:justify-center compact-height:bg-subtle',
             secondary && 'text-xs',
             isActive &&
-              '!bg-palette-blue3 font-medium text-link hocus:!bg-palette-blue4 hocus:text-link'
+              'bg-palette-blue3! text-link hocus:bg-palette-blue4! hocus:text-link font-medium'
           )}
           {...(shouldLeakReferrer && { target: '_blank', referrerPolicy: 'origin' })}
           {...(isActive && mainSection && { 'data-main-section': mainSection })}>
@@ -53,7 +53,7 @@ export const SidebarSingleEntry = ({
           <span className={mergeClasses(allowCompactDisplay && 'compact-height:hidden')}>
             {title}
           </span>
-          {isExternal && <ArrowUpRightIcon className="icon-sm ml-auto text-icon-secondary" />}
+          {isExternal && <ArrowUpRightIcon className="icon-sm text-icon-secondary ml-auto" />}
         </LinkBase>
       </Tooltip.Trigger>
       <Tooltip.Content

--- a/docs/ui/components/Snippet/FileStatus.tsx
+++ b/docs/ui/components/Snippet/FileStatus.tsx
@@ -15,7 +15,7 @@ export const FileStatus = ({ type }: FileStatusProps) => {
   return (
     <div
       className={mergeClasses(
-        'inline-flex h-[21px] items-center gap-1 rounded-sm border px-1.5 py-1 text-3xs font-semibold',
+        'text-3xs inline-flex h-[21px] items-center gap-1 rounded-sm border px-1.5 py-1 font-semibold',
         getStatusTheme(type)
       )}>
       {STATUS_LABELS[type]}

--- a/docs/ui/components/Snippet/SnippetAction.tsx
+++ b/docs/ui/components/Snippet/SnippetAction.tsx
@@ -23,14 +23,14 @@ export const SnippetAction = ({
       className={mergeClasses(
         'gap-1.5 focus-visible:-outline-offset-2',
         alwaysDark &&
-          'dark-theme border-transparent bg-transparent hocus:border-palette-gray9 hocus:bg-palette-gray5 hocus:shadow-xs',
+          'dark-theme hocus:border-palette-gray9 hocus:bg-palette-gray5 hocus:shadow-xs border-transparent bg-transparent',
         !alwaysDark &&
-          'h-10 rounded-none border-0 border-l border-l-default leading-10 hocus:bg-subtle hocus:shadow-none',
+          'border-l-default hocus:bg-subtle hocus:shadow-none h-10 rounded-none border-0 border-l leading-10',
         className
       )}
       {...rest}>
       {children && (
-        <FOOTNOTE className={mergeClasses(alwaysDark && '!text-palette-white')}>
+        <FOOTNOTE className={mergeClasses(alwaysDark && 'text-palette-white!')}>
           {children}
         </FOOTNOTE>
       )}

--- a/docs/ui/components/Snippet/SnippetContent.tsx
+++ b/docs/ui/components/Snippet/SnippetContent.tsx
@@ -19,11 +19,11 @@ export const SnippetContent = forwardRef<HTMLDivElement, SnippetContentProps>(
         data-md={alwaysDark ? 'code-block' : undefined}
         className={mergeClasses(
           preferredTheme === Themes.DARK && 'dark-theme',
-          wordWrap && '!break-words !whitespace-pre-wrap',
-          'relative overflow-x-auto rounded-b-md border border-default bg-subtle p-4 !leading-[18px] text-default',
-          'prose-code:!px-0',
-          alwaysDark && 'dark-theme whitespace-nowrap border-transparent bg-palette-black',
-          hideOverflow && 'overflow-hidden prose-code:!whitespace-nowrap',
+          wordWrap && 'break-words! whitespace-pre-wrap!',
+          'border-default bg-subtle text-default relative overflow-x-auto rounded-b-md border p-4 leading-[18px]!',
+          'prose-code:px-0!',
+          alwaysDark && 'dark-theme bg-palette-black border-transparent whitespace-nowrap',
+          hideOverflow && 'prose-code:whitespace-nowrap! overflow-hidden',
           className
         )}>
         {children}

--- a/docs/ui/components/Snippet/SnippetExpandOverlay.tsx
+++ b/docs/ui/components/Snippet/SnippetExpandOverlay.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 export function SnippetExpandOverlay({ onClick }: Props) {
   return (
-    <div className="sticky bottom-0 left-0 flex w-full bg-gradient-to-b from-transparent to-default p-6">
+    <div className="to-default sticky bottom-0 left-0 flex w-full bg-linear-to-b from-transparent p-6">
       <Button theme="secondary" onClick={onClick} className="asset-sm-shadow mx-auto">
         Show more
       </Button>

--- a/docs/ui/components/Snippet/SnippetHeader.tsx
+++ b/docs/ui/components/Snippet/SnippetHeader.tsx
@@ -28,19 +28,19 @@ export const SnippetHeader = ({
   <div
     data-md="snippet-header"
     className={mergeClasses(
-      'flex min-h-[40px] justify-between overflow-hidden border border-default bg-default pl-4',
+      'border-default bg-default flex min-h-[40px] justify-between overflow-hidden border pl-4',
       !float && 'rounded-t-md border-b-0',
       float && 'rounded-md',
       Icon && 'pl-3',
-      alwaysDark && 'dark-theme !bg-palette-gray3 pr-2 dark:border-transparent'
+      alwaysDark && 'dark-theme bg-palette-gray3! pr-2 dark:border-transparent'
     )}>
     <LABEL
       className={mergeClasses(
-        'flex min-h-10 w-full items-center gap-2 overflow-x-auto py-1 pr-4 font-medium !leading-tight',
+        'flex min-h-10 w-full items-center gap-2 overflow-x-auto py-1 pr-4 leading-tight! font-medium',
         alwaysDark && 'text-palette-white'
       )}>
       {Icon && <Icon className="icon-sm shrink-0" />}
-      <span className="break-words w-max max-w-[60dvw] truncate">{title}</span>
+      <span className="w-max max-w-[60dvw] truncate break-words">{title}</span>
       {showOperation && operationType ? <FileStatus type={operationType} /> : null}
       {titleSlot}
     </LABEL>

--- a/docs/ui/components/Snippet/actions/SettingsAction.tsx
+++ b/docs/ui/components/Snippet/actions/SettingsAction.tsx
@@ -29,7 +29,7 @@ export const SettingsAction = ({ ...rest }: SnippetActionProps) => {
         <SnippetAction
           className="min-w-[44px] px-3"
           aria-label="Show settings"
-          leftSlot={<DotsVerticalIcon className="icon-md shrink-0 text-icon-secondary" />}
+          leftSlot={<DotsVerticalIcon className="icon-md text-icon-secondary shrink-0" />}
           {...rest}
         />
       }>

--- a/docs/ui/components/Snippet/blocks/DiffBlock.tsx
+++ b/docs/ui/components/Snippet/blocks/DiffBlock.tsx
@@ -133,7 +133,7 @@ export const DiffBlock = ({
           float={collapseDeletedFiles && type === 'delete'}>
           {newPath && filenameToLinkUrl && type !== 'delete' ? (
             <SnippetAction
-              rightSlot={<ArrowUpRightIcon className="icon-sm shrink-0 text-icon-secondary" />}
+              rightSlot={<ArrowUpRightIcon className="icon-sm text-icon-secondary shrink-0" />}
               onClick={() => {
                 window.open(filenameToLinkUrl(newPath), '_blank');
               }}>

--- a/docs/ui/components/Snippet/blocks/SnackInline.tsx
+++ b/docs/ui/components/Snippet/blocks/SnackInline.tsx
@@ -72,7 +72,7 @@ export const SnackInline = ({
   const { language, value } = getCodeBlockDataFromChildren(children);
 
   return (
-    <Snippet className="mb-3 flex flex-col prose-pre:!m-0 prose-pre:!border-0">
+    <Snippet className="prose-pre:m-0! prose-pre:border-0! mb-3 flex flex-col">
       <SnippetHeader title={label ?? 'Example'} Icon={SnackLogo}>
         <form action={SNACK_URL} method="POST" target="_blank" className="contents">
           <input type="hidden" name="platform" value={defaultPlatform ?? DEFAULT_PLATFORM} />

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -220,7 +220,7 @@ const PackageTabs = ({ managers, activeManager, onSelect, className }: PackageTa
 const PackageSelect = ({ managers, activeManager, onSelect, className }: PackageTabsProps) => (
   <Select
     className={mergeClasses(
-      '!h-6 !min-h-[16px] min-w-[76px] !gap-1 !px-2 !py-0 text-xs [&_svg]:!h-3 [&_svg]:!w-3',
+      'h-6! min-h-[16px]! min-w-[76px] gap-1! px-2! py-0! text-xs [&_svg]:size-3!',
       className
     )}
     ariaLabel="Select package manager"
@@ -238,7 +238,7 @@ const BrowserAction = ({ href, label }: BrowserActionProps) => (
   <SnippetAction
     alwaysDark
     className="max-sm-gutters:gap-0 [&_p]:max-sm-gutters:hidden"
-    rightSlot={<ArrowUpRightIcon className="icon-sm shrink-0 text-icon-secondary" />}
+    rightSlot={<ArrowUpRightIcon className="icon-sm text-icon-secondary shrink-0" />}
     onClick={() => {
       if (typeof window !== 'undefined') {
         window.open(href, '_blank', 'noopener,noreferrer');
@@ -268,7 +268,7 @@ function cmdMapper(line: string, index: number) {
       <CODE
         key={key}
         data-md="skip"
-        className="select-none whitespace-pre !border-none !bg-transparent !text-palette-gray10">
+        className="text-palette-gray10! border-none! bg-transparent! whitespace-pre select-none">
         {line}
       </CODE>
     );
@@ -279,11 +279,11 @@ function cmdMapper(line: string, index: number) {
       <div key={key} className="w-fit">
         <CODE
           data-md="skip"
-          className="select-none whitespace-pre !border-none !bg-transparent !text-secondary">
+          className="text-secondary! border-none! bg-transparent! whitespace-pre select-none">
           -&nbsp;
         </CODE>
         <CODE
-          className="whitespace-pre !border-none !bg-transparent text-default"
+          className="text-default border-none! bg-transparent! whitespace-pre"
           dangerouslySetInnerHTML={{
             __html: Prism.highlight(
               line.slice(1).trim(),
@@ -297,7 +297,7 @@ function cmdMapper(line: string, index: number) {
   }
 
   return (
-    <CODE key={key} className="whitespace-pre !border-none !bg-transparent text-default">
+    <CODE key={key} className="text-default border-none! bg-transparent! whitespace-pre">
       {line}
     </CODE>
   );

--- a/docs/ui/components/StateOfRNBanner/index.tsx
+++ b/docs/ui/components/StateOfRNBanner/index.tsx
@@ -26,9 +26,9 @@ export function StateOfRNBanner() {
         'max-md-gutters:flex-wrap'
       )}>
       <div className="flex items-center gap-4">
-        <div className="relative z-10 p-2 max-sm-gutters:hidden">
+        <div className="max-sm-gutters:hidden relative z-10 p-2">
           <div className="asset-sm-shadow absolute inset-0 rounded-md bg-[#001a72] dark:bg-[#b1dfd0]" />
-          <ReactLogo className="icon-lg relative z-10 text-palette-white dark:text-[#001a72]" />
+          <ReactLogo className="icon-lg text-palette-white relative z-10 dark:text-[#001a72]" />
         </div>
         <div className="relative grid grid-cols-1 gap-1">
           <HEADLINE className="text-[#001a72] dark:text-[#b1dfd0]">
@@ -48,7 +48,7 @@ export function StateOfRNBanner() {
             <ArrowUpRightIcon className="icon-xs text-palette-white opacity-75 dark:text-[#001a72]" />
           }
           className={mergeClasses(
-            'gap-1.5 border-[#001a72] bg-[#001a72] text-palette-white',
+            'text-palette-white gap-1.5 border-[#001a72] bg-[#001a72]',
             'dark:border-[#b1dfd0] dark:bg-[#b1dfd0] dark:text-[#001a72]',
             'hocus:border-[#0026a3] hocus:bg-[#0026a3]',
             'dark:hocus:border-[#8bd0b9] dark:hocus:bg-[#8bd0b9]'

--- a/docs/ui/components/Step/Step.tsx
+++ b/docs/ui/components/Step/Step.tsx
@@ -9,18 +9,18 @@ type Props = PropsWithChildren<{
 
 export const Step = ({ children, label }: Props) => {
   return (
-    <div data-md="step" className="mb-8 mt-6 flex gap-4">
+    <div data-md="step" className="mt-6 mb-8 flex gap-4">
       <HEADLINE
         theme="secondary"
         className={mergeClasses(
-          'mt-1 flex h-7 min-w-[28px] items-center justify-center rounded-full bg-element',
-          label.length >= 3 && '!text-xs'
+          'bg-element mt-1 flex h-7 min-w-[28px] items-center justify-center rounded-full',
+          label.length >= 3 && 'text-xs!'
         )}>
         {label}
       </HEADLINE>
       <div
         data-md="step-content"
-        className="w-full max-w-[calc(100%-44px)] pt-1.5 prose-h2:!-mt-1.5 prose-h3:!-mt-1 prose-h4:!-mt-px [&>*:last-child]:!mb-0">
+        className="prose-h2:!-mt-1.5 prose-h3:!-mt-1 prose-h4:!-mt-px w-full max-w-[calc(100%-44px)] pt-1.5 [&>*:last-child]:mb-0!">
         {typeof children === 'string' ? <P>{children}</P> : children}
       </div>
     </div>

--- a/docs/ui/components/Switch/index.tsx
+++ b/docs/ui/components/Switch/index.tsx
@@ -22,10 +22,10 @@ export function Switch({ value = false, size = 'md', onChange, disabled }: Props
     <ButtonBase
       role="switch"
       className={mergeClasses(
-        'flex justify-start rounded-full border border-default bg-palette-gray4 outline-offset-2',
+        'border-default bg-palette-gray4 flex justify-start rounded-full border outline-offset-2',
         size === 'md' && 'h-6 min-w-[44px]',
         size === 'sm' && 'h-5 min-w-[36px]',
-        value && 'justify-end border-palette-blue10 bg-palette-blue10',
+        value && 'border-palette-blue10 bg-palette-blue10 justify-end',
         disabled && 'opacity-50',
         !shouldReduceMotion && 'transition-colors'
       )}
@@ -37,7 +37,7 @@ export function Switch({ value = false, size = 'md', onChange, disabled }: Props
       }}>
       <motion.div
         className={mergeClasses(
-          'm-px rounded-full bg-palette-white shadow-xs dark:bg-palette-gray11',
+          'bg-palette-white dark:bg-palette-gray11 m-px rounded-full shadow-xs',
           size === 'md' && 'h-5 min-w-[20px]',
           size === 'sm' && 'h-4 min-w-[16px]',
           value && 'dark:bg-palette-white',

--- a/docs/ui/components/Table/Cell.tsx
+++ b/docs/ui/components/Table/Cell.tsx
@@ -20,7 +20,7 @@ export const Cell = ({
 }: CellProps) => (
   <td
     className={mergeClasses(
-      'border-r border-secondary p-4',
+      'border-secondary border-r p-4',
       convertAlignToClass(align),
       fitContent && 'w-fit',
       'last:border-r-0',

--- a/docs/ui/components/Table/HeaderCell.tsx
+++ b/docs/ui/components/Table/HeaderCell.tsx
@@ -18,9 +18,9 @@ export const HeaderCell = ({
 }: HeaderCellProps) => (
   <th
     className={mergeClasses(
-      'border-r border-secondary px-4 py-3.5 text-2xs font-medium text-secondary',
+      'border-secondary text-2xs text-secondary border-r px-4 py-3.5 font-medium',
       convertAlignToClass(align),
-      size === 'sm' && 'py-2 text-3xs',
+      size === 'sm' && 'text-3xs py-2',
       '[&_code]:text-3xs [&_code]:text-secondary',
       'last:border-r-0',
       className

--- a/docs/ui/components/Table/Row.tsx
+++ b/docs/ui/components/Table/Row.tsx
@@ -6,13 +6,5 @@ type RowProps = PropsWithChildren<{
 }>;
 
 export const Row = ({ children, subtle }: RowProps) => (
-  <tr
-    className={mergeClasses(
-      'even:bg-subtle',
-      'even:[&_summary]:bg-element',
-      'even:[&_blockquote]:bg-default',
-      subtle && 'opacity-50'
-    )}>
-    {children}
-  </tr>
+  <tr className={mergeClasses('even:bg-subtle', subtle && 'opacity-50')}>{children}</tr>
 );

--- a/docs/ui/components/Table/Table.tsx
+++ b/docs/ui/components/Table/Table.tsx
@@ -20,12 +20,12 @@ export const Table = ({
 }: TableProps) => (
   <div
     className={mergeClasses(
-      'table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs',
+      'table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs',
       containerClassName
     )}>
     <table
       className={mergeClasses(
-        'w-full rounded-none border-0 text-xs text-default',
+        'text-default w-full rounded-none border-0 text-xs',
         '[&_p]:text-xs',
         '[&_li]:text-xs',
         '[&_span]:text-xs',

--- a/docs/ui/components/Table/TableHead.tsx
+++ b/docs/ui/components/Table/TableHead.tsx
@@ -3,5 +3,5 @@ import { PropsWithChildren } from 'react';
 type TableHeadProps = PropsWithChildren<object>;
 
 export const TableHead = ({ children }: TableHeadProps) => (
-  <thead className="border-b border-b-default bg-subtle">{children}</thead>
+  <thead className="border-b-default bg-subtle border-b">{children}</thead>
 );

--- a/docs/ui/components/TableOfContents/TableOfContents.test.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContents.test.tsx
@@ -101,15 +101,15 @@ describe('TableOfContents', () => {
     act(() => tocRef.current?.handleContentScroll?.(0));
     expect(tocRef.current).not.toBeNull();
     const introText = getByText('Intro');
-    expect(introText).toHaveClass('!text-link');
+    expect(introText).toHaveClass('text-link!');
 
     act(() => tocRef.current?.handleContentScroll?.(950));
     const middleText = getByText('Middle');
-    expect(middleText).toHaveClass('!text-link');
+    expect(middleText).toHaveClass('text-link!');
 
     act(() => tocRef.current?.handleContentScroll?.(1500));
     const endText = getByText('End');
-    expect(endText).toHaveClass('!text-link');
+    expect(endText).toHaveClass('text-link!');
   });
 
   test('scrolls to align heading with activation line on click', () => {

--- a/docs/ui/components/TableOfContents/TableOfContents.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContents.tsx
@@ -392,7 +392,7 @@ export const TableOfContents = forwardRef<
               }}
               aria-expanded={!collapsedH3s.has(heading.slug)}
               aria-controls={`toc-section-${heading.slug}`}
-              className="-mr-2 flex h-full cursor-pointer items-center justify-center self-start pt-0.5 hocus:opacity-75"
+              className="hocus:opacity-75 -mr-2 flex h-full cursor-pointer items-center justify-center self-start pt-0.5"
               aria-label={`${collapsedH3s.has(heading.slug) ? 'Expand' : 'Collapse'} section ${heading.title}`}>
               <ChevronDownIcon
                 className={mergeClasses(
@@ -417,19 +417,19 @@ export const TableOfContents = forwardRef<
   };
 
   return (
-    <nav className="w-[280px] px-6 pb-10 pt-[52px]" data-toc>
+    <nav className="w-[280px] px-6 pt-[52px] pb-10" data-toc>
       <CALLOUT
         weight="medium"
         className={mergeClasses(
-          'absolute z-[100] -ml-6 -mt-[52px] flex min-h-[32px] w-[272px] select-none',
-          'items-center gap-2 bg-gradient-to-b from-default from-80% to-transparent py-3 pl-6'
+          'absolute z-[100] -mt-[52px] -ml-6 flex min-h-[32px] w-[272px] select-none',
+          'from-default items-center gap-2 bg-linear-to-b from-80% to-transparent py-3 pl-6'
         )}>
         <LayoutAlt03Icon className="icon-sm" /> On this page
         <Button
           theme="quaternary"
           size="xs"
           className={mergeClasses(
-            'ml-auto mr-2 px-2 transition-opacity duration-300',
+            'mr-2 ml-auto px-2 transition-opacity duration-300',
             !showScrollTop && 'pointer-events-none opacity-0'
           )}
           onClick={handleTopClick}>

--- a/docs/ui/components/TableOfContents/TableOfContentsLink.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContentsLink.tsx
@@ -46,21 +46,21 @@ export const TableOfContentsLink = forwardRef<HTMLAnchorElement, SidebarLinkProp
             href={'#' + slug}
             onClick={onClick}
             className={mergeClasses(
-              'mb-1.5 flex items-center justify-between truncate !text-pretty',
+              'mb-1.5 flex items-center justify-between truncate text-pretty!',
               convertToIndentClass(level - BASE_HEADING_LEVEL),
               'focus-visible:relative focus-visible:z-10'
             )}>
             <TitleElement
               className={mergeClasses(
-                'w-full !text-secondary hocus:!text-link',
-                isCodeOrFilePath && 'truncate !text-2xs',
-                isActive && '!text-link',
+                'text-secondary! hocus:text-link! w-full',
+                isCodeOrFilePath && 'text-2xs! truncate',
+                isActive && 'text-link!',
                 isDeprecated && 'line-through opacity-80'
               )}>
               {displayTitle}
               {hasOverloads && (
                 <>
-                  <BracketsEllipsesDuotoneIcon className="icon-xs ml-1 inline text-icon-secondary" />
+                  <BracketsEllipsesDuotoneIcon className="icon-xs text-icon-secondary ml-1 inline" />
                   <span className="sr-only">Has overloads</span>
                 </>
               )}

--- a/docs/ui/components/TableOfContents/__snapshots__/TableOfContents.test.tsx.snap
+++ b/docs/ui/components/TableOfContents/__snapshots__/TableOfContents.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`TableOfContents correctly matches snapshot 1`] = `
 <div>
   <nav
-    class="w-[280px] px-6 pb-10 pt-[52px]"
+    class="w-[280px] px-6 pt-[52px] pb-10"
     data-toc="true"
   >
     <p
-      class="text-default text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium absolute z-[100] -ml-6 -mt-[52px] flex min-h-[32px] w-[272px] select-none items-center gap-2 bg-gradient-to-b from-default from-80% to-transparent py-3 pl-6"
+      class="text-inherit text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium absolute z-[100] -mt-[52px] -ml-6 flex min-h-[32px] w-[272px] select-none from-default items-center gap-2 bg-linear-to-b from-80% to-transparent py-3 pl-6"
       data-text="true"
     >
       <svg
@@ -31,7 +31,7 @@ exports[`TableOfContents correctly matches snapshot 1`] = `
       </svg>
        On this page
       <button
-        class="cursor-pointer inline-flex border border-solid rounded-full font-medium items-center whitespace-nowrap gap-1.5 h-8 text-3xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 ml-auto mr-2 px-2 transition-opacity duration-300 pointer-events-none opacity-0"
+        class="cursor-pointer inline-flex border border-solid rounded-full font-medium items-center whitespace-nowrap gap-1.5 h-8 text-3xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 mr-2 ml-auto px-2 transition-opacity duration-300 pointer-events-none opacity-0"
         type="button"
       >
         <span
@@ -67,12 +67,12 @@ exports[`TableOfContents correctly matches snapshot 1`] = `
         class="flex items-center"
       >
         <a
-          class="mb-1.5 flex items-center justify-between truncate !text-pretty focus-visible:relative focus-visible:z-10"
+          class="mb-1.5 flex items-center justify-between truncate text-pretty! focus-visible:relative focus-visible:z-10"
           data-state="closed"
           href="#base-level-heading"
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] w-full !text-secondary hocus:!text-link"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary! hocus:text-link! w-full"
             data-text="true"
           >
             Base level heading
@@ -83,12 +83,12 @@ exports[`TableOfContents correctly matches snapshot 1`] = `
         class="flex items-center"
       >
         <a
-          class="mb-1.5 flex items-center justify-between truncate !text-pretty pl-3 focus-visible:relative focus-visible:z-10"
+          class="mb-1.5 flex items-center justify-between truncate text-pretty! pl-3 focus-visible:relative focus-visible:z-10"
           data-state="closed"
           href="#level-3-subheading"
         >
           <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] w-full !text-secondary hocus:!text-link"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary! hocus:text-link! w-full"
             data-text="true"
           >
             Level 3 subheading
@@ -99,12 +99,12 @@ exports[`TableOfContents correctly matches snapshot 1`] = `
         class="flex items-center"
       >
         <a
-          class="mb-1.5 flex items-center justify-between truncate !text-pretty pl-3 focus-visible:relative focus-visible:z-10"
+          class="mb-1.5 flex items-center justify-between truncate text-pretty! pl-3 focus-visible:relative focus-visible:z-10"
           data-state="closed"
           href="#code-heading-depth-1"
         >
           <code
-            class="leading-[1.6154] text-default w-full !text-secondary hocus:!text-link truncate !text-2xs"
+            class="leading-[1.6154] text-inherit text-secondary! hocus:text-link! w-full text-2xs! truncate"
             data-text="true"
           >
             Code heading depth 1

--- a/docs/ui/components/Tabs/TabButton.tsx
+++ b/docs/ui/components/Tabs/TabButton.tsx
@@ -46,7 +46,7 @@ export function TabButton({
           className={mergeClasses(
             'absolute inset-0 rounded-md border',
             theme === 'default' && 'border-secondary bg-screen dark:bg-hover dark:drop-shadow-none',
-            theme === 'secondary' && 'border-button-secondary bg-default shadow-xs dark:bg-subtle'
+            theme === 'secondary' && 'border-button-secondary bg-default dark:bg-subtle shadow-xs'
           )}
         />
       )}
@@ -67,7 +67,7 @@ export function TabButton({
           <LabelElement
             theme={active ? 'default' : 'tertiary'}
             weight="medium"
-            className="transition-colors max-md-gutters:text-sm max-sm-gutters:text-xs">
+            className="max-md-gutters:text-sm max-sm-gutters:text-xs transition-colors">
             {label}
           </LabelElement>
           {rightSlot}

--- a/docs/ui/components/Tabs/Tabs.tsx
+++ b/docs/ui/components/Tabs/Tabs.tsx
@@ -75,8 +75,8 @@ const InnerTabs = ({
     <ReachTabs
       index={tabIndex}
       onChange={setIndex}
-      className="my-4 rounded-md border border-default shadow-xs">
-      <TabList className="flex flex-wrap gap-1 border-b border-secondary px-4 py-3">
+      className="border-default my-4 rounded-md border shadow-xs">
+      <TabList className="border-secondary flex flex-wrap gap-1 border-b px-4 py-3">
         {tabTitles.map((title, index) => (
           <TabButton key={index} active={index === tabIndex} label={title} layoutId={layoutId} />
         ))}
@@ -85,8 +85,8 @@ const InnerTabs = ({
         className={mergeClasses(
           'px-5 py-4',
           '[&_ul]:mb-3',
-          'first:[&_figure]:mt-1 first:[&_pre]:mt-1',
-          'last:[&>div>*]:!mb-0'
+          '[&_figure:first-child]:mt-1 [&_pre:first-child]:mt-1',
+          '[&>div>*:last-child]:mb-0!'
         )}>
         {tabPanels}
       </TabPanels>

--- a/docs/ui/components/Tag/PlatformIcon.tsx
+++ b/docs/ui/components/Tag/PlatformIcon.tsx
@@ -17,7 +17,7 @@ export const PlatformIcon = ({ platform }: PlatformIconProps) => {
       return (
         <AppleIcon
           className={mergeClasses(
-            'icon-2xs mt-[-0.5px] shrink-0 text-palette-blue12 opacity-80',
+            'icon-2xs text-palette-blue12 mt-[-0.5px] shrink-0 opacity-80',
             platform === 'macos' && 'text-palette-purple12',
             platform === 'tvos' && 'text-palette-pink12'
           )}
@@ -25,10 +25,10 @@ export const PlatformIcon = ({ platform }: PlatformIconProps) => {
       );
     case 'android':
       return (
-        <AndroidIcon className="icon-2xs mt-[-0.5px] shrink-0 text-palette-green12 opacity-80" />
+        <AndroidIcon className="icon-2xs text-palette-green12 mt-[-0.5px] shrink-0 opacity-80" />
       );
     case 'web':
-      return <AtSignIcon className="icon-2xs shrink-0 text-palette-orange12 opacity-80" />;
+      return <AtSignIcon className="icon-2xs text-palette-orange12 shrink-0 opacity-80" />;
     case 'expo':
       return <ExpoGoLogo className="icon-2xs shrink-0 text-current opacity-80" />;
     default:

--- a/docs/ui/components/Tag/PlatformTag.tsx
+++ b/docs/ui/components/Tag/PlatformTag.tsx
@@ -21,7 +21,7 @@ export const PlatformTag = ({ platform, label, className, suffix, ...rest }: Pla
     <div
       data-md="platform-badge"
       className={mergeClasses(
-        'mr-2 inline-flex min-h-[21px] select-none items-center gap-1 rounded-full border border-default bg-element px-[7px] py-0.5',
+        'border-default bg-element mr-2 inline-flex min-h-[21px] items-center gap-1 rounded-full border px-[7px] py-0.5 select-none',
         'last:mr-0',
         '[table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5',
         '[h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0',
@@ -30,7 +30,7 @@ export const PlatformTag = ({ platform, label, className, suffix, ...rest }: Pla
       )}
       {...rest}>
       <PlatformIcon platform={platformName} />
-      <span className={mergeClasses('whitespace-nowrap !text-3xs font-normal !leading-none')}>
+      <span className={mergeClasses('text-3xs! leading-none! font-normal whitespace-nowrap')}>
         {displayLabel}
       </span>
       {suffix}

--- a/docs/ui/components/Tag/PlatformTags.tsx
+++ b/docs/ui/components/Tag/PlatformTags.tsx
@@ -19,7 +19,7 @@ export const PlatformTags = ({ prefix, platforms }: PlatformTagsProps) => {
   return (
     <CALLOUT tag="span" className="inline-flex items-center">
       {prefix && (
-        <span className={mergeClasses(STYLES_SECONDARY, '[table_&]:!text-2xs')}>
+        <span className={mergeClasses(STYLES_SECONDARY, '[table_&]:text-2xs!')}>
           {prefix}&ensp;
         </span>
       )}

--- a/docs/ui/components/Tag/SDKRangeTag.tsx
+++ b/docs/ui/components/Tag/SDKRangeTag.tsx
@@ -35,7 +35,7 @@ export const SDKRangeTag = ({ min, max, exact, className, ...rest }: SDKRangeTag
       <Tooltip.Trigger asChild>
         <div
           className={mergeClasses(
-            'inline-flex min-h-[21px] select-none items-center gap-1 rounded-full border border-default bg-element px-[7px] py-0.5 align-middle',
+            'border-default bg-element inline-flex min-h-[21px] items-center gap-1 rounded-full border px-[7px] py-0.5 align-middle select-none',
             '[table_&]:mt-0 [table_&]:px-1.5 [table_&]:py-0.5',
             '[h2_&]:px-2 [h2_&]:py-1',
             '[h3_&]:px-2 [h3_&]:py-0.5',
@@ -46,7 +46,7 @@ export const SDKRangeTag = ({ min, max, exact, className, ...rest }: SDKRangeTag
           {...rest}>
           <span
             className={mergeClasses(
-              'whitespace-nowrap text-3xs font-normal leading-none',
+              'text-3xs leading-none font-normal whitespace-nowrap',
               '[h2_&]:text-2xs'
             )}>
             {label}

--- a/docs/ui/components/Tag/StatusTag.tsx
+++ b/docs/ui/components/Tag/StatusTag.tsx
@@ -14,7 +14,7 @@ export const StatusTag = ({ status, note, className }: StatusTagProps) => {
   return (
     <div
       className={mergeClasses(
-        'mr-2 inline-flex min-h-[21px] select-none items-center gap-1 rounded-full border border-default bg-element px-[7px] py-0.5 font-medium',
+        'border-default bg-element mr-2 inline-flex min-h-[21px] items-center gap-1 rounded-full border px-[7px] py-0.5 font-medium select-none',
         '[table_&]:mt-0 [table_&]:px-2.5 [table_&]:py-0.5',
         '[h3_&]:last-of-type:mr-0 [h4_&]:last-of-type:mr-0',
         status === 'deprecated' && getTagClasses('deprecated'),
@@ -22,7 +22,7 @@ export const StatusTag = ({ status, note, className }: StatusTagProps) => {
         className
       )}>
       {status === 'experimental' && <Star06Icon className="icon-2xs text-palette-pink12" />}
-      <span className={mergeClasses('whitespace-nowrap !text-3xs font-normal !leading-none')}>
+      <span className={mergeClasses('text-3xs! leading-none! font-normal whitespace-nowrap')}>
         {status ? formatName(status) + (note ? `: ${note}` : '') : note}
       </span>
     </div>

--- a/docs/ui/components/TemplateBareMinimumDiffViewer/index.tsx
+++ b/docs/ui/components/TemplateBareMinimumDiffViewer/index.tsx
@@ -50,7 +50,7 @@ export const TemplateBareMinimumDiffViewer = () => {
     <>
       <div className={mergeClasses('grid grid-cols-2 gap-4', 'max-sm-gutters:grid-cols-1')}>
         <div>
-          <RawH4 className="mt-2 max-sm-gutters:!my-0">From SDK version:</RawH4>
+          <RawH4 className="max-sm-gutters:my-0! mt-2">From SDK version:</RawH4>
           <VersionSelector
             version={fromVersion as string}
             setVersion={newFromVersion =>
@@ -60,7 +60,7 @@ export const TemplateBareMinimumDiffViewer = () => {
           />
         </div>
         <div>
-          <RawH4 className="mt-2 max-sm-gutters:!my-0">To SDK version:</RawH4>
+          <RawH4 className="max-sm-gutters:my-0! mt-2">To SDK version:</RawH4>
           <VersionSelector
             version={toVersion as string}
             setVersion={newToVersion =>

--- a/docs/ui/components/Text/index.tsx
+++ b/docs/ui/components/Text/index.tsx
@@ -72,7 +72,7 @@ export function createTextComponent(Element: TextElement, textClassName?: string
     return (
       <TextElementTag
         className={mergeClasses(
-          'text-inherit leading-[1.6154] text-default',
+          'text-default leading-[1.6154] text-inherit',
           textClassName,
           getTextWeightClassName(textWeight),
           getTextColorClassName(textTheme),
@@ -100,7 +100,7 @@ export const A = (props: LinkBaseProps & { isStyled?: boolean; shouldLeakReferre
         'cursor-pointer decoration-0',
         'hocus:opacity-80',
         !isStyled &&
-          'font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline',
+          'text-link visited:text-link hocus:underline [&_code]:hocus:underline font-normal',
         !isStyled &&
           '[&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link',
         className
@@ -156,7 +156,7 @@ function getTextColorClassName(theme?: TextTheme) {
 export const H1 = createTextComponent(
   TextElement.H1,
   mergeClasses(
-    'text-[31px] font-bold leading-[1.29] tracking-[-0.022rem]',
+    'text-[31px] leading-[1.29] font-bold tracking-[-0.022rem]',
     'my-2 [&_code]:text-[90%]',
     'max-md-gutters:text-[27px] max-md-gutters:leading-[1.3333]',
     'max-sm-gutters:text-[23px] max-sm-gutters:leading-[1.3913]'
@@ -165,8 +165,8 @@ export const H1 = createTextComponent(
 export const RawH2 = createTextComponent(
   TextElement.H2,
   mergeClasses(
-    'text-[25px] font-bold leading-[1.4] tracking-[-0.021rem]',
-    'mb-3.5 mt-8 [&_code]:text-[90%]',
+    'text-[25px] leading-[1.4] font-bold tracking-[-0.021rem]',
+    'mt-8 mb-3.5 [&_code]:text-[90%]',
     'max-md-gutters:text-[22px] max-md-gutters:leading-[1.409]',
     'max-sm-gutters:text-[19px] max-sm-gutters:leading-[1.5263]'
   )
@@ -174,8 +174,8 @@ export const RawH2 = createTextComponent(
 export const RawH3 = createTextComponent(
   TextElement.H3,
   mergeClasses(
-    'text-[20px] font-semibold leading-normal tracking-[-0.017rem]',
-    'mb-3 mt-7 [&_code]:text-[90%]',
+    'text-[20px] leading-normal font-semibold tracking-[-0.017rem]',
+    'mt-7 mb-3 [&_code]:text-[90%]',
     'max-md-gutters:text-[18px] max-md-gutters:leading-[1.5555]',
     'max-sm-gutters:text-[16px] max-sm-gutters:leading-relaxed'
   )
@@ -183,15 +183,15 @@ export const RawH3 = createTextComponent(
 export const RawH4 = createTextComponent(
   TextElement.H4,
   mergeClasses(
-    'text-[16px] font-semibold leading-relaxed tracking-[-0.011rem]',
-    'mb-2 mt-6 [&_code]:text-[90%]'
+    'text-[16px] leading-relaxed font-semibold tracking-[-0.011rem]',
+    'mt-6 mb-2 [&_code]:text-[90%]'
   )
 );
 export const RawH5 = createTextComponent(
   TextElement.H5,
   mergeClasses(
-    'text-[13px] font-medium leading-[1.5833] tracking-[-0.003rem]',
-    'mb-1 mt-4 [&_code]:text-[90%]'
+    'text-[13px] leading-[1.5833] font-medium tracking-[-0.003rem]',
+    'mt-4 mb-1 [&_code]:text-[90%]'
   )
 );
 
@@ -199,13 +199,13 @@ export const P = createTextComponent(TextElement.P, 'font-normal text-base [&_st
 export const CODE = createTextComponent(
   TextElement.CODE,
   mergeClasses(
-    'text-[13px] font-normal leading-[130%] tracking-[-0.003rem]',
-    'inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5'
+    'text-[13px] leading-[130%] font-normal tracking-[-0.003rem]',
+    'border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5'
   )
 );
 export const LI = createTextComponent(
   TextElement.LI,
-  mergeClasses('text-base font-normal leading-relaxed', 'mb-2')
+  mergeClasses('text-base leading-relaxed font-normal', 'mb-2')
 );
 export const HEADLINE = createTextComponent(TextElement.P, 'font-medium text-base');
 export const LABEL = createTextComponent(
@@ -241,8 +241,8 @@ export const OL = createTextComponent(
 export const KBD = createTextComponent(
   TextElement.KBD,
   mergeClasses(
-    'relative -top-px inline-block min-h-[20px] min-w-[22px] rounded-sm border border-secondary bg-subtle px-1 shadow-kbd',
-    'text-center text-2xs font-semibold leading-[20px] text-secondary',
+    'border-secondary bg-subtle shadow-kbd relative -top-px inline-block min-h-[20px] min-w-[22px] rounded-sm border px-1',
+    'text-2xs text-secondary text-center leading-[20px] font-semibold',
     'dark:bg-element'
   )
 );

--- a/docs/ui/components/Tooltip/Content.tsx
+++ b/docs/ui/components/Tooltip/Content.tsx
@@ -10,7 +10,7 @@ export function Content({ children, className, sideOffset = 4, ...rest }: Toolti
       <TooltipPrimitive.Content
         sideOffset={sideOffset}
         className={mergeClasses(
-          'dark-theme relative z-[101] flex flex-col rounded-md bg-palette-gray2 px-3 py-1.5 text-default shadow-md',
+          'dark-theme bg-palette-gray2 text-default relative z-[101] flex flex-col rounded-md px-3 py-1.5 shadow-md',
           'data-[side=bottom]:animate-slideUpAndFade data-[side=left]:animate-slideRightAndFade data-[side=right]:animate-slideLeftAndFade data-[side=top]:animate-slideDownAndFade',
           className
         )}

--- a/docs/ui/components/VideoBoxLink/index.tsx
+++ b/docs/ui/components/VideoBoxLink/index.tsx
@@ -34,16 +34,16 @@ export function VideoBoxLink({ title, description, videoId, time, className }: V
         openInNewTab
         href={`https://www.youtube.com/watch?v=${videoId}${time ? `&t=${time}` : ''}`}
         className={mergeClasses(
-          'group relative flex items-stretch overflow-hidden rounded-lg border border-default bg-default shadow-xs transition',
+          'group border-default bg-default relative flex items-stretch overflow-hidden rounded-lg border shadow-xs transition',
           'hocus:bg-subtle hocus:shadow-sm',
           'max-sm-gutters:flex-col',
-          '[&+hr]:!mt-6',
+          '[&+hr]:mt-6!',
           className
         )}
         aria-label={`Watch video: ${title} (opens in new tab)`}>
         <div
           className={mergeClasses(
-            'relative flex max-w-[200px] items-center justify-center overflow-hidden border-r border-secondary bg-element',
+            'border-secondary bg-element relative flex max-w-[200px] items-center justify-center overflow-hidden border-r',
             'max-sm-gutters:max-w-full max-sm-gutters:border-b max-sm-gutters:border-r-0'
           )}>
           <img
@@ -53,10 +53,10 @@ export function VideoBoxLink({ title, description, videoId, time, className }: V
             aria-label={`Video thumbnail for ${title}`}
           />
           <div
-            className="absolute right-[calc(50%-22px)] top-[calc(50%-22px)] flex size-[44px] items-center justify-center rounded-full bg-[#000a]"
+            className="absolute top-[calc(50%-22px)] right-[calc(50%-22px)] flex size-[44px] items-center justify-center rounded-full bg-[#000a]"
             role="presentation"
             aria-hidden="true">
-            <PlaySolidIcon className="icon-lg ml-0.5 text-palette-white" />
+            <PlaySolidIcon className="icon-lg text-palette-white ml-0.5" />
           </div>
         </div>
         <div className="flex flex-col justify-center gap-1 px-4 py-2">
@@ -68,7 +68,7 @@ export function VideoBoxLink({ title, description, videoId, time, className }: V
           )}
         </div>
         <ArrowUpRightIcon
-          className="icon-md my-auto ml-auto mr-4 shrink-0 text-icon-secondary max-sm-gutters:hidden"
+          className="icon-md text-icon-secondary max-sm-gutters:hidden my-auto mr-4 ml-auto shrink-0"
           aria-hidden="true"
         />
       </LinkBase>

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -495,12 +495,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/runtime@npm:^1.7.0":
+"@emnapi/core@npm:^1.7.1, @emnapi/core@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "@emnapi/core@npm:1.8.1"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:1.1.0"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/2c242f4b49779bac403e1cbcc98edacdb1c8ad36562408ba9a20663824669e930bc8493be46a2522d9dc946b8d96cd7073970bae914928c7671b5221c85b432e
+  languageName: node
+  linkType: hard
+
+"@emnapi/runtime@npm:^1.7.0, @emnapi/runtime@npm:^1.7.1, @emnapi/runtime@npm:^1.8.1":
   version: 1.8.1
   resolution: "@emnapi/runtime@npm:1.8.1"
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/f4929d75e37aafb24da77d2f58816761fe3f826aad2e37fa6d4421dac9060cbd5098eea1ac3c9ecc4526b89deb58153852fa432f87021dc57863f2ff726d713f
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:1.1.0, @emnapi/wasi-threads@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@emnapi/wasi-threads@npm:1.1.0"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/e6d54bf2b1e64cdd83d2916411e44e579b6ae35d5def0dea61a3c452d9921373044dff32a8b8473ae60c80692bdc39323e98b96a3f3d87ba6886b24dd0ef7ca1
   languageName: node
   linkType: hard
 
@@ -733,6 +752,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint/css-tree@npm:^3.6.9":
+  version: 3.6.9
+  resolution: "@eslint/css-tree@npm:3.6.9"
+  dependencies:
+    mdn-data: "npm:2.23.0"
+    source-map-js: "npm:^1.0.1"
+  checksum: 10c0/5dd436fb6e9aa2cc3a00252cea6287f78fde1cba664894fc9b46c4817f23d5d5614bfbe55decd05ae062877b80a653bc73106e8e3ca311d4ff18e2baa9e71634
+  languageName: node
+  linkType: hard
+
 "@eslint/eslintrc@npm:^3.3.1":
   version: 3.3.1
   resolution: "@eslint/eslintrc@npm:3.3.1"
@@ -809,23 +838,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/styleguide-icons@npm:^2.3.4":
-  version: 2.3.4
-  resolution: "@expo/styleguide-icons@npm:2.3.4"
+"@expo/styleguide-icons@npm:^3.0.0, @expo/styleguide-icons@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@expo/styleguide-icons@npm:3.0.1"
   dependencies:
-    tailwind-merge: "npm:^2.5.4"
+    tailwind-merge: "npm:^3.0.0"
   peerDependencies:
     react: ">= 16"
-  checksum: 10c0/27150c7977d047acb9ac9aceb0e05b5298869fddfea5d94878ed5f2c953d052c3f5965e8a932eceab7cca6d903cffff1d3ed40a949f6bbe33068f3dc73df353e
+    tailwindcss: ^4.0.0
+  checksum: 10c0/e7cde09667243e54bc1ca4a30e259446d9b0fd0aca3981f097c21ae46388165c5a2f3b46b9ad9fcc31211cdd07b999811a9c5783a163f19ec84ab54aafe23e35
   languageName: node
   linkType: hard
 
-"@expo/styleguide-search-ui@npm:^3.3.3":
-  version: 3.3.3
-  resolution: "@expo/styleguide-search-ui@npm:3.3.3"
+"@expo/styleguide-search-ui@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "@expo/styleguide-search-ui@npm:4.0.1"
   dependencies:
-    "@expo/styleguide": "npm:^9.3.1"
-    "@expo/styleguide-icons": "npm:^2.3.4"
+    "@expo/styleguide": "npm:^10.0.1"
+    "@expo/styleguide-icons": "npm:^3.0.1"
     "@kapaai/react-sdk": "npm:^0.5.1"
     "@sanity/client": "npm:^7.13.2"
     "@sanity/image-url": "npm:^2.0.2"
@@ -838,21 +868,23 @@ __metadata:
   peerDependencies:
     next: ">= 13"
     react: ">= 19"
-  checksum: 10c0/fa48338c1ff3fb6be6de7e08a0fa7b6ec005e290771af7443fc35628c120d41f2bf24c761031fc95b83a94ce7d3e5b7ff6e803d1ba2ad7aa3e3145c4e7c3b25a
+    tailwindcss: ^4.0.0
+  checksum: 10c0/3b7fce33432822b7e4946102613c2a0ec376b496907007549de2c2cce45da8c3be21d3ba2aec4e8f06d6e6ed719fd045fbda3fd2fd3370897011b7a28b20d796
   languageName: node
   linkType: hard
 
-"@expo/styleguide@npm:^9.3.1":
-  version: 9.3.1
-  resolution: "@expo/styleguide@npm:9.3.1"
+"@expo/styleguide@npm:^10.0.1":
+  version: 10.0.1
+  resolution: "@expo/styleguide@npm:10.0.1"
   dependencies:
     "@expo/styleguide-base": "npm:^2.0.5"
-    tailwind-merge: "npm:^2.5.4"
+    tailwind-merge: "npm:^3.0.0"
     use-effect-event: "npm:^2.0.3"
   peerDependencies:
     next: ">= 13"
     react: ">= 19"
-  checksum: 10c0/5af23146bf5a90bb9f20fb1741aa7e1c78c4fbbb6646defc4ef2e99ca974432e59ac6f2f453bb680fd685cc98602c6d8eb3cee59d76a8ff07819faf427cfbcb3
+    tailwindcss: ^4.0.0
+  checksum: 10c0/57397eeeebb6258695203b7721e21834029c4b97aa0cbd31e4426acaeb47507f81d723cb3766bc0b0503427e3fdca9f8856d9873c5763258873f9dc1adbdc68f
   languageName: node
   linkType: hard
 
@@ -1481,7 +1513,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/gen-mapping@npm:^0.3.12, @jridgewell/gen-mapping@npm:^0.3.2, @jridgewell/gen-mapping@npm:^0.3.5":
+"@jridgewell/gen-mapping@npm:^0.3.12, @jridgewell/gen-mapping@npm:^0.3.5":
   version: 0.3.13
   resolution: "@jridgewell/gen-mapping@npm:0.3.13"
   dependencies:
@@ -1508,7 +1540,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.4.15, @jridgewell/sourcemap-codec@npm:^1.5.0":
+"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.4.15, @jridgewell/sourcemap-codec@npm:^1.5.0, @jridgewell/sourcemap-codec@npm:^1.5.5":
   version: 1.5.5
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
   checksum: 10c0/f9e538f302b63c0ebc06eecb1dd9918dd4289ed36147a0ddce35d6ea4d7ebbda243cda7b2213b6a5e1d8087a298d5cf630fb2bd39329cdecb82017023f6081a0
@@ -1702,6 +1734,17 @@ __metadata:
     hls.js: "npm:~1.6.13"
     mux-embed: "npm:^5.8.3"
   checksum: 10c0/c6837425576ac505e762fdb31bcd27c38bf6ac957c2058966f3e7eb7e34d9883149bde9aa934f41671c9329d2db299400d81cf52467f693f6df65cdeb175a2e6
+  languageName: node
+  linkType: hard
+
+"@napi-rs/wasm-runtime@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@napi-rs/wasm-runtime@npm:1.1.1"
+  dependencies:
+    "@emnapi/core": "npm:^1.7.1"
+    "@emnapi/runtime": "npm:^1.7.1"
+    "@tybys/wasm-util": "npm:^0.10.1"
+  checksum: 10c0/04d57b67e80736e41fe44674a011878db0a8ad893f4d44abb9d3608debb7c174224cba2796ed5b0c1d367368159f3ca6be45f1c59222f70e32ddc880f803d447
   languageName: node
   linkType: hard
 
@@ -3989,6 +4032,170 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tailwindcss/node@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/node@npm:4.2.1"
+  dependencies:
+    "@jridgewell/remapping": "npm:^2.3.5"
+    enhanced-resolve: "npm:^5.19.0"
+    jiti: "npm:^2.6.1"
+    lightningcss: "npm:1.31.1"
+    magic-string: "npm:^0.30.21"
+    source-map-js: "npm:^1.2.1"
+    tailwindcss: "npm:4.2.1"
+  checksum: 10c0/7b1bf77d2d714df98201cc2f308bee8edfebaf2ef520ec15cb9515e2aadabb28b4d2ecb165dd278716b3f6767da10e4d9a445de34ee8f7ec056fc9c1d8e275a1
+  languageName: node
+  linkType: hard
+
+"@tailwindcss/oxide-android-arm64@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide-android-arm64@npm:4.2.1"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@tailwindcss/oxide-darwin-arm64@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide-darwin-arm64@npm:4.2.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@tailwindcss/oxide-darwin-x64@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide-darwin-x64@npm:4.2.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@tailwindcss/oxide-freebsd-x64@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide-freebsd-x64@npm:4.2.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@tailwindcss/oxide-linux-arm-gnueabihf@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide-linux-arm-gnueabihf@npm:4.2.1"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@tailwindcss/oxide-linux-arm64-gnu@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide-linux-arm64-gnu@npm:4.2.1"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@tailwindcss/oxide-linux-arm64-musl@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide-linux-arm64-musl@npm:4.2.1"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@tailwindcss/oxide-linux-x64-gnu@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide-linux-x64-gnu@npm:4.2.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@tailwindcss/oxide-linux-x64-musl@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide-linux-x64-musl@npm:4.2.1"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@tailwindcss/oxide-wasm32-wasi@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide-wasm32-wasi@npm:4.2.1"
+  dependencies:
+    "@emnapi/core": "npm:^1.8.1"
+    "@emnapi/runtime": "npm:^1.8.1"
+    "@emnapi/wasi-threads": "npm:^1.1.0"
+    "@napi-rs/wasm-runtime": "npm:^1.1.1"
+    "@tybys/wasm-util": "npm:^0.10.1"
+    tslib: "npm:^2.8.1"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@tailwindcss/oxide-win32-arm64-msvc@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide-win32-arm64-msvc@npm:4.2.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@tailwindcss/oxide-win32-x64-msvc@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide-win32-x64-msvc@npm:4.2.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@tailwindcss/oxide@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@tailwindcss/oxide@npm:4.2.1"
+  dependencies:
+    "@tailwindcss/oxide-android-arm64": "npm:4.2.1"
+    "@tailwindcss/oxide-darwin-arm64": "npm:4.2.1"
+    "@tailwindcss/oxide-darwin-x64": "npm:4.2.1"
+    "@tailwindcss/oxide-freebsd-x64": "npm:4.2.1"
+    "@tailwindcss/oxide-linux-arm-gnueabihf": "npm:4.2.1"
+    "@tailwindcss/oxide-linux-arm64-gnu": "npm:4.2.1"
+    "@tailwindcss/oxide-linux-arm64-musl": "npm:4.2.1"
+    "@tailwindcss/oxide-linux-x64-gnu": "npm:4.2.1"
+    "@tailwindcss/oxide-linux-x64-musl": "npm:4.2.1"
+    "@tailwindcss/oxide-wasm32-wasi": "npm:4.2.1"
+    "@tailwindcss/oxide-win32-arm64-msvc": "npm:4.2.1"
+    "@tailwindcss/oxide-win32-x64-msvc": "npm:4.2.1"
+  dependenciesMeta:
+    "@tailwindcss/oxide-android-arm64":
+      optional: true
+    "@tailwindcss/oxide-darwin-arm64":
+      optional: true
+    "@tailwindcss/oxide-darwin-x64":
+      optional: true
+    "@tailwindcss/oxide-freebsd-x64":
+      optional: true
+    "@tailwindcss/oxide-linux-arm-gnueabihf":
+      optional: true
+    "@tailwindcss/oxide-linux-arm64-gnu":
+      optional: true
+    "@tailwindcss/oxide-linux-arm64-musl":
+      optional: true
+    "@tailwindcss/oxide-linux-x64-gnu":
+      optional: true
+    "@tailwindcss/oxide-linux-x64-musl":
+      optional: true
+    "@tailwindcss/oxide-wasm32-wasi":
+      optional: true
+    "@tailwindcss/oxide-win32-arm64-msvc":
+      optional: true
+    "@tailwindcss/oxide-win32-x64-msvc":
+      optional: true
+  checksum: 10c0/4f9bfa40cde6925eed1759caf857831779a834a1b8776cc7df5bb48a279b7dcd2e761a31ffbd297d135a64b58f25e092d7c781c06cf44667746f7e5a5a3e0183
+  languageName: node
+  linkType: hard
+
+"@tailwindcss/postcss@npm:^4.0.0":
+  version: 4.2.1
+  resolution: "@tailwindcss/postcss@npm:4.2.1"
+  dependencies:
+    "@alloc/quick-lru": "npm:^5.2.0"
+    "@tailwindcss/node": "npm:4.2.1"
+    "@tailwindcss/oxide": "npm:4.2.1"
+    postcss: "npm:^8.5.6"
+    tailwindcss: "npm:4.2.1"
+  checksum: 10c0/c9869a10c284241b2e51ba25750ae711d1ac3187356093c3a047eb8139124e73412036de7a11ad5c145360a312dcdebde59849f6d65e6296cba525186a8243f6
+  languageName: node
+  linkType: hard
+
 "@tailwindcss/typography@npm:^0.5.19":
   version: 0.5.19
   resolution: "@tailwindcss/typography@npm:0.5.19"
@@ -4081,6 +4288,15 @@ __metadata:
   version: 2.0.0
   resolution: "@tootallnate/once@npm:2.0.0"
   checksum: 10c0/073bfa548026b1ebaf1659eb8961e526be22fa77139b10d60e712f46d2f0f05f4e6c8bec62a087d41088ee9e29faa7f54838568e475ab2f776171003c3920858
+  languageName: node
+  linkType: hard
+
+"@tybys/wasm-util@npm:^0.10.1":
+  version: 0.10.1
+  resolution: "@tybys/wasm-util@npm:0.10.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/b255094f293794c6d2289300c5fbcafbb5532a3aed3a5ffd2f8dc1828e639b88d75f6a376dd8f94347a44813fd7a7149d8463477a9a49525c8b2dcaa38c2d1e8
   languageName: node
   linkType: hard
 
@@ -4740,6 +4956,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@valibot/to-json-schema@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@valibot/to-json-schema@npm:1.5.0"
+  peerDependencies:
+    valibot: ^1.2.0
+  checksum: 10c0/d06aa771eda520c0e4b798f080181091e723c991b925947e7565bd5af2a0f1452bd63e491aa2afd9e76c9ae6930f26554af319bd0e7ba421b759558d8161ff91
+  languageName: node
+  linkType: hard
+
 "@vimeo/player@npm:2.29.0":
   version: 2.29.0
   resolution: "@vimeo/player@npm:2.29.0"
@@ -4929,13 +5154,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"any-promise@npm:^1.0.0":
-  version: 1.3.0
-  resolution: "any-promise@npm:1.3.0"
-  checksum: 10c0/60f0298ed34c74fef50daab88e8dab786036ed5a7fad02e012ab57e376e0a0b4b29e83b95ea9b5e7d89df762f5f25119b83e00706ecaccb22cfbacee98d74889
-  languageName: node
-  linkType: hard
-
 "anymatch@npm:^3.0.3, anymatch@npm:~3.1.2":
   version: 3.1.3
   resolution: "anymatch@npm:3.1.3"
@@ -4946,7 +5164,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"arg@npm:^5.0.0, arg@npm:^5.0.2":
+"arg@npm:^5.0.0":
   version: 5.0.2
   resolution: "arg@npm:5.0.2"
   checksum: 10c0/ccaf86f4e05d342af6666c569f844bec426595c567d32a8289715087825c2ca7edd8a3d204e4d2fb2aa4602e09a57d0c13ea8c9eea75aac3dbb4af5514e6800e
@@ -5130,24 +5348,6 @@ __metadata:
   version: 0.4.0
   resolution: "asynckit@npm:0.4.0"
   checksum: 10c0/d73e2ddf20c4eb9337e1b3df1a0f6159481050a5de457c55b14ea2e5cb6d90bb69e004c9af54737a5ee0917fcf2c9e25de67777bbe58261847846066ba75bc9d
-  languageName: node
-  linkType: hard
-
-"autoprefixer@npm:^10.4.21":
-  version: 10.4.21
-  resolution: "autoprefixer@npm:10.4.21"
-  dependencies:
-    browserslist: "npm:^4.24.4"
-    caniuse-lite: "npm:^1.0.30001702"
-    fraction.js: "npm:^4.3.7"
-    normalize-range: "npm:^0.1.2"
-    picocolors: "npm:^1.1.1"
-    postcss-value-parser: "npm:^4.2.0"
-  peerDependencies:
-    postcss: ^8.1.0
-  bin:
-    autoprefixer: bin/autoprefixer
-  checksum: 10c0/de5b71d26d0baff4bbfb3d59f7cf7114a6030c9eeb66167acf49a32c5b61c68e308f1e0f869d92334436a221035d08b51cd1b2f2c4689b8d955149423c16d4d4
   languageName: node
   linkType: hard
 
@@ -5397,7 +5597,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.24.0, browserslist@npm:^4.24.4, browserslist@npm:^4.28.0":
+"browserslist@npm:^4.24.0, browserslist@npm:^4.28.0":
   version: 4.28.0
   resolution: "browserslist@npm:4.28.0"
   dependencies:
@@ -5508,13 +5708,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camelcase-css@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "camelcase-css@npm:2.0.1"
-  checksum: 10c0/1a1a3137e8a781e6cbeaeab75634c60ffd8e27850de410c162cce222ea331cd1ba5364e8fb21c95e5ca76f52ac34b81a090925ca00a87221355746d049c6e273
-  languageName: node
-  linkType: hard
-
 "camelcase@npm:^5.3.1":
   version: 5.3.1
   resolution: "camelcase@npm:5.3.1"
@@ -5529,7 +5722,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001579, caniuse-lite@npm:^1.0.30001702, caniuse-lite@npm:^1.0.30001754":
+"caniuse-lite@npm:^1.0.30001579, caniuse-lite@npm:^1.0.30001754":
   version: 1.0.30001755
   resolution: "caniuse-lite@npm:1.0.30001755"
   checksum: 10c0/7b8e32a4ec307b50f557d30176651cf69f20a0ea4de6f5f34149ea65a1f0cfcc0677b403484aea3661c7469ab11f2df6528027b9ec2d0265635ede9d5b517380
@@ -5570,7 +5763,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.2":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -5662,7 +5855,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:^3.0.0, chokidar@npm:^3.5.3, chokidar@npm:^3.6.0":
+"chokidar@npm:^3.0.0, chokidar@npm:^3.5.3":
   version: 3.6.0
   resolution: "chokidar@npm:3.6.0"
   dependencies:
@@ -5854,13 +6047,6 @@ __metadata:
   version: 2.0.3
   resolution: "comma-separated-tokens@npm:2.0.3"
   checksum: 10c0/91f90f1aae320f1755d6957ef0b864fe4f54737f3313bd95e0802686ee2ca38bff1dd381964d00ae5db42912dd1f4ae5c2709644e82706ffc6f6842a813cdd67
-  languageName: node
-  linkType: hard
-
-"commander@npm:^4.0.0":
-  version: 4.1.1
-  resolution: "commander@npm:4.1.1"
-  checksum: 10c0/84a76c08fe6cc08c9c93f62ac573d2907d8e79138999312c92d4155bc2325d487d64d13f669b2000c9f8caf70493c1be2dac74fec3c51d5a04f8bc3ae1830bab
   languageName: node
   linkType: hard
 
@@ -6305,7 +6491,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-libc@npm:^2.1.2":
+"detect-libc@npm:^2.0.3, detect-libc@npm:^2.1.2":
   version: 2.1.2
   resolution: "detect-libc@npm:2.1.2"
   checksum: 10c0/acc675c29a5649fa1fb6e255f993b8ee829e510b6b56b0910666949c80c364738833417d0edb5f90e4e46be17228b0f2b66a010513984e18b15deeeac49369c4
@@ -6335,13 +6521,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"didyoumean@npm:^1.2.2":
-  version: 1.2.2
-  resolution: "didyoumean@npm:1.2.2"
-  checksum: 10c0/95d0b53d23b851aacff56dfadb7ecfedce49da4232233baecfeecb7710248c4aa03f0aa8995062f0acafaf925adf8536bd7044a2e68316fd7d411477599bc27b
-  languageName: node
-  linkType: hard
-
 "diff-match-patch@npm:^1.0.5":
   version: 1.0.5
   resolution: "diff-match-patch@npm:1.0.5"
@@ -6360,13 +6539,6 @@ __metadata:
   version: 5.2.0
   resolution: "diff@npm:5.2.0"
   checksum: 10c0/aed0941f206fe261ecb258dc8d0ceea8abbde3ace5827518ff8d302f0fc9cc81ce116c4d8f379151171336caf0516b79e01abdc1ed1201b6440d895a66689eb4
-  languageName: node
-  linkType: hard
-
-"dlv@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "dlv@npm:1.1.3"
-  checksum: 10c0/03eb4e769f19a027fd5b43b59e8a05e3fd2100ac239ebb0bf9a745de35d449e2f25cfaf3aa3934664551d72856f4ae8b7822016ce5c42c2d27c18ae79429ec42
   languageName: node
   linkType: hard
 
@@ -6535,6 +6707,16 @@ __metadata:
     graceful-fs: "npm:^4.2.4"
     tapable: "npm:^2.2.0"
   checksum: 10c0/4cffd9b125225184e2abed9fdf0ed3dbd2224c873b165d0838fd066cde32e0918626cba2f1f4bf6860762f13a7e2364fd89a82b99566be2873d813573ac71846
+  languageName: node
+  linkType: hard
+
+"enhanced-resolve@npm:^5.19.0, enhanced-resolve@npm:^5.7.0":
+  version: 5.20.0
+  resolution: "enhanced-resolve@npm:5.20.0"
+  dependencies:
+    graceful-fs: "npm:^4.2.4"
+    tapable: "npm:^2.3.0"
+  checksum: 10c0/4ed5f38406fc9ad74c58a3d63b8215862243ab0ed6b0efc51ccdb72cdcedd3ac8638abe298680b279d7a83c3cb140e5eea7a5f8bd99696c74588f07ad89a95a7
   languageName: node
   linkType: hard
 
@@ -7040,6 +7222,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-better-tailwindcss@npm:^4.0.0":
+  version: 4.3.1
+  resolution: "eslint-plugin-better-tailwindcss@npm:4.3.1"
+  dependencies:
+    "@eslint/css-tree": "npm:^3.6.9"
+    "@valibot/to-json-schema": "npm:^1.5.0"
+    enhanced-resolve: "npm:^5.19.0"
+    jiti: "npm:^2.6.1"
+    synckit: "npm:^0.11.12"
+    tailwind-csstree: "npm:^0.1.4"
+    tsconfig-paths-webpack-plugin: "npm:^4.2.0"
+    valibot: "npm:^1.2.0"
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
+    oxlint: ^1.35.0
+    tailwindcss: ^3.3.0 || ^4.1.17
+  peerDependenciesMeta:
+    eslint:
+      optional: true
+    oxlint:
+      optional: true
+  checksum: 10c0/77ee6e4dd7512b12ee6494754a020b404038c39d4283827777e19a536cc1bfdd0ef302ec024bfc5ac6cc7c25993b4d4511d4ef201900fb71d3bab2cc1252b29f
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-es-x@npm:^7.8.0":
   version: 7.8.0
   resolution: "eslint-plugin-es-x@npm:7.8.0"
@@ -7253,18 +7460,6 @@ __metadata:
   peerDependencies:
     eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
   checksum: 10c0/c850bfd556291d4d9234f5ca38db1436924a1013627c8ab1853f77cac73ec19b020e861e6c7b783436a48b6ffcdfba4547598235a37ad4611b6739f65fd8ad57
-  languageName: node
-  linkType: hard
-
-"eslint-plugin-tailwindcss@npm:^3.18.2":
-  version: 3.18.2
-  resolution: "eslint-plugin-tailwindcss@npm:3.18.2"
-  dependencies:
-    fast-glob: "npm:^3.2.5"
-    postcss: "npm:^8.4.4"
-  peerDependencies:
-    tailwindcss: ^3.4.0
-  checksum: 10c0/2903923f81d5dd1813279cc419421612d7d3f58ba57aa48a931beaa18e2529fdea223e0c60135c3fd2aa55e3d798b4299a0280602c8c508480bebd4f6019ac9c
   languageName: node
   linkType: hard
 
@@ -7598,11 +7793,11 @@ __metadata:
   dependencies:
     "@apidevtools/json-schema-ref-parser": "npm:^11.9.3"
     "@expo/spawn-async": "npm:^1.7.2"
-    "@expo/styleguide": "npm:^9.3.1"
+    "@expo/styleguide": "npm:^10.0.1"
     "@expo/styleguide-base": "npm:^2.0.5"
     "@expo/styleguide-cookie-consent": "npm:^0.1.13"
-    "@expo/styleguide-icons": "npm:^2.3.4"
-    "@expo/styleguide-search-ui": "npm:^3.3.3"
+    "@expo/styleguide-icons": "npm:^3.0.0"
+    "@expo/styleguide-search-ui": "npm:^4.0.0"
     "@kapaai/react-sdk": "npm:^0.9.0"
     "@mdx-js/loader": "npm:^3.1.1"
     "@mdx-js/mdx": "npm:^3.1.1"
@@ -7614,6 +7809,7 @@ __metadata:
     "@reach/tabs": "npm:^0.18.0"
     "@sentry/nextjs": "npm:^10.37.0"
     "@sentry/react": "npm:^10.37.0"
+    "@tailwindcss/postcss": "npm:^4.0.0"
     "@tailwindcss/typography": "npm:^0.5.19"
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/jest-dom": "npm:^6.9.1"
@@ -7634,7 +7830,6 @@ __metadata:
     "@vvago/vale": "npm:3.12.0"
     "@xyflow/react": "npm:^12.10.0"
     acorn: "npm:^8.15.0"
-    autoprefixer: "npm:^10.4.21"
     axios: "npm:^1.12.2"
     cheerio: "npm:^1.2.0"
     clipboard-copy: "npm:^4.0.1"
@@ -7643,9 +7838,9 @@ __metadata:
     eslint: "npm:^9.39.2"
     eslint-config-next: "npm:^16.1.6"
     eslint-config-universe: "npm:^15.0.3"
+    eslint-plugin-better-tailwindcss: "npm:^4.0.0"
     eslint-plugin-lodash: "npm:^8.0.0"
     eslint-plugin-mdx: "npm:^3.6.2"
-    eslint-plugin-tailwindcss: "npm:^3.18.2"
     eslint-plugin-testing-library: "npm:^7.13.4"
     eslint-plugin-unicorn: "npm:^62.0.0"
     framer-motion: "npm:^12.23.26"
@@ -7661,7 +7856,6 @@ __metadata:
     nprogress: "npm:0.2.0"
     path-browserify: "npm:^1.0.1"
     postcss: "npm:^8.5.6"
-    postcss-import: "npm:^16.1.1"
     prettier: "npm:^3.8.1"
     prettier-plugin-tailwindcss: "npm:^0.7.2"
     prism-react-renderer: "npm:^2.4.1"
@@ -7686,7 +7880,7 @@ __metadata:
     remark-validate-links: "npm:^13.1.0"
     semver: "npm:^7.7.3"
     sitemap: "npm:^8.0.2"
-    tailwindcss: "npm:^3.4.18"
+    tailwindcss: "npm:^4.0.0"
     tippy.js: "npm:^6.3.7"
     turndown: "npm:^7.2.2"
     turndown-plugin-gfm: "npm:^1.0.2"
@@ -7740,7 +7934,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.2.5, fast-glob@npm:^3.3.2":
+"fast-glob@npm:^3.3.2":
   version: 3.3.3
   resolution: "fast-glob@npm:3.3.3"
   dependencies:
@@ -7921,13 +8115,6 @@ __metadata:
   version: 2.1.2
   resolution: "forwarded-parse@npm:2.1.2"
   checksum: 10c0/0c6b4c631775f272b4475e935108635495e8a5b261d1b4a5caef31c47c5a0b04134adc564e655aadfef366a02647fa3ae90a1d3ac19929f3ade47f9bed53036a
-  languageName: node
-  linkType: hard
-
-"fraction.js@npm:^4.3.7":
-  version: 4.3.7
-  resolution: "fraction.js@npm:4.3.7"
-  checksum: 10c0/df291391beea9ab4c263487ffd9d17fed162dbb736982dee1379b2a8cc94e4e24e46ed508c6d278aded9080ba51872f1bc5f3a5fd8d7c74e5f105b508ac28711
   languageName: node
   linkType: hard
 
@@ -9683,12 +9870,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jiti@npm:^1.21.7":
-  version: 1.21.7
-  resolution: "jiti@npm:1.21.7"
+"jiti@npm:^2.6.1":
+  version: 2.6.1
+  resolution: "jiti@npm:2.6.1"
   bin:
-    jiti: bin/jiti.js
-  checksum: 10c0/77b61989c758ff32407cdae8ddc77f85e18e1a13fc4977110dbd2e05fc761842f5f71bce684d9a01316e1c4263971315a111385759951080bbfe17cbb5de8f7a
+    jiti: lib/jiti-cli.mjs
+  checksum: 10c0/79b2e96a8e623f66c1b703b98ec1b8be4500e1d217e09b09e343471bbb9c105381b83edbb979d01cef18318cc45ce6e153571b6c83122170eefa531c64b6789b
   languageName: node
   linkType: hard
 
@@ -9830,7 +10017,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^2.0.0, json5@npm:^2.2.3":
+"json5@npm:^2.0.0, json5@npm:^2.2.2, json5@npm:^2.2.3":
   version: 2.2.3
   resolution: "json5@npm:2.2.3"
   bin:
@@ -9938,10 +10125,123 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lilconfig@npm:^3.1.1, lilconfig@npm:^3.1.3":
-  version: 3.1.3
-  resolution: "lilconfig@npm:3.1.3"
-  checksum: 10c0/f5604e7240c5c275743561442fbc5abf2a84ad94da0f5adc71d25e31fa8483048de3dcedcb7a44112a942fed305fd75841cdf6c9681c7f640c63f1049e9a5dcc
+"lightningcss-android-arm64@npm:1.31.1":
+  version: 1.31.1
+  resolution: "lightningcss-android-arm64@npm:1.31.1"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-arm64@npm:1.31.1":
+  version: 1.31.1
+  resolution: "lightningcss-darwin-arm64@npm:1.31.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-x64@npm:1.31.1":
+  version: 1.31.1
+  resolution: "lightningcss-darwin-x64@npm:1.31.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-freebsd-x64@npm:1.31.1":
+  version: 1.31.1
+  resolution: "lightningcss-freebsd-x64@npm:1.31.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm-gnueabihf@npm:1.31.1":
+  version: 1.31.1
+  resolution: "lightningcss-linux-arm-gnueabihf@npm:1.31.1"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-gnu@npm:1.31.1":
+  version: 1.31.1
+  resolution: "lightningcss-linux-arm64-gnu@npm:1.31.1"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-musl@npm:1.31.1":
+  version: 1.31.1
+  resolution: "lightningcss-linux-arm64-musl@npm:1.31.1"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-gnu@npm:1.31.1":
+  version: 1.31.1
+  resolution: "lightningcss-linux-x64-gnu@npm:1.31.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-musl@npm:1.31.1":
+  version: 1.31.1
+  resolution: "lightningcss-linux-x64-musl@npm:1.31.1"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-arm64-msvc@npm:1.31.1":
+  version: 1.31.1
+  resolution: "lightningcss-win32-arm64-msvc@npm:1.31.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-x64-msvc@npm:1.31.1":
+  version: 1.31.1
+  resolution: "lightningcss-win32-x64-msvc@npm:1.31.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss@npm:1.31.1":
+  version: 1.31.1
+  resolution: "lightningcss@npm:1.31.1"
+  dependencies:
+    detect-libc: "npm:^2.0.3"
+    lightningcss-android-arm64: "npm:1.31.1"
+    lightningcss-darwin-arm64: "npm:1.31.1"
+    lightningcss-darwin-x64: "npm:1.31.1"
+    lightningcss-freebsd-x64: "npm:1.31.1"
+    lightningcss-linux-arm-gnueabihf: "npm:1.31.1"
+    lightningcss-linux-arm64-gnu: "npm:1.31.1"
+    lightningcss-linux-arm64-musl: "npm:1.31.1"
+    lightningcss-linux-x64-gnu: "npm:1.31.1"
+    lightningcss-linux-x64-musl: "npm:1.31.1"
+    lightningcss-win32-arm64-msvc: "npm:1.31.1"
+    lightningcss-win32-x64-msvc: "npm:1.31.1"
+  dependenciesMeta:
+    lightningcss-android-arm64:
+      optional: true
+    lightningcss-darwin-arm64:
+      optional: true
+    lightningcss-darwin-x64:
+      optional: true
+    lightningcss-freebsd-x64:
+      optional: true
+    lightningcss-linux-arm-gnueabihf:
+      optional: true
+    lightningcss-linux-arm64-gnu:
+      optional: true
+    lightningcss-linux-arm64-musl:
+      optional: true
+    lightningcss-linux-x64-gnu:
+      optional: true
+    lightningcss-linux-x64-musl:
+      optional: true
+    lightningcss-win32-arm64-msvc:
+      optional: true
+    lightningcss-win32-x64-msvc:
+      optional: true
+  checksum: 10c0/c6754b305d4a73652e472fc0d7d65384a6e16c336ea61068eca60de2a45bd5c30abbf012358b82eac56ee98b5d88028932cda5268ff61967cffa400b9e7ee2ba
   languageName: node
   linkType: hard
 
@@ -10073,6 +10373,15 @@ __metadata:
   dependencies:
     "@jridgewell/sourcemap-codec": "npm:^1.4.15"
   checksum: 10c0/51a1f06f678c082aceddfb5943de9b6bdb88f2ea1385a1c2adf116deb73dfcfa50df6c222901d691b529455222d4d68d0b28be5689ac6f69b3baa3462861f922
+  languageName: node
+  linkType: hard
+
+"magic-string@npm:^0.30.21":
+  version: 0.30.21
+  resolution: "magic-string@npm:0.30.21"
+  dependencies:
+    "@jridgewell/sourcemap-codec": "npm:^1.5.5"
+  checksum: 10c0/299378e38f9a270069fc62358522ddfb44e94244baa0d6a8980ab2a9b2490a1d03b236b447eee309e17eb3bddfa482c61259d47960eb018a904f0ded52780c4a
   languageName: node
   linkType: hard
 
@@ -10386,6 +10695,13 @@ __metadata:
   dependencies:
     "@types/mdast": "npm:^4.0.0"
   checksum: 10c0/2d3c1af29bf3fe9c20f552ee9685af308002488f3b04b12fa66652c9718f66f41a32f8362aa2d770c3ff464c034860b41715902ada2306bb0a055146cef064d7
+  languageName: node
+  linkType: hard
+
+"mdn-data@npm:2.23.0":
+  version: 2.23.0
+  resolution: "mdn-data@npm:2.23.0"
+  checksum: 10c0/7da2e4dda68da8f26077a328172afd8c1b167d8e9ac0518b8297d752b30a093debe5c6260fd7330e6d2d704a04b9ad0f7499a95a0526d50d7b32aae29d9db4e6
   languageName: node
   linkType: hard
 
@@ -11150,17 +11466,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mz@npm:^2.7.0":
-  version: 2.7.0
-  resolution: "mz@npm:2.7.0"
-  dependencies:
-    any-promise: "npm:^1.0.0"
-    object-assign: "npm:^4.0.1"
-    thenify-all: "npm:^1.0.0"
-  checksum: 10c0/103114e93f87362f0b56ab5b2e7245051ad0276b646e3902c98397d18bb8f4a77f2ea4a2c9d3ad516034ea3a56553b60d3f5f78220001ca4c404bd711bd0af39
-  languageName: node
-  linkType: hard
-
 "nanoid@npm:^3.3.11, nanoid@npm:^3.3.6":
   version: 3.3.11
   resolution: "nanoid@npm:3.3.11"
@@ -11409,13 +11714,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-range@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "normalize-range@npm:0.1.2"
-  checksum: 10c0/bf39b73a63e0a42ad1a48c2bd1bda5a07ede64a7e2567307a407674e595bcff0fa0d57e8e5f1e7fa5e91000797c7615e13613227aaaa4d6d6e87f5bd5cc95de6
-  languageName: node
-  linkType: hard
-
 "npm-install-checks@npm:^6.0.0":
   version: 6.3.0
   resolution: "npm-install-checks@npm:6.3.0"
@@ -11488,17 +11786,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-assign@npm:^4.0.1, object-assign@npm:^4.1.1":
+"object-assign@npm:^4.1.1":
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: 10c0/1f4df9945120325d041ccf7b86f31e8bcc14e73d29171e37a7903050e96b81323784ec59f93f102ec635bcf6fa8034ba3ea0a8c7e69fa202b87ae3b6cec5a414
-  languageName: node
-  linkType: hard
-
-"object-hash@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "object-hash@npm:3.0.0"
-  checksum: 10c0/a06844537107b960c1c8b96cd2ac8592a265186bfa0f6ccafe0d34eabdb526f6fa81da1f37c43df7ed13b12a4ae3457a16071603bcd39d8beddb5f08c37b0f47
   languageName: node
   linkType: hard
 
@@ -11870,14 +12161,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pify@npm:^2.3.0":
-  version: 2.3.0
-  resolution: "pify@npm:2.3.0"
-  checksum: 10c0/551ff8ab830b1052633f59cb8adc9ae8407a436e06b4a9718bcb27dc5844b83d535c3a8512b388b6062af65a98c49bdc0dd523d8b2617b188f7c8fee457158dc
-  languageName: node
-  linkType: hard
-
-"pirates@npm:^4.0.1, pirates@npm:^4.0.4":
+"pirates@npm:^4.0.4":
   version: 4.0.6
   resolution: "pirates@npm:4.0.6"
   checksum: 10c0/00d5fa51f8dded94d7429700fb91a0c1ead00ae2c7fd27089f0c5b63e6eca36197fe46384631872690a66f390c5e27198e99006ab77ae472692ab9c2ca903f36
@@ -11927,77 +12211,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-import@npm:^15.1.0":
-  version: 15.1.0
-  resolution: "postcss-import@npm:15.1.0"
-  dependencies:
-    postcss-value-parser: "npm:^4.0.0"
-    read-cache: "npm:^1.0.0"
-    resolve: "npm:^1.1.7"
-  peerDependencies:
-    postcss: ^8.0.0
-  checksum: 10c0/518aee5c83ea6940e890b0be675a2588db68b2582319f48c3b4e06535a50ea6ee45f7e63e4309f8754473245c47a0372632378d1d73d901310f295a92f26f17b
-  languageName: node
-  linkType: hard
-
-"postcss-import@npm:^16.1.1":
-  version: 16.1.1
-  resolution: "postcss-import@npm:16.1.1"
-  dependencies:
-    postcss-value-parser: "npm:^4.0.0"
-    read-cache: "npm:^1.0.0"
-    resolve: "npm:^1.1.7"
-  peerDependencies:
-    postcss: ^8.0.0
-  checksum: 10c0/b91245971564891110cb407c7459bd470893ccbdd3328fdd384ef2be4d0e5f304e5834acbb8b537ad562c001db34bee1c29b55994bead5ab5a53b1edc2a687b9
-  languageName: node
-  linkType: hard
-
-"postcss-js@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "postcss-js@npm:4.0.1"
-  dependencies:
-    camelcase-css: "npm:^2.0.1"
-  peerDependencies:
-    postcss: ^8.4.21
-  checksum: 10c0/af35d55cb873b0797d3b42529514f5318f447b134541844285c9ac31a17497297eb72296902967911bb737a75163441695737300ce2794e3bd8c70c13a3b106e
-  languageName: node
-  linkType: hard
-
-"postcss-load-config@npm:^4.0.2 || ^5.0 || ^6.0":
-  version: 6.0.1
-  resolution: "postcss-load-config@npm:6.0.1"
-  dependencies:
-    lilconfig: "npm:^3.1.1"
-  peerDependencies:
-    jiti: ">=1.21.0"
-    postcss: ">=8.0.9"
-    tsx: ^4.8.1
-    yaml: ^2.4.2
-  peerDependenciesMeta:
-    jiti:
-      optional: true
-    postcss:
-      optional: true
-    tsx:
-      optional: true
-    yaml:
-      optional: true
-  checksum: 10c0/74173a58816dac84e44853f7afbd283f4ef13ca0b6baeba27701214beec33f9e309b128f8102e2b173e8d45ecba45d279a9be94b46bf48d219626aa9b5730848
-  languageName: node
-  linkType: hard
-
-"postcss-nested@npm:^6.2.0":
-  version: 6.2.0
-  resolution: "postcss-nested@npm:6.2.0"
-  dependencies:
-    postcss-selector-parser: "npm:^6.1.1"
-  peerDependencies:
-    postcss: ^8.2.14
-  checksum: 10c0/7f9c3f2d764191a39364cbdcec350f26a312431a569c9ef17408021424726b0d67995ff5288405e3724bb7152a4c92f73c027e580ec91e798800ed3c52e2bc6e
-  languageName: node
-  linkType: hard
-
 "postcss-selector-parser@npm:6.0.10":
   version: 6.0.10
   resolution: "postcss-selector-parser@npm:6.0.10"
@@ -12005,23 +12218,6 @@ __metadata:
     cssesc: "npm:^3.0.0"
     util-deprecate: "npm:^1.0.2"
   checksum: 10c0/a0b27c5e3f7604c8dc7cd83f145fdd7b21448e0d86072da99e0d78e536ba27aa9db2d42024c50aa530408ee517c4bdc0260529e1afb56608f9a82e839c207e82
-  languageName: node
-  linkType: hard
-
-"postcss-selector-parser@npm:^6.1.1, postcss-selector-parser@npm:^6.1.2":
-  version: 6.1.2
-  resolution: "postcss-selector-parser@npm:6.1.2"
-  dependencies:
-    cssesc: "npm:^3.0.0"
-    util-deprecate: "npm:^1.0.2"
-  checksum: 10c0/523196a6bd8cf660bdf537ad95abd79e546d54180f9afb165a4ab3e651ac705d0f8b8ce6b3164fb9e3279ce482c5f751a69eb2d3a1e8eb0fd5e82294fb3ef13e
-  languageName: node
-  linkType: hard
-
-"postcss-value-parser@npm:^4.0.0, postcss-value-parser@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "postcss-value-parser@npm:4.2.0"
-  checksum: 10c0/f4142a4f56565f77c1831168e04e3effd9ffcc5aebaf0f538eee4b2d465adfd4b85a44257bb48418202a63806a7da7fe9f56c330aebb3cac898e46b4cbf49161
   languageName: node
   linkType: hard
 
@@ -12036,7 +12232,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.4.4, postcss@npm:^8.4.47, postcss@npm:^8.5.6":
+"postcss@npm:^8.5.6":
   version: 8.5.6
   resolution: "postcss@npm:8.5.6"
   dependencies:
@@ -12553,15 +12749,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"read-cache@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "read-cache@npm:1.0.0"
-  dependencies:
-    pify: "npm:^2.3.0"
-  checksum: 10c0/90cb2750213c7dd7c80cb420654344a311fdec12944e81eb912cd82f1bc92aea21885fa6ce442e3336d9fccd663b8a7a19c46d9698e6ca55620848ab932da814
-  languageName: node
-  linkType: hard
-
 "read-package-json-fast@npm:^3.0.0":
   version: 3.0.2
   resolution: "read-package-json-fast@npm:3.0.2"
@@ -12958,7 +13145,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.1.7, resolve@npm:^1.10.1, resolve@npm:^1.20.0, resolve@npm:^1.22.4, resolve@npm:^1.22.8":
+"resolve@npm:^1.10.1, resolve@npm:^1.20.0, resolve@npm:^1.22.4":
   version: 1.22.10
   resolution: "resolve@npm:1.22.10"
   dependencies:
@@ -12984,7 +13171,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.1.7#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.10.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>":
   version: 1.22.10
   resolution: "resolve@patch:resolve@npm%3A1.22.10#optional!builtin<compat/resolve>::version=1.22.10&hash=c3c19d"
   dependencies:
@@ -13542,7 +13729,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:^1.0.2, source-map-js@npm:^1.2.1":
+"source-map-js@npm:^1.0.1, source-map-js@npm:^1.0.2, source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
   checksum: 10c0/7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf
@@ -13917,24 +14104,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sucrase@npm:^3.35.0":
-  version: 3.35.0
-  resolution: "sucrase@npm:3.35.0"
-  dependencies:
-    "@jridgewell/gen-mapping": "npm:^0.3.2"
-    commander: "npm:^4.0.0"
-    glob: "npm:^10.3.10"
-    lines-and-columns: "npm:^1.1.6"
-    mz: "npm:^2.7.0"
-    pirates: "npm:^4.0.1"
-    ts-interface-checker: "npm:^0.1.9"
-  bin:
-    sucrase: bin/sucrase
-    sucrase-node: bin/sucrase-node
-  checksum: 10c0/ac85f3359d2c2ecbf5febca6a24ae9bf96c931f05fde533c22a94f59c6a74895e5d5f0e871878dfd59c2697a75ebb04e4b2224ef0bfc24ca1210735c2ec191ef
-  languageName: node
-  linkType: hard
-
 "super-media-element@npm:~1.4.2":
   version: 1.4.2
   resolution: "super-media-element@npm:1.4.2"
@@ -13997,43 +14166,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tailwind-merge@npm:^2.5.4":
-  version: 2.6.0
-  resolution: "tailwind-merge@npm:2.6.0"
-  checksum: 10c0/fc8a5535524de9f4dacf1c16ab298581c7bb757d68a95faaf28942b1c555a619bba9d4c6726fe83986e44973b315410c1a5226e5354c30ba82353bd6d2288fa5
+"synckit@npm:^0.11.12":
+  version: 0.11.12
+  resolution: "synckit@npm:0.11.12"
+  dependencies:
+    "@pkgr/core": "npm:^0.2.9"
+  checksum: 10c0/cc4d446806688ae0d728ae7bb3f53176d065cf9536647fb85bdd721dcefbd7bf94874df6799ff61580f2b03a392659219b778a9254ad499f9a1f56c34787c235
   languageName: node
   linkType: hard
 
-"tailwindcss@npm:^3.4.18":
-  version: 3.4.18
-  resolution: "tailwindcss@npm:3.4.18"
-  dependencies:
-    "@alloc/quick-lru": "npm:^5.2.0"
-    arg: "npm:^5.0.2"
-    chokidar: "npm:^3.6.0"
-    didyoumean: "npm:^1.2.2"
-    dlv: "npm:^1.1.3"
-    fast-glob: "npm:^3.3.2"
-    glob-parent: "npm:^6.0.2"
-    is-glob: "npm:^4.0.3"
-    jiti: "npm:^1.21.7"
-    lilconfig: "npm:^3.1.3"
-    micromatch: "npm:^4.0.8"
-    normalize-path: "npm:^3.0.0"
-    object-hash: "npm:^3.0.0"
-    picocolors: "npm:^1.1.1"
-    postcss: "npm:^8.4.47"
-    postcss-import: "npm:^15.1.0"
-    postcss-js: "npm:^4.0.1"
-    postcss-load-config: "npm:^4.0.2 || ^5.0 || ^6.0"
-    postcss-nested: "npm:^6.2.0"
-    postcss-selector-parser: "npm:^6.1.2"
-    resolve: "npm:^1.22.8"
-    sucrase: "npm:^3.35.0"
-  bin:
-    tailwind: lib/cli.js
-    tailwindcss: lib/cli.js
-  checksum: 10c0/230c0815d0b981f4952d1902e025d7571929e5fc133b4bb4fcbbc3b642e7ab0cecb9687f80f311afd0db07df8f383ce4317b3ca75ae93156c2ddc777e59fc31b
+"tailwind-csstree@npm:^0.1.4":
+  version: 0.1.4
+  resolution: "tailwind-csstree@npm:0.1.4"
+  checksum: 10c0/5f874f4f835d6fb8c90b94633c6467bd9284799b8bfd83c14573226eee32efb365f1e732741214a5a222d9544bb6eeea206ab303dfe8f8279ed1a971f4c2d8b2
+  languageName: node
+  linkType: hard
+
+"tailwind-merge@npm:^3.0.0":
+  version: 3.5.0
+  resolution: "tailwind-merge@npm:3.5.0"
+  checksum: 10c0/4dc588f5b5296ba3f38e1ebb41f02b6d24a8c5bb45e44b33748c118fb4b5767dd0efc464431ca3e75404056b618b5f67bec3708158baa65fed8a2fc9201e0c53
+  languageName: node
+  linkType: hard
+
+"tailwindcss@npm:4.2.1, tailwindcss@npm:^4.0.0":
+  version: 4.2.1
+  resolution: "tailwindcss@npm:4.2.1"
+  checksum: 10c0/482d734b582e9da509042ff59c1d7564d99e39e238c50ae907c20fa56177a8a00c3902f6971329971bd6a1c5357026ac76a849b8f2c69c94f0f59be99530ba54
   languageName: node
   linkType: hard
 
@@ -14041,6 +14200,13 @@ __metadata:
   version: 2.2.1
   resolution: "tapable@npm:2.2.1"
   checksum: 10c0/bc40e6efe1e554d075469cedaba69a30eeb373552aaf41caeaaa45bf56ffacc2674261b106245bd566b35d8f3329b52d838e851ee0a852120acae26e622925c9
+  languageName: node
+  linkType: hard
+
+"tapable@npm:^2.2.1, tapable@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "tapable@npm:2.3.0"
+  checksum: 10c0/cb9d67cc2c6a74dedc812ef3085d9d681edd2c1fa18e4aef57a3c0605fdbe44e6b8ea00bd9ef21bc74dd45314e39d31227aa031ebf2f5e38164df514136f2681
   languageName: node
   linkType: hard
 
@@ -14087,24 +14253,6 @@ __metadata:
   version: 0.2.0
   resolution: "text-table@npm:0.2.0"
   checksum: 10c0/02805740c12851ea5982686810702e2f14369a5f4c5c40a836821e3eefc65ffeec3131ba324692a37608294b0fd8c1e55a2dd571ffed4909822787668ddbee5c
-  languageName: node
-  linkType: hard
-
-"thenify-all@npm:^1.0.0":
-  version: 1.6.0
-  resolution: "thenify-all@npm:1.6.0"
-  dependencies:
-    thenify: "npm:>= 3.1.0 < 4"
-  checksum: 10c0/9b896a22735e8122754fe70f1d65f7ee691c1d70b1f116fda04fea103d0f9b356e3676cb789506e3909ae0486a79a476e4914b0f92472c2e093d206aed4b7d6b
-  languageName: node
-  linkType: hard
-
-"thenify@npm:>= 3.1.0 < 4":
-  version: 3.3.1
-  resolution: "thenify@npm:3.3.1"
-  dependencies:
-    any-promise: "npm:^1.0.0"
-  checksum: 10c0/f375aeb2b05c100a456a30bc3ed07ef03a39cbdefe02e0403fb714b8c7e57eeaad1a2f5c4ecfb9ce554ce3db9c2b024eba144843cd9e344566d9fcee73b04767
   languageName: node
   linkType: hard
 
@@ -14242,10 +14390,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-interface-checker@npm:^0.1.9":
-  version: 0.1.13
-  resolution: "ts-interface-checker@npm:0.1.13"
-  checksum: 10c0/232509f1b84192d07b81d1e9b9677088e590ac1303436da1e92b296e9be8e31ea042e3e1fd3d29b1742ad2c959e95afe30f63117b8f1bc3a3850070a5142fea7
+"tsconfig-paths-webpack-plugin@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "tsconfig-paths-webpack-plugin@npm:4.2.0"
+  dependencies:
+    chalk: "npm:^4.1.0"
+    enhanced-resolve: "npm:^5.7.0"
+    tapable: "npm:^2.2.1"
+    tsconfig-paths: "npm:^4.1.2"
+  checksum: 10c0/495c5ab7c1cb079217d98fe25d61def01e4bab38047c7ab25ec11876cc8c697ff01f43ea6c9933181875e51e49835407fc71afd92ea6cca1ba1bebf513dfb510
   languageName: node
   linkType: hard
 
@@ -14261,7 +14414,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.0, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.4.1, tslib@npm:^2.7.0, tslib@npm:^2.8.0":
+"tsconfig-paths@npm:^4.1.2":
+  version: 4.2.0
+  resolution: "tsconfig-paths@npm:4.2.0"
+  dependencies:
+    json5: "npm:^2.2.2"
+    minimist: "npm:^1.2.6"
+    strip-bom: "npm:^3.0.0"
+  checksum: 10c0/09a5877402d082bb1134930c10249edeebc0211f36150c35e1c542e5b91f1047b1ccf7da1e59babca1ef1f014c525510f4f870de7c9bda470c73bb4e2721b3ea
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.0.0, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.4.1, tslib@npm:^2.7.0, tslib@npm:^2.8.0, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
@@ -14900,6 +15064,18 @@ __metadata:
     "@types/istanbul-lib-coverage": "npm:^2.0.1"
     convert-source-map: "npm:^2.0.0"
   checksum: 10c0/968bcf1c7c88c04df1ffb463c179558a2ec17aa49e49376120504958239d9e9dad5281aa05f2a78542b8557f2be0b0b4c325710262f3b838b40d703d5ed30c23
+  languageName: node
+  linkType: hard
+
+"valibot@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "valibot@npm:1.2.0"
+  peerDependencies:
+    typescript: ">=5"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/e6897ed2008fc900380a6ce39b62bc5fca45fd5e070f70571c6380ede3ba026d0b7016230215d87f7f3d672a28dbde5a0522d39830b493fdc3dccd1a59ef4ee6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why

Fix ENG-19921

This migration updates the docs from Tailwind CSS v3 to v4, along with the companion `@expo/styleguide` packages that were updated for TW4 compatibility.

# How

**Core migration:**

- Upgrade `tailwindcss` from v3 to v4, replace `postcss-import` and `autoprefixer` with `@tailwindcss/postcss`
- Upgrade `@expo/styleguide` v9 to v10, `@expo/styleguide-icons` v2 to v3, `@expo/styleguide-search-ui` v3 to v4
- Convert `global.css` from `@tailwind` directives to `@import "tailwindcss"` with `@config` reference
- Replace `eslint-plugin-tailwindcss` (TW3 only) with `eslint-plugin-better-tailwindcss` (TW4 compatible), following `@expo/styleguide`.

**TW4 syntax conversions**

- Convert TW3 important prefix syntax (`!p-0`, `!mb-0`) to TW4 suffix syntax (`p-0!`, `mb-0!`)
- Convert TW3 gradient classes (`bg-gradient-to-b`) to TW4 syntax (`bg-linear-to-b`)
- Reorder classes to match TW4 canonical ordering (handled by linter)

**TW4 variant composition fixes:**

- Fix `last:[&>*]:mb-0!` pattern in 4 files (`APICommentTextBlock`, `APIBox`, `Collapsible`, `Requirement`). TW4 generates two selectors for this pattern, one of which targets ALL children when the parent is `:last-child`, instead of only the last child. Changed to `[&>*:last-child]:mb-0!` which generates a single correct selector.
- Fix `last:[&>div>*]:mb-0!` and `first:[&_figure]:mt-1`/`first:[&_pre]:mt-1` in `Tabs.tsx` with the same approach.
- Remove `even:[&_blockquote]:bg-default` and `even:[&_summary]:bg-element` from `Table/Row.tsx`. In TW3, these generated selectors that never matched (e.g., `blockquote:nth-child(2n)` instead of the intended parent-scoped selector). In TW4, they became active and incorrectly overrode callout background colors (like deprecated notice yellow backgrounds) on even table rows.

**Base layer fix:**

- Wrap bare HTML styles (`html`, `body`, `img`, `input`) in `@layer base` so TW4 utility classes can properly override them.

# Test Plan

Run docs locally using `yarn run dev` and:
- Check the homepage, sidebar navigation, and Ask AI overlay panel for visual correctness.
- Check large pages such as Expo Router and Expo Camera reference, Set up your environment guide, app config reference, etc. where multiple components are used.
- Compare the local dev site against `docs.expo.dev` for any visual regressions.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
