### PR TITLE
[build-properties] Update useHermesV1 to react-native 0.84

### DIFF
--- a/packages/expo-build-properties/CHANGELOG.md
+++ b/packages/expo-build-properties/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Update useHermesV1 to support React Native 0.84 ([#43625](https://github.com/expo/expo/pull/43625) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 55.0.9 — 2026-02-25
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-build-properties/build/pluginConfig.js
+++ b/packages/expo-build-properties/build/pluginConfig.js
@@ -25,11 +25,11 @@ const EXPO_SDK_MINIMAL_SUPPORTED_VERSIONS = {
     },
 };
 /**
- * The hermes-compiler version expected to use hermesV1 compiler version.
+ * The hermes-compiler version expected to use legacy Hermes compiler version.
  * Keep this in sync with the expected `react-native` version.
  * @ignore
  */
-const HERMES_V1_COMPILER_VERSION = '250829098.0.4';
+const LEGACY_HERMES_COMPILER_VERSION = '0.15.0';
 /**
  * Resolves a shared config value with platform-specific override.
  * Platform-specific values take precedence over top-level values.
@@ -309,27 +309,26 @@ function validateConfig(config, projectRoot) {
         config.android?.enableMinifyInReleaseBuilds !== true) {
         throw new Error('`android.enableShrinkResourcesInReleaseBuilds` requires `android.enableMinifyInReleaseBuilds` to be enabled.');
     }
-    const androidUseHermesV1 = resolveConfigValue(config, 'android', 'useHermesV1');
-    const iosUseHermesV1 = resolveConfigValue(config, 'ios', 'useHermesV1');
-    // TODO(gabrieldonadel): Revisit this before releasing SDK 56
-    // Hermes v1 requires a specific hermes-compiler version
-    if ((androidUseHermesV1 || iosUseHermesV1) && projectRoot) {
+    const androidUseHermesV1 = resolveConfigValue(config, 'android', 'useHermesV1') ?? true;
+    const iosUseHermesV1 = resolveConfigValue(config, 'ios', 'useHermesV1') ?? true;
+    // Disabling Hermes V1 requires a specific hermes-compiler version
+    if ((!androidUseHermesV1 || !iosUseHermesV1) && projectRoot) {
         const hermesCompilerVersion = getHermesCompilerVersion(projectRoot);
-        if (hermesCompilerVersion && hermesCompilerVersion !== HERMES_V1_COMPILER_VERSION) {
-            throw new Error(`\`useHermesV1\` requires setting the hermes-compiler version to ${HERMES_V1_COMPILER_VERSION} through resolutions. ` +
+        if (hermesCompilerVersion && hermesCompilerVersion !== LEGACY_HERMES_COMPILER_VERSION) {
+            throw new Error(`\`useHermesV1\`: false, requires setting the hermes-compiler version to ${LEGACY_HERMES_COMPILER_VERSION} through resolutions. ` +
                 `Found version "${hermesCompilerVersion}" instead.`);
         }
     }
-    // Validate useHermesV1 requires buildReactNativeFromSource for Android
+    // Validate legacy Hermes requires buildReactNativeFromSource for Android
     const androidBuildFromSource = resolveConfigValue(config, 'android', 'buildReactNativeFromSource') ??
         config.android?.buildFromSource; // Deprecated fallback
-    if (androidUseHermesV1 === true && androidBuildFromSource !== true) {
-        throw new Error('`useHermesV1` requires `buildReactNativeFromSource` to be `true` for Android.');
+    if (androidUseHermesV1 === false && androidBuildFromSource !== true) {
+        throw new Error('`useHermesV1`: false requires `buildReactNativeFromSource` to be `true` for Android.');
     }
-    // Validate useHermesV1 requires buildReactNativeFromSource for iOS
+    // Validate legacy Hermes requires buildReactNativeFromSource for iOS
     const iosBuildFromSource = resolveConfigValue(config, 'ios', 'buildReactNativeFromSource');
-    if (iosUseHermesV1 === true && iosBuildFromSource !== true) {
-        throw new Error('`useHermesV1` requires `buildReactNativeFromSource` to be `true` for iOS.');
+    if (iosUseHermesV1 === false && iosBuildFromSource !== true) {
+        throw new Error('`useHermesV1`: false requires `buildReactNativeFromSource` to be `true` for iOS.');
     }
     return config;
 }

--- a/packages/expo-build-properties/src/__tests__/pluginConfig-test.ts
+++ b/packages/expo-build-properties/src/__tests__/pluginConfig-test.ts
@@ -228,27 +228,27 @@ describe(validateConfig, () => {
 });
 
 describe('shared config resolution', () => {
-  it('should throw when useHermesV1 is true without buildReactNativeFromSource', () => {
-    expect(() => validateConfig({ useHermesV1: true })).toThrow(
-      '`useHermesV1` requires `buildReactNativeFromSource` to be `true`'
+  it('should throw when useHermesV1 is false without buildReactNativeFromSource', () => {
+    expect(() => validateConfig({ useHermesV1: false })).toThrow(
+      '`useHermesV1`: false requires `buildReactNativeFromSource` to be `true`'
     );
   });
 
   it('should validate useHermesV1 with buildReactNativeFromSource', () => {
     expect(() =>
-      validateConfig({ useHermesV1: true, buildReactNativeFromSource: true })
+      validateConfig({ useHermesV1: false, buildReactNativeFromSource: true })
     ).not.toThrow();
   });
 
   it('should throw for android-specific useHermesV1 without buildReactNativeFromSource', () => {
-    expect(() => validateConfig({ android: { useHermesV1: true } })).toThrow(
-      '`useHermesV1` requires `buildReactNativeFromSource` to be `true` for Android.'
+    expect(() => validateConfig({ android: { useHermesV1: false } })).toThrow(
+      '`useHermesV1`: false requires `buildReactNativeFromSource` to be `true` for Android.'
     );
   });
 
   it('should throw for ios-specific useHermesV1 without buildReactNativeFromSource', () => {
-    expect(() => validateConfig({ ios: { useHermesV1: true } })).toThrow(
-      '`useHermesV1` requires `buildReactNativeFromSource` to be `true` for iOS.'
+    expect(() => validateConfig({ ios: { useHermesV1: false } })).toThrow(
+      '`useHermesV1`: false requires `buildReactNativeFromSource` to be `true` for iOS.'
     );
   });
 
@@ -264,7 +264,7 @@ describe('shared config resolution', () => {
     expect(() =>
       validateConfig({
         buildReactNativeFromSource: true,
-        useHermesV1: true,
+        useHermesV1: false,
         reactNativeReleaseLevel: 'experimental',
         android: {
           minSdkVersion: 24,
@@ -277,10 +277,10 @@ describe('shared config resolution', () => {
     ).not.toThrow();
   });
 
-  it('should allow platform-specific buildReactNativeFromSource to satisfy useHermesV1', () => {
+  it('should allow platform-specific buildReactNativeFromSource to satisfy useHermesV1: false', () => {
     expect(() =>
       validateConfig({
-        useHermesV1: true,
+        useHermesV1: false,
         android: { buildReactNativeFromSource: true },
         ios: { buildReactNativeFromSource: true },
       })

--- a/packages/expo-build-properties/src/pluginConfig.ts
+++ b/packages/expo-build-properties/src/pluginConfig.ts
@@ -20,11 +20,11 @@ const EXPO_SDK_MINIMAL_SUPPORTED_VERSIONS = {
 };
 
 /**
- * The hermes-compiler version expected to use hermesV1 compiler version.
+ * The hermes-compiler version expected to use legacy Hermes compiler version.
  * Keep this in sync with the expected `react-native` version.
  * @ignore
  */
-const HERMES_V1_COMPILER_VERSION = '250829098.0.4';
+const LEGACY_HERMES_COMPILER_VERSION = '0.15.0';
 
 /**
  * Shared build configuration fields that can be set at the top level
@@ -904,35 +904,36 @@ export function validateConfig(config: unknown, projectRoot?: string): PluginCon
     );
   }
 
-  const androidUseHermesV1 = resolveConfigValue(config, 'android', 'useHermesV1');
-  const iosUseHermesV1 = resolveConfigValue(config, 'ios', 'useHermesV1');
+  const androidUseHermesV1 = resolveConfigValue(config, 'android', 'useHermesV1') ?? true;
+  const iosUseHermesV1 = resolveConfigValue(config, 'ios', 'useHermesV1') ?? true;
 
-  // TODO(gabrieldonadel): Revisit this before releasing SDK 56
-  // Hermes v1 requires a specific hermes-compiler version
-  if ((androidUseHermesV1 || iosUseHermesV1) && projectRoot) {
+  // Disabling Hermes V1 requires a specific hermes-compiler version
+  if ((!androidUseHermesV1 || !iosUseHermesV1) && projectRoot) {
     const hermesCompilerVersion = getHermesCompilerVersion(projectRoot);
-    if (hermesCompilerVersion && hermesCompilerVersion !== HERMES_V1_COMPILER_VERSION) {
+    if (hermesCompilerVersion && hermesCompilerVersion !== LEGACY_HERMES_COMPILER_VERSION) {
       throw new Error(
-        `\`useHermesV1\` requires setting the hermes-compiler version to ${HERMES_V1_COMPILER_VERSION} through resolutions. ` +
+        `\`useHermesV1\`: false, requires setting the hermes-compiler version to ${LEGACY_HERMES_COMPILER_VERSION} through resolutions. ` +
           `Found version "${hermesCompilerVersion}" instead.`
       );
     }
   }
 
-  // Validate useHermesV1 requires buildReactNativeFromSource for Android
+  // Validate legacy Hermes requires buildReactNativeFromSource for Android
   const androidBuildFromSource =
     resolveConfigValue(config, 'android', 'buildReactNativeFromSource') ??
     config.android?.buildFromSource; // Deprecated fallback
-  if (androidUseHermesV1 === true && androidBuildFromSource !== true) {
+  if (androidUseHermesV1 === false && androidBuildFromSource !== true) {
     throw new Error(
-      '`useHermesV1` requires `buildReactNativeFromSource` to be `true` for Android.'
+      '`useHermesV1`: false requires `buildReactNativeFromSource` to be `true` for Android.'
     );
   }
 
-  // Validate useHermesV1 requires buildReactNativeFromSource for iOS
+  // Validate legacy Hermes requires buildReactNativeFromSource for iOS
   const iosBuildFromSource = resolveConfigValue(config, 'ios', 'buildReactNativeFromSource');
-  if (iosUseHermesV1 === true && iosBuildFromSource !== true) {
-    throw new Error('`useHermesV1` requires `buildReactNativeFromSource` to be `true` for iOS.');
+  if (iosUseHermesV1 === false && iosBuildFromSource !== true) {
+    throw new Error(
+      '`useHermesV1`: false requires `buildReactNativeFromSource` to be `true` for iOS.'
+    );
   }
 
   return config;


### PR DESCRIPTION
# Why

Starting from React Native 0.84 HermesV1 is enabled by default. For that reason, we must update our `useHermesV1 ` logic to check for legacy hermes instread 

# How

Update expo-build-properties `useHermesV1` check for legacy hermes


# Test Plan


In sandbox app add the following to app.json

```json
"plugins": [
      [
        "expo-build-properties",
        {
          "ios": {
            "useHermesV1": false,
            "buildReactNativeFromSource": true
          },
          "android": {
            "useHermesV1": false,
            "buildReactNativeFromSource": true
          }
        }
      ]
    ],
```
 Then set your package.json to resolve the experimental version of Hermes V1 compiler  
```json
"resolutions": { "hermes-compiler": "0.15.0" }
```

To confirm that the app is running legacy Hermes, check if `HermesInternal.getRuntimeProperties()['OSS Release Version'];` return `"0.15.0"`
 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
