### PR TITLE
[docs] Clarify `matchContents` limitation for flexible-width SwiftUI components                                                        

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/host.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/host.mdx
@@ -23,6 +23,8 @@ Since the `Host` component is a React Native [`View`](https://reactnative.dev/do
 
 Use `matchContents` to let the `Host` automatically size itself to fit its SwiftUI content, instead of requiring explicit dimensions.
 
+> **Note:** `matchContents` only works correctly with components that have an intrinsic size or an explicit [`frame`](modifiers/#frameparams) (for example, `Button`, `Toggle`, `Text`). Flexible-width components like `Slider` and linear `ProgressView` expand to fill available space and have no intrinsic width, using `matchContents` with them will result in near-zero width. For those components, either apply a [`frame`](modifiers/#frameparams) modifier on the component to give it an explicit width, or use explicit sizing with `style` on the `Host` instead (for example, `style={{ flex: 1 }}` or `style={{ width: 300 }}`).
+
 ```tsx MatchContentsExample.tsx
 import { Button, Host } from '@expo/ui/swift-ui';
 
@@ -42,7 +44,7 @@ export default function MatchContentsExample() {
 
 ### Explicit sizing with style
 
-Use `style` to set explicit sizes on the `Host`, such as filling the available space with `flex: 1`.
+Use `style` to set explicit sizes on the `Host`, such as filling the available space with `flex: 1`. This is the recommended approach for flexible-width SwiftUI components like `Slider` and linear `ProgressView`.
 
 ```tsx ExplicitSizingExample.tsx
 import { Button, Host, VStack, Text } from '@expo/ui/swift-ui';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/host.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/host.mdx
@@ -44,7 +44,7 @@ export default function MatchContentsExample() {
 
 ### Explicit sizing with style
 
-Use `style` to set explicit sizes on the `Host`, such as filling the available space with `flex: 1`. This is the recommended approach for flexible-width SwiftUI components like `Slider` and linear `ProgressView`.
+Use `style` to set explicit sizes on the `Host`, such as filling the available space with `flex: 1`.
 
 ```tsx ExplicitSizingExample.tsx
 import { Button, Host, VStack, Text } from '@expo/ui/swift-ui';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/progressview.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/progressview.mdx
@@ -17,6 +17,8 @@ Expo UI ProgressView matches the official SwiftUI [ProgressView API](https://dev
 
 ## Usage
 
+> **Note:** When using the `linear` style (which is the default for determinate progress), `ProgressView` is a flexible-width component, it expands to fill available horizontal space. When using `matchContents` on the `Host`, you should apply a [`frame`](modifiers/#frameparams) modifier on the `ProgressView` to give it an explicit width. Alternatively, give the `Host` an explicit size using `style` (for example, `style={{ width: 300 }}` or `style={{ flex: 1 }}`). The `circular` style and indeterminate spinner have a fixed size and work with `matchContents`.
+
 ### Indeterminate progress
 
 When no `value` is provided, the progress view displays an indeterminate indicator (spinner).
@@ -42,7 +44,7 @@ import { Host, ProgressView } from '@expo/ui/swift-ui';
 
 export default function DeterminateExample() {
   return (
-    <Host matchContents>
+    <Host style={{ flex: 1 }}>
       <ProgressView value={0.5} />
     </Host>
   );
@@ -59,7 +61,7 @@ import { progressViewStyle } from '@expo/ui/swift-ui/modifiers';
 
 export default function ProgressViewStylesExample() {
   return (
-    <Host matchContents>
+    <Host style={{ flex: 1 }}>
       <ProgressView value={0.5} modifiers={[progressViewStyle('linear')]} />
     </Host>
   );
@@ -75,7 +77,7 @@ import { Host, ProgressView, Text } from '@expo/ui/swift-ui';
 
 export default function LabelExample() {
   return (
-    <Host matchContents>
+    <Host style={{ flex: 1 }}>
       <ProgressView value={0.25}>
         <Text>Loading...</Text>
       </ProgressView>
@@ -94,7 +96,7 @@ import { tint } from '@expo/ui/swift-ui/modifiers';
 
 export default function TintedExample() {
   return (
-    <Host matchContents>
+    <Host style={{ flex: 1 }}>
       <ProgressView value={0.7} modifiers={[tint('red')]} />
     </Host>
   );
@@ -115,7 +117,7 @@ export default function TimerExample() {
   const endDate = new Date(Date.now() + 10000); // 10 seconds from now
 
   return (
-    <Host matchContents>
+    <Host style={{ flex: 1 }}>
       <VStack spacing={16}>
         <ProgressView timerInterval={{ lower: startDate, upper: endDate }} />
         <ProgressView timerInterval={{ lower: startDate, upper: endDate }} countsDown={false}>

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/slider.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/slider.mdx
@@ -17,6 +17,8 @@ Expo UI Slider matches the official SwiftUI [Slider API](https://developer.apple
 
 ## Usage
 
+> **Note:** `Slider` is a flexible-width component, it expands to fill available horizontal space and does not have an intrinsic width. When using `matchContents` on the `Host`, you should apply a [`frame`](modifiers/#frameparams) modifier on the `Slider` to give it an explicit width. Alternatively, give the `Host` an explicit size using `style` (for example, `style={{ width: 300 }}` or `style={{ flex: 1 }}`), or place the `Slider` inside a SwiftUI container like `Form` that provides width constraints.
+
 ### Basic slider
 
 ```tsx BasicSliderExample.tsx
@@ -27,7 +29,7 @@ export default function BasicSliderExample() {
   const [value, setValue] = useState(0.5);
 
   return (
-    <Host matchContents>
+    <Host style={{ flex: 1 }}>
       <Slider value={value} onValueChange={setValue} />
     </Host>
   );
@@ -44,7 +46,7 @@ export default function CustomRangeSliderExample() {
   const [value, setValue] = useState(50);
 
   return (
-    <Host matchContents>
+    <Host style={{ flex: 1 }}>
       <Slider value={value} min={0} max={100} onValueChange={setValue} />
     </Host>
   );
@@ -63,7 +65,7 @@ export default function SteppedSliderExample() {
   const [value, setValue] = useState(0);
 
   return (
-    <Host matchContents>
+    <Host style={{ flex: 1 }}>
       <Slider value={value} min={0} max={100} step={10} onValueChange={setValue} />
     </Host>
   );
@@ -82,7 +84,7 @@ export default function LabeledSliderExample() {
   const [value, setValue] = useState(50);
 
   return (
-    <Host matchContents>
+    <Host style={{ flex: 1 }}>
       <Slider
         value={value}
         min={0}

--- a/docs/pages/versions/v55.0.0/sdk/ui/swift-ui/host.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/ui/swift-ui/host.mdx
@@ -23,6 +23,8 @@ Since the `Host` component is a React Native [`View`](https://reactnative.dev/do
 
 Use `matchContents` to let the `Host` automatically size itself to fit its SwiftUI content, instead of requiring explicit dimensions.
 
+> **Note:** `matchContents` only works correctly with components that have an intrinsic size or an explicit [`frame`](modifiers/#frameparams) (for example, `Button`, `Toggle`, `Text`). Flexible-width components like `Slider` and linear `ProgressView` expand to fill available space and have no intrinsic width, using `matchContents` with them will result in near-zero width. For those components, either apply a [`frame`](modifiers/#frameparams) modifier on the component to give it an explicit width, or use explicit sizing with `style` on the `Host` instead (for example, `style={{ flex: 1 }}` or `style={{ width: 300 }}`).
+
 ```tsx MatchContentsExample.tsx
 import { Button, Host } from '@expo/ui/swift-ui';
 

--- a/docs/pages/versions/v55.0.0/sdk/ui/swift-ui/progressview.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/ui/swift-ui/progressview.mdx
@@ -17,6 +17,8 @@ Expo UI ProgressView matches the official SwiftUI [ProgressView API](https://dev
 
 ## Usage
 
+> **Note:** When using the `linear` style (which is the default for determinate progress), `ProgressView` is a flexible-width component, it expands to fill available horizontal space. When using `matchContents` on the `Host`, you should apply a [`frame`](modifiers/#frameparams) modifier on the `ProgressView` to give it an explicit width. Alternatively, give the `Host` an explicit size using `style` (for example, `style={{ width: 300 }}` or `style={{ flex: 1 }}`). The `circular` style and indeterminate spinner have a fixed size and work with `matchContents`.
+
 ### Indeterminate progress
 
 When no `value` is provided, the progress view displays an indeterminate indicator (spinner).
@@ -42,7 +44,7 @@ import { Host, ProgressView } from '@expo/ui/swift-ui';
 
 export default function DeterminateExample() {
   return (
-    <Host matchContents>
+    <Host style={{ flex: 1 }}>
       <ProgressView value={0.5} />
     </Host>
   );
@@ -59,7 +61,7 @@ import { progressViewStyle } from '@expo/ui/swift-ui/modifiers';
 
 export default function ProgressViewStylesExample() {
   return (
-    <Host matchContents>
+    <Host style={{ flex: 1 }}>
       <ProgressView value={0.5} modifiers={[progressViewStyle('linear')]} />
     </Host>
   );
@@ -75,7 +77,7 @@ import { Host, ProgressView, Text } from '@expo/ui/swift-ui';
 
 export default function LabelExample() {
   return (
-    <Host matchContents>
+    <Host style={{ flex: 1 }}>
       <ProgressView value={0.25}>
         <Text>Loading...</Text>
       </ProgressView>
@@ -94,7 +96,7 @@ import { tint } from '@expo/ui/swift-ui/modifiers';
 
 export default function TintedExample() {
   return (
-    <Host matchContents>
+    <Host style={{ flex: 1 }}>
       <ProgressView value={0.7} modifiers={[tint('red')]} />
     </Host>
   );
@@ -115,7 +117,7 @@ export default function TimerExample() {
   const endDate = new Date(Date.now() + 10000); // 10 seconds from now
 
   return (
-    <Host matchContents>
+    <Host style={{ flex: 1 }}>
       <VStack spacing={16}>
         <ProgressView timerInterval={{ lower: startDate, upper: endDate }} />
         <ProgressView timerInterval={{ lower: startDate, upper: endDate }} countsDown={false}>

--- a/docs/pages/versions/v55.0.0/sdk/ui/swift-ui/slider.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/ui/swift-ui/slider.mdx
@@ -17,6 +17,8 @@ Expo UI Slider matches the official SwiftUI [Slider API](https://developer.apple
 
 ## Usage
 
+> **Note:** `Slider` is a flexible-width component, it expands to fill available horizontal space and does not have an intrinsic width. When using `matchContents` on the `Host`, you should apply a [`frame`](modifiers/#frameparams) modifier on the `Slider` to give it an explicit width. Alternatively, give the `Host` an explicit size using `style` (for example, `style={{ width: 300 }}` or `style={{ flex: 1 }}`), or place the `Slider` inside a SwiftUI container like `Form` that provides width constraints.
+
 ### Basic slider
 
 ```tsx BasicSliderExample.tsx
@@ -27,7 +29,7 @@ export default function BasicSliderExample() {
   const [value, setValue] = useState(0.5);
 
   return (
-    <Host matchContents>
+    <Host style={{ flex: 1 }}>
       <Slider value={value} onValueChange={setValue} />
     </Host>
   );
@@ -44,7 +46,7 @@ export default function CustomRangeSliderExample() {
   const [value, setValue] = useState(50);
 
   return (
-    <Host matchContents>
+    <Host style={{ flex: 1 }}>
       <Slider value={value} min={0} max={100} onValueChange={setValue} />
     </Host>
   );
@@ -63,7 +65,7 @@ export default function SteppedSliderExample() {
   const [value, setValue] = useState(0);
 
   return (
-    <Host matchContents>
+    <Host style={{ flex: 1 }}>
       <Slider value={value} min={0} max={100} step={10} onValueChange={setValue} />
     </Host>
   );
@@ -82,7 +84,7 @@ export default function LabeledSliderExample() {
   const [value, setValue] = useState(50);
 
   return (
-    <Host matchContents>
+    <Host style={{ flex: 1 }}>
       <Slider
         value={value}
         min={0}


### PR DESCRIPTION
  ## Why                                                                                                                                             
  Fixes https://github.com/expo/expo/issues/43616

  - Adds notes to `Host`, `Slider`, and `ProgressView` docs clarifying that `matchContents` does not work correctly with flexible-width SwiftUI          
  components (`Slider`, linear `ProgressView`)
  - Updates code examples for `Slider` and determinate `ProgressView` to use `style={{ flex: 1 }}` instead of `matchContents`                            
  - Mentions `frame` modifier as an alternative to give flexible components an explicit width when using `matchContents`                                 
                                                                                                                                                         

  ## Test plan
  - Verify docs render correctly on the docs site
  - Confirm the code examples in Slider, ProgressView, and Host docs are accurate