### PR TITLE
fix: Worklets Serializable enum compilation issue

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix memory leak due to retain cycle in SwiftUI views. ([#43468](https://github.com/expo/expo/pull/43468) by [@nishan](https://github.com/intergalacticspacehighway))
-- [iOS] Fixed compilation issues due to missing fallthrough case in `EXJavaScriptSerializable`.
+- [iOS] Fixed compilation issues due to missing fallthrough case in `EXJavaScriptSerializable`. ([#43634](https://github.com/expo/expo/pull/43634) by [@tjzel](https://github.com/tjzel))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix memory leak due to retain cycle in SwiftUI views. ([#43468](https://github.com/expo/expo/pull/43468) by [@nishan](https://github.com/intergalacticspacehighway))
+- [iOS] Fixed compilation issues due to missing fallthrough case in `EXJavaScriptSerializable`.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Worklets/EXJavaScriptSerializable.mm
+++ b/packages/expo-modules-core/ios/Worklets/EXJavaScriptSerializable.mm
@@ -48,6 +48,8 @@ EXSerializableValueType toObjCValueType(worklets::Serializable::ValueType type) 
       return EXSerializableValueTypeSynchronizable;
     case worklets::Serializable::ValueType::CustomType:
       return EXSerializableValueTypeCustom;
+    default:
+      return EXSerializableValueTypeUndefined;
   }
 }
 


### PR DESCRIPTION
# Why

Recently Worklets added more types of `Serializable`. This makes the `@next` version of expo to fail on compilation CI due to these types not being handled in a switch statement.

I'm adding a default fallthrough case to fix compilation.

# How

I added a default case just to fix compilation issues.

# Test Plan

Try compilation with `react-native-worklets@nightly`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
