### PR TITLE
fix(expo-updates): load @expo/env before evaluating Expo config in build utilities

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Load `@expo/env` before evaluating Expo config in native build phase scripts ([#43635](https://github.com/expo/expo/pull/43635) by [@leeseonghyun21](https://github.com/leeseonghyun21))
 - [Android] Widen `UpdatesLogEntry.create`'s catch from `JSONException` to `Exception` so log-line parse failures consistently degrade to "skip the entry" instead of propagating. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
 - [Android] Correct `UpdatesLogReader.ONE_DAY_MILLISECONDS` from `86400` (seconds) to `86_400_000` (milliseconds), so the "older than one day" purge filter actually retains a day's worth of entries instead of ~86 seconds' worth. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
 - [iOS] Isolate UpdatesLogReaderTests from concurrent suites. ([#47082](https://github.com/expo/expo/pull/47082) by [@douglowder](https://github.com/douglowder))

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "@expo/code-signing-certificates": "^0.0.6",
+    "@expo/env": "workspace:^2.3.0",
     "@expo/plist": "workspace:^0.7.0",
     "@expo/spawn-async": "^1.8.0",
     "arg": "^4.1.0",

--- a/packages/expo-updates/utils/src/createUpdatesResources.ts
+++ b/packages/expo-updates/utils/src/createUpdatesResources.ts
@@ -30,6 +30,8 @@ import { findUpProjectRoot } from './findUpProjectRoot';
 
   const entryFileArg = process.argv[6];
 
+  require('@expo/env').load(possibleProjectRoot);
+
   await Promise.all([
     createUpdatesResourcesMode === 'all'
       ? createManifestForBuildAsync(platform, possibleProjectRoot, destinationDir, entryFileArg)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5928,6 +5928,9 @@ importers:
       '@expo/code-signing-certificates':
         specifier: ^0.0.6
         version: 0.0.6
+      '@expo/env':
+        specifier: workspace:^2.3.0
+        version: link:../@expo/env
       '@expo/plist':
         specifier: workspace:^0.7.0
         version: link:../@expo/plist


### PR DESCRIPTION
# Why

Native build phase scripts (Xcode build phase / Gradle plugin) invoke `createUpdatesResources.js` directly as a standalone Node.js process, bypassing the Expo CLI. The Expo CLI normally loads `@expo/env` before evaluating the Expo config, but this entry point does not — causing `.env` file variables to be `undefined` when `app.config.ts` is evaluated during native builds.

This breaks any project that references `process.env.*` in their Expo config:

```
Error reading Expo config at /path/to/project/app.config.ts:
Invalid app stage: undefined
    at getConfig (...)
    at createFingerprintForBuildAsync (.../expo-updates/utils/build/createFingerprintForBuildAsync.js:25:52)
    at .../expo-updates/utils/build/createUpdatesResources.js:30:77
```

The issue only occurs when building directly from Xcode or Gradle (not via `npx expo run:ios/android`), because the CLI entry points all call `loadEnvFiles()` before config evaluation.

# How

Add `require('@expo/env').load(possibleProjectRoot)` in `createUpdatesResources.ts` (the entry point for native build scripts) before any `getConfig()` calls downstream.

This follows the same pattern used by:
- `@expo/fingerprint`'s `ExpoConfigLoader.ts` — loads the project env before `getConfig()`
- All 14+ `@expo/cli` command entry points — `loadEnvFiles(projectRoot)` before `getConfig()`

> **Correction.** An earlier revision of this description cited `ExpoConfigLoader.ts` as calling `require('@expo/env').load(projectRoot)`. That is the published `@expo/fingerprint@0.20.10` build, not `main` — at `6d84a5d` the file calls `consumeConfigEnvMode()` followed by `loadProjectEnv(projectRoot, { mode })`. The deprecated `load()` in the diff below is being reworked into `loadProjectEnv` with an explicit mode; see https://github.com/expo/expo/pull/43635#issuecomment-5435987422 for the two shapes awaiting a maintainer decision.

# Test Plan

- Build an app that uses `process.env.*` in `app.config.ts` with a `.env` file
- Build directly from Xcode (Product → Build) — should no longer fail with undefined env vars
- Build via `npx expo run:ios` — should continue to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
