### PR TITLE
[expo-ui][android] fix modifiers export

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [Android] Added `RNHostView` to improve RN component layout inside Compose views. ([#43495](https://github.com/expo/expo/pull/43495) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Fix `ContextMenu` not expanding when triggered by `IconButton`. ([#43592](https://github.com/expo/expo/pull/43592) by [@nishan](https://github.com/intergalacticspacehighway))
+- [android] fix modifiers export ([#43639](https://github.com/expo/expo/pull/43639) by [@Ubax](https://github.com/Ubax))
 
 ### 💡 Others
 

--- a/packages/expo-ui/jetpack-compose.d.ts
+++ b/packages/expo-ui/jetpack-compose.d.ts
@@ -1,1 +1,0 @@
-export * from './build/jetpack-compose';

--- a/packages/expo-ui/jetpack-compose.js
+++ b/packages/expo-ui/jetpack-compose.js
@@ -1,1 +1,0 @@
-export * from './src/jetpack-compose';

--- a/packages/expo-ui/jetpack-compose/index.d.ts
+++ b/packages/expo-ui/jetpack-compose/index.d.ts
@@ -1,0 +1,1 @@
+export * from '../build/jetpack-compose';

--- a/packages/expo-ui/jetpack-compose/index.js
+++ b/packages/expo-ui/jetpack-compose/index.js
@@ -1,0 +1,1 @@
+export * from '../src/jetpack-compose';

--- a/packages/expo-ui/jetpack-compose/modifiers.d.ts
+++ b/packages/expo-ui/jetpack-compose/modifiers.d.ts
@@ -1,0 +1,1 @@
+export * from '../build/jetpack-compose/modifiers';

--- a/packages/expo-ui/jetpack-compose/modifiers.js
+++ b/packages/expo-ui/jetpack-compose/modifiers.js
@@ -1,0 +1,1 @@
+export * from '../src/jetpack-compose/modifiers';

--- a/packages/jest-expo/src/preset/moduleMocks/expoModules.js
+++ b/packages/jest-expo/src/preset/moduleMocks/expoModules.js
@@ -736,6 +736,7 @@ module.exports = {
           { name: 'reload', argumentsCount: 0, key: 'reload' },
           { name: 'setExtraParamAsync', argumentsCount: 2, key: 'setExtraParamAsync' },
         ],
+        ExpoUI: [],
         ExpoVideo: [
           { name: 'clearVideoCacheAsync', argumentsCount: 0, key: 'clearVideoCacheAsync' },
           { name: 'getCurrentVideoCacheSize', argumentsCount: 0, key: 'getCurrentVideoCacheSize' },


### PR DESCRIPTION
# Why

When importing `jetpack-compose/modifiers` in `expo-router`, typescript cannot find correct files. This is because `moduleResolution` is set to `"node10"`.

# How

Add `.js` and `.d.ts` files similar to swift ui approach.

Additionally adds `ExpoUI` to `expoModules.js`, so that it is mocked in jest tests

# Test Plan

Importing the modifiers in expo-router, compiles without any problems.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
