### PR TITLE
fix(@expo/cli): sort async chunks by route `entryPoints` order when `asyncRoutes` is enabled

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix server being started before Metro is ready, or, if it's started, status middleware responding too soon ([#43557](https://github.com/expo/expo/pull/43557) by [@kitten](https://github.com/kitten))
 - Don't let `expo start`'s dependency validation fail the `start` command ([#43619](https://github.com/expo/expo/pull/43619) by [@kitten](https://github.com/kitten))
+- Sort async chunks by route `entryPoints` order when `asyncRoutes` is enabled ([#43531](https://github.com/expo/expo/pull/43531) by [@hassankhan](https://github.com/hassankhan))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/e2e/__tests__/export/server-rendering-async.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-rendering-async.test.ts
@@ -85,9 +85,7 @@ describe('server rendering with async routes', () => {
         });
 
         const routeName = route.page.replace('/', '');
-        expect(jsFilenames).toEqual(
-          expect.arrayContaining(['_layout-<HASH>.js', `${routeName}-<HASH>.js`])
-        );
+        expect(jsFilenames).toEqual(['_layout-<HASH>.js', `${routeName}-<HASH>.js`]);
       }
     });
   });

--- a/packages/@expo/cli/e2e/__tests__/export/static-splitting.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-splitting.test.ts
@@ -69,7 +69,7 @@ describe('exports static with bundle splitting', () => {
     const staticParamsPage = await getScriptTagsAsync('welcome-to-the-universe.html');
 
     expect(staticParamsPage).toEqual(
-      ['__expo-metro-runtime', '__common', 'entry', '[post]', '_layout'].map(
+      ['__expo-metro-runtime', '__common', 'entry', '_layout', '[post]'].map(
         expectChunkPathMatching
       )
     );

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import { ExpoConfig } from '@expo/config';
+import type { SerialAsset } from '@expo/metro-config/build/serializer/serializerAssets';
 import chalk from 'chalk';
 import { RouteNode } from 'expo-router/build/Route';
 import { getContextKey, stripGroupSegmentsFromPath } from 'expo-router/build/matchers';
@@ -24,7 +25,11 @@ import {
 } from '../start/server/metro/MetroBundlerDevServer';
 import { logMetroErrorAsync } from '../start/server/metro/metroErrorInterface';
 import { getApiRoutesForDirectory, getMiddlewareForDirectory } from '../start/server/metro/router';
-import { assetsRequiresSort, serializeHtmlWithAssets } from '../start/server/metro/serializeHtml';
+import {
+  assetsRequiresSort,
+  serializeHtmlWithAssets,
+  sortMatchedAssetsByEntryPoints,
+} from '../start/server/metro/serializeHtml';
 import { learnMore } from '../utils/link';
 
 const debug = require('debug')('expo:export:generateStaticRoutes') as typeof console.log;
@@ -374,7 +379,7 @@ export async function exportFromServerAsync(
           continue;
         }
 
-        const matchedChunks: string[] = [];
+        const matchedChunks: SerialAsset[] = [];
         for (const asyncChunk of asyncJs) {
           if (!asyncChunk.metadata.modulePaths || !Array.isArray(asyncChunk.metadata.modulePaths)) {
             continue;
@@ -383,12 +388,16 @@ export async function exportFromServerAsync(
             (asyncChunk.metadata.modulePaths as string[]).includes(entryPoint)
           );
           if (hasRouteEntryPoint) {
-            matchedChunks.push(toAssetUrl(asyncChunk.filename));
+            matchedChunks.push(asyncChunk);
           }
         }
 
         if (matchedChunks.length > 0) {
-          routeAssets.set(route.contextKey, matchedChunks);
+          const sorted = sortMatchedAssetsByEntryPoints(matchedChunks, route.entryPoints);
+          routeAssets.set(
+            route.contextKey,
+            sorted.map((chunk) => toAssetUrl(chunk.filename))
+          );
         }
       }
 

--- a/packages/@expo/cli/src/start/server/metro/__tests__/serializeHtml.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/serializeHtml.test.ts
@@ -1,6 +1,10 @@
 import { SerialAsset } from '@expo/metro-config/src/serializer/serializerAssets';
 
-import { serializeHtmlWithAssets, assetsRequiresSort } from '../serializeHtml';
+import {
+  serializeHtmlWithAssets,
+  assetsRequiresSort,
+  sortMatchedAssetsByEntryPoints,
+} from '../serializeHtml';
 
 it('serializes development static html', () => {
   const res = serializeHtmlWithAssets({
@@ -111,6 +115,45 @@ it('serializes development export static html with correct baseUrl and script sr
   );
 });
 
+it('serializes HTML with async chunks in correct order for dynamic routes', () => {
+  const res = serializeHtmlWithAssets({
+    resources: [
+      {
+        filename: 'dist/entry.js',
+        originFilename: 'entry.js',
+        type: 'js',
+        metadata: { isAsync: false, requires: [], modulePaths: [] },
+        source: '',
+      },
+      {
+        filename: 'dist/chunk-page.js',
+        originFilename: 'chunk-page.js',
+        type: 'js',
+        metadata: { isAsync: true, requires: [], modulePaths: ['/app/[slug].tsx'] },
+        source: '',
+      },
+      {
+        filename: 'dist/chunk-layout.js',
+        originFilename: 'chunk-layout.js',
+        type: 'js',
+        metadata: { isAsync: true, requires: [], modulePaths: ['/app/_layout.tsx'] },
+        source: '',
+      },
+    ],
+    baseUrl: '',
+    isExporting: true,
+    template: '<!DOCTYPE html><html><head></head><body><div id="root"></div></body></html>',
+    route: {
+      contextKey: './[slug].tsx',
+      entryPoints: ['/app/_layout.tsx', '/app/[slug].tsx'],
+    } as any,
+  });
+
+  expect(res).toContain(
+    '<script src="/dist/chunk-layout.js" defer></script><script src="/dist/chunk-page.js" defer></script>'
+  );
+});
+
 it('sorts assets based on requires tree', () => {
   const assets: SerialAsset[] = [
     {
@@ -190,4 +233,86 @@ it('sorts assets based on requires tree', () => {
       },
     ]
   `);
+});
+
+describe(sortMatchedAssetsByEntryPoints, () => {
+  it('corrects incorrectly ordered chunks', () => {
+    const assets: SerialAsset[] = [
+      {
+        filename: 'chunk-page.js',
+        originFilename: 'chunk-page.js',
+        type: 'js',
+        metadata: { isAsync: true, modulePaths: ['/app/[slug].tsx'] },
+        source: '',
+      },
+      {
+        filename: 'chunk-layout.js',
+        originFilename: 'chunk-layout.js',
+        type: 'js',
+        metadata: { isAsync: true, modulePaths: ['/app/_layout.tsx'] },
+        source: '',
+      },
+    ];
+
+    const sorted = sortMatchedAssetsByEntryPoints(assets, ['/app/_layout.tsx', '/app/[slug].tsx']);
+    expect(sorted.map((a) => a.filename)).toEqual(['chunk-layout.js', 'chunk-page.js']);
+  });
+
+  it('preserves already correct order', () => {
+    const assets: SerialAsset[] = [
+      {
+        filename: 'chunk-layout.js',
+        originFilename: 'chunk-layout.js',
+        type: 'js',
+        metadata: { isAsync: true, modulePaths: ['/app/_layout.tsx'] },
+        source: '',
+      },
+      {
+        filename: 'chunk-page.js',
+        originFilename: 'chunk-page.js',
+        type: 'js',
+        metadata: { isAsync: true, modulePaths: ['/app/index.tsx'] },
+        source: '',
+      },
+    ];
+    const sorted = sortMatchedAssetsByEntryPoints(assets, ['/app/_layout.tsx', '/app/index.tsx']);
+    expect(sorted.map((a) => a.filename)).toEqual(['chunk-layout.js', 'chunk-page.js']);
+  });
+
+  it('handles nested layouts', () => {
+    const assets: SerialAsset[] = [
+      {
+        filename: 'chunk-root.js',
+        originFilename: 'chunk-root.js',
+        type: 'js',
+        metadata: { isAsync: true, modulePaths: ['/app/_layout.tsx'] },
+        source: '',
+      },
+      {
+        filename: 'chunk-nested.js',
+        originFilename: 'chunk-nested.js',
+        type: 'js',
+        metadata: { isAsync: true, modulePaths: ['/app/settings/_layout.tsx'] },
+        source: '',
+      },
+      {
+        filename: 'chunk-page.js',
+        originFilename: 'chunk-page.js',
+        type: 'js',
+        metadata: { isAsync: true, modulePaths: ['/app/settings/profile.tsx'] },
+        source: '',
+      },
+    ];
+
+    const sorted = sortMatchedAssetsByEntryPoints(assets, [
+      '/app/_layout.tsx',
+      '/app/settings/_layout.tsx',
+      '/app/settings/profile.tsx',
+    ]);
+    expect(sorted.map((a) => a.filename)).toEqual([
+      'chunk-root.js',
+      'chunk-nested.js',
+      'chunk-page.js',
+    ]);
+  });
 });

--- a/packages/@expo/cli/src/start/server/metro/serializeHtml.ts
+++ b/packages/@expo/cli/src/start/server/metro/serializeHtml.ts
@@ -88,7 +88,16 @@ function htmlFromSerialAssets(
     })
     .join('');
 
-  const orderedJsAssets = assetsRequiresSort(assets.filter((asset) => asset.type === 'js'));
+  let orderedJsAssets = assetsRequiresSort(assets.filter((asset) => asset.type === 'js'));
+
+  if (route?.entryPoints && Array.isArray(route.entryPoints)) {
+    const syncAssets = orderedJsAssets.filter((a) => !a.metadata.isAsync);
+    const sortedAsync = sortMatchedAssetsByEntryPoints(
+      orderedJsAssets.filter((a) => a.metadata.isAsync),
+      route.entryPoints
+    );
+    orderedJsAssets = [...syncAssets, ...sortedAsync];
+  }
 
   const scripts = bundleUrl
     ? `<script src="${bundleUrl}" defer></script>`
@@ -131,6 +140,23 @@ function htmlFromSerialAssets(
   return template
     .replace('</head>', `${styleString}</head>`)
     .replace('</body>', `${scripts}\n</body>`);
+}
+
+/**
+ * Sorts matched async assets by their matching `entryPoint` in the route's `entryPoints` array.
+ * This ensures layout chunks come before page chunks.
+ */
+export function sortMatchedAssetsByEntryPoints(
+  matchedAssets: SerialAsset[],
+  entryPoints: string[]
+): SerialAsset[] {
+  const getEntryPointIndex = (modulePaths?: string[]) =>
+    modulePaths ? entryPoints.findIndex((ep) => modulePaths.includes(ep)) : -1;
+
+  return matchedAssets.sort(
+    (a, b) =>
+      getEntryPointIndex(a.metadata.modulePaths) - getEntryPointIndex(b.metadata.modulePaths)
+  );
 }
 
 /**


### PR DESCRIPTION
# Why

Backports https://github.com/expo/expo/pull/43531 to SDK 55. 

Followup to https://github.com/expo/expo/pull/43446.

When `asyncRoutes: true` is enabled with SSR, each route gets its own async JavaScript chunk(s). Currently, these chunks are added to the serialized HTML in the correct order for regular/static routes, but are reversed for dynamic routes like `[slug]` or `[...rest]`.

| Route | Async chunks order |
|---|---|
| `app/index.tsx` | `_layout-<HASH>.js`, `index-<HASH>.js` |
| `app/slug.tsx` | `[slug]-<HASH>.js`, `_layout.tsx` |

Both the SSG and SSR export pipelines currently exhibit this issue.

# How

Added a `sortMatchedAssetsByEntryPoints()` utility that sorts matched async assets by the index of their matching entryPoint in the route's `entryPoints` array (which is always correctly ordered) and applied it to both the SSG and SSR pipelines.

# Test Plan

- CI
- Manual testing against the blog and E2E fixture

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
