### PR TITLE
[device][ios] Update Apple devices

### DIFF
--- a/packages/expo-device/CHANGELOG.md
+++ b/packages/expo-device/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### 🛠 Breaking changes
 
+- [iOS] Change the names of "iPad Air (11-inch) (6th generation)", "iPad Air (13-inch) (6th generation)" and "iPhone SE" to "iPad Air 11-inch (M2)", "iPad Air 13-inch (M2)" and "iPhone SE (1st generation)". ([#43644](https://github.com/expo/expo/pull/43644) by [@prusnak](https://github.com/prusnak))
+
 ### 🎉 New features
+
+- [iOS] Update Apple devices ([#43644](https://github.com/expo/expo/pull/43644) by [@prusnak](https://github.com/prusnak))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-device/ios/UIDevice.swift
+++ b/packages/expo-device/ios/UIDevice.swift
@@ -96,6 +96,8 @@ public extension UIDevice {
         return ExpoDeviceType(modelName: "iPhone 16 Pro", deviceYearClass: 2024)
       case "iPhone17,2":
         return ExpoDeviceType(modelName: "iPhone 16 Pro Max", deviceYearClass: 2024)
+      case "iPhone17,5":
+        return ExpoDeviceType(modelName: "iPhone 16e", deviceYearClass: 2025)
       case "iPhone18,1":
         return ExpoDeviceType(modelName: "iPhone 17 Pro", deviceYearClass: 2025)
       case "iPhone18,2":
@@ -104,8 +106,10 @@ public extension UIDevice {
         return ExpoDeviceType(modelName: "iPhone 17", deviceYearClass: 2025)
       case "iPhone18,4":
         return ExpoDeviceType(modelName: "iPhone Air", deviceYearClass: 2025)
+      case "iPhone18,5":
+        return ExpoDeviceType(modelName: "iPhone 17e", deviceYearClass: 2026)
       case "iPhone8,4":
-        return ExpoDeviceType(modelName: "iPhone SE", deviceYearClass: 2016)
+        return ExpoDeviceType(modelName: "iPhone SE (1st generation)", deviceYearClass: 2016)
       case "iPhone12,8":
         return ExpoDeviceType(modelName: "iPhone SE (2nd generation)", deviceYearClass: 2020)
       case "iPhone14,6":
@@ -122,6 +126,8 @@ public extension UIDevice {
         return ExpoDeviceType(modelName: "iPad (9th generation)", deviceYearClass: 2021)
       case "iPad13,18", "iPad13,19":
         return ExpoDeviceType(modelName: "iPad (10th generation)", deviceYearClass: 2022)
+      case "iPad15,7", "iPad15,8":
+        return ExpoDeviceType(modelName: "iPad (A16)", deviceYearClass: 2025)
       case "iPad5,3", "iPad5,4":
         return ExpoDeviceType(modelName: "iPad Air 2", deviceYearClass: 2014)
       case "iPad11,3", "iPad11,4":
@@ -131,15 +137,25 @@ public extension UIDevice {
       case "iPad13,16", "iPad13,17":
         return ExpoDeviceType(modelName: "iPad Air (5th generation)", deviceYearClass: 2022)
       case "iPad14,8", "iPad14,9":
-        return ExpoDeviceType(modelName: "iPad Air (11-inch) (6th generation)", deviceYearClass: 2024)
-      case "iPad 14,10", "iPad 14,11":
-        return ExpoDeviceType(modelName: "iPad Air (13-inch) (6th generation)", deviceYearClass: 2024)
+        return ExpoDeviceType(modelName: "iPad Air 11-inch (M2)", deviceYearClass: 2024)
+      case "iPad14,10", "iPad14,11":
+        return ExpoDeviceType(modelName: "iPad Air 13-inch (M2)", deviceYearClass: 2024)
+      case "iPad15,3", "iPad15,4":
+        return ExpoDeviceType(modelName: "iPad Air 11-inch (M3)", deviceYearClass: 2025)
+      case "iPad15,5", "iPad15,6":
+        return ExpoDeviceType(modelName: "iPad Air 13-inch (M3)", deviceYearClass: 2025)
+      case "iPad16,8", "iPad16,9":
+        return ExpoDeviceType(modelName: "iPad Air 11-inch (M4)", deviceYearClass: 2026)
+      case "iPad16,10", "iPad16,11":
+        return ExpoDeviceType(modelName: "iPad Air 13-inch (M4)", deviceYearClass: 2026)
       case "iPad5,1", "iPad5,2":
         return ExpoDeviceType(modelName: "iPad mini 4", deviceYearClass: 2015)
       case "iPad11,1", "iPad11,2":
         return ExpoDeviceType(modelName: "iPad mini (5th generation)", deviceYearClass: 2019)
       case "iPad14,1", "iPad14,2":
         return ExpoDeviceType(modelName: "iPad mini (6th generation)", deviceYearClass: 2021)
+      case "iPad16,1", "iPad16,2":
+        return ExpoDeviceType(modelName: "iPad mini (A17 Pro)", deviceYearClass: 2024)
       case "iPad6,3", "iPad6,4":
         return ExpoDeviceType(modelName: "iPad Pro (9.7-inch)", deviceYearClass: 2016)
       case "iPad7,3", "iPad7,4":
@@ -151,7 +167,7 @@ public extension UIDevice {
       case "iPad13,4", "iPad13,5", "iPad13,6", "iPad13,7":
         return ExpoDeviceType(modelName: "iPad Pro (11-inch) (3rd generation)", deviceYearClass: 2021)
       case "iPad14,3-A", "iPad14,3-B", "iPad14,4-A", "iPad14,4-B":
-        return ExpoDeviceType(modelName: "iPad Pro (11-inch) (4rd generation)", deviceYearClass: 2022)
+        return ExpoDeviceType(modelName: "iPad Pro (11-inch) (4th generation)", deviceYearClass: 2022)
       case "iPad6,7", "iPad6,8":
         return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (1st generation)", deviceYearClass: 2015)
       case "iPad7,1", "iPad7,2":
@@ -164,10 +180,14 @@ public extension UIDevice {
         return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (5th generation)", deviceYearClass: 2021)
       case "iPad14,5-A", "iPad14,5-B", "iPad14,6-A", "iPad14,6-B":
         return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (6th generation)", deviceYearClass: 2022)
-      case "iPad16,3", "iPad16,4":
-        return ExpoDeviceType(modelName: "iPad Pro (11-inch) (7th generation)", deviceYearClass: 2024)
-      case "iPad16,5", "iPad16,6":
-        return ExpoDeviceType(modelName: "iPad Pro (13-inch) (7th generation)", deviceYearClass: 2024)
+      case "iPad16,3-A", "iPad16,3-B", "iPad16,4-A", "iPad16,4-B":
+        return ExpoDeviceType(modelName: "iPad Pro 11-inch (M4)", deviceYearClass: 2024)
+      case "iPad16,5-A", "iPad16,5-B", "iPad16,6-A", "iPad16,6-B":
+        return ExpoDeviceType(modelName: "iPad Pro 13-inch (M4)", deviceYearClass: 2024)
+      case "iPad17,1-A", "iPad17,1-B", "iPad17,2-A", "iPad17,2-B":
+        return ExpoDeviceType(modelName: "iPad Pro 11-inch (M5)", deviceYearClass: 2025)
+      case "iPad17,3-A", "iPad17,3-B", "iPad17,4-A", "iPad17,4-B":
+        return ExpoDeviceType(modelName: "iPad Pro 13-inch (M5)", deviceYearClass: 2025)
       case "i386", "x86_64", "arm64":
         return ExpoDeviceType(modelName: "Simulator iOS", deviceYearClass: currentYear)
       default:
@@ -179,6 +199,10 @@ public extension UIDevice {
         return ExpoDeviceType(modelName: "Apple TV HD (4th Generation, Siri)", deviceYearClass: 2015)
       case "AppleTV6,2":
         return ExpoDeviceType(modelName: "Apple TV 4K", deviceYearClass: 2017)
+      case "AppleTV11,1":
+        return ExpoDeviceType(modelName: "Apple TV 4K (2nd generation)", deviceYearClass: 2021)
+      case "AppleTV14,1":
+        return ExpoDeviceType(modelName: "Apple TV 4K (3rd generation)", deviceYearClass: 2022)
       case "i386", "x86_64":
         return ExpoDeviceType(modelName: "Simulator tvOS", deviceYearClass: currentYear)
       default:


### PR DESCRIPTION
# Why

newer Apple devices were missing, so `Device.modelName` was not behaving as expected for these models

# How

synced with the latest Xcode 26.3 database

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
