### PR TITLE
fix(expo-widgets): JS bundle missing from .appex + containerBackground

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Add missing project root to `watchFolders` in `metro.config.js` ([#43449](https://github.com/expo/expo/pull/43449) by [@kitten](https://github.com/kitten))
 - [plugin] Fix reading undefined when config is not provided. ([#43568](https://github.com/expo/expo/pull/43568) by [@jakex7](https://github.com/jakex7))
 - Skip server bundling in `export:embed` call for `expo-widgets` bundle ([#43602](https://github.com/expo/expo/pull/43602) by [@kitten](https://github.com/kitten))
+- Fix JS runtime bundle not copied into widget extension — copy destination targeted the framework instead of the resource bundle directory. ([#43654](https://github.com/expo/expo/pull/43654) by [@MarianoFacundoArch](https://github.com/MarianoFacundoArch))
+- Fix build script skipping JS bundle generation for local `npx expo run:ios` builds. ([#43654](https://github.com/expo/expo/pull/43654) by [@MarianoFacundoArch](https://github.com/MarianoFacundoArch))
+- Fix `containerBackground(.clear)` causing white borders on iOS 17+ — now dynamically extracts background color from root node modifiers. ([#43654](https://github.com/expo/expo/pull/43654) by [@MarianoFacundoArch](https://github.com/MarianoFacundoArch))
 
 ### 💡 Others
 

--- a/packages/expo-widgets/ios/ExpoWidgets.podspec
+++ b/packages/expo-widgets/ios/ExpoWidgets.podspec
@@ -47,8 +47,12 @@ Pod::Spec.new do |s|
     :script => %Q{
       echo "Preparing ExpoWidgets.bundle..."
       source="#{__dir__}/../bundle/build/ExpoWidgets.bundle"
-      dest="${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoWidgets.bundle"
+      # Copy into the resource bundle directory (NOT the framework).
+      # resource_bundles creates ExpoWidgets.bundle/ at ${TARGET_BUILD_DIR}/,
+      # not at ${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/.
+      dest="${TARGET_BUILD_DIR}/ExpoWidgets.bundle/ExpoWidgets.bundle"
       echo "Copying ${source} to ${dest}"
+      mkdir -p "$(dirname "${dest}")"
       cp "${source}" "${dest}"
     },
     :execution_position => :before_compile,

--- a/packages/expo-widgets/ios/Widgets/EntryView.swift
+++ b/packages/expo-widgets/ios/Widgets/EntryView.swift
@@ -14,12 +14,49 @@ public struct WidgetsEntryView: View {
     if let node = entry.node {
       if #available(iOS 17.0, *) {
         WidgetsDynamicView(source: entry.source, kind: .widget, node: node, entryIndex: entry.entryIndex)
-          .containerBackground(.clear, for: .widget)
+          .containerBackground(Self.extractContainerBackground(from: node), for: .widget)
       } else {
         WidgetsDynamicView(source: entry.source, kind: .widget, node: node, entryIndex: entry.entryIndex)
       }
     } else {
       EmptyView()
     }
+  }
+
+  /// Extracts the background color from the root node's modifiers to propagate
+  /// it as the containerBackground. This ensures the system-applied padding area
+  /// matches the content background, eliminating visible borders on iOS 17+.
+  ///
+  /// Node structure: node["props"]["modifiers"][N]["$type"] == "background"
+  ///                 node["props"]["modifiers"][N]["color"] == "#RRGGBB"
+  private static func extractContainerBackground(from node: [String: Any]) -> Color {
+    guard
+      let props = node["props"] as? [String: Any],
+      let modifiers = props["modifiers"] as? [[String: Any]],
+      let bgModifier = modifiers.first(where: { ($0["$type"] as? String) == "background" }),
+      let hex = bgModifier["color"] as? String
+    else {
+      return Color.black
+    }
+    return Color(hex: hex) ?? Color.black
+  }
+}
+
+// MARK: - Hex color parsing
+
+extension Color {
+  init?(hex: String) {
+    var hexString = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+    if hexString.hasPrefix("#") {
+      hexString.removeFirst()
+    }
+    guard hexString.count == 6, let rgb = UInt64(hexString, radix: 16) else {
+      return nil
+    }
+    self.init(
+      red: Double((rgb >> 16) & 0xFF) / 255.0,
+      green: Double((rgb >> 8) & 0xFF) / 255.0,
+      blue: Double(rgb & 0xFF) / 255.0
+    )
   }
 }

--- a/packages/expo-widgets/scripts/xcode-build-bundle.sh
+++ b/packages/expo-widgets/scripts/xcode-build-bundle.sh
@@ -4,15 +4,9 @@ set -eo pipefail
 
 EXPO_WIDGETS_PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 
-# For classic main project build phases integration, will be no-op to prevent duplicated bundle creation.
-#
-# `$PROJECT_DIR` is passed by Xcode as the directory to the xcodeproj file.
-# in classic main project setup it is something like /path/to/app/ios
-# in new style pod project setup it is something like /path/to/app/ios/Pods
-PROJECT_DIR_BASENAME=$(basename $PROJECT_DIR)
-if [ "x$PROJECT_DIR_BASENAME" != "xPods" ]; then
-  exit 0
-fi
+# NOTE: Early exit for non-Pods PROJECT_DIR removed — it prevented JS bundle
+# generation during `npx expo run:ios` (basename = "ios", not "Pods").
+# The build script is idempotent, so running it in both contexts is safe.
 
 # If PROJECT_ROOT is not specified, fallback to use Xcode PROJECT_DIR
 PROJECT_ROOT=${PROJECT_ROOT:-"$PROJECT_DIR/../.."}


### PR DESCRIPTION
## Summary

Fixes three issues in `expo-widgets` 55.0.x that cause **all widgets and Live Activities to render blank** on iOS, and fixes the `containerBackground` behavior on iOS 17+.

### Fix 1: JS runtime bundle not copied into widget extension

**File:** `ios/ExpoWidgets.podspec`

The "Prepare ExpoWidgets Resources" copy script writes the JS runtime to the **wrong destination**:

```bash
# Before (broken) — copies into the framework directory
dest="${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoWidgets.bundle"

# After (fixed) — copies into the resource bundle directory  
dest="${TARGET_BUILD_DIR}/ExpoWidgets.bundle/ExpoWidgets.bundle"
```

`UNLOCALIZED_RESOURCES_FOLDER_PATH` resolves to the framework path (e.g. `ExpoWidgets.framework`), but the widget extension's `.appex` receives resources from the `resource_bundles` target, which creates `ExpoWidgets.bundle/` at `${TARGET_BUILD_DIR}/` — a different location.

At runtime, `WidgetContext.swift` does a nested bundle lookup that expects the JS file **inside** the resource bundle directory. Since it was never copied there, `createWidgetContext()` returns nil and the widget renders `EmptyView()`.

**Result:**
- Before: `.appex/ExpoWidgets.bundle/` contains only `Info.plist` (747 bytes)
- After: `.appex/ExpoWidgets.bundle/` contains `Info.plist` + `ExpoWidgets.bundle` (~123KB)

### Fix 2: Build script skips JS bundle generation for local builds

**File:** `scripts/xcode-build-bundle.sh`

The script exits early when `PROJECT_DIR` basename is not `"Pods"`:

```bash
PROJECT_DIR_BASENAME=$(basename $PROJECT_DIR)
if [ "x$PROJECT_DIR_BASENAME" != "xPods" ]; then
  exit 0
fi
```

When building via `npx expo run:ios`, `$PROJECT_DIR` is typically `/path/to/app/ios` (basename = `"ios"`), not `"Pods"`. This skips JS bundle generation for **the most common development workflow**.

The script is idempotent — running it in both project contexts is safe. Removed the early exit.

### Fix 3: `containerBackground(.clear)` causes white borders on iOS 17+

**File:** `ios/Widgets/EntryView.swift`

`.containerBackground(.clear, for: .widget)` does **not** render transparent in widgets — iOS replaces `.clear` with the system default background (white in light mode). This causes:

1. A visible white border between the content background and the widget container edge
2. Hierarchical foreground styles (`.primary`, `.secondary`) adapt to the white container background instead of the content background, making text invisible on dark backgrounds

**Fix:** Dynamically extract the background color from the root node's modifiers and propagate it to `containerBackground`:

```swift
.containerBackground(Self.extractContainerBackground(from: node), for: .widget)
```

The extraction reads the node tree at render time:
- `node["props"]["modifiers"][N]["$type"] == "background"`
- `node["props"]["modifiers"][N]["color"]` → `"#RRGGBB"` hex string

This works because the node is a `[String: Any]` dictionary from JavaScriptCore evaluation (available at render time, not compiled into binary), and `@expo/ui`'s `background()` modifier always creates `{ $type: "background", color: "#RRGGBB" }` via `createModifier()`.

Falls back to `Color.black` when no background modifier is found (dark backgrounds are the common case for home/lock screen widgets).

## Test Plan

- [x] Build with `npx expo run:ios` — widgets render (not blank)
- [x] Verify `.appex` contains `ExpoWidgets.bundle` (~123KB) via `find DerivedData -name "*.appex" -path "*Widget*"`
- [x] Widget with `background('#000000')` fills entire area with no white border
- [x] Changed to `background('#FF0000')` — red fills entire widget including system padding, confirming dynamic extraction works
- [x] Live Activities use the same JS runtime pipeline and render correctly

## Affected versions

`expo-widgets` 55.0.0, 55.0.1, 55.0.2