### PR TITLE
[ui] fix Android ripple effect clipped on sides

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixed Compose view clipping that caused Material ripple effects to be cut off (e.g., Switch thumb ripple).
+- [Android] Fixed Compose view clipping that caused Material ripple effects to be cut off (e.g., Switch thumb ripple). ([#43656](https://github.com/expo/expo/pull/43656) by [@vonovak](https://github.com/vonovak))
 - [iOS] Fix memory leak due to retain cycle in SwiftUI views. ([#43468](https://github.com/expo/expo/pull/43468) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fixed compilation issues due to missing fallthrough case in `EXJavaScriptSerializable`. ([#43634](https://github.com/expo/expo/pull/43634) by [@tjzel](https://github.com/tjzel))
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed Compose view clipping that caused Material ripple effects to be cut off (e.g., Switch thumb ripple).
 - [iOS] Fix memory leak due to retain cycle in SwiftUI views. ([#43468](https://github.com/expo/expo/pull/43468) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fixed compilation issues due to missing fallthrough case in `EXJavaScriptSerializable`. ([#43634](https://github.com/expo/expo/pull/43634) by [@tjzel](https://github.com/tjzel))
 

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -149,6 +149,8 @@ abstract class ExpoComposeView<T : ComposeProps>(
 
   init {
     if (withHostingView) {
+      clipChildren = false
+      clipToPadding = false
       addComposeView()
     } else {
       this.visibility = GONE


### PR DESCRIPTION
# Fix Android Switch ripple effect clipped on sides

## Summary

Fixes https://github.com/expo/expo/issues/43554

The Switch ripple effect on Android was clipped to a rectangle instead of rendering as a circle extending beyond the component bounds.

## Root cause

`ExpoComposeView` extends `ExpoView` which extends `LinearLayout`. By default, `LinearLayout` has clips the children. Also, `ExpoView.dispatchDraw()` calls `clipToPaddingBox(canvas)` which clips the drawing canvas to the view's bounds before dispatching to children.

When `Host` uses `matchContents`, the view is sized to exactly fit the Switch content. The ripple effect on the Switch thumb gets cut off at the view boundary.

## Fix

Disable `clipChildren` and `clipToPadding` on `ExpoComposeView` when `withHostingView = true`

- `clipToPadding = false` — skips the `clipToPaddingBox` canvas clipping in `dispatchDraw`, allowing content (ripples, shadows) to render outside view bounds
- `clipChildren = false` — allows child views to draw outside their own bounds within the parent

## Test plan

- Open NCL → Expo UI → Switch on Android
- The ripple should render as a circle, not clipped on the sides


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
