### PR TITLE
[docs] Add hasVideoLink to Android production build tutorial

### DIFF
--- a/docs/pages/tutorial/eas/android-production-build.mdx
+++ b/docs/pages/tutorial/eas/android-production-build.mdx
@@ -2,6 +2,7 @@
 title: Create a production build for Android
 sidebar_title: Android production build
 description: Learn about the process of creating a production build for Android and automating the release process.
+hasVideoLink: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';


### PR DESCRIPTION
## Summary
- add `hasVideoLink: true` to the Android production build tutorial frontmatter

## Why
- the page already includes a VideoBoxLink, but the frontmatter flag is missing
- this aligns it with the iOS production build tutorial so the docs UI can show the video link consistently
