### PR TITLE
[cli] Warn when typescript is missing for tsconfig path resolution

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Warn when `tsconfig.json` exists but `typescript` is not installed, which silently disables path alias resolution in production builds. ([#43664](https://github.com/expo/expo/issues/43664) by [@MBlancoC](https://github.com/MBlancoC))
+- Warn when `tsconfig.json` exists but `typescript` is not installed, which silently disables path alias resolution in production builds. ([#43664](https://github.com/expo/expo/issues/43664) by [@MBlancoC](https://github.com/MBlancoC)) ([#43665](https://github.com/expo/expo/pull/43665) by [@MBlancoC](https://github.com/MBlancoC))
 - Prevent hanging when installing iOS apps on device. ([#43618](https://github.com/expo/expo/pull/43618) by [@EvanBacon](https://github.com/EvanBacon))
 - Correctly handle JavaScript assets when `asyncRoutes: true` in SSR ([#43446](https://github.com/expo/expo/pull/43446) by [@hassankhan](https://github.com/hassankhan))
 - Fix server being started before Metro is ready, or, if it's started, status middleware responding too soon ([#43557](https://github.com/expo/expo/pull/43557) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Warn when `tsconfig.json` exists but `typescript` is not installed, which silently disables path alias resolution in production builds. ([#43664](https://github.com/expo/expo/issues/43664) by [@MBlancoC](https://github.com/MBlancoC))
 - Prevent hanging when installing iOS apps on device. ([#43618](https://github.com/expo/expo/pull/43618) by [@EvanBacon](https://github.com/EvanBacon))
 - Correctly handle JavaScript assets when `asyncRoutes: true` in SSR ([#43446](https://github.com/expo/expo/pull/43446) by [@hassankhan](https://github.com/hassankhan))
 - Fix server being started before Metro is ready, or, if it's started, status middleware responding too soon ([#43557](https://github.com/expo/expo/pull/43557) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/cli/src/utils/tsconfig/loadTsConfigPaths.ts
+++ b/packages/@expo/cli/src/utils/tsconfig/loadTsConfigPaths.ts
@@ -3,6 +3,7 @@ import path from 'path';
 
 import { evaluateTsConfig, importTypeScriptFromProjectOptionally } from './evaluateTsConfig';
 import { fileExistsAsync } from '../dir';
+import { Log } from '../../log';
 
 export type TsConfigPaths = {
   paths?: Record<string, string[]>;
@@ -55,7 +56,9 @@ export async function readTsconfigAsync(projectRoot: string): Promise<null | Con
     if (ts) {
       return [configPath, evaluateTsConfig(ts, configPath)];
     }
-    debug(`typescript module not found in: ${projectRoot}`);
+    Log.warn(
+      `Found tsconfig.json but 'typescript' is not installed. tsconfig.json settings such as path aliases will not be applied.`
+    );
   }
   return null;
 }


### PR DESCRIPTION
# Why

When `typescript` is in `devDependencies` (the default for new Expo projects), EAS production builds run `npm install --omit=dev` and skip it. This causes `importTypeScriptFromProjectOptionally()` to return `null`, which silently disables the tsconfig paths resolver — making `@/` aliases fail with a misleading "Unable to resolve module" error.

The existing `debug()` log is invisible unless `DEBUG=expo:*` is set.

# How

Replace the `debug()` call in `readTsconfigAsync()` with `Log.warn()` so users get a visible warning when this happens.

# Test Plan

1. Create a project with `npx create-expo-app@latest --template blank-typescript`
2. Add `paths` to `tsconfig.json` and use an `@/` alias in an import
3. Remove `node_modules/typescript` and run `npx expo export --platform ios`
4. Before this change: silent failure with "Unable to resolve module"
5. After this change: warning is printed before the resolve error

Minimal reproduction: https://github.com/MBlancoC/tsconfig-paths-bug

Fixes #43664