### PR TITLE
[docs] Fix Video structured data issues flagged by Google Search Console

### DIFF
--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -19,7 +19,11 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 When you create a new Expo app with `npx create-expo-app`, you start off with a project where you update the JavaScript code on your local machine and view the changes in the Expo Go app. A **development build** is essentially **your own version of Expo Go** where you are free to use any native libraries and change any native config. In this guide, you will learn how to convert your project that runs on Expo Go into a development build, which will make the native side of your app fully customizable.
 
-<VideoBoxLink videoId="uQCE9zl3dXU" title="How to create a development build" />
+<VideoBoxLink
+  videoId="uQCE9zl3dXU"
+  title="How to create a development build"
+  description="Learn how to configure and create a development build for your Expo project using EAS Build."
+/>
 
 ## Prerequisites
 

--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -22,7 +22,7 @@ When you create a new Expo app with `npx create-expo-app`, you start off with a 
 <VideoBoxLink
   videoId="uQCE9zl3dXU"
   title="How to create a development build"
-  description="Learn how to configure and create a development build for your Expo project using EAS Build."
+  description="Configure and create a development build for your Expo project using EAS Build."
 />
 
 ## Prerequisites

--- a/docs/pages/linking/ios-universal-links.mdx
+++ b/docs/pages/linking/ios-universal-links.mdx
@@ -15,6 +15,7 @@ To configure iOS Universal Links for your app, you need to set up the **two-way 
   videoId="kNbEEYlFIPs"
   time={68}
   title="Watch: Set up iOS Universal Links with Expo Router"
+  description="Learn how to configure iOS Universal Links so your Expo app opens from standard web URLs."
 />
 
 ## Set up two-way association

--- a/docs/pages/router/advanced/protected.mdx
+++ b/docs/pages/router/advanced/protected.mdx
@@ -9,7 +9,11 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 > **warning** Protected routes are available in SDK 53 and later.
 
-<VideoBoxLink videoId="zHZjJDTTHJg" title="Watch: Using protected routes" />
+<VideoBoxLink
+  videoId="zHZjJDTTHJg"
+  title="Watch: Using protected routes"
+  description="Learn how to make screens inaccessible based on authentication state using protected routes in Expo Router."
+/>
 
 ## Overview
 

--- a/docs/pages/router/advanced/protected.mdx
+++ b/docs/pages/router/advanced/protected.mdx
@@ -12,7 +12,7 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 <VideoBoxLink
   videoId="zHZjJDTTHJg"
   title="Watch: Using protected routes"
-  description="Learn how to make screens inaccessible based on authentication state using protected routes in Expo Router."
+  description="Restrict screen access based on authentication state using protected routes in Expo Router."
 />
 
 ## Overview

--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -20,7 +20,7 @@ In this chapter, let's learn how to create a new Expo project and how to get it 
 <VideoBoxLink
   videoId="m1-bc53EGh8"
   title="Watch: Creating your first universal Expo app"
-  description="Learn how to create a new Expo project and run it on Android, iOS, and web."
+  description="Create a new Expo project from scratch and get it running on Android, iOS, and web."
 />
 
 ---

--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -17,7 +17,11 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 In this chapter, let's learn how to create a new Expo project and how to get it running.
 
-<VideoBoxLink videoId="m1-bc53EGh8" title="Watch: Creating your first universal Expo app" />
+<VideoBoxLink
+  videoId="m1-bc53EGh8"
+  title="Watch: Creating your first universal Expo app"
+  description="Learn how to create a new Expo project and run it on Android, iOS, and web."
+/>
 
 ---
 

--- a/docs/pages/tutorial/image-picker.mdx
+++ b/docs/pages/tutorial/image-picker.mdx
@@ -20,6 +20,7 @@ We'll use [`expo-image-picker`](/versions/latest/sdk/imagepicker), a library fro
 <VideoBoxLink
   videoId="iEQZU58naS8"
   title="Watch: Using an image picker in your universal Expo app"
+  description="Learn how to use expo-image-picker to select images from the device's media library."
 />
 
 ---

--- a/docs/pages/versions/unversioned/sdk/background-task.mdx
+++ b/docs/pages/versions/unversioned/sdk/background-task.mdx
@@ -19,7 +19,7 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 <VideoBoxLink
   videoId="4lFus7TvayI"
   title="Watch: Expo Background Task Deep Dive"
-  description="Learn how to use expo-background-task to sync data, prefetch content, and run deferred work when your app is in the background."
+  description="Sync data, prefetch content, and run deferred work in the background with expo-background-task."
 />
 
 ## Background tasks

--- a/docs/pages/versions/unversioned/sdk/background-task.mdx
+++ b/docs/pages/versions/unversioned/sdk/background-task.mdx
@@ -16,7 +16,11 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 `expo-background-task` provides an API to run deferrable background tasks in a way that optimizes battery and power consumption on the end user's device. This module uses the [`WorkManager`](https://developer.android.com/topic/libraries/architecture/workmanager) API on Android and the [`BGTaskScheduler`](https://developer.apple.com/documentation/backgroundtasks/bgtaskscheduler) API on iOS to schedule tasks. It also uses the [`expo-task-manager`](task-manager.mdx) Native API to run JavaScript tasks.
 
-<VideoBoxLink videoId="4lFus7TvayI" title="Watch: Expo Background Task Deep Dive" />
+<VideoBoxLink
+  videoId="4lFus7TvayI"
+  title="Watch: Expo Background Task Deep Dive"
+  description="Learn how to use expo-background-task to sync data, prefetch content, and run deferred work when your app is in the background."
+/>
 
 ## Background tasks
 

--- a/docs/pages/versions/unversioned/sdk/maps.mdx
+++ b/docs/pages/versions/unversioned/sdk/maps.mdx
@@ -26,7 +26,11 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 <APIInstallSection />
 
 <br />
-<VideoBoxLink videoId="jDCuaIQ9vd0" title="Watch: Expo Maps Deep Dive" />
+<VideoBoxLink
+  videoId="jDCuaIQ9vd0"
+  title="Watch: Expo Maps Deep Dive"
+  description="Learn how to use the expo-maps library to add Google Maps and Apple Maps to your Expo app."
+/>
 
 ## Configuration
 

--- a/docs/pages/versions/unversioned/sdk/maps.mdx
+++ b/docs/pages/versions/unversioned/sdk/maps.mdx
@@ -29,7 +29,7 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 <VideoBoxLink
   videoId="jDCuaIQ9vd0"
   title="Watch: Expo Maps Deep Dive"
-  description="Learn how to use the expo-maps library to add Google Maps and Apple Maps to your Expo app."
+  description="Add Google Maps and Apple Maps to your Expo app with the expo-maps library."
 />
 
 ## Configuration

--- a/docs/pages/versions/unversioned/sdk/stripe.mdx
+++ b/docs/pages/versions/unversioned/sdk/stripe.mdx
@@ -18,7 +18,7 @@ Expo includes support for [`@stripe/stripe-react-native`](https://github.com/str
 <VideoBoxLink
   videoId="J0tyxUV_omY"
   title="Watch: Universal Full-Stack Expo Stripe Payment Integration"
-  description="Learn how to integrate Stripe payments in a universal Expo app for Android, iOS, and web."
+  description="A complete walkthrough for integrating Stripe payments in a universal Expo app across Android, iOS, and web."
 />
 
 ## Installation

--- a/docs/pages/versions/unversioned/sdk/stripe.mdx
+++ b/docs/pages/versions/unversioned/sdk/stripe.mdx
@@ -18,6 +18,7 @@ Expo includes support for [`@stripe/stripe-react-native`](https://github.com/str
 <VideoBoxLink
   videoId="J0tyxUV_omY"
   title="Watch: Universal Full-Stack Expo Stripe Payment Integration"
+  description="Learn how to integrate Stripe payments in a universal Expo app for Android, iOS, and web."
 />
 
 ## Installation

--- a/docs/pages/versions/v53.0.0/sdk/background-task.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/background-task.mdx
@@ -17,7 +17,11 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 `expo-background-task` provides an API to run deferrable background tasks in a way that optimizes battery and power consumption on the end user's device. This module uses the [`WorkManager`](https://developer.android.com/topic/libraries/architecture/workmanager) API on Android and the [`BGTaskScheduler`](https://developer.apple.com/documentation/backgroundtasks/bgtaskscheduler) API on iOS to schedule tasks. It also uses the [`expo-task-manager`](task-manager.mdx) Native API to run JavaScript tasks.
 
-<VideoBoxLink videoId="4lFus7TvayI" title="Watch: Expo Background Task Deep Dive" />
+<VideoBoxLink
+  videoId="4lFus7TvayI"
+  title="Watch: Expo Background Task Deep Dive"
+  description="Learn how to use expo-background-task to sync data, prefetch content, and run deferred work when your app is in the background."
+/>
 
 ## Background tasks
 

--- a/docs/pages/versions/v53.0.0/sdk/background-task.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/background-task.mdx
@@ -20,7 +20,7 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 <VideoBoxLink
   videoId="4lFus7TvayI"
   title="Watch: Expo Background Task Deep Dive"
-  description="Learn how to use expo-background-task to sync data, prefetch content, and run deferred work when your app is in the background."
+  description="Sync data, prefetch content, and run deferred work in the background with expo-background-task."
 />
 
 ## Background tasks

--- a/docs/pages/versions/v53.0.0/sdk/maps.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/maps.mdx
@@ -26,7 +26,11 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 <APIInstallSection />
 
 <br />
-<VideoBoxLink videoId="jDCuaIQ9vd0" title="Watch: Expo Maps Deep Dive" />
+<VideoBoxLink
+  videoId="jDCuaIQ9vd0"
+  title="Watch: Expo Maps Deep Dive"
+  description="Learn how to use the expo-maps library to add Google Maps and Apple Maps to your Expo app."
+/>
 
 ## Configuration
 

--- a/docs/pages/versions/v53.0.0/sdk/maps.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/maps.mdx
@@ -29,7 +29,7 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 <VideoBoxLink
   videoId="jDCuaIQ9vd0"
   title="Watch: Expo Maps Deep Dive"
-  description="Learn how to use the expo-maps library to add Google Maps and Apple Maps to your Expo app."
+  description="Add Google Maps and Apple Maps to your Expo app with the expo-maps library."
 />
 
 ## Configuration

--- a/docs/pages/versions/v53.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/stripe.mdx
@@ -18,7 +18,7 @@ Expo includes support for [`@stripe/stripe-react-native`](https://github.com/str
 <VideoBoxLink
   videoId="J0tyxUV_omY"
   title="Watch: Universal Full-Stack Expo Stripe Payment Integration"
-  description="Learn how to integrate Stripe payments in a universal Expo app for Android, iOS, and web."
+  description="A complete walkthrough for integrating Stripe payments in a universal Expo app across Android, iOS, and web."
 />
 
 ## Installation

--- a/docs/pages/versions/v53.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/stripe.mdx
@@ -18,6 +18,7 @@ Expo includes support for [`@stripe/stripe-react-native`](https://github.com/str
 <VideoBoxLink
   videoId="J0tyxUV_omY"
   title="Watch: Universal Full-Stack Expo Stripe Payment Integration"
+  description="Learn how to integrate Stripe payments in a universal Expo app for Android, iOS, and web."
 />
 
 ## Installation

--- a/docs/pages/versions/v54.0.0/sdk/background-task.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/background-task.mdx
@@ -19,7 +19,7 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 <VideoBoxLink
   videoId="4lFus7TvayI"
   title="Watch: Expo Background Task Deep Dive"
-  description="Learn how to use expo-background-task to sync data, prefetch content, and run deferred work when your app is in the background."
+  description="Sync data, prefetch content, and run deferred work in the background with expo-background-task."
 />
 
 ## Background tasks

--- a/docs/pages/versions/v54.0.0/sdk/background-task.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/background-task.mdx
@@ -16,7 +16,11 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 `expo-background-task` provides an API to run deferrable background tasks in a way that optimizes battery and power consumption on the end user's device. This module uses the [`WorkManager`](https://developer.android.com/topic/libraries/architecture/workmanager) API on Android and the [`BGTaskScheduler`](https://developer.apple.com/documentation/backgroundtasks/bgtaskscheduler) API on iOS to schedule tasks. It also uses the [`expo-task-manager`](task-manager.mdx) Native API to run JavaScript tasks.
 
-<VideoBoxLink videoId="4lFus7TvayI" title="Watch: Expo Background Task Deep Dive" />
+<VideoBoxLink
+  videoId="4lFus7TvayI"
+  title="Watch: Expo Background Task Deep Dive"
+  description="Learn how to use expo-background-task to sync data, prefetch content, and run deferred work when your app is in the background."
+/>
 
 ## Background tasks
 

--- a/docs/pages/versions/v54.0.0/sdk/maps.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/maps.mdx
@@ -26,7 +26,11 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 <APIInstallSection />
 
 <br />
-<VideoBoxLink videoId="jDCuaIQ9vd0" title="Watch: Expo Maps Deep Dive" />
+<VideoBoxLink
+  videoId="jDCuaIQ9vd0"
+  title="Watch: Expo Maps Deep Dive"
+  description="Learn how to use the expo-maps library to add Google Maps and Apple Maps to your Expo app."
+/>
 
 ## Configuration
 

--- a/docs/pages/versions/v54.0.0/sdk/maps.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/maps.mdx
@@ -29,7 +29,7 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 <VideoBoxLink
   videoId="jDCuaIQ9vd0"
   title="Watch: Expo Maps Deep Dive"
-  description="Learn how to use the expo-maps library to add Google Maps and Apple Maps to your Expo app."
+  description="Add Google Maps and Apple Maps to your Expo app with the expo-maps library."
 />
 
 ## Configuration

--- a/docs/pages/versions/v54.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/stripe.mdx
@@ -18,7 +18,7 @@ Expo includes support for [`@stripe/stripe-react-native`](https://github.com/str
 <VideoBoxLink
   videoId="J0tyxUV_omY"
   title="Watch: Universal Full-Stack Expo Stripe Payment Integration"
-  description="Learn how to integrate Stripe payments in a universal Expo app for Android, iOS, and web."
+  description="A complete walkthrough for integrating Stripe payments in a universal Expo app across Android, iOS, and web."
 />
 
 ## Installation

--- a/docs/pages/versions/v54.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/stripe.mdx
@@ -18,6 +18,7 @@ Expo includes support for [`@stripe/stripe-react-native`](https://github.com/str
 <VideoBoxLink
   videoId="J0tyxUV_omY"
   title="Watch: Universal Full-Stack Expo Stripe Payment Integration"
+  description="Learn how to integrate Stripe payments in a universal Expo app for Android, iOS, and web."
 />
 
 ## Installation

--- a/docs/pages/versions/v55.0.0/sdk/background-task.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/background-task.mdx
@@ -19,7 +19,7 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 <VideoBoxLink
   videoId="4lFus7TvayI"
   title="Watch: Expo Background Task Deep Dive"
-  description="Learn how to use expo-background-task to sync data, prefetch content, and run deferred work when your app is in the background."
+  description="Sync data, prefetch content, and run deferred work in the background with expo-background-task."
 />
 
 ## Background tasks

--- a/docs/pages/versions/v55.0.0/sdk/background-task.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/background-task.mdx
@@ -16,7 +16,11 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 `expo-background-task` provides an API to run deferrable background tasks in a way that optimizes battery and power consumption on the end user's device. This module uses the [`WorkManager`](https://developer.android.com/topic/libraries/architecture/workmanager) API on Android and the [`BGTaskScheduler`](https://developer.apple.com/documentation/backgroundtasks/bgtaskscheduler) API on iOS to schedule tasks. It also uses the [`expo-task-manager`](task-manager.mdx) Native API to run JavaScript tasks.
 
-<VideoBoxLink videoId="4lFus7TvayI" title="Watch: Expo Background Task Deep Dive" />
+<VideoBoxLink
+  videoId="4lFus7TvayI"
+  title="Watch: Expo Background Task Deep Dive"
+  description="Learn how to use expo-background-task to sync data, prefetch content, and run deferred work when your app is in the background."
+/>
 
 ## Background tasks
 

--- a/docs/pages/versions/v55.0.0/sdk/maps.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/maps.mdx
@@ -26,7 +26,11 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 <APIInstallSection />
 
 <br />
-<VideoBoxLink videoId="jDCuaIQ9vd0" title="Watch: Expo Maps Deep Dive" />
+<VideoBoxLink
+  videoId="jDCuaIQ9vd0"
+  title="Watch: Expo Maps Deep Dive"
+  description="Learn how to use the expo-maps library to add Google Maps and Apple Maps to your Expo app."
+/>
 
 ## Configuration
 

--- a/docs/pages/versions/v55.0.0/sdk/maps.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/maps.mdx
@@ -29,7 +29,7 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 <VideoBoxLink
   videoId="jDCuaIQ9vd0"
   title="Watch: Expo Maps Deep Dive"
-  description="Learn how to use the expo-maps library to add Google Maps and Apple Maps to your Expo app."
+  description="Add Google Maps and Apple Maps to your Expo app with the expo-maps library."
 />
 
 ## Configuration

--- a/docs/pages/versions/v55.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/stripe.mdx
@@ -18,7 +18,7 @@ Expo includes support for [`@stripe/stripe-react-native`](https://github.com/str
 <VideoBoxLink
   videoId="J0tyxUV_omY"
   title="Watch: Universal Full-Stack Expo Stripe Payment Integration"
-  description="Learn how to integrate Stripe payments in a universal Expo app for Android, iOS, and web."
+  description="A complete walkthrough for integrating Stripe payments in a universal Expo app across Android, iOS, and web."
 />
 
 ## Installation

--- a/docs/pages/versions/v55.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/stripe.mdx
@@ -18,6 +18,7 @@ Expo includes support for [`@stripe/stripe-react-native`](https://github.com/str
 <VideoBoxLink
   videoId="J0tyxUV_omY"
   title="Watch: Universal Full-Stack Expo Stripe Payment Integration"
+  description="Learn how to integrate Stripe payments in a universal Expo app for Android, iOS, and web."
 />
 
 ## Installation

--- a/docs/public/static/talks.ts
+++ b/docs/public/static/talks.ts
@@ -852,6 +852,12 @@ export const YOUTUBE_VIDEOS = [
     uploadDate: '2024-09-12',
   },
   {
+    title: 'Expo Notifications with EAS | Complete Guide',
+    event: 'Expo Tutorials',
+    videoId: 'BCCjGtKtBjE',
+    uploadDate: '2024-09-11',
+  },
+  {
     title: 'How to create a native module with the Expo modules API',
     event: 'Expo Tutorials',
     videoId: 'CdaQSlyGik8',
@@ -898,6 +904,18 @@ export const YOUTUBE_VIDEOS = [
     event: 'Expo Tutorials',
     videoId: 'LvCci4Bwmpc',
     uploadDate: '2023-09-27',
+  },
+  {
+    title: 'How to quickly publish to the App Store & Play Store with EAS Submit',
+    event: 'EAS Tutorials',
+    videoId: '-KZjr576tuE',
+    uploadDate: '2023-05-30',
+  },
+  {
+    title: 'Automatic App Version Management',
+    event: 'Expo Tutorials',
+    videoId: 'Gk7RHDWsLsQ',
+    uploadDate: '2023-01-05',
   },
 ] as Talk[];
 

--- a/docs/ui/components/VideoBoxLink/index.tsx
+++ b/docs/ui/components/VideoBoxLink/index.tsx
@@ -21,10 +21,11 @@ export function VideoBoxLink({ title, description, videoId, time, className }: V
     '@context': 'https://schema.org',
     '@type': 'VideoObject',
     name: title,
+    ...(typeof description === 'string' && { description }),
     thumbnailUrl: `https://i3.ytimg.com/vi/${videoId}/maxresdefault.jpg`,
     embedUrl: `https://www.youtube.com/embed/${videoId}`,
     contentUrl: `https://www.youtube.com/watch?v=${videoId}`,
-    ...(uploadDate && { uploadDate }),
+    ...(uploadDate && { uploadDate: `${uploadDate}T00:00:00Z` }),
   };
 
   return (


### PR DESCRIPTION
# Why

Resolves ENG-19917


# How

**Component fix (`ui/components/VideoBoxLink/index.tsx`):**
- Include `description` in the JSON-LD schema when it's a plain string (skips React elements to avoid serialization issues)
- Append `T00:00:00Z` to `uploadDate` to produce valid ISO 8601 datetime with timezone, fixing both the "invalid datetime" and "missing timezone" issues globally for all videos

**Missing videos added to `public/static/talks.ts`:**
- `-KZjr576tuE` ("How to quickly publish to the App Store & Play Store with EAS Submit", 2023-05-30)
- `BCCjGtKtBjE` ("Expo Notifications with EAS | Complete Guide", 2024-09-11)
- `Gk7RHDWsLsQ` ("Automatic App Version Management", 2023-01-05)

**Added missing `description` props to `VideoBoxLink`:**
- `stripe.mdx` (latest, unversioned, v53, v54, v55)
- `background-task.mdx` (latest, unversioned, v53, v54, v55)
- `maps.mdx` (latest, unversioned, v53, v54, v55)
- `protected.mdx`, `ios-universal-links.mdx`, `image-picker.mdx`, `create-your-first-app.mdx`, `create-a-build.mdx`

# Test Plan

View page source on any affected page (for example, `/versions/latest/sdk/stripe/`) and confirm the `VideoObject` JSON-LD block includes `description` and `uploadDate` with a `T00:00:00Z` suffix. Validate the JSON-LD at https://search.google.com/test/rich-results. 

After deploying, click "VALIDATE FIX" in Google Search Console for each of the 4 issues manually.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
