### PR TITLE
[docs] EAS workflows GitHub events trigger syntax docs: inform about commit message commands for skipping workflow runs

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -62,6 +62,8 @@ on:
       - version-*
 ```
 
+> **info** You can skip `push` and `pull_request` triggered workflow runs by including `[eas skip]`, `[skip eas]`, or `[no eas]` in the commit message.
+
 ### `on.push`
 
 Runs your workflow when you push a commit to matching branches and/or tags.


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-15626/skip-workflow-runs-based-on-commit-message – added the commit message skip commands for EAS workflows.

Companion PR to https://github.com/expo/universe/pull/25442

# How

Updated the docs for `on` EAS workflows syntax section by adding an "info" block that tell about this.

# Test Plan

Tested manually:

<img width="1144" height="479" alt="image" src="https://github.com/user-attachments/assets/2dc33f52-a4fb-4349-a19b-f6c730c7aaec" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
