### PR TITLE
[ios][dev-launcher] Fix missing navigation bar padding

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix issue when using `fullScreenModal` with `expo-router`. ([#43520](https://github.com/expo/expo/pull/43520) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix missing navigation bar padding ([#43672](https://github.com/expo/expo/pull/43672) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -117,26 +117,38 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, EXDe
     )
     developmentClientController.appBridge = RCTBridge.current()
 
-    guard let rootViewController = rootViewController ?? self.reactDelegate?.createRootViewController() else {
+    let windowRootVC = rootViewController?.view?.window?.rootViewController
+    let targetVC: UIViewController
+    if let windowRootVC, windowRootVC.view is DevLauncherWrapperView {
+      // Greenfield: set root view on the window's root VC so react-native-screens parents its
+      // UINavigationController to a VC in the containment hierarchy with correct layout margins.
+      targetVC = windowRootVC
+    } else if let rootViewController {
+      // Brownfield: the wrapper is embedded in a custom hierarchy, fall back to
+      // DevLauncherViewController to avoid replacing the host app's root view.
+      targetVC = rootViewController
+    } else if let fallbackVC = self.reactDelegate?.createRootViewController() {
+      targetVC = fallbackVC
+    } else {
       fatalError("Invalid rootViewController returned from ExpoReactDelegate")
     }
 #if os(macOS)
     let newViewController = UIViewController()
     newViewController.view = rootView
 
-    rootViewController.view.subviews.forEach { $0.removeFromSuperview() }
-    rootViewController.addChild(newViewController)
-    rootViewController.view.addSubview(newViewController.view)
+    targetVC.view.subviews.forEach { $0.removeFromSuperview() }
+    targetVC.addChild(newViewController)
+    targetVC.view.addSubview(newViewController.view)
 
     newViewController.view.translatesAutoresizingMaskIntoConstraints = false
     NSLayoutConstraint.activate([
-      newViewController.view.topAnchor.constraint(equalTo: rootViewController.view.topAnchor),
-      newViewController.view.leadingAnchor.constraint(equalTo: rootViewController.view.leadingAnchor),
-      newViewController.view.trailingAnchor.constraint(equalTo: rootViewController.view.trailingAnchor),
-      newViewController.view.bottomAnchor.constraint(equalTo: rootViewController.view.bottomAnchor)
+      newViewController.view.topAnchor.constraint(equalTo: targetVC.view.topAnchor),
+      newViewController.view.leadingAnchor.constraint(equalTo: targetVC.view.leadingAnchor),
+      newViewController.view.trailingAnchor.constraint(equalTo: targetVC.view.trailingAnchor),
+      newViewController.view.bottomAnchor.constraint(equalTo: targetVC.view.bottomAnchor)
     ])
 #else
-    rootViewController.view = rootView
+    targetVC.view = rootView
 #endif
     // it is purposeful that we don't clean up saved properties here, because we may initialize
     // several React instances over a single app lifetime and we want them all to have the same

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -117,8 +117,9 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, EXDe
     )
     developmentClientController.appBridge = RCTBridge.current()
 
-    let windowRootVC = rootViewController?.view?.window?.rootViewController
     let targetVC: UIViewController
+#if !os(macOS)
+    let windowRootVC = rootViewController?.view?.window?.rootViewController
     if let windowRootVC, windowRootVC.view is DevLauncherWrapperView {
       // Greenfield: set root view on the window's root VC so react-native-screens parents its
       // UINavigationController to a VC in the containment hierarchy with correct layout margins.
@@ -132,6 +133,16 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, EXDe
     } else {
       fatalError("Invalid rootViewController returned from ExpoReactDelegate")
     }
+#else
+    // macOS: NSWindow has no rootViewController, fall back to DevLauncherViewController.
+    if let rootViewController {
+      targetVC = rootViewController
+    } else if let fallbackVC = self.reactDelegate?.createRootViewController() {
+      targetVC = fallbackVC
+    } else {
+      fatalError("Invalid rootViewController returned from ExpoReactDelegate")
+    }
+#endif
 #if os(macOS)
     let newViewController = UIViewController()
     newViewController.view = rootView


### PR DESCRIPTION
# Why
Closes #43662
Closes #40785

# How
When react-native-screens adds a `UINavigationController`, it uses `reactAddControllerToClosestParent` to find a parent VC using the responder chain. It would find `DevLauncherViewController` which was not a part of the window's containment hierarchy. Because it wasn't a child of the window's root VC, the nav controller got zero layout margins. `DevLauncherViewController` is only used to host dev launchers ui and screens should not consider part of the apps view hierarchy.

The fix is to set the root view on `window.rootViewController`, this allows react native screens to find the correct root vc and the layout margins will correctly propagate. 

# Test Plan
Used the provided repro in #43662 

