### PR TITLE
fix(cli): Fix incorrect `--device` input for `run:ios`'s `launchApp` call and strenghten types

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Add missing support for self-resolution via fallback resolver ([#44077](https://github.com/expo/expo/pull/44077) by [@kitten](https://github.com/kitten))
 - Add fallback resolution for `../../App` in `expo/AppEntry.js` ([#44084](https://github.com/expo/expo/pull/44084) by [@kitten](https://github.com/kitten))
 - Prevent out-of-monorepo `expo/expo` CLI detection to not mistrigger for user monorepos and update for pnpm compatibility ([#44101](https://github.com/expo/expo/pull/44101) by [@kitten](https://github.com/kitten))
+- Fix device being incorrectly tracked for `run:ios --device` invocation ([#43673](https://github.com/expo/expo/pull/43673) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/run/android/runAndroidAsync.ts
+++ b/packages/@expo/cli/src/run/android/runAndroidAsync.ts
@@ -107,7 +107,7 @@ export async function runAndroidAsync(projectRoot: string, { install, ...options
   await manager.getDefaultDevServer().openCustomRuntimeAsync(
     'emulator',
     {
-      applicationId: props.packageName + 'test',
+      applicationId: props.packageName,
       customAppId: props.customAppId,
       launchActivity: props.launchActivity,
     },

--- a/packages/@expo/cli/src/run/android/runAndroidAsync.ts
+++ b/packages/@expo/cli/src/run/android/runAndroidAsync.ts
@@ -104,10 +104,10 @@ export async function runAndroidAsync(projectRoot: string, { install, ...options
     await installAppAsync(androidProjectRoot, props);
   }
 
-  await manager.getDefaultDevServer().openCustomRuntimeAsync<AndroidOpenInCustomProps>(
+  await manager.getDefaultDevServer().openCustomRuntimeAsync(
     'emulator',
     {
-      applicationId: props.packageName,
+      applicationId: props.packageName + 'test',
       customAppId: props.customAppId,
       launchActivity: props.launchActivity,
     },

--- a/packages/@expo/cli/src/run/ios/launchApp.ts
+++ b/packages/@expo/cli/src/run/ios/launchApp.ts
@@ -65,7 +65,7 @@ export async function launchAppAsync(
     {
       applicationId: appId,
     },
-    { device }
+    { device: device.device }
   );
 }
 

--- a/packages/@expo/cli/src/start/platforms/android/AndroidPlatformManager.ts
+++ b/packages/@expo/cli/src/start/platforms/android/AndroidPlatformManager.ts
@@ -59,7 +59,7 @@ export class AndroidPlatformManager extends PlatformManager<Device, AndroidOpenI
     options:
       | { runtime: 'expo' | 'web' }
       | { runtime: 'custom'; props?: Partial<AndroidOpenInCustomProps> },
-    resolveSettings?: Partial<BaseResolveDeviceProps<Device>>
+    resolveSettings?: BaseResolveDeviceProps<Device>
   ): Promise<{ url: string }> {
     await startAdbReverseAsync([this.port]);
 

--- a/packages/@expo/cli/src/start/platforms/ios/ApplePlatformManager.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/ApplePlatformManager.ts
@@ -2,7 +2,7 @@ import { AppleAppIdResolver } from './AppleAppIdResolver';
 import { AppleDeviceManager } from './AppleDeviceManager';
 import { Device } from './simctl';
 import { AppIdResolver } from '../AppIdResolver';
-import { BaseOpenInCustomProps, PlatformManager } from '../PlatformManager';
+import { BaseOpenInCustomProps, BaseResolveDeviceProps, PlatformManager } from '../PlatformManager';
 
 /** Manages launching apps on Apple simulators. */
 export class ApplePlatformManager extends PlatformManager<Device> {
@@ -31,7 +31,7 @@ export class ApplePlatformManager extends PlatformManager<Device> {
     options:
       | { runtime: 'expo' | 'web' }
       | { runtime: 'custom'; props?: Partial<BaseOpenInCustomProps> },
-    resolveSettings?: Partial<{ shouldPrompt?: boolean; device?: Device }>
+    resolveSettings?: BaseResolveDeviceProps<Device>
   ): Promise<{ url: string }> {
     await AppleDeviceManager.assertSystemRequirementsAsync();
     return super.openAsync(options, resolveSettings);

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -88,6 +88,16 @@ const PLATFORM_MANAGERS = {
       .AndroidPlatformManager as typeof import('../platforms/android/AndroidPlatformManager').AndroidPlatformManager,
 };
 
+type PlatformManagers = {
+  [K in keyof typeof PLATFORM_MANAGERS]: InstanceType<ReturnType<(typeof PLATFORM_MANAGERS)[K]>>;
+};
+
+type PlatformDevice<Platform extends keyof PlatformManagers> =
+  PlatformManagers[Platform] extends PlatformManager<infer Device, any> ? Device : never;
+
+type PlatformLaunchProps<Platform extends keyof PlatformManagers> =
+  PlatformManagers[Platform] extends PlatformManager<any, infer LaunchProps> ? LaunchProps : never;
+
 export abstract class BundlerDevServer {
   /** Name of the bundler. */
   abstract get name(): string;
@@ -101,7 +111,8 @@ export abstract class BundlerDevServer {
   /** Http server and related info. */
   protected instance: DevServerInstance | null = null;
   /** Native platform interfaces for opening projects.  */
-  private platformManagers: Record<string, PlatformManager<any>> = {};
+  private platformManagers: { [K in keyof PlatformManagers]?: PlatformManagers[K] | undefined } =
+    {};
   /** Manages the creation of dev server URLs. */
   protected urlCreator?: UrlCreator | null = null;
 
@@ -444,7 +455,7 @@ export abstract class BundlerDevServer {
 
   /** Open the dev server in a runtime. */
   public async openPlatformAsync(
-    launchTarget: keyof typeof PLATFORM_MANAGERS | 'desktop',
+    launchTarget: keyof PlatformManagers | 'desktop',
     resolver: BaseResolveDeviceProps<any> = {}
   ) {
     if (launchTarget === 'desktop') {
@@ -461,10 +472,10 @@ export abstract class BundlerDevServer {
   }
 
   /** Open the dev server in a runtime. */
-  public async openCustomRuntimeAsync<T extends BaseOpenInCustomProps = BaseOpenInCustomProps>(
-    launchTarget: keyof typeof PLATFORM_MANAGERS,
-    launchProps: Partial<T> = {},
-    resolver: BaseResolveDeviceProps<any> = {}
+  public async openCustomRuntimeAsync<Platform extends keyof PlatformManagers>(
+    launchTarget: Platform,
+    launchProps: Partial<PlatformLaunchProps<Platform>> = {},
+    resolver: BaseResolveDeviceProps<PlatformDevice<Platform>> = {}
   ) {
     const runtime = this.isTargetingNative() ? (this.isDevClient ? 'custom' : 'expo') : 'web';
     if (runtime !== 'custom') {
@@ -474,7 +485,10 @@ export abstract class BundlerDevServer {
     }
 
     const manager = await this.getPlatformManagerAsync(launchTarget);
-    return manager.openAsync({ runtime: 'custom', props: launchProps }, resolver);
+    return manager.openAsync(
+      { runtime: 'custom', props: launchProps },
+      resolver as BaseResolveDeviceProps<any>
+    );
   }
 
   /** Get the URL for opening in Expo Go. */
@@ -494,7 +508,7 @@ export abstract class BundlerDevServer {
   }
 
   /** Get the redirect URL when redirecting is enabled. */
-  public getRedirectUrl(platform: keyof typeof PLATFORM_MANAGERS | null = null): string | null {
+  public getRedirectUrl(platform: keyof PlatformManagers | null = null): string | null {
     if (!this.isRedirectPageEnabled()) {
       debug('Redirect page is disabled');
       return null;
@@ -508,9 +522,11 @@ export abstract class BundlerDevServer {
     );
   }
 
-  protected async getPlatformManagerAsync(platform: keyof typeof PLATFORM_MANAGERS) {
+  protected async getPlatformManagerAsync<Platform extends keyof PlatformManagers>(
+    ofPlatform: Platform
+  ): Promise<PlatformManagers[Platform]> {
+    const platform: keyof PlatformManagers = ofPlatform;
     if (!this.platformManagers[platform]) {
-      const Manager = PLATFORM_MANAGERS[platform]();
       const port = this.getInstance()?.location.port;
       if (!port || !this.urlCreator) {
         throw new CommandError(
@@ -519,13 +535,25 @@ export abstract class BundlerDevServer {
         );
       }
       debug(`Creating platform manager (platform: ${platform}, port: ${port})`);
-      this.platformManagers[platform] = new Manager(this.projectRoot, port, {
+      const managerParams = {
         getCustomRuntimeUrl: this.urlCreator.constructDevClientUrl.bind(this.urlCreator),
         getExpoGoUrl: this.getExpoGoUrl.bind(this),
         getRedirectUrl: this.getRedirectUrl.bind(this, platform),
         getDevServerUrl: this.getDevServerUrl.bind(this, { hostType: 'localhost' }),
-      });
+      };
+      switch (platform) {
+        case 'simulator': {
+          const Manager = PLATFORM_MANAGERS[platform]();
+          this.platformManagers[platform] = new Manager(this.projectRoot, port, managerParams);
+          break;
+        }
+        case 'emulator': {
+          const Manager = PLATFORM_MANAGERS[platform]();
+          this.platformManagers[platform] = new Manager(this.projectRoot, port, managerParams);
+          break;
+        }
+      }
     }
-    return this.platformManagers[platform];
+    return this.platformManagers[platform] as PlatformManagers[Platform];
   }
 }


### PR DESCRIPTION
# Why

Resolves #43144
Resolves #42611
Supersedes #35570

The types of the `BundlerDevServer`'s `PlatformManager` calls were very loosely typed, which cause us to miss that we passed the device manager (`device`) itself rather than the device (`device.device`). A few utility types can strengthen this and prevent this from happening again.

# How

- Determine strict `Platform`-dependent device, device manager, and launch props types
- Update `launchApp` to use `device.device`

# Test Plan

- Types themselves document the correctness of this change
- For reproduction steps of the issue itself, check the resolved issue (#43144)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
