### PR TITLE
[docs] Add lastmod dates to sitemap

### DIFF
--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -1,6 +1,8 @@
 import { withSentryConfig } from '@sentry/nextjs';
+import frontmatter from 'front-matter';
 import type { NextConfig } from 'next';
 import { event, error } from 'next/dist/build/output/log.js';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { exit } from 'node:process';
 import rehypeSlug from 'rehype-slug';
@@ -151,6 +153,37 @@ const nextConfig: NextConfig = {
       })
     );
 
+    // Build a map of URL paths to ISO date strings from MDX frontmatter
+    const modificationDates: Record<string, string> = {};
+    const pagesDir = join(__dirname, 'pages');
+    for (const urlPath of Object.keys(pathMap)) {
+      const mdxPath =
+        [join(pagesDir, `${urlPath}.mdx`), join(pagesDir, urlPath, 'index.mdx')].find(
+          existsSync
+        ) ?? null;
+      if (mdxPath) {
+        try {
+          const { attributes } = frontmatter<{ modificationDate?: string }>(
+            readFileSync(mdxPath, 'utf-8')
+          );
+          if (attributes.modificationDate) {
+            // Strip ordinal suffixes (e.g., "17th" -> "17") before parsing
+            const cleaned = attributes.modificationDate.replace(/(\d+)(st|nd|rd|th)/, '$1');
+            const parsed = new Date(cleaned);
+            if (!isNaN(parsed.getTime())) {
+              // Use local date parts to avoid timezone shift (Date parses as local midnight)
+              const y = parsed.getFullYear();
+              const m = String(parsed.getMonth() + 1).padStart(2, '0');
+              const d = String(parsed.getDate()).padStart(2, '0');
+              modificationDates[urlPath] = `${y}-${m}-${d}`;
+            }
+          }
+        } catch (e) {
+          error(`Failed to read lastmod date from ${mdxPath}: ${e}`);
+        }
+      }
+    }
+
     const sitemapEntries = createSitemap({
       pathMap,
       domain: `https://docs.expo.dev`,
@@ -167,6 +200,7 @@ const nextConfig: NextConfig = {
       ],
       // Some of our pages are "hidden" and should not be added to the sitemap
       pathsHidden: [...navigation.previewDirectories, ...navigation.archiveDirectories, 'internal'],
+      modificationDates,
     });
     event(`Generated sitemap with ${sitemapEntries.length} entries`);
 

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -158,9 +158,8 @@ const nextConfig: NextConfig = {
     const pagesDir = join(__dirname, 'pages');
     for (const urlPath of Object.keys(pathMap)) {
       const mdxPath =
-        [join(pagesDir, `${urlPath}.mdx`), join(pagesDir, urlPath, 'index.mdx')].find(
-          existsSync
-        ) ?? null;
+        [join(pagesDir, `${urlPath}.mdx`), join(pagesDir, urlPath, 'index.mdx')].find(existsSync) ??
+        null;
       if (mdxPath) {
         try {
           const { attributes } = frontmatter<{ modificationDate?: string }>(
@@ -178,8 +177,8 @@ const nextConfig: NextConfig = {
               modificationDates[urlPath] = `${y}-${m}-${d}`;
             }
           }
-        } catch (e) {
-          error(`Failed to read lastmod date from ${mdxPath}: ${e}`);
+        } catch (catchError) {
+          error(`Failed to read lastmod date from ${mdxPath}: ${catchError}`);
         }
       }
     }

--- a/docs/scripts/create-sitemap.js
+++ b/docs/scripts/create-sitemap.js
@@ -11,7 +11,14 @@ const IGNORED_PAGES = new Set([
  * Create a sitemap for crawlers like Algolia Docsearch.
  * This allows crawlers to index _all_ pages, without a full page-link-chain.
  */
-export default function createSitemap({ pathMap, domain, output, pathsPriority, pathsHidden }) {
+export default function createSitemap({
+  pathMap,
+  domain,
+  output,
+  pathsPriority,
+  pathsHidden,
+  modificationDates = {},
+}) {
   if (!pathMap) {
     throw new Error(`⚠️ Couldn't generate sitemap, no 'pathMap' provided`);
   }
@@ -44,7 +51,11 @@ export default function createSitemap({ pathMap, domain, output, pathsPriority, 
   });
 
   sitemap.pipe(target);
-  urls.forEach(url => sitemap.write({ url }));
+  urls.forEach(url => {
+    const key = url.endsWith('/') ? url.slice(0, -1) : url;
+    const lastmod = modificationDates[key];
+    sitemap.write(lastmod ? { url, lastmod } : { url });
+  });
   sitemap.end();
 
   return urls;


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

ENG-19964

# How

<!--
How did you build this feature or fix this bug and why?
-->

- In `next.config.ts` `exportPathMap()`, read each page's MDX frontmatter at build time using the existing `front-matter` dependency. Extract `modificationDate`, strip ordinal suffixes ("17th" to "17"), and convert to ISO date format (`YYYY-MM-DD`). Uses local date getters instead of `toISOString()` to avoid timezone-dependent off-by-one errors.
- In `scripts/create-sitemap.js`, accept the new `modificationDates` param (defaulting to `{}`). For each URL, look up its date by stripping the trailing slash and write `{ url, lastmod }` when a date exists. Entries without dates render as before (no empty `<lastmod>` tags).

# Test Plan

**See preview:** https://pr-43678.expo-docs.pages.dev/sitemap.xml

Or test to locally, run the following commands:
- yarn append-last-modified-dates
- yarn export
- Then serve the `out/` directory using `npx serve out`
- Open http://localhost:3000/sitemap.xml and you will notice that the `lastmod` entry is present for pages we add modification date:

<img width="4112" height="2488" alt="CleanShot 2026-03-05 at 18 45 57@2x" src="https://github.com/user-attachments/assets/0f7cb762-1f34-422b-b7a1-93bec61b3d81" />


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
