### PR TITLE
[install-expo-modules] Add version mapping for SDK 55 and react native 0.83

### DIFF
--- a/packages/install-expo-modules/CHANGELOG.md
+++ b/packages/install-expo-modules/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add version mapping for SDK 55 and react native 0.83 ([#43682](https://github.com/expo/expo/pull/43682) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 0.14.9 — 2026-02-25

--- a/packages/install-expo-modules/src/utils/expoVersionMappings.ts
+++ b/packages/install-expo-modules/src/utils/expoVersionMappings.ts
@@ -14,6 +14,13 @@ export interface VersionInfo {
 export const ExpoVersionMappings: VersionInfo[] = [
   // Please keep sdk versions in sorted order (latest sdk first)
   {
+    expoPackageVersion: '~55.0.0',
+    sdkVersion: '55.0.0',
+    iosDeploymentTarget: '15.1',
+    reactNativeVersionRange: '~0.83.0',
+    supportCliIntegration: true,
+  },
+  {
     expoPackageVersion: '~54.0.0',
     sdkVersion: '54.0.0',
     iosDeploymentTarget: '15.1',


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/43645

# How

Add version mapping for SDK 55 and react native 0.83 to install-expo-modules

# Test Plan

Tested locally 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
