### PR TITLE
[docs] Fix incorrect fullscreenOptions prop in video SDK example

### DIFF
--- a/docs/pages/versions/unversioned/sdk/video.mdx
+++ b/docs/pages/versions/unversioned/sdk/video.mdx
@@ -90,7 +90,7 @@ export default function VideoScreen() {
       <VideoView
         style={styles.video}
         player={player}
-        fullScreenOptions={{ allowsFullscreen: true }}
+        fullscreenOptions={{ enable: true }}
         allowsPictureInPicture
       />
       <View style={styles.controlsContainer}>

--- a/docs/pages/versions/v55.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/video.mdx
@@ -90,7 +90,7 @@ export default function VideoScreen() {
       <VideoView
         style={styles.video}
         player={player}
-        fullScreenOptions={{ allowsFullscreen: true }}
+        fullscreenOptions={{ enable: true }}
         allowsPictureInPicture
       />
       <View style={styles.controlsContainer}>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The `VideoView` usage example in the video SDK docs uses an incorrect prop name and shape that doesn't match the actual TypeScript types in `expo-video`.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Updated the `VideoView` example in the video SDK docs:

```diff
- fullScreenOptions={{ allowsFullscreen: true }}
+ fullscreenOptions={{ enable: true }}
```

The prop is `fullscreenOptions` (lowercase `s`) with `{ enable: boolean }`, not `fullScreenOptions` with `{ allowsFullscreen: boolean }`.

Only v55.0.0 and unversioned docs are affected — v53 and v54 correctly use the old `allowsFullscreen` boolean prop that existed in those SDK versions.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Verified the prop name and shape against the TypeScript types in `expo-video` source (`VideoView.types.ts`):
- `fullscreenOptions` is the correct prop name (not `fullScreenOptions`)
- `FullscreenOptions` type has `enable?: boolean` (not `allowsFullscreen`)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)