### PR TITLE
[launcher][Android] Improve how close state is handled

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/BindingView.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/BindingView.kt
@@ -3,10 +3,14 @@ package expo.modules.devlauncher.compose
 import android.content.Context
 import android.widget.LinearLayout
 import androidx.compose.ui.platform.ComposeView
+import expo.modules.devlauncher.services.PackagerService
+import expo.modules.devlauncher.services.injectService
 import expo.modules.devmenu.compose.newtheme.AppTheme
 
 class BindingView(context: Context) : LinearLayout(context) {
   init {
+    injectService<PackagerService>().start()
+
     addView(
       ComposeView(context).apply {
         setContent {
@@ -16,5 +20,10 @@ class BindingView(context: Context) : LinearLayout(context) {
         }
       }
     )
+  }
+
+  override fun onDetachedFromWindow() {
+    super.onDetachedFromWindow()
+    injectService<PackagerService>().stop()
   }
 }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/DevLauncherBottomTabsNavigator.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/DevLauncherBottomTabsNavigator.kt
@@ -135,7 +135,7 @@ fun DevLauncherBottomTabsNavigator() {
 
   DevelopmentServersRoute(developmentServersBottomSheetState)
 
-  val isVisible by (DevLauncherController.instance as DevLauncherController).isLoadingToBundler
+  val isVisible by DevLauncherController.instance.isLoadingToBundler
 
   AnimatedVisibility(
     visible = isVisible,

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/models/HomeViewModel.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/models/HomeViewModel.kt
@@ -60,11 +60,11 @@ class HomeViewModel() : ViewModel() {
       }
       .launchIn(viewModelScope)
 
-    packagerService.start()
+    packagerService.resumeHealthCheck()
   }
 
   override fun onCleared() {
-    packagerService.stop()
+    packagerService.pauseHealthCheck()
   }
 
   fun onAction(action: HomeAction) {

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/nsd/NsdDiscovery.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/nsd/NsdDiscovery.kt
@@ -5,21 +5,48 @@ import android.content.Context
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.util.Log
+import expo.modules.devlauncher.helpers.await
 import expo.modules.devlauncher.services.PackagerInfo
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+import kotlin.time.toJavaDuration
 
 private const val SERVICE_TYPE = "_expo._tcp."
+private val HEALTH_CHECK_INTERVAL = 3.toDuration(DurationUnit.SECONDS)
+private val HEALTH_CHECK_TIMEOUT = 5.toDuration(DurationUnit.SECONDS).toJavaDuration()
+
+data class PotentialPackager(
+  val serviceName: String,
+  val url: String,
+  val name: String
+)
 
 class NsdDiscovery(
-  application: Application
+  application: Application,
+  httpClient: OkHttpClient
 ) {
   private val coroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+  private val healthCheckClient = httpClient.newBuilder()
+    .connectTimeout(HEALTH_CHECK_TIMEOUT)
+    .readTimeout(HEALTH_CHECK_TIMEOUT)
+    .writeTimeout(HEALTH_CHECK_TIMEOUT)
+    .build()
 
   private val _manger: NsdManager? =
     application.getSystemService(Context.NSD_SERVICE) as? NsdManager
@@ -27,12 +54,19 @@ class NsdDiscovery(
   private val manager: NsdManager
     get() = requireNotNull(_manger) { "NsdManager not available on this device" }
 
+  private val _potentialPackagers = MutableStateFlow<Set<PotentialPackager>>(emptySet())
+
   private val _discoveredPackagers = MutableStateFlow<Set<PackagerInfo>>(emptySet())
   val discoveredPackagers = _discoveredPackagers.asStateFlow()
 
   private var isDiscovering = false
+  private var healthCheckJob: Job? = null
 
   private var discoveryListener = NsdDiscoveryListener(
+    onStopped = {
+      _potentialPackagers.value = emptySet()
+      _discoveredPackagers.value = emptySet()
+    },
     onServiceFound = {
       coroutineScope.launch { resolveAndAddService(it) }
     },
@@ -44,7 +78,7 @@ class NsdDiscovery(
     }
   )
 
-  fun start() {
+  fun start() = synchronized(this) {
     if (isDiscovering) {
       return
     }
@@ -57,7 +91,19 @@ class NsdDiscovery(
     isDiscovering = true
   }
 
-  fun stop() {
+  fun resumeHealthCheck() = synchronized(this) {
+    if (isDiscovering) {
+      startHealthCheckLoop()
+    }
+  }
+
+  fun pauseHealthCheck() = synchronized(this) {
+    if (isDiscovering) {
+      stopHealthCheckLoop()
+    }
+  }
+
+  fun stop() = synchronized(this) {
     if (!isDiscovering) {
       return
     }
@@ -67,34 +113,77 @@ class NsdDiscovery(
     }.onFailure {
       Log.e("DevLauncher", "Failed to stop NSD discovery", it)
     }
-
     isDiscovering = false
-    _discoveredPackagers.value = emptySet()
   }
 
   private suspend fun resolveAndAddService(serviceInfo: NsdServiceInfo) {
     val resolved = manager.resolveServiceCoroutine(serviceInfo)
     coroutineScope.ensureActive()
 
+    val serviceName = resolved.serviceName ?: return
     val url = resolved.getUrl() ?: return
+    val name = resolved.getAttribute("name") ?: return
 
-    val description = resolved.getAttribute("name") ?: "Unknown Packager"
-
-    val packager = PackagerInfo(
+    val packager = PotentialPackager(
       url = url,
-      description = description
+      serviceName = serviceName,
+      name = name
     )
-    _discoveredPackagers.value = _discoveredPackagers.value.plus(packager)
+    _potentialPackagers.value = _potentialPackagers.value.plus(packager)
   }
 
   private fun removeService(serviceInfo: NsdServiceInfo) {
-    val url = serviceInfo.getUrl() ?: run {
-      Log.e("DevLauncher", "Failed to get URL from service info during removal: $serviceInfo")
-      return
+    val serviceName = serviceInfo.serviceName ?: return
+    _potentialPackagers.update {
+      it.filter { packager ->
+        packager.serviceName != serviceName
+      }.toSet()
+    }
+  }
+
+  private fun startHealthCheckLoop() {
+    stopHealthCheckLoop()
+    healthCheckJob = coroutineScope.launch {
+      while (isActive) {
+        val currentPackagers = _potentialPackagers.value
+        val alivePackagers = currentPackagers
+          .map { packager ->
+            async {
+              packager to checkPackagerStatus(packager.url)
+            }
+          }
+          .awaitAll()
+          .filter { (_, isAlive) -> isAlive }
+          .map { (packager, _) -> PackagerInfo(url = packager.url, description = packager.name) }
+          .toSet()
+
+        ensureActive()
+        _discoveredPackagers.value = alivePackagers
+
+        delay(HEALTH_CHECK_INTERVAL)
+      }
+    }
+  }
+
+  private fun stopHealthCheckLoop() {
+    healthCheckJob?.cancel()
+    healthCheckJob = null
+  }
+
+  private suspend fun checkPackagerStatus(url: String): Boolean {
+    runCatching {
+      val request = Request.Builder()
+        .url("$url/status")
+        .build()
+      val response = request.await(healthCheckClient)
+      if (!response.isSuccessful) {
+        return false
+      }
+
+      val body = response.body?.string() ?: return false
+      return body.contains("packager-status:running")
     }
 
-    _discoveredPackagers.value = _discoveredPackagers.value.filter { packager ->
-      packager.url == url
-    }.toSet()
+    return false
   }
 }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/nsd/NsdDiscoveryListener.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/nsd/NsdDiscoveryListener.kt
@@ -4,13 +4,16 @@ import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 
 class NsdDiscoveryListener(
+  private val onStopped: (errorCode: Int?) -> Unit,
   private val onServiceFound: (NsdServiceInfo) -> Unit,
   private val onServiceLost: (NsdServiceInfo) -> Unit,
   private val onStartFailed: () -> Unit
 ) : NsdManager.DiscoveryListener {
   override fun onDiscoveryStarted(serviceType: String) = Unit
 
-  override fun onDiscoveryStopped(serviceType: String) = Unit
+  override fun onDiscoveryStopped(serviceType: String) {
+    onStopped.invoke(null)
+  }
 
   override fun onServiceFound(serviceInfo: NsdServiceInfo) {
     onServiceFound.invoke(serviceInfo)
@@ -24,5 +27,7 @@ class NsdDiscoveryListener(
     onStartFailed.invoke()
   }
 
-  override fun onStopDiscoveryFailed(serviceType: String, errorCode: Int) = Unit
+  override fun onStopDiscoveryFailed(serviceType: String, errorCode: Int) {
+    onStopped.invoke(null)
+  }
 }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/services/DependencyInjection.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/services/DependencyInjection.kt
@@ -68,7 +68,7 @@ object DependencyInjection {
 
     errorRegistryService = ErrorRegistryService(context.applicationContext)
 
-    packagerService = PackagerService(application)
+    packagerService = PackagerService(application, httpClientService.httpClient)
 
     wasInitialized = true
   }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/services/PackagerService.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/services/PackagerService.kt
@@ -2,8 +2,7 @@ package expo.modules.devlauncher.services
 
 import android.app.Application
 import expo.modules.devlauncher.nsd.NsdDiscovery
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import okhttp3.OkHttpClient
 
 data class PackagerInfo(
   val url: String,
@@ -11,17 +10,22 @@ data class PackagerInfo(
 )
 
 class PackagerService(
-  application: Application
+  application: Application,
+  httpClient: OkHttpClient
 ) {
-  private var nsdDiscovery = NsdDiscovery(application)
-
-  private val _isLoading = MutableStateFlow(false)
-
+  private var nsdDiscovery = NsdDiscovery(application, httpClient)
   val runningPackagers = nsdDiscovery.discoveredPackagers
-  val isLoading = _isLoading.asStateFlow()
 
   fun start() {
     nsdDiscovery.start()
+  }
+
+  fun resumeHealthCheck() {
+    nsdDiscovery.resumeHealthCheck()
+  }
+
+  fun pauseHealthCheck() {
+    nsdDiscovery.pauseHealthCheck()
   }
 
   fun stop() {

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_runUpdate.yml
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_runUpdate.yml
@@ -26,8 +26,8 @@ onFlowStart:
       platform: android
     commands:
       - extendedWaitUntil:
-          visible: 'New development server'
-          timeout: 30000
+          visible: New development server
+          timeout: 1800000
       - tapOn:
           label: Tap on "New development server"
           text: New development server

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_runUpdate.yml
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_runUpdate.yml
@@ -26,8 +26,8 @@ onFlowStart:
       platform: android
     commands:
       - extendedWaitUntil:
-        visible: 'New development server'
-        timeout: 30000
+          visible: 'New development server'
+          timeout: 30000
       - tapOn:
           label: Tap on "New development server"
           text: New development server

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_runUpdate.yml
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_runUpdate.yml
@@ -25,16 +25,7 @@ onFlowStart:
     when:
       platform: android
     commands:
-      - extendedWaitUntil:
-          visible: New development server
-          timeout: 1800000
-      - tapOn:
-          label: Tap on "New development server"
-          text: New development server
-      - tapOn:
-          label: Tap on "Updates URL" text field
-          text: '.*exp:.*'
-          below: New development server
+      - tapOn: exp://
 - inputText:
     label: Input local update server URL
     text: "http://localhost:4747/update\n"

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_runUpdate.yml
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_runUpdate.yml
@@ -25,6 +25,9 @@ onFlowStart:
     when:
       platform: android
     commands:
+      - extendedWaitUntil:
+        visible: 'New development server'
+        timeout: 30000
       - tapOn:
           label: Tap on "New development server"
           text: New development server

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_verifyState.yml
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_verifyState.yml
@@ -20,16 +20,7 @@ onFlowStart:
     when:
       platform: android
     commands:
-      - extendedWaitUntil:
-          visible: New development server
-          timeout: 1800000
-      - tapOn:
-          label: Tap on "New development server"
-          text: New development server
-      - tapOn:
-          label: Tap on "Updates URL" text field
-          text: '.*exp:.*'
-          below: New development server
+      - tapOn: exp://
 - inputText:
     label: Input local update server URL
     text: "http://localhost:8081\n"

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_verifyState.yml
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_verifyState.yml
@@ -20,6 +20,9 @@ onFlowStart:
     when:
       platform: android
     commands:
+      - extendedWaitUntil:
+        visible: 'New development server'
+        timeout: 30000
       - tapOn:
           label: Tap on "New development server"
           text: New development server

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_verifyState.yml
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_verifyState.yml
@@ -21,8 +21,8 @@ onFlowStart:
       platform: android
     commands:
       - extendedWaitUntil:
-        visible: 'New development server'
-        timeout: 30000
+          visible: 'New development server'
+          timeout: 30000
       - tapOn:
           label: Tap on "New development server"
           text: New development server

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_verifyState.yml
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_verifyState.yml
@@ -21,8 +21,8 @@ onFlowStart:
       platform: android
     commands:
       - extendedWaitUntil:
-          visible: 'New development server'
-          timeout: 30000
+          visible: New development server
+          timeout: 1800000
       - tapOn:
           label: Tap on "New development server"
           text: New development server


### PR DESCRIPTION
# Why

Improves how close state is handled. These changes will remove inactive servers more quickly. 
I've applied feedback from Phil - https://github.com/expo/expo/pull/43650#pullrequestreview-3891688419

# How

It turns out that NSD is not respecting the 'goodbye' message sent on the bundler's exit. The 'service lost' callback is only called after the TTL expires (which takes 2 minutes). I've also improved how the state is retained in memory when navigating between screens.

# Test Plan

- bare-expo ✅