### PR TITLE
[ios][dev-launcher] Remove port scanning

### DIFF
--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
@@ -54,19 +54,10 @@ class DevLauncherViewModel: ObservableObject {
   @Published var isLoadingServer: Bool = false
   @Published var permissionStatus: LocalNetworkPermissionStatus = .unknown
 
-  @Published var browserDevServers: [DevServer] = [] {
-    didSet { updateDevServers() }
-  }
-
-  @Published var localDevServers: [DevServer] = [] {
-    didSet { updateDevServers() }
-  }
-
   @Published var devServers: [DevServer] = []
 
   private var browser: NWBrowser?
   private var pingTask: Task<Void, Never>?
-  private var scanTask: Task<Void, Never>?
 
   #if !os(tvOS)
   private let presentationContext = DevLauncherAuthPresentationContext()
@@ -94,36 +85,8 @@ class DevLauncherViewModel: ObservableObject {
     checkForStoredCrashes()
   }
 
-  private func updateDevServers() {
-    let allServers = browserDevServers + localDevServers
-    var serversByPort: [String: DevServer] = [:]
-
-    for server in allServers {
-      guard let port = extractPort(from: server.url) else {
-        serversByPort[server.url] = server
-        continue
-      }
-
-      if let existing = serversByPort[port] {
-        let existingHasName = existing.description != existing.url
-        let newHasName = server.description != server.url
-
-        if newHasName && !existingHasName {
-          serversByPort[port] = server
-        } else if existingHasName == newHasName {
-          let existingIsLinkLocal = existing.url.contains("169.254.")
-          let newIsLinkLocal = server.url.contains("169.254.")
-
-          if existingIsLinkLocal && !newIsLinkLocal {
-            serversByPort[port] = server
-          }
-        }
-      } else {
-        serversByPort[port] = server
-      }
-    }
-
-    devServers = serversByPort.values.sorted(by: <)
+  private func updateDevServers(_ servers: [DevServer]) {
+    devServers = servers.sorted(by: <)
   }
 
   private func extractPort(from url: String) -> String? {
@@ -214,7 +177,6 @@ class DevLauncherViewModel: ObservableObject {
 
     stopServerDiscovery()
     startDevServerBrowser()
-    startLocalDevServerScanner()
   }
   
   func markNetworkPermissionGranted() {
@@ -284,25 +246,9 @@ class DevLauncherViewModel: ObservableObject {
 
   func stopServerDiscovery() {
     pingTask?.cancel()
-    scanTask?.cancel()
     browser?.cancel()
     pingTask = nil
-    scanTask = nil
     browser = nil
-  }
-
-  private func startLocalDevServerScanner() {
-    scanTask?.cancel()
-    scanTask = Task {
-      await scanLocalDevServers()
-      while !Task.isCancelled {
-        try? await Task.sleep(nanoseconds: 2_000_000_000)
-        if Task.isCancelled {
-          break
-        }
-        await scanLocalDevServers()
-      }
-    }
   }
 
   private func startDevServerBrowser() {
@@ -357,31 +303,6 @@ class DevLauncherViewModel: ObservableObject {
     browser?.start(queue: DispatchQueue(label: "expo.devlauncher.discovery"))
   }
 
-  private func scanLocalDevServers() async {
-    guard !Task.isCancelled else {
-      return
-    }
-
-    var discoveredServers: [DevServer] = []
-    await withTaskGroup(of: DevServer?.self) { group in
-      for result in NetworkUtilities.getLocalEndpointsToScan() {
-        group.addTask {
-          return await self.resolveDevServer(result)
-        }
-      }
-
-      for await server in group {
-        if let server {
-          discoveredServers.append(server)
-        }
-      }
-    }
-
-    await MainActor.run {
-      self.localDevServers = discoveredServers
-    }
-  }
-
   private func pingDiscoveryResults(_ results: [DiscoveryResult]) async {
     guard !Task.isCancelled else {
       return
@@ -407,7 +328,7 @@ class DevLauncherViewModel: ObservableObject {
     }
 
     await MainActor.run {
-      self.browserDevServers = discoveredServers
+      self.updateDevServers(discoveredServers)
     }
   }
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/NetworkUtilities.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/NetworkUtilities.swift
@@ -129,67 +129,6 @@ func connectionReceive(_ connection: NWConnection) async throws -> String {
 }
 
 class NetworkUtilities {
-  // Same approach as expo-network just without throwing.
-  static func getLocalIPAddress() -> String? {
-    var address: String?
-
-    var ifaddr: UnsafeMutablePointer<ifaddrs>?
-    guard getifaddrs(&ifaddr) == 0 else { return nil }
-    guard let firstAddr = ifaddr else { return nil }
-
-    defer { freeifaddrs(ifaddr) }
-
-    for ifptr in sequence(first: firstAddr, next: { $0.pointee.ifa_next }) {
-      let interface = ifptr.pointee
-
-      let addrFamily = interface.ifa_addr.pointee.sa_family
-      if addrFamily == UInt8(AF_INET) {
-        let name = String(cString: interface.ifa_name)
-
-        if name == "en0" || name == "en1" {
-          var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
-          getnameinfo(
-            interface.ifa_addr,
-            socklen_t(interface.ifa_addr.pointee.sa_len),
-            &hostname,
-            socklen_t(hostname.count),
-            nil,
-            socklen_t(0),
-            NI_NUMERICHOST
-          )
-          address = String(cString: hostname)
-          break
-        }
-      }
-    }
-
-    return address
-  }
-
-  static func isSimulator() -> Bool {
-    #if targetEnvironment(simulator)
-    return true
-    #else
-    return false
-    #endif
-  }
-
-  static func getLocalEndpointsToScan() -> [DiscoveryResult] {
-    let portsToScan = ["8081", "8082", "8083"]
-    if !isSimulator() {
-      return []
-    }
-    return portsToScan.map { port in
-      DiscoveryResult(
-        name: nil,
-        endpoint: NWEndpoint.hostPort(
-          host: NWEndpoint.Host.init(getLocalIPAddress() ?? "localhost"),
-          port: NWEndpoint.Port.init(port)!
-        )
-      )
-    }
-  }
-
   static func getNWBrowserResultName(_ result: NWBrowser.Result) -> String? {
     if case .bonjour(let txtRecord) = result.metadata {
       return txtRecord.getEntry(for: "name").flatMap {


### PR DESCRIPTION
# Why
Removes the old port scanning from dev-launcher

# How
There should be no scenario where we fallback to using the old port scanning. Simulators automatically get local network access and bonjour is the only method that works on real devices.

# Test Plan
Bare expo

