### PR TITLE
[expo-go] Copy dev menu UI

### DIFF
--- a/apps/expo-go/ios/Client/EXRootViewController.m
+++ b/apps/expo-go/ios/Client/EXRootViewController.m
@@ -10,7 +10,6 @@
 #import "EXKernelAppRecord.h"
 #import "EXKernelAppRegistry.h"
 #import "EXRootViewController.h"
-#import "EXDevMenu-Swift.h"
 #import "EXUtil.h"
 
 #import "Expo_Go-Swift.h"
@@ -55,6 +54,11 @@ NS_ASSUME_NONNULL_BEGIN
 {
   [super viewDidAppear:animated];
   [self becomeFirstResponder];
+
+  // Attach three-finger long press gesture recognizer for dev menu
+  if (self.view.window) {
+    [[DevMenuManager shared] attachGestureRecognizerToWindow:self.view.window];
+  }
 }
 
 - (void)viewWillDisappear:(BOOL)animated
@@ -351,22 +355,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.contentViewController = viewController;
 
     if (isShowingApp && appRecord.appManager.reactHost) {
-      [[DevMenuManager shared] updateCurrentManifest:appRecord.appLoader.manifest manifestURL:appRecord.appLoader.manifestUrl];
-
-      DevMenuConfiguration *config = [DevMenuManager shared].configuration;
-
-      BOOL isDev = appRecord.appLoader.manifest.isDevelopmentMode || appRecord.appLoader.manifest.isUsingDeveloperTool;
-      BOOL isSnack = [self _isSnackURL:appRecord.appLoader.manifestUrl];
-
-      if (!isDev) {
-        config.showDebuggingTip = NO;
-        config.showFastRefresh = NO;
-        config.showHostUrl = isSnack;
-      } else {
-        config.showDebuggingTip = YES;
-        config.showFastRefresh = YES;
-        config.showHostUrl = NO;
-      }
+      [[DevMenuManager shared] notifyManifestChanged];
     }
   }
 

--- a/apps/expo-go/ios/Client/SwiftUI/Services/SettingsManager.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Services/SettingsManager.swift
@@ -2,7 +2,6 @@
 
 import Foundation
 import UIKit
-import EXDevMenu
 
 @MainActor
 class SettingsManager: ObservableObject {

--- a/apps/expo-go/ios/Exponent-Bridging-Header.h
+++ b/apps/expo-go/ios/Exponent-Bridging-Header.h
@@ -28,4 +28,5 @@
 #import "ExpoGoReactNativeFactory.h"
 #import "EXUtil.h"
 #import "EXReactAppManager.h"
+#import "EXAbstractLoader.h"
 #import "EXProgressHUD.h"

--- a/apps/expo-go/ios/Exponent.xcodeproj/project.pbxproj
+++ b/apps/expo-go/ios/Exponent.xcodeproj/project.pbxproj
@@ -103,8 +103,6 @@
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		XXEXPOCLIENTXXXXXXXXXXXX /* Client */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = Client;
 			sourceTree = "<group>";
 		};
@@ -470,9 +468,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Expo Go/Pods-Expo Go-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Expo Go/Pods-Expo Go-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -502,9 +504,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Expo Go/Pods-Expo Go-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Expo Go/Pods-Expo Go-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -519,9 +525,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Expo Go-Tests/Pods-Expo Go-Tests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Expo Go-Tests/Pods-Expo Go-Tests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -605,9 +615,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Expo Go-Tests/Pods-Expo Go-Tests-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Expo Go-Tests/Pods-Expo Go-Tests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -748,10 +762,7 @@
 					"$(inherited)",
 					"-DRCT_REMOVE_LEGACY_ARCH=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../../react-native-lab/react-native/packages/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -824,10 +835,7 @@
 					"$(inherited)",
 					"-DRCT_REMOVE_LEGACY_ARCH=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../../react-native-lab/react-native/packages/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ENABLE_EXPLICIT_MODULES = NO;

--- a/apps/expo-go/ios/Exponent/DevMenu/DevMenuGestureRecognizer.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/DevMenuGestureRecognizer.swift
@@ -1,0 +1,12 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import UIKit
+
+class DevMenuGestureRecognizer: UILongPressGestureRecognizer {
+  init() {
+    super.init(target: nil, action: nil)
+    numberOfTouchesRequired = 3
+    minimumPressDuration = 0.5
+    allowableMovement = 30
+  }
+}

--- a/apps/expo-go/ios/Exponent/DevMenu/DevMenuManager.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/DevMenuManager.swift
@@ -1,0 +1,330 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import React
+import ExpoModulesCore
+import EXManifests
+import Combine
+
+@objc
+@MainActor
+public class DevMenuManager: NSObject {
+  @objc static let shared = DevMenuManager()
+
+  private let menuWillShowSubject = PassthroughSubject<Void, Never>()
+  var menuWillShowPublisher: AnyPublisher<Void, Never> {
+    menuWillShowSubject.eraseToAnyPublisher()
+  }
+
+  private let manifestSubject = PassthroughSubject<Void, Never>()
+  var manifestPublisher: AnyPublisher<Void, Never> {
+    manifestSubject.eraseToAnyPublisher()
+  }
+
+  var window: DevMenuWindow?
+  var fabWindow: DevMenuFABWindow?
+  private var isNavigatingHome = false
+
+  override init() {
+    super.init()
+    self.window = DevMenuWindow(manager: self)
+    DevMenuPreferences.setup()
+    readAutoLaunchDisabledState()
+  }
+
+  deinit {
+    NotificationCenter.default.removeObserver(self)
+  }
+
+  var currentManifest: Manifest? {
+    return EXKernel.sharedInstance().visibleApp.appLoader.manifest
+  }
+
+  var currentManifestURL: URL? {
+    return EXKernel.sharedInstance().visibleApp.appLoader.manifestUrl
+  }
+
+  var currentBridge: RCTBridge? {
+    return RCTBridge.current()
+  }
+
+  var isCurrentAppSnack: Bool {
+    guard let url = currentManifestURL?.absoluteString else { return false }
+    return url.contains("snack")
+  }
+
+  @objc var isVisible: Bool {
+    return !(window?.isHidden ?? true)
+  }
+
+  @objc
+  @discardableResult
+  func openMenu(_ screen: String? = nil) -> Bool {
+    return setVisibility(true)
+  }
+
+  @objc
+  @discardableResult
+  func closeMenu(completion: (() -> Void)? = nil) -> Bool {
+    if isVisible {
+      if Thread.isMainThread {
+        window?.closeBottomSheet(completion)
+      } else {
+        DispatchQueue.main.async { [self] in
+          window?.closeBottomSheet(completion)
+        }
+      }
+      return true
+    }
+    return false
+  }
+
+  @objc
+  @discardableResult
+  func hideMenu() -> Bool {
+    return setVisibility(false)
+  }
+
+  @objc
+  @discardableResult
+  func toggleMenu() -> Bool {
+    return isVisible ? closeMenu() : openMenu()
+  }
+
+  private func setVisibility(_ visible: Bool) -> Bool {
+    if isVisible == visible { return false }
+    if visible && currentBridge == nil { return false }
+
+    if visible {
+      menuWillShowSubject.send()
+      DispatchQueue.main.async {
+        self.updateFABVisibility()
+
+        if self.window?.windowScene == nil {
+          let windowScene = UIApplication.shared.connectedScenes
+            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
+          self.window?.windowScene = windowScene
+        }
+        self.window?.makeKeyAndVisible()
+      }
+    } else {
+      DispatchQueue.main.async {
+        self.window?.closeBottomSheet(nil)
+      }
+    }
+    return true
+  }
+
+  func reload() {
+    hideMenu()
+
+    guard let bridge = currentBridge else { return }
+    let emc = bridge.module(forName: "ExpoModulesCore") as? ExpoBridgeModule
+    emc?.appContext?.reloadAppAsync()
+  }
+
+  @objc func goHome() {
+    isNavigatingHome = true
+    fabWindow?.setVisible(false, animated: false)
+    EXKernel.sharedInstance().switchTasks()
+  }
+
+  func togglePerformanceMonitor() {
+    EXKernel.sharedInstance().visibleApp.appManager.togglePerformanceMonitor()
+  }
+
+  func toggleElementInspector() {
+    EXKernel.sharedInstance().visibleApp.appManager.toggleElementInspector()
+  }
+
+  func openJSInspector() {
+    guard let bridge = currentBridge, let bundleURL = bridge.bundleURL else {
+      return
+    }
+    let port = bundleURL.port ?? Int(RCT_METRO_PORT)
+    let host = bundleURL.host ?? "localhost"
+    let openURL = "http://\(host):\(port)/_expo/debugger?applicationId=\(Bundle.main.bundleIdentifier ?? "")"
+    guard let url = URL(string: openURL) else { return }
+    let request = NSMutableURLRequest(url: url)
+    request.httpMethod = "PUT"
+    URLSession.shared.dataTask(with: request as URLRequest).resume()
+  }
+
+  func toggleFastRefresh() {
+    guard let bridge = currentBridge,
+          let devSettings = bridge.module(forName: "DevSettings") as? RCTDevSettings else {
+      return
+    }
+    devSettings.isHotLoadingEnabled = !devSettings.isHotLoadingEnabled
+  }
+
+  func getAppInfo() -> AppInfo {
+    let manifest = currentManifest
+    let manifestURL = currentManifestURL
+
+    let appName = manifest?.name() ?? bundleDisplayName()
+    let appVersion = manifest?.version() ?? formattedAppVersion()
+    let runtimeVersion: String? = nil // only available on ExpoUpdatesManifest
+    let sdkVersion = manifest?.expoGoSDKVersion()
+    let hostUrl = manifestURL?.absoluteString
+    let appIcon = manifest?.iosAppIconUrl() ?? bundleAppIcon()
+    let engine = resolveEngine()
+
+    return AppInfo(
+      appName: appName,
+      appVersion: appVersion,
+      runtimeVersion: runtimeVersion,
+      sdkVersion: sdkVersion,
+      hostUrl: hostUrl,
+      appIcon: appIcon,
+      engine: engine
+    )
+  }
+
+  func getDevSettings() -> DevSettings {
+    guard let bridge = currentBridge,
+          let bridgeSettings = bridge.module(forName: "DevSettings") as? RCTDevSettings else {
+      return DevSettings(
+        isElementInspectorAvailable: false,
+        isHotLoadingAvailable: false,
+        isPerfMonitorAvailable: false,
+        isJSInspectorAvailable: false,
+        isHotLoadingEnabled: false
+      )
+    }
+
+    let perfMonitor = bridge.module(forName: "PerfMonitor")
+    let isDev = currentManifest?.isDevelopmentMode() == true
+    let isPerfMonitorAvailable = perfMonitor != nil && isDev
+
+    return DevSettings(
+      isElementInspectorAvailable: isDev,
+      isHotLoadingAvailable: bridgeSettings.isHotLoadingAvailable,
+      isPerfMonitorAvailable: isPerfMonitorAvailable,
+      isJSInspectorAvailable: bridgeSettings.isDeviceDebuggingAvailable,
+      isHotLoadingEnabled: bridgeSettings.isHotLoadingEnabled
+    )
+  }
+
+  func updateFABVisibility() {
+    DispatchQueue.main.async { [weak self] in
+      guard let self else { return }
+
+      if self.fabWindow == nil {
+        if let windowScene = UIApplication.shared.connectedScenes
+          .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
+          self.setupFABWindowIfNeeded(for: windowScene)
+        }
+      }
+
+      let shouldShow = DevMenuPreferences.showFloatingActionButton
+        && !self.isVisible
+        && self.currentBridge != nil
+        && !self.isNavigatingHome
+        && DevMenuPreferences.isOnboardingFinished
+      self.fabWindow?.setVisible(shouldShow, animated: true)
+    }
+  }
+
+  func setupFABWindowIfNeeded(for windowScene: UIWindowScene) {
+    guard fabWindow == nil else { return }
+    fabWindow = DevMenuFABWindow(manager: self, windowScene: windowScene)
+  }
+
+  @objc func attachGestureRecognizerToWindow(_ window: UIWindow) {
+    let gestureRecognizer = DevMenuGestureRecognizer()
+    gestureRecognizer.addTarget(self, action: #selector(handleThreeFingerLongPress(_:)))
+    window.addGestureRecognizer(gestureRecognizer)
+  }
+
+  @objc func handleThreeFingerLongPress(_ recognizer: UIGestureRecognizer) {
+    if recognizer.state == .began {
+      toggleMenu()
+    }
+  }
+
+  private var canLaunchDevMenuOnStart = true
+
+  func shouldAutoLaunch() -> Bool {
+    return canLaunchDevMenuOnStart
+      && currentBridge != nil
+      && (DevMenuPreferences.showsAtLaunch || shouldShowOnboarding())
+  }
+
+  @objc func autoLaunch() {
+    NotificationCenter.default.removeObserver(self)
+    DispatchQueue.main.async {
+      self.openMenu()
+    }
+  }
+
+  func shouldShowOnboarding() -> Bool {
+    return !isOnboardingFinished
+  }
+
+  private func readAutoLaunchDisabledState() {
+    let userDefaultsValue = UserDefaults.standard.bool(forKey: "EXDevMenuDisableAutoLaunch")
+    if userDefaultsValue {
+      canLaunchDevMenuOnStart = false
+      UserDefaults.standard.removeObject(forKey: "EXDevMenuDisableAutoLaunch")
+    } else {
+      canLaunchDevMenuOnStart = true
+    }
+  }
+
+  @objc var isOnboardingFinished: Bool {
+    return DevMenuPreferences.isOnboardingFinished
+  }
+
+  @objc func setOnboardingFinished(_ finished: Bool) {
+    DevMenuPreferences.isOnboardingFinished = finished
+  }
+
+  @objc func getMotionGestureEnabled() -> Bool {
+    return DevMenuPreferences.motionGestureEnabled
+  }
+
+  @objc func setMotionGestureEnabled(_ enabled: Bool) {
+    DevMenuPreferences.motionGestureEnabled = enabled
+  }
+
+  @objc func getTouchGestureEnabled() -> Bool {
+    return DevMenuPreferences.touchGestureEnabled
+  }
+
+  @objc func setTouchGestureEnabled(_ enabled: Bool) {
+    DevMenuPreferences.touchGestureEnabled = enabled
+  }
+
+  @objc func notifyManifestChanged() {
+    manifestSubject.send()
+  }
+
+  private func bundleDisplayName() -> String {
+    return Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
+      ?? Bundle.main.object(forInfoDictionaryKey: "CFBundleExecutable") as? String
+      ?? "Expo Go"
+  }
+
+  private func formattedAppVersion() -> String {
+    let shortVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
+    let buildVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? ""
+    return "\(shortVersion) (\(buildVersion))"
+  }
+
+  private func bundleAppIcon() -> String {
+    guard let iconFiles = (Bundle.main.infoDictionary?["CFBundleIcons"] as? [String: Any])?["CFBundlePrimaryIcon"] as? [String: Any],
+          let iconName = (iconFiles["CFBundleIconFiles"] as? [String])?.last else {
+      return ""
+    }
+    let resourcePath = Bundle.main.resourcePath ?? ""
+    return "file://" + resourcePath + "/" + iconName + ".png"
+  }
+
+  private func resolveEngine() -> String {
+    #if USE_HERMES
+    return "Hermes"
+    #else
+    return "JSC"
+    #endif
+  }
+}

--- a/apps/expo-go/ios/Exponent/DevMenu/DevMenuPreferences.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/DevMenuPreferences.swift
@@ -1,0 +1,98 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+
+private let motionGestureEnabledKey = "EXDevMenuMotionGestureEnabled"
+private let touchGestureEnabledKey = "EXDevMenuTouchGestureEnabled"
+private let keyCommandsEnabledKey = "EXDevMenuKeyCommandsEnabled"
+private let showsAtLaunchKey = "EXDevMenuShowsAtLaunch"
+private let isOnboardingFinishedKey = "EXDevMenuIsOnboardingFinished"
+private let showFloatingActionButtonKey = "EXDevMenuShowFloatingActionButton"
+
+class DevMenuPreferences {
+  /*
+   Initializes dev menu preferences by registering user defaults.
+   */
+  static func setup() {
+    UserDefaults.standard.register(defaults: [
+      motionGestureEnabledKey: true,
+      touchGestureEnabledKey: true,
+      keyCommandsEnabledKey: true,
+      showsAtLaunchKey: false,
+      isOnboardingFinishedKey: false,
+      showFloatingActionButtonKey: true
+    ])
+  }
+
+  /**
+   Whether to enable shake gesture.
+   */
+  static var motionGestureEnabled: Bool {
+    get {
+      return UserDefaults.standard.bool(forKey: motionGestureEnabledKey)
+    }
+    set {
+      UserDefaults.standard.set(newValue, forKey: motionGestureEnabledKey)
+    }
+  }
+
+  /**
+   Whether to enable three-finger long press gesture.
+   */
+  static var touchGestureEnabled: Bool {
+    get {
+      return UserDefaults.standard.bool(forKey: touchGestureEnabledKey)
+    }
+    set {
+      UserDefaults.standard.set(newValue, forKey: touchGestureEnabledKey)
+    }
+  }
+
+  /**
+   Whether to enable key commands.
+   */
+  static var keyCommandsEnabled: Bool {
+    get {
+      return UserDefaults.standard.bool(forKey: keyCommandsEnabledKey)
+    }
+    set {
+      UserDefaults.standard.set(newValue, forKey: keyCommandsEnabledKey)
+    }
+  }
+
+  /**
+   Whether to automatically show the dev menu once its delegate is set and the bridge is loaded.
+   */
+  static var showsAtLaunch: Bool {
+    get {
+      return UserDefaults.standard.bool(forKey: showsAtLaunchKey)
+    }
+    set {
+      UserDefaults.standard.set(newValue, forKey: showsAtLaunchKey)
+    }
+  }
+
+  /**
+   Returns `true` only if the user finished onboarding, `false` otherwise.
+   */
+  static var isOnboardingFinished: Bool {
+    get {
+      return UserDefaults.standard.bool(forKey: isOnboardingFinishedKey)
+    }
+    set {
+      UserDefaults.standard.set(newValue, forKey: isOnboardingFinishedKey)
+    }
+  }
+
+  /**
+   Whether to show the floating action button.
+   */
+  static var showFloatingActionButton: Bool {
+    get {
+      return UserDefaults.standard.bool(forKey: showFloatingActionButtonKey)
+    }
+    set {
+      UserDefaults.standard.set(newValue, forKey: showFloatingActionButtonKey)
+    }
+  }
+}

--- a/apps/expo-go/ios/Exponent/DevMenu/DevMenuViewController.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/DevMenuViewController.swift
@@ -1,0 +1,59 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+@MainActor
+class DevMenuViewController: UIViewController {
+  private let manager: DevMenuManager
+  private var hostingController: UIHostingController<DevMenuRootView>?
+
+  init(manager: DevMenuManager) {
+    self.manager = manager
+    super.init(nibName: nil, bundle: nil)
+
+    edgesForExtendedLayout = UIRectEdge.init(rawValue: 0)
+    extendedLayoutIncludesOpaqueBars = true
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    setupSwiftUIView()
+  }
+
+  override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+    return .all
+  }
+
+  override var overrideUserInterfaceStyle: UIUserInterfaceStyle {
+    get {
+      return .unspecified
+    }
+    set {}
+  }
+
+  private func setupSwiftUIView() {
+    let rootView = DevMenuRootView()
+    let hostingController = UIHostingController(rootView: rootView)
+
+    hostingController.view.backgroundColor = .clear
+
+    addChild(hostingController)
+    view.addSubview(hostingController.view)
+    hostingController.didMove(toParent: self)
+
+    hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      hostingController.view.topAnchor.constraint(equalTo: view.topAnchor),
+      hostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+    ])
+
+    self.hostingController = hostingController
+  }
+}

--- a/apps/expo-go/ios/Exponent/DevMenu/DevMenuWindow.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/DevMenuWindow.swift
@@ -1,0 +1,126 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+@MainActor
+class DevMenuWindow: UIWindow, UISheetPresentationControllerDelegate {
+  private let manager: DevMenuManager
+  private let devMenuViewController: DevMenuViewController
+  private var isPresenting = false
+  private var isDismissing = false
+
+  required init(manager: DevMenuManager) {
+    self.manager = manager
+    self.devMenuViewController = DevMenuViewController(manager: manager)
+
+    super.init(frame: .zero)
+
+    self.rootViewController = UIViewController()
+    self.backgroundColor = UIColor(white: 0, alpha: 0.4)
+    self.windowLevel = .statusBar
+    self.isHidden = true
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func becomeKey() {
+    super.becomeKey()
+    if !isPresenting && !isDismissing {
+      presentDevMenu()
+    }
+  }
+
+  private func presentDevMenu() {
+    guard !isPresenting && !isDismissing else {
+      return
+    }
+
+    guard let rootVC = self.rootViewController, rootVC.presentedViewController == nil else {
+      return
+    }
+
+    guard rootVC.isViewLoaded && rootVC.view.window != nil else {
+      return
+    }
+
+    isPresenting = true
+    devMenuViewController.modalPresentationStyle = .pageSheet
+
+    if #available(iOS 15.0, *) {
+      if let sheet = devMenuViewController.sheetPresentationController {
+        if #available(iOS 16.0, *) {
+          sheet.detents = [
+            .custom(resolver: { context in
+              return context.maximumDetentValue * 0.6
+            }),
+            .large()
+          ]
+        } else {
+          sheet.detents = [.medium(), .large()]
+        }
+
+        sheet.largestUndimmedDetentIdentifier = .large
+        sheet.prefersEdgeAttachedInCompactHeight = true
+        sheet.delegate = self
+      }
+    }
+
+    rootVC.present(devMenuViewController, animated: true) { [weak self] in
+      self?.isPresenting = false
+    }
+  }
+
+  func closeBottomSheet(_ completion: (() -> Void)? = nil) {
+    guard !isDismissing && !isPresenting else {
+      return
+    }
+    isDismissing = true
+
+    resetScrollPosition()
+    UIView.animate(withDuration: 0.3) {
+      self.backgroundColor = .clear
+    }
+
+    devMenuViewController.dismiss(animated: true) {
+      self.isDismissing = false
+      self.isHidden = true
+      self.backgroundColor = UIColor(white: 0, alpha: 0.4)
+      self.manager.updateFABVisibility()
+      completion?()
+    }
+  }
+
+  private func resetScrollPosition() {
+    if let scrollView = findScrollView(in: devMenuViewController.view) {
+      scrollView.setContentOffset(.zero, animated: false)
+    }
+  }
+
+  private func findScrollView(in view: UIView) -> UIScrollView? {
+    if let scrollView = view as? UIScrollView {
+      return scrollView
+    }
+
+    for subview in view.subviews {
+      if let scrollView = findScrollView(in: subview) {
+        return scrollView
+      }
+    }
+
+    return nil
+  }
+
+  override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+    let view = super.hitTest(point, with: event)
+    if view == self.rootViewController?.view && event?.type == .touches {
+      manager.hideMenu()
+      return self.rootViewController?.view
+    }
+    return view
+  }
+
+  func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+    manager.hideMenu()
+  }
+}

--- a/apps/expo-go/ios/Exponent/DevMenu/FAB/DevMenuFABView.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/FAB/DevMenuFABView.swift
@@ -1,0 +1,291 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+enum FABConstants {
+  static let iconSize: CGFloat = 44
+  static let margin: CGFloat = 10
+  static let verticalPadding: CGFloat = 0
+  static let dragThreshold: CGFloat = 10
+  static let momentumFactor: CGFloat = 0.35
+  static let labelDismissDelay: TimeInterval = 10
+  static let idleTimeout: UInt64 = 5_000_000_000
+  static let imageSize: CGFloat = 26
+
+  static let snapAnimation: Animation = .spring(
+    response: 0.6,
+    dampingFraction: 0.7,
+    blendDuration: 0
+  )
+}
+
+struct FabPill: View {
+  @Binding var isPressed: Bool
+  @Binding var isDragging: Bool
+  @State private var showLabel = true
+  @State private var isIdle = false
+  @State private var idleTask: Task<Void, Never>?
+
+  private var isInteracting: Bool {
+    isPressed || isDragging
+  }
+
+  var body: some View {
+    VStack(spacing: 8) {
+      actionButton
+        .scaleEffect(isPressed ? 0.9 : 1.0)
+        .animation(.easeInOut(duration: 0.1), value: isPressed)
+        .onChange(of: isInteracting) { interacting in
+          if interacting {
+            idleTask?.cancel()
+            withAnimation {
+              isIdle = false
+            }
+          } else {
+            startIdleTimer()
+          }
+        }
+        .onAppear {
+          startIdleTimer()
+        }
+
+      if showLabel {
+        Text("Tools")
+          .font(.system(size: 11, weight: .medium))
+          .foregroundStyle(.secondary)
+          .fixedSize()
+          .padding(.horizontal, 8)
+          .padding(.vertical, 3)
+          .background(.regularMaterial, in: Capsule())
+          .transition(.opacity.combined(with: .scale(scale: 0.8)))
+      }
+    }
+    .saturation(isIdle ? 0 : 1)
+    .opacity(isIdle ? 0.5 : 1)
+    .animation(.easeInOut(duration: 0.3), value: isIdle)
+    .task {
+      try? await Task.sleep(nanoseconds: UInt64(1_000_000_000 * FABConstants.labelDismissDelay))
+      await MainActor.run {
+        withAnimation(.easeOut(duration: 0.3)) {
+          showLabel = false
+        }
+      }
+    }
+  }
+
+  private func startIdleTimer() {
+    idleTask?.cancel()
+    idleTask = Task {
+      try? await Task.sleep(nanoseconds: FABConstants.idleTimeout)
+      guard !Task.isCancelled else { return }
+      await MainActor.run {
+        withAnimation {
+          isIdle = true
+        }
+      }
+    }
+  }
+
+  private var actionButton: some View {
+    Image(systemName: "gearshape.fill")
+      .resizable()
+      .frame(width: FABConstants.imageSize, height: FABConstants.imageSize)
+      .foregroundStyle(.white)
+      .frame(width: FABConstants.iconSize, height: FABConstants.iconSize)
+      .background(Color.blue, in: Circle())
+      .background(
+        Circle()
+          .stroke(Color.blue.opacity(0.5), lineWidth: 4)
+          .frame(width: FABConstants.iconSize + 4, height: FABConstants.iconSize + 4)
+      )
+      .shadow(color: .black.opacity(0.4), radius: 8, x: 0, y: 4)
+  }
+}
+
+struct DevMenuFABView: View {
+  let onOpenMenu: () -> Void
+  let onFrameChange: (CGRect) -> Void
+
+  private let fabSize = CGSize(width: 72, height: FABConstants.iconSize + 50)
+
+  // UserDefaults keys for persisting position
+  private static let positionXKey = "DevMenuFAB.positionX"
+  private static let positionYKey = "DevMenuFAB.positionY"
+  private static let hasStoredPositionKey = "DevMenuFAB.hasStoredPosition"
+
+  private static func loadStoredPosition() -> CGPoint? {
+    guard UserDefaults.standard.bool(forKey: hasStoredPositionKey) else { return nil }
+    let x = UserDefaults.standard.double(forKey: positionXKey)
+    let y = UserDefaults.standard.double(forKey: positionYKey)
+    return CGPoint(x: x, y: y)
+  }
+
+  private static func savePosition(_ position: CGPoint) {
+    UserDefaults.standard.set(position.x, forKey: positionXKey)
+    UserDefaults.standard.set(position.y, forKey: positionYKey)
+    UserDefaults.standard.set(true, forKey: hasStoredPositionKey)
+  }
+
+  @State private var position: CGPoint = .zero
+  @State private var isDragging = false
+  @State private var isPressed = false
+  @State private var dragStartPosition: CGPoint = .zero
+
+  // Get safe area from window since .ignoresSafeArea() may zero out geometry values
+  private var windowSafeArea: UIEdgeInsets {
+    guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+          let window = windowScene.windows.first else {
+      return .zero
+    }
+    return window.safeAreaInsets
+  }
+
+  private let dragSpring: Animation = .spring(
+    response: 0.25,
+    dampingFraction: 0.85,
+    blendDuration: 0
+  )
+
+  private var currentFrame: CGRect {
+    CGRect(origin: position, size: fabSize)
+  }
+
+  var body: some View {
+    GeometryReader { geometry in
+      // Use window safe area - geometry values may be incorrect initially or due to .ignoresSafeArea()
+      let safeArea = EdgeInsets(
+        top: windowSafeArea.top,
+        leading: windowSafeArea.left,
+        bottom: windowSafeArea.bottom,
+        trailing: windowSafeArea.right
+      )
+
+      FabPill(isPressed: $isPressed, isDragging: $isDragging)
+        .frame(width: fabSize.width, height: fabSize.height)
+        .position(x: currentFrame.midX, y: currentFrame.midY)
+        .gesture(dragGesture(bounds: geometry.size, safeArea: safeArea))
+        .onAppear {
+          let initialPos: CGPoint
+          if let storedPos = Self.loadStoredPosition() {
+            let margin = FABConstants.margin
+            let minX = margin / 2
+            let maxX = geometry.size.width - fabSize.width - margin / 2
+            let minY = safeArea.top + FABConstants.verticalPadding
+            let maxY = geometry.size.height - fabSize.height - safeArea.bottom - FABConstants.verticalPadding
+
+            initialPos = CGPoint(
+              x: storedPos.x.clamped(to: minX...maxX),
+              y: storedPos.y.clamped(to: minY...maxY)
+            )
+          } else {
+            initialPos = defaultPosition(bounds: geometry.size, safeArea: safeArea)
+          }
+          position = initialPos
+          onFrameChange(CGRect(origin: initialPos, size: fabSize))
+        }
+        .onChange(of: geometry.size) { newSize in
+          let newPos = snapToEdge(
+            from: position,
+            velocity: .zero,
+            bounds: newSize,
+            safeArea: safeArea
+          )
+          position = newPos
+          onFrameChange(CGRect(origin: newPos, size: fabSize))
+        }
+        .animation(isDragging ? dragSpring : FABConstants.snapAnimation, value: position)
+    }
+    .ignoresSafeArea()
+  }
+
+  private func dragGesture(bounds: CGSize, safeArea: EdgeInsets) -> some Gesture {
+    DragGesture(minimumDistance: 0)
+      .onChanged { value in
+        if !isPressed {
+          isPressed = true
+        }
+        if !isDragging && value.translation.magnitude > FABConstants.dragThreshold {
+          isDragging = true
+          isPressed = false
+          dragStartPosition = position
+        }
+        if isDragging {
+          let rawX = dragStartPosition.x + value.translation.width
+          let rawY = dragStartPosition.y + value.translation.height
+
+          position = CGPoint(x: rawX, y: rawY)
+          onFrameChange(currentFrame)
+        }
+      }
+      .onEnded { value in
+        isPressed = false
+        let dragDistance = value.translation.magnitude
+
+        if dragDistance < FABConstants.dragThreshold {
+          isDragging = false
+          onOpenMenu()
+        } else {
+          let velocity = CGPoint(
+            x: value.predictedEndLocation.x - value.location.x,
+            y: value.predictedEndLocation.y - value.location.y
+          )
+
+          let newPos = snapToEdge(
+            from: position,
+            velocity: velocity,
+            bounds: bounds,
+            safeArea: safeArea
+          )
+
+          DispatchQueue.main.async {
+            isDragging = false
+            position = newPos
+            Self.savePosition(newPos)
+            onFrameChange(CGRect(origin: newPos, size: fabSize))
+          }
+        }
+      }
+  }
+
+  private func defaultPosition(bounds: CGSize, safeArea: EdgeInsets) -> CGPoint {
+    CGPoint(
+      x: bounds.width - fabSize.width - FABConstants.margin / 2,
+      y: safeArea.top + FABConstants.verticalPadding
+    )
+  }
+
+  private func snapToEdge(
+    from point: CGPoint,
+    velocity: CGPoint,
+    bounds: CGSize,
+    safeArea: EdgeInsets
+  ) -> CGPoint {
+    let margin = FABConstants.margin
+    let edgeMargin = margin / 2  // Closer to screen edge when snapped
+    let momentumX = velocity.x * FABConstants.momentumFactor
+    let momentumY = velocity.y * FABConstants.momentumFactor
+
+    let estimatedCenterX = point.x + self.fabSize.width / 2 + momentumX
+    let targetX: CGFloat = estimatedCenterX < bounds.width / 2
+      ? edgeMargin
+    : bounds.width - self.fabSize.width - edgeMargin
+
+    let minY = safeArea.top + FABConstants.verticalPadding
+    let maxY = bounds.height - self.fabSize.height - safeArea.bottom - FABConstants.verticalPadding
+    let targetY = (point.y + momentumY).clamped(to: minY...maxY)
+
+    return CGPoint(x: targetX, y: targetY)
+  }
+}
+
+private extension CGSize {
+  var magnitude: CGFloat {
+    sqrt(width * width + height * height)
+  }
+}
+
+private extension Comparable {
+  func clamped(to range: ClosedRange<Self>) -> Self {
+    min(max(self, range.lowerBound), range.upperBound)
+  }
+}

--- a/apps/expo-go/ios/Exponent/DevMenu/FAB/DevMenuFABWindow.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/FAB/DevMenuFABWindow.swift
@@ -1,0 +1,107 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import UIKit
+import SwiftUI
+
+/// A passthrough window that hosts the floating action button.
+class DevMenuFABWindow: UIWindow {
+  private weak var manager: DevMenuManager?
+  private var hostingController: UIHostingController<DevMenuFABView>?
+  var fabFrame: CGRect = .zero
+  private var currentAnimator: UIViewPropertyAnimator?
+  private var targetVisibility: Bool?
+
+  init(manager: DevMenuManager, windowScene: UIWindowScene) {
+    self.manager = manager
+    super.init(windowScene: windowScene)
+    setupWindow()
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  private func setupWindow() {
+    windowLevel = UIWindow.Level.statusBar - 1
+    backgroundColor = .clear
+    isHidden = true
+    alpha = 0
+
+    let fabView = DevMenuFABView(
+      onOpenMenu: { [weak self] in
+        self?.manager?.openMenu()
+      },
+      onFrameChange: { [weak self] frame in
+        self?.fabFrame = frame
+      }
+    )
+
+    let hostingController = UIHostingController(rootView: fabView)
+    hostingController.view.backgroundColor = .clear
+    self.hostingController = hostingController
+    rootViewController = hostingController
+  }
+
+  private var edgeTranslation: CGAffineTransform {
+    let screenWidth = windowScene?.screen.bounds.width ?? UIScreen.main.bounds.width
+    let isOnRight = fabFrame == .zero || fabFrame.midX > (screenWidth / 2)
+    let dx: CGFloat = isOnRight ? 60 : -60
+    return CGAffineTransform(translationX: dx, y: 0)
+  }
+
+  func setVisible(_ visible: Bool, animated: Bool = true) {
+    // Skip if already animating to the same state
+    if targetVisibility == visible {
+      return
+    }
+
+    // Cancel any in-progress animation and reset to clean state
+    if currentAnimator != nil {
+      currentAnimator?.stopAnimation(true)
+      currentAnimator = nil
+      transform = .identity
+    }
+
+    targetVisibility = visible
+
+    if visible {
+      isHidden = false
+      alpha = 0
+      transform = edgeTranslation
+
+      let animator = UIViewPropertyAnimator(duration: animated ? 0.5 : 0, dampingRatio: 0.6) {
+        self.alpha = 1
+        self.transform = .identity
+      }
+      animator.addCompletion { [weak self] _ in
+        self?.targetVisibility = nil
+      }
+      currentAnimator = animator
+      animator.startAnimation()
+    } else {
+      let animator = UIViewPropertyAnimator(duration: animated ? 0.3 : 0, dampingRatio: 0.8) {
+        self.alpha = 0
+        self.transform = self.edgeTranslation
+      }
+      animator.addCompletion { [weak self] position in
+        self?.targetVisibility = nil
+        if position == .end {
+          self?.isHidden = true
+          self?.transform = .identity
+        }
+      }
+      currentAnimator = animator
+      animator.startAnimation()
+    }
+  }
+
+  override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+    let hitArea = fabFrame.insetBy(dx: -10, dy: -10)
+    if hitArea.contains(point) {
+      return super.hitTest(point, with: event)
+    }
+
+    return nil
+  }
+}

--- a/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/DevMenuActions.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/DevMenuActions.swift
@@ -1,0 +1,29 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+struct DevMenuActions: View {
+  let canNavigateHome: Bool
+  let onReload: () -> Void
+  let onGoHome: () -> Void
+
+  var body: some View {
+    HStack {
+      DevMenuActionButton(
+        title: "Reload",
+        icon: "arrow.clockwise",
+        action: onReload
+      )
+      .cornerRadius(18)
+
+      if canNavigateHome {
+        DevMenuActionButton(
+          title: "Go home",
+          icon: "house.fill",
+          action: onGoHome
+        )
+        .cornerRadius(18)
+      }
+    }
+  }
+}

--- a/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/DevMenuAppInfo.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/DevMenuAppInfo.swift
@@ -1,0 +1,70 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+// swiftlint:disable closure_body_length
+
+struct DevMenuAppInfo: View {
+  @EnvironmentObject var viewModel: DevMenuViewModel
+
+  var body: some View {
+    VStack(alignment: .leading) {
+      Text("SYSTEM")
+        .font(.caption)
+        .foregroundColor(.primary.opacity(0.6))
+
+      VStack(spacing: 0) {
+        InfoRow(title: "Version", value: viewModel.appInfo?.appVersion ?? "Unknown")
+
+        if let runtimeVersion = viewModel.appInfo?.runtimeVersion {
+          Divider()
+          InfoRow(title: "Runtime version", value: runtimeVersion)
+        } else if let sdkVersion = viewModel.appInfo?.sdkVersion {
+          Divider()
+          InfoRow(title: "SDK Version", value: sdkVersion)
+        }
+
+        Divider()
+
+        Button {
+          viewModel.copyAppInfo()
+        }
+        label: {
+          HStack {
+            Text(viewModel.clipboardMessage ?? "Copy system info")
+              .foregroundColor(.blue)
+            Spacer()
+            Image(systemName: "document.on.clipboard")
+              .resizable()
+              .frame(width: 16, height: 16)
+              .opacity(0.6)
+          }
+          .padding(.vertical)
+          .disabled(viewModel.clipboardMessage != nil)
+        }
+      }
+      .padding(.horizontal)
+      .background(Color.expoSecondarySystemBackground, in: RoundedRectangle(cornerRadius: 18))
+    }
+  }
+}
+
+struct InfoRow: View {
+  let title: String
+  let value: String
+
+  var body: some View {
+    HStack {
+      Text(title)
+        .foregroundColor(.primary)
+
+      Spacer()
+
+      Text(value)
+        .foregroundColor(.primary)
+        .lineLimit(2)
+    }
+    .padding(.vertical)
+  }
+}
+// swiftlint:enable closure_body_length

--- a/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/DevMenuButtons.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/DevMenuButtons.swift
@@ -1,0 +1,83 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+struct DevMenuActionButton: View {
+  let title: String
+  let icon: String
+  let action: () -> Void
+  let disabled: Bool
+
+  init(title: String, icon: String, action: @escaping () -> Void, disabled: Bool = false) {
+    self.title = title
+    self.icon = icon
+    self.action = action
+    self.disabled = disabled
+  }
+
+  var body: some View {
+    Button { action() }
+    label: {
+      HStack {
+        Image(systemName: icon)
+          .frame(width: 24, height: 24)
+          .foregroundColor(disabled ? .secondary : .primary)
+          .opacity(0.6)
+
+        Text(title)
+          .foregroundColor(disabled ? .secondary : .primary)
+
+        Spacer()
+      }
+      .padding()
+    }
+    .disabled(disabled)
+    .background(Color.expoSecondarySystemBackground)
+    .opacity(disabled ? 0.6 : 1.0)
+  }
+}
+
+struct DevMenuToggleButton: View {
+  let title: String
+  let icon: String
+  let isEnabled: Bool
+  let action: () -> Void
+  let disabled: Bool
+
+  init(title: String, icon: String, isEnabled: Bool, action: @escaping () -> Void, disabled: Bool = false) {
+    self.title = title
+    self.icon = icon
+    self.isEnabled = isEnabled
+    self.action = action
+    self.disabled = disabled
+  }
+
+  var body: some View {
+    HStack {
+      Image(systemName: icon)
+        .frame(width: 24, height: 24)
+        .foregroundColor(disabled ? .secondary : .primary)
+        .opacity(0.6)
+
+      Text(title)
+        .foregroundColor(disabled ? .secondary : .primary)
+        .lineLimit(1)
+        .minimumScaleFactor(0.8)
+
+      Spacer()
+
+      Toggle("", isOn: Binding(
+        get: { isEnabled && !disabled },
+        set: { _ in if !disabled { action() } }
+      ))
+      .disabled(disabled)
+    }
+    .padding()
+    .background(Color.expoSecondarySystemBackground)
+    .opacity(disabled ? 0.6 : 1.0)
+  }
+}
+
+#Preview {
+  DevMenuActionButton(title: "Action", icon: "person.fast") {}
+}

--- a/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/DevMenuColors.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/DevMenuColors.swift
@@ -1,0 +1,21 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import SwiftUI
+import UIKit
+
+struct DevMenuColors {
+  let colorScheme: ColorScheme
+
+  // Tip colors (blue.11 and blue.3)
+  var tipBlue: Color {
+    let darkColor = UIColor(displayP3Red: 0.49, green: 0.72, blue: 1.0, alpha: 1.0)
+    let lightColor = UIColor(displayP3Red: 0.15, green: 0.44, blue: 0.84, alpha: 1.0)
+    return Color(colorScheme == .dark ? darkColor : lightColor)
+  }
+
+  var tipBackground: Color {
+    let darkColor = UIColor(displayP3Red: 0.078, green: 0.154, blue: 0.27, alpha: 1.0)
+    let lightColor = UIColor(displayP3Red: 0.912, green: 0.956, blue: 0.991, alpha: 1.0)
+    return Color(colorScheme == .dark ? darkColor : lightColor)
+  }
+}

--- a/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/DevMenuDeveloperTools.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/DevMenuDeveloperTools.swift
@@ -1,0 +1,96 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+// swiftlint:disable closure_body_length
+
+struct DevMenuDeveloperTools: View {
+  @EnvironmentObject var viewModel: DevMenuViewModel
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("TOOLS")
+        .font(.caption)
+        .foregroundColor(.primary.opacity(0.6))
+
+      VStack(spacing: 0) {
+        NavigationLink(destination: SourceMapExplorerView()) {
+          HStack {
+            Image(systemName: "map")
+              .frame(width: 24, height: 24)
+              .foregroundColor(.primary)
+              .opacity(0.6)
+
+            Text("Source code explorer")
+              .foregroundColor(.primary)
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+          .padding()
+          .background(Color.expoSecondarySystemBackground)
+        }
+        .buttonStyle(.plain)
+
+        Divider()
+
+        DevMenuActionButton(
+          title: "Toggle performance monitor",
+          icon: "speedometer",
+          action: viewModel.togglePerformanceMonitor,
+          disabled: !(viewModel.devSettings?.isPerfMonitorAvailable ?? true)
+        )
+
+        Divider()
+
+        DevMenuActionButton(
+          title: "Toggle element inspector",
+          icon: "viewfinder",
+          action: viewModel.toggleElementInspector,
+          disabled: !(viewModel.devSettings?.isElementInspectorAvailable ?? true)
+        )
+
+        if viewModel.devSettings?.isJSInspectorAvailable == true {
+          Divider()
+
+          DevMenuActionButton(
+            title: "Open DevTools",
+            icon: "chevron.left.chevron.right",
+            action: viewModel.openJSInspector
+          )
+        }
+
+        if viewModel.showFastRefresh {
+          Divider()
+
+          DevMenuToggleButton(
+            title: "Fast refresh",
+            icon: "figure.run",
+            isEnabled: viewModel.devSettings?.isHotLoadingEnabled ?? false,
+            action: viewModel.toggleFastRefresh,
+            disabled: !(viewModel.devSettings?.isHotLoadingAvailable ?? true)
+          )
+        }
+
+        Divider()
+
+        DevMenuToggleButton(
+          title: "Tools button",
+          icon: "hand.tap",
+          isEnabled: viewModel.showFloatingActionButton,
+          action: viewModel.toggleFloatingActionButton
+        )
+      }
+      .background(Color.expoSecondarySystemBackground, in: RoundedRectangle(cornerRadius: 18))
+    }
+  }
+}
+
+#Preview {
+  DevMenuDeveloperTools()
+}
+
+// swiftlint:enable closure_body_length

--- a/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/DevMenuMainView.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/DevMenuMainView.swift
@@ -1,0 +1,40 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+struct DevMenuMainView: View {
+  @EnvironmentObject var viewModel: DevMenuViewModel
+
+  var body: some View {
+    ScrollView {
+      VStack(spacing: 32) {
+        DevMenuActions(
+          canNavigateHome: true,
+          onReload: viewModel.reload,
+          onGoHome: viewModel.goHome
+        )
+
+        DevMenuDeveloperTools()
+
+        if viewModel.showDebuggingTip && viewModel.appInfo?.engine == "Hermes" {
+          HermesDebuggerTip()
+        }
+
+        if viewModel.showHostUrl, let hostUrl = viewModel.appInfo?.hostUrl {
+          HostUrl(
+            hostUrl: hostUrl,
+            onCopy: viewModel.copyToClipboard,
+            copiedMessage: viewModel.hostUrlCopiedMessage
+          )
+        }
+
+        DevMenuAppInfo()
+      }
+      .padding()
+    }
+    .environmentObject(viewModel)
+    .navigationTitle("Dev Menu")
+    .navigationBarHidden(true)
+    .navigationBarTitleDisplayMode(.inline)
+  }
+}

--- a/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/DevMenuModels.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/DevMenuModels.swift
@@ -1,0 +1,19 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+struct AppInfo {
+  let appName: String
+  let appVersion: String
+  let runtimeVersion: String?
+  let sdkVersion: String?
+  let hostUrl: String?
+  let appIcon: String?
+  let engine: String?
+}
+
+struct DevSettings {
+  let isElementInspectorAvailable: Bool
+  let isHotLoadingAvailable: Bool
+  let isPerfMonitorAvailable: Bool
+  let isJSInspectorAvailable: Bool
+  let isHotLoadingEnabled: Bool
+}

--- a/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/DevMenuOnboardingView.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/DevMenuOnboardingView.swift
@@ -1,0 +1,87 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+struct DevMenuOnboardingView: View {
+  let onFinish: () -> Void
+  @State private var isVisible = true
+
+  var body: some View {
+    Rectangle()
+      .fill(.ultraThinMaterial)
+      .ignoresSafeArea()
+      .overlay(OnboardingOverlay(onFinish: onFinish, isVisible: $isVisible))
+      .offset(x: 0, y: isVisible ? 0.0 : 650.0)
+      .animation(.easeInOut(duration: 0.5), value: isVisible)
+  }
+}
+
+private struct OnboardingOverlay: View {
+  let onFinish: () -> Void
+  @Binding var isVisible: Bool
+
+  var body: some View {
+    ScrollView {
+      VStack(spacing: 16) {
+        Image(systemName: "wrench.and.screwdriver")
+          .resizable()
+          .scaledToFit()
+          .frame(height: 80)
+          .frame(maxWidth: .infinity)
+          .padding(.vertical, 20)
+          .background(Color.black)
+          .foregroundColor(.white)
+          .cornerRadius(12)
+
+        VStack(spacing: 12) {
+          Text("This is the developer menu. It gives you access to useful tools in Expo Go.")
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .font(.callout)
+
+#if targetEnvironment(simulator)
+          VStack(spacing: 4) {
+            Text("You can open it at any time by pressing the blue button with the gear icon, or with the **⌃ + d** keyboard shortcut.")
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .font(.callout)
+
+            Text("(Connect Hardware Keyboard must be enabled on your simulator to use this shortcut, you can toggle it with **⌘ + shift + K**.)")
+              .foregroundColor(.secondary)
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .font(.footnote)
+          }
+#else
+          Text("You can shake your device or long press anywhere on the screen with three fingers to get back to it at any time.")
+            .foregroundColor(.primary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+#endif
+        }
+
+        ContinueButton(onFinish: onFinish, isVisible: $isVisible)
+      }
+      .padding()
+    }
+  }
+}
+
+private struct ContinueButton: View {
+  let onFinish: () -> Void
+  @Binding var isVisible: Bool
+
+  var body: some View {
+    Button {
+      withAnimation(.easeInOut(duration: 0.3)) {
+        isVisible = false
+      }
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+        onFinish()
+      }
+    }
+    label: {
+      Text("Continue")
+        .font(.system(size: 16, weight: .semibold))
+        .frame(maxWidth: .infinity)
+        .frame(height: 32)
+    }
+    .buttonStyle(.borderedProminent)
+  }
+}

--- a/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/DevMenuRootView.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/DevMenuRootView.swift
@@ -1,0 +1,39 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+struct DevMenuRootView: View {
+  @StateObject private var viewModel = DevMenuViewModel(manager: DevMenuManager.shared)
+  @State private var navigationId = UUID()
+
+  var body: some View {
+    let mainView = VStack(spacing: 0) {
+      HeaderView()
+        .environmentObject(viewModel)
+
+      ZStack {
+        DevMenuMainView()
+          .environmentObject(viewModel)
+
+        if !viewModel.isOnboardingFinished {
+          DevMenuOnboardingView(
+            onFinish: viewModel.finishOnboarding
+          )
+        }
+      }
+    }
+
+    NavigationView {
+      mainView
+    }
+    .navigationViewStyle(.stack)
+    .id(navigationId)
+    .onReceive(DevMenuManager.shared.menuWillShowPublisher) { _ in
+      navigationId = UUID()
+    }
+  }
+}
+
+#Preview {
+  DevMenuRootView()
+}

--- a/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/DevMenuViewModel.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/DevMenuViewModel.swift
@@ -1,0 +1,154 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+import Combine
+
+@MainActor
+class DevMenuViewModel: ObservableObject {
+  @Published var appInfo: AppInfo?
+  @Published var devSettings: DevSettings?
+  @Published var clipboardMessage: String?
+  @Published var hostUrlCopiedMessage: String?
+  @Published var isOnboardingFinished: Bool = true
+  @Published var showFloatingActionButton: Bool = false
+  @Published var showDebuggingTip: Bool = false
+  @Published var showFastRefresh: Bool = false
+  @Published var showHostUrl: Bool = false
+
+  private let manager: DevMenuManager
+  private var cancellables = Set<AnyCancellable>()
+
+  var canNavigateHome: Bool {
+    return true
+  }
+
+  init(manager: DevMenuManager) {
+    self.manager = manager
+    loadData()
+    checkOnboardingStatus()
+    observeManifestChanges()
+  }
+
+  private func loadData() {
+    loadAppInfo()
+    loadDevSettings()
+    loadFloatingActionButtonState()
+    updateSectionVisibility()
+  }
+
+  private func loadAppInfo() {
+    self.appInfo = manager.getAppInfo()
+  }
+
+  private func loadDevSettings() {
+    self.devSettings = manager.getDevSettings()
+  }
+
+  private func updateSectionVisibility() {
+    let manifest = manager.currentManifest
+    let isDev = manifest?.isDevelopmentMode() == true || manifest?.isUsingDeveloperTool() == true
+    showDebuggingTip = isDev
+    showFastRefresh = isDev
+    showHostUrl = !isDev && manager.isCurrentAppSnack
+  }
+
+  func hideMenu() {
+    manager.hideMenu()
+  }
+
+  func reload() {
+    manager.reload()
+  }
+
+  func goHome() {
+    manager.closeMenu()
+    manager.goHome()
+  }
+
+  func togglePerformanceMonitor() {
+    manager.togglePerformanceMonitor()
+    manager.closeMenu()
+  }
+
+  func toggleElementInspector() {
+    manager.toggleElementInspector()
+    manager.closeMenu()
+  }
+
+  func openJSInspector() {
+    manager.openJSInspector()
+    manager.closeMenu()
+  }
+
+  func toggleFastRefresh() {
+    manager.toggleFastRefresh()
+    loadDevSettings()
+  }
+
+  func copyToClipboard(_ content: String) {
+    UIPasteboard.general.string = content
+    hostUrlCopiedMessage = "Copied!"
+
+    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+      self.hostUrlCopiedMessage = nil
+    }
+  }
+
+  func copyAppInfo() {
+    guard let appInfo = appInfo else {
+      return
+    }
+
+    var info: [String: String] = [
+      "appName": appInfo.appName,
+      "appVersion": appInfo.appVersion
+    ]
+
+    if let runtimeVersion = appInfo.runtimeVersion {
+      info["runtimeVersion"] = runtimeVersion
+    }
+
+    if let sdkVersion = appInfo.sdkVersion {
+      info["sdkVersion"] = sdkVersion
+    }
+
+    let jsonData = try? JSONSerialization.data(withJSONObject: info, options: .prettyPrinted)
+    let jsonString = jsonData.flatMap { String(data: $0, encoding: .utf8) } ?? "Unable to serialize app info"
+
+    UIPasteboard.general.string = jsonString
+    clipboardMessage = "Copied to clipboard!"
+
+    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+      self.clipboardMessage = nil
+    }
+  }
+
+  func finishOnboarding() {
+    manager.setOnboardingFinished(true)
+    isOnboardingFinished = true
+  }
+
+  private func checkOnboardingStatus() {
+    isOnboardingFinished = manager.isOnboardingFinished
+  }
+
+  private func loadFloatingActionButtonState() {
+    showFloatingActionButton = DevMenuPreferences.showFloatingActionButton
+  }
+
+  func toggleFloatingActionButton() {
+    showFloatingActionButton.toggle()
+    DevMenuPreferences.showFloatingActionButton = showFloatingActionButton
+  }
+
+  private func observeManifestChanges() {
+    manager.manifestPublisher
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] _ in
+        self?.loadAppInfo()
+        self?.loadDevSettings()
+        self?.updateSectionVisibility()
+      }
+      .store(in: &cancellables)
+  }
+}

--- a/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/HeaderView.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/HeaderView.swift
@@ -1,0 +1,93 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import SwiftUI
+import UIKit
+
+struct HeaderView: View {
+  @EnvironmentObject var viewModel: DevMenuViewModel
+  @State private var appIcon: UIImage?
+
+  var body: some View {
+    HStack(spacing: 12) {
+      if let icon = appIcon {
+        Image(uiImage: icon)
+          .resizable()
+          .scaledToFit()
+          .frame(width: 38, height: 38)
+          .clipShape(RoundedRectangle(cornerRadius: 16))
+      }
+
+      VersionInfo(appInfo: viewModel.appInfo)
+
+      Spacer()
+
+      Button {
+        viewModel.hideMenu()
+      } label: {
+        ZStack {
+          Circle()
+            .fill(Color.expoSystemGray6)
+            .frame(width: 36, height: 36)
+
+          Image(systemName: "xmark")
+            .font(.headline)
+            .tint(.gray.opacity(0.6))
+        }
+      }
+    }
+    .onChange(of: viewModel.appInfo?.appIcon) { newIconPath in
+      Task {
+        await loadIcon(from: newIconPath)
+      }
+    }
+    .task {
+      await loadIcon(from: viewModel.appInfo?.appIcon)
+    }
+    .padding()
+  }
+
+  private func loadIcon(from path: String?) async {
+    guard let path, let url = URL(string: path) else {
+      appIcon = nil
+      return
+    }
+
+    if url.isFileURL {
+      appIcon = UIImage(contentsOfFile: url.path)
+    } else {
+      do {
+        let (data, _) = try await URLSession.shared.data(from: url)
+        if let loadedImage = UIImage(data: data) {
+          appIcon = loadedImage
+        }
+      } catch {
+        appIcon = nil
+      }
+    }
+  }
+}
+
+private struct VersionInfo: View {
+  let appInfo: AppInfo?
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 2) {
+      Text(appInfo?.appName ?? "")
+        .font(.headline)
+        .fontWeight(.bold)
+        .lineLimit(1)
+
+      if let runtimeVersion = appInfo?.runtimeVersion {
+        Text("Runtime version: \(runtimeVersion)")
+          .font(.caption)
+          .foregroundColor(.secondary)
+      }
+
+      if let sdkVersion = appInfo?.sdkVersion {
+        Text("SDK version: \(sdkVersion)")
+          .font(.caption)
+          .foregroundColor(.secondary)
+      }
+    }
+  }
+}

--- a/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/HermesDebuggerTip.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/HermesDebuggerTip.swift
@@ -1,0 +1,30 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+struct HermesDebuggerTip: View {
+  @Environment(\.colorScheme) private var colorScheme
+
+  private var colors: DevMenuColors {
+    DevMenuColors(colorScheme: colorScheme)
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack {
+        Image(systemName: "lightbulb.fill")
+        Text("Tip")
+          .font(.headline)
+
+        Spacer()
+      }
+      .foregroundColor(colors.tipBlue)
+
+      Text("Debugging not working? Try manually reloading first.")
+        .font(.caption)
+    }
+    .padding()
+    .background(colors.tipBackground)
+    .cornerRadius(18)
+  }
+}

--- a/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/HostUrl.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/HostUrl.swift
@@ -1,0 +1,37 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+struct HostUrl: View {
+  let hostUrl: String
+  let onCopy: (String) -> Void
+  let copiedMessage: String?
+
+  var body: some View {
+    Button {
+      onCopy(hostUrl)
+    } label: {
+      HStack {
+        VStack(alignment: .leading) {
+          Text("Connected to:")
+            .font(.subheadline)
+            .foregroundColor(.secondary)
+
+          Text(copiedMessage ?? hostUrl)
+            .font(.subheadline)
+            .foregroundColor(.primary)
+            .lineLimit(2)
+        }
+
+        Spacer()
+
+        Image(systemName: "doc.on.clipboard")
+          .foregroundColor(.secondary.opacity(0.7))
+      }
+      .padding()
+      .background(Color.expoSecondarySystemBackground)
+      .cornerRadius(20)
+    }
+    .buttonStyle(.plain)
+  }
+}

--- a/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/SourceMapExplorerView.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/SourceMapExplorerView.swift
@@ -1,0 +1,519 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+private let toolbarPlacement: ToolbarItemPlacement = .navigationBarTrailing
+
+struct SourceMapExplorerView: View {
+  @StateObject private var viewModel = SourceMapExplorerViewModel()
+  @State private var showNavigationBar = false
+  @State private var showContent = false
+
+  private var isSearching: Bool {
+    !viewModel.searchText.isEmpty
+  }
+
+  private var isLoading: Bool {
+    switch viewModel.loadingState {
+    case .idle, .loading:
+      return true
+    case .loaded, .error:
+      return false
+    }
+  }
+
+  var body: some View {
+    contentView
+      .task {
+        await viewModel.loadSourceMap()
+        // Show nav bar first
+        showNavigationBar = true
+        // Wait for layout to settle, then fade in content
+        DispatchQueue.main.async {
+          withAnimation(.easeOut(duration: 0.2)) {
+            showContent = true
+          }
+        }
+      }
+  }
+
+  @ViewBuilder
+  private var contentView: some View {
+    ZStack {
+      // Content layer
+      switch viewModel.loadingState {
+      case .idle, .loading:
+        Color.clear
+      case .loaded:
+        loadedView
+          .opacity(showContent ? 1 : 0)
+          .animation(.easeOut(duration: 0.2), value: showContent)
+      case .error(let error):
+        errorView(error)
+          .opacity(showContent ? 1 : 0)
+          .animation(.easeOut(duration: 0.2), value: showContent)
+      }
+
+      // Loading overlay - fades out when showContent becomes true
+      loadingView
+        .opacity(showContent ? 0 : 1)
+        .animation(.easeOut(duration: 0.2).delay(0.2), value: showContent)
+        .allowsHitTesting(!showContent)
+    }
+    .navigationTitle(showNavigationBar ? "Source code explorer" : "")
+    .inlineNavigationBar()
+    .navigationBarHidden(!showNavigationBar)
+    .modifier(ConditionalSearchable(isEnabled: showContent, text: $viewModel.searchText))
+  }
+
+  private var loadedView: some View {
+    FolderListView(
+      title: "Source code explorer",
+      nodes: isSearching ? viewModel.filteredFileTree : viewModel.fileTree,
+      sourceMap: viewModel.sourceMap,
+      isSearching: isSearching
+    )
+  }
+
+  private var loadingView: some View {
+    VStack(spacing: 12) {
+      ProgressView()
+      Text("Loading source code...")
+        .font(.subheadline)
+        .foregroundColor(.secondary)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Color(uiColor: .systemGroupedBackground))
+    .ignoresSafeArea()
+  }
+
+  private func errorView(_ error: SourceMapError) -> some View {
+    VStack(spacing: 16) {
+      Image(systemName: "exclamationmark.triangle")
+        .font(.system(size: 40))
+        .foregroundColor(.orange)
+
+      Text("Failed to load source map")
+        .font(.headline)
+
+      Text(error.errorDescription ?? "Unknown error")
+        .font(.subheadline)
+        .foregroundColor(.secondary)
+        .multilineTextAlignment(.center)
+
+      Button("Retry") {
+        Task { await viewModel.loadSourceMap() }
+      }
+      .buttonStyle(.borderedProminent)
+    }
+    .padding()
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+}
+
+private struct ConditionalSearchable: ViewModifier {
+  let isEnabled: Bool
+  @Binding var text: String
+
+  func body(content: Content) -> some View {
+    if isEnabled {
+      content.searchable(text: $text, placement: .automatic, prompt: "Search files")
+    } else {
+      content
+    }
+  }
+}
+
+struct FolderListView: View {
+  let title: String
+  let nodes: [FileTreeNode]
+  let sourceMap: SourceMap?
+  let isSearching: Bool
+
+  var body: some View {
+    List {
+      if nodes.isEmpty {
+        Text(isSearching ? "No files found" : "Empty folder")
+          .foregroundColor(.secondary)
+      } else {
+        ForEach(nodes) { node in
+          NavigationLink(destination: destinationView(for: node)) {
+            FileRow(node: node, showPath: isSearching)
+          }
+        }
+      }
+    }
+    .defaultListStyle()
+    .navigationTitle(isSearching ? "Search Results" : title)
+    .inlineNavigationBar()
+  }
+
+  @ViewBuilder
+  private func destinationView(for node: FileTreeNode) -> some View {
+    if node.isDirectory {
+      FolderListView(
+        title: node.name,
+        nodes: node.children,
+        sourceMap: sourceMap,
+        isSearching: false
+      )
+    } else {
+      CodeFileView(node: node, sourceMap: sourceMap)
+    }
+  }
+}
+
+struct FileRow: View {
+  let node: FileTreeNode
+  var showPath: Bool = false
+
+  private var parentDirectory: String? {
+    let path = node.path
+    guard let lastSlash = path.lastIndex(of: "/") else { return nil }
+    let parent = String(path[..<lastSlash])
+    return parent.isEmpty ? nil : parent
+  }
+
+  var body: some View {
+    Label {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(node.name)
+          .lineLimit(1)
+        if showPath, let parent = parentDirectory {
+          Text(parent)
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .lineLimit(1)
+        }
+      }
+    } icon: {
+      Image(systemName: node.isDirectory ? "folder.fill" : fileIcon)
+        .foregroundColor(node.isDirectory ? .blue : iconColor)
+    }
+  }
+
+  private var fileIcon: String {
+    let ext = (node.name as NSString).pathExtension.lowercased()
+    switch ext {
+    case "ts", "tsx", "js", "jsx": return "curlybraces"
+    case "json": return "doc.text"
+    case "css", "scss", "sass": return "paintbrush"
+    case "png", "jpg", "jpeg", "gif", "svg": return "photo"
+    case "md", "txt": return "doc.plaintext"
+    default: return "doc"
+    }
+  }
+
+  private var iconColor: Color {
+    let ext = (node.name as NSString).pathExtension.lowercased()
+    switch ext {
+    case "ts", "tsx": return .blue
+    case "js", "jsx": return .yellow
+    case "json": return .orange
+    case "css", "scss", "sass": return .pink
+    default: return .secondary
+    }
+  }
+}
+
+struct CodeFileView: View {
+  let node: FileTreeNode
+  let sourceMap: SourceMap?
+  @Environment(\.colorScheme) private var colorScheme
+  @State private var highlightedLines: [AttributedString]?
+  @State private var isEditing = false
+  @State private var displayContent: String = ""
+  @State private var showCopiedConfirmation = false
+  @State private var wrapLines = false
+  @State private var fontSize: CGFloat = 12
+
+  private var isImageFile: Bool {
+    let ext = (node.name as NSString).pathExtension.lowercased()
+    return ["png", "jpg", "jpeg", "gif", "svg", "webp", "ico", "bmp"].contains(ext)
+  }
+
+  private var originalContent: String {
+    guard let contentIndex = node.contentIndex,
+          let sourceMap,
+          let sourcesContent = sourceMap.sourcesContent,
+          contentIndex < sourcesContent.count,
+          let code = sourcesContent[contentIndex] else {
+      return "// Content not available"
+    }
+    return code
+  }
+
+  private var lines: [String] {
+    displayContent.components(separatedBy: "\n")
+  }
+
+  private var theme: SyntaxHighlighter.Theme {
+    colorScheme == .dark ? .dark : .light
+  }
+
+  private var lineNumberWidth: CGFloat {
+    let digits = String(lines.count).count
+    let charWidth = fontSize * 0.6
+    return CGFloat(digits) * charWidth + 16
+  }
+
+  private var codeToolbar: some View {
+    HStack(spacing: 0) {
+      // Copy button
+      Button {
+        UIPasteboard.general.string = displayContent
+        showCopiedConfirmation = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+          showCopiedConfirmation = false
+        }
+      } label: {
+        Label("Copy", systemImage: "doc.on.doc")
+          .font(.system(size: 14))
+          .frame(maxWidth: .infinity)
+      }
+
+      Divider().frame(height: 24)
+
+      // Wrap lines button
+      Button {
+        wrapLines.toggle()
+      } label: {
+        Label(wrapLines ? "Unwrap" : "Wrap", systemImage: wrapLines ? "arrow.left.and.right.text.vertical" : "text.justify.leading")
+          .font(.system(size: 14))
+          .frame(maxWidth: .infinity)
+      }
+
+      Divider().frame(height: 24)
+
+      // Font size decrease
+      Button {
+        if fontSize > 8 {
+          fontSize -= 1
+        }
+      } label: {
+        HStack(spacing: 2) {
+          Image(systemName: "minus")
+            .font(.system(size: 10, weight: .bold))
+          Text("A")
+            .font(.system(size: 16, weight: .medium))
+        }
+        .frame(maxWidth: .infinity)
+      }
+
+      Divider().frame(height: 24)
+
+      // Font size increase
+      Button {
+        if fontSize < 24 {
+          fontSize += 1
+        }
+      } label: {
+        HStack(spacing: 2) {
+          Image(systemName: "plus")
+            .font(.system(size: 10, weight: .bold))
+          Text("A")
+            .font(.system(size: 16, weight: .medium))
+        }
+        .frame(maxWidth: .infinity)
+      }
+    }
+    .foregroundColor(Color(uiColor: .label))
+    .padding(.vertical, 10)
+    .background(Color(uiColor: .secondarySystemBackground))
+  }
+
+  var body: some View {
+    VStack(spacing: 0) {
+      if !isImageFile {
+        codeToolbar
+      }
+
+      Group {
+        if isImageFile {
+          imagePreviewUnavailableView()
+        } else if isEditing {
+          editingView()
+        } else {
+          readOnlyView()
+        }
+      }
+    }
+    .background(isImageFile ? Color(uiColor: .systemGroupedBackground) : theme.background)
+    .navigationTitle(node.name)
+    .inlineNavigationBar()
+    .toolbar {
+      ToolbarItem(placement: toolbarPlacement) {
+        if !isImageFile {
+          Button(isEditing ? "Done" : "Edit") {
+            if isEditing {
+              isEditing = false
+              Task {
+                highlightedLines = await SyntaxHighlighter.highlightLines(lines, theme: theme)
+              }
+            } else {
+              isEditing = true
+            }
+          }
+        }
+      }
+    }
+    .overlay {
+      if showCopiedConfirmation {
+        copiedConfirmationView
+          .transition(.opacity.combined(with: .scale(scale: 0.9)))
+      }
+    }
+    .animation(.easeOut(duration: 0.2), value: showCopiedConfirmation)
+    .onAppear {
+      if displayContent.isEmpty {
+        displayContent = originalContent
+      }
+    }
+    .task(id: colorScheme) {
+      if !isImageFile {
+        highlightedLines = await SyntaxHighlighter.highlightLines(lines, theme: theme)
+      }
+    }
+  }
+
+  private func imagePreviewUnavailableView() -> some View {
+    VStack(spacing: 12) {
+      Image(systemName: "photo")
+        .font(.system(size: 40))
+        .foregroundColor(.secondary)
+      Text("Image preview not available")
+        .font(.subheadline)
+        .foregroundColor(.secondary)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+
+  private var copiedConfirmationView: some View {
+    HStack(spacing: 8) {
+      Image(systemName: "checkmark")
+        .font(.system(size: 14, weight: .semibold))
+      Text("Copied")
+        .font(.system(size: 16, weight: .medium))
+    }
+    .foregroundColor(.white)
+    .padding(.horizontal, 16)
+    .padding(.vertical, 10)
+    .background(Color(uiColor: .darkGray))
+    .cornerRadius(8)
+  }
+
+  private func readOnlyView() -> some View {
+    ScrollView(.vertical) {
+      if wrapLines {
+        HStack(alignment: .top, spacing: 0) {
+          LineNumbersColumn(lines: lines, theme: theme, lineNumberWidth: lineNumberWidth, fontSize: fontSize)
+          CodeColumn(lines: lines, highlightedLines: highlightedLines, theme: theme, fontSize: fontSize, wrapLines: true)
+        }
+      } else {
+        ScrollView(.horizontal, showsIndicators: false) {
+          HStack(alignment: .top, spacing: 0) {
+            LineNumbersColumn(lines: lines, theme: theme, lineNumberWidth: lineNumberWidth, fontSize: fontSize)
+            CodeColumn(lines: lines, highlightedLines: highlightedLines, theme: theme, fontSize: fontSize, wrapLines: false)
+          }
+        }
+      }
+    }
+  }
+
+  private func editingView() -> some View {
+    TextEditor(text: $displayContent)
+      .font(.system(size: fontSize, weight: .regular, design: .monospaced))
+      .textInputAutocapitalization(.never)
+      .autocorrectionDisabled()
+      .modifier(ScrollContentBackgroundModifier())
+      .background(theme.background)
+      .foregroundColor(theme.plain)
+  }
+}
+
+private struct ScrollContentBackgroundModifier: ViewModifier {
+  func body(content: Content) -> some View {
+    if #available(iOS 16.0, *) {
+      content.scrollContentBackground(.hidden)
+    } else {
+      content
+    }
+  }
+}
+
+struct LineNumbersColumn: View {
+  let lines: [String]
+  let theme: SyntaxHighlighter.Theme
+  let lineNumberWidth: CGFloat
+  var fontSize: CGFloat = 13
+
+  private var lineHeight: CGFloat {
+    fontSize * 1.5
+  }
+
+  var body: some View {
+    VStack(alignment: .trailing, spacing: 0) {
+      ForEach(0..<lines.count, id: \.self) { index in
+        Text("\(index + 1)")
+          .font(.system(size: fontSize, weight: .regular, design: .monospaced))
+          .foregroundColor(theme.lineNumber)
+          .frame(height: lineHeight)
+      }
+    }
+    .frame(width: lineNumberWidth)
+    .padding(.vertical, 12)
+    .background(theme.background.opacity(0.8))
+  }
+}
+
+struct CodeColumn: View {
+  let lines: [String]
+  let highlightedLines: [AttributedString]?
+  let theme: SyntaxHighlighter.Theme
+  var fontSize: CGFloat = 13
+  var wrapLines: Bool = false
+
+  private var lineHeight: CGFloat {
+    fontSize * 1.5
+  }
+
+  var body: some View {
+    codeContent
+      .padding(.vertical, 12)
+      .padding(.trailing, 16)
+  }
+
+  @ViewBuilder
+  private var codeContent: some View {
+    let content = VStack(alignment: .leading, spacing: 0) {
+      ForEach(0..<lines.count, id: \.self) { index in
+        if let highlightedLines, index < highlightedLines.count {
+          Text(highlightedLines[index])
+            .font(.system(size: fontSize, weight: .regular, design: .monospaced))
+            .frame(minHeight: lineHeight, alignment: .leading)
+        } else {
+          Text(lines[index].isEmpty ? " " : lines[index])
+            .font(.system(size: fontSize, weight: .regular, design: .monospaced))
+            .foregroundColor(theme.plain)
+            .frame(minHeight: lineHeight, alignment: .leading)
+        }
+      }
+    }
+
+    if wrapLines {
+      content
+    } else {
+      content.fixedSize(horizontal: true, vertical: false)
+    }
+  }
+}
+
+private extension View {
+  func inlineNavigationBar() -> some View {
+    self.navigationBarTitleDisplayMode(.inline)
+  }
+
+  func defaultListStyle() -> some View {
+    self.listStyle(.insetGrouped)
+  }
+}

--- a/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/SourceMapExplorerViewModel.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/SourceMapExplorerViewModel.swift
@@ -1,0 +1,56 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+import Combine
+
+@MainActor
+class SourceMapExplorerViewModel: ObservableObject {
+  @Published var loadingState: SourceMapLoadingState = .idle
+  @Published var fileTree: [FileTreeNode] = []
+  @Published var searchText: String = ""
+
+  private let service = SourceMapService()
+  private(set) var sourceMap: SourceMap?
+
+  var filteredFileTree: [FileTreeNode] {
+    guard !searchText.isEmpty else { return fileTree }
+    // When searching, flatten to show matching files directly
+    return findMatchingFiles(in: fileTree, searchText: searchText.lowercased())
+  }
+
+  func loadSourceMap() async {
+    if case .loaded = loadingState { return }
+
+    loadingState = .loading
+
+    do {
+      let sourceMap = try await service.fetchSourceMap()
+      self.sourceMap = sourceMap
+      self.fileTree = await service.buildFileTree(from: sourceMap)
+      loadingState = .loaded(sourceMap)
+    } catch let error as SourceMapError {
+      loadingState = .error(error)
+    } catch {
+      loadingState = .error(.networkError(error))
+    }
+  }
+
+  /// Finds all matching files and returns them as a flat list with full paths
+  private func findMatchingFiles(in nodes: [FileTreeNode], searchText: String) -> [FileTreeNode] {
+    var results: [FileTreeNode] = []
+
+    for node in nodes {
+      if node.isDirectory {
+        // Recursively search children
+        results.append(contentsOf: findMatchingFiles(in: node.children, searchText: searchText))
+      } else {
+        // Check if file name or path matches
+        if node.searchableName.contains(searchText) || node.searchablePath.contains(searchText) {
+          results.append(node)
+        }
+      }
+    }
+
+    return results
+  }
+}

--- a/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/SourceMapModels.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/SourceMapModels.swift
@@ -1,0 +1,81 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+
+/// Represents the parsed source map from Metro bundler
+struct SourceMap: Codable {
+  let version: Int
+  let sources: [String]
+  let sourcesContent: [String?]?
+  let mappings: String
+  let names: [String]
+}
+
+/// Represents a node in the file tree (file or directory)
+struct FileTreeNode: Identifiable, Hashable {
+  var id: String { path }
+  let name: String
+  let path: String
+  let isDirectory: Bool
+  var children: [FileTreeNode]
+  let contentIndex: Int?
+
+  let searchableName: String
+  let searchablePath: String
+
+  init(name: String, path: String, isDirectory: Bool, children: [FileTreeNode] = [], contentIndex: Int? = nil) {
+    self.name = name
+    self.path = path
+    self.isDirectory = isDirectory
+    self.children = children
+    self.contentIndex = contentIndex
+    self.searchableName = name.lowercased()
+    self.searchablePath = path.lowercased()
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(id)
+  }
+
+  static func == (lhs: FileTreeNode, rhs: FileTreeNode) -> Bool {
+    lhs.id == rhs.id
+  }
+}
+
+/// Loading states for the source map explorer
+enum SourceMapLoadingState {
+  case idle
+  case loading
+  case loaded(SourceMap)
+  case error(SourceMapError)
+}
+
+/// Errors that can occur when fetching source maps
+enum SourceMapError: Error, LocalizedError {
+  case noBundleURL
+  case invalidSourceMapURL
+  case networkError(Error)
+  case parseError(Error)
+  case httpError(Int)
+  case noSourceMapFound
+  case invalidInlineSourceMap
+
+  var errorDescription: String? {
+    switch self {
+    case .noBundleURL:
+      return "No bundle URL available. Make sure the app is connected to Metro."
+    case .invalidSourceMapURL:
+      return "Could not construct source map URL."
+    case .networkError(let error):
+      return "Network error: \(error.localizedDescription)"
+    case .parseError(let error):
+      return "Failed to parse source map: \(error.localizedDescription)"
+    case .httpError(let code):
+      return "HTTP error: \(code)"
+    case .noSourceMapFound:
+      return "No source map found. Enable inline source maps in your Metro config or ensure the bundle is stored locally."
+    case .invalidInlineSourceMap:
+      return "Found inline source map but failed to decode it."
+    }
+  }
+}

--- a/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/SourceMapService.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/SourceMapService.swift
@@ -1,0 +1,253 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+
+@MainActor
+class SourceMapService {
+  private let devMenuManager = DevMenuManager.shared
+
+  /// Checks if a URL is an EAS CDN URL (assets.eascdn.net)
+  private func isEASCDNURL(_ url: URL) -> Bool {
+    return url.host == "assets.eascdn.net"
+  }
+
+  /// Constructs the source map URL from the bundle URL
+  /// Bundle: http://localhost:8081/index.bundle?platform=ios&dev=true
+  /// SourceMap: http://localhost:8081/index.map?platform=ios&dev=true
+  func getSourceMapURL() -> URL? {
+    guard let bundleURL = devMenuManager.currentBridge?.bundleURL else {
+      return nil
+    }
+
+    var urlString = bundleURL.absoluteString
+
+    // Replace .bundle with .map
+    if urlString.contains(".bundle") {
+      urlString = urlString.replacingOccurrences(of: ".bundle", with: ".map")
+    } else {
+      // If no .bundle extension, insert .map before query params
+      if let queryIndex = urlString.firstIndex(of: "?") {
+        urlString.insert(contentsOf: ".map", at: queryIndex)
+      } else {
+        urlString += ".map"
+      }
+    }
+
+    return URL(string: urlString)
+  }
+
+  // MARK: - Expo Go Integration via EXKernel
+
+  /// Gets the local bundle path from Expo Go's EXKernel
+  /// Path: EXKernel.sharedInstance.visibleApp.appLoader.appLauncher.launchAssetUrl
+  private func getLaunchAssetURL() -> URL? {
+    // Direct access to EXKernel instead of runtime reflection
+    // NOTE: This will compile once EXKernel headers are available via the ObjC bridging header
+    return nil // placeholder - will be connected when integrated
+  }
+
+  // MARK: - Source Map Fetching
+
+  /// Fetches and parses the source map, trying multiple strategies
+  func fetchSourceMap() async throws -> SourceMap {
+    let bundleURL = devMenuManager.currentBridge?.bundleURL
+
+    // Strategy 1: If the bundle is from Metro dev server, try to fetch external .map file
+    if let bundleURL = bundleURL,
+       !bundleURL.isFileURL,
+       !isEASCDNURL(bundleURL),
+       let externalSourceMap = try? await fetchExternalSourceMap() {
+      return externalSourceMap
+    }
+
+    // Strategy 2: Check if Expo Go has downloaded the bundle locally
+    if let localBundleURL = getLaunchAssetURL(), localBundleURL.isFileURL {
+      return try extractInlineSourceMapFromLocalFile(localBundleURL)
+    }
+
+    // Strategy 3: Check if bridge's bundle URL is a local file
+    if let bundleURL = bundleURL, bundleURL.isFileURL {
+      return try extractInlineSourceMapFromLocalFile(bundleURL)
+    }
+
+    throw SourceMapError.noSourceMapFound
+  }
+
+  /// Attempts to fetch an external .map file (used in dev mode)
+  private func fetchExternalSourceMap() async throws -> SourceMap {
+    guard let sourceMapURL = getSourceMapURL() else {
+      throw SourceMapError.invalidSourceMapURL
+    }
+
+    let (data, response) = try await URLSession.shared.data(from: sourceMapURL)
+
+    if let httpResponse = response as? HTTPURLResponse,
+       !(200...299).contains(httpResponse.statusCode) {
+      throw SourceMapError.httpError(httpResponse.statusCode)
+    }
+
+    return try JSONDecoder().decode(SourceMap.self, from: data)
+  }
+
+  /// Reads a local bundle file and extracts inline source map
+  private func extractInlineSourceMapFromLocalFile(_ fileURL: URL) throws -> SourceMap {
+    let data = try Data(contentsOf: fileURL)
+
+    guard let bundleContent = String(data: data, encoding: .utf8) else {
+      throw SourceMapError.noSourceMapFound
+    }
+
+    return try extractInlineSourceMap(from: bundleContent)
+  }
+
+  /// Extracts and decodes an inline source map from bundle content
+  /// Looks for: //# sourceMappingURL=data:application/json;charset=utf-8;base64,<base64data>
+  private func extractInlineSourceMap(from bundleContent: String) throws -> SourceMap {
+    let patterns = [
+      "//# sourceMappingURL=data:application/json;charset=utf-8;base64,",
+      "//# sourceMappingURL=data:application/json;base64,"
+    ]
+
+    for pattern in patterns {
+      if let range = bundleContent.range(of: pattern) {
+        let base64Start = range.upperBound
+        let endIndex = bundleContent[base64Start...].firstIndex(where: { $0.isNewline }) ?? bundleContent.endIndex
+        let base64String = String(bundleContent[base64Start..<endIndex])
+
+        guard let decodedData = Data(base64Encoded: base64String) else {
+          throw SourceMapError.invalidInlineSourceMap
+        }
+
+        do {
+          return try JSONDecoder().decode(SourceMap.self, from: decodedData)
+        } catch {
+          throw SourceMapError.parseError(error)
+        }
+      }
+    }
+
+    throw SourceMapError.noSourceMapFound
+  }
+
+  // MARK: - File Tree Building
+  private class Node {
+    let name: String
+    let path: String
+    var children: [String: Node] = [:]
+    var contentIndex: Int?
+    let isDirectory: Bool
+
+    init(name: String, path: String, isDirectory: Bool, contentIndex: Int? = nil) {
+      self.name = name
+      self.path = path
+      self.isDirectory = isDirectory
+      self.contentIndex = contentIndex
+    }
+  }
+
+  /// Builds a file tree from the source map sources array
+  func buildFileTree(from sourceMap: SourceMap) async -> [FileTreeNode] {
+    let root = Node(name: "", path: "", isDirectory: true)
+
+    for (index, sourcePath) in sourceMap.sources.enumerated() {
+      insertPath(sourcePath, contentIndex: index, into: root)
+    }
+
+    let nodes = root.children.values.map { convertToNode($0) }
+    let sorted = sortNodes(nodes)
+    let collapsed = collapseSingleChildFolders(sorted)
+
+    // Unwrap single top-level directory
+    let directories = collapsed.filter { $0.isDirectory }
+    if directories.count == 1, let mainDir = directories.first {
+      return mainDir.children
+    }
+
+    return collapsed
+  }
+
+  private func convertToNode(_ builder: Node) -> FileTreeNode {
+    FileTreeNode(
+      name: builder.name,
+      path: builder.path,
+      isDirectory: builder.isDirectory,
+      children: builder.children.values.map { convertToNode($0) },
+      contentIndex: builder.contentIndex
+    )
+  }
+
+  /// Collapses folder chains that have only a single child folder
+  private func collapseSingleChildFolders(_ nodes: [FileTreeNode]) -> [FileTreeNode] {
+    return nodes.map { node in
+      var current = node
+
+      // Don't collapse ".." directory - keep it as a container for modules
+      while current.isDirectory && current.children.count == 1 && current.children[0].isDirectory && current.name != ".." {
+        let child = current.children[0]
+        current = FileTreeNode(
+          name: child.name,
+          path: child.path,
+          isDirectory: true,
+          children: child.children,
+          contentIndex: nil
+        )
+      }
+
+      if current.isDirectory && !current.children.isEmpty {
+        var collapsed = current
+        collapsed.children = collapseSingleChildFolders(current.children)
+        return collapsed
+      }
+
+      return current
+    }
+  }
+
+  private func insertPath(_ path: String, contentIndex: Int, into parent: Node) {
+    var components = path.split(separator: "/").map(String.init)
+    guard !components.isEmpty else { return }
+
+    // Skip files starting with "app?ctx="
+    if let last = components.last, last.hasPrefix("app?ctx=") {
+      return
+    }
+
+    // Move node_modules into a ".." directory and rename to "modules"
+    components = components.flatMap { $0 == "node_modules" ? ["..", "modules"] : [$0] }
+
+    var current = parent
+    let lastIndex = components.count - 1
+
+    for (index, component) in components.enumerated() {
+      let isLast = index == lastIndex
+
+      if let existing = current.children[component] {
+        current = existing
+      } else {
+        let newNode = Node(
+          name: component,
+          path: components[0...index].joined(separator: "/"),
+          isDirectory: !isLast,
+          contentIndex: isLast ? contentIndex : nil
+        )
+        current.children[component] = newNode
+        current = newNode
+      }
+    }
+  }
+
+  private func sortNodes(_ nodes: [FileTreeNode]) -> [FileTreeNode] {
+    var sorted = nodes.sorted { node1, node2 in
+      if node1.isDirectory != node2.isDirectory {
+        return node1.isDirectory
+      }
+      return node1.name.localizedCaseInsensitiveCompare(node2.name) == .orderedAscending
+    }
+
+    for i in sorted.indices {
+      sorted[i].children = sortNodes(sorted[i].children)
+    }
+
+    return sorted
+  }
+}

--- a/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/SyntaxHighlighter.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/SyntaxHighlighter.swift
@@ -1,0 +1,206 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+/// Lightweight JavaScript/TypeScript syntax highlighter
+struct SyntaxHighlighter {
+
+  struct Theme {
+    let keyword: Color
+    let string: Color
+    let number: Color
+    let comment: Color
+    let punctuation: Color
+    let property: Color
+    let plain: Color
+    let background: Color
+    let lineNumber: Color
+
+    static var light: Theme {
+      Theme(
+        keyword: Color(red: 0.67, green: 0.05, blue: 0.57),   // purple
+        string: Color(red: 0.77, green: 0.10, blue: 0.09),    // red
+        number: Color(red: 0.11, green: 0.44, blue: 0.69),    // blue
+        comment: Color(red: 0.42, green: 0.47, blue: 0.44),   // gray
+        punctuation: Color(red: 0.31, green: 0.31, blue: 0.31),
+        property: Color(red: 0.15, green: 0.44, blue: 0.56),  // teal
+        plain: Color(red: 0.15, green: 0.15, blue: 0.15),
+        background: Color(red: 0.98, green: 0.98, blue: 0.98),
+        lineNumber: Color(red: 0.6, green: 0.6, blue: 0.6)
+      )
+    }
+
+    static var dark: Theme {
+      Theme(
+        keyword: Color(red: 0.78, green: 0.56, blue: 0.90),   // purple
+        string: Color(red: 0.80, green: 0.58, blue: 0.46),    // orange
+        number: Color(red: 0.71, green: 0.84, blue: 0.65),    // green
+        comment: Color(red: 0.50, green: 0.55, blue: 0.52),   // gray
+        punctuation: Color(red: 0.80, green: 0.80, blue: 0.80),
+        property: Color(red: 0.61, green: 0.80, blue: 0.92),  // light blue
+        plain: Color(red: 0.92, green: 0.92, blue: 0.92),
+        background: Color(red: 0.11, green: 0.12, blue: 0.13),
+        lineNumber: Color(red: 0.45, green: 0.45, blue: 0.45)
+      )
+    }
+  }
+
+  private static let keywords = Set([
+    "async", "await", "break", "case", "catch", "class", "const", "continue",
+    "debugger", "default", "delete", "do", "else", "enum", "export", "extends",
+    "false", "finally", "for", "from", "function", "if", "implements", "import",
+    "in", "instanceof", "interface", "let", "new", "null", "of", "package",
+    "private", "protected", "public", "return", "static", "super", "switch",
+    "this", "throw", "true", "try", "type", "typeof", "undefined", "var",
+    "void", "while", "with", "yield"
+  ])
+
+  private static let punctuationChars: Set<Character> = Set("{}[]();:,.<>+-*/%=!&|?@#~^")
+
+  enum TokenType {
+    case keyword, string, number, comment, punctuation, property, plain
+
+    func color(in theme: Theme) -> Color {
+      switch self {
+      case .keyword: return theme.keyword
+      case .string: return theme.string
+      case .number: return theme.number
+      case .comment: return theme.comment
+      case .punctuation: return theme.punctuation
+      case .property: return theme.property
+      case .plain: return theme.plain
+      }
+    }
+  }
+
+  struct Token {
+    let text: String
+    let type: TokenType
+  }
+
+  static func tokenize(_ code: String) -> [Token] {
+    var tokens: [Token] = []
+    var index = code.startIndex
+
+    while index < code.endIndex {
+      let remaining = code[index...]
+
+      // Single-line comment
+      if remaining.hasPrefix("//") {
+        let end = remaining.firstIndex(of: "\n") ?? remaining.endIndex
+        tokens.append(Token(text: String(remaining[..<end]), type: .comment))
+        index = end
+        continue
+      }
+
+      // Multi-line comment
+      if remaining.hasPrefix("/*") {
+        if let endRange = remaining.range(of: "*/") {
+          let end = endRange.upperBound
+          tokens.append(Token(text: String(remaining[..<end]), type: .comment))
+          index = end
+          continue
+        }
+      }
+
+      // Strings
+      let quote = remaining.first
+      if quote == "\"" || quote == "'" || quote == "`" {
+        var end = remaining.index(after: index)
+        var escaped = false
+        while end < remaining.endIndex {
+          let char = remaining[end]
+          if escaped {
+            escaped = false
+          } else if char == "\\" {
+            escaped = true
+          } else if char == quote {
+            end = remaining.index(after: end)
+            break
+          } else if quote != "`" && char == "\n" {
+            break
+          }
+          end = remaining.index(after: end)
+        }
+        tokens.append(Token(text: String(remaining[index..<end]), type: .string))
+        index = end
+        continue
+      }
+
+      // Numbers
+      let char = remaining.first!
+      if char.isNumber || (char == "." && remaining.dropFirst().first?.isNumber == true) {
+        var end = index
+        var hasDecimal = char == "."
+        while end < remaining.endIndex {
+          let c = remaining[end]
+          if c.isNumber {
+            end = remaining.index(after: end)
+          } else if c == "." && !hasDecimal {
+            hasDecimal = true
+            end = remaining.index(after: end)
+          } else if c == "x" || c == "X" || c == "e" || c == "E" ||
+                    c == "b" || c == "B" || c == "o" || c == "O" ||
+                    (c >= "a" && c <= "f") || (c >= "A" && c <= "F") {
+            end = remaining.index(after: end)
+          } else {
+            break
+          }
+        }
+        tokens.append(Token(text: String(remaining[index..<end]), type: .number))
+        index = end
+        continue
+      }
+
+      // Identifiers and keywords
+      if char.isLetter || char == "_" || char == "$" {
+        var end = index
+        while end < remaining.endIndex {
+          let c = remaining[end]
+          if c.isLetter || c.isNumber || c == "_" || c == "$" {
+            end = remaining.index(after: end)
+          } else {
+            break
+          }
+        }
+        let word = String(remaining[index..<end])
+        let type: TokenType = keywords.contains(word) ? .keyword : .plain
+        tokens.append(Token(text: word, type: type))
+        index = end
+        continue
+      }
+
+      // Punctuation
+      if punctuationChars.contains(char) {
+        tokens.append(Token(text: String(char), type: .punctuation))
+        index = remaining.index(after: index)
+        continue
+      }
+
+      // Whitespace and other
+      tokens.append(Token(text: String(char), type: .plain))
+      index = remaining.index(after: index)
+    }
+
+    return tokens
+  }
+
+  static func highlight(_ code: String, theme: Theme) -> AttributedString {
+    let tokens = tokenize(code)
+    var result = AttributedString()
+
+    for token in tokens {
+      var attributed = AttributedString(token.text)
+      attributed.foregroundColor = token.type.color(in: theme)
+      result.append(attributed)
+    }
+
+    return result
+  }
+
+  static func highlightLines(_ lines: [String], theme: Theme) async -> [AttributedString] {
+    lines.map { line in
+      highlight(line.isEmpty ? " " : line, theme: theme)
+    }
+  }
+}

--- a/apps/expo-go/ios/Exponent/Kernel/Core/EXKernel.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Core/EXKernel.m
@@ -16,10 +16,7 @@
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTModuleData.h>
 #import <React/RCTUtils.h>
-#import "EXDevMenu-Swift.h"
-#import "EXDevMenuInterface-Swift.h"
-
-@interface EXKernel () <DevMenuHostDelegate>
+@interface EXKernel ()
 @end
 
 NS_ASSUME_NONNULL_BEGIN
@@ -61,9 +58,8 @@ NSString * const kEXReloadActiveAppRequest = @"EXReloadActiveAppRequest";
     // init service registry: classes which manage shared resources among all hosts
     _serviceRegistry = [[EXKernelServiceRegistry alloc] init];
 
-    [DevMenuManager.shared setDelegate:self];
-    [DevMenuManager shared].configuration.onboardingAppName = @"Expo Go";
-    [[DevMenuManager shared] setShowFloatingActionButton:YES];
+    // Initialize the Expo Go dev menu manager (triggers lazy singleton init)
+    (void)[DevMenuManager shared];
 
     // Register keyboard commands (e.g., Cmd+D) for simulator
     [[EXKernelDevKeyCommands sharedInstance] registerDevCommands];
@@ -287,24 +283,6 @@ NSString * const kEXReloadActiveAppRequest = @"EXReloadActiveAppRequest";
       [self->_browserController moveAppToVisible:appRecord];
     }];
   }
-}
-
-#pragma mark - DevMenuHostDelegate
-
-- (void)devMenuNavigateHome {
-  [self switchTasks];
-}
-
-- (void)devMenuTogglePerformanceMonitor {
-  [[self visibleApp].appManager togglePerformanceMonitor];
-}
-
-- (void)devMenuToggleElementInspector {
-  [[self visibleApp].appManager toggleElementInspector];
-}
-
-- (BOOL)devMenuShouldShowReactNativeDevMenu {
-  return NO;
 }
 
 @end

--- a/apps/expo-go/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
+++ b/apps/expo-go/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
@@ -4,6 +4,7 @@
 #import "EXKernel.h"
 #import "EXKernelAppRegistry.h"
 #import "EXReactAppManager.h"
+#import "Expo_Go-Swift.h"
 
 #import <React/RCTDefines.h>
 #import <React/RCTUtils.h>
@@ -256,7 +257,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
 - (void)_handleMenuCommand
 {
-  [[EXKernel sharedInstance].visibleApp.appManager showDevMenu];
+  [[DevMenuManager shared] toggleMenu];
 }
 
 - (void)_handleRefreshCommand

--- a/apps/expo-go/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
+++ b/apps/expo-go/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
@@ -29,13 +29,6 @@
 #import <ExpoModulesCore-Swift.h>
 #endif
 
-#if __has_include(<EXDevMenu/EXDevMenu-Swift.h>)
-#import <EXDevMenu/EXDevMenu-Swift.h>
-#else
-#import "EXDevMenu-Swift.h"
-#endif
-
-
 #import "Expo_Go-Swift.h"
 
 NSString *const RCTInstanceDidLoadBundle = @"RCTInstanceDidLoadBundle";
@@ -135,12 +128,6 @@ NSString *const RCTInstanceDidLoadBundle = @"RCTInstanceDidLoadBundle";
     
     if (!_isHeadless) {
       _reactRootView = [self.expoAppInstance.reactNativeFactory.rootViewFactory viewWithModuleName:[self applicationKeyForRootView] initialProperties:[self initialPropertiesForRootView]];
-    }
-
-    RCTHost *host = (RCTHost *)self.reactHost;
-    if (host) {
-      [DevMenuManager.shared updateCurrentManifest:_appRecord.appLoader.manifest
-                                       manifestURL:_appRecord.appLoader.manifestUrl];
     }
 
     [self setupWebSocketControls];
@@ -339,10 +326,9 @@ NSString *const RCTInstanceDidLoadBundle = @"RCTInstanceDidLoadBundle";
     _hasHostEverLoaded = YES;
     [_versionManager hostFinishedLoading:self.reactHost];
 
-    // Update expo-dev-menu with the manifest
+    // Notify the dev menu that the manifest has changed
     if ([self enablesDeveloperTools]) {
-      [[DevMenuManager shared] updateCurrentManifest:_appRecord.appLoader.manifest
-                                         manifestURL:_appRecord.appLoader.manifestUrl];
+      [[DevMenuManager shared] notifyManifestChanged];
     }
 
     // TODO: temporary solution for hiding LoadingProgressWindow

--- a/apps/expo-go/ios/Podfile
+++ b/apps/expo-go/ios/Podfile
@@ -69,8 +69,6 @@ target 'Expo Go' do
   # Install vendored pods.
   use_pods! 'vendored/unversioned/**/*.podspec.json'
 
-  pod 'expo-dev-menu', :path => '../../../packages/expo-dev-menu', :configurations => ['Debug', 'Release']
-
   config_command = [
     'node',
     '--no-warnings',

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -51,68 +51,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-menu (55.0.9):
-    - boost
-    - DoubleConversion
-    - expo-dev-menu/Main (= 55.0.9)
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
   - expo-dev-menu-interface (55.0.1)
-  - expo-dev-menu/Main (55.0.9):
-    - boost
-    - DoubleConversion
-    - EXManifests
-    - expo-dev-menu-interface
-    - ExpoModulesCore
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-jsinspector
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
   - Expo/Tests (55.0.2):
     - boost
     - DoubleConversion
@@ -4057,7 +3996,6 @@ DEPENDENCIES:
   - EXManifests (from `../../../packages/expo-manifests/ios`)
   - EXManifests/Tests (from `../../../packages/expo-manifests/ios`)
   - Expo (from `../../../packages/expo`)
-  - expo-dev-menu (from `../../../packages/expo-dev-menu`)
   - expo-dev-menu-interface (from `../../../packages/expo-dev-menu-interface/ios`)
   - Expo/Tests (from `../../../packages/expo`)
   - ExpoAgeRange (from `../../../packages/expo-age-range/ios`)
@@ -4303,8 +4241,6 @@ EXTERNAL SOURCES:
     :path: "../../../packages/expo-manifests/ios"
   Expo:
     :path: "../../../packages/expo"
-  expo-dev-menu:
-    :path: "../../../packages/expo-dev-menu"
   expo-dev-menu-interface:
     :path: "../../../packages/expo-dev-menu-interface/ios"
   ExpoAgeRange:


### PR DESCRIPTION
# Why
We want expo go to own it's own implementation of the dev menu. This makes it easier to make changes without impacting expo-dev-menu

# How
Copy over dev menus ui and integrate with the kernel

# Test Plan
Expo go

