### PR TITLE
[notifications] use a selector for parsePermissionFromRequester on iOS

### DIFF
--- a/packages/expo-modules-core/ios/Legacy/Services/Permissions/EXPermissionsService.h
+++ b/packages/expo-modules-core/ios/Legacy/Services/Permissions/EXPermissionsService.h
@@ -9,8 +9,6 @@
 
 + (NSString *)permissionStringForStatus:(EXPermissionStatus)status;
 
-+ (NSDictionary *)parsePermissionFromRequester:(NSDictionary *)permission;
-
 - (void)askForGlobalPermissionUsingRequesterClass:(Class)requesterClass
                                     withResolver:(EXPromiseResolveBlock)resolver
                                     withRejecter:(EXPromiseRejectBlock)reject;

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Fixed build issue with Expo Go in `PermissionsModule.swift` ([#43690](https://github.com/expo/expo/pull/43690) by [@vonovak](https://github.com/vonovak))
+
 ### 💡 Others
 
 ## 55.0.11 — 2026-03-05

--- a/packages/expo-notifications/ios/ExpoNotifications/Permissions/PermissionsModule.swift
+++ b/packages/expo-notifications/ios/ExpoNotifications/Permissions/PermissionsModule.swift
@@ -36,10 +36,17 @@ public class PermissionsModule: Module {
       // Call `requestAuthorization` directly to ensure new options are always
       // forwarded to the OS, even if notifications were previously granted.
       // iOS safely handles repeated calls to `requestAuthorization(options:)`.
-      // Expo Go notifications permissions are not scoped
+      // Expo Go notifications permissions are not scoped.
+      // We use a selector on SDK 55 because Expo Go doesn't have `parsePermissionFromRequester` in the public header.
       let resolver: EXPromiseResolveBlock = { result in
         if let permission = result as? [AnyHashable: Any] {
-          promise.resolver(EXPermissionsService.parsePermission(fromRequester: permission))
+          let selector = NSSelectorFromString("parsePermissionFromRequester:")
+          if EXPermissionsService.responds(to: selector),
+            let parsed = EXPermissionsService.perform(selector, with: permission)?.takeUnretainedValue() as? [AnyHashable: Any] {
+            promise.resolver(parsed)
+          } else {
+            promise.legacyRejecter("ERR_PERMISSIONS_REQUEST_NOTIFICATIONS", "Unexpected error in requestPermissionsAsync: EXPermissionsService doesn't respond to parsePermissionFromRequester:", nil)
+          }
         } else {
           promise.legacyRejecter("ERR_PERMISSIONS_REQUEST_NOTIFICATIONS", "Unexpected permission result type", nil)
         }


### PR DESCRIPTION
# Why

fixes #43680

the `parsePermissionFromRequester` is not part of the public header on expo go so building that combination fails.

# How

- revert the change of the header, use selector to dynamically call the method since it's there in the implementation file

# Test Plan

- tested locally in notification tester

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
