### PR TITLE
[ui][android] - RNHostView throws "The specified child already has a parent"

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `RNHostView` child parent related crash. ([#43691](https://github.com/expo/expo/pull/43691) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Added `RNHostView` to improve RN component layout inside Compose views. ([#43495](https://github.com/expo/expo/pull/43495) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Fix `ContextMenu` not expanding when triggered by `IconButton`. ([#43592](https://github.com/expo/expo/pull/43592) by [@nishan](https://github.com/intergalacticspacehighway))
 

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/RNHostView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/RNHostView.kt
@@ -31,18 +31,29 @@ internal class RNHostView(context: Context, appContext: AppContext) :
   ExpoComposeView<RNHostViewProps>(context, appContext) {
   override val props = RNHostViewProps()
 
-  private var childView: View? = null
+  private val childViewState = mutableStateOf<View?>(null)
 
   override fun addView(child: View, index: Int, params: ViewGroup.LayoutParams) {
-    childView = child
-    super.addView(child, index, params)
+    childViewState.value = child
+  }
+
+  override fun removeView(view: View) {
+    if (view == childViewState.value) {
+      childViewState.value = null
+    } else {
+      super.removeView(view)
+    }
+  }
+
+  override fun removeViewAt(index: Int) {
+    childViewState.value = null
   }
 
   @Composable
   override fun ComposableScope.Content() {
     val matchContents = props.matchContents.value ?: false
 
-    childView?.let { view ->
+    childViewState.value?.let { view ->
       if (matchContents) {
         AndroidView(
           factory = { view },


### PR DESCRIPTION
# Why

RNHostView should not call `super.addView` in `addView` since it renders the child using `AndroidView` compose view. This can lead to below error in some cases. e.g. RN mounts the child first and then compose tree renders and tries to attach child to `AndroidView`.


```bash
java.lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.
                                                                                                    	at android.view.ViewGroup.addViewInner(ViewGroup.java:5286)
                                                                                                    	at android.view.ViewGroup.addView(ViewGroup.java:5115)
                                                                                                    	at android.view.ViewGroup.addView(ViewGroup.java:5055)
                                                                                                    	at android.view.ViewGroup.addView(ViewGroup.java:5027)
```

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Do not add view using view methods but put it in state and render it via compose.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested examples in NCL.


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
