### PR TITLE
[docs] Fix broken Android developer docs links in Jetpack Compose

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/dockedsearchbar.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/dockedsearchbar.mdx
@@ -9,7 +9,7 @@ platforms: ['android']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-Expo UI DockedSearchBar matches the official Jetpack Compose [SearchBar API](https://developer.android.com/develop/ui/compose/components/search) and displays a search input that remains anchored in its parent layout rather than expanding to full screen.
+Expo UI DockedSearchBar matches the official Jetpack Compose [SearchBar API](https://developer.android.com/develop/ui/compose/components/search-bar) and displays a search input that remains anchored in its parent layout rather than expanding to full screen.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/horizontalfloatingtoolbar.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/horizontalfloatingtoolbar.mdx
@@ -9,7 +9,7 @@ platforms: ['android']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-Expo UI HorizontalFloatingToolbar matches the official Jetpack Compose [FloatingActionButton API](https://developer.android.com/develop/ui/compose/components/floating-action-button) and displays a horizontal toolbar that floats above content, containing action buttons.
+Expo UI HorizontalFloatingToolbar matches the official Jetpack Compose [FloatingActionButton API](https://developer.android.com/develop/ui/compose/components/fab) and displays a horizontal toolbar that floats above content, containing action buttons.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/listitem.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/listitem.mdx
@@ -9,7 +9,7 @@ platforms: ['android']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-A list item component that follows Material Design 3 guidelines for structured list entries with headline, supporting text, and leading/trailing slots. See the [official Jetpack Compose documentation](https://developer.android.com/develop/ui/compose/components/lists) for more information.
+A list item component that follows Material Design 3 guidelines for structured list entries with headline, supporting text, and leading/trailing slots. See the [official Jetpack Compose documentation](https://developer.android.com/develop/ui/compose/lists) for more information.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/searchbar.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/searchbar.mdx
@@ -9,7 +9,7 @@ platforms: ['android']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-Expo UI SearchBar matches the official Jetpack Compose [Search](https://developer.android.com/develop/ui/compose/components/search) API and provides a search input with support for placeholder text and expanded full-screen search.
+Expo UI SearchBar matches the official Jetpack Compose [Search](https://developer.android.com/develop/ui/compose/components/search-bar) API and provides a search input with support for placeholder text and expanded full-screen search.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/surface.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/surface.mdx
@@ -9,7 +9,7 @@ platforms: ['android']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-Expo UI Surface matches the official Jetpack Compose [Surface](https://developer.android.com/develop/ui/compose/components/surfaces) API and provides a container that applies Material Design surface styling including color, elevation, and content color.
+Expo UI Surface matches the official Jetpack Compose [Surface](https://developer.android.com/develop/ui/compose/designsystems/material3) API and provides a container that applies Material Design surface styling including color, elevation, and content color.
 
 ## Installation
 

--- a/docs/pages/versions/v55.0.0/sdk/ui/jetpack-compose/dockedsearchbar.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/ui/jetpack-compose/dockedsearchbar.mdx
@@ -9,7 +9,7 @@ platforms: ['android']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-Expo UI DockedSearchBar matches the official Jetpack Compose [SearchBar API](https://developer.android.com/develop/ui/compose/components/search) and displays a search input that remains anchored in its parent layout rather than expanding to full screen.
+Expo UI DockedSearchBar matches the official Jetpack Compose [SearchBar API](https://developer.android.com/develop/ui/compose/components/search-bar) and displays a search input that remains anchored in its parent layout rather than expanding to full screen.
 
 ## Installation
 

--- a/docs/pages/versions/v55.0.0/sdk/ui/jetpack-compose/horizontalfloatingtoolbar.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/ui/jetpack-compose/horizontalfloatingtoolbar.mdx
@@ -9,7 +9,7 @@ platforms: ['android']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-Expo UI HorizontalFloatingToolbar matches the official Jetpack Compose [FloatingActionButton API](https://developer.android.com/develop/ui/compose/components/floating-action-button) and displays a horizontal toolbar that floats above content, containing action buttons.
+Expo UI HorizontalFloatingToolbar matches the official Jetpack Compose [FloatingActionButton API](https://developer.android.com/develop/ui/compose/components/fab) and displays a horizontal toolbar that floats above content, containing action buttons.
 
 ## Installation
 

--- a/docs/pages/versions/v55.0.0/sdk/ui/jetpack-compose/listitem.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/ui/jetpack-compose/listitem.mdx
@@ -9,7 +9,7 @@ platforms: ['android']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-A list item component that follows Material Design 3 guidelines for structured list entries with headline, supporting text, and leading/trailing slots. See the [official Jetpack Compose documentation](https://developer.android.com/develop/ui/compose/components/lists) for more information.
+A list item component that follows Material Design 3 guidelines for structured list entries with headline, supporting text, and leading/trailing slots. See the [official Jetpack Compose documentation](https://developer.android.com/develop/ui/compose/lists) for more information.
 
 ## Installation
 

--- a/docs/pages/versions/v55.0.0/sdk/ui/jetpack-compose/searchbar.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/ui/jetpack-compose/searchbar.mdx
@@ -9,7 +9,7 @@ platforms: ['android']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-Expo UI SearchBar matches the official Jetpack Compose [Search](https://developer.android.com/develop/ui/compose/components/search) API and provides a search input with support for placeholder text and expanded full-screen search.
+Expo UI SearchBar matches the official Jetpack Compose [Search](https://developer.android.com/develop/ui/compose/components/search-bar) API and provides a search input with support for placeholder text and expanded full-screen search.
 
 ## Installation
 

--- a/docs/pages/versions/v55.0.0/sdk/ui/jetpack-compose/surface.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/ui/jetpack-compose/surface.mdx
@@ -9,7 +9,7 @@ platforms: ['android']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-Expo UI Surface matches the official Jetpack Compose [Surface](https://developer.android.com/develop/ui/compose/components/surfaces) API and provides a container that applies Material Design surface styling including color, elevation, and content color.
+Expo UI Surface matches the official Jetpack Compose [Surface](https://developer.android.com/develop/ui/compose/designsystems/material3) API and provides a container that applies Material Design surface styling including color, elevation, and content color.
 
 ## Installation
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-19962

Several Jetpack Compose API reference pages link to Android developer docs URLs that have been moved or restructured. These broken links lead to 404 pages, making it harder for developers to find the official documentation for the components they're using.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
