### PR TITLE
[docs] Add Expo Skills page

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -302,3 +302,4 @@ exceptions:
   - 'Prerequisite: Creating Live Activity'
   - Hiding the Tab bar
   - Integrated vs Isolated
+  - Expo Skills

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -146,7 +146,7 @@ export const home = [
     makePage('deploy/web.mdx'),
   ]),
   makeSection('Monitor', [makePage('monitoring/services.mdx')]),
-  makeSection('AI agents', [makePage('skills.mdx')]),
+  makeSection('AI', [makePage('skills.mdx')]),
   makeSection('More', [makePage('core-concepts.mdx'), makePage('faq.mdx'), makePage('llms.mdx')]),
 ];
 

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -146,6 +146,7 @@ export const home = [
     makePage('deploy/web.mdx'),
   ]),
   makeSection('Monitor', [makePage('monitoring/services.mdx')]),
+  makeSection('AI agents', [makePage('skills.mdx')]),
   makeSection('More', [makePage('core-concepts.mdx'), makePage('faq.mdx'), makePage('llms.mdx')]),
 ];
 

--- a/docs/pages/skills.mdx
+++ b/docs/pages/skills.mdx
@@ -1,0 +1,124 @@
+---
+title: Expo Skills for coding agents
+sidebar_title: Expo Skills
+description: A list of official AI agent skills provided by Expo for building, deploying, and debugging robust Expo apps.
+---
+
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { Terminal } from '~/ui/components/Snippet';
+import { Tabs, Tab } from '~/ui/components/Tabs';
+import { CODE } from '~/ui/components/Text';
+
+Expo Skills are structured instruction files that teach AI agents how to build, deploy, and debug robust Expo apps accurately and efficiently. They work with Claude Code, Cursor, Codex, and other AI agents.
+
+## Install Expo Skills
+
+<Tabs>
+
+<Tab label="Claude Code">
+
+Run the following command to add Expo Skills from the plugin marketplace:
+
+<Terminal cmd={['$ /plugin marketplace add expo/skills']} />
+
+Then install a specific plugin:
+
+<Terminal
+  cmd={[
+    '$ /plugin install expo-app-design',
+    '',
+    '$ /plugin install upgrading-expo',
+    '',
+    '$ /plugin install expo-deployment',
+  ]}
+/>
+
+</Tab>
+
+<Tab label="Cursor">
+
+Follow the steps below in your Cursor app to add Expo Skills as a remote rule:
+
+- Open **Settings** > **Rules & Command** > **Project Rules** > **Add Rule** and select **Remote Rule**.
+- Enter the following URL of the remote rule and click **Add**.
+
+```text Remote URL
+https://github.com/expo/skills.git
+```
+
+> **important** **Note:** Skills in Cursor are not shown in the slash command (`/`) menu. They work via auto-discovery when you ask the agent Expo-related questions.
+
+</Tab>
+
+<Tab label="Other agents">
+
+Use the [skills CLI](https://skills.sh/docs/cli) to add Expo Skills to any compatible agent:
+
+<Terminal
+  cmd={{
+    npm: ['$ npx skills add expo/skills'],
+    yarn: ['$ yarn dlx skills add expo/skills'],
+    pnpm: ['$ pnpm dlx skills add expo/skills'],
+    bun: ['$ bunx skills add expo/skills'],
+  }}
+/>
+
+</Tab>
+
+</Tabs>
+
+## Available Expo Skills
+
+The following skills are available, organized by plugin:
+
+| Skill                                                                                                                        | Description                                                                                                                                                                          | Plugin            |
+| ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------- |
+| [`building-native-ui`](https://github.com/expo/skills/tree/main/plugins/expo-app-design/skills/building-native-ui)           | Use for building beautiful apps with [Expo Router](/router/introduction/). Covers fundamentals, styling, components, navigation, animations, patterns, and native tabs.              | `expo-app-design` |
+| [`native-data-fetching`](https://github.com/expo/skills/tree/main/plugins/expo-app-design/skills/native-data-fetching)       | Use to implement or debug a network request, API call, or data fetching. Covers fetch API, React Query, SWR, error handling, caching, offline support, and Expo Router data loaders. | `expo-app-design` |
+| [`expo-api-routes`](https://github.com/expo/skills/tree/main/plugins/expo-app-design/skills/expo-api-routes)                 | Use to create [API routes](/router/web/api-routes/) in Expo Router with EAS Hosting.                                                                                                 | `expo-app-design` |
+| [`expo-dev-client`](https://github.com/expo/skills/tree/main/plugins/expo-app-design/skills/expo-dev-client)                 | Use to build and distribute [development clients](/develop/development-builds/use-development-builds/) locally or via TestFlight.                                                    | `expo-app-design` |
+| [`expo-tailwind-setup`](https://github.com/expo/skills/tree/main/plugins/expo-app-design/skills/expo-tailwind-setup)         | Use to set up [Tailwind CSS](/guides/tailwind/) with `react-native-css` and NativeWind for universal styling.                                                                        | `expo-app-design` |
+| [`use-dom`](https://github.com/expo/skills/tree/main/plugins/expo-app-design/skills/use-dom)                                 | Use Expo [DOM components](/guides/dom-components/) to run web code in a webview on native or web.                                                                                    | `expo-app-design` |
+| [`expo-ui-jetpack-compose`](https://github.com/expo/skills/tree/main/plugins/expo-app-design/skills/expo-ui-jetpack-compose) | Use for [Jetpack Compose](/versions/latest/sdk/ui/jetpack-compose/) Views and modifiers in Expo apps.                                                                                | `expo-app-design` |
+| [`expo-ui-swift-ui`](https://github.com/expo/skills/tree/main/plugins/expo-app-design/skills/expo-ui-swift-ui)               | Use for [SwiftUI](/versions/latest/sdk/ui/swift-ui/) Views and modifiers in Expo apps.                                                                                               | `expo-app-design` |
+| [`expo-deployment`](https://github.com/expo/skills/tree/main/plugins/expo-deployment/skills/expo-deployment)                 | Use to deploy to Google Play Store, Apple App Store, web hosting, and API routes via [EAS](/eas/).                                                                                   | `expo-deployment` |
+| [`expo-cicd-workflows`](https://github.com/expo/skills/tree/main/plugins/expo-deployment/skills/expo-cicd-workflows)         | Use to create [EAS Workflows](/eas/workflows/introduction/) YAML files for CI/CD automation.                                                                                         | `expo-deployment` |
+| [`upgrading-expo`](https://github.com/expo/skills/tree/main/plugins/upgrading-expo/skills/upgrading-expo)                    | Use to [upgrade Expo SDK versions](/workflow/upgrading-expo-sdk-walkthrough/), fix dependency issues, or handle breaking changes.                                                    | `upgrading-expo`  |
+
+## Example prompts
+
+Try the following prompts after installing Expo Skills. Your AI agent will use the relevant skill appropriately:
+
+| Example prompt                                         | Skill used                |
+| ------------------------------------------------------ | ------------------------- |
+| Build a settings screen with a form and navigation     | `building-native-ui`      |
+| Set up Tailwind CSS in my Expo project                 | `expo-tailwind-setup`     |
+| Embed a recharts chart in my native app using web code | `use-dom`                 |
+| Add a SwiftUI picker component to my Expo app          | `expo-ui-swift-ui`        |
+| Use Material Design 3 components with Jetpack Compose  | `expo-ui-jetpack-compose` |
+| How do I deploy my Expo app to the Apple App Store?    | `expo-deployment`         |
+| Create a CI/CD workflow that builds on every PR        | `expo-cicd-workflows`     |
+| Upgrade my project to the latest Expo SDK              | `upgrading-expo`          |
+
+## Additional resources
+
+<BoxLink
+  title={
+    <>
+      <CODE>expo/skills</CODE> GitHub repository
+    </>
+  }
+  description="Browse the source for all available Expo Skills, or report issues."
+  href="https://github.com/expo/skills"
+  Icon={GithubIcon}
+/>
+
+<BoxLink
+  title="Expo MCP Server"
+  description="Companion AI tooling that gives coding agents direct access to Expo and EAS services."
+  href="/eas/ai/mcp/"
+  Icon={BookOpen02Icon}
+/>

--- a/docs/pages/skills.mdx
+++ b/docs/pages/skills.mdx
@@ -1,5 +1,5 @@
 ---
-title: Expo Skills for coding agents
+title: Expo Skills for AI agents
 sidebar_title: Expo Skills
 description: A list of official AI agent skills provided by Expo for building, deploying, and debugging robust Expo apps.
 ---

--- a/docs/pages/skills.mdx
+++ b/docs/pages/skills.mdx
@@ -1,7 +1,7 @@
 ---
 title: Expo Skills for AI agents
 sidebar_title: Expo Skills
-description: A list of official AI agent skills provided by Expo for building, deploying, and debugging robust Expo apps.
+description: A list of official AI agent skills provided by Expo for building, deploying, and debugging Expo apps.
 ---
 
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
@@ -12,7 +12,7 @@ import { Terminal } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { CODE } from '~/ui/components/Text';
 
-Expo Skills are structured instruction files that teach AI agents how to build, deploy, and debug robust Expo apps accurately and efficiently. They work with Claude Code, Cursor, Codex, and other AI agents.
+Expo Skills are structured instruction files that teach AI agents how to build, deploy, and debug robust Expo React Native apps accurately and efficiently. They work with Claude Code, Cursor, Codex, and other AI agents.
 
 ## Install Expo Skills
 
@@ -94,7 +94,7 @@ The following skills are available, organized by plugin:
 
 ## Example prompts
 
-Try the following prompts after installing Expo Skills. Your AI agent will use the relevant skill appropriately:
+Try the following prompts after installing Expo Skills. Your AI agent will automatically use the appropriate skill:
 
 | Example prompt                                         | Skill used                |
 | ------------------------------------------------------ | ------------------------- |

--- a/docs/pages/skills.mdx
+++ b/docs/pages/skills.mdx
@@ -4,8 +4,8 @@ sidebar_title: Expo Skills
 description: A list of official AI agent skills provided by Expo for building, deploying, and debugging robust Expo apps.
 ---
 
-import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';

--- a/docs/pages/skills.mdx
+++ b/docs/pages/skills.mdx
@@ -1,7 +1,7 @@
 ---
 title: Expo Skills for AI agents
 sidebar_title: Expo Skills
-description: A list of official AI agent skills provided by Expo for building, deploying, and debugging Expo apps.
+description: A list of official AI agent skills provided by Expo for building, deploying, and debugging Expo and React Native apps.
 ---
 
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
@@ -12,7 +12,7 @@ import { Terminal } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { CODE } from '~/ui/components/Text';
 
-Expo Skills are structured instruction files that teach AI agents how to build, deploy, and debug robust Expo React Native apps accurately and efficiently. They work with Claude Code, Cursor, Codex, and other AI agents.
+Expo Skills are structured instruction files that teach AI agents how to build, deploy, and debug Expo and React Native apps accurately and efficiently. They work with Claude Code, Cursor, Codex, and other AI agents.
 
 ## Install Expo Skills
 

--- a/docs/pages/skills.mdx
+++ b/docs/pages/skills.mdx
@@ -42,8 +42,12 @@ Then install a specific plugin:
 
 Follow the steps below in your Cursor app to add Expo Skills as a remote rule:
 
+{/* vale off */}
+
 - Open **Settings** > **Rules & Command** > **Project Rules** > **Add Rule** and select **Remote Rule**.
 - Enter the following URL of the remote rule and click **Add**.
+
+{/* vale on */}
 
 ```text Remote URL
 https://github.com/expo/skills.git

--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -229,6 +229,7 @@ function shouldSkipTitle(info: NavigationRoute, parentGroup?: NavigationRoute) {
 function getIconElement(iconName?: string) {
   switch (iconName) {
     case 'AI':
+    case 'AI agents':
       return Star06Icon;
     case 'Develop':
       return TerminalBrowserIcon;

--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -229,7 +229,6 @@ function shouldSkipTitle(info: NavigationRoute, parentGroup?: NavigationRoute) {
 function getIconElement(iconName?: string) {
   switch (iconName) {
     case 'AI':
-    case 'AI agents':
       return Star06Icon;
     case 'Develop':
       return TerminalBrowserIcon;


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-19908

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add `pages/skills.mdx` with install instructions (Claude Code, Cursor, other agents via skills CLI), a table of all 11 available skills across 3 plugins, example prompts, and links to additional resources.
- Add an "AI agents" section to the Home area sidebar.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview: https://pr-43698.expo-docs.pages.dev/skills/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
