### PR TITLE
fix(cli): fall back to name-based activity lookup in resolveLaunchProps

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Add fallback resolution for `../../App` in `expo/AppEntry.js` ([#44084](https://github.com/expo/expo/pull/44084) by [@kitten](https://github.com/kitten))
 - Prevent out-of-monorepo `expo/expo` CLI detection to not mistrigger for user monorepos and update for pnpm compatibility ([#44101](https://github.com/expo/expo/pull/44101) by [@kitten](https://github.com/kitten))
 - Fix device being incorrectly tracked for `run:ios --device` invocation ([#43673](https://github.com/expo/expo/pull/43673) by [@kitten](https://github.com/kitten))
+- Fall back to name-based `.MainActivity` lookup when no runnable activity with `MAIN`/`LAUNCHER` intent filters exists in the manifest. ([#43702](https://github.com/expo/expo/pull/43702) by [@hwhh](https://github.com/hwhh))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/run/android/resolveLaunchProps.ts
+++ b/packages/@expo/cli/src/run/android/resolveLaunchProps.ts
@@ -31,17 +31,18 @@ export interface LaunchProps {
 async function getMainActivityAsync(projectRoot: string): Promise<string> {
   const filePath = await AndroidConfig.Paths.getAndroidManifestAsync(projectRoot);
   const androidManifest = await AndroidConfig.Manifest.readAndroidManifestAsync(filePath);
-
-  // Assert MainActivity defined.
-  const activity = await AndroidConfig.Manifest.getRunnableActivity(androidManifest);
-  if (!activity) {
+  const runnableActivity = AndroidConfig.Manifest.getRunnableActivity(androidManifest);
+  if (runnableActivity) {
+    return runnableActivity.$['android:name'];
+  }
+  const mainActivity = AndroidConfig.Manifest.getMainActivity(androidManifest);
+  if (!mainActivity) {
     throw new CommandError(
       'ANDROID_MALFORMED',
       `${filePath} is missing a runnable activity element.`
     );
   }
-  // Often this is ".MainActivity"
-  return activity.$['android:name'];
+  return mainActivity.$['android:name'];
 }
 
 export async function resolveLaunchPropsAsync(


### PR DESCRIPTION
# Why
Apps that use a custom launcher activity (e.g., a splash/routing activity that delegates to `.MainActivity`) intentionally remove the `android.intent.action.MAIN` + `android.intent.category.LAUNCHER` intent filters from `.MainActivity`. This causes `expo run:android` to fail with:
> `AndroidManifest.xml is missing a runnable activity element.`
The activity name is only needed to construct the `adb am start -n` command -- the intent filters themselves are not required.
# How
`getMainActivityAsync` in `resolveLaunchProps.ts` currently uses only `getRunnableActivity()` which looks up activities by intent filter. This change adds a fallback to `getMainActivity()` (which looks up by `android:name=".MainActivity"`) when no runnable activity is found. The error is only thrown if neither lookup succeeds.
# Test Plan
1. Project **with** MAIN/LAUNCHER on `.MainActivity` (default Expo template): `expo run:android` resolves activity via the first code path -- no behavior change
2. Project **without** MAIN/LAUNCHER on `.MainActivity` (custom launcher activity): `expo run:android` now resolves `.MainActivity` via the fallback instead of throwing
# Checklist
- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
