### PR TITLE
[iOS] fix(expo-audio): set playback rate to 0 when paused in Now Playing info

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix Now Playing elapsed time continuing to advance while paused in Control Center. ([#43704](https://github.com/expo/expo/pull/43704) by [@alecdhansen](https://github.com/alecdhansen))
 - [iOS] Fix crash during seek. ([#43564](https://github.com/expo/expo/pull/43564) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Improve looping support. ([#43600](https://github.com/expo/expo/pull/43600) by [@alanjhughes](https://github.com/alanjhughes))
 

--- a/packages/expo-audio/ios/MediaController.swift
+++ b/packages/expo-audio/ios/MediaController.swift
@@ -55,7 +55,7 @@ class MediaController {
   private func applyPlaybackInfo(_ info: inout [String: Any], for player: AudioPlayer) {
     info[MPMediaItemPropertyPlaybackDuration] = player.duration
     info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = player.currentTime
-    info[MPNowPlayingInfoPropertyPlaybackRate] = player.isPlaying ? player.ref.rate : 1.0
+    info[MPNowPlayingInfoPropertyPlaybackRate] = player.isPlaying ? player.ref.rate : 0.0
     info[MPNowPlayingInfoPropertyMediaType] = MPNowPlayingInfoMediaType.audio.rawValue
   }
 
@@ -154,6 +154,7 @@ class MediaController {
       }
 
       player.play(at: Float(player.currentRate > 0 ? player.currentRate : 1.0))
+      self?.updateNowPlayingInfo(for: player)
       return .success
     }
 
@@ -163,6 +164,7 @@ class MediaController {
       }
 
       player.ref.pause()
+      self?.updateNowPlayingInfo(for: player)
       return .success
     }
 
@@ -176,6 +178,7 @@ class MediaController {
       } else {
         player.play(at: Float(player.currentRate > 0 ? player.currentRate : 1.0))
       }
+      self?.updateNowPlayingInfo(for: player)
       return .success
     }
 


### PR DESCRIPTION
# Why

The iOS Control Center elapsed time scrubber continues advancing while audio is paused. This happens because `MPNowPlayingInfoPropertyPlaybackRate` remains `1.0` when paused, and the system uses `elapsedPlaybackTime + playbackRate` to animate the time display.

# How

- Set `MPNowPlayingInfoPropertyPlaybackRate` to `0.0` when `player.isPlaying` is false (was `1.0`)
- Call `updateNowPlayingInfo(for:)` immediately after remote `play`, `pause`, and `togglePlayPause` commands so the updated rate takes effect right away

# Test Plan

1. Start audio playback
2. Pause via Control Center
3. Wait 10+ seconds — elapsed time should **not** advance
4. Resume playback — time continues from the paused position