### PR TITLE
[brownfield][test] temporarily disable dev-menu e2e tests

### DIFF
--- a/.github/workflows/test-suite-brownfield-isolated.yml
+++ b/.github/workflows/test-suite-brownfield-isolated.yml
@@ -239,11 +239,12 @@ jobs:
           echo "${HOME}/.maestro/bin" >> $GITHUB_PATH
       - name: 🧪 Run e2e tests (Release)
         run: ./packages/expo-brownfield/e2e/scripts/run-e2e-ios.sh
-      - name: 🍏 Build iOS artifacts (Debug)
-        run: |
-          npx expo-brownfield build:ios -d --verbose -a ../../../artifacts -p BrownfieldPackage
-      - name: 🧪 Run e2e tests (Debug)
-        run: CONFIGURATION=Debug ./packages/expo-brownfield/e2e/scripts/run-e2e-ios.sh
+      # TODO(pmleczek): Re-enable once all issues are resolved
+      # - name: 🍏 Build iOS artifacts (Debug)
+      #   run: |
+      #     npx expo-brownfield build:ios -d --verbose -a ../../../artifacts -p BrownfieldPackage
+      # - name: 🧪 Run e2e tests (Debug)
+      #   run: CONFIGURATION=Debug ./packages/expo-brownfield/e2e/scripts/run-e2e-ios.sh
       - name: 💾 Save ccache
         if: always()
         uses: actions/cache/save@v4


### PR DESCRIPTION
# Why

The tests are still failing due to reasons other than dev-menu issues on RN 0.84. There seems to be more than one problem, so I believe we could disable them and reenable once all the issues are resolved, to avoid blocking the CI with pointless, always failing jobs

# How

Temporarily disable Debug E2E tests for iOS - to be re-enabled in https://github.com/expo/expo/pull/43703 once we resolve all of the issues

# Test Plan

Ensured that the workflow passes with the Debug tests disabled

# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
