### PR TITLE
[docs] workflows syntax: add ready for review type for on pull request trigger documentation

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -109,6 +109,7 @@ With the `branches` list, you can trigger the workflow only when those specified
 With the `types` list, you can trigger the workflow only on the specified pull request event types. For example, if you use `types: ['opened']`, only the `pull_request.opened` event (sent when a pull request is first opened) will trigger the workflow. Defaults to `['opened', 'reopened', 'synchronize']` when not provided. Supported event types:
 
 - `opened`
+- `ready_for_review`
 - `reopened`
 - `synchronize`
 - `labeled`


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-17386/add-support-for-draft-and-ready-for-review-to-pull-request-event – I have added support for `ready_for_review` GitHub pull request trigger to EAS worklows. Docs need to be updated so that people know about this.

# How

Updated the docs for `on.pull_request` EAS workflows syntax section by adding the information about the `ready_for_review` possible event type.

# Test Plan

Tested manually:
<img width="1115" height="494" alt="image" src="https://github.com/user-attachments/assets/8b132abf-460b-4ae1-9755-fdb13604113f" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
