### PR TITLE
[docs] Update llms.txt page and move to AI section

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -146,8 +146,8 @@ export const home = [
     makePage('deploy/web.mdx'),
   ]),
   makeSection('Monitor', [makePage('monitoring/services.mdx')]),
-  makeSection('AI', [makePage('skills.mdx')]),
-  makeSection('More', [makePage('core-concepts.mdx'), makePage('faq.mdx'), makePage('llms.mdx')]),
+  makeSection('AI', [makePage('skills.mdx'), makePage('llms.mdx')]),
+  makeSection('More', [makePage('core-concepts.mdx'), makePage('faq.mdx')]),
 ];
 
 export const general = [

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -74,6 +74,7 @@ export const home = [
     makePage('get-started/start-developing.mdx'),
     makePage('get-started/next-steps.mdx'),
   ]),
+  makeSection('AI', [makePage('skills.mdx'), makePage('llms.mdx')]),
   makeSection('Develop', [
     makePage('develop/tools.mdx'),
     makePage('develop/app-navigation.mdx'),
@@ -146,7 +147,6 @@ export const home = [
     makePage('deploy/web.mdx'),
   ]),
   makeSection('Monitor', [makePage('monitoring/services.mdx')]),
-  makeSection('AI', [makePage('skills.mdx'), makePage('llms.mdx')]),
   makeSection('More', [makePage('core-concepts.mdx'), makePage('faq.mdx')]),
 ];
 

--- a/docs/pages/llms.mdx
+++ b/docs/pages/llms.mdx
@@ -1,16 +1,45 @@
 ---
-title: Documentation for LLMs
-sidebar_title: llms.txt
-description: A list of Expo and EAS documentation files available for large language models (LLMs) and apps that use them.
+title: Documentation for AI agents and LLMs
+sidebar_title: AI agents
+description: Efficient ways for AI agents and LLMs to access and consume Expo documentation.
 hideTOC: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
 
-At Expo, we support the [llms.txt](https://llmstxt.org/) initiative to provide documentation for large language models (LLMs) and apps that use them. Below is a list of documentation files available:
+Use the following endpoints and tools to give AI agents and LLMs access to Expo documentation at lower token cost than fetching full web pages.
+
+## Quick start
+
+Pick the method that matches your tool:
+
+| Method                 | Best for                             | How                                                                                                     |
+| ---------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| **Per-page markdown**  | Chat interfaces (ChatGPT, Claude.ai) | Append `/index.md` to any docs page URL.                                                                |
+| **Copy page** dropdown | Quick prompts with a single page     | Click **Copy page** at the top of any docs page.                                                        |
+| **Section bundles**    | Project rules and coding assistants  | Add a section-level `llms.txt` URL to your AI tool config or the general purpose sitemap (`/llms.txt`). |
+
+## Per-page markdown
+
+Every documentation page has a lightweight markdown version accessible by appending `/index.md` to the page URL. For example:
+
+```text Create a development build on EAS
+https://docs.expo.dev/develop/development-builds/create-a-build/index.md
+```
+
+This method is useful when you want to give an AI agent context about a specific topic or page without overwhelming it with the full HTML of that page.
+
+## Documentation bundles
+
+At Expo, we support the [llms.txt](https://llmstxt.org/) initiative to provide documentation for large language models (LLMs) and apps that use them. Below is a list of documentation files available.
+
+### Site-wide bundles
 
 - [/llms.txt](/llms.txt): A list of all available documentation files
 - [/llms-full.txt](/llms-full.txt): Complete documentation for Expo, including Expo Router, Expo Modules API, development process, and more
+
+### By section
+
 - [/llms-eas.txt](/llms-eas.txt): Complete documentation for the Expo Application Services (EAS)
 - [/llms-sdk.txt](/llms-sdk.txt): Complete documentation for the latest Expo SDK
 
@@ -25,3 +54,4 @@ At Expo, we support the [llms.txt](https://llmstxt.org/) initiative to provide d
 - [/llms-sdk-v51.0.0.txt](/llms-sdk-v51.0.0.txt): Documentation for the Expo SDK v51.0.0
 
 </Collapsible>
+```

--- a/docs/pages/llms.mdx
+++ b/docs/pages/llms.mdx
@@ -2,7 +2,6 @@
 title: Documentation for AI agents and LLMs
 sidebar_title: AI agents
 description: Efficient ways for AI agents and LLMs to access and consume Expo documentation.
-hideTOC: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
@@ -13,18 +12,18 @@ Use the following endpoints and tools to give AI agents and LLMs access to Expo 
 
 Pick the method that matches your tool:
 
-| Method                 | Best for                             | How                                                                                                     |
-| ---------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------- |
-| **Per-page markdown**  | Chat interfaces (ChatGPT, Claude.ai) | Append `/index.md` to any docs page URL.                                                                |
-| **Copy page** dropdown | Quick prompts with a single page     | Click **Copy page** at the top of any docs page.                                                        |
-| **Section bundles**    | Project rules and coding assistants  | Add a section-level `llms.txt` URL to your AI tool config or the general purpose sitemap (`/llms.txt`). |
+| Method                 | Best for                                               | How                                                                                                            |
+| ---------------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| Per-page markdown      | Chat interfaces (ChatGPT, Claude.ai) and coding agents | Append `/index.md` to any documentation page URL.                                                              |
+| Copy Markdown dropdown | Quick prompts with a single page                       | Click **Copy Markdown** at the top of any documentation page.                                                  |
+| Section bundles        | Project rules and coding agents                        | Add a section-level `llms-*.txt` URL to your AI tool configuration or the general purpose index (`/llms.txt`). |
 
 ## Per-page markdown
 
 Every documentation page has a lightweight markdown version accessible by appending `/index.md` to the page URL. For example:
 
 ```text Create a development build on EAS
-https://docs.expo.dev/develop/development-builds/create-a-build/index.md
+https://documentation.expo.dev/develop/development-builds/create-a-build/index.md
 ```
 
 This method is useful when you want to give an AI agent context about a specific topic or page without overwhelming it with the full HTML of that page.
@@ -35,13 +34,17 @@ At Expo, we support the [llms.txt](https://llmstxt.org/) initiative to provide d
 
 ### Site-wide bundles
 
-- [/llms.txt](/llms.txt): A list of all available documentation files
-- [/llms-full.txt](/llms-full.txt): Complete documentation for Expo, including Expo Router, Expo Modules API, development process, and more
+| Endpoint                         | Description                                                                                              | Size    |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------- | ------- |
+| [/llms.txt](/llms.txt)           | Index page with a list of all available documentation files.                                             | ~94 KB  |
+| [/llms-full.txt](/llms-full.txt) | Complete documentation for Expo, including Expo Router, Expo Modules API, development process, and more. | ~1.9 MB |
 
-### By section
+### Section-wide bundles
 
-- [/llms-eas.txt](/llms-eas.txt): Complete documentation for the Expo Application Services (EAS)
-- [/llms-sdk.txt](/llms-sdk.txt): Complete documentation for the latest Expo SDK
+| Endpoint                       | Description                                                 | Size    |
+| ------------------------------ | ----------------------------------------------------------- | ------- |
+| [/llms-eas.txt](/llms-eas.txt) | Complete documentation for Expo Application Services (EAS). | ~974 KB |
+| [/llms-sdk.txt](/llms-sdk.txt) | Complete documentation for the latest Expo SDK.             | ~2.6 MB |
 
 <Collapsible summary="Looking for deprecated Expo SDK versions?">
 
@@ -54,4 +57,3 @@ At Expo, we support the [llms.txt](https://llmstxt.org/) initiative to provide d
 - [/llms-sdk-v51.0.0.txt](/llms-sdk-v51.0.0.txt): Documentation for the Expo SDK v51.0.0
 
 </Collapsible>
-```

--- a/docs/pages/llms.mdx
+++ b/docs/pages/llms.mdx
@@ -15,8 +15,8 @@ Pick the method that matches your tool:
 | Method                 | Best for                                               | How                                                                                                            |
 | ---------------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
 | Per-page markdown      | Chat interfaces (ChatGPT, Claude.ai) and coding agents | Append `/index.md` to any documentation page URL.                                                              |
-| Copy Markdown dropdown | Quick prompts with a single page                       | Click **Copy Markdown** at the top of any documentation page.                                                  |
-| Section bundles        | Project rules and coding agents                        | Add a section-level `llms-*.txt` URL to your AI tool configuration or the general purpose index (`/llms.txt`). |
+| Copy Markdown dropdown | Quick prompts with a single page                       | Click **Copy page** > **Copy Markdown** at the top of any documentation page.                                  |
+| Section bundles        | Project rules and coding agents                        | Add a section-level `llms-*.txt` URL to your AI tool configuration or the general-purpose index (`/llms.txt`). |
 
 ## Per-page markdown
 
@@ -26,7 +26,7 @@ Every documentation page has a lightweight markdown version accessible by append
 https://documentation.expo.dev/develop/development-builds/create-a-build/index.md
 ```
 
-This method is useful when you want to give an AI agent context about a specific topic or page without overwhelming it with the full HTML of that page.
+The above method is useful when you want to give an AI agent context about a specific topic or page without overwhelming it with the full HTML of that page.
 
 ## Documentation bundles
 

--- a/docs/pages/llms.mdx
+++ b/docs/pages/llms.mdx
@@ -36,14 +36,14 @@ At Expo, we support the [llms.txt](https://llmstxt.org/) initiative to provide d
 
 | Endpoint                         | Description                                                                                              | Size    |
 | -------------------------------- | -------------------------------------------------------------------------------------------------------- | ------- |
-| [/llms.txt](/llms.txt)           | Index page with a list of all available documentation files.                                             | ~94 KB  |
+| [/llms.txt](/llms.txt)           | Index page with a list of all available documentation files.                                             | ~94 kB  |
 | [/llms-full.txt](/llms-full.txt) | Complete documentation for Expo, including Expo Router, Expo Modules API, development process, and more. | ~1.9 MB |
 
 ### Section-wide bundles
 
 | Endpoint                       | Description                                                 | Size    |
 | ------------------------------ | ----------------------------------------------------------- | ------- |
-| [/llms-eas.txt](/llms-eas.txt) | Complete documentation for Expo Application Services (EAS). | ~974 KB |
+| [/llms-eas.txt](/llms-eas.txt) | Complete documentation for Expo Application Services (EAS). | ~974 kB |
 | [/llms-sdk.txt](/llms-sdk.txt) | Complete documentation for the latest Expo SDK.             | ~2.6 MB |
 
 <Collapsible summary="Looking for deprecated Expo SDK versions?">

--- a/docs/ui/components/MarkdownActions/paths.ts
+++ b/docs/ui/components/MarkdownActions/paths.ts
@@ -1,7 +1,6 @@
 const DYNAMIC_DATA_PATHS = [
   /^\/additional-resources\/?$/,
   /^\/archive(\/.*)?$/,
-  /^\/llms\/?$/,
   /^\/bare\/upgrade\/?$/,
 ];
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-19993

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Move `llms.mdx` from the "More" navigation section to the "AI" section in docs/constants/navigation.js, placing it next to the
  Expo Skills page.
- Rewrite `llms.mdx` from a flat link list to a structured guide with three sections: Quick start table, Per-page markdown, and Documentation bundles.
- Remove `llms.mdx` from `DYNAMIC_DATA_PATHS` to re-enable the Copy Markdown dropdown on this page.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview: https://pr-43715.expo-docs.pages.dev/llms/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
