### PR TITLE
[ui][android] - Fix touch events with RN views in Compose BottomSheet

### DIFF
--- a/apps/native-component-list/src/screens/UI/BottomSheetScreen.android.tsx
+++ b/apps/native-component-list/src/screens/UI/BottomSheetScreen.android.tsx
@@ -1,33 +1,142 @@
-import { Button, BottomSheet, Host } from '@expo/ui/jetpack-compose';
+import {
+  Button,
+  Card,
+  Column,
+  Host,
+  LazyColumn,
+  ModalBottomSheet,
+  RNHostView,
+  Row,
+  Text as ComposeText,
+} from '@expo/ui/jetpack-compose';
+import { fillMaxWidth, height, padding } from '@expo/ui/jetpack-compose/modifiers';
 import * as React from 'react';
-import { ScrollView, Text, View } from 'react-native';
+import { Pressable, Text as RNText, View } from 'react-native';
 
 export default function BottomSheetScreen() {
-  const [isOpened, setIsOpened] = React.useState<boolean>(false);
+  const [showRNContent, setShowRNContent] = React.useState(false);
+  const [showRNContentWithFlex, setShowRNContentWithFlex] = React.useState(false);
+  const [counter, setCounter] = React.useState(0);
 
   return (
-    <ScrollView
-      contentContainerStyle={{
-        flex: 1,
-        justifyContent: 'flex-start',
-        alignItems: 'flex-start',
-        padding: 8,
-      }}>
-      <Host matchContents>
-        <Button onPress={() => setIsOpened((h) => !h)}>Toggle</Button>
-      </Host>
+    <Host style={{ flex: 1 }}>
+      <LazyColumn verticalArrangement={{ spacedBy: 16 }} modifiers={[padding(16, 16, 16, 16)]}>
+        <Card modifiers={[fillMaxWidth()]}>
+          <Column verticalArrangement={{ spacedBy: 12 }} modifiers={[padding(16, 16, 16, 16)]}>
+            <ComposeText>React Native Content</ComposeText>
+            <ComposeText>Sheet with interactive RN views inside</ComposeText>
+            <Row horizontalArrangement={{ spacedBy: 12 }}>
+              <Button onPress={() => setShowRNContent(true)}>Open RN Content Sheet</Button>
+            </Row>
+          </Column>
+        </Card>
 
-      <Text>isOpened: {isOpened ? 'yes' : 'no'}</Text>
-      {isOpened && (
-        <Host matchContents>
-          <BottomSheet onDismissRequest={() => setIsOpened(false)}>
-            <View style={{ padding: 20 }}>
-              <Text>Hello world</Text>
-            </View>
-          </BottomSheet>
-        </Host>
+        <Card modifiers={[fillMaxWidth()]}>
+          <Column verticalArrangement={{ spacedBy: 12 }} modifiers={[padding(16, 16, 16, 16)]}>
+            <ComposeText>React Native Content with flex: 1</ComposeText>
+            <ComposeText>Sheet with RN views that fill available space</ComposeText>
+            <Row horizontalArrangement={{ spacedBy: 12 }}>
+              <Button onPress={() => setShowRNContentWithFlex(true)}>
+                Open Flex Content Sheet
+              </Button>
+            </Row>
+          </Column>
+        </Card>
+      </LazyColumn>
+
+      {showRNContent && (
+        <ModalBottomSheet
+          onDismissRequest={() => setShowRNContent(false)}
+          skipPartiallyExpanded={false}>
+          <Column verticalArrangement={{ spacedBy: 16 }} modifiers={[padding(16, 16, 16, 16)]}>
+            <ComposeText>Mixing Compose + RN in a Bottom Sheet</ComposeText>
+            <Row horizontalArrangement={{ spacedBy: 24 }} verticalAlignment="center">
+              <RNHostView matchContents>
+                <Pressable
+                  onPress={() => setCounter((prev) => prev - 1)}
+                  style={{
+                    height: 50,
+                    width: 50,
+                    borderRadius: 100,
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    backgroundColor: '#9B59B6',
+                  }}>
+                  <RNText style={{ color: 'white', fontSize: 24 }}>-</RNText>
+                </Pressable>
+              </RNHostView>
+              <ComposeText>{counter}</ComposeText>
+              <RNHostView matchContents>
+                <Pressable
+                  onPress={() => setCounter((prev) => prev + 1)}
+                  style={{
+                    height: 50,
+                    width: 50,
+                    borderRadius: 100,
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    backgroundColor: '#9B59B6',
+                  }}>
+                  <RNText style={{ color: 'white', fontSize: 24 }}>+</RNText>
+                </Pressable>
+              </RNHostView>
+            </Row>
+            <RNHostView matchContents>
+              <View style={{ padding: 24 }}>
+                <RNText style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 8 }}>
+                  React Native Content
+                </RNText>
+                <RNText style={{ color: '#666', marginBottom: 16 }}>Counter: {counter}</RNText>
+                <Pressable
+                  style={{
+                    backgroundColor: '#007AFF',
+                    padding: 12,
+                    borderRadius: 8,
+                    alignItems: 'center',
+                    marginBottom: 12,
+                  }}
+                  onPress={() => setCounter((prev) => prev + 1)}>
+                  <RNText style={{ color: 'white', fontWeight: '600' }}>Increment</RNText>
+                </Pressable>
+                <Pressable
+                  style={{
+                    backgroundColor: '#FF3B30',
+                    padding: 12,
+                    borderRadius: 8,
+                    alignItems: 'center',
+                  }}
+                  onPress={() => setShowRNContent(false)}>
+                  <RNText style={{ color: 'white', fontWeight: '600' }}>Close</RNText>
+                </Pressable>
+              </View>
+            </RNHostView>
+          </Column>
+        </ModalBottomSheet>
       )}
-    </ScrollView>
+
+      {showRNContentWithFlex && (
+        <ModalBottomSheet
+          onDismissRequest={() => setShowRNContentWithFlex(false)}
+          skipPartiallyExpanded>
+          <Column modifiers={[height(400), padding(16, 16, 16, 16)]}>
+            <ComposeText>RN View with flex: 1</ComposeText>
+            <RNHostView>
+              <View style={{ flex: 1, backgroundColor: '#9B59B6', borderRadius: 10 }}>
+                <RNText
+                  style={{
+                    color: 'white',
+                    fontSize: 18,
+                    fontWeight: 'bold',
+                    padding: 16,
+                  }}>
+                  React Native Content (flex: 1)
+                </RNText>
+              </View>
+            </RNHostView>
+          </Column>
+        </ModalBottomSheet>
+      )}
+    </Host>
   );
 }
 

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix touch events for RN views inside Compose BottomSheet. ([#43716](https://github.com/expo/expo/pull/43716) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Fix `RNHostView` child parent related crash. ([#43691](https://github.com/expo/expo/pull/43691) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Added `RNHostView` to improve RN component layout inside Compose views. ([#43495](https://github.com/expo/expo/pull/43495) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Fix `ContextMenu` not expanding when triggered by `IconButton`. ([#43592](https://github.com/expo/expo/pull/43592) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/RNHostView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/RNHostView.kt
@@ -2,8 +2,10 @@ package expo.modules.ui
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.widget.FrameLayout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.runtime.Composable
@@ -16,6 +18,15 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.viewinterop.AndroidView
+import com.facebook.react.bridge.ReactContext
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
+import com.facebook.react.config.ReactFeatureFlags
+import com.facebook.react.uimanager.JSPointerDispatcher
+import com.facebook.react.uimanager.JSTouchDispatcher
+import com.facebook.react.uimanager.RootView
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.UIManagerHelper
+import com.facebook.react.uimanager.events.EventDispatcher
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
@@ -32,14 +43,24 @@ internal class RNHostView(context: Context, appContext: AppContext) :
   override val props = RNHostViewProps()
 
   private val childViewState = mutableStateOf<View?>(null)
+  private val wrapperState = mutableStateOf<TouchDispatchingRootViewGroup?>(null)
 
   override fun addView(child: View, index: Int, params: ViewGroup.LayoutParams) {
     childViewState.value = child
+    val wrapper = TouchDispatchingRootViewGroup(child.context).apply {
+      val reactContext = child.context as? ReactContext
+      if (reactContext != null) {
+        eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, child.id)
+      }
+      addView(child, FrameLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT))
+    }
+    wrapperState.value = wrapper
   }
 
   override fun removeView(view: View) {
     if (view == childViewState.value) {
       childViewState.value = null
+      wrapperState.value = null
     } else {
       super.removeView(view)
     }
@@ -47,21 +68,23 @@ internal class RNHostView(context: Context, appContext: AppContext) :
 
   override fun removeViewAt(index: Int) {
     childViewState.value = null
+    wrapperState.value = null
   }
 
   @Composable
   override fun ComposableScope.Content() {
     val matchContents = props.matchContents.value ?: false
 
-    childViewState.value?.let { view ->
+    wrapperState.value?.let { wrapper ->
+      val childView = childViewState.value ?: return@let
       if (matchContents) {
         AndroidView(
-          factory = { view },
-          modifier = applySizeFromYogaNodeModifier(view)
+          factory = { wrapper },
+          modifier = applySizeFromYogaNodeModifier(childView)
         )
       } else {
         AndroidView(
-          factory = { view },
+          factory = { wrapper },
           modifier = Modifier
             .fillMaxSize()
             .then(reportSizeToYogaNodeModifier())
@@ -116,5 +139,92 @@ internal class RNHostView(context: Context, appContext: AppContext) :
         )
       }
     }
+  }
+}
+
+/**
+ * A thin FrameLayout that intercepts touch events and dispatches them to JS via
+ * JSTouchDispatcher/JSPointerDispatcher, replicating the pattern from React Native's
+ * DialogRootViewGroup in ReactModalHostView.
+ */
+private class TouchDispatchingRootViewGroup(
+  context: Context
+) : FrameLayout(context), RootView {
+  private val jsTouchDispatcher = JSTouchDispatcher(this)
+  private var jsPointerDispatcher: JSPointerDispatcher? = null
+
+  var eventDispatcher: EventDispatcher? = null
+
+  private val reactContext: ThemedReactContext
+    get() = context as ThemedReactContext
+
+  init {
+    if (ReactFeatureFlags.dispatchPointerEvents) {
+      jsPointerDispatcher = JSPointerDispatcher(this)
+    }
+  }
+
+  override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+    // Always gets called with EXACTLY mode
+    // because parent has either fillMaxSize (matchContents = false) or requiredSize (matchContents = true) modifiers
+    setMeasuredDimension(
+      MeasureSpec.getSize(widthMeasureSpec),
+      MeasureSpec.getSize(heightMeasureSpec)
+    )
+  }
+
+  override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+    // No-op: don't re-layout children. Yoga calls child.layout() directly
+    // and we must not override those values.
+  }
+
+  override fun onInterceptTouchEvent(event: MotionEvent): Boolean {
+    eventDispatcher?.let { dispatcher ->
+      jsTouchDispatcher.handleTouchEvent(event, dispatcher, reactContext)
+      jsPointerDispatcher?.handleMotionEvent(event, dispatcher, true)
+    }
+    return super.onInterceptTouchEvent(event)
+  }
+
+  @SuppressLint("ClickableViewAccessibility")
+  override fun onTouchEvent(event: MotionEvent): Boolean {
+    eventDispatcher?.let { dispatcher ->
+      jsTouchDispatcher.handleTouchEvent(event, dispatcher, reactContext)
+      jsPointerDispatcher?.handleMotionEvent(event, dispatcher, false)
+    }
+    super.onTouchEvent(event)
+    return true
+  }
+
+  override fun onInterceptHoverEvent(event: MotionEvent): Boolean {
+    eventDispatcher?.let { jsPointerDispatcher?.handleMotionEvent(event, it, true) }
+    return super.onInterceptHoverEvent(event)
+  }
+
+  override fun onHoverEvent(event: MotionEvent): Boolean {
+    eventDispatcher?.let { jsPointerDispatcher?.handleMotionEvent(event, it, false) }
+    return super.onHoverEvent(event)
+  }
+
+  @OptIn(UnstableReactNativeAPI::class)
+  override fun onChildStartedNativeGesture(childView: View?, ev: MotionEvent) {
+    eventDispatcher?.let { dispatcher ->
+      jsTouchDispatcher.onChildStartedNativeGesture(ev, dispatcher, reactContext)
+      jsPointerDispatcher?.onChildStartedNativeGesture(childView, ev, dispatcher)
+    }
+  }
+
+  override fun onChildEndedNativeGesture(childView: View, ev: MotionEvent) {
+    eventDispatcher?.let { jsTouchDispatcher.onChildEndedNativeGesture(ev, it) }
+    jsPointerDispatcher?.onChildEndedNativeGesture()
+  }
+
+  override fun requestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {
+    // No-op - override to still receive events in onInterceptTouchEvent
+    // even when a child view disallows interception
+  }
+
+  override fun handleException(t: Throwable) {
+    reactContext.reactApplicationContext.handleException(RuntimeException(t))
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/RNHostView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/RNHostView.kt
@@ -2,6 +2,7 @@ package expo.modules.ui
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.util.Log
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
@@ -40,6 +41,10 @@ internal data class RNHostViewProps(
 @SuppressLint("ViewConstructor")
 internal class RNHostView(context: Context, appContext: AppContext) :
   ExpoComposeView<RNHostViewProps>(context, appContext) {
+  companion object {
+    private const val TAG = "RNHostView"
+  }
+
   override val props = RNHostViewProps()
 
   private val childViewState = mutableStateOf<View?>(null)
@@ -51,6 +56,8 @@ internal class RNHostView(context: Context, appContext: AppContext) :
       val reactContext = child.context as? ReactContext
       if (reactContext != null) {
         eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, child.id)
+      } else {
+        Log.e(TAG, "RNHostView: child context is not a ReactContext, touch events will not be dispatched to JS")
       }
       addView(child, FrameLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT))
     }
@@ -59,6 +66,7 @@ internal class RNHostView(context: Context, appContext: AppContext) :
 
   override fun removeView(view: View) {
     if (view == childViewState.value) {
+      wrapperState.value?.removeView(view)
       childViewState.value = null
       wrapperState.value = null
     } else {
@@ -67,6 +75,9 @@ internal class RNHostView(context: Context, appContext: AppContext) :
   }
 
   override fun removeViewAt(index: Int) {
+    childViewState.value?.let { child ->
+      wrapperState.value?.removeView(child)
+    }
     childViewState.value = null
     wrapperState.value = null
   }


### PR DESCRIPTION
# Why

RN views inside BottomSheet do not receive touch events as they are detached from react root view in a separate window. RN Modal solves the same issue using [DialogGroup](https://github.com/facebook/react-native/blob/3483dfa4609d34d1b2b4812ee2c280b37cf88231/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt#L501) view. 
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Follows the approach used by RN Modal. Adds a `RootView` and overrides event interception methods to dispatch touch events to JS.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Added example in NCL.

https://github.com/user-attachments/assets/43205556-7e2a-446a-b785-edbfcbf838a9



<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
