### PR TITLE
[docs] workflows syntax: update the `github` context properties

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -627,7 +627,7 @@ type GitHubContext = {
       state: 'open' | 'closed';
       draft: boolean;
       merged: boolean | null;
-      // ... and all other fields from the GitHub Pull Request webhook payload
+      // ... Other fields from the GitHub Pull Request webhook payload
     };
     number?: number;
     schedule?: string;

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -622,6 +622,12 @@ type GitHubContext = {
     };
     pull_request?: {
       number: number;
+      title: string;
+      body: string | null;
+      state: 'open' | 'closed';
+      draft: boolean;
+      merged: boolean | null;
+      // ... and all other fields from the GitHub Pull Request webhook payload
     };
     number?: number;
     schedule?: string;
@@ -629,6 +635,8 @@ type GitHubContext = {
   };
 };
 ```
+
+> **info** The `event` object contains the full [GitHub webhook payload](https://docs.github.com/en/webhooks/webhook-events-and-payloads). For `pull_request` events, `event.pull_request` includes all fields from GitHub's Pull Request webhook payload. The commonly used fields are shown above, but additional fields such as `user`, `labels`, `milestone`, and others are also available.
 
 If a workflow run is started from `eas workflow:run`, its `event_name` will be `workflow_dispatch` and all the rest of the properties will be empty.
 


### PR DESCRIPTION
# Why

The backend was updated to preserve the whole GitHub event payload on workflow runs (https://github.com/expo/universe/pull/23969), but the user-facing documentation was never updated.

# How

Updated the docs for EAS workflows Syntax -> Interpolation -> Context Properties -> `github`.

# Test Plan

Tested manually:
<img width="1204" height="968" alt="image" src="https://github.com/user-attachments/assets/ad3b8f7d-72f5-4973-b4a3-c28fd57a7121" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
