### PR TITLE
[widgets] Filter out invalid children

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add missing project root to `watchFolders` in `metro.config.js` ([#43449](https://github.com/expo/expo/pull/43449) by [@kitten](https://github.com/kitten))
 - [plugin] Fix reading undefined when config is not provided. ([#43568](https://github.com/expo/expo/pull/43568) by [@jakex7](https://github.com/jakex7))
 - Skip server bundling in `export:embed` call for `expo-widgets` bundle ([#43602](https://github.com/expo/expo/pull/43602) by [@kitten](https://github.com/kitten))
+- Filter out invalid children. ([#43720](https://github.com/expo/expo/pull/43720) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-widgets/ios/Widgets/DynamicView.swift
+++ b/packages/expo-widgets/ios/Widgets/DynamicView.swift
@@ -127,8 +127,9 @@ public struct WidgetsDynamicView: View, ExpoSwiftUI.AnyChild {
   private func updateChildren<P>(_ initialProps: P) throws
   where P: UIBaseViewProps {
     if let props = node["props"] as? [String: Any] {
-      if let children = props["children"] as? [[String: Any]] {
-        initialProps.children = children.map { WidgetsDynamicView(source: source, kind: kind, node: $0, entryIndex: entryIndex) }
+      if let children = props["children"] as? [Any] {
+        let validChildren = children.compactMap { $0 as? [String: Any] }
+        initialProps.children = validChildren.map { WidgetsDynamicView(source: source, kind: kind, node: $0, entryIndex: entryIndex) }
       } else if let child = props["children"] as? [String: Any] {
         initialProps.children = [WidgetsDynamicView(source: source, kind: kind, node: child, entryIndex: entryIndex)]
       }


### PR DESCRIPTION
# Why

When rendering elements conditionally, JSX produces invalid children that can't be cast to `[String: Any]`, like this component
```jsx
const TestWidget = (props, env) => {
  'widget';

  return (
    <VStack>
      {env.widgetFamily === 'systemSmall' && <Text>systemSmall</Text>}
      {env.widgetFamily === 'systemMedium' && <Text>systemMedium</Text>}
      {env.widgetFamily === 'systemLarge' && <Text>systemLarge</Text>}
    </VStack>
  );
};
```

will produce
```js
{
  type: 'VStackView',
  props: {
    children: [
      false,
      false,
      {
        type: 'TextView',
        // ...
      }
    ]
  }
}
```

# How

Filter out invalid children using compactMap

# Test Plan

Render the widget form Why section

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
