### PR TITLE
[expo-image-manipulator] preserve orientation for local images on iOS

### DIFF
--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Preserve HEIC orientation when loading local files for image manipulation. ([#43725](https://github.com/expo/expo/pull/43725) by [@maxsz](https://github.com/maxsz))
+
 ### 💡 Others
 
 ## 55.0.9 — 2026-02-25

--- a/packages/expo-image-manipulator/ios/ImageManipulatorUtils.swift
+++ b/packages/expo-image-manipulator/ios/ImageManipulatorUtils.swift
@@ -18,22 +18,27 @@ internal func loadImage(atUrl url: URL, appContext: AppContext) async throws -> 
     return try await loadImageFromPhotoLibrary(url: url)
   }
 
-  guard let imageLoader = appContext.imageLoader else {
-    throw ImageLoaderNotFoundException()
-  }
   guard FileSystemUtilities.isReadableFile(appContext, url) else {
-    throw FileSystemReadPermissionException(url.absoluteString)
+    guard let imageLoader = appContext.imageLoader else {
+      throw ImageLoaderNotFoundException()
+    }
+
+    do {
+      if let result = try await imageLoader.loadImage(for: url) {
+        return result
+      }
+    } catch {
+      throw ImageLoadingFailedException((error as NSError).debugDescription)
+    }
+
+    throw ImageLoadingFailedException("")
   }
 
-  do {
-    if let result = try await imageLoader.loadImage(for: url) {
-      return result
-    }
-  } catch {
-    throw ImageLoadingFailedException((error as NSError).debugDescription)
+  // Read local files directly so UIKit preserves HEIC/EXIF orientation metadata.
+  guard let data = try? Data(contentsOf: url), let image = UIImage(data: data) else {
+    throw FileSystemReadPermissionException(url.absoluteString)
   }
-  // TODO: throw something better
-  throw ImageLoadingFailedException("")
+  return image
 }
 
 /**


### PR DESCRIPTION
# Why

`expo-image-manipulator` was loading local HEIC images incorrectly on iOS before resizing/compressing them.

In our app, the original HEIC selected from the photo library displayed correctly before upload, but after running through `expo-image-manipulator` and being exported as JPEG, the uploaded image came out rotated incorrectly. 

For local file URLs, `expo-image-manipulator` currently uses React Native's `RCTImageLoader`. For HEIC files on iOS, that path appears to lose the source orientation semantics needed for later manipulation/export. As a result, the manipulator writes a JPEG with the wrong physical pixel orientation.


# How

This change updates `packages/expo-image-manipulator/ios/ImageManipulatorUtils.swift`.

Before:
  - `data:` URLs were decoded directly with `UIImage(data:)`
  - `ph://` and `assets-library://` URLs used the Photos-specific loading path
  - other URLs, including readable local file URLs, went through `appContext.imageLoader` / `RCTImageLoader`

After:
  - `data:` URLs still use `UIImage(data:)`
  - `ph://` and `assets-library://` still use the Photos path
  - readable local file URLs are now loaded directly with `Data(contentsOf:)` + `UIImage(data:)`
  - only non-readable / non-file URLs continue to use `appContext.imageLoader`

The reason for this split is that image manipulation needs the original image orientation preserved before resize/compression/export. For local HEIC files on iOS, direct UIKit decoding preserves that correctly, while the `RCTImageLoader` path does not appear to.

# Test Plan

I tested this manually with a real HEIC sample on iOS.

Reviewer reproduction:
  1. Use a portrait HEIC image from an iPhone photo library.
  2. In any iOS app flow that uses `expo-image-manipulator` to resize/compress a local image to JPEG, run the image through the manipulator.
  3. Before this change, the exported JPEG may be rotated incorrectly.
  4. After this change, the exported JPEG should remain upright.

# Checklist
- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)