### PR TITLE
[notifications] update error message

### DIFF
--- a/apps/notification-tester/app.config.js
+++ b/apps/notification-tester/app.config.js
@@ -1,0 +1,21 @@
+const googleServicesFile = getGoogleServices();
+
+export default ({ config }) => {
+  return {
+    ...config,
+    android: {
+      ...config.android,
+      googleServicesFile,
+    },
+  };
+};
+
+function getGoogleServices() {
+  if (process.env.RELEASE) {
+    return process.env.MICROFOAM_GOOGLE_SERVICES_JSON;
+  } else if (process.env.PREVIEW) {
+    return process.env.GOOGLE_SERVICES_JSON_PREVIEW;
+  } else {
+    return process.env.GOOGLE_SERVICES_JSON_DEV;
+  }
+}

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/tokens/PushTokenModule.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/tokens/PushTokenModule.kt
@@ -90,7 +90,7 @@ class PushTokenModule : Module(), FirebaseTokenListener {
     } catch (e: IllegalStateException) {
       promise.reject(
         REGISTRATION_FAIL_CODE,
-        "Make sure to complete the guide at https://docs.expo.dev/push-notifications/fcm-credentials/ : ${e.message}",
+        "Unable to get Firebase Messaging instance. Did you configure `googleServicesFile` path in app config? Make sure to complete the guide at https://docs.expo.dev/push-notifications/fcm-credentials/ : ${e.message}",
         e
       )
       null


### PR DESCRIPTION
# Why

This PR improves the developer experience when configuring Firebase Cloud Messaging for push notifications by adding better error messaging and configuration support.

# How

- Added a new `app.config.js` file because it was previously removed
- Enhanced the error message in `PushTokenModule.kt` to specifically mention checking the `googleServicesFile` path configuration when Firebase Messaging instance initialization fails

# Test Plan

- on device

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)