### PR TITLE
[image-picker] fix reported mime type potentially null

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- fix potential `null` mime type reported ([#43734](https://github.com/expo/expo/pull/43734) by [@vonovak](https://github.com/vonovak))
 - [android] fix cropper default colors in light mode ([#42437](https://github.com/expo/expo/pull/42437) by [@fobos531](https://github.com/fobos531))
 
 ### 💡 Others

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerUtils.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerUtils.kt
@@ -40,14 +40,14 @@ internal fun getType(contentResolver: ContentResolver, uri: Uri): String? {
         null,
         null,
         null
-      ).use { cursor ->
-        if (cursor?.moveToFirst() == true) {
+      )?.use { cursor ->
+        if (cursor.moveToFirst()) {
           val columnIndex = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_MIME_TYPE)
           if (columnIndex != -1 && !cursor.isNull(columnIndex)) {
-            cursor.getString(columnIndex)
+            return@use cursor.getString(columnIndex)
           }
         }
-        null
+        return@use null
       }
   }
 


### PR DESCRIPTION
# Why

Fix returning `null` from `mimeFromCursor` instead of string value. This issue is hard to manifest because this function is only used as a fallback and usually isn't executed.

# How

added `return` statement

# Test Plan

- used `mimeFromCursor` as the primary way to obtain mime [here](https://github.com/expo/expo/blob/206617830ee54fcf5ad9498a3da7504628df955e/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerUtils.kt#L55)

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)