### PR TITLE
fix(expo-audio): make seekTo synchronous on iOS to fix unreliable seeking

### DIFF
--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -277,8 +277,8 @@ public class AudioModule: Module {
         }
       }
 
-      AsyncFunction("seekTo") { (player: AudioPlayer, seconds: Double, toleranceMillisBefore: Double?, toleranceMillisAfter: Double?) in
-        await player.seekTo(
+      Function("seekTo") { (player: AudioPlayer, seconds: Double, toleranceMillisBefore: Double?, toleranceMillisAfter: Double?) in
+        player.seekTo(
           seconds: seconds,
           toleranceMillisBefore: toleranceMillisBefore,
           toleranceMillisAfter: toleranceMillisAfter

--- a/packages/expo-audio/ios/AudioPlayer.swift
+++ b/packages/expo-audio/ios/AudioPlayer.swift
@@ -161,7 +161,7 @@ public class AudioPlayer: SharedRef<AVPlayer>, Playable {
     }
   }
 
-  func seekTo(seconds: Double, toleranceMillisBefore: Double? = nil, toleranceMillisAfter: Double? = nil) async {
+  func seekTo(seconds: Double, toleranceMillisBefore: Double? = nil, toleranceMillisAfter: Double? = nil) {
     let time = CMTime(seconds: seconds, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
     let toleranceBefore = toleranceMillisBefore.map {
       CMTime(seconds: $0 / 1000.0, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
@@ -170,15 +170,11 @@ public class AudioPlayer: SharedRef<AVPlayer>, Playable {
       CMTime(seconds: $0 / 1000.0, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
     } ?? CMTime.positiveInfinity
 
-    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-      ref.seek(to: time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter) { [weak self] _ in
-        if let self {
-          self.updateStatus(with: [
-            "currentTime": self.currentTime
-          ])
-        }
-        continuation.resume()
-      }
+    ref.seek(to: time, toleranceBefore: toleranceBefore, toleranceAfter: toleranceAfter) { [weak self] _ in
+      guard let self else { return }
+      self.updateStatus(with: [
+        "currentTime": self.currentTime
+      ])
     }
   }
 


### PR DESCRIPTION
## Summary

The `async` `seekTo` method in `AudioPlayer.swift` wraps `AVPlayer.seek(to:)` in `withCheckedContinuation`, which causes unreliable seeking behavior on iOS. Seek operations would intermittently fail to complete or produce incorrect playback positions.

This PR makes `seekTo` synchronous by:
- Removing the `async` keyword and `withCheckedContinuation` wrapper from `AudioPlayer.seekTo`
- Calling `ref.seek(to:toleranceBefore:toleranceAfter:)` directly with a completion handler that updates the playback status
- Updating `AudioModule.swift` to use `Function` instead of `AsyncFunction` for the `seekTo` binding, since the underlying method is no longer async

The completion handler still fires the status update with the current time after the seek completes, preserving the existing behavior.

## Test plan

- Call `player.seekTo(seconds)` repeatedly in quick succession and verify each seek lands at the correct position
- Verify `onPlaybackStatusUpdate` fires with the correct `currentTime` after seeking
- Test seeking while paused and while playing
- Test with custom tolerance values (`toleranceMillisBefore`, `toleranceMillisAfter`)