### PR TITLE
fix: update glass effect when colorScheme prop changes

### DIFF
--- a/packages/expo-glass-effect/CHANGELOG.md
+++ b/packages/expo-glass-effect/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `colorScheme` prop not visually updating the glass effect when changed. ([#43754](https://github.com/expo/expo/pull/43754) by [@mohi86](https://github.com/mohi86))
+
 ### 💡 Others
 
 ## 55.0.7 — 2026-02-25

--- a/packages/expo-glass-effect/ios/GlassView.swift
+++ b/packages/expo-glass-effect/ios/GlassView.swift
@@ -222,6 +222,22 @@ public final class GlassView: ExpoView {
 
   func setColorScheme(_ colorScheme: GlassColorScheme) {
     overrideUserInterfaceStyle = colorScheme.toUIUserInterfaceStyle()
+    glassEffectView.overrideUserInterfaceStyle = colorScheme.toUIUserInterfaceStyle()
+    setNeedsLayout()
+    layoutIfNeeded()
+    DispatchQueue.main.async { [weak self] in
+      guard let self = self, self.isGlassEffectAvailable() else { return }
+      if #available(iOS 26.0, tvOS 26.0, macOS 26.0, *) {
+        #if compiler(>=6.2)
+        if let currentStyle = self.glassStyle, let uiStyle = currentStyle.toUIGlassEffectStyle() {
+          let effect = UIGlassEffect(style: uiStyle)
+          self.glassEffectView.effect = effect
+          self.glassEffect = effect
+          self.updateEffect()
+        }
+        #endif
+      }
+    }
   }
 
   private func updateEffect() {


### PR DESCRIPTION
The setColorScheme() method was updating overrideUserInterfaceStyle but failing to re-apply the UIGlassEffect, causing visual updates to not appear when toggling between light and dark color schemes.

This fix follows the established pattern from setTintColor() and setInteractive() by recreating the glass effect and calling updateEffect() to force the visual effect view to re-render with the updated appearance settings.

Fixes #43743