### PR TITLE
fix(cli): support files >= 2 GiB in AFC device upload

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- Support files >= 2 GiB in AFC device upload ([#43755](https://github.com/expo/expo/pull/43755) by [@yocontra](https://github.com/yocontra))
 - Revert the `-quiet` change to ensure build env vars are always printed. ([#43906](https://github.com/expo/expo/pull/43906) by [@EvanBacon](https://github.com/EvanBacon))
 - Avoid `ERR_TTY_INIT_FAILED` when `LOG_EVENTS=1` or `LOG_EVENTS=2` is used in non-interactive terminals. ([#43796](https://github.com/expo/expo/pull/43796) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Correctly handle JavaScript assets when `asyncRoutes: true` in SSR ([#43446](https://github.com/expo/expo/pull/43446) by [@hassankhan](https://github.com/hassankhan))`

--- a/packages/@expo/cli/src/run/ios/appleDevice/client/AFCClient.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/client/AFCClient.ts
@@ -106,31 +106,17 @@ export class AFCClient extends ServiceClient<AFCProtocolClient> {
   protected async uploadFile(srcPath: string, destPath: string): Promise<void> {
     debug(`uploadFile: ${srcPath}, ${destPath}`);
 
-    const stat = fs.statSync(srcPath);
     const destFile = await this.openFile(destPath);
 
     try {
       // fs.readFile cannot handle files >= 2 GiB due to Node.js Buffer limitations.
-      // Read and write in chunks to support large files (e.g. ML models).
-      const CHUNK_SIZE = 8 * 1024 * 1024; // 8 MiB
-      const fd = fs.openSync(srcPath, 'r');
-      try {
-        const buf = Buffer.allocUnsafe(Math.min(CHUNK_SIZE, stat.size));
-        let bytesRead = 0;
-        let offset = 0;
-        while (offset < stat.size) {
-          const toRead = Math.min(CHUNK_SIZE, stat.size - offset);
-          bytesRead = fs.readSync(fd, buf, 0, toRead, offset);
-          await this.writeFile(destFile, buf.subarray(0, bytesRead));
-          offset += bytesRead;
-        }
-      } finally {
-        fs.closeSync(fd);
+      // Stream the file in chunks to support large files (e.g. ML models).
+      const stream = fs.createReadStream(srcPath, { highWaterMark: 8 * 1024 * 1024 });
+      for await (const chunk of stream) {
+        await this.writeFile(destFile, chunk);
       }
+    } finally {
       await this.closeFile(destFile);
-    } catch (err) {
-      await this.closeFile(destFile);
-      throw err;
     }
   }
 

--- a/packages/@expo/cli/src/run/ios/appleDevice/client/AFCClient.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/client/AFCClient.ts
@@ -9,6 +9,7 @@ import Debug from 'debug';
 import * as fs from 'fs';
 import { Socket } from 'net';
 import * as path from 'path';
+
 import { ServiceClient } from './ServiceClient';
 import { CommandError } from '../../../../utils/errors';
 import {

--- a/packages/@expo/cli/src/run/ios/appleDevice/client/AFCClient.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/client/AFCClient.ts
@@ -9,8 +9,6 @@ import Debug from 'debug';
 import * as fs from 'fs';
 import { Socket } from 'net';
 import * as path from 'path';
-import { promisify } from 'util';
-
 import { ServiceClient } from './ServiceClient';
 import { CommandError } from '../../../../utils/errors';
 import {
@@ -108,14 +106,27 @@ export class AFCClient extends ServiceClient<AFCProtocolClient> {
   protected async uploadFile(srcPath: string, destPath: string): Promise<void> {
     debug(`uploadFile: ${srcPath}, ${destPath}`);
 
-    // read local file and get fd of destination
-    const [srcFile, destFile] = await Promise.all([
-      await promisify(fs.readFile)(srcPath),
-      await this.openFile(destPath),
-    ]);
+    const stat = fs.statSync(srcPath);
+    const destFile = await this.openFile(destPath);
 
     try {
-      await this.writeFile(destFile, srcFile);
+      // fs.readFile cannot handle files >= 2 GiB due to Node.js Buffer limitations.
+      // Read and write in chunks to support large files (e.g. ML models).
+      const CHUNK_SIZE = 8 * 1024 * 1024; // 8 MiB
+      const fd = fs.openSync(srcPath, 'r');
+      try {
+        const buf = Buffer.allocUnsafe(Math.min(CHUNK_SIZE, stat.size));
+        let bytesRead = 0;
+        let offset = 0;
+        while (offset < stat.size) {
+          const toRead = Math.min(CHUNK_SIZE, stat.size - offset);
+          bytesRead = fs.readSync(fd, buf, 0, toRead, offset);
+          await this.writeFile(destFile, buf.subarray(0, bytesRead));
+          offset += bytesRead;
+        }
+      } finally {
+        fs.closeSync(fd);
+      }
       await this.closeFile(destFile);
     } catch (err) {
       await this.closeFile(destFile);

--- a/packages/@expo/cli/src/run/ios/appleDevice/client/__tests__/AFCClient-test.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/client/__tests__/AFCClient-test.ts
@@ -1,3 +1,6 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { Socket } from 'net';
 
 import { AFCClient } from '../AFCClient';
@@ -117,6 +120,96 @@ describe('closeFile', () => {
       data: expect.anything(),
       operation: 20,
     });
+  });
+});
+
+describe('uploadFile', () => {
+  it(`reads and writes file in chunks`, async () => {
+    // Create a temp file with known content
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'afc-test-'));
+    const tmpFile = path.join(tmpDir, 'test.bin');
+    // Write 20 MiB so it requires multiple chunks (chunk size is 8 MiB)
+    const size = 20 * 1024 * 1024;
+    const data = Buffer.alloc(size, 0x42);
+    fs.writeFileSync(tmpFile, data);
+
+    const socket = mockSocket();
+    const client = new AFCClient(socket);
+
+    // Mock openFile to return a fake fd
+    const fakeFd = Buffer.from([1, 0, 0, 0, 0, 0, 0, 0]);
+    client['openFile'] = jest.fn(async () => fakeFd);
+    client['closeFile'] = jest.fn(async () => ({ operation: 2, id: 0, data: Buffer.from('') }));
+
+    const writeChunks: number[] = [];
+    client['writeFile'] = jest.fn(async (_fd: Buffer, chunk: Buffer) => {
+      writeChunks.push(chunk.length);
+      return { operation: 2, id: 0, data: Buffer.from('') };
+    });
+
+    await client['uploadFile'](tmpFile, 'PublicStaging/test.bin');
+
+    // Should have been called 3 times: 8 MiB + 8 MiB + 4 MiB
+    expect(client['writeFile']).toHaveBeenCalledTimes(3);
+    expect(writeChunks).toEqual([
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      4 * 1024 * 1024,
+    ]);
+    expect(client['openFile']).toHaveBeenCalledWith('PublicStaging/test.bin');
+    expect(client['closeFile']).toHaveBeenCalledWith(fakeFd);
+
+    // Cleanup
+    fs.unlinkSync(tmpFile);
+    fs.rmdirSync(tmpDir);
+  });
+
+  it(`handles empty files`, async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'afc-test-'));
+    const tmpFile = path.join(tmpDir, 'empty.bin');
+    fs.writeFileSync(tmpFile, Buffer.alloc(0));
+
+    const socket = mockSocket();
+    const client = new AFCClient(socket);
+
+    const fakeFd = Buffer.from([1, 0, 0, 0, 0, 0, 0, 0]);
+    client['openFile'] = jest.fn(async () => fakeFd);
+    client['closeFile'] = jest.fn(async () => ({ operation: 2, id: 0, data: Buffer.from('') }));
+    client['writeFile'] = jest.fn();
+
+    await client['uploadFile'](tmpFile, 'PublicStaging/empty.bin');
+
+    // No writes for empty file
+    expect(client['writeFile']).not.toHaveBeenCalled();
+    expect(client['closeFile']).toHaveBeenCalledWith(fakeFd);
+
+    fs.unlinkSync(tmpFile);
+    fs.rmdirSync(tmpDir);
+  });
+
+  it(`closes remote file on write error`, async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'afc-test-'));
+    const tmpFile = path.join(tmpDir, 'fail.bin');
+    fs.writeFileSync(tmpFile, Buffer.alloc(1024));
+
+    const socket = mockSocket();
+    const client = new AFCClient(socket);
+
+    const fakeFd = Buffer.from([1, 0, 0, 0, 0, 0, 0, 0]);
+    client['openFile'] = jest.fn(async () => fakeFd);
+    client['closeFile'] = jest.fn(async () => ({ operation: 2, id: 0, data: Buffer.from('') }));
+    client['writeFile'] = jest.fn(async () => {
+      throw new Error('write failed');
+    });
+
+    await expect(client['uploadFile'](tmpFile, 'PublicStaging/fail.bin')).rejects.toThrow(
+      'write failed'
+    );
+    // Remote file should still be closed
+    expect(client['closeFile']).toHaveBeenCalledWith(fakeFd);
+
+    fs.unlinkSync(tmpFile);
+    fs.rmdirSync(tmpDir);
   });
 });
 

--- a/packages/@expo/cli/src/run/ios/appleDevice/client/__tests__/AFCClient-test.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/client/__tests__/AFCClient-test.ts
@@ -124,80 +124,61 @@ describe('closeFile', () => {
 });
 
 describe('uploadFile', () => {
-  it(`reads and writes file in chunks`, async () => {
-    // Create a temp file with known content
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'afc-test-'));
-    const tmpFile = path.join(tmpDir, 'test.bin');
-    // Write 20 MiB so it requires multiple chunks (chunk size is 8 MiB)
-    const size = 20 * 1024 * 1024;
-    const data = Buffer.alloc(size, 0x42);
-    fs.writeFileSync(tmpFile, data);
+  const fakeFd = Buffer.from([1, 0, 0, 0, 0, 0, 0, 0]);
+  const mockResponse = { operation: 2, id: 0, data: Buffer.from('') };
+  let tmpDir: string;
 
-    const socket = mockSocket();
-    const client = new AFCClient(socket);
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'afc-test-'));
+  });
 
-    // Mock openFile to return a fake fd
-    const fakeFd = Buffer.from([1, 0, 0, 0, 0, 0, 0, 0]);
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function mockClient() {
+    const client = new AFCClient(mockSocket());
     client['openFile'] = jest.fn(async () => fakeFd);
-    client['closeFile'] = jest.fn(async () => ({ operation: 2, id: 0, data: Buffer.from('') }));
+    client['closeFile'] = jest.fn(async () => mockResponse);
+    return client;
+  }
 
-    const writeChunks: number[] = [];
+  it(`streams file in chunks`, async () => {
+    const tmpFile = path.join(tmpDir, 'test.bin');
+    fs.writeFileSync(tmpFile, Buffer.alloc(1024, 0x42));
+
+    const client = mockClient();
+    const chunks: number[] = [];
     client['writeFile'] = jest.fn(async (_fd: Buffer, chunk: Buffer) => {
-      writeChunks.push(chunk.length);
-      return { operation: 2, id: 0, data: Buffer.from('') };
+      chunks.push(chunk.length);
+      return mockResponse;
     });
 
     await client['uploadFile'](tmpFile, 'PublicStaging/test.bin');
 
-    // Should have been called 3 times: 8 MiB + 8 MiB + 4 MiB
-    expect(client['writeFile']).toHaveBeenCalledTimes(3);
-    expect(writeChunks).toEqual([
-      8 * 1024 * 1024,
-      8 * 1024 * 1024,
-      4 * 1024 * 1024,
-    ]);
+    expect(chunks.reduce((a, b) => a + b, 0)).toBe(1024);
     expect(client['openFile']).toHaveBeenCalledWith('PublicStaging/test.bin');
     expect(client['closeFile']).toHaveBeenCalledWith(fakeFd);
-
-    // Cleanup
-    fs.unlinkSync(tmpFile);
-    fs.rmdirSync(tmpDir);
   });
 
   it(`handles empty files`, async () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'afc-test-'));
     const tmpFile = path.join(tmpDir, 'empty.bin');
     fs.writeFileSync(tmpFile, Buffer.alloc(0));
 
-    const socket = mockSocket();
-    const client = new AFCClient(socket);
-
-    const fakeFd = Buffer.from([1, 0, 0, 0, 0, 0, 0, 0]);
-    client['openFile'] = jest.fn(async () => fakeFd);
-    client['closeFile'] = jest.fn(async () => ({ operation: 2, id: 0, data: Buffer.from('') }));
+    const client = mockClient();
     client['writeFile'] = jest.fn();
 
     await client['uploadFile'](tmpFile, 'PublicStaging/empty.bin');
 
-    // No writes for empty file
     expect(client['writeFile']).not.toHaveBeenCalled();
     expect(client['closeFile']).toHaveBeenCalledWith(fakeFd);
-
-    fs.unlinkSync(tmpFile);
-    fs.rmdirSync(tmpDir);
   });
 
   it(`closes remote file on write error`, async () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'afc-test-'));
     const tmpFile = path.join(tmpDir, 'fail.bin');
     fs.writeFileSync(tmpFile, Buffer.alloc(1024));
 
-    const socket = mockSocket();
-    const client = new AFCClient(socket);
-
-    const fakeFd = Buffer.from([1, 0, 0, 0, 0, 0, 0, 0]);
-    client['openFile'] = jest.fn(async () => fakeFd);
-    client['closeFile'] = jest.fn(async () => ({ operation: 2, id: 0, data: Buffer.from('') }));
+    const client = mockClient();
     client['writeFile'] = jest.fn(async () => {
       throw new Error('write failed');
     });
@@ -205,11 +186,7 @@ describe('uploadFile', () => {
     await expect(client['uploadFile'](tmpFile, 'PublicStaging/fail.bin')).rejects.toThrow(
       'write failed'
     );
-    // Remote file should still be closed
     expect(client['closeFile']).toHaveBeenCalledWith(fakeFd);
-
-    fs.unlinkSync(tmpFile);
-    fs.rmdirSync(tmpDir);
   });
 });
 

--- a/packages/@expo/cli/src/run/ios/appleDevice/client/__tests__/AFCClient-test.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/client/__tests__/AFCClient-test.ts
@@ -1,7 +1,8 @@
 import * as fs from 'fs';
+import { vol } from 'memfs';
+import type { Socket } from 'net';
 import * as os from 'os';
 import * as path from 'path';
-import { Socket } from 'net';
 
 import { AFCClient } from '../AFCClient';
 
@@ -129,11 +130,12 @@ describe('uploadFile', () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'afc-test-'));
+    tmpDir = path.join(os.tmpdir(), 'afc-test');
+    vol.mkdirSync(tmpDir, { recursive: true });
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vol.rmSync(tmpDir, { recursive: true, force: true });
   });
 
   function mockClient() {


### PR DESCRIPTION
Fixes `RangeError [ERR_FS_FILE_TOO_LARGE]` when installing apps that contain files >= 2 GiB onto physical iOS devices via `npx expo run:ios`.

`AFCClient.uploadFile()` used `fs.readFile()` to read the entire source file into a `Buffer` before uploading. Node.js `Buffer` has a hard 2 GiB limit (`kMaxLength`), so any individual file in the `.app` bundle exceeding this size causes the install to fail with:

```
RangeError [ERR_FS_FILE_TOO_LARGE]: File size (2472937860) is greater than 2 GiB
    at FSReqCallback.readFileAfterStat [as oncomplete] (node:fs:316:11)
```

This is increasingly common with apps bundling on-device ML models (e.g. LLaMA, Stable Diffusion).

## Fix

Replace `fs.readFile()` with chunked reading via `fs.openSync`/`fs.readSync` in 8 MiB chunks. Each chunk is written to the device using the existing `FILE_WRITE` AFC operation. The AFC protocol already supports multiple sequential writes to an open file descriptor, so no protocol-level changes are needed.

- Removed unused `promisify` import from `util`
- Added tests for chunked upload behavior, empty files, and error handling (remote fd cleanup)