### PR TITLE
[docs] Add missing description field to video structured data

### DIFF
--- a/docs/pages/archive/e2e-tests.mdx
+++ b/docs/pages/archive/e2e-tests.mdx
@@ -16,7 +16,11 @@ In this guide, you will learn how to create and run E2E tests on EAS Build using
 
 The example demonstrates how to configure your EAS Build Maestro E2E tests workflow using the [default Expo template](/more/create-expo/#--template). For your own app, you will need to adjust the flows to match your app's UI.
 
-<VideoBoxLink videoId="-o-bfIRrg9U" title="Watch: How to run E2E tests on EAS Build" />
+<VideoBoxLink
+  videoId="-o-bfIRrg9U"
+  title="Watch: How to run E2E tests on EAS Build"
+  description="Set up and run end-to-end tests on EAS Build using Maestro to automate UI testing for your app."
+/>
 
 <Step label="1">
 ## Initialize a new project

--- a/docs/pages/eas/hosting/get-started.mdx
+++ b/docs/pages/eas/hosting/get-started.mdx
@@ -15,7 +15,11 @@ EAS Hosting is a react hosting service that allows you to deploy an exported Exp
 
 This guide will walk you through the process of creating your first web deployment.
 
-<VideoBoxLink videoId="NaKsfWciJLo" title="Watch: Deploy your Expo Router web project" />
+<VideoBoxLink
+  videoId="NaKsfWciJLo"
+  title="Watch: Deploy your Expo Router web project"
+  description="Set up EAS Hosting for your Expo Router web project, create your first deployment, and get a preview URL up and running."
+/>
 
 ## Prerequisites
 

--- a/docs/pages/eas/workflows/examples/create-development-builds.mdx
+++ b/docs/pages/eas/workflows/examples/create-development-builds.mdx
@@ -24,6 +24,7 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
   className="mb-4"
   videoId="u8MAJ0F18s0"
   title="Expo Golden Workflow: Automate the creation of development builds"
+  description="Learn how to automate development builds for Android, iOS devices, and simulators using EAS Workflows."
 />
 
 ## Get started

--- a/docs/pages/eas/workflows/examples/deploy-to-production.mdx
+++ b/docs/pages/eas/workflows/examples/deploy-to-production.mdx
@@ -24,6 +24,7 @@ When you're ready to deliver changes to your users, you can build and submit to 
   className="mb-4"
   videoId="o-peODF6E2o"
   title="Expo Golden Workflow: Deploy your app to production with an automated workflow"
+  description="Automate your production releases with EAS Workflows to build, submit to app stores, or send an update when new builds aren't needed."
 />
 
 ## Get started

--- a/docs/pages/eas/workflows/examples/publish-preview-update.mdx
+++ b/docs/pages/eas/workflows/examples/publish-preview-update.mdx
@@ -23,6 +23,7 @@ You can access preview updates in the development build UI and through scannable
   className="mb-4"
   videoId="v_rzRcVSQYQ"
   title="Expo Golden Workflow: Share preview updates with your team"
+  description="Publish preview updates on every commit with EAS Workflows so your team can review changes without pulling code locally."
 />
 
 ## Get started

--- a/docs/pages/guides/editing-richtext.mdx
+++ b/docs/pages/guides/editing-richtext.mdx
@@ -15,6 +15,7 @@ There is currently no default solution for that in the React Native ecosystem. H
 <VideoBoxLink
   videoId="CxORa1tXMjw"
   title="Watch: How to implement a Rich Text Editor using DOM components"
+  description="Build a rich text editor in React Native using Expo DOM components to render a web-based editor inside a native app."
 />
 
 ## Render rich text

--- a/docs/pages/guides/in-app-purchases.mdx
+++ b/docs/pages/guides/in-app-purchases.mdx
@@ -18,7 +18,11 @@ In-app purchases (IAP) are transactions within a mobile or desktop application w
 
 ## Tutorial
 
-<VideoBoxLink videoId="R3fLKC-2Qh0" title="Watch: How to Implement In-App Purchases in Expo" />
+<VideoBoxLink
+  videoId="R3fLKC-2Qh0"
+  title="Watch: How to Implement In-App Purchases in Expo"
+  description="Set up in-app purchases and subscriptions in your Expo app using RevenueCat."
+/>
 
 <br />
 

--- a/docs/pages/guides/local-first.mdx
+++ b/docs/pages/guides/local-first.mdx
@@ -65,6 +65,7 @@ TinyBase works seamlessly with Expo Go, allowing you to develop quickly. On Andr
 <VideoBoxLink
   videoId="HqOiB2tDM8Q"
   title="Watch: Build a Local-First Real-Time Shopping List App with Expo and TinyBase"
+  description="Build a real-time shopping list app using TinyBase with expo-sqlite for persistence and automatic syncing."
 />
 
 ### SQLite
@@ -82,6 +83,7 @@ TinyBase works seamlessly with Expo Go, allowing you to develop quickly. On Andr
 <VideoBoxLink
   videoId="uTrPte0sCiw"
   title="Watch: Building a Local-first Notion Clone with React Native Expo and Prisma"
+  description="Build a local-first Notion clone with Prisma ORM for Expo, covering state management, syncing, and persistence."
 />
 
 ### Jazz
@@ -95,6 +97,7 @@ TinyBase works seamlessly with Expo Go, allowing you to develop quickly. On Andr
 <VideoBoxLink
   videoId="zQIhJqYU1Qw"
   title="Watch: How to build local-first native apps with LiveStore and Expo"
+  description="Use LiveStore's SQLite-based data layer to build a high-performance local-first app with Expo."
 />
 
 ### Turso
@@ -104,6 +107,7 @@ TinyBase works seamlessly with Expo Go, allowing you to develop quickly. On Andr
 <VideoBoxLink
   videoId="SBv32tmyb3k"
   title="Watch: How to build a local-first Notes App with Turso and Expo"
+  description="Build a local-first notes app with Turso's offline sync and expo-sqlite for bidirectional data syncing."
 />
 
 ### Instant
@@ -113,6 +117,7 @@ TinyBase works seamlessly with Expo Go, allowing you to develop quickly. On Andr
 <VideoBoxLink
   videoId="DEJIcaGN3vY"
   title="Watch: Build a Local-First Sketch App with Expo, Instant & Reanimated"
+  description="Build a collaborative sketch app with Instant's real-time database and Reanimated for smooth drawing interactions."
 />
 
 ### RxDB

--- a/docs/pages/guides/using-resend.mdx
+++ b/docs/pages/guides/using-resend.mdx
@@ -11,7 +11,11 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 This guide demonstrates the **essential steps to integrate Resend with your Expo and React Native project**.
 
-<VideoBoxLink videoId="8sPD8SNcUFA" title="How to send emails with Resend from your Expo app" />
+<VideoBoxLink
+  videoId="8sPD8SNcUFA"
+  title="How to send emails with Resend from your Expo app"
+  description="Integrate Resend with Expo Router API routes to send emails programmatically and deploy to EAS Hosting."
+/>
 
 ## Prerequisites
 

--- a/docs/pages/linking/android-app-links.mdx
+++ b/docs/pages/linking/android-app-links.mdx
@@ -18,6 +18,7 @@ To configure Android App Links for your app, you need to:
   videoId="kNbEEYlFIPs"
   time={399}
   title="Watch: Set up Android App Links with Expo Router"
+  description="Configure intent filters with autoVerify, set up the two-way association between your website and app, and verify Android App Links."
 />
 
 ## Add `intentFilters` to the app config

--- a/docs/pages/linking/overview.mdx
+++ b/docs/pages/linking/overview.mdx
@@ -17,7 +17,11 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 Linking allows your app to interact with incoming and outgoing URLs. In this process, the user not only gets directed to open your app, but they are taken to a specific screen (route) within the app.
 
-<VideoBoxLink videoId="kNbEEYlFIPs" title="Watch: Setting up linking with Expo" />
+<VideoBoxLink
+  videoId="kNbEEYlFIPs"
+  title="Watch: Setting up linking with Expo"
+  description="Set up deep links, universal links, and app links in your Expo app to handle incoming and outgoing URLs."
+/>
 
 ### Linking strategies
 

--- a/docs/pages/modules/native-module-tutorial.mdx
+++ b/docs/pages/modules/native-module-tutorial.mdx
@@ -17,6 +17,7 @@ In this tutorial, you build a module that stores the user's preferred app theme:
 <VideoBoxLink
   videoId="CdaQSlyGik8"
   title="Watch: How to create a native module with the Expo Modules API"
+  description="Build a native module that persists user settings using SharedPreferences on Android and UserDefaults on iOS."
 />
 
 ---

--- a/docs/pages/router/web/api-routes.mdx
+++ b/docs/pages/router/web/api-routes.mdx
@@ -26,6 +26,7 @@ Server features require a custom server, which can be deployed to EAS or most [o
 <VideoBoxLink
   videoId="2_UzR1wdimI"
   title="Watch: Expo Router API Routes Handle Requests & Stream Data"
+  description="Create server endpoints with Expo Router API routes to handle requests, return JSON, and stream data."
 />
 
 ## What are API Routes

--- a/docs/pages/tutorial/add-navigation.mdx
+++ b/docs/pages/tutorial/add-navigation.mdx
@@ -14,7 +14,11 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 In this chapter, we'll learn Expo Router's fundamentals to create stack navigation and a bottom tab bar with two tabs.
 
-<VideoBoxLink videoId="8336fcFV_T4" title="Watch: Adding navigation in your universal Expo app" />
+<VideoBoxLink
+  videoId="8336fcFV_T4"
+  title="Watch: Adding navigation in your universal Expo app"
+  description="Set up file-based routing with Expo Router, create stack navigation between screens, and build a bottom tab bar."
+/>
 
 ## Expo Router basics
 

--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -23,7 +23,11 @@ The screen above displays an image and two buttons. The app user can select an i
 
 Once the user selects an image, they can add a sticker to it. So, let's start creating this screen.
 
-<VideoBoxLink videoId="3rcOP8xDwTQ" title="Watch: Building a screen in your universal Expo app" />
+<VideoBoxLink
+  videoId="3rcOP8xDwTQ"
+  title="Watch: Building a screen in your universal Expo app"
+  description="Build the StickerSmash app's first screen using Pressable, Expo Image, and other core components to create an image picker layout."
+/>
 
 ---
 

--- a/docs/pages/tutorial/configuration.mdx
+++ b/docs/pages/tutorial/configuration.mdx
@@ -14,6 +14,7 @@ In this chapter, we'll address some app details before deploying our app to an a
 <VideoBoxLink
   videoId="OgGCYdElcZo"
   title="Watch: Adding the finishing touches to your universal Expo app"
+  description="Configure the status bar, customize your app icon, and set up the splash screen before deploying to the app store."
 />
 
 ---

--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -13,7 +13,11 @@ React Native provides a [`<Modal>` component](https://reactnative.dev/docs/modal
 
 In this chapter, we'll create a modal that shows an emoji picker list.
 
-<VideoBoxLink videoId="HRAMzrBwVeo" title="Watch: Creating a modal in your universal Expo app" />
+<VideoBoxLink
+  videoId="HRAMzrBwVeo"
+  title="Watch: Creating a modal in your universal Expo app"
+  description="Build a modal component using React Native's Modal API to display an emoji picker and handle user interactions."
+/>
 
 ---
 

--- a/docs/pages/tutorial/eas/android-development-build.mdx
+++ b/docs/pages/tutorial/eas/android-development-build.mdx
@@ -19,6 +19,7 @@ The process for creating and running a build on Android devices or emulators is 
 <VideoBoxLink
   videoId="D612BUtvvl8"
   title="Watch: How to create and run a cloud build for Android"
+  description="Learn how to create an Android development build with EAS Build and install it on a device or emulator."
 />
 
 ---

--- a/docs/pages/tutorial/eas/android-production-build.mdx
+++ b/docs/pages/tutorial/eas/android-production-build.mdx
@@ -18,6 +18,7 @@ In this chapter, we'll create our example app's production version and submit it
 <VideoBoxLink
   videoId="nxlt8uwqhpE"
   title="Watch: Creating and releasing a production build for Android"
+  description="Create a production build for Android with EAS, submit it to the Google Play Store, and automate the release process."
 />
 
 ---

--- a/docs/pages/tutorial/eas/configure-development-build.mdx
+++ b/docs/pages/tutorial/eas/configure-development-build.mdx
@@ -15,7 +15,11 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 In this chapter, we'll set up and configure a development build with EAS for our example app.
 
-<VideoBoxLink videoId="uQCE9zl3dXU" title="Watch: How to configure a development build" />
+<VideoBoxLink
+  videoId="uQCE9zl3dXU"
+  title="Watch: How to configure a development build"
+  description="Learn how to install expo-dev-client, configure build profiles in eas.json, and create your first development build with EAS Build."
+/>
 
 ---
 

--- a/docs/pages/tutorial/eas/internal-distribution-builds.mdx
+++ b/docs/pages/tutorial/eas/internal-distribution-builds.mdx
@@ -19,6 +19,7 @@ In this chapter, we'll learn how to set up [internal distribution builds](/build
 <VideoBoxLink
   videoId="1fQuGLHxWks"
   title="Watch: How to create and share an internal distribution build"
+  description="Create an internal distribution build with EAS and share it directly with your team for testing."
 />
 
 ---

--- a/docs/pages/tutorial/eas/ios-development-build-for-devices.mdx
+++ b/docs/pages/tutorial/eas/ios-development-build-for-devices.mdx
@@ -19,6 +19,7 @@ Development builds for iOS devices are generated in the **.ipa** format, which i
 <VideoBoxLink
   videoId="HbfWU7_o4cU"
   title="Watch: Creating a development build for iOS physical device"
+  description="Learn how to build and run a development build on a physical iOS device using EAS Build, including setting up code signing."
 />
 
 ---

--- a/docs/pages/tutorial/eas/ios-development-build-for-simulators.mdx
+++ b/docs/pages/tutorial/eas/ios-development-build-for-simulators.mdx
@@ -16,7 +16,11 @@ In this chapter, we'll create a development build that can run on an iOS Simulat
 
 Development builds for iOS Simulators are generated in the **.app** format which is different from iOS devices.
 
-<VideoBoxLink videoId="SgL97PFZctg" title="Watch: Creating a development build for iOS Simulator" />
+<VideoBoxLink
+  videoId="SgL97PFZctg"
+  title="Watch: Creating a development build for iOS Simulator"
+  description="Learn how to create a simulator build profile in eas.json and run a development build on iOS Simulator."
+/>
 
 ---
 

--- a/docs/pages/tutorial/eas/ios-production-build.mdx
+++ b/docs/pages/tutorial/eas/ios-production-build.mdx
@@ -17,6 +17,7 @@ In this chapter, we'll create our example app's production version and submit it
 <VideoBoxLink
   videoId="VZL_e0cEwo8"
   title="Watch: Creating and releasing a production build for iOS"
+  description="Create a production build for iOS with EAS, test it using TestFlight, and submit it to the App Store."
 />
 
 ---

--- a/docs/pages/tutorial/eas/manage-app-versions.mdx
+++ b/docs/pages/tutorial/eas/manage-app-versions.mdx
@@ -12,7 +12,11 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 In this chapter, we'll learn how EAS Build automatically manages the developer-facing app version for Android and iOS. Learning about it will be useful before we dive into production build in the next two chapters.
 
-<VideoBoxLink videoId="C8x4N9UmzS8" title="Watch: Automating app version code" />
+<VideoBoxLink
+  videoId="C8x4N9UmzS8"
+  title="Watch: Automating app version code"
+  description="Understand developer-facing and user-facing app versions and how EAS Build automates version management for you."
+/>
 
 ---
 

--- a/docs/pages/tutorial/eas/multiple-app-variants.mdx
+++ b/docs/pages/tutorial/eas/multiple-app-variants.mdx
@@ -13,7 +13,11 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 In this chapter, we'll configure our project to run multiple build types (development, preview, production) on a single device simultaneously. This setup will allow us to test various stages of our app development without the need to uninstall and reinstall different versions.
 
-<VideoBoxLink videoId="UtJJCAfrjIg" title="Watch: How to configure multiple app variants" />
+<VideoBoxLink
+  videoId="UtJJCAfrjIg"
+  title="Watch: How to configure multiple app variants"
+  description="Configure development, preview, and production app variants with unique bundle identifiers to run them side by side on one device."
+/>
 
 ---
 

--- a/docs/pages/tutorial/eas/team-development.mdx
+++ b/docs/pages/tutorial/eas/team-development.mdx
@@ -16,7 +16,11 @@ Updates generally fix small bugs and push small changes in between app store rel
 
 In this chapter, we'll use [EAS Update](/eas-update/introduction/) to share changes with our team. This will help [us and our team quickly share previews](/review/overview/) of the change.
 
-<VideoBoxLink videoId="vPKh-tNm-yI" title="Watch: How to share previews with your team" />
+<VideoBoxLink
+  videoId="vPKh-tNm-yI"
+  title="Watch: How to share previews with your team"
+  description="Set up EAS Update to share preview versions of your app with your team between app store releases."
+/>
 
 ---
 

--- a/docs/pages/tutorial/eas/using-github.mdx
+++ b/docs/pages/tutorial/eas/using-github.mdx
@@ -14,7 +14,11 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 In this chapter, we'll configure this functionality. We already have a GitHub repository for our example app to demonstrate this.
 
-<VideoBoxLink videoId="fBLFEFC0ip0" title="Watch: How to trigger builds from a GitHub repository" />
+<VideoBoxLink
+  videoId="fBLFEFC0ip0"
+  title="Watch: How to trigger builds from a GitHub repository"
+  description="Connect the Expo GitHub App to your repository and configure it to trigger EAS builds on push or pull request."
+/>
 
 ---
 

--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -16,7 +16,11 @@ Gestures are a great way to provide an intuitive user experience in an app. The 
 
 We'll also use the [Reanimated](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/handling-gestures/) library to animate between gesture states.
 
-<VideoBoxLink videoId="0q48LLvTGDU" title="Watch: Adding gestures to your universal Expo app" />
+<VideoBoxLink
+  videoId="0q48LLvTGDU"
+  title="Watch: Adding gestures to your universal Expo app"
+  description="Add double tap and pan gestures to the emoji sticker using React Native Gesture Handler and Reanimated."
+/>
 
 ---
 

--- a/docs/pages/tutorial/platform-differences.mdx
+++ b/docs/pages/tutorial/platform-differences.mdx
@@ -19,6 +19,7 @@ In this chapter, we'll learn how to handle capturing screenshots for web browser
 <VideoBoxLink
   videoId="mEKQvF4irBM"
   title="Watch: Handling platform differences in your universal Expo app"
+  description="Handle platform differences between Android, iOS, and web by implementing platform-specific screenshot capture with dom-to-image."
 />
 
 ---

--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -15,7 +15,11 @@ In this chapter, we'll learn how to take a screenshot using a third-party librar
 
 > **info** So far, we have used third-party libraries, such as `react-native-gesture-handler`, `react-native-reanimated`. We can find hundreds of other third-party libraries on [React Native Directory](https://reactnative.directory/) depending on a use case.
 
-<VideoBoxLink videoId="Jft3_Yfr-p4" title="Watch: Taking screenshots in your universal Expo app" />
+<VideoBoxLink
+  videoId="Jft3_Yfr-p4"
+  title="Watch: Taking screenshots in your universal Expo app"
+  description="Capture a screenshot with react-native-view-shot and save it to the device's media library using expo-media-library."
+/>
 
 ---
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-20031 ENG-20032

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Added `description` string prop to `VideoBoxLink` on pages that were missing it. The component already supports this prop and conditionally includes it in the `VideoObject` JSON-LD schema when the value is a string.
- The 15th page (`router/advanced/nesting-navigators`) already had a description, so it just needs a GSC re-validation, which I'll be running manually once we merge this PR.
- Each description is unique and specific to what the video covers.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs site locally and inspect the page source on any of the affected pages. Verify the `VideoObject` JSON-LD script tag includes a `description` field.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
