### PR TITLE
[docs] Display enum values on app config reference page

### DIFF
--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -370,6 +370,34 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             >
               enum
             </code>
+             • 
+            One of: 
+            <span>
+              <code
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
+                data-text="true"
+              >
+                leanback
+              </code>
+            </span>
+            <span>
+              , 
+              <code
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
+                data-text="true"
+              >
+                immersive
+              </code>
+            </span>
+            <span>
+              , 
+              <code
+                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
+                data-text="true"
+              >
+                sticky-immersive
+              </code>
+            </span>
           </span>
           <span
             class="font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] text-secondary"

--- a/docs/ui/components/AppConfigSchemaTable/helpers.ts
+++ b/docs/ui/components/AppConfigSchemaTable/helpers.ts
@@ -47,6 +47,7 @@ export function formatProperty(property: [string, Property], parent?: string): F
     type: _getType(propertyValue),
     example: propertyValue.example,
     bareWorkflow: propertyValue?.meta?.bareWorkflow,
+    enum: propertyValue.enum,
     subproperties,
     parent,
   };

--- a/docs/ui/components/AppConfigSchemaTable/index.tsx
+++ b/docs/ui/components/AppConfigSchemaTable/index.tsx
@@ -79,6 +79,7 @@ function AppConfigProperty({
   nestingLevel,
   subproperties,
   parent,
+  enum: enumValues,
 }: FormattedProperty & { nestingLevel: number }) {
   const canHaveMultipleValues = Array.isArray(type);
   return (
@@ -160,6 +161,17 @@ function AppConfigProperty({
         ) : (
           <CALLOUT theme="secondary" tag="span">
             Type: <CODE>{type ?? 'undefined'}</CODE>
+            {enumValues && (
+              <>
+                &emsp;&bull;&emsp;{'One of: '}
+                {enumValues.map((value, i) => (
+                  <span key={value}>
+                    {i > 0 && ', '}
+                    <CODE>{value}</CODE>
+                  </span>
+                ))}
+              </>
+            )}
           </CALLOUT>
         )}
         {!canHaveMultipleValues && nestingLevel > 0 && (


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-20033

Current behavior:

<img width="2296" height="350" alt="CleanShot 2026-03-08 at 17 54 34@2x" src="https://github.com/user-attachments/assets/c763be90-5e3a-40c7-ae94-406736c0ab9a" />


# How

<!--
How did you build this feature or fix this bug and why?
-->

- Pass enum values through `formatProperty()` in `helpers.ts`. The `FormattedProperty` type already had an enum field but it was never populated.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->



<img width="2318" height="324" alt="CleanShot 2026-03-08 at 17 54 46@2x" src="https://github.com/user-attachments/assets/528d1344-4404-48b1-b4d1-d31f060c2647" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
