### PR TITLE
[glass-effect] - Fix GlassView not rendering correctly on `colorScheme` appearance change

### DIFF
--- a/apps/native-component-list/src/screens/GlassView/GlassViewScreen.ios.tsx
+++ b/apps/native-component-list/src/screens/GlassView/GlassViewScreen.ios.tsx
@@ -90,8 +90,6 @@ export default function GlassViewScreen() {
             colorScheme={colorScheme}
             tintColor={tintColor}
             isInteractive={isInteractive}
-            // known issue: the `isInteractive` prop can only be set once on mount
-            key={`${selectedStyle}-${isInteractive}`}
           />
         </GestureDetector>
       </View>

--- a/docs/pages/versions/unversioned/sdk/glass-effect.mdx
+++ b/docs/pages/versions/unversioned/sdk/glass-effect.mdx
@@ -16,8 +16,6 @@ React components that render native iOS liquid glass effect using [`UIVisualEffe
 
 #### Known issues
 
-- The `isInteractive` prop can only be set once on mount and cannot be changed dynamically after the component has been rendered. If you need to toggle interactive behavior, you must remount the component with a different `key`.
-
 - Setting `opacity` to `0` on `GlassView` or any of its parent views causes the glass effect to not render at all. To fade in/out the glass effect, use the built-in [`animate` and `animationDuration`](#animated-glass-effect-style) props in `glassEffectStyle` instead of changing opacity. If you still want to use `opacity`, see the [opacity animation workaround](#opacity-animation-workaround) example. For more details, see [Apple's documentation](https://developer.apple.com/documentation/uikit/uivisualeffectview#Set-the-correct-alpha-value) and [GitHub issue #41024](https://github.com/expo/expo/issues/41024).
 
 ## Installation

--- a/docs/pages/versions/v55.0.0/sdk/glass-effect.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/glass-effect.mdx
@@ -16,8 +16,6 @@ React components that render native iOS liquid glass effect using [`UIVisualEffe
 
 #### Known issues
 
-- The `isInteractive` prop can only be set once on mount and cannot be changed dynamically after the component has been rendered. If you need to toggle interactive behavior, you must remount the component with a different `key`.
-
 - Setting `opacity` to `0` on `GlassView` or any of its parent views causes the glass effect to not render at all. To fade in/out the glass effect, use the built-in [`animate` and `animationDuration`](#animated-glass-effect-style) props in `glassEffectStyle` instead of changing opacity. If you still want to use `opacity`, see the [opacity animation workaround](#opacity-animation-workaround) example. For more details, see [Apple's documentation](https://developer.apple.com/documentation/uikit/uivisualeffectview#Set-the-correct-alpha-value) and [GitHub issue #41024](https://github.com/expo/expo/issues/41024).
 
 ## Installation

--- a/packages/expo-glass-effect/CHANGELOG.md
+++ b/packages/expo-glass-effect/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### 🐛 Bug fixes
 
+- Fix glass effect not rendering correctly after appearance change while view is off-screen. ([#43771](https://github.com/expo/expo/pull/43771) by [@nishan](https://github.com/intergalacticspacehighway))
+- Fix `isInteractive` prop not being dynamically changeable after mount. ([#43771](https://github.com/expo/expo/pull/43771) by [@nishan](https://github.com/intergalacticspacehighway))
+
 ### 💡 Others
 
 ## 55.0.7 — 2026-02-25

--- a/packages/expo-glass-effect/ios/GlassView.swift
+++ b/packages/expo-glass-effect/ios/GlassView.swift
@@ -14,6 +14,7 @@ public final class GlassView: ExpoView {
   private var glassStyle: GlassStyle?
   private var glassTintColor: UIColor?
   private var glassIsInteractive: Bool?
+  private var glassColorScheme: GlassColorScheme?
 
   private var radius: CGFloat?
   private var bottomLeftRadius: CGFloat?
@@ -53,6 +54,10 @@ public final class GlassView: ExpoView {
     super.layoutSubviews()
     if !isMounted {
       isMounted = true
+      // Clear the stale effect before re-applying so UIKit fully tears down
+      // the old UIGlassEffect, otherwise re-assigning does not render GlassView correctly. 
+      // https://github.com/expo/expo/issues/43732
+      glassEffectView.effect = UIVisualEffect()
       updateEffect()
     }
   }
@@ -221,7 +226,24 @@ public final class GlassView: ExpoView {
   }
 
   func setColorScheme(_ colorScheme: GlassColorScheme) {
-    overrideUserInterfaceStyle = colorScheme.toUIUserInterfaceStyle()
+    if glassColorScheme != colorScheme {
+      glassColorScheme = colorScheme
+      updateEffect()
+    }
+  }
+  
+  public override func didMoveToWindow() {
+    super.didMoveToWindow()
+    if (self.window == nil) {
+      isMounted = false
+    } else {
+      // https://github.com/expo/expo/issues/43732
+      // UIGlassEffect must be created during layoutSubviews
+      // creating it in didMoveToWindow does not render correctly.
+      // layoutSubviews may not fire on re-entry if the geometry hasn't changed,
+      // so explicitly request a layout pass to re-apply the glass effect.
+      setNeedsLayout()
+    }
   }
 
   private func updateEffect() {
@@ -236,6 +258,9 @@ public final class GlassView: ExpoView {
       if let effect = glassEffect as? UIGlassEffect {
         effect.tintColor = glassTintColor
         effect.isInteractive = glassIsInteractive ?? false
+        if let colorScheme = glassColorScheme {
+          glassEffectView.overrideUserInterfaceStyle = colorScheme.toUIUserInterfaceStyle()
+        }
         // we need to set the effect again or it has no effect!
         glassEffectView.effect = effect
         updateBorderRadius()

--- a/packages/expo-glass-effect/ios/GlassView.swift
+++ b/packages/expo-glass-effect/ios/GlassView.swift
@@ -221,6 +221,8 @@ public final class GlassView: ExpoView {
   func setInteractive(_ interactive: Bool) {
     if interactive != glassIsInteractive {
       glassIsInteractive = interactive
+      // Changing isInteractive requires a new UIGlassEffect
+//      glassEffectView.effect = UIVisualEffect()
       updateEffect()
     }
   }

--- a/packages/expo-glass-effect/ios/GlassView.swift
+++ b/packages/expo-glass-effect/ios/GlassView.swift
@@ -221,8 +221,8 @@ public final class GlassView: ExpoView {
   func setInteractive(_ interactive: Bool) {
     if interactive != glassIsInteractive {
       glassIsInteractive = interactive
-      // Changing isInteractive requires a new UIGlassEffect
-//      glassEffectView.effect = UIVisualEffect()
+      // Changing isInteractive requires cleaning of previous GlassEffect
+      glassEffectView.effect = UIVisualEffect()
       updateEffect()
     }
   }


### PR DESCRIPTION
# Why

Fixes - https://github.com/expo/expo/issues/43732, https://github.com/expo/expo/issues/43743

GlassView has another quirk:
- Use native Tabs - Tab A and Tab B. Render `GlassView` in Tab B.
- Start app on Tab A, switch to Tab B, GlassView renders correctly. (This was fixed with https://github.com/expo/expo/pull/43330)
- Now, switch back to Tab A -> change color scheme appearance (cmd + shift + A on simulator) -> Switch to Tab B, `GlassView` disappears. This PR solves this issue. Checkout below recording.

https://github.com/user-attachments/assets/0db1f907-ff3f-4a52-a6a4-eba2f6588482



<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Re-create `UIGlassEffect` when view is attached to window. 
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
