### PR TITLE
Allow Ruby 4 in top level .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -50,4 +50,4 @@ use_ruby() {
 source_secrets secrets/expotools.env
 source_local
 install_git_hooks
-use_ruby "3.3" "3.4"
+use_ruby "3.3" "3.4" "4.0"


### PR DESCRIPTION
# Why

Ruby 4 is now commonly used, and is even a dependency for some tools, like the current version of Fastlane.

# How

Add Ruby 4 to the list of allowed versions.

# Test Plan

CI should pass

