### PR TITLE
[docs] Add Android platform to Expo MeshGradient

### DIFF
--- a/docs/pages/versions/unversioned/sdk/mesh-gradient.mdx
+++ b/docs/pages/versions/unversioned/sdk/mesh-gradient.mdx
@@ -4,7 +4,7 @@ description: A module that exposes MeshGradient view from SwiftUI to React Nativ
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-mesh-gradient'
 packageName: 'expo-mesh-gradient'
 iconUrl: '/static/images/packages/expo-mesh-gradient.png'
-platforms: ['ios', 'tvos', 'expo-go']
+platforms: ['android', 'ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/v54.0.0/sdk/mesh-gradient.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/mesh-gradient.mdx
@@ -4,7 +4,7 @@ description: A module that exposes MeshGradient view from SwiftUI to React Nativ
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-54/packages/expo-mesh-gradient'
 packageName: 'expo-mesh-gradient'
 iconUrl: '/static/images/packages/expo-mesh-gradient.png'
-platforms: ['ios', 'tvos', 'expo-go']
+platforms: ['android', 'ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/v55.0.0/sdk/mesh-gradient.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/mesh-gradient.mdx
@@ -4,7 +4,7 @@ description: A module that exposes MeshGradient view from SwiftUI to React Nativ
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-mesh-gradient'
 packageName: 'expo-mesh-gradient'
 iconUrl: '/static/images/packages/expo-mesh-gradient.png'
-platforms: ['ios', 'tvos', 'expo-go']
+platforms: ['android', 'ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-20036

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add `'android'` to the `platforms` frontmatter array in `mesh-gradient.mdx` for v54, v55, and unversioned.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="4112" height="1272" alt="CleanShot 2026-03-09 at 16 03 33@2x" src="https://github.com/user-attachments/assets/3c07bcf5-2338-42cc-b2c5-83999d491e1f" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
