### PR TITLE
[docs] Fix AsyncStorage docs links

### DIFF
--- a/docs/pages/develop/user-interface/store-data.mdx
+++ b/docs/pages/develop/user-interface/store-data.mdx
@@ -44,12 +44,12 @@ Storing data can be essential to the features implemented in your mobile app. Th
 
 ## Async Storage
 
-[Async Storage](https://react-native-async-storage.github.io/3.0/integrations/expo/) is an asynchronous, unencrypted, persistent key-value storage for React Native apps. It has a simple API and is a good choice for storing small amounts of data. It is also a good choice for storing data that does not need encryption, such as user preferences or app state.
+[Async Storage](https://react-native-async-storage.github.io/2.0/integrations/expo/) is an asynchronous, unencrypted, persistent key-value storage for React Native apps. It has a simple API and is a good choice for storing small amounts of data. It is also a good choice for storing data that does not need encryption, such as user preferences or app state.
 
 <BoxLink
   title="Async Storage documentation"
   description="For more information on how to install and use Async Storage, see its documentation."
-  href="https://react-native-async-storage.github.io/3.0/api/usage/"
+  href="https://react-native-async-storage.github.io/2.0/api/usage/"
   Icon={Globe01Icon}
 />
 

--- a/docs/pages/versions/unversioned/sdk/async-storage.mdx
+++ b/docs/pages/versions/unversioned/sdk/async-storage.mdx
@@ -16,7 +16,7 @@ Async Storage is asynchronous, unencrypted, persistent, key-value storage soluti
 
 ## Installation
 
-<APIInstallSection href="https://react-native-async-storage.github.io/3.0/integrations/expo/" />
+<APIInstallSection href="https://react-native-async-storage.github.io/2.0/integrations/expo/" />
 
 ## Learn more
 
@@ -24,5 +24,5 @@ Async Storage is asynchronous, unencrypted, persistent, key-value storage soluti
   title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
-  href="https://react-native-async-storage.github.io/3.0/api/usage/"
+  href="https://react-native-async-storage.github.io/2.0/api/usage/"
 />

--- a/docs/pages/versions/v53.0.0/sdk/async-storage.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/async-storage.mdx
@@ -16,7 +16,7 @@ Async Storage is asynchronous, unencrypted, persistent, key-value storage soluti
 
 ## Installation
 
-<APIInstallSection href="https://react-native-async-storage.github.io/3.0/" />
+<APIInstallSection href="https://react-native-async-storage.github.io/2.0/" />
 
 ## Learn more
 
@@ -24,5 +24,5 @@ Async Storage is asynchronous, unencrypted, persistent, key-value storage soluti
   title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
-  href="https://react-native-async-storage.github.io/3.0/api/usage/"
+  href="https://react-native-async-storage.github.io/2.0/api/usage/"
 />

--- a/docs/pages/versions/v54.0.0/sdk/async-storage.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/async-storage.mdx
@@ -16,7 +16,7 @@ Async Storage is asynchronous, unencrypted, persistent, key-value storage soluti
 
 ## Installation
 
-<APIInstallSection href="https://react-native-async-storage.github.io/3.0/" />
+<APIInstallSection href="https://react-native-async-storage.github.io/2.0/" />
 
 ## Learn more
 
@@ -24,5 +24,5 @@ Async Storage is asynchronous, unencrypted, persistent, key-value storage soluti
   title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
-  href="https://react-native-async-storage.github.io/3.0/api/usage/"
+  href="https://react-native-async-storage.github.io/2.0/api/usage/"
 />

--- a/docs/pages/versions/v55.0.0/sdk/async-storage.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/async-storage.mdx
@@ -16,7 +16,7 @@ Async Storage is asynchronous, unencrypted, persistent, key-value storage soluti
 
 ## Installation
 
-<APIInstallSection href="https://react-native-async-storage.github.io/3.0/integrations/expo/" />
+<APIInstallSection href="https://react-native-async-storage.github.io/2.0/integrations/expo/" />
 
 ## Learn more
 
@@ -24,5 +24,5 @@ Async Storage is asynchronous, unencrypted, persistent, key-value storage soluti
   title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
-  href="https://react-native-async-storage.github.io/3.0/api/usage/"
+  href="https://react-native-async-storage.github.io/2.0/api/usage/"
 />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

All AsyncStorage doc links that were updated to 3.0 need to be reversed to 2.0 because bundled version in Expo Go is still `2.2.0`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
