### PR TITLE
[docs][expo-router] Add callout about react-native-screens 4.24.0

### DIFF
--- a/docs/pages/router/advanced/stack-toolbar.mdx
+++ b/docs/pages/router/advanced/stack-toolbar.mdx
@@ -60,7 +60,9 @@ You can browse available symbols in Apple's SF Symbols app.
 
 ### Custom images
 
-You can also use custom images. In header toolbars (`placement="left"` or `placement="right"`), pass an image source directly to the `icon` prop:
+You can also use custom images. In header toolbars (`placement="left"` or `placement="right"`), pass an image source directly to the `icon` prop.
+
+> **info** Using custom images inside submenus (`Stack.Toolbar.Menu`) in header placements requires `react-native-screens` 4.24.0 or later. SDK 55 bundles `~4.23.0`, so you need to install `react-native-screens@~4.24.0` manually to use this feature.
 
 ```tsx
 import { Stack } from 'expo-router';

--- a/docs/pages/versions/unversioned/sdk/router/split-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/router/split-view.mdx
@@ -42,6 +42,8 @@ Accepted values are `primary`, `supplementary`, and `secondary`. When not set, t
 
 ### Navigating between columns
 
+> **info** The `.show()` method requires `react-native-screens` 4.24.0 or later. SDK 55 bundles `~4.23.0`, so you need to install `react-native-screens@~4.24.0` manually to use this feature.
+
 Use a `ref` to programmatically show a specific column with the `show` method:
 
 ```tsx

--- a/docs/pages/versions/v55.0.0/sdk/router-split-view.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/router-split-view.mdx
@@ -42,6 +42,8 @@ Accepted values are `primary`, `supplementary`, and `secondary`. When not set, t
 
 ### Navigating between columns
 
+> **info** The `.show()` method requires `react-native-screens` 4.24.0 or later. SDK 55 bundles `~4.23.0`, so you need to install `react-native-screens@~4.24.0` manually to use this feature.
+
 Use a `ref` to programmatically show a specific column with the `show` method:
 
 ```tsx


### PR DESCRIPTION
# Why

We needed to revert screens upgrade to `4.24.0` in SDK 55, but the docs are not reflecting it.

# How

Add callouts for different version.

**I'm not sure how to update `Reference > latest` docs for split view**

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
