### PR TITLE
[docs] Fix client-side redirects for unversioned SDK paths

### DIFF
--- a/docs/common/client-redirects.ts
+++ b/docs/common/client-redirects.ts
@@ -25,14 +25,14 @@ export function getRedirectPath(redirectPath: string): string {
 
   // A list of pages we know are renamed and can redirect
   if (RENAMED_PAGES[redirectPath]) {
-    redirectPath = RENAMED_PAGES[redirectPath];
+    return RENAMED_PAGES[redirectPath];
   }
 
   // Catch any unversioned paths which are also renamed
   if (isVersionedPath(redirectPath)) {
     const unversionedPath = removeVersionFromPath(redirectPath);
     if (RENAMED_PAGES[unversionedPath]) {
-      redirectPath = RENAMED_PAGES[unversionedPath];
+      return RENAMED_PAGES[unversionedPath];
     }
   }
 


### PR DESCRIPTION
# Why


@Ubax pointed out the that using `/versions/unversioned/` paths don't work correctly for client-side redirects.

When visiting `/versions/unversioned/sdk/router-split-view/`, the redirect destination (`/versions/unversioned/sdk/router/split-view/`) gets mangled by subsequent processing in `getRedirectPath`. The `isVersionDocumented` check treats `unversioned` as an unsupported version and rewrites it to `latest`, which points to a page that doesn't exist yet.

This affects the three new router subsection redirects added in #43674.

# How

- Return early from `getRedirectPath` after a `RENAMED_PAGES` match is found in `common/client-redirects.ts`. Since these destinations are explicitly authored, they should not be processed further through version-mangling, version-stripping, or fallback-to-root logic.

# Test Plan

Run the docs site locally and visit `/versions/unversioned/sdk/router-split-view/`. Confirm it redirects to `/versions/unversioned/sdk/router/split-view/` instead of `/versions/latest/sdk/router/split-view/?redirected`. Repeat for `/versions/unversioned/sdk/router-ui/` and `/versions/unversioned/sdk/router-native-tabs/`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
