### PR TITLE
[expo-module-template] Fix metro config.resolver.blockList on Windows

### DIFF
--- a/packages/expo-module-template/example/metro.config.js
+++ b/packages/expo-module-template/example/metro.config.js
@@ -9,8 +9,9 @@ const config = getDefaultConfig(__dirname);
 // excludes the one from the parent folder when bundling.
 config.resolver.blockList = [
   ...Array.from(config.resolver.blockList ?? []),
-  new RegExp(path.resolve('..', 'node_modules', 'react')),
-  new RegExp(path.resolve('..', 'node_modules', 'react-native')),
+  // On windows the path will resolve with `\`. We need to escape it with `\\` for the RegExp.
+  new RegExp(path.resolve('..', 'node_modules', 'react').replace(/\\/g, '\\\\')),
+  new RegExp(path.resolve('..', 'node_modules', 'react-native').replace(/\\/g, '\\\\')),
 ];
 
 config.resolver.nodeModulesPaths = [


### PR DESCRIPTION
# Why

While testing removal of `expo-module-scripts` on Windows I noticed that the default example doesn't work on windows. After a lot of debugging I've discovered that the metro config blockList doesn't work, because the forward slash from the resolved path conflicts with the regular expression. 

# How

Replace `\` with `\\`

# Test Plan

Tested by running `create-expo-module` on Windows and running the project.
