### PR TITLE
fix(cli): avoid TTY init crash in non-interactive terminals

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- Avoid `ERR_TTY_INIT_FAILED` when `LOG_EVENTS=1` or `LOG_EVENTS=2` is used in non-interactive terminals. ([#43796](https://github.com/expo/expo/pull/43796) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Correctly handle JavaScript assets when `asyncRoutes: true` in SSR ([#43446](https://github.com/expo/expo/pull/43446) by [@hassankhan](https://github.com/hassankhan))`
 - Prevent hanging when installing iOS apps on device. ([#43618](https://github.com/expo/expo/pull/43618) by [@EvanBacon](https://github.com/EvanBacon))
 - Correctly handle JavaScript assets when `asyncRoutes: true` in SSR ([#43446](https://github.com/expo/expo/pull/43446) by [@hassankhan](https://github.com/hassankhan))

--- a/packages/@expo/cli/src/events/__tests__/index-test.ts
+++ b/packages/@expo/cli/src/events/__tests__/index-test.ts
@@ -1,0 +1,98 @@
+import { Writable } from 'node:stream';
+
+const originalConsole = globalThis.console;
+const originalStdoutDescriptor = Object.getOwnPropertyDescriptor(process, 'stdout');
+const originalStderrDescriptor = Object.getOwnPropertyDescriptor(process, 'stderr');
+
+type MockWriteStream = Writable &
+  NodeJS.WriteStream & {
+    getOutput(): string;
+  };
+
+function createMockStream(fd: number): MockWriteStream {
+  let output = '';
+
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      output += chunk.toString();
+      callback();
+    },
+  }) as MockWriteStream;
+
+  Object.defineProperties(stream, {
+    fd: { value: fd, configurable: true },
+    isTTY: { value: false, configurable: true },
+  });
+
+  stream.getOutput = () => output;
+  return stream;
+}
+
+afterEach(() => {
+  if (originalStdoutDescriptor) {
+    Object.defineProperty(process, 'stdout', originalStdoutDescriptor);
+  }
+  if (originalStderrDescriptor) {
+    Object.defineProperty(process, 'stderr', originalStderrDescriptor);
+  }
+  globalThis.console = originalConsole;
+  jest.resetModules();
+  jest.unmock('../stream');
+  jest.unmock('node:tty');
+});
+
+describe('installEventLogger', () => {
+  it('reuses the existing stderr stream when logging events to stdout', () => {
+    const stderr = createMockStream(2);
+    const LogStream = jest.fn().mockImplementation(() => ({
+      writable: true,
+      _write: jest.fn(),
+    }));
+
+    jest.isolateModules(() => {
+      jest.doMock('../stream', () => ({ LogStream }));
+      jest.doMock('node:tty', () => ({
+        WriteStream: jest.fn(() => {
+          throw new Error('TTY initialization should not run');
+        }),
+      }));
+
+      Object.defineProperty(process, 'stderr', { value: stderr, configurable: true });
+
+      const { installEventLogger } = require('..') as typeof import('..');
+      expect(() => installEventLogger('1')).not.toThrow();
+    });
+
+    expect(process.stdout).toBe(stderr);
+    console.log('hello stderr');
+    expect(stderr.getOutput()).toContain('hello stderr');
+    expect(LogStream).toHaveBeenCalledWith(1);
+  });
+
+  it('reuses the existing stdout stream when logging events to stderr', () => {
+    const stdout = createMockStream(1);
+    const LogStream = jest.fn().mockImplementation(() => ({
+      writable: true,
+      _write: jest.fn(),
+    }));
+
+    jest.isolateModules(() => {
+      jest.doMock('../stream', () => ({ LogStream }));
+      jest.doMock('node:tty', () => ({
+        WriteStream: jest.fn(() => {
+          throw new Error('TTY initialization should not run');
+        }),
+      }));
+
+      Object.defineProperty(process, 'stdout', { value: stdout, configurable: true });
+
+      const { installEventLogger } = require('..') as typeof import('..');
+      expect(() => installEventLogger('2')).not.toThrow();
+    });
+
+    expect(process.stderr).toBe(stdout);
+    console.error('hello stdout');
+    expect(stdout.getOutput()).toContain('hello stdout');
+    expect(LogStream).toHaveBeenCalledWith(2);
+  });
+});

--- a/packages/@expo/cli/src/events/index.ts
+++ b/packages/@expo/cli/src/events/index.ts
@@ -1,6 +1,5 @@
 import { Console } from 'node:console';
 import path from 'node:path';
-import { WriteStream } from 'node:tty';
 
 import type { EventBuilder, EventLoggerBuilder, EventShape } from './builder';
 import { LogStream } from './stream';
@@ -48,11 +47,13 @@ export function installEventLogger(env = process.env.LOG_EVENTS) {
   const eventLogDestination = parseLogTarget(env);
   if (eventLogDestination) {
     if (eventLogDestination === 1) {
-      const output = new WriteStream(2);
+      // Reuse Node's existing stdio streams so redirected or piped terminals don't
+      // attempt TTY-only initialization when LOG_EVENTS swaps console output.
+      const output = process.stderr;
       Object.defineProperty(process, 'stdout', { get: () => output });
       globalThis.console = new Console(output, output);
     } else if (eventLogDestination === 2) {
-      const output = new WriteStream(1);
+      const output = process.stdout;
       Object.defineProperty(process, 'stderr', { get: () => output });
       globalThis.console = new Console(output, output);
     }


### PR DESCRIPTION
## Summary
- reuse the existing `process.stdout` / `process.stderr` streams when `installEventLogger()` swaps console output for `LOG_EVENTS=1` or `LOG_EVENTS=2`
- avoid constructing new `node:tty` write streams in redirected or non-interactive terminals, which prevents the CLI from crashing with `ERR_TTY_INIT_FAILED`
- add regression tests covering both event logger redirection paths

## Original error
```text
Exit code 1
node:tty:97
    throw new ERR_TTY_INIT_FAILED(ctx);
    ^

SystemError [ERR_TTY_INIT_FAILED]: TTY initialization failed: uv_tty_init returned EINVAL (invalid argument)
    at new WriteStream (node:tty:97:11)
    at installEventLogger (/home/user/workspace/node_modules/@expo/cli/build/src/events/index.js:87:28)
    at Object.<anonymous> (/home/user/workspace/node_modules/@expo/cli/build/bin/cli:84:32)
```

## Test Plan
- `yarn test src/events/__tests__`
