### PR TITLE
[ios][ui] Fix Slider thumb snap-back during drag

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `Slider` thumb snapping back during drag by guarding `.onReceive` with `isEditing` state. ([#43701](https://github.com/expo/expo/issues/43701) by [@fedeciancaglini](https://github.com/fedeciancaglini))
 - [Android] Fix touch events for RN views inside Compose BottomSheet. ([#43716](https://github.com/expo/expo/pull/43716) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Fix `RNHostView` child parent related crash. ([#43691](https://github.com/expo/expo/pull/43691) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Added `RNHostView` to improve RN component layout inside Compose views. ([#43495](https://github.com/expo/expo/pull/43495) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix `Slider` thumb snapping back during drag by guarding `.onReceive` with `isEditing` state. ([#43701](https://github.com/expo/expo/issues/43701) by [@fedeciancaglini](https://github.com/fedeciancaglini))
+- [iOS] Fix `Slider` thumb snapping back during drag by guarding `.onReceive` with `isEditing` state. ([#43701](https://github.com/expo/expo/issues/43701) by [@fedeciancaglini](https://github.com/fedeciancaglini)) ([#43797](https://github.com/expo/expo/pull/43797) by [@fedeciancaglini](https://github.com/fedeciancaglini))
 - [Android] Fix touch events for RN views inside Compose BottomSheet. ([#43716](https://github.com/expo/expo/pull/43716) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Fix `RNHostView` child parent related crash. ([#43691](https://github.com/expo/expo/pull/43691) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Added `RNHostView` to improve RN component layout inside Compose views. ([#43495](https://github.com/expo/expo/pull/43495) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/ios/SliderView.swift
+++ b/packages/expo-ui/ios/SliderView.swift
@@ -6,6 +6,7 @@ import ExpoModulesCore
 struct SliderView: ExpoSwiftUI.View {
   @ObservedObject var props: SliderProps
   @State var value: Float = 0.0
+  @State var isEditing: Bool = false
 
   init(props: SliderProps) {
     self.props = props
@@ -23,8 +24,8 @@ struct SliderView: ExpoSwiftUI.View {
         }
       }
       .onReceive(props.value.publisher, perform: { newValue in
-        var sliderValue = newValue
-        value = sliderValue
+        guard !isEditing else { return }
+        value = newValue
       })
 #else
     Text("Slider is not supported on tvOS")
@@ -47,6 +48,7 @@ struct SliderView: ExpoSwiftUI.View {
         minimumValueLabel: { minimumValueLabel },
         maximumValueLabel: { maximumValueLabel }
       ) { isEditing in
+        self.isEditing = isEditing
         props.onEditingChanged(["isEditing": isEditing])
       }
     } else if let min = props.min, let max = props.max {
@@ -57,6 +59,7 @@ struct SliderView: ExpoSwiftUI.View {
         minimumValueLabel: { minimumValueLabel },
         maximumValueLabel: { maximumValueLabel }
       ) { isEditing in
+        self.isEditing = isEditing
         props.onEditingChanged(["isEditing": isEditing])
       }
     } else if let step = props.step {
@@ -68,6 +71,7 @@ struct SliderView: ExpoSwiftUI.View {
         minimumValueLabel: { minimumValueLabel },
         maximumValueLabel: { maximumValueLabel }
       ) { isEditing in
+        self.isEditing = isEditing
         props.onEditingChanged(["isEditing": isEditing])
       }
     } else {
@@ -77,6 +81,7 @@ struct SliderView: ExpoSwiftUI.View {
         minimumValueLabel: { minimumValueLabel },
         maximumValueLabel: { maximumValueLabel }
       ) { isEditing in
+        self.isEditing = isEditing
         props.onEditingChanged(["isEditing": isEditing])
       }
     }


### PR DESCRIPTION
## Summary

Fixes #43701

`SliderView.swift` unconditionally overwrites `@State var value` inside `.onReceive(props.value.publisher)` — even while the user is actively dragging the thumb. This causes the thumb to flicker/snap back to the previous prop value on every render cycle during the drag gesture.

**Fix:** Add an `@State var isEditing` flag that tracks whether a drag is in progress (via the `onEditingStatusChanged` closure already present on all four `Slider` branches). Guard `.onReceive` so external prop updates are only applied when the user is **not** dragging.

### Changes
- `packages/expo-ui/ios/SliderView.swift`: Added `@State var isEditing` + guard in `.onReceive` + set `self.isEditing` in all 4 slider closures
- `packages/expo-ui/CHANGELOG.md`: Added bug fix entry

## Test plan

- Build and run the [minimal repro from the issue](https://github.com/expo/expo/issues/43701)
- Drag the slider thumb — it should follow the finger smoothly without flickering or snapping back
- Verify that programmatic value updates (via props) still work when the user is not dragging