### PR TITLE
[widgets][plugin] Add `contentMarginsDisabled`

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Add support for `after(date)` dismissal policy, final content state, and `contentDate` when ending a Live Activity. ([#43472](https://github.com/expo/expo/pull/43472) by [@jakex7](https://github.com/jakex7))
+- [plugin] Add `contentMarginsDisabled`.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - Add support for `after(date)` dismissal policy, final content state, and `contentDate` when ending a Live Activity. ([#43472](https://github.com/expo/expo/pull/43472) by [@jakex7](https://github.com/jakex7))
-- [plugin] Add `contentMarginsDisabled`.
+- [plugin] Add `contentMarginsDisabled`. ([#43799](https://github.com/expo/expo/pull/43799) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-widgets/plugin/build/types/WidgetConfig.type.d.ts
+++ b/packages/expo-widgets/plugin/build/types/WidgetConfig.type.d.ts
@@ -4,4 +4,5 @@ export type WidgetConfig = {
     supportedFamilies: WidgetFamily[];
     displayName: string;
     description: string;
+    contentMarginsDisabled: boolean;
 };

--- a/packages/expo-widgets/plugin/build/withWidgetSourceFiles.js
+++ b/packages/expo-widgets/plugin/build/withWidgetSourceFiles.js
@@ -117,7 +117,7 @@ struct ${widget.name}: Widget {
     }
     .configurationDisplayName("${widget.displayName}")
     .description("${widget.description}")
-    .supportedFamilies([.${widget.supportedFamilies.join(', .')}])
+    .supportedFamilies([.${widget.supportedFamilies.join(', .')}])${widget.contentMarginsDisabled ? '\n    .contentMarginsDisabled()' : ''}
   }
 }`;
 const infoPlist = (groupIdentifier) => `<?xml version="1.0" encoding="UTF-8"?>

--- a/packages/expo-widgets/plugin/src/types/WidgetConfig.type.ts
+++ b/packages/expo-widgets/plugin/src/types/WidgetConfig.type.ts
@@ -5,4 +5,5 @@ export type WidgetConfig = {
   supportedFamilies: WidgetFamily[];
   displayName: string;
   description: string;
+  contentMarginsDisabled: boolean;
 };

--- a/packages/expo-widgets/plugin/src/withWidgetSourceFiles.ts
+++ b/packages/expo-widgets/plugin/src/withWidgetSourceFiles.ts
@@ -106,7 +106,7 @@ struct ${widget.name}: Widget {
     }
     .configurationDisplayName("${widget.displayName}")
     .description("${widget.description}")
-    .supportedFamilies([.${widget.supportedFamilies.join(', .')}])
+    .supportedFamilies([.${widget.supportedFamilies.join(', .')}])${widget.contentMarginsDisabled ? '\n    .contentMarginsDisabled()' : ''}
   }
 }`;
 


### PR DESCRIPTION
# Why

It's sometimes useful to disable default content margins and handle it yourself.

# How

I tried to make it a runtime property but unfortunately, widget configuration needs to be static. There is no ConfigurationBuilder and typing system just won't let me do that. 
So, it's another widget config property in config plugin.

# Test Plan

```tsx
const TestWidget = () => {
  'widget';

  return (
    <VStack
      modifiers={[containerRelativeFrame({ axes: 'both', span: 1, count: 1 }), background('red')]}>
      <Text>sadas</Text>
    </VStack>
  );
};
```

<img width="300" alt="SimShot_iPhone_17_Pro_with_Apple_Watch_2026-03-09_23-40-15" src="https://github.com/user-attachments/assets/4f6c908a-410c-459b-8755-4ad5270a03f9" />


# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
