### PR TITLE
[updates][Android] Deduplicate assets

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
@@ -188,7 +188,7 @@ abstract class Loader protected constructor(
   }
 
   private suspend fun downloadAllAssets(update: Update): LoaderResult {
-    val assetList = update.assetEntityList
+    val assetList = update.assetEntityList.distinctBy { it.key }
     assetTotal = assetList.size
 
     val embeddedUpdate = loaderFiles.readEmbeddedUpdate(context, configuration)


### PR DESCRIPTION
# Why

Fixes:
<img width="712" height="366" alt="image" src="https://github.com/user-attachments/assets/2caee2ab-bd0f-466f-85d1-e31768e47d98" />

Context: https://exponent-internal.slack.com/archives/C02T514E4RK/p1773078463923659

# How

The IOException is caused by a race condition. It appears that some assets are being downloaded multiple times (it's unclear why). The `verifySHA256AndWriteToFile` (https://github.com/expo/expo/blob/8ea84c9aad495dd9518cb22e8d99eaf3c417b32e/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt#L114) function is called multiple times for the same asset, causing it to delete the temporary file during the copy process.

I was able to resolve this by changing the downloadAllAssets function to remove all duplicates (`val assetList = update.assetEntityList` -> `val assetList = update.assetEntityList.distinctBy { it.key }`)

I'm not sure if this approach is correct! 

# Test Plan

- expo go ✅ 
