### PR TITLE
[image-picker][iOS] Fix base64 not returning JPEG data

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - fix potential `null` mime type reported ([#43734](https://github.com/expo/expo/pull/43734) by [@vonovak](https://github.com/vonovak))
 - [android] fix cropper default colors in light mode ([#42437](https://github.com/expo/expo/pull/42437) by [@fobos531](https://github.com/fobos531))
-- [iOS] Fix `base64` result not being a JPEG data.
+- [iOS] Fix `base64` result not being a JPEG data. ([#43806](https://github.com/expo/expo/pull/43806) by [@barthap](https://github.com/barthap))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - fix potential `null` mime type reported ([#43734](https://github.com/expo/expo/pull/43734) by [@vonovak](https://github.com/vonovak))
 - [android] fix cropper default colors in light mode ([#42437](https://github.com/expo/expo/pull/42437) by [@fobos531](https://github.com/fobos531))
+- [iOS] Fix `base64` result not being a JPEG data.
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/ios/ImageUtils.swift
+++ b/packages/expo-image-picker/ios/ImageUtils.swift
@@ -183,25 +183,37 @@ internal struct ImageUtils {
   }
 
   /**
-   Reads base64 representation of the image data. If the data is `nil` fallbacks to reading the data from the url.
+   Returns a base64-encoded JPEG representation of the image.
+   When `tryReadingFile` is true, reads the file at `fileUrl`, decodes it into a `UIImage`,
+   then re-encodes as JPEG so the result is always JPEG regardless of the source format.
+   Otherwise uses the provided `UIImage` directly.
    */
-  static func readBase64From(imageData: Data?, orImageFileUrl url: URL, tryReadingFile: Bool) throws
-    -> String? {
+  static func readJpegBase64From(
+    image: UIImage,
+    compressionQuality: Double,
+    orFileUrl fileUrl: URL,
+    tryReadingFile: Bool
+  ) throws -> String? {
+    let sourceImage: UIImage
     if tryReadingFile {
       do {
-        let data = try Data(contentsOf: url)
-        return data.base64EncodedString()
+        let data = try Data(contentsOf: fileUrl)
+        guard let loaded = UIImage(data: data) else {
+          throw FailedToReadImageDataException()
+        }
+        sourceImage = loaded
       } catch {
         throw FailedToReadImageDataException()
           .causedBy(error)
       }
+    } else {
+      sourceImage = image
     }
 
-    guard let data = imageData else {
+    guard let jpegData = sourceImage.jpegData(compressionQuality: compressionQuality) else {
       throw FailedToReadImageDataForBase64Exception()
     }
-
-    return data.base64EncodedString()
+    return jpegData.base64EncodedString()
   }
 
   static func readExifFrom(mediaInfo: MediaInfo) async -> ExifInfo? {

--- a/packages/expo-image-picker/ios/MediaHandler.swift
+++ b/packages/expo-image-picker/ios/MediaHandler.swift
@@ -91,10 +91,15 @@ internal struct MediaHandler {
       }
       let fileSize = getFileSize(from: targetUrl)
 
-      let base64 =
-        options.base64
-        ? try ImageUtils.readBase64From(
-          imageData: imageData, orImageFileUrl: targetUrl, tryReadingFile: fileWasCopied) : nil
+      let base64: String?
+      if options.base64 {
+        base64 = try ImageUtils.readJpegBase64From(image: image,
+                                                   compressionQuality: options.quality,
+                                                   orFileUrl: targetUrl,
+                                                   tryReadingFile: fileWasCopied)
+      } else {
+        base64 = nil
+      }
 
       let exif = options.exif ? await ImageUtils.readExifFrom(mediaInfo: mediaInfo) : nil
       let size = CGSize(width: image.size.width, height: image.size.height)


### PR DESCRIPTION
# Why

Fixes #43790

# How

Always use `UIImage.jpegData()` when exporting to base64 - previously we were reading original file data

# Test Plan

NCL - picked JPEG, PNG, HEIC images with `base64: true`. For all images, the base64 string started with `/9j/4AA` (JPEG magic bytes).

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
