### PR TITLE
inline modules CI fix

### DIFF
--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -41,7 +41,7 @@ function getExpoDependencyChunks({
     ['expo-modules-core'],
     ['unimodules-app-loader'],
     ['expo-task-manager'],
-    ['@expo/cli', 'expo', 'expo-asset', 'expo-modules-autolinking'],
+    ['@expo/cli', 'expo', 'expo-asset', 'expo-modules-autolinking', '@expo/inline-modules'],
     ['expo-manifests'],
     ['@expo/prebuild-config', '@expo/metro-config', 'expo-constants'],
     ['@expo/image-utils'],


### PR DESCRIPTION
# Why
EAS tests fail as I added a new package.
# What
Added the new `@expo/inline-modules` package to tests dependencies.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
