### PR TITLE
[expo-router][docs] document layout limitation without asChild

### DIFF
--- a/docs/pages/router/basics/navigation.mdx
+++ b/docs/pages/router/basics/navigation.mdx
@@ -70,7 +70,7 @@ export default function Page() {
 }
 ```
 
-By default, Links can only wrap `Text` components. You can use `Pressable` or other components that support `onPress` and `onClick` props inside a link with the `asChild` prop:
+By default, the `Link` component renders its children inside a `<Text>` element. This means non-text children (such as `View`) may have unexpected layout behavior. To have full control over the layout, use the `asChild` prop with a `Pressable` or another component that accepts `onPress`/`onClick` props:
 
 {/* prettier-ignore */}
 ```tsx


### PR DESCRIPTION
# Why

Solves: https://github.com/expo/expo/issues/43491

Emphasizes that rendering custom content inside link without `asChild` may break layout.

I'm not sure if this is the best place for such change, as this is fairly technical

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
