### PR TITLE
[blur][android] Fix the initial blur value not taking the `blurReductionFactor` into account

### DIFF
--- a/packages/expo-blur/CHANGELOG.md
+++ b/packages/expo-blur/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix Fabric mount/detach mismatch in `BlurTargetView` that could trigger `view already removed from parent` errors during root tree transitions. ([#43595](https://github.com/expo/expo/pull/43595) by [@stathis](https://github.com/efstathiosntonas))
+- [Android] Fix the initial blur value not taking the `blurReductionFactor` into account. ([#43814](https://github.com/expo/expo/pull/43814) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-blur/android/src/main/java/expo/modules/blur/ExpoBlurView.kt
+++ b/packages/expo-blur/android/src/main/java/expo/modules/blur/ExpoBlurView.kt
@@ -161,7 +161,7 @@ class ExpoBlurView(context: Context, appContext: AppContext) : ExpoView(context,
 
     blurView.setupWith(dimezisBlurTarget)
       .setFrameClearDrawable(decorView.background)
-      .setBlurRadius(blurRadius)
+      .setBlurRadius(blurRadius / blurReduction)
 
     blurConfiguration = BlurViewConfiguration.DIMEZIS
   }


### PR DESCRIPTION
# Why

While cherry picking another blur-related PR for sdk-55 I've noticed that the blur intensity is way too high, and gets fixed when `blurIntensity` prop is refreshed.

# How

In the initial blur setup we didn't take the blur reduction factor into account. Take it into account.

# Test Plan

Tested in BareExpo on a Pixel 8


