### PR TITLE
[expotools] Fix e-m-c not included in iOS unit tests

### DIFF
--- a/tools/src/commands/IosNativeUnitTests.ts
+++ b/tools/src/commands/IosNativeUnitTests.ts
@@ -34,13 +34,10 @@ export async function iosNativeUnitTests({ packages }: { packages?: string }) {
       if (packageNamesFilter.length > 0 && !packageNamesFilter.includes(pkg.packageName)) {
         continue;
       }
-      // @tsapeta: `expo-modules-core` has two podspecs – for the core and for the JSI. This is supported by autolinking,
-      // but not by expotools and as a result only `ExpoModulesJSI` tests are being included. Here we make sure the tests
-      // for the core are included. Long-term plan is to move JSI pod to a separate package, then this can be removed.
-      //
-      // @barthap: expo-modules-core has three podspecs - the two above and for Worklets. The worklets one is detected
-      // as primary `pkg.podspecPath` and `hasNativeTestsAsync` does not find any tests in it, so the whole
-      // expo-modules-core is skipped in the below check.
+      // @tsapeta @barthap: `expo-modules-core` contains multiple podspecs (Core, JSI, Worklets).
+      // This breaks `expotools` test discovery because it often resolves the wrong `podspecPath`.
+      // We manually include the core tests here as a workaround. If new podspecs are added
+      // to this package, they must be manually registered here.
       targetsToTest.push(`ExpoModulesCore-Unit-Tests`);
       targetsToTest.push(`ExpoModulesJSI-Unit-Tests`);
       packagesToTest.push(pkg.packageName);

--- a/tools/src/commands/IosNativeUnitTests.ts
+++ b/tools/src/commands/IosNativeUnitTests.ts
@@ -30,6 +30,23 @@ export async function iosNativeUnitTests({ packages }: { packages?: string }) {
   const targetsToTest: string[] = [];
   const packagesToTest: string[] = [];
   for (const pkg of allPackages) {
+    if (pkg.packageName === 'expo-modules-core') {
+      if (packageNamesFilter.length > 0 && !packageNamesFilter.includes(pkg.packageName)) {
+        continue;
+      }
+      // @tsapeta: `expo-modules-core` has two podspecs – for the core and for the JSI. This is supported by autolinking,
+      // but not by expotools and as a result only `ExpoModulesJSI` tests are being included. Here we make sure the tests
+      // for the core are included. Long-term plan is to move JSI pod to a separate package, then this can be removed.
+      //
+      // @barthap: expo-modules-core has three podspecs - the two above and for Worklets. The worklets one is detected
+      // as primary `pkg.podspecPath` and `hasNativeTestsAsync` does not find any tests in it, so the whole
+      // expo-modules-core is skipped in the below check.
+      targetsToTest.push(`ExpoModulesCore-Unit-Tests`);
+      targetsToTest.push(`ExpoModulesJSI-Unit-Tests`);
+      packagesToTest.push(pkg.packageName);
+      continue;
+    }
+
     if (!pkg.podspecName || !pkg.podspecPath || !(await pkg.hasNativeTestsAsync('ios'))) {
       if (packageNamesFilter.includes(pkg.packageName)) {
         throw new Error(`The package ${pkg.packageName} does not include iOS unit tests.`);
@@ -52,13 +69,6 @@ export async function iosNativeUnitTests({ packages }: { packages?: string }) {
       targetsToTest.push(`${pkg.podspecName}-Unit-${testSpecName}`);
     }
     packagesToTest.push(pkg.packageName);
-  }
-
-  // @tsapeta: `expo-modules-core` has two podspecs – for the core and for the JSI. This is supported by autolinking,
-  // but not by expotools and as a result only `ExpoModulesJSI` tests are being included. Here we make sure the tests
-  // for the core are included. Long-term plan is to move JSI pod to a separate package, then this can be removed.
-  if (packagesToTest.includes('expo-modules-core')) {
-    targetsToTest.unshift(`ExpoModulesCore-Unit-Tests`);
   }
 
   if (packageNamesFilter.length && !targetsToTest.length) {


### PR DESCRIPTION
# Why

<!-- disable:changelog-checks -->

After #42971 expo-modules-core unit tests are no longer detected - previous workaround stopped working

# How

Modified the workaround to explicitly and manually include podspec targets

# Test Plan

`et native-unit-tests -p ios` lists both ExpoModulesCore and ExpoModulesJSI unit test targets
