### PR TITLE
[docs] Fix missing video upload dates on local-first guide

### DIFF
--- a/docs/pages/guides/local-first.mdx
+++ b/docs/pages/guides/local-first.mdx
@@ -66,6 +66,7 @@ TinyBase works seamlessly with Expo Go, allowing you to develop quickly. On Andr
   videoId="HqOiB2tDM8Q"
   title="Watch: Build a Local-First Real-Time Shopping List App with Expo and TinyBase"
   description="Build a real-time shopping list app using TinyBase with expo-sqlite for persistence and automatic syncing."
+  uploadDate="2024-12-25"
 />
 
 ### SQLite
@@ -84,6 +85,7 @@ TinyBase works seamlessly with Expo Go, allowing you to develop quickly. On Andr
   videoId="uTrPte0sCiw"
   title="Watch: Building a Local-first Notion Clone with React Native Expo and Prisma"
   description="Build a local-first Notion clone with Prisma ORM for Expo, covering state management, syncing, and persistence."
+  uploadDate="2024-07-15"
 />
 
 ### Jazz
@@ -108,6 +110,7 @@ TinyBase works seamlessly with Expo Go, allowing you to develop quickly. On Andr
   videoId="SBv32tmyb3k"
   title="Watch: How to build a local-first Notes App with Turso and Expo"
   description="Build a local-first notes app with Turso's offline sync and expo-sqlite for bidirectional data syncing."
+  uploadDate="2025-04-03"
 />
 
 ### Instant

--- a/docs/ui/components/VideoBoxLink/index.tsx
+++ b/docs/ui/components/VideoBoxLink/index.tsx
@@ -13,10 +13,11 @@ type VideoBoxLinkProps = {
   videoId: string;
   time?: number;
   className?: string;
+  uploadDate?: string;
 };
 
-export function VideoBoxLink({ title, description, videoId, time, className }: VideoBoxLinkProps) {
-  const uploadDate = getVideoUploadDate(videoId);
+export function VideoBoxLink({ title, description, videoId, time, className, uploadDate }: VideoBoxLinkProps) {
+  const resolvedUploadDate = uploadDate ?? getVideoUploadDate(videoId);
   const videoStructuredData = {
     '@context': 'https://schema.org',
     '@type': 'VideoObject',
@@ -25,7 +26,7 @@ export function VideoBoxLink({ title, description, videoId, time, className }: V
     thumbnailUrl: `https://i3.ytimg.com/vi/${videoId}/maxresdefault.jpg`,
     embedUrl: `https://www.youtube.com/embed/${videoId}`,
     contentUrl: `https://www.youtube.com/watch?v=${videoId}`,
-    ...(uploadDate && { uploadDate: `${uploadDate}T00:00:00Z` }),
+    ...(resolvedUploadDate && { uploadDate: `${resolvedUploadDate}T00:00:00Z` }),
   };
 
   return (

--- a/docs/ui/components/VideoBoxLink/index.tsx
+++ b/docs/ui/components/VideoBoxLink/index.tsx
@@ -16,7 +16,14 @@ type VideoBoxLinkProps = {
   uploadDate?: string;
 };
 
-export function VideoBoxLink({ title, description, videoId, time, className, uploadDate }: VideoBoxLinkProps) {
+export function VideoBoxLink({
+  title,
+  description,
+  videoId,
+  time,
+  className,
+  uploadDate,
+}: VideoBoxLinkProps) {
   const resolvedUploadDate = uploadDate ?? getVideoUploadDate(videoId);
   const videoStructuredData = {
     '@context': 'https://schema.org',


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-20057

# How

- Add an optional `uploadDate` prop to the `VideoBoxLink` component in `ui/components/VideoBoxLink/index.tsx`. When passed, it takes priority over the `talks.ts` lookup. Existing videos that rely on the lookup continue to work as before.
- Pass `uploadDate` directly to the 3 affected `VideoBoxLink` instances in `pages/guides/local-first.mdx`:


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
