### PR TITLE
[docs] fix pnpm config path and contents

### DIFF
--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -192,10 +192,10 @@ With isolated dependencies, package managers don't hoist packages from nested `n
 
 A side-effect of **hoisted** installations is that you can accidentally depend on Node modules you haven't specified in your own **package.json**'s `dependencies` or `peerDependencies`. Instead, many more dependencies that other packages rely on are hoisted and become accessible to you. This can cause non-deterministic behavior, and allow you to have broken dependency chains, which are more fragile and can cause resolution errors when updating or upgrading packages. This is especially common in monorepos.
 
-**Starting with SDK 54**, Expo supports isolated dependencies. Unfortunately, not all packages you install will work and some React Native libraries may cause build or resolution errors when used with isolated dependencies. If you encounter issues with isolated installations with [pnpm](https://pnpm.io/settings#nodelinker), switch to the **hoisted** installation strategy by changing the `node-linker` setting in an **.npmrc** file in the root of your repository:
+**Starting with SDK 54**, Expo supports isolated dependencies. Unfortunately, not all packages you install will work and some React Native libraries may cause build or resolution errors when used with isolated dependencies. If you encounter issues with isolated installations with [pnpm](https://pnpm.io/settings#nodelinker), switch to the **hoisted** installation strategy by changing the `nodeLinker` setting in an **pnpm-workspace.yaml** file in the root of your repository:
 
-```plain .npmrc
-node-linker=hoisted
+```yaml pnpm-workspace.yaml
+nodeLinker: hoisted
 ```
 
 ### Duplicate native packages within monorepos

--- a/docs/pages/more/create-expo.mdx
+++ b/docs/pages/more/create-expo.mdx
@@ -132,13 +132,13 @@ Yarn Modern on EAS requires adding [`eas-build-pre-install` hook](/build-referen
 
 Requires installing Node.js. See [pnpm documentation](https://pnpm.io/installation) for installation instructions.
 
-By default, a project created with `create-expo-app` and pnpm uses [`node-linker`](https://pnpm.io/npmrc#node-linker) with its value set to `hoisted` to install dependencies.
+By default, a project created with `create-expo-app` and pnpm uses [`nodeLinker`](https://pnpm.io/settings#nodelinker) with its value set to `hoisted` to install dependencies.
 
-```ini .npmrc
-node-linker=hoisted
+```yaml pnpm-workspace.yaml
+nodeLinker: hoisted
 ```
 
-> **info** In **SDK 54** and later, Expo supports isolated installations, and you can delete the `node-linker` setting if you prefer to use isolated dependencies.
+> **info** In **SDK 54** and later, Expo supports isolated installations, and you can delete the `nodeLinker` setting if you prefer to use isolated dependencies.
 
 #### EAS installation
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

[`create-expo-app`](https://docs.expo.dev/more/create-expo/) does not create an `.npmrc` file as documented on [the `create-expo-app` docs page](https://docs.expo.dev/more/create-expo/#local-installation-3), it creates a `pnpm-workspace.yaml` file:

```bash
$ mkdir a && cd a

$ pnpm create expo-app@3.5.3 --template expo-template-default@54.0.60 .
.../19cd9775b71-15dfb                    |   +1 +
.../19cd9775b71-15dfb                    | Progress: resolved 1, reused 0, downloaded 1, added 1, done
Creating an Expo project using the expo-template-default@54.0.60 template.

✔ Downloaded and extracted project files.
> pnpm config --location project set node-linker hoisted
> pnpm install
 WARN  3 deprecated subdependencies found: glob@7.2.3, inflight@1.0.6, rimraf@3.0.2
Packages: +940
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Downloading react-native@0.81.5: 24.77 MB/24.77 MB, done
Progress: resolved 905, reused 578, downloaded 294, added 940, done
 ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: unrs-resolver@1.11.1

Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
Something went wrong installing JavaScript dependencies. Check your pnpm logs. Continuing to create the app.
Error: pnpm install exited with non-zero code: 1

✅ Your project is ready!

To run your project, run one of the following pnpm commands.

- pnpm run android
- pnpm run ios
- pnpm run web

$ cat pnpm-workspace.yaml
nodeLinker: hoisted
```

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix the path and contents of the pnpm config file generated by `create-expo-app`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Checked by running `create-expo-app`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
