### PR TITLE
create-expo-app: ignore unrs-resolver build with pnpm

### DIFF
--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Ignore unrs-resolver build with pnpm ([#43827](https://github.com/expo/expo/pull/43827) by [@karlhorky](https://github.com/karlhorky))
+
 ### 💡 Others
 
 ## 3.6.6 — 2026-02-25

--- a/packages/create-expo/src/resolvePackageManager.ts
+++ b/packages/create-expo/src/resolvePackageManager.ts
@@ -105,9 +105,13 @@ export async function configurePackageManager(
 ) {
   const manager = createPackageManager(packageManager, { cwd: projectRoot, ...flags });
   switch (manager.name) {
-    case 'pnpm':
+    case 'pnpm': {
       await manager.runAsync(['config', '--location', 'project', 'set', 'node-linker', 'hoisted']);
+
+      // Avoid build warnings / errors from pnpm v10+
+      await manager.runAsync(['config', '--location', 'project', '--json', 'set', 'ignoredBuiltDependencies', '["unrs-resolver"]']);
       break;
+    }
 
     case 'yarn': {
       const yarnVersion = await manager.versionAsync();

--- a/packages/create-expo/src/resolvePackageManager.ts
+++ b/packages/create-expo/src/resolvePackageManager.ts
@@ -109,7 +109,15 @@ export async function configurePackageManager(
       await manager.runAsync(['config', '--location', 'project', 'set', 'node-linker', 'hoisted']);
 
       // Avoid build warnings / errors from pnpm v10+
-      await manager.runAsync(['config', '--location', 'project', '--json', 'set', 'ignoredBuiltDependencies', '["unrs-resolver"]']);
+      await manager.runAsync([
+        'config',
+        '--location',
+        'project',
+        '--json',
+        'set',
+        'ignoredBuiltDependencies',
+        '["unrs-resolver"]'
+      ]);
       break;
     }
 


### PR DESCRIPTION
# Why

`create-expo-app` currently warns (or errors with [`strict-dep-builds=true`](https://pnpm.io/settings#strictdepbuilds) in `~/Library/Preferences/pnpm/rc`) because `unrs-resolver` is blocked by pnpm's build approval flow.

This leaves `create-expo-app` in a confusing partial-success state: the project is created, but dependency installation reports failure and tells the user to resolve it manually via `pnpm approve-builds`.

This matches the same class of issue addressed in Next.js by adding pnpm config to ignore blocked postinstall/build scripts instead of relying on interactive approval:

- https://github.com/vercel/next.js/pull/83168
- https://github.com/vercel/next.js/issues/83158

Erroring with [`strict-dep-builds=true`](https://pnpm.io/settings#strictdepbuilds) in `~/Library/Preferences/pnpm/rc`:

```bash
$ mkdir a && cd a

$ pnpm create expo-app@3.5.3 --template expo-template-default@54.0.60 .
.../19cd9775b71-15dfb                    |   +1 +
.../19cd9775b71-15dfb                    | Progress: resolved 1, reused 0, downloaded 1, added 1, done
Creating an Expo project using the expo-template-default@54.0.60 template.

✔ Downloaded and extracted project files.
> pnpm config --location project set node-linker hoisted
> pnpm install
 WARN  3 deprecated subdependencies found: glob@7.2.3, inflight@1.0.6, rimraf@3.0.2
Packages: +940
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Downloading react-native@0.81.5: 24.77 MB/24.77 MB, done
Progress: resolved 905, reused 578, downloaded 294, added 940, done
 ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: unrs-resolver@1.11.1

Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
Something went wrong installing JavaScript dependencies. Check your pnpm logs. Continuing to create the app.
Error: pnpm install exited with non-zero code: 1

✅ Your project is ready!

To run your project, run one of the following pnpm commands.

- pnpm run android
- pnpm run ios
- pnpm run web
```

# How

For `pnpm`, write `ignoredBuiltDependencies: ["unrs-resolver"]` into the project-level pnpm config before running `pnpm install`, following the same approach used in Next.js for this class of pnpm issue:

- https://github.com/vercel/next.js/pull/83168

# Test Plan

Reproduced the failure locally (see logs above).

I also tried the `pnpm config` command introduced in this PR:

```bash
$ cat pnpm-workspace.yaml
nodeLinker: hoisted

$ pnpm config --location project --json set ignoredBuiltDependencies '["unrs-resolver"]'

$ cat pnpm-workspace.yaml
ignoredBuiltDependencies:
  - unrs-resolver

nodeLinker: hoisted
```

Test this change by generating the same project again and verifying:

- `pnpm-workspace.yaml` contains both `nodeLinker: hoisted` and `ignoredBuiltDependencies:`
- `unrs-resolver` is listed under `ignoredBuiltDependencies`
- `pnpm install` no longer fails on `unrs-resolver`
- project creation completes without telling the user to run `pnpm approve-builds`

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)