### PR TITLE
[widgets] Add support for `React.Fragment`

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [plugin] Fix reading undefined when config is not provided. ([#43568](https://github.com/expo/expo/pull/43568) by [@jakex7](https://github.com/jakex7))
 - Skip server bundling in `export:embed` call for `expo-widgets` bundle ([#43602](https://github.com/expo/expo/pull/43602) by [@kitten](https://github.com/kitten))
 - Filter out invalid children. ([#43720](https://github.com/expo/expo/pull/43720) by [@jakex7](https://github.com/jakex7))
+- Add support for `React.Fragment`.
 
 ### 💡 Others
 

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -17,7 +17,7 @@
 - [plugin] Fix reading undefined when config is not provided. ([#43568](https://github.com/expo/expo/pull/43568) by [@jakex7](https://github.com/jakex7))
 - Skip server bundling in `export:embed` call for `expo-widgets` bundle ([#43602](https://github.com/expo/expo/pull/43602) by [@kitten](https://github.com/kitten))
 - Filter out invalid children. ([#43720](https://github.com/expo/expo/pull/43720) by [@jakex7](https://github.com/jakex7))
-- Add support for `React.Fragment`.
+- Add support for `React.Fragment`. ([#43833](https://github.com/expo/expo/pull/43833) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-widgets/bundle/index.ts
+++ b/packages/expo-widgets/bundle/index.ts
@@ -61,6 +61,7 @@ Object.assign(globalThis, {
   ...modifiers,
   ...jsxRuntime,
   ...React,
+  React,
   __expoWidgetRender,
   __expoWidgetHandlePress,
 });

--- a/packages/expo-widgets/bundle/jsx-runtime-stub.ts
+++ b/packages/expo-widgets/bundle/jsx-runtime-stub.ts
@@ -1,5 +1,4 @@
-export const REACT_ELEMENT_TYPE: symbol = Symbol.for('react.transitional.element');
-export const REACT_FRAGMENT_TYPE: symbol = Symbol.for('react.fragment');
+import { Fragment } from './react-stub';
 
 function ReactElement(type: typeof ReactElement, key: string | null, props: Record<string, any>) {
   if (typeof type === 'function') {
@@ -45,7 +44,8 @@ function hasValidKey(config: any) {
 
 const jsxFileName = 'widget';
 export {
-  REACT_FRAGMENT_TYPE as Fragment,
+  Fragment,
+  Fragment as _Fragment,
   jsxFileName as _jsxFileName,
   jsxProd,
   jsxProd as jsx,

--- a/packages/expo-widgets/bundle/react-stub.ts
+++ b/packages/expo-widgets/bundle/react-stub.ts
@@ -1,3 +1,5 @@
+export const Fragment = 'react.fragment';
+
 export const Children = {
   toArray(children: unknown) {
     if (children === undefined || children === null) {

--- a/packages/expo-widgets/ios/Widgets/DynamicView.swift
+++ b/packages/expo-widgets/ios/Widgets/DynamicView.swift
@@ -92,7 +92,8 @@ public struct WidgetsDynamicView: View, ExpoSwiftUI.AnyChild {
       } else {
         render(ExpoUI.Button.self, ExpoUI.ButtonProps.self, updateProps: updateChildren)
       }
-
+    case "react.fragment":
+      render(FragmentView.self, FragmentProps.self, updateProps: updateChildren)
     default:
       ZStack {
         Color.red.opacity(0.5)

--- a/packages/expo-widgets/ios/Widgets/Fragment.swift
+++ b/packages/expo-widgets/ios/Widgets/Fragment.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+import ExpoModulesCore
+import ExpoUI
+
+final class FragmentProps: ExpoUI.ButtonProps {}
+
+struct FragmentView: ExpoSwiftUI.View {
+  @ObservedObject var props: FragmentProps
+
+  var body: some View {
+    Children()
+  }
+}


### PR DESCRIPTION
# Why

> https://github.com/expo/expo/pull/43720#pullrequestreview-3922422423
> I was just wondering if there's a different code that could potentially produce an invalid prop that we would like to handle.

Yeaah, I think I just found another one @lukmccall

# How

Create a `Fragment` component to support both `<></>` and `<React.Fragment></React.Fragment>`.

# Test Plan

```jsx
() => {
  'widget';

  return (
    <HStack spacing={12}>
      <>
        <Text>sadas1</Text>
        <Text>sadas2</Text>
      </>
    </HStack>
  )
}
```

<img width="300" alt="image" src="https://github.com/user-attachments/assets/422dc5c6-a177-4c16-8037-6bac007bdf66" />


# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
