### PR TITLE
Fix metro-config isHermesV1 test expectations after projectRoot refactor

### DIFF
--- a/packages/@expo/metro-config/src/__tests__/babel-transformer.test.ts
+++ b/packages/@expo/metro-config/src/__tests__/babel-transformer.test.ts
@@ -65,7 +65,7 @@ it(`passes the environment as isServer to the babel preset`, () => {
       isDev: true,
       bundler: 'metro',
       engine: undefined,
-      isHermesV1: true,
+      isHermesV1: false,
       name: 'metro',
       platform: 'ios',
       baseUrl: '',
@@ -169,9 +169,22 @@ describe('isHermesV1 detection', () => {
 
   function setupTransformerWithHermesVersion(version: string | null) {
     jest.resetModules();
-    if (version !== null) {
-      jest.doMock('hermes-compiler/package.json', () => ({ version }));
-    }
+    const actualResolveFrom = jest.requireActual('resolve-from');
+    jest.doMock('resolve-from', () => ({
+      ...actualResolveFrom,
+      silent: (root: string, id: string) => {
+        if (id === 'react-native/package.json') {
+          return '/fake/node_modules/react-native/package.json';
+        }
+        return actualResolveFrom.silent(root, id);
+      },
+    }));
+    jest.doMock('../utils/getPkgVersion', () => ({
+      getPkgVersion: (_root: string, pkgName: string) => {
+        if (pkgName === 'hermes-compiler') return version;
+        return null;
+      },
+    }));
     jest.doMock('../babel-core', () => {
       const actual = jest.requireActual('../babel-core');
       return {


### PR DESCRIPTION
## Summary

- Fix `isHermesV1` test expectations in `babel-transformer.test.ts` that were broken by an implementation mismatch between SDK 56 and main.

The cherry-pick in e235295d413 brought test expectations from SDK 56 that assumed the old `require('hermes-compiler/package.json')` implementation of `getIsHermesV1`. However, on main, 59f7c0939ea had already refactored it to use `resolveFrom.silent(projectRoot, ...)` + `getPkgVersion()`, which behaves differently in the test environment (memfs with projectRoot `/`):

1. **First test** (`passes the environment as isServer`): `resolveFrom.silent('/', 'react-native/package.json')` returns `null` in memfs, so `getIsHermesV1` returns `false`. Fixed expected value from `true` to `false`.

2. **`isHermesV1 detection` tests**: The `jest.doMock('hermes-compiler/package.json')` mock was never hit by the refactored implementation (which uses `resolveFrom` + `getPkgVersion`, not a direct `require`). Replaced with proper mocks for `resolve-from` and `../utils/getPkgVersion`.

## Test plan

- [x] `yarn test --watch false --passWithNoTests` in `packages/@expo/metro-config` — all 41 suites pass (728 tests)
- [x] `yarn clean && yarn build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)