### PR TITLE
[babel-preset-expo] Fix test expectations for Hermes V1 class preservation

### DIFF
--- a/packages/babel-preset-expo/src/__tests__/hermes-bytecode.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/hermes-bytecode.test.ts
@@ -24,6 +24,14 @@ jest.mock('../common.ts', () => ({
   }),
 }));
 
+const SAMPLE_CODE = `
+try {
+
+} catch ({ message }) {
+
+}
+`;
+
 const LANGUAGE_SAMPLES: {
   name: string;
   code: string;
@@ -121,10 +129,7 @@ const LANGUAGE_SAMPLES: {
         }
       }`,
     getCompiledCode({ platform }) {
-      if (platform === 'web') {
-        return 'class Test{constructor(name){this.name=name;}logger(){console.log("Hello",this.name);}}';
-      }
-      return 'var _interopRequireDefault=require("@babel/runtime/helpers/interopRequireDefault").default;var _classCallCheck2=_interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));var _createClass2=_interopRequireDefault(require("@babel/runtime/helpers/createClass"));var Test=function(){function Test(name){(0,_classCallCheck2.default)(this,Test);this.name=name;}return(0,_createClass2.default)(Test,[{key:"logger",value:function logger(){console.log("Hello",this.name);}}]);}();';
+      return 'class Test{constructor(name){this.name=name;}logger(){console.log("Hello",this.name);}}';
     },
   },
   {
@@ -138,7 +143,7 @@ const LANGUAGE_SAMPLES: {
       if (platform === 'web') {
         return 'var _interopRequireDefault=require("@babel/runtime/helpers/interopRequireDefault");var _classPrivateFieldLooseKey2=_interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseKey"));var _foo=(0,_classPrivateFieldLooseKey2.default)("foo");class Counter{constructor(){Object.defineProperty(this,_foo,{value:_foo2});}}function _foo2(){}';
       }
-      return 'var _interopRequireDefault=require("@babel/runtime/helpers/interopRequireDefault").default;var _createClass2=_interopRequireDefault(require("@babel/runtime/helpers/createClass"));var _classCallCheck2=_interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));var _classPrivateFieldLooseKey2=_interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseKey"));var _foo=(0,_classPrivateFieldLooseKey2.default)("foo");var Counter=(0,_createClass2.default)(function Counter(){(0,_classCallCheck2.default)(this,Counter);Object.defineProperty(this,_foo,{value:_foo2});});function _foo2(){}';
+      return 'var _interopRequireDefault=require("@babel/runtime/helpers/interopRequireDefault").default;var _classPrivateFieldLooseKey2=_interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseKey"));var _foo=(0,_classPrivateFieldLooseKey2.default)("foo");class Counter{constructor(){Object.defineProperty(this,_foo,{value:_foo2});}}function _foo2(){}';
     },
   },
   {
@@ -155,7 +160,7 @@ const LANGUAGE_SAMPLES: {
       if (platform === 'web') {
         return `function _checkInRHS(e){if(Object(e)!==e)throw TypeError("right-hand side of 'in' should be an object, got "+(null!==e?typeof e:"null"));return e;}var _barBrandCheck=new WeakSet();class Foo{#bar=(_barBrandCheck.add(this),"bar");test(obj){return _barBrandCheck.has(_checkInRHS(obj));}}`;
       }
-      return 'var _interopRequireDefault=require("@babel/runtime/helpers/interopRequireDefault").default;var _classCallCheck2=_interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));var _createClass2=_interopRequireDefault(require("@babel/runtime/helpers/createClass"));var _checkInRHS2=_interopRequireDefault(require("@babel/runtime/helpers/checkInRHS"));var _classPrivateFieldLooseKey2=_interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseKey"));var _bar=(0,_classPrivateFieldLooseKey2.default)("bar");var Foo=function(){function Foo(){(0,_classCallCheck2.default)(this,Foo);Object.defineProperty(this,_bar,{writable:true,value:"bar"});}return(0,_createClass2.default)(Foo,[{key:"test",value:function test(obj){return Object.prototype.hasOwnProperty.call((0,_checkInRHS2.default)(obj),_bar);}}]);}();';
+      return `var _interopRequireDefault=require("@babel/runtime/helpers/interopRequireDefault").default;var _checkInRHS2=_interopRequireDefault(require("@babel/runtime/helpers/checkInRHS"));var _barBrandCheck=new WeakSet();class Foo{#bar=(_barBrandCheck.add(this),"bar");test(obj){return _barBrandCheck.has((0,_checkInRHS2.default)(obj));}}`;
     },
   },
   {
@@ -176,7 +181,7 @@ const LANGUAGE_SAMPLES: {
       if (platform === 'web') {
         return `var _interopRequireDefault=require("@babel/runtime/helpers/interopRequireDefault");var _classPrivateFieldLooseBase2=_interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseBase"));var _classPrivateFieldLooseKey2=_interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseKey"));var _C;var _x=(0,_classPrivateFieldLooseKey2.default)("x");class C{}_C=C;Object.defineProperty(C,_x,{writable:true,value:42});(()=>{try{_C.y=doSomethingWith((0,_classPrivateFieldLooseBase2.default)(_C,_x)[_x]);}catch{_C.y="unknown";}})();`;
       }
-      return `var _interopRequireDefault=require("@babel/runtime/helpers/interopRequireDefault").default;var _createClass2=_interopRequireDefault(require("@babel/runtime/helpers/createClass"));var _classCallCheck2=_interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));var _classPrivateFieldLooseBase2=_interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseBase"));var _classPrivateFieldLooseKey2=_interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseKey"));var _C;var _x=(0,_classPrivateFieldLooseKey2.default)("x");var C=(0,_createClass2.default)(function C(){(0,_classCallCheck2.default)(this,C);});_C=C;Object.defineProperty(C,_x,{writable:true,value:42});(()=>{try{_C.y=doSomethingWith((0,_classPrivateFieldLooseBase2.default)(_C,_x)[_x]);}catch(_unused){_C.y="unknown";}})();`;
+      return `var _interopRequireDefault=require("@babel/runtime/helpers/interopRequireDefault").default;var _classPrivateFieldLooseBase2=_interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseBase"));var _classPrivateFieldLooseKey2=_interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseKey"));var _C;var _x=(0,_classPrivateFieldLooseKey2.default)("x");class C{}_C=C;Object.defineProperty(C,_x,{writable:true,value:42});(()=>{try{_C.y=doSomethingWith((0,_classPrivateFieldLooseBase2.default)(_C,_x)[_x]);}catch(_unused){_C.y="unknown";}})();`;
     },
   },
   // This isn't transformed but also should be handled since the current minimum iOS version is 13.4 and logical assignment operators are iOS +14.

--- a/packages/babel-preset-expo/src/__tests__/index.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/index.test.ts
@@ -152,9 +152,11 @@ it(`compiles sample file with Metro targeting Hermes`, () => {
     caller: getCaller({ name: 'metro' }),
   })!;
 
+  expect(withHermes.code).not.toEqual(withoutHermes.code);
+
   // Hermes v1 supports most modern JS features natively, so the output
-  // is equivalent to the default profile when not in dev mode.
-  expect(withHermes.code).toEqual(withoutHermes.code);
+  // should be shorter than the default profile (fewer transforms applied).
+  expect(withHermes.code!.length).toBeLessThan(withoutHermes.code!.length);
 });
 
 it(`supports overwriting the default engine option`, () => {


### PR DESCRIPTION
# Why

Fix CI error: https://github.com/expo/expo/actions/runs/22921159207/job/66519594457

# How

## Summary

- Fix `babel-preset-expo` test failures introduced by the cherry-pick in #43579, which brought test expectations from SDK 56 that don't match the current `@react-native/babel-preset` behavior on main.

### Root cause

RN 0.85.0-rc.0 (adopted in #43648) includes [facebook/react-native#55093](https://github.com/facebook/react-native/pull/55093) which disables JS class transforms for Hermes V1. When `unstable_transformProfile` is `hermes-stable`, the preset now sets `preserveClasses = true`, skipping `@babel/plugin-transform-classes` and `@babel/plugin-transform-class-properties`. Native ES6 `class` syntax is preserved since Hermes V1 supports it natively.

The cherry-pick in #43579 was authored against SDK 56 where test expectations already accounted for this, but on main the test expectations were written for the pre-0.85 behavior where classes were still transformed.

### Fixes
- **`hermes-bytecode.test.ts`**: Restore `SAMPLE_CODE` constant that was removed in #43648 (RN 0.85 upgrade) but re-referenced by #43579
- **`hermes-bytecode.test.ts`**: Update expected compiled output for `classes`, `private-methods`, `private-property-in-object`, and `plugin-transform-class-static-block` to reflect preserved native class syntax (no more `classCallCheck`/`createClass` helpers)
- **`index.test.ts`**: Fix assertion — Hermes V1 output is shorter (fewer transforms) than default profile, not equal to it

## Test plan

- [x] `yarn test --watch false --passWithNoTests` in `packages/babel-preset-expo` — 23 suites, 511 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)