### PR TITLE
[iOS] fix: Remove RCTHostRuntimeDelegate usage

### DIFF
--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -531,7 +531,7 @@ public final class AppContext: NSObject, @unchecked Sendable {
     let coreObject = uiRuntime.createObject()
 
     // Initialize `global.expo`.
-    uiRuntime.global().defineProperty(EXGlobalCoreObjectPropertyName, value: coreObject, options: [.enumerable, .configurable])
+    uiRuntime.global().defineProperty(EXGlobalCoreObjectPropertyName, value: coreObject, options: .enumerable)
 
     // Install `global.expo.EventEmitter`.
     EXJavaScriptRuntimeManager.installEventEmitterClass(uiRuntime)

--- a/packages/expo-modules-core/ios/Core/ExpoRuntime.swift
+++ b/packages/expo-modules-core/ios/Core/ExpoRuntime.swift
@@ -7,7 +7,7 @@
 public extension ExpoRuntime {
   @JavaScriptActor
   internal func initializeCoreObject(_ coreObject: JavaScriptObject) throws {
-    global().defineProperty(EXGlobalCoreObjectPropertyName, value: coreObject, options: [.enumerable, .configurable])
+    global().defineProperty(EXGlobalCoreObjectPropertyName, value: coreObject, options: .enumerable)
   }
 
   @JavaScriptActor

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [iOS] Remove `RCTHostRuntimeDelegate` usage now that it's merged into `RCTHostDelegate`.
+- [iOS] Remove `RCTHostRuntimeDelegate` usage now that it's merged into `RCTHostDelegate`. ([#43838](https://github.com/expo/expo/pull/43838) by [@zoontek](https://github.com/zoontek))
 
 ### ⚠️ Notices
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [iOS] Remove `RCTHostRuntimeDelegate` usage now that it's merged into `RCTHostDelegate`.
+
 ### ⚠️ Notices
 
 - Added support for React Native 0.84.x. ([#43018](https://github.com/expo/expo/pull/43018) by [@chrfalch](https://github.com/chrfalch))

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.h
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.h
@@ -7,6 +7,6 @@
 @protocol RCTHostRuntimeDelegate;
 
 NS_SWIFT_NAME(ExpoReactNativeFactoryObjC)
-@interface EXReactNativeFactory : RCTReactNativeFactory <RCTHostDelegate, RCTHostRuntimeDelegate>
+@interface EXReactNativeFactory : RCTReactNativeFactory <RCTHostDelegate>
 
 @end

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
@@ -17,19 +17,6 @@
 
 #pragma mark - RCTHostDelegate
 
-// [main thread]
-- (void)hostDidStart:(nonnull RCTHost *)host
-{
-  // Setting the runtime delegate here doesn't feel right, but there is no other way
-  // to capture the `host:didInitializeRuntime:` method call.
-  // With the current API design we also depend that the runtime is initialized after the host started,
-  // which isn't obvious, especially they are invoked on different threads.
-  // Ideally if the current `RCTHostRuntimeDelegate` is part of `RCTHostDelegate`.
-  host.runtimeDelegate = self;
-}
-
-#pragma mark - RCTHostRuntimeDelegate
-
 // [JS thread]
 - (void)host:(nonnull RCTHost *)host didInitializeRuntime:(jsi::Runtime &)runtime
 {


### PR DESCRIPTION
# Why

React Native 0.85 merged `RCTHostRuntimeDelegate` into `RCTHostDelegate` ([facebook/react-native#54915](https://github.com/facebook/react-native/pull/54915)), removing the need to manually set `host.runtimeDelegate` via `hostDidStart:`. Our `EXReactNativeFactory` relied on this workaround.

# How

- Removed `RCTHostRuntimeDelegate` conformance from `EXReactNativeFactory`
- Removed the `hostDidStart:` method that was setting `host.runtimeDelegate = self`
- `host:didInitializeRuntime:` is now called directly through `RCTHostDelegate`

# Test Plan

Build and run an iOS app targeting React Native 0.85.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
