### PR TITLE
fix(expo-localization): prevent duplicate resourceConfigurations on repeated prebuild

### DIFF
--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [android] Prevent duplicate `resourceConfigurations` entries on repeated prebuild runs. ([#43839](https://github.com/expo/expo/pull/43839) by [@leeseonghyun21](https://github.com/leeseonghyun21))
+
 ### 💡 Others
 
 ## 56.0.6 — 2026-05-21

--- a/packages/expo-localization/plugin/__tests__/withExpoLocalization-test.ts
+++ b/packages/expo-localization/plugin/__tests__/withExpoLocalization-test.ts
@@ -1,4 +1,7 @@
-import { convertBcp47ToResourceQualifier } from '../src/withExpoLocalization';
+import {
+  convertBcp47ToResourceQualifier,
+  setResourceConfigurations,
+} from '../src/withExpoLocalization';
 
 describe('converts locales to BCP-47 format', () => {
   it('should convert simple language codes to BCP-47 format', () => {
@@ -17,5 +20,47 @@ describe('converts locales to BCP-47 format', () => {
     expect(convertBcp47ToResourceQualifier('zh-Hant')).toBe('b+zh+Hant');
     expect(convertBcp47ToResourceQualifier('es-419')).toBe('b+es+419');
     expect(convertBcp47ToResourceQualifier('zh-Hant-TW')).toBe('b+zh+Hant+TW');
+  });
+});
+
+describe('setResourceConfigurations', () => {
+  const buildGradle = `android {
+    defaultConfig {
+        applicationId "com.example.app"
+    }
+}`;
+
+  const countResourceConfigurations = (contents: string) =>
+    contents.match(/resourceConfigurations/g)?.length ?? 0;
+
+  it('adds the resourceConfigurations entry inside defaultConfig on first run', () => {
+    const result = setResourceConfigurations(buildGradle, ['b+ko']);
+
+    expect(result).toContain('resourceConfigurations += ["b+ko"]');
+    expect(countResourceConfigurations(result)).toBe(1);
+  });
+
+  it('formats multiple qualifiers as a single entry', () => {
+    const result = setResourceConfigurations(buildGradle, ['b+ko', 'b+en+US', 'b+ja']);
+
+    expect(result).toContain('resourceConfigurations += ["b+ko", "b+en+US", "b+ja"]');
+    expect(countResourceConfigurations(result)).toBe(1);
+  });
+
+  it('is idempotent across repeated runs with the same locales', () => {
+    const firstRun = setResourceConfigurations(buildGradle, ['b+ko']);
+    const secondRun = setResourceConfigurations(firstRun, ['b+ko']);
+
+    expect(secondRun).toBe(firstRun);
+    expect(countResourceConfigurations(secondRun)).toBe(1);
+  });
+
+  it('replaces the existing entry when the locales change instead of leaving both', () => {
+    const firstRun = setResourceConfigurations(buildGradle, ['b+ko']);
+    const secondRun = setResourceConfigurations(firstRun, ['b+ko', 'b+ja']);
+
+    expect(secondRun).toContain('resourceConfigurations += ["b+ko", "b+ja"]');
+    expect(secondRun).not.toContain('resourceConfigurations += ["b+ko"]');
+    expect(countResourceConfigurations(secondRun)).toBe(1);
   });
 });

--- a/packages/expo-localization/plugin/src/withExpoLocalization.ts
+++ b/packages/expo-localization/plugin/src/withExpoLocalization.ts
@@ -43,6 +43,36 @@ export function convertBcp47ToResourceQualifier(locale: string): string {
   return `b+${locale.replaceAll('-', '+')}`;
 }
 
+// Matches a `resourceConfigurations += [...]` entry (with its indentation) that this
+// plugin previously wrote to build.gradle.
+const RESOURCE_CONFIGURATIONS_REGEX = /^([ \t]*)resourceConfigurations\s*\+=\s*\[[^\]\n]*\]/m;
+
+/**
+ * Writes the `resourceConfigurations` entry into the `defaultConfig` block of a groovy
+ * build.gradle. If an entry from a previous prebuild already exists it is replaced in place,
+ * so repeated `expo prebuild` runs stay idempotent and reflect changes to `supportedLocales`
+ * instead of accumulating duplicate lines.
+ */
+export function setResourceConfigurations(
+  buildGradleContents: string,
+  resourceQualifiers: string[]
+): string {
+  const entry = `resourceConfigurations += [${resourceQualifiers
+    .map((qualifier) => `"${qualifier}"`)
+    .join(', ')}]`;
+  if (RESOURCE_CONFIGURATIONS_REGEX.test(buildGradleContents)) {
+    return buildGradleContents.replace(
+      RESOURCE_CONFIGURATIONS_REGEX,
+      (_match, indent) => `${indent}${entry}`
+    );
+  }
+  return AndroidConfig.CodeMod.appendContentsInsideDeclarationBlock(
+    buildGradleContents,
+    'defaultConfig',
+    `    ${entry}\n    `
+  );
+}
+
 function withExpoLocalizationIos(config: ExpoConfig, data: ConfigPluginProps) {
   const mergedConfig = { ...config.extra, ...data };
 
@@ -130,10 +160,9 @@ function withExpoLocalizationAndroid(config: ExpoConfig, data: ConfigPluginProps
         const resourceQualifiers = supportedLocales.map((locale) =>
           convertBcp47ToResourceQualifier(locale)
         );
-        config.modResults.contents = AndroidConfig.CodeMod.appendContentsInsideDeclarationBlock(
+        config.modResults.contents = setResourceConfigurations(
           config.modResults.contents,
-          'defaultConfig',
-          `    resourceConfigurations += [${resourceQualifiers.map((qualifier) => `"${qualifier}"`).join(', ')}]\n    `
+          resourceQualifiers
         );
       } else {
         WarningAggregator.addWarningAndroid(


### PR DESCRIPTION
# Why

Fixes #42209.

The `withExpoLocalization` Android config plugin appended `resourceConfigurations += [...]` to `build.gradle`'s `defaultConfig` block on **every** prebuild without checking for an existing entry. As a result, each `expo prebuild` run accumulated a duplicate `resourceConfigurations` line.

# How

- Extracted the gradle mutation into an exported, pure helper `setResourceConfigurations(buildGradleContents, resourceQualifiers)` and wired the `withAppBuildGradle` mod to use it.
- The helper **replaces** a previously-written `resourceConfigurations += [...]` entry in place (matched via regex) when one exists, and only appends when none does.
  - This keeps repeated prebuilds **idempotent**.
  - It also correctly reflects changes to `supportedLocales` (e.g. adding a locale) by updating the existing entry instead of leaving a stale one behind — an edge case a plain string `includes()` check would miss (it would leave both the old and new lines).

# Test Plan

Added unit tests in `packages/expo-localization/plugin/__tests__/withExpoLocalization-test.ts` that exercise the real exported `setResourceConfigurations` helper (not a copy of its logic):

- adds the entry inside `defaultConfig` on first run
- formats multiple qualifiers as a single entry (`["b+ko", "b+en+US", "b+ja"]`)
- is idempotent across repeated runs with the same locales (output is byte-for-byte identical, single entry)
- replaces the existing entry when the locales change, leaving no leftover / no duplicate

Runs with the package's Jest suite (`et check-packages expo-localization`).

# Checklist

- [x] Added a `CHANGELOG.md` entry.
- [x] No compiled `build/` output committed (source-only change).
- [x] This change is Android-only and does not require an EAS Build to verify.
