### PR TITLE
[tools] exclude expo-brownfield from check-packages-windows test

### DIFF
--- a/tools/src/check-packages/checkPackageAsync.ts
+++ b/tools/src/check-packages/checkPackageAsync.ts
@@ -27,6 +27,7 @@ const IGNORED_TEST_PACKAGES_ON_WINDOWS = [
   '@expo/router-server',
   'babel-preset-expo',
   'create-expo',
+  'expo-brownfield',
   'expo-doctor',
   'expo-modules-autolinking',
   'install-expo-modules',


### PR DESCRIPTION
# Why

fix ci errors: https://github.com/expo/expo/actions/runs/22907101244/job/66468732125

# How

exclude expo-brownfield from check-packages-windows test

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
