### PR TITLE
chore: bump @sentry/react-native to ~8.3.0

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -116,6 +116,6 @@
   "unimodules-image-loader-interface": "~6.1.0",
   "@shopify/react-native-skia": "2.4.18",
   "@shopify/flash-list": "2.0.2",
-  "@sentry/react-native": "~7.11.0",
+  "@sentry/react-native": "~8.3.0",
   "react-native-bootsplash": "^6.3.10"
 }


### PR DESCRIPTION
## Summary

Bump `@sentry/react-native` from `~7.11.0` to `~8.3.0` in `bundledNativeModules.json`.

## Checklist

- [x] Change is backwards compatible