### PR TITLE
[ios][dev-launcher] Fix regression on orientation change

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [iOS] Fix issue when using `fullScreenModal` with `expo-router`. ([#43520](https://github.com/expo/expo/pull/43520) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix missing navigation bar padding ([#43672](https://github.com/expo/expo/pull/43672) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix orientation change regression.
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - [iOS] Fix issue when using `fullScreenModal` with `expo-router`. ([#43520](https://github.com/expo/expo/pull/43520) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix missing navigation bar padding ([#43672](https://github.com/expo/expo/pull/43672) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fix orientation change regression.
+- [iOS] Fix orientation change regression. ([#43847](https://github.com/expo/expo/pull/43847) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -120,10 +120,15 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, EXDe
     let targetVC: UIViewController
 #if !os(macOS)
     let windowRootVC = rootViewController?.view?.window?.rootViewController
-    if let windowRootVC, windowRootVC.view is DevLauncherWrapperView {
-      // Greenfield: set root view on the window's root VC so react-native-screens parents its
-      // UINavigationController to a VC in the containment hierarchy with correct layout margins.
-      targetVC = windowRootVC
+    if let windowRootVC, let wrapperView = windowRootVC.view as? DevLauncherWrapperView {
+      // Greenfield: keep the wrapper view in the hierarchy so it can manage layout on orientation
+      // changes. Add rootView as a subview instead of replacing the wrapper, so react-native-screens
+      // finds window.rootViewController (in the containment hierarchy) with correct layout margins.
+      wrapperView.subviews.forEach { $0.removeFromSuperview() }
+      rootView.frame = wrapperView.bounds
+      rootView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+      wrapperView.addSubview(rootView)
+      return
     } else if let rootViewController {
       // Brownfield: the wrapper is embedded in a custom hierarchy, fall back to
       // DevLauncherViewController to avoid replacing the host app's root view.


### PR DESCRIPTION
# Why
Fixes a regression from #43672. Because we removed the wrapper from the view hierarchy, we were not responding to orientation changes.

# How
Add the rootView as a subview of the wrapper. 

# Test Plan
Tested in a new project. Orientation changes respond correctly, nav bar still has the correct layout margins.

