### PR TITLE
[launcher][Android] Add pull-to-refresh

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/models/HomeViewModel.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/models/HomeViewModel.kt
@@ -19,6 +19,7 @@ import expo.modules.devlauncher.services.NsdPreferences
 import expo.modules.devlauncher.services.PackagerInfo
 import expo.modules.devlauncher.services.PackagerService
 import expo.modules.devlauncher.services.inject
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -29,13 +30,15 @@ sealed interface HomeAction {
   class NavigateToCrashReport(val crashReport: DevLauncherErrorInstance) : HomeAction
   object ScanQRCode : HomeAction
   object ClearLoadingError : HomeAction
+  object RefreshServers : HomeAction
 }
 
 data class HomeState(
   val runningPackagers: Set<PackagerInfo> = emptySet(),
   val recentlyOpenedApps: List<DevLauncherAppEntry> = emptyList(),
   val crashReport: DevLauncherErrorInstance? = null,
-  val loadingError: String? = null
+  val loadingError: String? = null,
+  val isRefreshing: Boolean = false
 )
 
 class HomeViewModel : ViewModel(), DefaultLifecycleObserver {
@@ -130,9 +133,22 @@ class HomeViewModel : ViewModel(), DefaultLifecycleObserver {
 
       is HomeAction.ClearLoadingError -> _state.value = _state.value.copy(loadingError = null)
 
+      is HomeAction.RefreshServers -> refreshServers()
+
       is HomeAction.NavigateToCrashReport -> throw IllegalStateException("Navigation action should be handled by the UI layer, not the ViewModel.")
 
       is HomeAction.ScanQRCode -> throw IllegalStateException("QR code scanning should be handled by the UI layer, not the ViewModel.")
+    }
+  }
+
+  private fun refreshServers() {
+    if (_state.value.isRefreshing) return
+    _state.value = _state.value.copy(isRefreshing = true)
+
+    viewModelScope.launch {
+      packagerService.restart()
+      delay(2000)
+      _state.value = _state.value.copy(isRefreshing = false)
     }
   }
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/primitives/CircularProgressBar.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/primitives/CircularProgressBar.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.withTransform
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -26,6 +27,7 @@ import kotlin.time.Duration.Companion.seconds
 @Composable
 fun CircularProgressBar(
   modifier: Modifier = Modifier,
+  progress: Float? = null,
   startAngle: Float = 270f,
   size: Dp = 96.dp,
   strokeWidth: Dp = size / 8,
@@ -34,18 +36,36 @@ fun CircularProgressBar(
   val backgroundColor = NewAppTheme.pallet.gray.`3`
   val progressColor = NewAppTheme.pallet.blue.`8`
 
-  val transition = rememberInfiniteTransition(label = "infiniteSpinningTransition")
+  val effectiveProgress = if (progress != null) {
+    progress
+  } else {
+    val transition = rememberInfiniteTransition(label = "infiniteSpinningTransition")
+    val animatedProgress by transition.animateFloat(
+      initialValue = 0f,
+      targetValue = 1f,
+      animationSpec = infiniteRepeatable(
+        tween(duration.inWholeMilliseconds.toInt())
+      ),
+      label = "Progress Animation"
+    )
+    animatedProgress
+  }
 
-  val animatedProgress by transition.animateFloat(
-    initialValue = 0f,
-    targetValue = 1f,
-    animationSpec = infiniteRepeatable(
-      tween(duration.inWholeMilliseconds.toInt())
-    ),
-    label = "Progress Animation"
-  )
+  val determinateModifier = if (progress != null) {
+    Modifier.graphicsLayer {
+      alpha = progress
+      rotationZ = progress * 270f
+    }
+  } else {
+    Modifier
+  }
 
-  Canvas(modifier = Modifier.size(size).then(modifier)) {
+  Canvas(
+    modifier = Modifier
+      .size(size)
+      .then(determinateModifier)
+      .then(modifier)
+  ) {
     val strokeWidthPx = strokeWidth.toPx()
     val arcSize = size.toPx() - strokeWidthPx
     drawArc(
@@ -59,18 +79,30 @@ fun CircularProgressBar(
       style = Stroke(width = strokeWidthPx)
     )
 
-    withTransform({
-      rotate(degrees = startAngle, pivot = center)
-    }) {
+    if (progress != null) {
       drawArc(
         color = progressColor,
-        startAngle = 0f,
-        sweepAngle = animatedProgress * 360,
+        startAngle = 270f,
+        sweepAngle = progress * 270f,
         useCenter = false,
         topLeft = Offset(strokeWidthPx / 2, strokeWidthPx / 2),
         size = Size(arcSize, arcSize),
         style = Stroke(width = strokeWidthPx, cap = StrokeCap.Round)
       )
+    } else {
+      withTransform({
+        rotate(degrees = startAngle, pivot = center)
+      }) {
+        drawArc(
+          color = progressColor,
+          startAngle = 0f,
+          sweepAngle = effectiveProgress * 360,
+          useCenter = false,
+          topLeft = Offset(strokeWidthPx / 2, strokeWidthPx / 2),
+          size = Size(arcSize, arcSize),
+          style = Stroke(width = strokeWidthPx, cap = StrokeCap.Round)
+        )
+      }
     }
   }
 }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/HomeScreen.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/HomeScreen.kt
@@ -1,5 +1,10 @@
 package expo.modules.devlauncher.compose.screens
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -8,18 +13,22 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.composeunstyled.Button
-import expo.modules.devlauncher.compose.ui.DefaultScreenContainer
 import expo.modules.devlauncher.compose.models.HomeAction
 import expo.modules.devlauncher.compose.models.HomeState
 import expo.modules.devlauncher.compose.primitives.Accordion
+import expo.modules.devlauncher.compose.ui.AnimatedPackagerCard
 import expo.modules.devlauncher.compose.ui.AppHeader
 import expo.modules.devlauncher.compose.ui.AppLoadingErrorDialog
+import expo.modules.devlauncher.compose.ui.DefaultScreenContainer
 import expo.modules.devlauncher.compose.ui.DevelopmentSessionActions
 import expo.modules.devlauncher.compose.ui.DevelopmentSessionSection
+import expo.modules.devlauncher.compose.ui.PullToRefreshContainer
 import expo.modules.devlauncher.compose.ui.RunningAppCard
+import expo.modules.devlauncher.compose.ui.rememberAnimatedItemsState
 import expo.modules.devlauncher.compose.ui.rememberAppLoadingErrorDialogState
 import expo.modules.devlauncher.launcher.DevLauncherAppEntry
 import expo.modules.devlauncher.launcher.errors.DevLauncherErrorInstance
@@ -58,7 +67,6 @@ fun HomeScreen(
   onProfileClick: () -> Unit,
   onDevServersClick: () -> Unit
 ) {
-  val scrollState = rememberScrollState()
   val errorDialogState = rememberAppLoadingErrorDialogState(state, onAction)
 
   AppLoadingErrorDialog(
@@ -82,38 +90,54 @@ fun HomeScreen(
       }
     )
 
-    Column(
-      modifier = Modifier
-        .padding(vertical = NewAppTheme.spacing.`6`)
-        .verticalScroll(scrollState)
+    val runningPackagers = state.runningPackagers
+
+    PullToRefreshContainer(
+      isRefreshing = state.isRefreshing,
+      onRefresh = { onAction(HomeAction.RefreshServers) },
+      modifier = Modifier.weight(1f)
     ) {
-      Row(
-        horizontalArrangement = Arrangement.SpaceBetween,
-        modifier = Modifier.fillMaxWidth()
-      ) {
-        Section.Header("DEVELOPMENT SERVERS")
+      AnimatedContent(
+        targetState = runningPackagers,
+        contentKey = { it.isNotEmpty() },
+        transitionSpec = {
+          fadeIn(tween(300)) togetherWith fadeOut(tween(300))
+        },
+        label = "packagers-transition"
+      ) { packagers ->
+        Column(
+          modifier = Modifier
+            .padding(vertical = NewAppTheme.spacing.`6`)
+            .verticalScroll(rememberScrollState())
+        ) {
+          Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.fillMaxWidth()
+          ) {
+            Section.Header("DEVELOPMENT SERVERS")
 
-        Section.Button("INFO", onDevServersClick)
+            Section.Button("INFO", onDevServersClick)
+          }
+
+          Spacer(NewAppTheme.spacing.`3`)
+
+          if (packagers.isNotEmpty()) {
+            LocalPackagers(
+              packagers,
+              onAction
+            )
+          } else {
+            DevelopmentSessionSection(state.isRefreshing, onAction)
+          }
+
+          Spacer(NewAppTheme.spacing.`6`)
+
+          RecentlyOpenedApps(
+            state.recentlyOpenedApps,
+            onAction
+          )
+        }
       }
-
-      Spacer(NewAppTheme.spacing.`3`)
-
-      val runningPackagers = state.runningPackagers
-      if (runningPackagers.isNotEmpty()) {
-        LocalPackagers(
-          runningPackagers,
-          onAction
-        )
-      } else {
-        DevelopmentSessionSection(onAction)
-      }
-
-      Spacer(NewAppTheme.spacing.`6`)
-
-      RecentlyOpenedApps(
-        state.recentlyOpenedApps,
-        onAction
-      )
     }
   }
 }
@@ -123,18 +147,24 @@ private fun LocalPackagers(
   runningPackagers: Set<PackagerInfo>,
   onAction: (HomeAction) -> Unit
 ) {
+  val animatedItems = rememberAnimatedItemsState(
+    items = runningPackagers,
+    key = { it.url }
+  )
+
   Column(
     verticalArrangement = Arrangement.spacedBy(NewAppTheme.spacing.`2`)
   ) {
     Column(
       verticalArrangement = Arrangement.spacedBy(NewAppTheme.spacing.`2`)
     ) {
-      for (packager in runningPackagers) {
-        RunningAppCard(
-          appIp = packager.url,
-          appName = packager.description
-        ) {
-          onAction(HomeAction.OpenApp(packager.url))
+      for ((packager, visibleState) in animatedItems) {
+        key(packager.url) {
+          AnimatedPackagerCard(
+            packager = packager,
+            visibleState = visibleState,
+            onAction = onAction
+          )
         }
       }
     }
@@ -145,7 +175,7 @@ private fun LocalPackagers(
       modifier = Modifier
         .fillMaxWidth()
     ) {
-      DevelopmentSessionActions(onAction)
+      DevelopmentSessionActions(onAction = onAction)
     }
   }
 }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/AnimatedPackagerCard.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/AnimatedPackagerCard.kt
@@ -1,0 +1,76 @@
+package expo.modules.devlauncher.compose.ui
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import expo.modules.devlauncher.compose.models.HomeAction
+import expo.modules.devlauncher.services.PackagerInfo
+
+@Composable
+internal fun <T, Key> rememberAnimatedItemsState(
+  items: Set<T>,
+  key: (T) -> Key
+): List<Pair<T, MutableTransitionState<Boolean>>> {
+  val allItems = remember { mutableStateMapOf<Key, T>() }
+  val visibilityStates = remember { mutableMapOf<Key, MutableTransitionState<Boolean>>() }
+  val currentKeys = remember(items) { items.map(key).toSet() }
+
+  items
+    .map { key(it) to it }
+    .forEach { (key, item) ->
+      allItems[key] = item
+      visibilityStates.getOrPut(key) { MutableTransitionState(false) }
+    }
+
+  allItems
+    .keys
+    .forEach { k ->
+      visibilityStates[k]?.targetState = k in currentKeys
+    }
+
+  val staleKeys = visibilityStates
+    .entries
+    .filter { (_, state) -> !state.targetState && state.isIdle }
+    .map { it.key }
+
+  staleKeys.forEach {
+    allItems.remove(it)
+    visibilityStates.remove(it)
+  }
+
+  return allItems.map { (k, item) ->
+    item to (visibilityStates[k] ?: MutableTransitionState(true))
+  }
+}
+
+@Composable
+internal fun AnimatedPackagerCard(
+  packager: PackagerInfo,
+  visibleState: MutableTransitionState<Boolean>,
+  onAction: (HomeAction) -> Unit
+) {
+  AnimatedVisibility(
+    visibleState = visibleState,
+    enter = expandVertically(
+      animationSpec = tween(300),
+      expandFrom = Alignment.Top
+    ),
+    exit = shrinkVertically(
+      animationSpec = tween(300),
+      shrinkTowards = Alignment.Top
+    )
+  ) {
+    RunningAppCard(
+      appIp = packager.url,
+      appName = packager.description
+    ) {
+      onAction(HomeAction.OpenApp(packager.url))
+    }
+  }
+}

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/DevelopmentSession.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/DevelopmentSession.kt
@@ -19,6 +19,7 @@ import expo.modules.devmenu.compose.primitives.RoundedSurface
 
 @Composable
 fun DevelopmentSessionSection(
+  isRefreshing: Boolean = false,
   onAction: (HomeAction) -> Unit = {}
 ) {
   RoundedSurface(
@@ -31,7 +32,7 @@ fun DevelopmentSessionSection(
     ) {
       DevelopmentSessionHelp()
 
-      DevelopmentSessionActions(onAction)
+      DevelopmentSessionActions(isRefreshing, showRefetchButton = true, onAction)
     }
   }
 }
@@ -75,7 +76,7 @@ fun DevelopmentSessionHelp() {
 }
 
 @Composable
-fun DevelopmentSessionActions(onAction: (HomeAction) -> Unit) {
+fun DevelopmentSessionActions(isRefreshing: Boolean = false, showRefetchButton: Boolean = false, onAction: (HomeAction) -> Unit) {
   Column(
     verticalArrangement = Arrangement.spacedBy(NewAppTheme.spacing.`3`)
   ) {
@@ -84,6 +85,22 @@ fun DevelopmentSessionActions(onAction: (HomeAction) -> Unit) {
         onAction(HomeAction.OpenApp(urlValue))
       }
     )
+
+    if (showRefetchButton) {
+      NewText(
+        "Or",
+        color = NewAppTheme.colors.text.secondary,
+        style = NewAppTheme.font.sm.merge(
+          textAlign = TextAlign.Center
+        ),
+        modifier = Modifier.fillMaxWidth()
+      )
+
+      FetchDevelopmentServersButton(
+        isFetching = isRefreshing,
+        onAction = onAction
+      )
+    }
 
     if (!EmulatorUtilities.isRunningOnEmulator()) {
       NewText(

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/FetchDevelopmentServersButton.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/FetchDevelopmentServersButton.kt
@@ -1,0 +1,59 @@
+package expo.modules.devlauncher.compose.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.composeunstyled.Button
+import expo.modules.devlauncher.compose.models.HomeAction
+import expo.modules.devlauncher.compose.primitives.CircularProgressBar
+import expo.modules.devmenu.compose.newtheme.NewAppTheme
+import expo.modules.devmenu.compose.primitives.NewText
+import expo.modules.devmenu.compose.primitives.RoundedSurface
+
+@Composable
+fun FetchDevelopmentServersButton(
+  isFetching: Boolean,
+  onAction: (HomeAction) -> Unit
+) {
+  RoundedSurface(
+    color = NewAppTheme.colors.background.element,
+    borderRadius = NewAppTheme.borderRadius.xl
+  ) {
+    Button(
+      onClick = {
+        onAction(HomeAction.RefreshServers)
+      },
+      enabled = !isFetching
+    ) {
+      Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(NewAppTheme.spacing.`3`)
+      ) {
+        NewText(
+          if (isFetching) {
+            "Searching for development servers..."
+          } else {
+            "Fetch development servers"
+          }
+        )
+
+        if (isFetching) {
+          CircularProgressBar(size = 20.dp)
+        } else {
+          LauncherIcons.Download(
+            size = 20.dp,
+            tint = NewAppTheme.colors.icon.quaternary
+          )
+        }
+      }
+    }
+  }
+}

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/PullToRefresh.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/PullToRefresh.kt
@@ -1,0 +1,165 @@
+package expo.modules.devlauncher.compose.ui
+
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.Velocity
+import androidx.compose.ui.unit.dp
+import expo.modules.devlauncher.compose.primitives.CircularProgressBar
+import kotlin.math.roundToInt
+
+private val INDICATOR_SIZE = 28.dp
+private val REFRESH_THRESHOLD = 80.dp
+private val MAX_DRAG_DISTANCE = 120.dp
+private const val DRAG_MULTIPLIER = 0.5f
+
+@Composable
+fun PullToRefreshContainer(
+  isRefreshing: Boolean,
+  onRefresh: () -> Unit,
+  modifier: Modifier = Modifier,
+  content: @Composable () -> Unit
+) {
+  val density = LocalDensity.current
+  val refreshThresholdPx = with(density) { REFRESH_THRESHOLD.toPx() }
+  val maxDragPx = with(density) { MAX_DRAG_DISTANCE.toPx() }
+
+  var dragOffset by remember { mutableFloatStateOf(0f) }
+  var isAnimating by remember { mutableStateOf(false) }
+
+  val currentOnRefresh by rememberUpdatedState(onRefresh)
+  val currentIsRefreshing by rememberUpdatedState(isRefreshing)
+
+  LaunchedEffect(isRefreshing) {
+    if (isRefreshing) {
+      isAnimating = true
+      animate(
+        initialValue = dragOffset,
+        targetValue = refreshThresholdPx,
+        animationSpec = tween(200)
+      ) { value, _ ->
+        dragOffset = value
+      }
+      isAnimating = false
+    }
+  }
+
+  LaunchedEffect(isRefreshing) {
+    if (!isRefreshing && dragOffset > 0) {
+      isAnimating = true
+      animate(
+        initialValue = dragOffset,
+        targetValue = 0f,
+        animationSpec = tween(300)
+      ) { value, _ ->
+        dragOffset = value
+      }
+      isAnimating = false
+    }
+  }
+
+  val nestedScrollConnection = remember {
+    object : NestedScrollConnection {
+      override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+        // While refreshing or animating, don't allow pull gestures to interfere
+        if (currentIsRefreshing || isAnimating) {
+          return Offset.Zero
+        }
+
+        // If indicator is extended and user scrolls up, retract indicator first
+        if (dragOffset > 0 && available.y < 0) {
+          val newOffset = (dragOffset + available.y).coerceAtLeast(0f)
+          val consumed = dragOffset - newOffset
+          dragOffset = newOffset
+          return Offset(0f, -consumed)
+        }
+        return Offset.Zero
+      }
+
+      override fun onPostScroll(
+        consumed: Offset,
+        available: Offset,
+        source: NestedScrollSource
+      ): Offset {
+        if (currentIsRefreshing || isAnimating) {
+          return Offset.Zero
+        }
+
+        // Downward overscroll at the top of the child - extend the indicator
+        if (available.y > 0 && source == NestedScrollSource.UserInput) {
+          dragOffset = (dragOffset + available.y * DRAG_MULTIPLIER).coerceIn(0f, maxDragPx)
+          return Offset(0f, available.y)
+        }
+        return Offset.Zero
+      }
+
+      override suspend fun onPreFling(available: Velocity): Velocity {
+        if (currentIsRefreshing || isAnimating || dragOffset <= 0f) {
+          return Velocity.Zero
+        }
+
+        if (dragOffset >= refreshThresholdPx) {
+          currentOnRefresh()
+        } else {
+          isAnimating = true
+          animate(
+            initialValue = dragOffset,
+            targetValue = 0f,
+            animationSpec = tween(200)
+          ) { value, _ ->
+            dragOffset = value
+          }
+          isAnimating = false
+        }
+
+        return Velocity(0f, available.y)
+      }
+    }
+  }
+
+  val indicatorHeightDp = with(density) { dragOffset.toDp() }
+  val progress = dragOffset / refreshThresholdPx
+
+  Box(modifier = modifier.nestedScroll(nestedScrollConnection)) {
+    // Content is offset downward by the drag amount
+    Box(
+      modifier = Modifier.offset { IntOffset(0, dragOffset.roundToInt()) }
+    ) {
+      content()
+    }
+
+    // Indicator drawn on top, in the revealed area
+    if (dragOffset > 1f) {
+      Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+          .fillMaxWidth()
+          .height(indicatorHeightDp)
+      ) {
+        CircularProgressBar(
+          size = INDICATOR_SIZE,
+          progress = if (isRefreshing) null else progress
+        )
+      }
+    }
+  }
+}

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/nsd/NsdDiscovery.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/nsd/NsdDiscovery.kt
@@ -10,6 +10,7 @@ interface NsdDiscovery {
   val discoveredPackagers: StateFlow<Set<PackagerInfo>>
 
   fun start()
+  fun restart()
   fun resumeHealthCheck()
   fun pauseHealthCheck()
   fun stop()

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/nsd/NsdDiscoveryBase.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/nsd/NsdDiscoveryBase.kt
@@ -57,9 +57,11 @@ internal abstract class NsdDiscoveryBase(
 
   private val serviceJobs = mutableMapOf<String, Job>()
 
-  private val discoveryListener = NsdDiscoveryListener(
+  private var discoveryListener: NsdDiscoveryListener? = null
+
+  private fun createDiscoveryListener() = NsdDiscoveryListener(
     onStopped = {
-      cancelAllServiceJobs()
+      cancelServiceJobs()
     },
     onServiceFound = {
       onServiceFound(it)
@@ -68,7 +70,9 @@ internal abstract class NsdDiscoveryBase(
       onServiceLost(it)
     },
     onStartFailed = {
-      isDiscovering = false
+      synchronized(this) {
+        isDiscovering = false
+      }
     }
   )
 
@@ -77,10 +81,12 @@ internal abstract class NsdDiscoveryBase(
       return
     }
 
+    val listener = createDiscoveryListener()
+    discoveryListener = listener
     manager.discoverServices(
       SERVICE_TYPE,
       NsdManager.PROTOCOL_DNS_SD,
-      discoveryListener
+      listener
     )
     isDiscovering = true
   }
@@ -93,17 +99,44 @@ internal abstract class NsdDiscoveryBase(
     healthCheckActive.value = false
   }
 
+  override fun restart() = synchronized(this) {
+    val wasHealthCheckActive = healthCheckActive.value
+
+    // Stop the old discovery cycle without clearing the packager list.
+    // This keeps stale entries visible in the UI while new discovery runs,
+    // avoiding a layout jump where servers briefly disappear.
+    stopDiscoveryOnly()
+
+    start()
+    if (wasHealthCheckActive) {
+      resumeHealthCheck()
+    }
+  }
+
   override fun stop() = synchronized(this) {
+    stopDiscoveryOnly()
+    cancelAndClearServiceJobs()
+  }
+
+  /**
+   * Stops the NSD discovery listener and cancels service jobs, but keeps
+   * [alivePackagers] intact so the UI doesn't flash an empty state.
+   */
+  private fun stopDiscoveryOnly() {
     if (!isDiscovering) {
       return
     }
 
-    runCatching {
-      manager.stopServiceDiscovery(discoveryListener)
-    }.onFailure {
-      Log.e("DevLauncher", "Failed to stop NSD discovery", it)
+    val listener = discoveryListener
+    discoveryListener = null
+    if (listener != null) {
+      runCatching {
+        manager.stopServiceDiscovery(listener)
+      }.onFailure {
+        Log.e("DevLauncher", "Failed to stop NSD discovery", it)
+      }
     }
-    cancelAllServiceJobs()
+    cancelServiceJobs()
     healthCheckActive.value = false
     isDiscovering = false
   }
@@ -115,7 +148,7 @@ internal abstract class NsdDiscoveryBase(
 
     val job = coroutineScope.launch {
       launchServiceLoop(serviceName, serviceInfo)
-      // Loop ended (cancelled or error) — clean up
+      // Loop ended (canceled or error) - clean up
       removeDiscoveredPackager(serviceName)
     }
 
@@ -167,11 +200,21 @@ internal abstract class NsdDiscoveryBase(
     }
   }
 
-  private fun cancelAllServiceJobs() {
+  /**
+   * Cancels all running service coroutines without clearing [alivePackagers].
+   */
+  private fun cancelServiceJobs() {
     synchronized(serviceJobs) {
       serviceJobs.values.forEach { it.cancel() }
       serviceJobs.clear()
     }
+  }
+
+  /**
+   * Cancels all running service coroutines and clears the packager list.
+   */
+  private fun cancelAndClearServiceJobs() {
+    cancelServiceJobs()
     alivePackagers.clear()
     publishDiscoveredPackagers()
   }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/services/PackagerService.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/services/PackagerService.kt
@@ -22,6 +22,10 @@ class PackagerService(
     nsdDiscovery.start()
   }
 
+  fun restart() {
+    nsdDiscovery.restart()
+  }
+
   fun resumeHealthCheck() {
     nsdDiscovery.resumeHealthCheck()
   }


### PR DESCRIPTION
# Why

Adds pull-to-refresh to mitigate all problems with Android NSD, allowing users to refetch servers.  

# How

The restart functionality restarts the mDNS service, forcing Android to rescan the network. 
I've also added animation to make jumping between different states cleaner.  

# Test Plan

- bare-expo ✅ 

https://github.com/user-attachments/assets/08cb3c5c-8454-4021-a97b-e62da58e7ec2


<img width="1198" height="2531" alt="Screenshot_20260311_133836" src="https://github.com/user-attachments/assets/c962be94-e830-43a4-b1f4-1e9c1fe61a67" />
