### PR TITLE
[install-expo-modules] add rn083 support

### DIFF
--- a/packages/install-expo-modules/CHANGELOG.md
+++ b/packages/install-expo-modules/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added react-native 0.83 support.
+
 ### 🐛 Bug fixes
 
 - Add version mapping for SDK 55 and react native 0.83 ([#43682](https://github.com/expo/expo/pull/43682) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/install-expo-modules/CHANGELOG.md
+++ b/packages/install-expo-modules/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Added react-native 0.83 support.
+- Added react-native 0.83 support. ([#43855](https://github.com/expo/expo/pull/43855) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn083-updated.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn083-updated.kt
@@ -1,0 +1,36 @@
+package com.myapp
+import android.content.res.Configuration
+import expo.modules.ApplicationLifecycleDispatcher
+import expo.modules.ExpoReactHostFactory
+
+import android.app.Application
+import com.facebook.react.PackageList
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactHost
+import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
+import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
+
+class MainApplication : Application(), ReactApplication {
+
+  override val reactHost: ReactHost by lazy {
+    ExpoReactHostFactory.getDefaultReactHost(
+      context = applicationContext,
+      packageList =
+        PackageList(this).packages.apply {
+          // Packages that cannot be autolinked yet can be added manually here, for example:
+          // add(MyReactNativePackage())
+        },
+    )
+  }
+
+  override fun onCreate() {
+    super.onCreate()
+    loadReactNative(this)
+    ApplicationLifecycleDispatcher.onApplicationCreate(this)
+  }
+
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    super.onConfigurationChanged(newConfig)
+    ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig)
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn083-updated.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn083-updated.kt
@@ -1,4 +1,4 @@
-package com.myapp
+package com.helloworld
 import android.content.res.Configuration
 import expo.modules.ApplicationLifecycleDispatcher
 import expo.modules.ExpoReactHostFactory

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn083.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn083.kt
@@ -1,0 +1,27 @@
+package com.myapp
+
+import android.app.Application
+import com.facebook.react.PackageList
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactHost
+import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
+import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
+
+class MainApplication : Application(), ReactApplication {
+
+  override val reactHost: ReactHost by lazy {
+    getDefaultReactHost(
+      context = applicationContext,
+      packageList =
+        PackageList(this).packages.apply {
+          // Packages that cannot be autolinked yet can be added manually here, for example:
+          // add(MyReactNativePackage())
+        },
+    )
+  }
+
+  override fun onCreate() {
+    super.onCreate()
+    loadReactNative(this)
+  }
+}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn083.kt
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/MainApplication-rn083.kt
@@ -1,4 +1,4 @@
-package com.myapp
+package com.helloworld
 
 import android.app.Application
 import com.facebook.react.PackageList

--- a/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainApplication-test.ts
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainApplication-test.ts
@@ -8,6 +8,20 @@ import { setModulesMainApplication } from '../withAndroidModulesMainApplication'
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 
 describe(setModulesMainApplication, () => {
+  it('should able to update from react-native@>=0.83.0 kotlin template', async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'MainApplication-rn083.kt'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'MainApplication-rn083-updated.kt'), 'utf8'),
+    ]);
+
+    const sdkVersion = getSdkVersion('0.83.0');
+    const contents = setModulesMainApplication(sdkVersion, rawContents, 'kt');
+    expect(contents).toEqual(expectContents);
+    // Try it twice...
+    const nextContents = setModulesMainApplication(sdkVersion, contents, 'kt');
+    expect(nextContents).toEqual(expectContents);
+  });
+
   it('should able to update from react-native@>=0.74.0 kotlin template', async () => {
     const [rawContents, expectContents] = await Promise.all([
       fs.promises.readFile(path.join(fixturesPath, 'MainApplication-rn074.kt'), 'utf8'),

--- a/packages/install-expo-modules/src/plugins/android/withAndroidModulesMainApplication.ts
+++ b/packages/install-expo-modules/src/plugins/android/withAndroidModulesMainApplication.ts
@@ -88,8 +88,9 @@ function addDefaultReactNativeHostWrapperIfNeeded(
 }
 
 /**
- * Replace `ReactNativeHostWrapper.create()` for `getDefaultReactHost()`.
- * For react-native@>=0.74 and SDK >= 51.0.0
+ * Replace `getDefaultReactHost()` with Expo's wrapper.
+ * For SDK >= 55.0.0: uses `ExpoReactHostFactory.getDefaultReactHost()` (ReactNativeHostWrapper was removed)
+ * For SDK >= 51.0.0: uses `ReactNativeHostWrapper.createReactHost()`
  */
 function addReactHostWrapperIfNeeded(
   sdkVersion: string,
@@ -98,6 +99,19 @@ function addReactHostWrapperIfNeeded(
   isJava: boolean
 ): string {
   if (semver.lt(sdkVersion, '51.0.0')) {
+    return mainApplication;
+  }
+
+  if (semver.gte(sdkVersion, '55.0.0')) {
+    const updated = mainApplication.replace(
+      /(\s+)getDefaultReactHost\(/gm,
+      '$1ExpoReactHostFactory.getDefaultReactHost('
+    );
+
+    if (updated !== mainApplication) {
+      return addImports(updated, ['expo.modules.ExpoReactHostFactory'], isJava);
+    }
+
     return mainApplication;
   }
 
@@ -112,7 +126,7 @@ function addReactNativeHostWrapperIfNeeded(
   language: 'java' | 'kt',
   isJava: boolean
 ): string {
-  if (mainApplication.match(/\s+ReactNativeHostWrapper\(/m)) {
+  if (mainApplication.match(/\s+(ReactNativeHostWrapper|ExpoReactHostFactory)[.(]/m)) {
     return mainApplication;
   }
 

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-rn083-updated.swift
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-rn083-updated.swift
@@ -1,0 +1,50 @@
+import UIKit
+internal import Expo
+import React
+import React_RCTAppDelegate
+import ReactAppDependencyProvider
+
+@main
+class AppDelegate: ExpoAppDelegate {
+  var window: UIWindow?
+
+  var reactNativeDelegate: ReactNativeDelegate?
+  var reactNativeFactory: RCTReactNativeFactory?
+
+  override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    let delegate = ReactNativeDelegate()
+    let factory = ExpoReactNativeFactory(delegate: delegate)
+    delegate.dependencyProvider = RCTAppDependencyProvider()
+
+    reactNativeDelegate = delegate
+    reactNativeFactory = factory
+
+    window = UIWindow(frame: UIScreen.main.bounds)
+
+    factory.startReactNative(
+      withModuleName: "HelloWorld",
+      in: window,
+      launchOptions: launchOptions
+    )
+
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+}
+
+class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
+  override func sourceURL(for bridge: RCTBridge) -> URL? {
+    // needed to return the correct URL for expo-dev-client.
+    bridge.bundleURL ?? bundleURL()
+  }
+
+  override func bundleURL() -> URL? {
+#if DEBUG
+    RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
+#else
+    Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+#endif
+  }
+}

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-rn083.swift
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-rn083.swift
@@ -1,0 +1,48 @@
+import UIKit
+import React
+import React_RCTAppDelegate
+import ReactAppDependencyProvider
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+  var window: UIWindow?
+
+  var reactNativeDelegate: ReactNativeDelegate?
+  var reactNativeFactory: RCTReactNativeFactory?
+
+  func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    let delegate = ReactNativeDelegate()
+    let factory = RCTReactNativeFactory(delegate: delegate)
+    delegate.dependencyProvider = RCTAppDependencyProvider()
+
+    reactNativeDelegate = delegate
+    reactNativeFactory = factory
+
+    window = UIWindow(frame: UIScreen.main.bounds)
+
+    factory.startReactNative(
+      withModuleName: "HelloWorld",
+      in: window,
+      launchOptions: launchOptions
+    )
+
+    return true
+  }
+}
+
+class ReactNativeDelegate: RCTDefaultReactNativeFactoryDelegate {
+  override func sourceURL(for bridge: RCTBridge) -> URL? {
+    self.bundleURL()
+  }
+
+  override func bundleURL() -> URL? {
+#if DEBUG
+    RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
+#else
+    Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+#endif
+  }
+}

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/withIosModulesAppDelegate-test.ts
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/withIosModulesAppDelegate-test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { getLatestSdkVersion, getSdkVersion } from '../../../utils/expoVersionMappings';
+import { getSdkVersion } from '../../../utils/expoVersionMappings';
 import { updateVirtualMetroEntryIos } from '../../cli/withCliIntegration';
 import {
   updateModulesAppDelegateObjcHeader,
@@ -12,13 +12,27 @@ import {
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 
 describe(updateModulesAppDelegateObjcHeader, () => {
+  it('should migrate from react-native@>=0.83.0 AppDelegate.swift', async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'AppDelegate-rn083.swift'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'AppDelegate-rn083-updated.swift'), 'utf8'),
+    ]);
+
+    const sdkVersion = getSdkVersion('0.83.0');
+    const contents = updateModulesAppDelegateSwift(rawContents, sdkVersion);
+    expect(contents).toEqual(expectContents);
+    // Try it twice...
+    const nextContents = updateModulesAppDelegateSwift(contents, sdkVersion);
+    expect(nextContents).toEqual(expectContents);
+  });
+
   it('should migrate from react-native@>=0.79.0 AppDelegate.swift', async () => {
     const [rawContents, expectContents] = await Promise.all([
       fs.promises.readFile(path.join(fixturesPath, 'AppDelegate-rn079.swift'), 'utf8'),
       fs.promises.readFile(path.join(fixturesPath, 'AppDelegate-rn079-updated.swift'), 'utf8'),
     ]);
 
-    const sdkVersion = getLatestSdkVersion().sdkVersion;
+    const sdkVersion = getSdkVersion('0.79.0');
     const contents = updateModulesAppDelegateSwift(rawContents, sdkVersion);
     expect(contents).toEqual(expectContents);
     // Try it twice...

--- a/packages/install-expo-modules/src/plugins/ios/withIosModulesAppDelegate.ts
+++ b/packages/install-expo-modules/src/plugins/ios/withIosModulesAppDelegate.ts
@@ -143,9 +143,14 @@ export function updateModulesAppDelegateSwift(
     }
   }
 
-  // Add imports if needed
-  if (!contents.match(/^import\s+Expo\s*$/m)) {
+  // Add imports if needed.
+  // SDK 55+ uses `internal import` to match ExpoModulesProvider.swift (Swift 6 compatibility).
+  const useInternalImport = sdkVersion && semver.gte(sdkVersion, '55.0.0');
+  if (!contents.match(/^(internal\s+)?import\s+Expo\s*$/m)) {
     contents = addSwiftImports(contents, ['Expo']);
+    if (useInternalImport) {
+      contents = contents.replace(/^import Expo$/m, 'internal import Expo');
+    }
   }
 
   // Replace superclass with ExpoAppDelegate


### PR DESCRIPTION
# Why
Add support for RN 0.83

# How
- Add `internal import Expo` to the AppDelegate
- Add `ExpoReactHostFactory` in the mainApplication on android instead of `ReactNativeHostWrapper`

# Test Plan
Added tests.
Tested in a RN 0.83 project. Both projects build and run

