### PR TITLE
[docs] Fix syntax of expo workflow file

### DIFF
--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -110,6 +110,8 @@ on:
         platform: android
     build_ios:
       type: build
+      params:
+        platform: ios
 ```
 
 ### VS Code extension


### PR DESCRIPTION
# Why

The recommended workflow file is not valid as the job needs the platform specifying

# How

Using the syntax from the code block above it

# Test Plan

Copy the old codeblock into VS Code with the Expo tools extension and note that there is a syntax error, copy the new codeblock and see that the error has been removed

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
