### PR TITLE
fix(android): don't intercept R key when focus is in TextInput with hardware keyboard

### DIFF
--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuFragment.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuFragment.kt
@@ -34,6 +34,7 @@ import expo.modules.devmenu.detectors.ThreeFingerLongPressDetector
 import expo.modules.devmenu.devtools.DevMenuDevToolsDelegate
 import expo.modules.devmenu.fab.MovableFloatingActionButton
 import expo.modules.devmenu.helpers.isAcceptingText
+import expo.modules.devmenu.helpers.isFocusInEditText
 import expo.modules.kotlin.weak
 import java.lang.ref.WeakReference
 
@@ -199,6 +200,12 @@ class DevMenuFragment(
     // However, this event is also triggered when input is edited. A better way to handle that case
     // is use onKeyDown event. However, it doesn't work well with key commands and we can't override RN implementation in that approach.
     if (activity.isAcceptingText()) {
+      return false
+    }
+
+    // When using a hardware keyboard (Bluetooth, emulator, USB), isAcceptingText is false even when
+    // focus is in a TextInput. Check if focus is in an EditText to avoid intercepting "r" while typing.
+    if (activity.isFocusInEditText()) {
       return false
     }
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/helpers/ActivityExtension.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/helpers/ActivityExtension.kt
@@ -2,9 +2,26 @@ package expo.modules.devmenu.helpers
 
 import android.app.Activity
 import android.content.Context
+import android.view.View
 import android.view.inputmethod.InputMethodManager
+import android.widget.EditText
 
 internal fun Activity.isAcceptingText(): Boolean {
   val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
   return imm?.isAcceptingText ?: false
+}
+
+/**
+ * Returns true if the current focus is in an EditText (or descendant).
+ * Used to avoid intercepting "r" key when typing in TextInput with hardware keyboard.
+ * When using a hardware keyboard (Bluetooth, emulator, USB), isAcceptingText is false
+ * even when focus is in a TextInput, so we need this additional check.
+ */
+internal fun Activity.isFocusInEditText(): Boolean {
+  var view: View? = currentFocus ?: return false
+  while (view != null) {
+    if (view is EditText) return true
+    view = view.parent as? View
+  }
+  return false
 }


### PR DESCRIPTION
## Problem

When using a hardware keyboard (Bluetooth, emulator, USB) with the Expo dev client, pressing `r` while typing in a TextInput (e.g. location search, search boxes) triggers an app reload instead of inserting the character. This happens because `InputMethodManager.isAcceptingText` returns `false` when the soft keyboard isn't shown—even when focus is in a text field.

## Solution

Add `isFocusInEditText()` to check if the current focus is in an EditText (or descendant). When true, don't handle the R key so it passes through to the text input. This complements the existing `isAcceptingText()` check which covers the soft-keyboard case.

## Changes

- **ActivityExtension.kt**: Add `isFocusInEditText()` helper that walks up the view hierarchy from `currentFocus` to detect EditText
- **DevMenuFragment.kt**: Call `isFocusInEditText()` before handling key commands; return `false` (don't intercept) when focus is in a text field

## Testing

Verified on Android emulator (Pixel 8a API 36) with hardware keyboard: typing place names containing 'r' (e.g. Reddish, Redhill) in location fields no longer triggers reload.

Made with [Cursor](https://cursor.com)