### PR TITLE
[font] include xml-fonts in the `getLoadedFonts()` list on Android

### DIFF
--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [android] include xml-fonts in the `getLoadedFonts()` list
+- [android] include xml-fonts in the `getLoadedFonts()` list ([#43860](https://github.com/expo/expo/pull/43860) by [@vonovak](https://github.com/vonovak))
 
 ### 💡 Others
 

--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [android] include xml-fonts in the `getLoadedFonts()` list
+
 ### 💡 Others
 
 ## 56.0.3 — 2026-05-06

--- a/packages/expo-font/android/src/main/java/expo/modules/font/FontLoaderModule.kt
+++ b/packages/expo-font/android/src/main/java/expo/modules/font/FontLoaderModule.kt
@@ -22,13 +22,16 @@ open class FontLoaderModule : Module() {
     get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
 
   override fun definition() = ModuleDefinition {
-    // could be a Set, but to be able to pass to JS we keep it as an array
-    var loadedFonts: List<String> = queryCustomNativeFonts()
+    var loadedFonts: List<String>? = null
+
+    fun getLoadedFonts(): List<String> {
+      return loadedFonts ?: queryCustomNativeFonts().also { loadedFonts = it }
+    }
 
     Name("ExpoFontLoader")
 
     Function("getLoadedFonts") {
-      return@Function loadedFonts
+      return@Function getLoadedFonts()
     }
 
     AsyncFunction("loadAsync") { fontFamilyName: String, localUri: String ->
@@ -54,7 +57,7 @@ open class FontLoaderModule : Module() {
       }
 
       ReactFontManager.getInstance().setTypeface(fontFamilyName, Typeface.NORMAL, typeface)
-      loadedFonts = loadedFonts.toMutableSet().apply { add(fontFamilyName) }.toList()
+      loadedFonts = getLoadedFonts().toMutableSet().apply { add(fontFamilyName) }.toList()
     }
   }
 
@@ -66,12 +69,14 @@ open class FontLoaderModule : Module() {
   private fun queryCustomNativeFonts(): List<String> {
     val assetManager = context.assets
     val fontFileRegex = Regex("^(.+?)(_bold|_italic|_bold_italic)?\\.(ttf|otf)$")
+    val customFontFamilies = ReactFontManager.getInstance().customFontFamilies
 
-    return assetManager.list("fonts/")
+    val assetFonts = assetManager.list("fonts/")
       ?.mapNotNull { fileName ->
         fontFileRegex.find(fileName)?.groupValues?.get(1)
       }
-      ?.filter { it.isNotBlank() }
       .orEmpty()
+
+    return customFontFamilies.union(assetFonts).filter { it.isNotBlank() }
   }
 }


### PR DESCRIPTION
# Why

The `getLoadedFonts()` function on Android was not including XML-defined fonts in its returned list, only showing fonts loaded the module or present in the `fonts` dir on the FS.

closes https://github.com/expo/expo/issues/42973

# How

Modified the font loading logic to include both custom font families from `ReactFontManager` and asset-based fonts. The `loadedFonts` variable is now lazily initialized and combines fonts from both sources

# Test Plan

- Test that `getLoadedFonts()` returns both programmatically loaded fonts and XML-defined fonts on Android.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)