### PR TITLE
chore(ci): pin Bun to `1.x`

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -81,9 +81,7 @@ jobs:
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
-          # TODO(cedric): swap `latest` back once the issue is resolved
-          bun-version: latest
+          bun-version: '1.x'
 
       - name: 📦 Install node modules in root dir
         run: pnpm install --frozen-lockfile
@@ -141,9 +139,7 @@ jobs:
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
-          # TODO(cedric): swap `latest` back once the issue is resolved
-          bun-version: latest
+          bun-version: '1.x'
 
       - name: 📦 Install node modules in root dir
         run: pnpm install --frozen-lockfile
@@ -183,9 +179,7 @@ jobs:
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
-          # TODO(cedric): swap `latest` back once the issue is resolved
-          bun-version: latest
+          bun-version: '1.x'
 
       - name: 📦 Install node modules in root dir
         run: pnpm install --frozen-lockfile
@@ -265,9 +259,7 @@ jobs:
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
-          # TODO(cedric): swap `latest` back once the issue is resolved
-          bun-version: latest
+          bun-version: '1.x'
 
       - name: 📦 Install node modules in root dir
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/create-expo-app.yml
+++ b/.github/workflows/create-expo-app.yml
@@ -39,11 +39,9 @@ jobs:
         with:
           version: 10
       - name: 🏗️ Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
-          # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
-          # TODO(cedric): swap `latest` back once the issue is resolved
-          bun-version: latest
+          bun-version: 1.x
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}

--- a/.github/workflows/test-suite-brownfield-isolated.yml
+++ b/.github/workflows/test-suite-brownfield-isolated.yml
@@ -67,9 +67,7 @@ jobs:
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
-          # TODO(cedric): swap `latest` back once the issue is resolved
-          bun-version: latest
+          bun-version: 1.x
       - name: 🔨 Use JDK 17
         uses: actions/setup-java@v4
         with:
@@ -133,9 +131,7 @@ jobs:
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
-          # TODO(cedric): swap `latest` back once the issue is resolved
-          bun-version: latest
+          bun-version: 1.x
       - name: 🌠 Download build (Release)
         uses: actions/download-artifact@v4
         with:
@@ -155,7 +151,7 @@ jobs:
         with:
           avd-api: ${{ matrix.api-level }}
           avd-name: avd-${{ matrix.api-level }}
-          script: 
+          script:
             ./packages/expo-brownfield/e2e/scripts/run-e2e-android.sh
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@v4
@@ -198,9 +194,7 @@ jobs:
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
-          # TODO(cedric): swap `latest` back once the issue is resolved
-          bun-version: latest
+          bun-version: 1.x
       - name: 🔨 Switch to Xcode 26.2
         run: sudo xcode-select --switch /Applications/Xcode_26.2.app
       - name: 🍺 Install required tools

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -29,9 +29,7 @@ jobs:
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
-          # TODO(cedric): swap `latest` back once the issue is resolved
-          bun-version: latest
+          bun-version: 1.x
       - name: 🔨 Switch to Xcode 26.2
         run: sudo xcode-select --switch /Applications/Xcode_26.2.app
       - name: 🍺 Install required tools
@@ -99,9 +97,7 @@ jobs:
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
-          # TODO(cedric): swap `latest` back once the issue is resolved
-          bun-version: latest
+          bun-version: 1.x
       - name: 🔨 Switch to Xcode 26.2
         run: sudo xcode-select --switch /Applications/Xcode_26.2.app
       - name: ➕ Add `bin` to GITHUB_PATH
@@ -171,9 +167,7 @@ jobs:
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
-          # TODO(cedric): swap `latest` back once the issue is resolved
-          bun-version: latest
+          bun-version: 1.x
       - name: 🔨 Use JDK 17
         uses: actions/setup-java@v4
         with:
@@ -233,9 +227,7 @@ jobs:
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
-          # TODO(cedric): swap `latest` back once the issue is resolved
-          bun-version: latest
+          bun-version: 1.x
       - name: 🌠 Download builds
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -145,9 +145,7 @@ jobs:
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
-          # TODO(cedric): swap `latest` back once the issue is resolved
-          bun-version: latest
+          bun-version: 1.x
       - name: 🔨 Switch to Xcode 26.2
         run: sudo xcode-select --switch /Applications/Xcode_26.2.app
       - name: 🍺 Install required tools
@@ -247,9 +245,7 @@ jobs:
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
-          # TODO(cedric): swap `latest` back once the issue is resolved
-          bun-version: latest
+          bun-version: 1.x
       - name: 🔨 Switch to Xcode 26.2
         run: sudo xcode-select --switch /Applications/Xcode_26.2.app
       - name: ➕ Add `bin` to GITHUB_PATH
@@ -358,9 +354,7 @@ jobs:
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
-          # TODO(cedric): swap `latest` back once the issue is resolved
-          bun-version: latest
+          bun-version: 1.x
       - name: 🔨 Use JDK 17
         uses: actions/setup-java@v4
         with:
@@ -452,9 +446,7 @@ jobs:
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
-          # TODO(cedric): swap `latest` back once the issue is resolved
-          bun-version: latest
+          bun-version: 1.x
       - name: 🌠 Download builds
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
# Why

Pins the version of Bun now that https://github.com/oven-sh/setup-bun/issues/37 is resolved.

# How

Replace `latest` with `1.x`

# Test Plan

- CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
