### PR TITLE
fix(expo-router): Bump @react-navigation/native to ^7.1.33

### DIFF
--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -136,7 +136,7 @@
     "@radix-ui/react-slot": "^1.2.0",
     "@radix-ui/react-tabs": "^1.1.12",
     "@react-navigation/bottom-tabs": "^7.10.1",
-    "@react-navigation/native": "^7.1.28",
+    "@react-navigation/native": "^7.1.33",
     "@react-navigation/native-stack": "^7.10.1",
     "client-only": "^0.0.1",
     "debug": "^4.3.4",

--- a/packages/expo-router/src/__tests__/dismissTo.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/dismissTo.test.ios.tsx
@@ -44,6 +44,10 @@ it('should go back to a previous route in the same stack', () => {
             {
               key: expect.any(String),
               name: '1',
+              params: {
+                params: {},
+                screen: 'a',
+              },
               path: undefined,
               state: {
                 index: 2,
@@ -111,6 +115,10 @@ it('should go back to a previous route in the same stack', () => {
             {
               key: expect.any(String),
               name: '1',
+              params: {
+                params: {},
+                screen: 'a',
+              },
               path: undefined,
               state: {
                 index: 0,
@@ -184,6 +192,10 @@ it('should go back to a previous route in different stacks', () => {
             {
               key: expect.any(String),
               name: '1',
+              params: {
+                params: {},
+                screen: 'a',
+              },
               path: undefined,
               state: {
                 index: 1,
@@ -200,6 +212,10 @@ it('should go back to a previous route in different stacks', () => {
                   {
                     key: expect.any(String),
                     name: '2',
+                    params: {
+                      params: {},
+                      screen: 'c',
+                    },
                     path: undefined,
                     state: {
                       index: 1,
@@ -216,6 +232,10 @@ it('should go back to a previous route in different stacks', () => {
                         {
                           key: expect.any(String),
                           name: '3',
+                          params: {
+                            params: {},
+                            screen: 'e',
+                          },
                           path: undefined,
                           state: {
                             index: 0,
@@ -281,6 +301,10 @@ it('should go back to a previous route in different stacks', () => {
             {
               key: expect.any(String),
               name: '1',
+              params: {
+                params: {},
+                screen: 'a',
+              },
               path: undefined,
               state: {
                 index: 0,
@@ -355,6 +379,10 @@ it('will replace the route if the provided href is not in the history', () => {
             {
               key: expect.any(String),
               name: '1',
+              params: {
+                params: {},
+                screen: 'a',
+              },
               path: undefined,
               state: {
                 index: 1,
@@ -371,6 +399,10 @@ it('will replace the route if the provided href is not in the history', () => {
                   {
                     key: expect.any(String),
                     name: '2',
+                    params: {
+                      params: {},
+                      screen: 'c',
+                    },
                     path: undefined,
                     state: {
                       index: 0,
@@ -381,6 +413,10 @@ it('will replace the route if the provided href is not in the history', () => {
                         {
                           key: expect.any(String),
                           name: '3',
+                          params: {
+                            params: {},
+                            screen: 'e',
+                          },
                           state: {
                             index: 0,
                             key: expect.any(String),

--- a/packages/expo-router/src/__tests__/hooks.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/hooks.test.ios.tsx
@@ -260,17 +260,12 @@ describe(useGlobalSearchParams, () => {
 
     expect(results1).toEqual([{ id: '1' }]);
     act(() => router.push('/2'));
-    // TODO(@ubax): Investigate extra render caused by react-navigation params cleanup
-    expect(results1).toEqual([{ id: '1' }, { id: '2' }, { id: '2' }]);
+    expect(results1).toEqual([{ id: '1' }, { id: '2' }]);
 
     act(() => router.push('/3/apple'));
     // The first screen has not rerendered
-    expect(results1).toEqual([{ id: '1' }, { id: '2' }, { id: '2' }]);
-    // TODO(@ubax): Investigate extra render caused by react-navigation params cleanup
-    expect(results2).toEqual([
-      { id: '3', fruit: 'apple' },
-      { id: '3', fruit: 'apple' },
-    ]);
+    expect(results1).toEqual([{ id: '1' }, { id: '2' }]);
+    expect(results2).toEqual([{ id: '3', fruit: 'apple' }]);
   });
 
   it(`handles encoded params`, () => {
@@ -348,17 +343,12 @@ describe(useLocalSearchParams, () => {
 
     expect(results1).toEqual([{ id: '1' }]);
     act(() => router.push('/2'));
-    // TODO(@ubax): Investigate extra render caused by react-navigation params cleanup
-    expect(results1).toEqual([{ id: '1' }, { id: '2' }, { id: '2' }]);
+    expect(results1).toEqual([{ id: '1' }, { id: '2' }]);
 
     act(() => router.push('/3/apple'));
     // The first screen has not rerendered
-    expect(results1).toEqual([{ id: '1' }, { id: '2' }, { id: '2' }]);
-    // TODO(@ubax): Investigate extra render caused by react-navigation params cleanup
-    expect(results2).toEqual([
-      { id: '3', fruit: 'apple' },
-      { id: '3', fruit: 'apple' },
-    ]);
+    expect(results1).toEqual([{ id: '1' }, { id: '2' }]);
+    expect(results2).toEqual([{ id: '3', fruit: 'apple' }]);
   });
 
   it(`defaults abstract types`, () => {
@@ -503,10 +493,8 @@ describe(useSearchParams, () => {
 
     expect(results1).toEqual([['id', '1']]);
     act(() => router.push('/2'));
-    // TODO(@ubax): Investigate extra render caused by react-navigation params cleanup
     expect(results1).toEqual([
       ['id', '1'],
-      ['id', '2'],
       ['id', '2'],
     ]);
 
@@ -515,12 +503,8 @@ describe(useSearchParams, () => {
     expect(results1).toEqual([
       ['id', '1'],
       ['id', '2'],
-      ['id', '2'],
     ]);
-    // TODO(@ubax): Investigate extra render caused by react-navigation params cleanup
     expect(results2).toEqual([
-      ['id', '3'],
-      ['fruit', 'apple'],
       ['id', '3'],
       ['fruit', 'apple'],
     ]);

--- a/packages/expo-router/src/__tests__/initialRouteName.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/initialRouteName.test.ios.tsx
@@ -145,6 +145,13 @@ it('push should include (group)/index as an anchor route when using withAnchor',
             {
               key: expect.any(String),
               name: '(group)',
+              params: {
+                initial: false,
+                params: {
+                  initial: false,
+                },
+                screen: 'orange',
+              },
               path: undefined,
               state: {
                 index: 1,
@@ -233,6 +240,10 @@ it('push should ignore (group)/index as an initial route if no anchor is specifi
             {
               key: expect.any(String),
               name: '(group)',
+              params: {
+                params: {},
+                screen: 'orange',
+              },
               path: undefined,
               state: {
                 index: 0,

--- a/packages/expo-router/src/__tests__/issues.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/issues.test.ios.tsx
@@ -92,8 +92,7 @@ it('should return correct pathname for nested stack with initialRouteName, after
   expect(screen.queryByTestId('inner-a-pathname')).toBeNull();
   expect(screen.getByTestId('inner-index-pathname')).toHaveTextContent('/inner');
   expect(indexRenderCount).toHaveBeenCalledTimes(1);
-  // TODO(@ubax): Investigate extra render caused by react-navigation params cleanup
-  expect(innerIndexRenderCount).toHaveBeenCalledTimes(2);
+  expect(innerIndexRenderCount).toHaveBeenCalledTimes(1);
   expect(innerARenderCount).toHaveBeenCalledTimes(0);
 });
 

--- a/packages/expo-router/src/__tests__/push.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/push.test.ios.tsx
@@ -64,6 +64,14 @@ it('stacks should always push a new route', () => {
               name: '(group)',
               params: {
                 id: '1',
+                params: {
+                  id: '1',
+                  params: {
+                    id: '1',
+                  },
+                  screen: 'index',
+                },
+                screen: 'post/[id]',
               },
               path: undefined,
               state: {
@@ -77,6 +85,10 @@ it('stacks should always push a new route', () => {
                     name: 'post/[id]',
                     params: {
                       id: '1',
+                      params: {
+                        id: '1',
+                      },
+                      screen: 'index',
                     },
                     path: undefined,
                     state: {
@@ -103,6 +115,10 @@ it('stacks should always push a new route', () => {
                     name: 'user/[id]',
                     params: {
                       id: '1',
+                      params: {
+                        id: '1',
+                      },
+                      screen: 'index',
                     },
                     path: undefined,
                     state: {
@@ -129,6 +145,10 @@ it('stacks should always push a new route', () => {
                     name: 'post/[id]',
                     params: {
                       id: '2',
+                      params: {
+                        id: '2',
+                      },
+                      screen: 'index',
                     },
                     path: undefined,
                     state: {
@@ -155,6 +175,10 @@ it('stacks should always push a new route', () => {
                     name: 'user/[id]',
                     params: {
                       id: '1',
+                      params: {
+                        id: '1',
+                      },
+                      screen: 'index',
                     },
                     path: undefined,
                     state: {
@@ -305,6 +329,10 @@ it('works in a nested layout Stack->Tab->Stack', () => {
             {
               key: expect.any(String),
               name: '(tabs)',
+              params: {
+                params: {},
+                screen: 'a',
+              },
               path: undefined,
               state: {
                 history: [
@@ -337,6 +365,10 @@ it('works in a nested layout Stack->Tab->Stack', () => {
                   {
                     key: expect.any(String),
                     name: 'c',
+                    params: {
+                      params: {},
+                      screen: 'one',
+                    },
                     path: undefined,
                     state: {
                       index: 2,
@@ -454,6 +486,10 @@ it('targets the correct Stack when pushing to a nested layout', () => {
             {
               key: expect.any(String),
               name: 'one',
+              params: {
+                params: {},
+                screen: 'index',
+              },
               path: undefined,
               state: {
                 index: 2,
@@ -476,6 +512,10 @@ it('targets the correct Stack when pushing to a nested layout', () => {
                   {
                     key: expect.any(String),
                     name: 'two',
+                    params: {
+                      params: {},
+                      screen: 'index',
+                    },
                     path: undefined,
                     state: {
                       index: 1,
@@ -580,6 +620,13 @@ it('push should also add anchor routes', () => {
             {
               key: expect.any(String),
               name: '(group)',
+              params: {
+                initial: false,
+                params: {
+                  initial: false,
+                },
+                screen: 'orange',
+              },
               path: undefined,
               state: {
                 index: 1,

--- a/packages/expo-router/src/__tests__/renderCount.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/renderCount.test.ios.tsx
@@ -360,13 +360,10 @@ describe('Stack nested in Tabs render counts', () => {
       expect(screen.getByTestId('index')).toBeVisible();
 
       expect(layoutRender).not.toHaveBeenCalled();
-      // TODO(@ubax): reduce the number of renders
-      expect(homeTabRender).toHaveBeenCalledTimes(2);
+      expect(homeTabRender).toHaveBeenCalledTimes(1);
       expect(indexMount).toHaveBeenCalledTimes(1);
-      // TODO(@ubax): reduce the number of renders
-      expect(indexRender).toHaveBeenCalledTimes(4);
-      // TODO(@ubax): reduce the number of renders
-      expect(twoRender).toHaveBeenCalledTimes(2);
+      expect(indexRender).toHaveBeenCalledTimes(2);
+      expect(twoRender).toHaveBeenCalledTimes(1);
       expect(otherRender).not.toHaveBeenCalled();
       expect(router.canGoBack()).toBe(true);
 
@@ -470,12 +467,9 @@ describe('Stack nested in Tabs render counts', () => {
     expect(screen.getByTestId('index')).toBeVisible();
 
     expect(layoutRender).toHaveBeenCalledTimes(1);
-    // TODO(@ubax): reduce the number of renders
     expect(homeTabRender).toHaveBeenCalledTimes(2);
     expect(indexMount).toHaveBeenCalledTimes(1);
-    // TODO(@ubax): reduce the number of renders
-    expect(indexRender).toHaveBeenCalledTimes(4); // pathname change causes rerender
-    // TODO(@ubax): reduce the number of renders
+    expect(indexRender).toHaveBeenCalledTimes(3); // pathname change causes rerender
     expect(twoRender).toHaveBeenCalledTimes(2);
     expect(otherRender).toHaveBeenCalledTimes(1);
     expect(router.canGoBack()).toBe(true);

--- a/packages/expo-router/src/__tests__/smoke.test.android.tsx
+++ b/packages/expo-router/src/__tests__/smoke.test.android.tsx
@@ -193,11 +193,10 @@ it('nested layouts', async () => {
   expect(await screen.findByText('HomeNested')).toBeOnTheScreen();
 
   expect(AppLayout).toHaveBeenCalledTimes(1);
-  expect(TabsLayout).toHaveBeenCalledTimes(2);
-  expect(StackLayout).toHaveBeenCalledTimes(2);
+  expect(TabsLayout).toHaveBeenCalledTimes(1);
+  expect(StackLayout).toHaveBeenCalledTimes(1);
   expect(Index).toHaveBeenCalledTimes(1);
-  // TODO(@ubax): Investigate extra render caused by react-navigation params cleanup
-  expect(Home).toHaveBeenCalledTimes(2);
+  expect(Home).toHaveBeenCalledTimes(1);
   expect(HomeNested).toHaveBeenCalledTimes(1);
 });
 
@@ -238,9 +237,8 @@ it('deep linking nested groups', async () => {
 
   expect(RootLayout).toHaveBeenCalledTimes(1);
   expect(AppLayout).toHaveBeenCalledTimes(1);
-  // TODO(@ubax): Investigate extra render caused by react-navigation params cleanup
-  expect(TabsLayout).toHaveBeenCalledTimes(2);
-  expect(HomeLayout).toHaveBeenCalledTimes(2);
+  expect(TabsLayout).toHaveBeenCalledTimes(1);
+  expect(HomeLayout).toHaveBeenCalledTimes(1);
   expect(OtherTabsLayout).toHaveBeenCalledTimes(1);
   expect(NestedTabsLayout).toHaveBeenCalledTimes(1);
   expect(OtherTabsIndex).toHaveBeenCalledTimes(1);

--- a/packages/expo-router/src/__tests__/smoke.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/smoke.test.ios.tsx
@@ -194,11 +194,10 @@ it('nested layouts', async () => {
   expect(await screen.findByText('HomeNested')).toBeOnTheScreen();
 
   expect(AppLayout).toHaveBeenCalledTimes(1);
-  expect(TabsLayout).toHaveBeenCalledTimes(2);
-  expect(StackLayout).toHaveBeenCalledTimes(2);
+  expect(TabsLayout).toHaveBeenCalledTimes(1);
+  expect(StackLayout).toHaveBeenCalledTimes(1);
   expect(Index).toHaveBeenCalledTimes(1);
-  // TODO(@ubax): Investigate extra render caused by react-navigation params cleanup
-  expect(Home).toHaveBeenCalledTimes(2);
+  expect(Home).toHaveBeenCalledTimes(1);
   expect(HomeNested).toHaveBeenCalledTimes(1);
 });
 
@@ -239,9 +238,8 @@ it('deep linking nested groups', async () => {
 
   expect(RootLayout).toHaveBeenCalledTimes(1);
   expect(AppLayout).toHaveBeenCalledTimes(1);
-  // TODO(@ubax): Investigate extra render caused by react-navigation params cleanup
-  expect(TabsLayout).toHaveBeenCalledTimes(2);
-  expect(HomeLayout).toHaveBeenCalledTimes(2);
+  expect(TabsLayout).toHaveBeenCalledTimes(1);
+  expect(HomeLayout).toHaveBeenCalledTimes(1);
   expect(OtherTabsLayout).toHaveBeenCalledTimes(1);
   expect(NestedTabsLayout).toHaveBeenCalledTimes(1);
   expect(OtherTabsIndex).toHaveBeenCalledTimes(1);

--- a/packages/expo-router/src/__tests__/stacks.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/stacks.test.ios.tsx
@@ -187,6 +187,10 @@ test('dismissAll nested', () => {
             {
               key: expect.any(String),
               name: 'one',
+              params: {
+                params: {},
+                screen: 'index',
+              },
               path: undefined,
               state: {
                 index: 3,
@@ -215,6 +219,10 @@ test('dismissAll nested', () => {
                   {
                     key: expect.any(String),
                     name: 'two',
+                    params: {
+                      params: {},
+                      screen: 'index',
+                    },
                     path: undefined,
                     state: {
                       index: 2,
@@ -304,6 +312,10 @@ test('dismissAll nested', () => {
             {
               key: expect.any(String),
               name: 'one',
+              params: {
+                params: {},
+                screen: 'index',
+              },
               path: undefined,
               state: {
                 index: 3,
@@ -332,6 +344,10 @@ test('dismissAll nested', () => {
                   {
                     key: expect.any(String),
                     name: 'two',
+                    params: {
+                      params: {},
+                      screen: 'index',
+                    },
                     path: undefined,
                     state: {
                       index: 0,
@@ -409,6 +425,10 @@ test('dismissAll nested', () => {
             {
               key: expect.any(String),
               name: 'one',
+              params: {
+                params: {},
+                screen: 'index',
+              },
               path: undefined,
               state: {
                 index: 0,
@@ -468,8 +488,7 @@ test('pushing in a nested stack should only rerender the nested stack', () => {
   testRouter.push('/one/two/a');
   expect(RootLayout).toHaveBeenCalledTimes(1);
   expect(NestedLayout).toHaveBeenCalledTimes(1);
-  // TODO(@ubax): Investigate extra render caused by react-navigation params cleanup
-  expect(NestedNestedLayout).toHaveBeenCalledTimes(2);
+  expect(NestedNestedLayout).toHaveBeenCalledTimes(1);
 });
 
 test('can preserve the nested initialRouteName when navigating to a nested stack', () => {

--- a/packages/expo-router/src/native-tabs/__tests__/render.test.ios.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/render.test.ios.tsx
@@ -275,12 +275,11 @@ describe('First focused tab', () => {
 
     expect(screen.getByTestId('first')).toBeVisible();
     expect(screen.getByTestId('second')).toBeVisible();
-    // TODO(@ubax): Investigate extra renders caused by react-navigation params cleanup
-    expect(TabsScreen).toHaveBeenCalledTimes(4);
-    expect(TabsScreen.mock.calls[2][0].isFocused).toBe(false);
-    expect(TabsScreen.mock.calls[2][0].tabKey).toMatch(/^first-[-\w]+/);
-    expect(TabsScreen.mock.calls[3][0].isFocused).toBe(true);
-    expect(TabsScreen.mock.calls[3][0].tabKey).toMatch(/^second-[-\w]+/);
+    expect(TabsScreen).toHaveBeenCalledTimes(2);
+    expect(TabsScreen.mock.calls[0][0].isFocused).toBe(false);
+    expect(TabsScreen.mock.calls[0][0].tabKey).toMatch(/^first-[-\w]+/);
+    expect(TabsScreen.mock.calls[1][0].isFocused).toBe(true);
+    expect(TabsScreen.mock.calls[1][0].tabKey).toMatch(/^second-[-\w]+/);
   });
 
   it('Correct tab is shown, when index does not exist, redirect is set in layout and +not-found is specified', () => {
@@ -305,12 +304,11 @@ describe('First focused tab', () => {
 
     expect(screen.getByTestId('first')).toBeVisible();
     expect(screen.getByTestId('second')).toBeVisible();
-    // TODO(@ubax): Investigate extra renders caused by react-navigation params cleanup
-    expect(TabsScreen).toHaveBeenCalledTimes(4);
-    expect(TabsScreen.mock.calls[2][0].isFocused).toBe(false);
-    expect(TabsScreen.mock.calls[2][0].tabKey).toMatch(/^first-[-\w]+/);
-    expect(TabsScreen.mock.calls[3][0].isFocused).toBe(true);
-    expect(TabsScreen.mock.calls[3][0].tabKey).toMatch(/^second-[-\w]+/);
+    expect(TabsScreen).toHaveBeenCalledTimes(2);
+    expect(TabsScreen.mock.calls[0][0].isFocused).toBe(false);
+    expect(TabsScreen.mock.calls[0][0].tabKey).toMatch(/^first-[-\w]+/);
+    expect(TabsScreen.mock.calls[1][0].isFocused).toBe(true);
+    expect(TabsScreen.mock.calls[1][0].tabKey).toMatch(/^second-[-\w]+/);
   });
 
   it('404 is shown, when index does not exist, redirect is set in layout and no +not-found is specified', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3780,10 +3780,10 @@
     color "^4.2.3"
     sf-symbols-typescript "^2.1.0"
 
-"@react-navigation/core@^7.14.0":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-7.14.0.tgz#d24f93d424ab33f645262dc4775e4708aa3d9a8b"
-  integrity sha512-tMpzskBzVp0E7CRNdNtJIdXjk54Kwe/TF9ViXAef+YFM1kSfGv4e/B2ozfXE+YyYgmh4WavTv8fkdJz1CNyu+g==
+"@react-navigation/core@^7.16.1":
+  version "7.16.1"
+  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-7.16.1.tgz#a8f6799a7b18f6d5c45616cbf792ec8f08d1aadc"
+  integrity sha512-xhquoyhKdqDfiL7LuupbwYnmauUGfVFGDEJO34m26k8zSN1eDjQ2stBZcHN8ILOI1PrG9885nf8ZmfaQxPS0ww==
   dependencies:
     "@react-navigation/routers" "^7.5.3"
     escape-string-regexp "^4.0.0"
@@ -3823,12 +3823,12 @@
     sf-symbols-typescript "^2.1.0"
     warn-once "^0.1.1"
 
-"@react-navigation/native@^7.1.28", "@react-navigation/native@^7.1.6":
-  version "7.1.28"
-  resolved "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.28.tgz#1ee75cf3a8b3e4365f94c5d657bb3c015e387720"
-  integrity sha512-d1QDn+KNHfHGt3UIwOZvupvdsDdiHYZBEj7+wL2yDVo3tMezamYy60H9s3EnNVE1Ae1ty0trc7F2OKqo/RmsdQ==
+"@react-navigation/native@^7.1.28", "@react-navigation/native@^7.1.33", "@react-navigation/native@^7.1.6":
+  version "7.1.33"
+  resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-7.1.33.tgz#a9910b51b42373e8977cf8d76ac960077ad4a2fc"
+  integrity sha512-DpFdWGcgLajKZ1TuIvDNQsblN2QaUFWpTQaB8v7WRP9Mix8H/6TFoIrZd93pbymI2hybd6UYrD+lI408eWVcfw==
   dependencies:
-    "@react-navigation/core" "^7.14.0"
+    "@react-navigation/core" "^7.16.1"
     escape-string-regexp "^4.0.0"
     fast-deep-equal "^3.1.3"
     nanoid "^3.3.11"
@@ -16045,9 +16045,9 @@ use-latest-callback@^0.1.5:
   integrity sha512-CL/29uS74AwreI/f2oz2hLTW7ZqVeV5+gxFeGudzQrgkCytrHw33G4KbnQOrRlAEzzAFXi7dDLMC9zhWcVpzmw==
 
 use-latest-callback@^0.2.1, use-latest-callback@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/use-latest-callback/-/use-latest-callback-0.2.4.tgz#35c0f028f85a3f4cf025b06011110e87cc18f57e"
-  integrity sha512-LS2s2n1usUUnDq4oVh1ca6JFX9uSqUncTfAm44WMg0v6TxL7POUTk1B044NH8TeLkFbNajIsgDHcgNpNzZucdg==
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/use-latest-callback/-/use-latest-callback-0.2.6.tgz#e5ea752808c86219acc179ace0ae3c1203255e77"
+  integrity sha512-FvRG9i1HSo0wagmX63Vrm8SnlUU3LMM3WyZkQ76RnslpBrX694AdG4A0zQBx2B3ZifFA0yv/BaEHGBnEax5rZg==
 
 use-sidecar@^1.1.3:
   version "1.1.3"
@@ -16058,9 +16058,9 @@ use-sidecar@^1.1.3:
     tslib "^2.0.0"
 
 use-sync-external-store@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz#55122e2a3edd2a6c106174c27485e0fd59bcfca0"
-  integrity sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
+  integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
# Why

Fixes #43706

Enabling `headerShown: true` on web in an Expo Router app with SDK 55 causes a runtime crash:

```
Uncaught Error: Element type is invalid: expected a string (for built-in components)
or a class/function (for composite components) but got: undefined.

Check the render method of `Screen`.
```

This is caused by a transitive dependency version mismatch: `@react-navigation/native@^7.1.28` allows `@react-navigation/core@^7.14.0` to resolve, which can install `core@7.15.1` — a version that does **not** export `NavigationProvider`. The `Screen` component in `@react-navigation/elements` imports `NavigationProvider` and receives `undefined`, triggering the React crash.

The upstream fix was published in `@react-navigation/native@7.1.33`, which tightens the dependency to `@react-navigation/core@^7.16.1`.

Related upstream issue: https://github.com/react-navigation/react-navigation/issues/13013 (closed/fixed)

# How

Bumped `@react-navigation/native` from `^7.1.28` to `^7.1.33` in `packages/expo-router/package.json`.

This ensures `@react-navigation/core@7.16.1+` is always resolved, which includes the required `NavigationProvider` export.

```
BEFORE (broken):
expo-router
  └── @react-navigation/native@^7.1.28
        └── @react-navigation/core@^7.14.0  → 7.15.1 ❌ (missing NavigationProvider)

AFTER (fixed):
expo-router
  └── @react-navigation/native@^7.1.33
        └── @react-navigation/core@^7.16.1  → 7.16.1 ✅ (has NavigationProvider)
```

# Test Plan

Tested with a minimal Expo Router SDK 55 reproduction app using `headerShown: true` on a Stack navigator, running on web.

**Before** — crash on web with `@react-navigation/native@7.1.28` + `@react-navigation/core@7.15.1`:

![before](https://github.com/jakub-agent/expo-router-issues/blob/main/43706-before.png?raw=true)

**After** — app renders correctly with `@react-navigation/native@7.1.33` + `@react-navigation/core@7.16.1`:

![after](https://github.com/jakub-agent/expo-router-issues/blob/main/43706-after.png?raw=true)

Reproduction app:

```tsx
// app/_layout.tsx
import { Stack } from "expo-router";
export default function RootLayout() {
  return <Stack screenOptions={{ headerShown: true }} />;
}

// app/index.tsx
import { View, Text } from "react-native";
export default function HomeScreen() {
  return (
    <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
      <Text>Home Screen</Text>
    </View>
  );
}
```

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)