### PR TITLE
fix: handle uninitialized `hmrClient` in `registerBundle`

### DIFF
--- a/packages/expo/src/async-require/hmr.ts
+++ b/packages/expo/src/async-require/hmr.ts
@@ -92,9 +92,12 @@ const HMRClient = {
   },
 
   registerBundle(requestUrl: string) {
-    assert(hmrClient, 'Expected HMRClient.setup() call at startup.');
     pendingEntryPoints.push(requestUrl);
-    registerBundleEntryPoints(hmrClient);
+    if (hmrClient) {
+      registerBundleEntryPoints(hmrClient);
+    }
+    // If hmrClient is not yet initialized, entry points will be
+    // processed when setup() calls registerBundleEntryPoints().
   },
 
   log(level: LogLevel, data: any[]) {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The registerBundle function in the HMR client was throwing an assertion error when called before HMRClient.setup(). This could happen in certain initialization sequences where bundles are registered early in the app lifecycle, causing crashes with "Expected HMRClient.setup() call at startup" errors.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Removed the assertion and added a conditional check for hmrClient initialization. If the HMR client is already initialized, it processes the bundle immediately. Otherwise, the bundle URL is added to pendingEntryPoints and will be processed later when setup() is called and invokes registerBundleEntryPoints().
This maintains the same functionality while being more resilient to different initialization orders.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

1. Test that HMR continues to work normally when bundles are registered after setup:
- Run a development build with Metro
- Make changes to source files
- Verify hot reload works without errors
2. Test early bundle registration (before setup):
- Modify app initialization to call code that triggers registerBundle before HMR setup
- Verify no assertion errors occur
- Confirm bundles are still processed correctly once setup completes

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
