### PR TITLE
[module-template] Fix linting errors in the template

### DIFF
--- a/packages/expo-module-template-local/src/{%- project.viewName %}.tsx
+++ b/packages/expo-module-template-local/src/{%- project.viewName %}.tsx
@@ -3,8 +3,7 @@ import * as React from 'react';
 
 import { <%- project.viewName %>Props } from './<%- project.name %>.types';
 
-const NativeView: React.ComponentType<<%- project.viewName %>Props> =
-  requireNativeView('<%- project.name %>');
+const NativeView: React.ComponentType<<%- project.viewName %>Props> = requireNativeView('<%- project.name %>');
 
 export default function <%- project.viewName %>(props: <%- project.viewName %>Props) {
   return <NativeView {...props} />;

--- a/packages/expo-module-template/$.prettierrc
+++ b/packages/expo-module-template/$.prettierrc
@@ -1,0 +1,8 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "singleQuote": true,
+  "bracketSameLine": true,
+  "trailingComma": "es5"
+  "jsxSingleQuote": false,
+}

--- a/packages/expo-module-template/$.prettierrc
+++ b/packages/expo-module-template/$.prettierrc
@@ -3,6 +3,6 @@
   "tabWidth": 2,
   "singleQuote": true,
   "bracketSameLine": true,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
   "jsxSingleQuote": false,
 }

--- a/packages/expo-module-template/$package.json
+++ b/packages/expo-module-template/$package.json
@@ -32,7 +32,7 @@
     "@types/jest": "^29.2.1",
     "@types/react": "~19.1.1",
     "babel-preset-expo": "~55.0.8",
-    "eslint": "^8.57.1",
+    "eslint": "~9.39.4",
     "eslint-config-universe": "^15.0.3",
     "expo": "^55.0.2",
     "jest": "^29.7.0",

--- a/packages/expo-module-template/.eslintrc.js
+++ b/packages/expo-module-template/.eslintrc.js
@@ -1,5 +1,0 @@
-module.exports = {
-  root: true,
-  extends: ['universe/native', 'universe/web'],
-  ignorePatterns: ['build'],
-};

--- a/packages/expo-module-template/eslint.config.cjs
+++ b/packages/expo-module-template/eslint.config.cjs
@@ -1,0 +1,5 @@
+const { defineConfig } = require('eslint/config');
+const universe = require('eslint-config-universe/flat/native');
+const universeWeb = require('eslint-config-universe/flat/web');
+
+module.exports = defineConfig([{ ignores: ['build'] }, ...universe, ...universeWeb]);

--- a/packages/expo-module-template/src/index.ts
+++ b/packages/expo-module-template/src/index.ts
@@ -2,4 +2,4 @@
 // and on native platforms to <%- project.moduleName %>.ts
 export { default } from './<%- project.moduleName %>';
 export { default as <%- project.viewName %> } from './<%- project.viewName %>';
-export * from  './<%- project.name %>.types';
+export * from './<%- project.name %>.types';

--- a/packages/expo-module-template/src/{%- project.viewName %}.tsx
+++ b/packages/expo-module-template/src/{%- project.viewName %}.tsx
@@ -3,8 +3,7 @@ import * as React from 'react';
 
 import { <%- project.viewName %>Props } from './<%- project.name %>.types';
 
-const NativeView: React.ComponentType<<%- project.viewName %>Props> =
-  requireNativeView('<%- project.name %>');
+const NativeView: React.ComponentType<<%- project.viewName %>Props> = requireNativeView('<%- project.name %>');
 
 export default function <%- project.viewName %>(props: <%- project.viewName %>Props) {
   return <NativeView {...props} />;


### PR DESCRIPTION
# Why

Currently when using `npx create-expo-module@latest` the `yarn lint` command fails entirely. This has been fixed in https://github.com/expo/expo/pull/43816, but the current configuration doesn't match what the template does - it raises errors about using a single quote.

Also we are using an outdated `eslint` version.

# How

- Update the `eslint` version in the template to `v9` (I couldn't get `v10` to work)
- Update the `eslint` configuration file to work with `v9`
- Add `.prettierrc` to the template in order to configure the quotes to match the template - I wasn't sure whether to not add `.prettierrc` and configure quotes or to update the template. I've decided to to the former but let me know if the latter was the better option.
- Fix an extra space in the template


# Test Plan

Tested on MacOS by creating a module with the local template.
