### PR TITLE
[ios][dev-launcher] Fix issue on second launch

### DIFF
--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -120,14 +120,19 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, EXDe
     let targetVC: UIViewController
 #if !os(macOS)
     let windowRootVC = rootViewController?.view?.window?.rootViewController
-    if let windowRootVC, let wrapperView = windowRootVC.view as? DevLauncherWrapperView {
-      // Greenfield: keep the wrapper view in the hierarchy so it can manage layout on orientation
-      // changes. Add rootView as a subview instead of replacing the wrapper, so react-native-screens
-      // finds window.rootViewController (in the containment hierarchy) with correct layout margins.
-      wrapperView.subviews.forEach { $0.removeFromSuperview() }
-      rootView.frame = wrapperView.bounds
-      rootView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-      wrapperView.addSubview(rootView)
+
+    if let windowRootVC, let rootViewController {
+      // Greenfield: add DevLauncherViewController as a child of the window's root VC
+      // so react-native-screens finds a VC in the containment hierarchy with correct
+      // layout margins.
+      rootViewController.view = rootView
+      if rootViewController.parent != windowRootVC {
+        windowRootVC.addChild(rootViewController)
+      }
+      rootViewController.view.frame = windowRootVC.view.bounds
+      rootViewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+      windowRootVC.view.addSubview(rootViewController.view)
+      rootViewController.didMove(toParent: windowRootVC)
       return
     } else if let rootViewController {
       // Brownfield: the wrapper is embedded in a custom hierarchy, fall back to


### PR DESCRIPTION
# Why
Closes #43851

# How
Originally, I was setting the `rootView` on `DevLauncherViewController`. This worked for rendering, but screens would find `DevLauncherViewController` and because it wasn't in the window's containment hierarchy, the nav controller got zero layout margins.

In #43672, I tried to fix the margins by setting `rootView` on the window's root VC instead. This fixed margins but caused a black screen the issue identifies because the React surface needs rootView set as DevLauncherViewController's .view property to render. It would work on the initial launch and fail after that

This fix attempts to combine both: set `rootView` on `DevLauncherViewController`, then add it as a child VC of the window's root VC. Now when screens finds `DevLauncherViewController`, it is in the containment hierarchy, so layout margins propagate correctly. Also, orientation changes work correctly and the status bar issue that the wrapper view originally addressed is also working.

# Test Plan
In an app using router to check the nav bar
In bare-expo, returning to home etc works
In the user's provided repro
On a physical device to check safe area issue
