### PR TITLE
[fetch][iOS] Add client certificate authentication (mTLS) support

### DIFF
--- a/packages/expo-modules-core/ios/DevTools/URLSessionSessionDelegateProxy.swift
+++ b/packages/expo-modules-core/ios/DevTools/URLSessionSessionDelegateProxy.swift
@@ -1,11 +1,22 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 /**
+ Protocol for handling authentication challenges from URLSession.
+ Native modules can implement this to provide credentials for challenges
+ like client certificate authentication (mTLS).
+ */
+public protocol URLSessionAuthenticationChallengeDelegate: AnyObject {
+  func credential(for challenge: URLAuthenticationChallenge) -> URLCredential?
+}
+
+/**
  Shared URLSessionDelegate instance and delete calls back to ExpoRequestInterceptorProtocol instances.
  */
 public final class URLSessionSessionDelegateProxy: NSObject, URLSessionDataDelegate {
   private let dispatchQueue: DispatchQueue
   private var delegateMap: [AnyHashable: URLSessionDataDelegate] = [:]
+
+  public weak var authenticationChallengeDelegate: URLSessionAuthenticationChallengeDelegate?
 
   public init(dispatchQueue: DispatchQueue) {
     self.dispatchQueue = dispatchQueue
@@ -89,6 +100,7 @@ public final class URLSessionSessionDelegateProxy: NSObject, URLSessionDataDeleg
     didReceive challenge: URLAuthenticationChallenge,
     completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
   ) {
+    // 1. Check per-task delegate first
     if let delegate = getDelegate(task: task),
       delegate.responds(to: #selector(URLSessionTaskDelegate.urlSession(_:task:didReceive:completionHandler:))) {
       delegate.urlSession?(
@@ -96,9 +108,23 @@ public final class URLSessionSessionDelegateProxy: NSObject, URLSessionDataDeleg
         task: task,
         didReceive: challenge,
         completionHandler: completionHandler)
-    } else {
-      completionHandler(.performDefaultHandling, nil)
+      return
     }
+
+    // 2. Check authentication challenge delegate
+    if let credential = authenticationChallengeDelegate?.credential(for: challenge) {
+      completionHandler(.useCredential, credential)
+      return
+    }
+
+    // 3. Check URLCredentialStorage for stored credentials
+    if let credential = URLCredentialStorage.shared.defaultCredential(for: challenge.protectionSpace) {
+      completionHandler(.useCredential, credential)
+      return
+    }
+
+    // 4. Fall back to default handling
+    completionHandler(.performDefaultHandling, nil)
   }
 
   public func urlSession(

--- a/packages/expo/ios/Fetch/ExpoFetchCustomExtension.swift
+++ b/packages/expo/ios/Fetch/ExpoFetchCustomExtension.swift
@@ -1,5 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import ExpoModulesCore
+
 /**
  For callsites to customize network fetch functionalities like having custom `URLSessionConfiguration`.
  */
@@ -8,5 +10,26 @@ public class ExpoFetchCustomExtension: NSObject {
   @MainActor @objc
   public static func setCustomURLSessionConfigurationProvider(_ provider: NSURLSessionConfigurationProvider?) {
     urlSessionConfigurationProvider = provider
+  }
+
+  /**
+   Set a custom factory that creates the URLSession used by ExpoFetchModule.
+   The factory receives the `URLSessionSessionDelegateProxy` which must be used as the session's delegate.
+   Consumers can set `authenticationChallengeDelegate` on the proxy to handle auth challenges like mTLS.
+   Takes precedence over `setCustomURLSessionConfigurationProvider`.
+   */
+  @MainActor
+  public static func setCustomURLSessionFactory(
+    _ factory: ((_ delegateProxy: URLSessionSessionDelegateProxy) -> URLSession)?
+  ) {
+    urlSessionFactory = factory
+  }
+
+  /**
+   Recreates the URLSession used by ExpoFetchModule, destroying all cached TLS sessions.
+   Call this after configuring new credentials to ensure the next request triggers a fresh TLS handshake.
+   */
+  public static func recreateURLSession() {
+    requestURLSessionRecreation()
   }
 }

--- a/packages/expo/ios/Fetch/ExpoFetchModule.swift
+++ b/packages/expo/ios/Fetch/ExpoFetchModule.swift
@@ -2,23 +2,32 @@
 
 @preconcurrency import ExpoModulesCore
 
-private let fetchRequestQueue = DispatchQueue(label: "expo.modules.fetch.RequestQueue")
+internal let fetchRequestQueue = DispatchQueue(label: "expo.modules.fetch.RequestQueue")
 nonisolated(unsafe) internal var urlSessionConfigurationProvider: NSURLSessionConfigurationProvider?
+nonisolated(unsafe) internal var urlSessionFactory: ((_ delegateProxy: URLSessionSessionDelegateProxy) -> URLSession)?
+nonisolated(unsafe) internal weak var currentFetchModule: ExpoFetchModule?
+
+func requestURLSessionRecreation() {
+  fetchRequestQueue.async {
+    currentFetchModule?.recreateURLSession()
+  }
+}
 
 public final class ExpoFetchModule: Module {
-  private lazy var urlSession = createURLSession()
+  private var urlSession: URLSession?
   private let urlSessionDelegate: URLSessionSessionDelegateProxy
 
   public required init(appContext: AppContext) {
     urlSessionDelegate = URLSessionSessionDelegateProxy(dispatchQueue: fetchRequestQueue)
     super.init(appContext: appContext)
+    currentFetchModule = self
   }
 
   public func definition() -> ModuleDefinition {
     Name("ExpoFetchModule")
 
     OnDestroy {
-      urlSession.invalidateAndCancel()
+      urlSession?.invalidateAndCancel()
     }
 
     // swiftlint:disable:next closure_body_length
@@ -78,8 +87,8 @@ public final class ExpoFetchModule: Module {
 
       AsyncFunction("start") { (request: NativeRequest, url: URL, requestInit: NativeRequestInit, requestBody: Data?, promise: Promise) in
         request.start(
-          urlSession: urlSession,
-          urlSessionDelegate: urlSessionDelegate,
+          urlSession: self.getOrCreateURLSession(),
+          urlSessionDelegate: self.urlSessionDelegate,
           url: url,
           requestInit: requestInit,
           requestBody: requestBody
@@ -99,7 +108,25 @@ public final class ExpoFetchModule: Module {
     }
   }
 
+  private func getOrCreateURLSession() -> URLSession {
+    if let session = urlSession {
+      return session
+    }
+    let session = createURLSession()
+    urlSession = session
+    return session
+  }
+
+  internal func recreateURLSession() {
+    urlSession?.invalidateAndCancel()
+    urlSession = nil
+  }
+
   private func createURLSession() -> URLSession {
+    if let urlSessionFactory {
+      return urlSessionFactory(urlSessionDelegate)
+    }
+
     let config: URLSessionConfiguration
     if let urlSessionConfigurationProvider, let concreteConfig = urlSessionConfigurationProvider() {
       config = concreteConfig


### PR DESCRIPTION
## Summary

Add public APIs for native modules to handle URLSession authentication challenges (e.g., client certificate / mTLS) and recreate URLSessions to clear cached TLS state.

### Changes

**`URLSessionSessionDelegateProxy` (expo-modules-core)**
- New `URLSessionAuthenticationChallengeDelegate` protocol with `credential(for:)` method
- New `authenticationChallengeDelegate` property on the proxy (instance-scoped, no singleton)
- Auth challenge fallback chain: per-task delegate → auth challenge delegate → `URLCredentialStorage` → `.performDefaultHandling`

**`ExpoFetchModule` (expo)**
- URLSession changed from eager `lazy var` to lazy-on-demand via `getOrCreateURLSession()`
- New `recreateURLSession()` invalidates the current session; next request creates a fresh one
- New `urlSessionFactory` support — factory receives the delegate proxy, takes precedence over config-only provider

**`ExpoFetchCustomExtension` (expo)**
- `setCustomURLSessionFactory(_:)` — full URLSession factory that gives consumers control over session creation and auth delegate setup
- `recreateURLSession()` — thread-safe session recreation dispatched on `fetchRequestQueue`

### Motivation

Enterprise apps using mTLS currently have no supported way to:
1. Respond to client certificate challenges during TLS handshake
2. Clear cached TLS sessions after configuring new credentials
3. Control the URLSession used by ExpoFetchModule

This PR adds clean public APIs for all three.

### Usage

```swift
// Set up mTLS auth
ExpoFetchCustomExtension.setCustomURLSessionFactory { delegateProxy in
  delegateProxy.authenticationChallengeDelegate = MyAuthDelegate.shared
  let config = URLSessionConfiguration.default
  return URLSession(configuration: config, delegate: delegateProxy, delegateQueue: nil)
}

// After configuring new credentials, force fresh TLS handshake
ExpoFetchCustomExtension.recreateURLSession()
```

## Test plan

- [ ] Verify existing `expo/fetch` tests pass (no regression from `lazy var` → optional session)
- [ ] Manual: set `authenticationChallengeDelegate` on proxy, verify `credential(for:)` is called on server auth challenge
- [ ] Manual: store credential in `URLCredentialStorage`, verify it's used when no auth delegate is set
- [ ] Manual: call `recreateURLSession()`, verify next request triggers a new TLS handshake
- [ ] Manual: use `setCustomURLSessionFactory`, verify factory is called and takes precedence over config provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)