### PR TITLE
docs: added a tech stack card to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Let everyone know your app can be run instantly in the _Expo Go_ app!
 [![runs with Expo Go](https://img.shields.io/badge/Runs%20with%20Expo%20Go-4630EB.svg?style=flat-square&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://expo.dev/client)
 ```
 
+![Stack Fingerprint](https://stackfingerprint.vercel.app/api/card?repo=expo/expo&theme=obsidian&layout=classic&size=md&icons=color&pills=round)
+
 ## 👏 Contributing
 
 If you like Expo and want to help make it better then check out our [contributing guide](/CONTRIBUTING.md)! Check out the [CLI package](https://github.com/expo/expo/tree/main/packages/%40expo/cli) to work on the Expo CLI.


### PR DESCRIPTION
Added a Stack Fingerprint badge to the README.

# Why
Because I think a developer who is new to the repository would be happy to have an instant overview of the tech stacks used.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
Simply added a Stack Fingerprint card badge

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
No test needed.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
