### PR TITLE
[docs] Move comments for easier copying in Local App Production guide

### DIFF
--- a/docs/pages/guides/local-app-production.mdx
+++ b/docs/pages/guides/local-app-production.mdx
@@ -64,10 +64,14 @@ These variables contain information about your upload key:
 ```ruby android/gradle.properties
 # If you've downloaded the credentials from `eas credentials` command, see comments below for each value.
 
-MYAPP_UPLOAD_STORE_FILE=my-upload-key.keystore     # Path to the "keystore" file
-MYAPP_UPLOAD_KEY_ALIAS=my-key-alias                # Replace with value of the `keystore.keyAlias` field in the credentials.json file
-MYAPP_UPLOAD_STORE_PASSWORD=*****                  # Replace with value of the `keystore.password` field in the credentials.json file
-MYAPP_UPLOAD_KEY_PASSWORD=*****                    # Replace with value of the `keystore.keyPassword` field in the credentials.json file
+# Path to the "keystore" file
+MYAPP_UPLOAD_STORE_FILE=my-upload-key.keystore
+# Replace with value of the `keystore.keyAlias` field in the credentials.json file
+MYAPP_UPLOAD_KEY_ALIAS=my-key-alias
+# Replace with value of the `keystore.password` field in the credentials.json file
+MYAPP_UPLOAD_STORE_PASSWORD=*****
+# Replace with value of the `keystore.keyPassword` field in the credentials.json file
+MYAPP_UPLOAD_KEY_PASSWORD=*****
 ```
 
 > **warning** If you commit the **android** directory to a version control system like Git, don't commit the above information. Instead, create a **~/.gradle/gradle.properties** file on your computer and add the above variables to this file.


### PR DESCRIPTION
These inline "comments" look like comments, but actually are part of the value. This can lead to confusion, especially because they are rendered as comments on the web.

<img width="783" height="220" alt="image" src="https://github.com/user-attachments/assets/cf19eb95-55d1-4744-91c5-b5407fc452f3" />


# Why

The web UI makes it seem like those are inline comments, however they are actually part of the value and need to be removed. This caught us off guard and was annoying to debug.

# How

Move comments above the respective lines they talk about, so that when a user copies the code as is, they don't think those are inline comments.

# Test Plan

Not needed.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
