### PR TITLE
[cli] Add username to DNS entry

### DIFF
--- a/packages/@expo/cli/src/start/server/Bonjour.ts
+++ b/packages/@expo/cli/src/start/server/Bonjour.ts
@@ -1,5 +1,6 @@
 import { ExpoConfig, getConfig } from '@expo/config';
 
+import { getSession } from '../../api/user/UserSettings';
 import { env } from '../../utils/env';
 
 const debug = require('debug')('expo:start:server:bonjour') as typeof console.log;
@@ -14,7 +15,13 @@ export class Bonjour {
     private port: number | undefined
   ) {}
 
-  public async announceAsync({ exp = getConfig(this.projectRoot).exp }: { exp?: ExpoConfig }) {
+  public async announceAsync({
+    exp = getConfig(this.projectRoot).exp,
+    username = getSession()?.username,
+  }: {
+    exp?: ExpoConfig;
+    username?: string;
+  }): Promise<void> {
     if (env.CI || !env.EXPO_UNSTABLE_BONJOUR) {
       return;
     } else if (!this.port) {
@@ -39,6 +46,7 @@ export class Bonjour {
         slug: exp.slug?.slice(0, 255),
         androidPackage: exp.android?.package?.slice(0, 255),
         iosBundleIdentifier: exp.ios?.bundleIdentifier?.slice(0, 255),
+        username: username?.slice(0, 255),
       },
     });
   }


### PR DESCRIPTION
# Why

Adds username to the DNS entry to be able to filter it out on the native side.

# Test Plan

- run cli and check if DNS entry contains username 
<img width="1472" height="60" alt="Screenshot 2026-03-12 at 12 44 55" src="https://github.com/user-attachments/assets/ea2f16e0-0f10-41e9-8cd8-2fce7d535045" />
