### PR TITLE
[fix] Fix bare-expo expo run:ios

### DIFF
--- a/packages/@expo/cli/src/run/ios/XcodeBuild.ts
+++ b/packages/@expo/cli/src/run/ios/XcodeBuild.ts
@@ -216,12 +216,6 @@ export async function getXcodeBuildArgsAsync(
     'COMPILER_INDEX_STORE_ENABLE=NO',
   ];
 
-  // Use -quiet flag to reduce xcodebuild output noise when not in debug/verbose mode.
-  // This reduces output processing overhead and makes logs cleaner.
-  if (!env.EXPO_DEBUG) {
-    args.push('-quiet');
-  }
-
   // Skip code signing setup for generic simulator builds (no device).
   if (
     props.device &&


### PR DESCRIPTION
# Why

When running `yarn expo run:ios` in `bare-expo` it fails and outputs:
```
CommandError: Malformed xcodebuild results: app binary path was not generated in build output. Report this issue and run your project with Xcode instead.
```

# How

The problem seems to originate in:
```
// Use -quiet flag to reduce xcodebuild output noise when not in debug/verbose mode. 
 // This reduces output processing overhead and makes logs cleaner.
  if (!env.EXPO_DEBUG) {
    args.push('-quiet');
  }
```   
When `getAppBinaryPath` uses build output to get the `appBinaryPath`, it calls `extractEnvVariableFromBuild`. Because of the `-quiet` flag the build output doesn't contain `UNLOCALIZED_RESOURCES_FOLDER_PATH` and `CONFIGURATION_BUILD_DIR` variables, so this function throws an error.

# Test Plan

I've run `yarn expo run:ios` in `bare-expo` with these changes and it now works.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
