### PR TITLE
[create-expo-module] Make it possible to select platforms when creating a module

### DIFF
--- a/packages/create-expo-module/e2e/__tests__/index-test.ts
+++ b/packages/create-expo-module/e2e/__tests__/index-test.ts
@@ -7,11 +7,32 @@ import {
   ensureFolderExists,
   executePassing,
   expectFileExists,
+  expectFileNotExists,
   getTemporaryPath,
   getTestPath,
   projectRoot,
   readJson,
 } from './utils';
+
+/** Absolute path to the local expo-module-template package */
+const localTemplatePath = path.resolve(__dirname, '../../../expo-module-template');
+
+/** Absolute path to the local expo-module-template-local package */
+const localTemplateLocalPath = path.resolve(__dirname, '../../../expo-module-template-local');
+
+/**
+ * Creates a minimal project directory (with package.json) inside the shared
+ * test root and returns its absolute path. Required for --local module tests
+ * because create-expo-module walks up from INIT_CWD looking for package.json.
+ */
+function createFakeProject(projectName: string): string {
+  const dir = createTestPath(projectName);
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ name: projectName, version: '1.0.0' })
+  );
+  return dir;
+}
 
 beforeAll(async () => {
   ensureFolderExists(projectRoot);
@@ -34,6 +55,7 @@ describe('CLI flags', () => {
     expect(result.stdout).toMatch(/--package/);
     expect(result.stdout).toMatch(/--author-name/);
     expect(result.stdout).toMatch(/--barrel/);
+    expect(result.stdout).toMatch(/--platform/);
   });
 
   it('shows version with --version flag', async () => {
@@ -41,6 +63,262 @@ describe('CLI flags', () => {
 
     // Should output a semver version
     expect(result.stdout).toMatch(/\d+\.\d+\.\d+/);
+  });
+});
+
+describe('--platform option', () => {
+  it('creates a module with --platform apple (single platform)', async () => {
+    const projectName = 'platform-apple-only';
+
+    await executePassing([
+      projectName,
+      '--no-example',
+      '--name',
+      'PlatformTest',
+      '--package',
+      'com.test.platform',
+      '--platform',
+      'apple',
+      '--source',
+      localTemplatePath,
+    ]);
+
+    expectFileExists(projectName, 'expo-module.config.json');
+    const moduleConfig = readJson(projectName, 'expo-module.config.json');
+    expect(moduleConfig.platforms).toEqual(['apple']);
+    expect(moduleConfig.apple).toBeDefined();
+    expect(moduleConfig.android).toBeUndefined();
+
+    // Platform directories should reflect the selected platforms
+    expectFileExists(projectName, 'ios');
+    expectFileNotExists(projectName, 'android');
+
+    // Web files should exist but contain the "not available" stub
+    expectFileExists(projectName, 'src/PlatformTestModule.web.ts');
+    expectFileExists(projectName, 'src/PlatformTestView.web.tsx');
+    expect(
+      fs.readFileSync(getTestPath(projectName, 'src/PlatformTestModule.web.ts'), 'utf8')
+    ).toContain('not available on the web platform');
+    expect(
+      fs.readFileSync(getTestPath(projectName, 'src/PlatformTestView.web.tsx'), 'utf8')
+    ).toContain('not available on the web platform');
+  });
+
+  it('creates a module with --platform apple android (multiple platforms)', async () => {
+    const projectName = 'platform-multi';
+
+    await executePassing([
+      projectName,
+      '--no-example',
+      '--name',
+      'MultiPlatform',
+      '--package',
+      'com.test.multi',
+      '--platform',
+      'apple',
+      'android',
+      '--source',
+      localTemplatePath,
+    ]);
+
+    const moduleConfig = readJson(projectName, 'expo-module.config.json');
+    expect(moduleConfig.platforms).toEqual(['apple', 'android']);
+    expect(moduleConfig.apple).toBeDefined();
+    expect(moduleConfig.android).toBeDefined();
+
+    // Both platform directories should be present
+    expectFileExists(projectName, 'ios');
+    expectFileExists(projectName, 'android');
+
+    // Web files should exist but contain the "not available" stub
+    expectFileExists(projectName, 'src/MultiPlatformModule.web.ts');
+    expectFileExists(projectName, 'src/MultiPlatformView.web.tsx');
+    expect(
+      fs.readFileSync(getTestPath(projectName, 'src/MultiPlatformModule.web.ts'), 'utf8')
+    ).toContain('not available on the web platform');
+    expect(
+      fs.readFileSync(getTestPath(projectName, 'src/MultiPlatformView.web.tsx'), 'utf8')
+    ).toContain('not available on the web platform');
+  });
+
+  it('defaults to all platforms when --platform is not provided', async () => {
+    const projectName = 'platform-default';
+
+    await executePassing([
+      projectName,
+      '--no-example',
+      '--name',
+      'DefaultPlatform',
+      '--package',
+      'com.test.default',
+      '--source',
+      localTemplatePath,
+    ]);
+
+    const moduleConfig = readJson(projectName, 'expo-module.config.json');
+    expect(moduleConfig.platforms).toEqual(['apple', 'android', 'web']);
+    expect(moduleConfig.apple).toBeDefined();
+    expect(moduleConfig.android).toBeDefined();
+
+    // Both platform directories should be present
+    expectFileExists(projectName, 'ios');
+    expectFileExists(projectName, 'android');
+
+    // Web files should exist with the full implementation
+    expectFileExists(projectName, 'src/DefaultPlatformModule.web.ts');
+    expectFileExists(projectName, 'src/DefaultPlatformView.web.tsx');
+    expect(
+      fs.readFileSync(getTestPath(projectName, 'src/DefaultPlatformModule.web.ts'), 'utf8')
+    ).not.toContain('not available on the web platform');
+    expect(
+      fs.readFileSync(getTestPath(projectName, 'src/DefaultPlatformView.web.tsx'), 'utf8')
+    ).not.toContain('not available on the web platform');
+  });
+
+  it('creates a web-only module with no apple/android sections', async () => {
+    const projectName = 'platform-web-only';
+
+    await executePassing([
+      projectName,
+      '--no-example',
+      '--name',
+      'WebOnly',
+      '--package',
+      'com.test.webonly',
+      '--platform',
+      'web',
+      '--source',
+      localTemplatePath,
+    ]);
+
+    const moduleConfig = readJson(projectName, 'expo-module.config.json');
+    expect(moduleConfig.platforms).toEqual(['web']);
+    expect(moduleConfig.apple).toBeUndefined();
+    expect(moduleConfig.android).toBeUndefined();
+
+    // Neither platform directory should be present
+    expectFileNotExists(projectName, 'ios');
+    expectFileNotExists(projectName, 'android');
+
+    // Web files should exist with the full implementation
+    expectFileExists(projectName, 'src/WebOnlyModule.web.ts');
+    expectFileExists(projectName, 'src/WebOnlyView.web.tsx');
+    expect(
+      fs.readFileSync(getTestPath(projectName, 'src/WebOnlyModule.web.ts'), 'utf8')
+    ).not.toContain('not available on the web platform');
+    expect(
+      fs.readFileSync(getTestPath(projectName, 'src/WebOnlyView.web.tsx'), 'utf8')
+    ).not.toContain('not available on the web platform');
+  });
+
+  it('creates an android-only module', async () => {
+    const projectName = 'platform-android-only';
+
+    await executePassing([
+      projectName,
+      '--no-example',
+      '--name',
+      'AndroidOnly',
+      '--package',
+      'com.test.androidonly',
+      '--platform',
+      'android',
+      '--source',
+      localTemplatePath,
+    ]);
+
+    const moduleConfig = readJson(projectName, 'expo-module.config.json');
+    expect(moduleConfig.platforms).toEqual(['android']);
+    expect(moduleConfig.android).toBeDefined();
+    expect(moduleConfig.apple).toBeUndefined();
+
+    // android/ should exist, ios/ should not
+    expectFileExists(projectName, 'android');
+    expectFileNotExists(projectName, 'ios');
+
+    // Web files should exist but contain the "not available" stub
+    expectFileExists(projectName, 'src/AndroidOnlyModule.web.ts');
+    expectFileExists(projectName, 'src/AndroidOnlyView.web.tsx');
+    expect(
+      fs.readFileSync(getTestPath(projectName, 'src/AndroidOnlyModule.web.ts'), 'utf8')
+    ).toContain('not available on the web platform');
+    expect(
+      fs.readFileSync(getTestPath(projectName, 'src/AndroidOnlyView.web.tsx'), 'utf8')
+    ).toContain('not available on the web platform');
+  });
+
+  it('warns and defaults to all platforms when only invalid values are given', async () => {
+    const fakeProject = createFakeProject('local-invalid-only');
+
+    // "ios" is not a valid platform value (the correct value is "apple")
+    const result = await executePassing(
+      ['my-module', '--local', '--platform', 'ios', '--source', localTemplateLocalPath],
+      { cwd: fakeProject }
+    );
+
+    // Should warn about the unknown platform and the fallback
+    expect(result.stderr).toMatch(/ios/);
+    expect(result.stderr).toMatch(/Defaulting to all platforms/i);
+
+    // Should have fallen back to all platforms
+    const moduleConfig = readJson(
+      'local-invalid-only/modules/my-module',
+      'expo-module.config.json'
+    );
+    expect(moduleConfig.platforms).toEqual(['apple', 'android', 'web']);
+    expect(moduleConfig.apple).toBeDefined();
+    expect(moduleConfig.android).toBeDefined();
+  });
+
+  it('warns about and ignores invalid values when mixed with valid ones', async () => {
+    const fakeProject = createFakeProject('local-mixed-invalid');
+
+    // "ios" is invalid; "apple" is the correct value — only apple should be used
+    const result = await executePassing(
+      ['my-module', '--local', '--platform', 'apple', 'ios', '--source', localTemplateLocalPath],
+      { cwd: fakeProject }
+    );
+
+    // Should warn about the unknown platform "ios"
+    expect(result.stderr).toMatch(/ios/);
+
+    // Should have used only the valid platform
+    const moduleConfig = readJson(
+      'local-mixed-invalid/modules/my-module',
+      'expo-module.config.json'
+    );
+    expect(moduleConfig.platforms).toEqual(['apple']);
+    expect(moduleConfig.apple).toBeDefined();
+    expect(moduleConfig.android).toBeUndefined();
+  });
+
+  it('creates a local module with --platform respecting the selected platforms', async () => {
+    const fakeProject = createFakeProject('local-platform-project');
+
+    await executePassing(
+      ['my-module', '--local', '--platform', 'android', '--source', localTemplateLocalPath],
+      { cwd: fakeProject }
+    );
+
+    const moduleConfig = readJson(
+      'local-platform-project/modules/my-module',
+      'expo-module.config.json'
+    );
+    expect(moduleConfig.platforms).toEqual(['android']);
+    expect(moduleConfig.android).toBeDefined();
+    expect(moduleConfig.apple).toBeUndefined();
+
+    // android/ should exist, ios/ should not
+    expectFileExists('local-platform-project/modules/my-module', 'android');
+    expectFileNotExists('local-platform-project/modules/my-module', 'ios');
+
+    // Web stub should be present
+    expect(
+      fs.readFileSync(
+        getTestPath('local-platform-project/modules/my-module', 'src/MyModule.web.ts'),
+        'utf8'
+      )
+    ).toContain('not available on the web platform');
   });
 });
 

--- a/packages/create-expo-module/e2e/__tests__/index-test.ts
+++ b/packages/create-expo-module/e2e/__tests__/index-test.ts
@@ -20,20 +20,6 @@ const localTemplatePath = path.resolve(__dirname, '../../../expo-module-template
 /** Absolute path to the local expo-module-template-local package */
 const localTemplateLocalPath = path.resolve(__dirname, '../../../expo-module-template-local');
 
-/**
- * Creates a minimal project directory (with package.json) inside the shared
- * test root and returns its absolute path. Required for --local module tests
- * because create-expo-module walks up from INIT_CWD looking for package.json.
- */
-function createFakeProject(projectName: string): string {
-  const dir = createTestPath(projectName);
-  fs.writeFileSync(
-    path.join(dir, 'package.json'),
-    JSON.stringify({ name: projectName, version: '1.0.0' })
-  );
-  return dir;
-}
-
 beforeAll(async () => {
   ensureFolderExists(projectRoot);
 });

--- a/packages/create-expo-module/e2e/__tests__/utils.ts
+++ b/packages/create-expo-module/e2e/__tests__/utils.ts
@@ -12,7 +12,10 @@ export const projectRoot = getTemporaryPath();
 
 /** Create a new temporary path for e2e tests */
 export function getTemporaryPath() {
-  return path.join(os.tmpdir(), 'create-expo-module-e2e-' + Math.random().toString(36).substring(2));
+  return path.join(
+    os.tmpdir(),
+    'create-expo-module-e2e-' + Math.random().toString(36).substring(2)
+  );
 }
 
 /** Get the path within the default project root or temporary path */
@@ -34,7 +37,7 @@ export function ensureFolderExists(folder: string) {
 
 /** Run `create-expo-module` asynchronously, with default settings for CI */
 export function execute(args: string[], { env = {}, cwd = projectRoot }: SpawnOptions = {}) {
-  const cwdPath = typeof cwd === 'string' ? cwd : cwd?.toString() ?? projectRoot;
+  const cwdPath = typeof cwd === 'string' ? cwd : (cwd?.toString() ?? projectRoot);
   return spawnAsync('node', [bin, ...args], {
     cwd: cwdPath,
     env: {
@@ -95,8 +98,8 @@ export function expectFileNotExists(projectName: string, ...filePath: string[]) 
  * Creates a temporary directory with a minimal package.json, simulating an Expo project root.
  * Used for --local module tests. The caller is responsible for cleaning up.
  */
-export function createFakeProject(): string {
-  const projectPath = getTemporaryPath();
+export function createFakeProject(name?: string): string {
+  const projectPath = name ? path.join(projectRoot, name) : getTemporaryPath();
   fs.mkdirSync(projectPath, { recursive: true });
   fs.writeFileSync(
     path.join(projectPath, 'package.json'),
@@ -110,4 +113,3 @@ export function readJson(projectName: string, ...filePath: string[]) {
   const targetPath = getTestPath(projectName, ...filePath);
   return JSON.parse(fs.readFileSync(targetPath, { encoding: 'utf8' }));
 }
-

--- a/packages/create-expo-module/src/create-expo-module.ts
+++ b/packages/create-expo-module/src/create-expo-module.ts
@@ -23,6 +23,7 @@ import {
   getPlatformPrompt,
   getSlugPrompt,
   getSubstitutionDataPrompts,
+  type Platform,
 } from './prompts';
 import { eventCreateExpoModule, getTelemetryClient, logEventAsync } from './telemetry';
 import type { CommandOptions, LocalSubstitutionData, SubstitutionData } from './types';
@@ -126,7 +127,7 @@ async function getCorrectLocalDirectory(targetOrSlug: string) {
  * and returns the `expo.platforms` list mapped to module platform names (`ios` → `apple`).
  * Returns `null` when `app.json` is absent or has no `expo.platforms` field.
  */
-async function getLocalAppJsonPlatforms(): Promise<string[] | null> {
+async function getLocalAppJsonPlatforms(): Promise<Platform[] | null> {
   let root: string | null = null;
   for (let dir = CWD; path.dirname(dir) !== dir; dir = path.dirname(dir)) {
     if (fs.existsSync(path.resolve(dir, 'package.json'))) {
@@ -152,7 +153,7 @@ async function getLocalAppJsonPlatforms(): Promise<string[] | null> {
     const platformMap: Record<string, string> = { ios: 'apple', android: 'android', web: 'web' };
     const mapped = raw
       .map((p) => platformMap[p] ?? p)
-      .filter((p) => (ALL_PLATFORMS as readonly string[]).includes(p));
+      .filter((p): p is Platform => (ALL_PLATFORMS as readonly string[]).includes(p));
     return mapped.length > 0 ? mapped : null;
   } catch {
     debug('Failed to read or parse app.json for platform defaults');
@@ -173,9 +174,11 @@ async function resolvePlatformsAsync(
   isLocal: boolean,
   interactive: boolean,
   options: CommandOptions
-): Promise<string[]> {
+): Promise<Platform[]> {
   if (options.platform && options.platform.length > 0) {
-    const valid = options.platform.filter((p) => (ALL_PLATFORMS as readonly string[]).includes(p));
+    const valid = options.platform.filter((p): p is Platform =>
+      (ALL_PLATFORMS as readonly string[]).includes(p)
+    );
     const invalid = options.platform.filter(
       (p) => !(ALL_PLATFORMS as readonly string[]).includes(p)
     );
@@ -208,7 +211,7 @@ async function resolvePlatformsAsync(
     onCancel: () => process.exit(0),
   });
 
-  return platforms as string[];
+  return platforms as Platform[];
 }
 
 /**
@@ -487,7 +490,7 @@ function handleSuffix(name: string, suffix: string): string {
  * Maps template top-level directory names to the platform name in `expo-module.config.json`.
  * Files under these directories are only copied when the corresponding platform is selected.
  */
-const TEMPLATE_DIR_TO_PLATFORM: Record<string, string> = {
+const TEMPLATE_DIR_TO_PLATFORM: Record<string, Platform> = {
   ios: 'apple',
   android: 'android',
 };
@@ -505,7 +508,7 @@ async function createModuleFromTemplate(
   // Iterate through all template files.
   for (const file of files) {
     // Skip platform-specific directories when the platform was not selected.
-    const topLevelDir = file.split(path.sep)[0];
+    const topLevelDir = file.split(path.sep)[0] ?? '';
     const requiredPlatform = TEMPLATE_DIR_TO_PLATFORM[topLevelDir];
     if (requiredPlatform && !data.project.platforms.includes(requiredPlatform)) {
       continue;
@@ -715,7 +718,7 @@ async function getSubstitutionDataFromOptions(
   slug: string,
   isLocal: boolean,
   options: CommandOptions,
-  platforms: string[]
+  platforms: Platform[]
 ): Promise<SubstitutionData | LocalSubstitutionData> {
   const rawName = options.name ?? slugToModuleName(slug);
   const { name, wasRenamed } = ensureSafeModuleName(rawName);

--- a/packages/create-expo-module/src/create-expo-module.ts
+++ b/packages/create-expo-module/src/create-expo-module.ts
@@ -17,8 +17,10 @@ import {
   type PackageManagerName,
 } from './packageManager';
 import {
+  ALL_PLATFORMS,
   getLocalFolderNamePrompt,
   getLocalSubstitutionDataPrompts,
+  getPlatformPrompt,
   getSlugPrompt,
   getSubstitutionDataPrompts,
 } from './prompts';
@@ -117,6 +119,96 @@ async function getCorrectLocalDirectory(targetOrSlug: string) {
     return null;
   }
   return path.join(packageJsonPath, '..', 'modules', targetOrSlug);
+}
+
+/**
+ * Reads `app.json` from the nearest project root (found by walking up from CWD)
+ * and returns the `expo.platforms` list mapped to module platform names (`ios` → `apple`).
+ * Returns `null` when `app.json` is absent or has no `expo.platforms` field.
+ */
+async function getLocalAppJsonPlatforms(): Promise<string[] | null> {
+  let root: string | null = null;
+  for (let dir = CWD; path.dirname(dir) !== dir; dir = path.dirname(dir)) {
+    if (fs.existsSync(path.resolve(dir, 'package.json'))) {
+      root = dir;
+      break;
+    }
+  }
+  if (!root) {
+    return null;
+  }
+  const appJsonPath = path.resolve(root, 'app.json');
+  if (!fs.existsSync(appJsonPath)) {
+    return null;
+  }
+  try {
+    const content = await fs.promises.readFile(appJsonPath, 'utf8');
+    const appJson = JSON.parse(content);
+    const raw: string[] | undefined = appJson?.expo?.platforms;
+    if (!Array.isArray(raw) || raw.length === 0) {
+      return null;
+    }
+    // app.json uses 'ios', expo-module.config.json uses 'apple'
+    const platformMap: Record<string, string> = { ios: 'apple', android: 'android', web: 'web' };
+    const mapped = raw
+      .map((p) => platformMap[p] ?? p)
+      .filter((p) => (ALL_PLATFORMS as readonly string[]).includes(p));
+    return mapped.length > 0 ? mapped : null;
+  } catch {
+    debug('Failed to read or parse app.json for platform defaults');
+    return null;
+  }
+}
+
+/**
+ * Determines the target platforms for the module.
+ *
+ * Priority:
+ *   1. `--platform` CLI flag
+ *   2. Non-interactive mode → all platforms
+ *   3. Interactive + local module → pre-select from app.json, then prompt
+ *   4. Interactive + non-local → prompt with all platforms pre-selected
+ */
+async function resolvePlatformsAsync(
+  isLocal: boolean,
+  interactive: boolean,
+  options: CommandOptions
+): Promise<string[]> {
+  if (options.platform && options.platform.length > 0) {
+    const valid = options.platform.filter((p) => (ALL_PLATFORMS as readonly string[]).includes(p));
+    const invalid = options.platform.filter(
+      (p) => !(ALL_PLATFORMS as readonly string[]).includes(p)
+    );
+    if (invalid.length > 0) {
+      console.warn(
+        chalk.yellow(
+          `⚠️  Unknown platform(s) ignored: ${invalid.join(', ')}. Valid values: ${ALL_PLATFORMS.join(', ')}`
+        )
+      );
+    }
+    if (valid.length === 0) {
+      console.warn(chalk.yellow(`⚠️  No valid platforms specified. Defaulting to all platforms.`));
+      return [...ALL_PLATFORMS];
+    }
+    return valid;
+  }
+
+  if (!interactive) {
+    return [...ALL_PLATFORMS];
+  }
+
+  const appJsonPlatforms = isLocal ? await getLocalAppJsonPlatforms() : null;
+  const preSelected: readonly string[] = appJsonPlatforms ?? ALL_PLATFORMS;
+
+  if (appJsonPlatforms) {
+    debug(`Using app.json platforms as defaults: ${appJsonPlatforms.join(', ')}`);
+  }
+
+  const { platforms } = await prompts(getPlatformPrompt(preSelected), {
+    onCancel: () => process.exit(0),
+  });
+
+  return platforms as string[];
 }
 
 /**
@@ -392,6 +484,15 @@ function handleSuffix(name: string, suffix: string): string {
 }
 
 /**
+ * Maps template top-level directory names to the platform name in `expo-module.config.json`.
+ * Files under these directories are only copied when the corresponding platform is selected.
+ */
+const TEMPLATE_DIR_TO_PLATFORM: Record<string, string> = {
+  ios: 'apple',
+  android: 'android',
+};
+
+/**
  * Creates the module based on the `ejs` template (e.g. `expo-module-template` package).
  */
 async function createModuleFromTemplate(
@@ -403,6 +504,13 @@ async function createModuleFromTemplate(
 
   // Iterate through all template files.
   for (const file of files) {
+    // Skip platform-specific directories when the platform was not selected.
+    const topLevelDir = file.split(path.sep)[0];
+    const requiredPlatform = TEMPLATE_DIR_TO_PLATFORM[topLevelDir];
+    if (requiredPlatform && !data.project.platforms.includes(requiredPlatform)) {
+      continue;
+    }
+
     const renderedRelativePath = ejs.render(file.replace(/^\$/, ''), data, {
       openDelimiter: '{',
       closeDelimiter: '}',
@@ -493,9 +601,10 @@ async function askForSubstitutionDataAsync(
 ): Promise<SubstitutionData | LocalSubstitutionData> {
   const interactive = isInteractive();
 
-  // Non-interactive mode: use CLI options and defaults
+  const platforms = await resolvePlatformsAsync(isLocal, interactive, options);
+
   if (!interactive) {
-    return getSubstitutionDataFromOptions(slug, isLocal, options);
+    return getSubstitutionDataFromOptions(slug, isLocal, options, platforms);
   }
 
   // Interactive mode: prompt for values, but skip prompts for CLI-provided values
@@ -541,6 +650,7 @@ async function askForSubstitutionDataAsync(
         package: projectPackage,
         moduleName: handleSuffix(name, 'Module'),
         viewName: handleSuffix(name, 'View'),
+        platforms,
       },
       type: 'local',
     };
@@ -565,6 +675,7 @@ async function askForSubstitutionDataAsync(
       package: projectPackage,
       moduleName: handleSuffix(name, 'Module'),
       viewName: handleSuffix(name, 'View'),
+      platforms,
     },
     author: `${authorName} <${authorEmail}> (${authorUrl})`,
     license: 'MIT',
@@ -603,7 +714,8 @@ function getCliValueForPrompt(promptName: string, options: CommandOptions): stri
 async function getSubstitutionDataFromOptions(
   slug: string,
   isLocal: boolean,
-  options: CommandOptions
+  options: CommandOptions,
+  platforms: string[]
 ): Promise<SubstitutionData | LocalSubstitutionData> {
   const rawName = options.name ?? slugToModuleName(slug);
   const { name, wasRenamed } = ensureSafeModuleName(rawName);
@@ -628,6 +740,7 @@ async function getSubstitutionDataFromOptions(
         package: projectPackage,
         moduleName: handleSuffix(name, 'Module'),
         viewName: handleSuffix(name, 'View'),
+        platforms,
       },
       type: 'local',
     };
@@ -654,6 +767,7 @@ async function getSubstitutionDataFromOptions(
       package: projectPackage,
       moduleName: handleSuffix(name, 'Module'),
       viewName: handleSuffix(name, 'View'),
+      platforms,
     },
     author: `${authorName} <${authorEmail}> (${authorUrl})`,
     license: 'MIT',
@@ -811,6 +925,10 @@ program
   .option('--author-email <email>', 'Author email for package.json.')
   .option('--author-url <url>', "URL to the author's profile (e.g., GitHub profile).")
   .option('--repo <url>', 'URL of the repository.')
+  .option(
+    '-p, --platform <platforms...>',
+    `Target platforms for the module. Available values: ${ALL_PLATFORMS.join(', ')}.`
+  )
   .action(main);
 
 program

--- a/packages/create-expo-module/src/prompts.ts
+++ b/packages/create-expo-module/src/prompts.ts
@@ -6,6 +6,24 @@ import { ensureSafeModuleName } from './appleFrameworks';
 import { findGitHubEmail, findMyName } from './utils/git';
 import { findGitHubUserFromEmail, guessRepoUrl } from './utils/github';
 
+export const ALL_PLATFORMS = ['apple', 'android', 'web'] as const;
+export type Platform = (typeof ALL_PLATFORMS)[number];
+
+export function getPlatformPrompt(preSelected: readonly string[] = ALL_PLATFORMS): PromptObject {
+  return {
+    type: 'multiselect',
+    name: 'platforms',
+    message: 'Which platforms should this module support?',
+    choices: ALL_PLATFORMS.map((p) => ({
+      title: p,
+      value: p,
+      selected: preSelected.includes(p),
+    })),
+    min: 1,
+    hint: '- Space to select. Enter to confirm.',
+  };
+}
+
 /**
  * Converts a slug to a native module name (PascalCase), ensuring it doesn't conflict with Apple frameworks.
  */

--- a/packages/create-expo-module/src/types.ts
+++ b/packages/create-expo-module/src/types.ts
@@ -1,5 +1,7 @@
 import type { PromptObject } from 'prompts';
 
+import type { Platform } from './prompts';
+
 /**
  * Possible command options.
  */
@@ -19,7 +21,7 @@ export type CommandOptions = {
   authorEmail?: string;
   authorUrl?: string;
   repo?: string;
-  platform?: string[];
+  platform?: Platform[];
 };
 
 /**
@@ -34,7 +36,7 @@ export type SubstitutionData = {
     package: string;
     moduleName: string;
     viewName: string;
-    platforms: string[];
+    platforms: Platform[];
   };
   author: string;
   license: string;
@@ -49,7 +51,7 @@ export type LocalSubstitutionData = {
     package: string;
     moduleName: string;
     viewName: string;
-    platforms: string[];
+    platforms: Platform[];
   };
   type: 'local';
 };

--- a/packages/create-expo-module/src/types.ts
+++ b/packages/create-expo-module/src/types.ts
@@ -19,6 +19,7 @@ export type CommandOptions = {
   authorEmail?: string;
   authorUrl?: string;
   repo?: string;
+  platform?: string[];
 };
 
 /**
@@ -33,6 +34,7 @@ export type SubstitutionData = {
     package: string;
     moduleName: string;
     viewName: string;
+    platforms: string[];
   };
   author: string;
   license: string;
@@ -47,6 +49,7 @@ export type LocalSubstitutionData = {
     package: string;
     moduleName: string;
     viewName: string;
+    platforms: string[];
   };
   type: 'local';
 };

--- a/packages/expo-module-template-local/expo-module.config.json
+++ b/packages/expo-module-template-local/expo-module.config.json
@@ -1,9 +1,10 @@
 {
-  "platforms": ["apple", "android", "web"],
+  "platforms": [<%- project.platforms.map(p => JSON.stringify(p)).join(', ') %>]<% if (project.platforms.includes('apple')) { %>,
   "apple": {
     "modules": ["<%- project.moduleName %>"]
-  },
+  }<% } -%>
+<% if (project.platforms.includes('android')) { %>,
   "android": {
     "modules": ["<%- project.package %>.<%- project.moduleName %>"]
-  }
+  }<% } %>
 }

--- a/packages/expo-module-template-local/src/{%- project.moduleName %}.web.ts
+++ b/packages/expo-module-template-local/src/{%- project.moduleName %}.web.ts
@@ -1,3 +1,4 @@
+<% if (project.platforms.includes('web')) { -%>
 import { registerWebModule, NativeModule } from 'expo';
 
 import { ChangeEventPayload } from './<%- project.name %>.types';
@@ -17,3 +18,17 @@ class <%- project.moduleName %> extends NativeModule<<%- project.moduleName %>Ev
 };
 
 export default registerWebModule(<%- project.moduleName %>, '<%- project.moduleName %>');
+<% } else { -%>
+import { registerWebModule, NativeModule } from 'expo';
+
+import { ChangeEventPayload } from './<%- project.name %>.types';
+
+type <%- project.moduleName %>Events = {
+  onChange: (params: ChangeEventPayload) => void;
+};
+
+// <%- project.moduleName %> is not available on the web platform.
+class <%- project.moduleName %> extends NativeModule<<%- project.moduleName %>Events> {}
+
+export default registerWebModule(<%- project.moduleName %>, '<%- project.moduleName %>');
+<% } -%>

--- a/packages/expo-module-template-local/src/{%- project.viewName %}.web.tsx
+++ b/packages/expo-module-template-local/src/{%- project.viewName %}.web.tsx
@@ -1,3 +1,4 @@
+<% if (project.platforms.includes('web')) { -%>
 import * as React from 'react';
 
 import { <%- project.viewName %>Props } from './<%- project.name %>.types';
@@ -13,3 +14,11 @@ export default function <%- project.viewName %>(props: <%- project.viewName %>Pr
     </div>
   );
 }
+<% } else { -%>
+import { <%- project.viewName %>Props } from './<%- project.name %>.types';
+
+// <%- project.viewName %> is not available on the web platform.
+export default function <%- project.viewName %>(_props: <%- project.viewName %>Props) {
+  throw new Error('<%- project.viewName %> is not available on the web platform.');
+}
+<% } -%>

--- a/packages/expo-module-template/expo-module.config.json
+++ b/packages/expo-module-template/expo-module.config.json
@@ -1,9 +1,10 @@
 {
-  "platforms": ["apple", "android", "web"],
+  "platforms": [<%- project.platforms.map(p => JSON.stringify(p)).join(', ') %>]<% if (project.platforms.includes('apple')) { %>,
   "apple": {
     "modules": ["<%- project.moduleName %>"]
-  },
+  }<% } -%>
+<% if (project.platforms.includes('android')) { %>,
   "android": {
     "modules": ["<%- project.package %>.<%- project.moduleName %>"]
-  }
+  }<% } %>
 }

--- a/packages/expo-module-template/src/{%- project.moduleName %}.web.ts
+++ b/packages/expo-module-template/src/{%- project.moduleName %}.web.ts
@@ -1,3 +1,4 @@
+<% if (project.platforms.includes('web')) { -%>
 import { registerWebModule, NativeModule } from 'expo';
 
 import { <%- project.moduleName %>Events } from './<%- project.name %>.types';
@@ -13,3 +14,13 @@ class <%- project.moduleName %> extends NativeModule<<%- project.moduleName %>Ev
 }
 
 export default registerWebModule(<%- project.moduleName %>, '<%- project.moduleName %>');
+<% } else { -%>
+import { registerWebModule, NativeModule } from 'expo';
+
+import { <%- project.moduleName %>Events } from './<%- project.name %>.types';
+
+// <%- project.moduleName %> is not available on the web platform.
+class <%- project.moduleName %> extends NativeModule<<%- project.moduleName %>Events> {}
+
+export default registerWebModule(<%- project.moduleName %>, '<%- project.moduleName %>');
+<% } -%>

--- a/packages/expo-module-template/src/{%- project.viewName %}.web.tsx
+++ b/packages/expo-module-template/src/{%- project.viewName %}.web.tsx
@@ -1,3 +1,4 @@
+<% if (project.platforms.includes('web')) { -%>
 import * as React from 'react';
 
 import { <%- project.viewName %>Props } from './<%- project.name %>.types';
@@ -13,3 +14,11 @@ export default function <%- project.viewName %>(props: <%- project.viewName %>Pr
     </div>
   );
 }
+<% } else { -%>
+import { <%- project.viewName %>Props } from './<%- project.name %>.types';
+
+// <%- project.viewName %> is not available on the web platform.
+export default function <%- project.viewName %>(_props: <%- project.viewName %>Props) {
+  throw new Error('<%- project.viewName %> is not available on the web platform.');
+}
+<% } -%>


### PR DESCRIPTION
# Why

Currently `create-expo-module` always creates modules for all platforms

# How

Add `--platform` option to specify platforms supported by the module
- For local modules the creator pre-selects platforms defined in `app.json` for the prompt
- For non local modules the creator defaults to all platforms when unspecified
- In non-interactive mode the local module will be created for all platforms when `--platform` is not provided
- Added tests

# Test Plan

Tested by creating a bunch of modules on MacOS, and by running the added e2e tests
