### PR TITLE
[create-expo-module] Do not add barrel file by default for local modules

### DIFF
--- a/packages/create-expo-module/e2e/__tests__/index-test.ts
+++ b/packages/create-expo-module/e2e/__tests__/index-test.ts
@@ -1,10 +1,12 @@
 import fs from 'fs';
+import path from 'path';
 
 import {
   createTestPath,
   ensureFolderExists,
   executePassing,
   expectFileExists,
+  getTemporaryPath,
   getTestPath,
   projectRoot,
   readJson,
@@ -30,6 +32,7 @@ describe('CLI flags', () => {
     expect(result.stdout).toMatch(/--description/);
     expect(result.stdout).toMatch(/--package/);
     expect(result.stdout).toMatch(/--author-name/);
+    expect(result.stdout).toMatch(/--barrel/);
   });
 
   it('shows version with --version flag', async () => {
@@ -105,5 +108,83 @@ describe('non-interactive module creation', () => {
 
     // Should still create the module
     expectFileExists(projectName, 'package.json');
+  });
+});
+
+describe('--barrel option', () => {
+  const localTemplatePath = path.resolve(
+    __dirname,
+    '../../../../packages/expo-module-template-local'
+  );
+  let localProjectRoot: string;
+
+  beforeAll(() => {
+    localProjectRoot = getTemporaryPath();
+    fs.mkdirSync(localProjectRoot, { recursive: true });
+    // Minimal package.json so the CLI can locate the project root when walking upward
+    fs.writeFileSync(
+      path.join(localProjectRoot, 'package.json'),
+      JSON.stringify({ name: 'test-app', version: '1.0.0' })
+    );
+  });
+
+  afterAll(async () => {
+    if (fs.existsSync(localProjectRoot)) {
+      await fs.promises.rm(localProjectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('does not generate index.ts barrel file by default', async () => {
+    const slug = 'no-barrel-module';
+
+    await executePassing([slug, '--local', '--source', localTemplatePath], {
+      cwd: localProjectRoot,
+    });
+
+    const indexPath = path.join(localProjectRoot, 'modules', slug, 'index.ts');
+    expect({ [indexPath]: fs.existsSync(indexPath) }).toEqual({ [indexPath]: false });
+  });
+
+  it('generates index.ts barrel file with correct re-exports when --barrel is set', async () => {
+    const slug = 'barrel-module';
+
+    await executePassing([slug, '--local', '--barrel', '--source', localTemplatePath], {
+      cwd: localProjectRoot,
+    });
+
+    const indexPath = path.join(localProjectRoot, 'modules', slug, 'index.ts');
+    expect({ [indexPath]: fs.existsSync(indexPath) }).toEqual({ [indexPath]: true });
+
+    const content = fs.readFileSync(indexPath, 'utf8');
+    // Re-exports the native module as default
+    expect(content).toMatch(/export \{ default \} from '\.\/src\//);
+    // Re-exports the view with its name
+    expect(content).toMatch(/export \{ default as \w+View \} from '\.\/src\//);
+    // Re-exports all types
+    expect(content).toMatch(/export \* from '\.\/src\//);
+  });
+
+  it('shows a single barrel-style import path in success output when --barrel is set', async () => {
+    const slug = 'barrel-message-module';
+
+    const result = await executePassing(
+      [slug, '--local', '--barrel', '--source', localTemplatePath],
+      { cwd: localProjectRoot }
+    );
+
+    // The success message should point to the module root (no /src/ sub-path)
+    expect(result.stdout).toMatch(new RegExp(`from './modules/${slug}'`));
+    expect(result.stdout).not.toMatch(new RegExp(`from './modules/${slug}/src/`));
+  });
+
+  it('shows direct src/ import paths in success output without --barrel', async () => {
+    const slug = 'no-barrel-message-module';
+
+    const result = await executePassing([slug, '--local', '--source', localTemplatePath], {
+      cwd: localProjectRoot,
+    });
+
+    // The success message should include a direct src/ path
+    expect(result.stdout).toMatch(new RegExp(`from './modules/${slug}/src/`));
   });
 });

--- a/packages/create-expo-module/src/create-expo-module.ts
+++ b/packages/create-expo-module/src/create-expo-module.ts
@@ -764,9 +764,7 @@ function printFurtherLocalInstructions(
         `import { default as ${viewName} } from './modules/${slug}/src/${viewName}';`
       )
     );
-    console.log(
-      chalk.gray.italic(`import type { } from './modules/${slug}/src/${name}.types';`)
-    );
+    console.log(chalk.gray.italic(`import type { } from './modules/${slug}/src/${name}.types';`));
   }
   console.log();
   console.log(`Learn more on Expo Modules APIs: ${chalk.blue.bold(DOCS_URL)}`);

--- a/packages/create-expo-module/src/create-expo-module.ts
+++ b/packages/create-expo-module/src/create-expo-module.ts
@@ -158,7 +158,7 @@ async function main(target: string | undefined, options: CommandOptions) {
 
   const packageManager = resolvePackageManager();
   const packagePath = options.source
-    ? path.join(CWD, options.source)
+    ? path.resolve(CWD, options.source)
     : await downloadPackageAsync(targetDir, options.local);
 
   await logEventAsync(eventCreateExpoModule(packageManager, options));
@@ -167,6 +167,12 @@ async function main(target: string | undefined, options: CommandOptions) {
     await createModuleFromTemplate(packagePath, targetDir, data);
     step.succeed('Created the module from template files');
   });
+  if (options.local && options.barrel) {
+    await newStep('Generating barrel file', async (step) => {
+      await generateBarrelFileAsync(targetDir, data as LocalSubstitutionData);
+      step.succeed('Generated barrel file (index.ts)');
+    });
+  }
   if (!options.local) {
     await newStep('Installing module dependencies', async (step) => {
       await installDependencies(packageManager, targetDir);
@@ -219,7 +225,12 @@ async function main(target: string | undefined, options: CommandOptions) {
   console.log();
   if (options.local) {
     console.log(`✅ Successfully created Expo module in ${chalk.bold.italic(`modules/${slug}`)}`);
-    printFurtherLocalInstructions(slug, data.project.moduleName);
+    printFurtherLocalInstructions(
+      slug,
+      data.project.moduleName,
+      data.project.viewName,
+      options.barrel
+    );
   } else {
     console.log('✅ Successfully created Expo module');
     printFurtherInstructions(targetDir, packageManager, options.example);
@@ -680,6 +691,25 @@ async function confirmTargetDirAsync(targetDir: string, options: CommandOptions)
 }
 
 /**
+ * Generates an `index.ts` barrel file that re-exports the module and view for local modules.
+ */
+async function generateBarrelFileAsync(
+  targetPath: string,
+  data: LocalSubstitutionData
+): Promise<void> {
+  const { moduleName, viewName, name } = data.project;
+  const content = [
+    `// Reexport the native module. On web, it will be resolved to ${moduleName}.web.ts`,
+    `// and on native platforms to ${moduleName}.ts`,
+    `export { default } from './src/${moduleName}';`,
+    `export { default as ${viewName} } from './src/${viewName}';`,
+    `export * from './src/${name}.types';`,
+    '',
+  ].join('\n');
+  await fs.promises.writeFile(path.join(targetPath, 'index.ts'), content, 'utf8');
+}
+
+/**
  * Prints how the user can follow up once the script finishes creating the module.
  */
 function printFurtherInstructions(
@@ -704,11 +734,19 @@ function printFurtherInstructions(
   console.log(`Learn more on Expo Modules APIs: ${chalk.blue.bold(DOCS_URL)}`);
 }
 
-function printFurtherLocalInstructions(slug: string, name: string) {
+function printFurtherLocalInstructions(
+  slug: string,
+  moduleName: string,
+  viewName: string,
+  barrel: boolean
+) {
+  const importMessage = barrel
+    ? `${chalk.gray.italic(`import ${moduleName}, { ${viewName} } from './modules/${slug}';`)}`
+    : `${chalk.gray.italic(`import ${moduleName} from './modules/${slug}/src/${moduleName}';`)}`;
   console.log();
   console.log(`You can now import this module inside your application.`);
-  console.log(`For example, you can add this line to your App.tsx or App.js file:`);
-  console.log(`${chalk.gray.italic(`import ${name} from './modules/${slug}';`)}`);
+  console.log(`For example, you can add these lines to your App.tsx or App.js file:`);
+  console.log(importMessage);
   console.log();
   console.log(`Learn more on Expo Modules APIs: ${chalk.blue.bold(DOCS_URL)}`);
   console.log(
@@ -735,6 +773,11 @@ program
   .option(
     '--local',
     'Whether to create a local module in the current project, skipping installing node_modules and creating the example directory.',
+    false
+  )
+  .option(
+    '--barrel',
+    'Whether to generate an index.ts barrel file for the local module. Only applies to local modules',
     false
   )
   // Module configuration options (skip prompts when provided)

--- a/packages/create-expo-module/src/create-expo-module.ts
+++ b/packages/create-expo-module/src/create-expo-module.ts
@@ -172,6 +172,12 @@ async function main(target: string | undefined, options: CommandOptions) {
       await generateBarrelFileAsync(targetDir, data as LocalSubstitutionData);
       step.succeed('Generated barrel file (index.ts)');
     });
+  } else if (!options.local && options.barrel) {
+    console.warn(
+      chalk.yellow(
+        'Warning: The --barrel flag only applies to local modules (--local). It will be ignored.'
+      )
+    );
   }
   if (!options.local) {
     await newStep('Installing module dependencies', async (step) => {
@@ -229,6 +235,7 @@ async function main(target: string | undefined, options: CommandOptions) {
       slug,
       data.project.moduleName,
       data.project.viewName,
+      data.project.name,
       options.barrel
     );
   } else {
@@ -699,7 +706,7 @@ async function generateBarrelFileAsync(
 ): Promise<void> {
   const { moduleName, viewName, name } = data.project;
   const content = [
-    `// Reexport the native module. On web, it will be resolved to ${moduleName}.web.ts`,
+    `// Re-export the native module. On web, it will be resolved to ${moduleName}.web.ts`,
     `// and on native platforms to ${moduleName}.ts`,
     `export { default } from './src/${moduleName}';`,
     `export { default as ${viewName} } from './src/${viewName}';`,
@@ -738,15 +745,29 @@ function printFurtherLocalInstructions(
   slug: string,
   moduleName: string,
   viewName: string,
+  name: string,
   barrel: boolean
 ) {
-  const importMessage = barrel
-    ? `${chalk.gray.italic(`import ${moduleName}, { ${viewName} } from './modules/${slug}';`)}`
-    : `${chalk.gray.italic(`import ${moduleName} from './modules/${slug}/src/${moduleName}';`)}`;
   console.log();
   console.log(`You can now import this module inside your application.`);
   console.log(`For example, you can add these lines to your App.tsx or App.js file:`);
-  console.log(importMessage);
+  if (barrel) {
+    console.log(
+      chalk.gray.italic(`import ${moduleName}, { ${viewName} } from './modules/${slug}';`)
+    );
+  } else {
+    console.log(
+      chalk.gray.italic(`import ${moduleName} from './modules/${slug}/src/${moduleName}';`)
+    );
+    console.log(
+      chalk.gray.italic(
+        `import { default as ${viewName} } from './modules/${slug}/src/${viewName}';`
+      )
+    );
+    console.log(
+      chalk.gray.italic(`import type { } from './modules/${slug}/src/${name}.types';`)
+    );
+  }
   console.log();
   console.log(`Learn more on Expo Modules APIs: ${chalk.blue.bold(DOCS_URL)}`);
   console.log(

--- a/packages/create-expo-module/src/types.ts
+++ b/packages/create-expo-module/src/types.ts
@@ -10,6 +10,7 @@ export type CommandOptions = {
   withChangelog: boolean;
   example: boolean;
   local: boolean;
+  barrel: boolean;
   // Module configuration options (skip prompts when provided)
   name?: string;
   description?: string;

--- a/packages/expo-module-template-local/index.ts
+++ b/packages/expo-module-template-local/index.ts
@@ -1,5 +1,0 @@
-// Reexport the native module. On web, it will be resolved to <%- project.moduleName %>.web.ts
-// and on native platforms to <%- project.moduleName %>.ts
-export { default } from './src/<%- project.moduleName %>';
-export { default as <%- project.viewName %> } from './src/<%- project.viewName %>';
-export * from  './src/<%- project.name %>.types';


### PR DESCRIPTION
# Why

We don't want to add the barrel file for local modules by default

# How

Remove the barrel file from the local template. For people who prefer to have a barrel file I've added a `--barrel` flag, but it's off by default and when in interactive mode the user won't be prompted whether they want the barrel file.

# Test Plan

Tested on MacOS by creating a bunch of modules, also added E2E tests
