### PR TITLE
[iOS][precompiled] fixed issue with building minimal tester with precompiled React frameworks

### DIFF
--- a/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
@@ -106,6 +106,9 @@ module Pod
       else
         Pod::UI.puts "[Expo] ".yellow + "ReactCodegen target not found in pods project"
       end
+
+      # TODO: chrfalch - remove when RN 0.85 ships (VFS overlay fixes the umbrella header)
+      disable_swift_module_interface_for_prebuilt_react()
     end
 
     define_method(:run_podfile_pre_install_hooks) do
@@ -147,6 +150,24 @@ module Pod
       return :dynamic if ENV["USE_FRAMEWORKS"].downcase == 'dynamic'
       return :static if ENV["USE_FRAMEWORKS"].downcase == 'static'
       nil
+    end
+
+    # Prevents swiftinterface verification failures caused by the prebuilt React.xcframework's
+    # broken umbrella header. Only applied to pod target xcconfigs — aggregate target xcconfigs
+    # are left untouched so brownfield targets retain SWIFT_EMIT_MODULE_INTERFACE=YES.
+    # TODO: chrfalch - remove when RN 0.85 ships (VFS overlay fixes the umbrella header)
+    def disable_swift_module_interface_for_prebuilt_react()
+      return unless ENV['RCT_USE_PREBUILT_RNCORE'] == '1'
+
+      Pod::UI.puts "[Expo] ".blue + "Disabling SWIFT_EMIT_MODULE_INTERFACE for prebuilt React compatibility"
+
+      self.pod_targets.each do |pod_target|
+        pod_target.build_settings.each do |config_name, build_settings|
+          xcconfig = build_settings.xcconfig
+          xcconfig.attributes['SWIFT_EMIT_MODULE_INTERFACE'] = 'NO'
+          xcconfig.save_as(pod_target.xcconfig_path(config_name))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# Why

Usually we build Minimal-tester on CI with React from source to ensure this is working. I noticed that it didn't support being built with React precompiled.

CocoaPods 1.16.2 propagates BUILD_LIBRARY_FOR_DISTRIBUTION = YES from the brownfield target to all pod targets. This forces Xcode to verify .swiftinterface files,  which tries to build the React Clang module through the xcframework's broken umbrella header (React/xxx.h paths don't match React_Core/xxx.h reality). Fixed in RN  0.85 with a VFS overlay, but broken on RN 0.84.

Reproducing it by running pod install with:

RCT_USE_RN_DEP=1
RCT_USE_PREBUILT_RNCORE=1

# How

Fixed by writing SWIFT_EMIT_MODULE_INTERFACE = NO to pod target xcconfig files in perform_post_install_actions, skipping aggregate xcconfigs so the brownfield target isn't affected.

# Test Plan

✅ Build Bare Expo from source + with precompiled
✅ Build Minimaltester from source + with precompiled

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).