### PR TITLE
[asset] fix md5 calculation

### DIFF
--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed incorrect MD5 checksum on Android. ([#43909](https://github.com/expo/expo/pull/43909) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 55.0.7 — 2026-02-25

--- a/packages/expo-asset/android/src/main/java/expo/modules/asset/AssetModule.kt
+++ b/packages/expo-asset/android/src/main/java/expo/modules/asset/AssetModule.kt
@@ -12,9 +12,7 @@ import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.kotlin.services.FilePermissionService
 import kotlinx.coroutines.withContext
 import java.io.File
-import java.io.FileInputStream
 import java.net.URI
-import java.security.DigestInputStream
 import java.security.MessageDigest
 
 internal class UnableToDownloadAssetException(url: String) :
@@ -27,22 +25,6 @@ class AssetModule : Module() {
   private fun getMD5HashOfFilePath(uri: URI): String {
     val md = MessageDigest.getInstance("MD5")
     return md.digest(uri.toString().toByteArray()).joinToString("") { "%02x".format(it) }
-  }
-
-  private fun getMD5HashOfFileContent(file: File): String? {
-    return try {
-      FileInputStream(file).use { inputStream ->
-        DigestInputStream(
-          inputStream,
-          MessageDigest.getInstance("MD5")
-        ).use { digestInputStream ->
-          digestInputStream.messageDigest.digest().joinToString(separator = "") { "%02x".format(it) }
-        }
-      }
-    } catch (e: Exception) {
-      e.printStackTrace()
-      null
-    }
   }
 
   private suspend fun downloadAsset(appContext: AppContext, uri: URI, localUrl: File): Uri {

--- a/packages/expo-asset/android/src/main/java/expo/modules/asset/FileUtils.kt
+++ b/packages/expo-asset/android/src/main/java/expo/modules/asset/FileUtils.kt
@@ -1,0 +1,23 @@
+package expo.modules.asset
+
+import java.io.File
+import java.io.FileInputStream
+import java.security.MessageDigest
+
+internal fun getMD5HashOfFileContent(file: File): String? {
+  return try {
+    val digest = MessageDigest.getInstance("MD5")
+    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+    FileInputStream(file).use { inputStream ->
+      while (true) {
+        val bytesRead = inputStream.read(buffer)
+        if (bytesRead == -1) break
+        digest.update(buffer, 0, bytesRead)
+      }
+    }
+    digest.digest().joinToString(separator = "") { "%02x".format(it) }
+  } catch (e: Exception) {
+    e.printStackTrace()
+    null
+  }
+}

--- a/packages/expo-asset/android/src/test/java/expo/modules/asset/FileUtilsTest.kt
+++ b/packages/expo-asset/android/src/test/java/expo/modules/asset/FileUtilsTest.kt
@@ -1,0 +1,30 @@
+package expo.modules.asset
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+import java.security.MessageDigest
+
+@RunWith(RobolectricTestRunner::class)
+class FileUtilsTest {
+  @Test
+  fun `getMD5HashOfFileContent should return correct MD5 hash for file content`() {
+    val content = "hello world"
+    val tempFile = File.createTempFile("test-asset", ".txt").apply {
+      deleteOnExit()
+      writeText(content)
+    }
+
+    val expected = MessageDigest.getInstance("MD5")
+      .digest(content.toByteArray())
+      .joinToString("") { "%02x".format(it) }
+
+    val result = getMD5HashOfFileContent(tempFile)
+
+    assertNotNull(result)
+    assertEquals(expected, result)
+  }
+}


### PR DESCRIPTION
# Why

fixes #43872

# How

fix the problem where the `DigestInputStream` early checksum without reading anything

the expo-updates implementation is correct actually:
https://github.com/expo/expo/blob/e0c0db8d19a069570b9e9386ed0fbb818669be91/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt#L69-L84

# Test Plan

move `getMD5HashOfFileContent` to a dedicated **FileUtils.kt** for testing and use TDD style for testing

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
