### PR TITLE
fix(autolinking): respect NO_COLOR and handle async errors in CLI entry

### DIFF
--- a/packages/expo-modules-autolinking/bin/expo-modules-autolinking.js
+++ b/packages/expo-modules-autolinking/bin/expo-modules-autolinking.js
@@ -3,6 +3,15 @@
 
 // Have to force color support — logs wouldn't have colors when spawned by another process.
 // It must be set before `supports-color` (`chalk` dependency) module is imported.
-process.env.FORCE_COLOR = 'true';
+// Respect NO_COLOR convention (https://no-color.org/) — tools like CocoaPods set this
+// to prevent ANSI codes from corrupting JSON output parsed by autolinking scripts.
+if (!process.env.NO_COLOR) {
+  process.env.FORCE_COLOR = 'true';
+}
 
-require('../build')(process.argv.slice(2));
+require('../build')(process.argv.slice(2)).catch((error) => {
+  // Ensure errors are visible on stderr — without this, unhandled async rejections
+  // can cause silent empty stdout, which breaks JSON parsing in CocoaPods/Ruby.
+  console.error('expo-modules-autolinking failed:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

The `expo-modules-autolinking` CLI entry point has two issues that combine to cause intermittent, hard-to-debug `pod install` failures during `expo prebuild`:

### 1. `FORCE_COLOR` overrides `NO_COLOR` convention

Line 6 of `bin/expo-modules-autolinking.js` unconditionally sets `process.env.FORCE_COLOR = 'true'`, ignoring the [`NO_COLOR`](https://no-color.org/) environment variable. Tools like CocoaPods' autolinking Ruby scripts set `NO_COLOR=1` to ensure clean JSON output, but this override causes ANSI color codes to leak into structured output.

### 2. Unhandled async rejection causes silent empty stdout

`require('../build')(process.argv.slice(2))` calls an `async main()` function but never awaits or catches the returned promise. If any step in the resolve command throws (e.g., transient file system issue during `prebuild --clean`), the rejection is unhandled — the error goes only to stderr, stdout is empty, and Ruby's `IO.popen` gets nothing to parse, producing:

```
Couldn't parse JSON coming from `expo-modules-autolinking` command:
unexpected end of input at line 1 column 1.
```

### Changes

- Check for `NO_COLOR` before setting `FORCE_COLOR` (per https://no-color.org/)
- Add `.catch()` handler to surface errors on stderr with a meaningful message and set a non-zero exit code

## Test plan

- [ ] Run `NO_COLOR=1 node bin/expo-modules-autolinking.js resolve --platform apple` — verify no ANSI codes in output
- [ ] Run without `NO_COLOR` — verify colors still work
- [ ] Simulate a failure in the resolve command — verify error appears on stderr instead of silent empty stdout