### PR TITLE
fix(autolinking): improve iOS resolve error messages with stderr capture

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Improved iOS autolinking resolve error messages with stderr capture. ([#43916](https://github.com/expo/expo/pull/43916) by [@yocontra](https://github.com/yocontra))
 - Fix regression that caused `pod install` to fail with `no implicit conversion of nil into String` due to an off-by-one in the depth limit check. ([#43731](https://github.com/expo/expo/pull/43731) by [@zoontek](https://github.com/zoontek))
 - Stop dependency resolution at depth limit and increase max depth limit to 9 ([#43636](https://github.com/expo/expo/pull/43636) by [@kitten](https://github.com/kitten))
 - Sort on unresolved path and load `version` for duplicate dependencies ([#43636](https://github.com/expo/expo/pull/43636) by [@kitten](https://github.com/kitten))

--- a/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
@@ -186,7 +186,8 @@ module Expo
           return JSON.parse(stdout)
         rescue => error
           raise "Couldn't parse JSON coming from `expo-modules-autolinking` command:\n#{error}\n" \
-                "stdout (first 500 chars): #{stdout[0..500]}\n" \
+                "Command: #{resolve_command_args.join(' ')}\n" \
+                "stdout: #{stdout.strip}\n" \
                 "stderr: #{stderr.strip}"
         end
       end

--- a/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
@@ -178,18 +178,27 @@ module Expo
     end
 
     public def resolve
-      json = []
+      require 'open3'
+      stdout, stderr, status = Open3.capture3(*resolve_command_args)
 
-      IO.popen(resolve_command_args) do |data|
-        while line = data.gets
-          json << line
-        end
+      if !status.success?
+        raise "expo-modules-autolinking command exited with status #{status.exitstatus}.\n" \
+              "Command: #{resolve_command_args.join(' ')}\n" \
+              "stderr: #{stderr.strip}"
+      end
+
+      if stdout.strip.empty?
+        raise "expo-modules-autolinking command returned empty output.\n" \
+              "Command: #{resolve_command_args.join(' ')}\n" \
+              "stderr: #{stderr.strip}"
       end
 
       begin
-        JSON.parse(json.join())
+        JSON.parse(stdout)
       rescue => error
-        raise "Couldn't parse JSON coming from `expo-modules-autolinking` command:\n#{error}"
+        raise "Couldn't parse JSON coming from `expo-modules-autolinking` command:\n#{error}\n" \
+              "stdout (first 500 chars): #{stdout[0..500]}\n" \
+              "stderr: #{stderr.strip}"
       end
     end
 

--- a/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
@@ -179,39 +179,27 @@ module Expo
 
     public def resolve
       require 'open3'
-      max_retries = 3
-      last_error = nil
+      stdout, stderr, status = Open3.capture3(*resolve_command_args)
 
-      max_retries.times do |attempt|
-        stdout, stderr, status = Open3.capture3(*resolve_command_args)
-
-        if status.success? && !stdout.strip.empty?
-          begin
-            return JSON.parse(stdout)
-          rescue => error
-            last_error = "Couldn't parse JSON coming from `expo-modules-autolinking` command:\n#{error}\n" \
-                         "stdout (first 500 chars): #{stdout[0..500]}\n" \
-                         "stderr: #{stderr.strip}"
-          end
-        else
-          if !status.success?
-            last_error = "expo-modules-autolinking command exited with status #{status.exitstatus}.\n" \
-                         "Command: #{resolve_command_args.join(' ')}\n" \
-                         "stderr: #{stderr.strip}"
-          else
-            last_error = "expo-modules-autolinking command returned empty output.\n" \
-                         "Command: #{resolve_command_args.join(' ')}\n" \
-                         "stderr: #{stderr.strip}"
-          end
-        end
-
-        if attempt < max_retries - 1
-          Pod::UI.warn "expo-modules-autolinking attempt #{attempt + 1} failed, retrying... (#{last_error.lines.first.strip})"
-          sleep(1)
+      if status.success? && !stdout.strip.empty?
+        begin
+          return JSON.parse(stdout)
+        rescue => error
+          raise "Couldn't parse JSON coming from `expo-modules-autolinking` command:\n#{error}\n" \
+                "stdout (first 500 chars): #{stdout[0..500]}\n" \
+                "stderr: #{stderr.strip}"
         end
       end
 
-      raise last_error
+      if !status.success?
+        raise "expo-modules-autolinking command exited with status #{status.exitstatus}.\n" \
+              "Command: #{resolve_command_args.join(' ')}\n" \
+              "stderr: #{stderr.strip}"
+      end
+
+      raise "expo-modules-autolinking command returned empty output.\n" \
+            "Command: #{resolve_command_args.join(' ')}\n" \
+            "stderr: #{stderr.strip}"
     end
 
     public def base_command_args

--- a/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
@@ -179,27 +179,39 @@ module Expo
 
     public def resolve
       require 'open3'
-      stdout, stderr, status = Open3.capture3(*resolve_command_args)
+      max_retries = 3
+      last_error = nil
 
-      if !status.success?
-        raise "expo-modules-autolinking command exited with status #{status.exitstatus}.\n" \
-              "Command: #{resolve_command_args.join(' ')}\n" \
-              "stderr: #{stderr.strip}"
+      max_retries.times do |attempt|
+        stdout, stderr, status = Open3.capture3(*resolve_command_args)
+
+        if status.success? && !stdout.strip.empty?
+          begin
+            return JSON.parse(stdout)
+          rescue => error
+            last_error = "Couldn't parse JSON coming from `expo-modules-autolinking` command:\n#{error}\n" \
+                         "stdout (first 500 chars): #{stdout[0..500]}\n" \
+                         "stderr: #{stderr.strip}"
+          end
+        else
+          if !status.success?
+            last_error = "expo-modules-autolinking command exited with status #{status.exitstatus}.\n" \
+                         "Command: #{resolve_command_args.join(' ')}\n" \
+                         "stderr: #{stderr.strip}"
+          else
+            last_error = "expo-modules-autolinking command returned empty output.\n" \
+                         "Command: #{resolve_command_args.join(' ')}\n" \
+                         "stderr: #{stderr.strip}"
+          end
+        end
+
+        if attempt < max_retries - 1
+          Pod::UI.warn "expo-modules-autolinking attempt #{attempt + 1} failed, retrying... (#{last_error.lines.first.strip})"
+          sleep(1)
+        end
       end
 
-      if stdout.strip.empty?
-        raise "expo-modules-autolinking command returned empty output.\n" \
-              "Command: #{resolve_command_args.join(' ')}\n" \
-              "stderr: #{stderr.strip}"
-      end
-
-      begin
-        JSON.parse(stdout)
-      rescue => error
-        raise "Couldn't parse JSON coming from `expo-modules-autolinking` command:\n#{error}\n" \
-              "stdout (first 500 chars): #{stdout[0..500]}\n" \
-              "stderr: #{stderr.strip}"
-      end
+      raise last_error
     end
 
     public def base_command_args


### PR DESCRIPTION
## Summary

Replaces IO.popen with Open3.capture3 in the iOS autolinking manager resolve method. The original code discards stderr and exit status, making failures impossible to diagnose.

### Changes

- Use Open3.capture3 to capture stdout, stderr, and exit status separately
- Report the actual command, exit status, and stderr content on failure
- Include first 500 chars of stdout in JSON parse errors for debugging
- Differentiate between non-zero exit, empty output, and JSON parse failures

Companion PR: #43915 (fixes the root cause - FORCE_COLOR overriding NO_COLOR)

## Test plan

- Verified pod install succeeds with the patched resolve method
- Verified error messages are properly surfaced when the command fails
- Tested with both NO_COLOR=1 and without