### PR TITLE
[widgets] Pass environment to AppIntent

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Add support for `after(date)` dismissal policy, final content state, and `contentDate` when ending a Live Activity. ([#43472](https://github.com/expo/expo/pull/43472) by [@jakex7](https://github.com/jakex7))
 - [plugin] Add `contentMarginsDisabled`. ([#43799](https://github.com/expo/expo/pull/43799) by [@jakex7](https://github.com/jakex7))
+- Pass environment to AppIntent ([#43925](https://github.com/expo/expo/pull/43925) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-widgets/ios/Widgets/AppIntent.swift
+++ b/packages/expo-widgets/ios/Widgets/AppIntent.swift
@@ -15,11 +15,15 @@ struct WidgetUserInteraction: AppIntent {
   @Parameter(title: "entryIndex")
   var entryIndex: Int?
 
+  @Parameter(title: "environmentString")
+  var environmentString: String?
+
   init() {}
-  init(source: String?, target: String?, entryIndex: Int?) {
+  init(source: String?, target: String?, entryIndex: Int?, environmentString: String?) {
     self.source = source
     self.target = target
     self.entryIndex = entryIndex
+    self.environmentString = environmentString
   }
 
   func perform() async throws -> some IntentResult {
@@ -34,15 +38,15 @@ struct WidgetUserInteraction: AppIntent {
           let entryIndex,
           let entry = timeline[entryIndex] as? [String: Any],
           let props = entry["props"] as? [String: Any],
-          let context = createWidgetContext(layout: layout) else {
+          let context = createWidgetContext(layout: layout),
+          let environmentData = environmentString?.data(using: .utf8),
+          var environment = try? JSONSerialization.jsonObject(with: environmentData) as? [String: Any] else {
       return .result()
     }
-    let pressEnvironment: [String: Any] = [
-      "timestamp": Int(Date.now.timeIntervalSince1970 * 1000),
-      "target": target as Any
-    ]
+    environment["target"] = target
+
     let result = context.objectForKeyedSubscript("__expoWidgetHandlePress")?.call(
-      withArguments: [props, pressEnvironment]
+      withArguments: [props, environment]
     )
     if let newProps = result?.toObject() as? [String: Any] {
       var newEntry = entry

--- a/packages/expo-widgets/ios/Widgets/Buttons.swift
+++ b/packages/expo-widgets/ios/Widgets/Buttons.swift
@@ -6,6 +6,7 @@ final class ButtonProps: ExpoUI.ButtonProps {
   @Field var source: String?
   @Field var target: String?
   @Field var entryIndex: Int?
+  @Field var environmentString: String?
 }
 
 @available(iOS 17.0, *)
@@ -18,7 +19,8 @@ struct WidgetButtonView: ExpoSwiftUI.View {
       intent: WidgetUserInteraction(
         source: props.source,
         target: props.target,
-        entryIndex: props.entryIndex
+        entryIndex: props.entryIndex,
+        environmentString: props.environmentString
       )
     ) {
       if let label = props.label {

--- a/packages/expo-widgets/ios/Widgets/DynamicView.swift
+++ b/packages/expo-widgets/ios/Widgets/DynamicView.swift
@@ -18,27 +18,30 @@ extension ObjectIdentifier: @retroactive Encodable {
 
 public struct WidgetsDynamicView: View, ExpoSwiftUI.AnyChild {
   let node: [String: Any]
-  let source: String
+  let name: String
   let kind: WidgetsKind
   let entryIndex: Int?
+  let environmentString: String?
 
   let uuid = NodeIdentityWrapper(id: UUID())
   public var id: ObjectIdentifier {
     ObjectIdentifier(uuid)
   }
 
-  public init(source: String, kind: WidgetsKind, node: [String: Any]) {
-    self.source = source
+  public init(name: String, kind: WidgetsKind, node: [String: Any]) {
+    self.name = name
     self.kind = kind
     self.node = node
     self.entryIndex = nil
+    self.environmentString = nil
   }
 
-  public init(source: String, kind: WidgetsKind, node: [String: Any], entryIndex: Int?) {
-    self.source = source
+  public init(name: String, kind: WidgetsKind, node: [String: Any], entryIndex: Int?, environmentString: String?) {
+    self.name = name
     self.kind = kind
     self.node = node
     self.entryIndex = entryIndex
+    self.environmentString = environmentString
   }
 
   @ViewBuilder
@@ -82,13 +85,14 @@ public struct WidgetsDynamicView: View, ExpoSwiftUI.AnyChild {
         case .widget:
           render(WidgetButtonView.self, ButtonProps.self) { buttonProps in
             try updateChildren(buttonProps)
-            buttonProps.source = source
+            buttonProps.source = name
             buttonProps.entryIndex = entryIndex
+            buttonProps.environmentString = environmentString
           }
         case .liveActivity:
           render(LiveActivityButtonView.self, ButtonProps.self) { buttonProps in
             try updateChildren(buttonProps)
-            buttonProps.source = source
+            buttonProps.source = name
           }
         }
       } else {
@@ -132,9 +136,9 @@ public struct WidgetsDynamicView: View, ExpoSwiftUI.AnyChild {
     if let props = node["props"] as? [String: Any] {
       if let children = props["children"] as? [Any] {
         let validChildren = children.compactMap { $0 as? [String: Any] }
-        initialProps.children = validChildren.map { WidgetsDynamicView(source: source, kind: kind, node: $0, entryIndex: entryIndex) }
+        initialProps.children = validChildren.map { WidgetsDynamicView(name: name, kind: kind, node: $0, entryIndex: entryIndex, environmentString: environmentString) }
       } else if let child = props["children"] as? [String: Any] {
-        initialProps.children = [WidgetsDynamicView(source: source, kind: kind, node: child, entryIndex: entryIndex)]
+        initialProps.children = [WidgetsDynamicView(name: name, kind: kind, node: child, entryIndex: entryIndex, environmentString: environmentString)]
       }
     }
   }

--- a/packages/expo-widgets/ios/Widgets/EntryView.swift
+++ b/packages/expo-widgets/ios/Widgets/EntryView.swift
@@ -16,16 +16,24 @@ public struct WidgetsEntryView: View {
     return env
   }
 
+  private var widgetEnvironmentString: String? {
+    guard let data = try? JSONSerialization.data(withJSONObject: widgetEnvironment),
+          let jsonString = String(data: data, encoding: .utf8) else {
+        return nil
+    }
+    return jsonString
+  }
+
   public var body: some View {
-    let layout = WidgetsStorage.getString(forKey: "__expo_widgets_\(entry.source)_layout") ?? ""
+    let layout = WidgetsStorage.getString(forKey: "__expo_widgets_\(entry.name)_layout") ?? ""
     let node = evaluateLayout(layout: layout, props: entry.props ?? [:], environment: widgetEnvironment)
 
     if let node {
       if #available(iOS 17.0, *) {
-        WidgetsDynamicView(source: entry.source, kind: .widget, node: node, entryIndex: entry.entryIndex)
+        WidgetsDynamicView(name: entry.name, kind: .widget, node: node, entryIndex: entry.entryIndex, environmentString: widgetEnvironmentString)
           .containerBackground(.clear, for: .widget)
       } else {
-        WidgetsDynamicView(source: entry.source, kind: .widget, node: node, entryIndex: entry.entryIndex)
+        WidgetsDynamicView(name: entry.name, kind: .widget, node: node, entryIndex: entry.entryIndex, environmentString: widgetEnvironmentString)
       }
     } else {
       EmptyView()

--- a/packages/expo-widgets/ios/Widgets/LiveActivityBanner.swift
+++ b/packages/expo-widgets/ios/Widgets/LiveActivityBanner.swift
@@ -9,9 +9,9 @@ struct LiveActivityBanner: View {
 
   var body: some View {
     if activityFamily == .small, let node = nodes?["bannerSmall"] as? [String: Any] {
-      WidgetsDynamicView(source: context.activityID, kind: .liveActivity, node: node)
+      WidgetsDynamicView(name: context.activityID, kind: .liveActivity, node: node)
     } else if let node = nodes?["banner"] as? [String: Any] {
-      WidgetsDynamicView(source: context.activityID, kind: .liveActivity, node: node)
+      WidgetsDynamicView(name: context.activityID, kind: .liveActivity, node: node)
     } else {
       EmptyView()
     }

--- a/packages/expo-widgets/ios/Widgets/TimelineEntry.swift
+++ b/packages/expo-widgets/ios/Widgets/TimelineEntry.swift
@@ -2,7 +2,7 @@ import WidgetKit
 
 public struct WidgetsTimelineEntry: WidgetKit.TimelineEntry {
   public let date: Date
-  public let source: String
+  public let name: String
   public let props: [String: Any]?
   public let entryIndex: Int?
 }

--- a/packages/expo-widgets/ios/Widgets/TimelineProvider.swift
+++ b/packages/expo-widgets/ios/Widgets/TimelineProvider.swift
@@ -2,7 +2,7 @@ import WidgetKit
 
 public struct WidgetsTimelineProvider: TimelineProvider {
   public func placeholder(in context: Context) -> WidgetsTimelineEntry {
-    WidgetsTimelineEntry(date: Date(), source: name, props: nil, entryIndex: nil)
+    WidgetsTimelineEntry(date: Date(), name: name, props: nil, entryIndex: nil)
   }
 
   public func getSnapshot(
@@ -11,12 +11,12 @@ public struct WidgetsTimelineProvider: TimelineProvider {
     let groupIdentifier =
       Bundle.main.object(forInfoDictionaryKey: "ExpoWidgetsAppGroupIdentifier") as? String
     guard let groupIdentifier else {
-      completion(WidgetsTimelineEntry(date: Date(), source: name, props: nil, entryIndex: nil))
+      completion(WidgetsTimelineEntry(date: Date(), name: name, props: nil, entryIndex: nil))
       return
     }
 
     let entries = parseTimeline(identifier: groupIdentifier, name: name, family: context.family)
-    completion(entries.first ?? WidgetsTimelineEntry(date: Date(), source: name, props: nil, entryIndex: nil))
+    completion(entries.first ?? WidgetsTimelineEntry(date: Date(), name: name, props: nil, entryIndex: nil))
   }
 
   public func getTimeline(

--- a/packages/expo-widgets/ios/Widgets/Utils.swift
+++ b/packages/expo-widgets/ios/Widgets/Utils.swift
@@ -9,7 +9,7 @@ func parseTimeline(identifier: String, name: String, family: WidgetFamily) -> [W
     if let entry = entry as? [String: Any], let timestamp = entry["timestamp"] as? Int, let props = entry["props"] as? [String: Any] {
       return WidgetsTimelineEntry(
         date: Date(timeIntervalSince1970: Double(timestamp) / 1000),
-        source: name,
+        name: name,
         props: props,
         entryIndex: index
       )

--- a/packages/expo-widgets/ios/Widgets/WidgetLiveActivity.swift
+++ b/packages/expo-widgets/ios/Widgets/WidgetLiveActivity.swift
@@ -65,7 +65,7 @@ private struct LiveActivitySectionView: View {
       environment: environment
     )
     if let node = nodes[sectionName] as? [String: Any] {
-      WidgetsDynamicView(source: context.activityID, kind: .liveActivity, node: node)
+      WidgetsDynamicView(name: context.activityID, kind: .liveActivity, node: node)
     } else {
       EmptyView()
     }
@@ -86,7 +86,7 @@ private struct LiveActivityBannerView: View {
     if #available(iOS 18.0, *) {
       LiveActivityBanner(context: context, nodes: nodes)
     } else if let node = nodes["banner"] as? [String: Any] {
-      WidgetsDynamicView(source: context.activityID, kind: .liveActivity, node: node)
+      WidgetsDynamicView(name: context.activityID, kind: .liveActivity, node: node)
     } else {
       EmptyView()
     }


### PR DESCRIPTION
# Why

It's first step to remove `target` requirement on `Button`.

# How

Pass stringified JSON widget environment to `AppIntent`

# Test Plan

Inspect environment in AppIntent execution.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
