### PR TITLE
[create-expo-module] Improve non-interactive detection, add tests

### DIFF
--- a/packages/create-expo-module/e2e/__tests__/index-test.ts
+++ b/packages/create-expo-module/e2e/__tests__/index-test.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 import {
+  createFakeProject,
   createTestPath,
   ensureFolderExists,
   executePassing,
@@ -186,5 +187,68 @@ describe('--barrel option', () => {
 
     // The success message should include a direct src/ path
     expect(result.stdout).toMatch(new RegExp(`from './modules/${slug}/src/`));
+  });
+});
+
+describe('CI mode detection', () => {
+  const localTemplatePath = path.resolve(
+    __dirname,
+    '../../../../packages/expo-module-template-local'
+  );
+  let ciProjectRoot: string;
+
+  beforeAll(() => {
+    ciProjectRoot = createFakeProject();
+  });
+
+  afterAll(async () => {
+    if (fs.existsSync(ciProjectRoot)) {
+      await fs.promises.rm(ciProjectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('completes non-interactively with CI=1', async () => {
+    const result = await executePassing(
+      ['detect-ci-one', '--local', '--source', localTemplatePath],
+      {
+        cwd: ciProjectRoot,
+        env: { CI: '1' },
+      }
+    );
+    expect(result.stdout).toMatch(/Successfully created/);
+  });
+
+  it('completes non-interactively with CI=true', async () => {
+    const result = await executePassing(
+      ['detect-ci-true', '--local', '--source', localTemplatePath],
+      { cwd: ciProjectRoot, env: { CI: 'true' } }
+    );
+    expect(result.stdout).toMatch(/Successfully created/);
+  });
+
+  it('completes non-interactively with CI=TRUE (case-insensitive)', async () => {
+    const result = await executePassing(
+      ['detect-ci-true-upper', '--local', '--source', localTemplatePath],
+      { cwd: ciProjectRoot, env: { CI: 'TRUE' } }
+    );
+    expect(result.stdout).toMatch(/Successfully created/);
+  });
+
+  it('completes non-interactively when EXPO_NONINTERACTIVE=1 and CI is not set', async () => {
+    const result = await executePassing(
+      ['detect-expo-noninteractive', '--local', '--source', localTemplatePath],
+      { cwd: ciProjectRoot, env: { CI: '0', EXPO_NONINTERACTIVE: '1' } }
+    );
+    expect(result.stdout).toMatch(/Successfully created/);
+  });
+
+  it('completes non-interactively via non-TTY stdin when neither CI nor EXPO_NONINTERACTIVE is set', async () => {
+    // CI=0 and EXPO_NONINTERACTIVE unset — spawned processes always have non-TTY stdin,
+    // so isInteractive() falls through to the isTTY check and returns false
+    const result = await executePassing(
+      ['detect-non-tty', '--local', '--source', localTemplatePath],
+      { cwd: ciProjectRoot, env: { CI: '0' } }
+    );
+    expect(result.stdout).toMatch(/Successfully created/);
   });
 });

--- a/packages/create-expo-module/e2e/__tests__/utils.ts
+++ b/packages/create-expo-module/e2e/__tests__/utils.ts
@@ -91,6 +91,20 @@ export function expectFileNotExists(projectName: string, ...filePath: string[]) 
   expect({ [targetPath]: fs.existsSync(targetPath) }).toEqual({ [targetPath]: false });
 }
 
+/**
+ * Creates a temporary directory with a minimal package.json, simulating an Expo project root.
+ * Used for --local module tests. The caller is responsible for cleaning up.
+ */
+export function createFakeProject(): string {
+  const projectPath = getTemporaryPath();
+  fs.mkdirSync(projectPath, { recursive: true });
+  fs.writeFileSync(
+    path.join(projectPath, 'package.json'),
+    JSON.stringify({ name: 'test-app', version: '1.0.0' })
+  );
+  return projectPath;
+}
+
 /** Read and parse a JSON file from the test project */
 export function readJson(projectName: string, ...filePath: string[]) {
   const targetPath = getTestPath(projectName, ...filePath);

--- a/packages/create-expo-module/src/create-expo-module.ts
+++ b/packages/create-expo-module/src/create-expo-module.ts
@@ -57,9 +57,13 @@ const FYI_LOCAL_DIR = 'https://expo.fyi/expo-module-local-autolinking.md';
  * Non-interactive when: CI=1/true or non-TTY stdin.
  */
 function isInteractive(): boolean {
-  // Check for CI environment
   const ci = process.env.CI;
-  if (ci === '1' || ci === 'true' || ci?.toLowerCase() === 'true') {
+  if (ci === '1' || ci?.toLowerCase() === 'true') {
+    return false;
+  }
+  // Check for Expo's own non-interactive flag, used across expo-module-scripts and @expo/cli
+  // to force non-interactive mode in sub-processes (e.g. during `prepare` or `prepublishOnly`)
+  if (process.env.EXPO_NONINTERACTIVE) {
     return false;
   }
   // Check for TTY


### PR DESCRIPTION
# Why

I was checking if any improvements can be made to the non-interactive mode in `create-expo-module`. I didn't really find much, I added some tests though.

# How

Check for `EXPO_NONINTERACTIVE` just in case, add a few detection tests to non-interactive mode.`ci === 'true' || ci?.toLowerCase() === 'true'` can be simplified to ` ci?.toLowerCase() === 'true' `

# Test Plan

Tested on MacOS by running `yarn test:e2e`
