### PR TITLE
[ios][sqlite] Fix database path handling for paths with whitespace

### DIFF
--- a/packages/expo-sqlite/ios/SQLiteModule.swift
+++ b/packages/expo-sqlite/ios/SQLiteModule.swift
@@ -311,9 +311,7 @@ public final class SQLiteModule: Module {
       throw Exceptions.FileSystemModuleNotFound()
     }
 
-    guard let pathUrl = URL(string: path) else {
-      throw DatabaseInvalidPathException(path)
-    }
+    let pathUrl = URL(fileURLWithPath: path)
     fileSystem.ensureDirExists(withPath: pathUrl.deletingLastPathComponent().toFilePath())
 
     return pathUrl


### PR DESCRIPTION
# Why

The `ensureDatabasePathExists` function in `SQLiteModule.swift` uses `URL(string:)` to parse file paths, which fails when the path contains whitespace or special characters. For example, paths like `/My Custom Path/Database` throw a `DatabaseInvalidPathException` even though they are valid file system paths.

# How

- Changed `URL(string: path)` to `URL(fileURLWithPath: path)` in ensureDatabasePathExists. URL(fileURLWithPath:) is the correct Swift API for creating URLs from file system paths
- Removed unnecessary `guard let` since `URL(fileURLWithPath:)` always returns a valid URL for file paths

# Test Plan

- Tested opening databases in directories with spaces in their names
- Verified existing tests still pass
- Confirmed database operations (create, read, write) work correctly with whitespace paths

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
