### PR TITLE
[ui][android] - Improve `ExpoUIView` definition builder to support events in props

### DIFF
--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeEventDispatcher.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeEventDispatcher.kt
@@ -1,0 +1,26 @@
+package expo.modules.kotlin.views
+
+/**
+ * A typed event dispatcher that lives on [ComposeProps] data classes.
+ * Auto-discovered by the framework at view registration time,
+ *
+ * Usage in a Props class:
+ * ```
+ * data class ButtonProps(
+ *   val enabled: Boolean = true,
+ *   val onButtonPressed: ComposeEventDispatcher<ButtonPressedEvent> = ComposeEventDispatcher()
+ * ) : ComposeProps
+ * ```
+ *
+ * Then in the Content composable:
+ * ```
+ * Button(onClick = { props.onButtonPressed(ButtonPressedEvent()) })
+ * ```
+ */
+class ComposeEventDispatcher<T> {
+  internal var callback: ((T) -> Unit)? = null
+
+  operator fun invoke(arg: T) {
+    callback?.invoke(arg)
+  }
+}

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeEventDispatcher.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeEventDispatcher.kt
@@ -1,8 +1,10 @@
 package expo.modules.kotlin.views
 
+import expo.modules.kotlin.viewevent.CoalescingKey
+
 /**
  * A typed event dispatcher that lives on [ComposeProps] data classes.
- * Auto-discovered by the framework at view registration time,
+ * Auto-discovered by the framework at view registration time.
  *
  * Usage in a Props class:
  * ```
@@ -16,8 +18,18 @@ package expo.modules.kotlin.views
  * ```
  * Button(onClick = { props.onButtonPressed(ButtonPressedEvent()) })
  * ```
+ *
+ * For high-frequency events, provide a [coalescingKey] so the bridge can merge
+ * rapid-fire events and only deliver the latest:
+ * ```
+ * val onValueChange: ComposeEventDispatcher<SliderEvent> = ComposeEventDispatcher(
+ *   coalescingKey = { (it.value.hashCode() % Short.MAX_VALUE).toShort() }
+ * )
+ * ```
  */
-class ComposeEventDispatcher<T> {
+class ComposeEventDispatcher<T>(
+  val coalescingKey: CoalescingKey<T>? = null
+) {
   internal var callback: ((T) -> Unit)? = null
 
   operator fun invoke(arg: T) {

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -17,10 +17,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.view.size
 import expo.modules.kotlin.AppContext
-import expo.modules.kotlin.viewevent.CoalescingKey
-import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.viewevent.ViewEvent
-import expo.modules.kotlin.viewevent.ViewEventDelegate
 
 data class ComposableScope(
   val rowScope: RowScope? = null,
@@ -231,9 +228,6 @@ class FunctionalComposableScope(
     view.Children(composableScope, filter)
   }
 
-  inline fun <reified T> EventDispatcher(noinline coalescingKey: CoalescingKey<T>? = null): ViewEventDelegate<T> {
-    return view.EventDispatcher<T>(coalescingKey)
-  }
 }
 
 @SuppressLint("ViewConstructor")

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ModuleDefinitionBuilderComposeExtension.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ModuleDefinitionBuilderComposeExtension.kt
@@ -85,7 +85,7 @@ class ComposeViewFunctionDefinitionBuilder<Props : ComposeProps>(
           val property = eventProp as KProperty1<Props, ComposeEventDispatcher<Any?>>
           property.isAccessible = true
           val dispatcher = property.get(instance)
-          dispatcher.callback = { arg -> ViewEvent(eventProp.name, holder, null).invoke(arg) }
+          dispatcher.callback = { arg -> ViewEvent(eventProp.name, holder, dispatcher.coalescingKey).invoke(arg) }
         }
 
         holder

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ModuleDefinitionBuilderComposeExtension.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ModuleDefinitionBuilderComposeExtension.kt
@@ -8,10 +8,13 @@ import expo.modules.kotlin.modules.InternalModuleDefinitionBuilder
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.types.AnyType
 import expo.modules.kotlin.types.LazyKType
+import expo.modules.kotlin.viewevent.ViewEvent
 import expo.modules.kotlin.views.decorators.UseCSSProps
 import kotlin.reflect.KClass
+import kotlin.reflect.KProperty1
 import kotlin.reflect.full.createInstance
 import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.isAccessible
 import kotlin.reflect.typeOf
 
 /**
@@ -44,11 +47,9 @@ open class ModuleDefinitionBuilderWithCompose(
   @JvmName("ComposeView")
   inline fun <reified Props : ComposeProps> View(
     name: String,
-    events: ComposeViewFunctionDefinitionBuilder<Props>.() -> Unit = {},
     noinline viewFunction: @Composable FunctionalComposableScope.(props: Props) -> Unit
   ) {
     val definitionBuilder = ComposeViewFunctionDefinitionBuilder(name, Props::class, viewFunction)
-    events.invoke(definitionBuilder)
     registerViewDefinition(definitionBuilder.build())
   }
 }
@@ -59,9 +60,15 @@ class ComposeViewFunctionDefinitionBuilder<Props : ComposeProps>(
   val propsClass: KClass<Props>,
   val viewFunction: @Composable FunctionalComposableScope.(props: Props) -> Unit
 ) {
-  private var callbacksDefinition: CallbacksDefinition = CallbacksDefinition(arrayOf(GLOBAL_EVENT_NAME))
-
   fun build(): ViewManagerDefinition {
+    val allProperties = propsClass.memberProperties
+    val (eventProperties, regularProperties) = allProperties.partition { prop ->
+      prop.returnType.classifier == ComposeEventDispatcher::class
+    }
+
+    val eventNames = eventProperties.map { it.name }.toTypedArray()
+    val callbacksDefinition = CallbacksDefinition(arrayOf(GLOBAL_EVENT_NAME, *eventNames))
+
     return ViewManagerDefinition(
       name = name,
       viewFactory = { context, appContext ->
@@ -70,33 +77,26 @@ class ComposeViewFunctionDefinitionBuilder<Props : ComposeProps>(
         } catch (e: Exception) {
           throw IllegalStateException("Could not instantiate props instance of $name compose component.", e)
         }
-        ComposeFunctionHolder(context, appContext, name, viewFunction, instance)
+        val holder = ComposeFunctionHolder(context, appContext, name, viewFunction, instance)
+
+        // Wire each ComposeEventDispatcher to a ViewEvent that emits through React Native
+        for (eventProp in eventProperties) {
+          @Suppress("UNCHECKED_CAST")
+          val property = eventProp as KProperty1<Props, ComposeEventDispatcher<Any?>>
+          property.isAccessible = true
+          val dispatcher = property.get(instance)
+          dispatcher.callback = { arg -> ViewEvent(eventProp.name, holder, null).invoke(arg) }
+        }
+
+        holder
       },
       callbacksDefinition = callbacksDefinition,
       viewType = ComposeFunctionHolder::class.java,
-      props = propsClass.memberProperties.associate { prop ->
+      // Only register regular (non-event) properties as props
+      props = regularProperties.associate { prop ->
         val kType = prop.returnType
         prop.name to ComposeViewProp(prop.name, AnyType(kType), prop)
       }
-    )
-  }
-
-  /**
-   * Defines prop names that should be treated as callbacks.
-   */
-  fun Events(vararg callbacks: String) {
-    callbacksDefinition = CallbacksDefinition(
-      arrayOf(GLOBAL_EVENT_NAME, *callbacks)
-    )
-  }
-
-  /**
-   * Defines prop names that should be treated as callbacks.
-   */
-  @JvmName("EventsWithArray")
-  fun Events(callbacks: Array<String>) {
-    callbacksDefinition = CallbacksDefinition(
-      arrayOf(GLOBAL_EVENT_NAME, *callbacks)
     )
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/AlertDialogView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/AlertDialogView.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.views.ComposeEventDispatcher
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import java.io.Serializable
@@ -17,14 +18,14 @@ data class AlertDialogProps(
   val confirmButtonText: String? = null,
   val dismissButtonText: String? = null,
   val visible: Boolean = false,
-  val modifiers: ModifierList = emptyList()
+  val modifiers: ModifierList = emptyList(),
+  val onDismissPressed: ComposeEventDispatcher<AlertDialogButtonPressedEvent> = ComposeEventDispatcher(),
+  val onConfirmPressed: ComposeEventDispatcher<AlertDialogButtonPressedEvent> = ComposeEventDispatcher()
 ) : ComposeProps
 
 @Composable
 fun FunctionalComposableScope.AlertDialogContent(
-  props: AlertDialogProps,
-  onDismissPressed: (AlertDialogButtonPressedEvent) -> Unit,
-  onConfirmPressed: (AlertDialogButtonPressedEvent) -> Unit
+  props: AlertDialogProps
 ) {
   if (!props.visible) {
     return
@@ -33,19 +34,19 @@ fun FunctionalComposableScope.AlertDialogContent(
   AlertDialog(
     confirmButton = {
       props.confirmButtonText?.let {
-        TextButton(onClick = { onConfirmPressed(AlertDialogButtonPressedEvent()) }) {
+        TextButton(onClick = { props.onConfirmPressed(AlertDialogButtonPressedEvent()) }) {
           Text(it)
         }
       }
     },
     dismissButton = {
       props.dismissButtonText?.let {
-        TextButton(onClick = { onDismissPressed(AlertDialogButtonPressedEvent()) }) {
+        TextButton(onClick = { props.onDismissPressed(AlertDialogButtonPressedEvent()) }) {
           Text(it)
         }
       }
     },
-    onDismissRequest = { onDismissPressed(AlertDialogButtonPressedEvent()) },
+    onDismissRequest = { props.onDismissPressed(AlertDialogButtonPressedEvent()) },
     title = { props.title?.let { Text(it) } },
     text = { props.text?.let { Text(it) } }
   )

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/BasicAlertDialogView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/BasicAlertDialogView.kt
@@ -4,21 +4,22 @@ import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import expo.modules.kotlin.views.ComposableScope
+import expo.modules.kotlin.views.ComposeEventDispatcher
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 
 data class BasicAlertDialogProps(
-  val modifiers: ModifierList = emptyList()
+  val modifiers: ModifierList = emptyList(),
+  val onDismissRequest: ComposeEventDispatcher<Unit> = ComposeEventDispatcher()
 ) : ComposeProps
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FunctionalComposableScope.BasicAlertDialogContent(
-  props: BasicAlertDialogProps,
-  onDismissRequest: () -> Unit
+  props: BasicAlertDialogProps
 ) {
   BasicAlertDialog(
-    onDismissRequest = { onDismissRequest() },
+    onDismissRequest = { props.onDismissRequest(Unit) },
     modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
   ) {
     Children(ComposableScope())

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/BottomSheetView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/BottomSheetView.kt
@@ -7,21 +7,23 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import expo.modules.kotlin.views.ComposableScope
+import expo.modules.kotlin.views.ComposeEventDispatcher
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 
 data class ModalBottomSheetProps(
   val skipPartiallyExpanded: Boolean = false,
-  val modifiers: ModifierList = emptyList()
+  val modifiers: ModifierList = emptyList(),
+  val onDismissRequest: ComposeEventDispatcher<Unit> = ComposeEventDispatcher()
 ) : ComposeProps
 
 @Composable
-fun FunctionalComposableScope.ModalBottomSheetContent(props: ModalBottomSheetProps, onDismissRequest: () -> Unit) {
+fun FunctionalComposableScope.ModalBottomSheetContent(props: ModalBottomSheetProps) {
   val sheetState = rememberModalBottomSheetState(props.skipPartiallyExpanded)
 
   ModalBottomSheet(
     sheetState = sheetState,
-    onDismissRequest = { onDismissRequest() },
+    onDismissRequest = { props.onDismissRequest(Unit) },
     modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
   ) {
     Children(ComposableScope())

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ChipView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ChipView.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposableScope
+import expo.modules.kotlin.views.ComposeEventDispatcher
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import java.io.Serializable
@@ -81,13 +82,13 @@ data class AssistChipProps(
   val colors: AssistChipColors = AssistChipColors(),
   val elevation: Float? = null,
   val border: ChipBorder? = null,
-  val modifiers: ModifierList = emptyList()
+  val modifiers: ModifierList = emptyList(),
+  val onNativeClick: ComposeEventDispatcher<ChipPressedEvent> = ComposeEventDispatcher()
 ) : ComposeProps
 
 @Composable
 fun FunctionalComposableScope.AssistChipContent(
-  props: AssistChipProps,
-  onPress: (ChipPressedEvent) -> Unit
+  props: AssistChipProps
 ) {
   val modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
 
@@ -116,7 +117,7 @@ fun FunctionalComposableScope.AssistChipContent(
   }
 
   AssistChip(
-    onClick = { onPress(ChipPressedEvent()) },
+    onClick = { props.onNativeClick(ChipPressedEvent()) },
     label = slotContent("label") ?: {},
     leadingIcon = slotContent("leadingIcon"),
     trailingIcon = slotContent("trailingIcon"),
@@ -138,13 +139,13 @@ data class FilterChipProps(
   val colors: FilterChipColors = FilterChipColors(),
   val elevation: Float? = null,
   val border: ChipBorder? = null,
-  val modifiers: ModifierList = emptyList()
+  val modifiers: ModifierList = emptyList(),
+  val onNativeClick: ComposeEventDispatcher<ChipPressedEvent> = ComposeEventDispatcher()
 ) : ComposeProps
 
 @Composable
 fun FunctionalComposableScope.FilterChipContent(
-  props: FilterChipProps,
-  onPress: (ChipPressedEvent) -> Unit
+  props: FilterChipProps
 ) {
   val modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
 
@@ -177,7 +178,7 @@ fun FunctionalComposableScope.FilterChipContent(
 
   FilterChip(
     selected = props.selected,
-    onClick = { onPress(ChipPressedEvent()) },
+    onClick = { props.onNativeClick(ChipPressedEvent()) },
     label = slotContent("label") ?: {},
     leadingIcon = slotContent("leadingIcon"),
     trailingIcon = slotContent("trailingIcon"),
@@ -199,14 +200,14 @@ data class InputChipProps(
   val colors: InputChipColors = InputChipColors(),
   val elevation: Float? = null,
   val border: ChipBorder? = null,
-  val modifiers: ModifierList = emptyList()
+  val modifiers: ModifierList = emptyList(),
+  val onNativeClick: ComposeEventDispatcher<ChipPressedEvent> = ComposeEventDispatcher()
 ) : ComposeProps
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FunctionalComposableScope.InputChipContent(
-  props: InputChipProps,
-  onPress: (ChipPressedEvent) -> Unit
+  props: InputChipProps
 ) {
   val modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
 
@@ -239,7 +240,7 @@ fun FunctionalComposableScope.InputChipContent(
   }
 
   InputChip(
-    onClick = { onPress(ChipPressedEvent()) },
+    onClick = { props.onNativeClick(ChipPressedEvent()) },
     label = slotContent("label") ?: {},
     enabled = props.enabled,
     selected = props.selected,
@@ -261,13 +262,13 @@ data class SuggestionChipProps(
   val colors: SuggestionChipColors = SuggestionChipColors(),
   val elevation: Float? = null,
   val border: ChipBorder? = null,
-  val modifiers: ModifierList = emptyList()
+  val modifiers: ModifierList = emptyList(),
+  val onNativeClick: ComposeEventDispatcher<ChipPressedEvent> = ComposeEventDispatcher()
 ) : ComposeProps
 
 @Composable
 fun FunctionalComposableScope.SuggestionChipContent(
-  props: SuggestionChipProps,
-  onPress: (ChipPressedEvent) -> Unit
+  props: SuggestionChipProps
 ) {
   val modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
 
@@ -295,7 +296,7 @@ fun FunctionalComposableScope.SuggestionChipContent(
   }
 
   SuggestionChip(
-    onClick = { onPress(ChipPressedEvent()) },
+    onClick = { props.onNativeClick(ChipPressedEvent()) },
     label = slotContent("label") ?: {},
     icon = slotContent("icon"),
     enabled = props.enabled,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/DatePickerView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/DatePickerView.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.views.ComposeEventDispatcher
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import java.util.Calendar
@@ -111,7 +112,8 @@ data class DateTimePickerProps(
   val color: AndroidColor? = null,
   val elementColors: DateTimePickerColorOverrides = DateTimePickerColorOverrides(),
   val selectableDates: SelectableDatesRecord? = null,
-  val modifiers: ModifierList = emptyList()
+  val modifiers: ModifierList = emptyList(),
+  val onDateSelected: ComposeEventDispatcher<DatePickerResult> = ComposeEventDispatcher()
 ) : ComposeProps
 
 data class DatePickerDialogProps(
@@ -123,6 +125,8 @@ data class DatePickerDialogProps(
   val color: AndroidColor? = null,
   val elementColors: DateTimePickerColorOverrides = DateTimePickerColorOverrides(),
   val selectableDates: SelectableDatesRecord? = null,
+  val onDateSelected: ComposeEventDispatcher<DatePickerResult> = ComposeEventDispatcher(),
+  val onDismissRequest: ComposeEventDispatcher<Unit> = ComposeEventDispatcher()
 ) : ComposeProps
 
 data class TimePickerDialogProps(
@@ -132,6 +136,8 @@ data class TimePickerDialogProps(
   val dismissButtonLabel: String? = null,
   val color: AndroidColor? = null,
   val elementColors: DateTimePickerColorOverrides = DateTimePickerColorOverrides(),
+  val onDateSelected: ComposeEventDispatcher<DatePickerResult> = ComposeEventDispatcher(),
+  val onDismissRequest: ComposeEventDispatcher<Unit> = ComposeEventDispatcher()
 ) : ComposeProps
 
 private fun toUtcDayMillis(localMillis: Long): Long {
@@ -245,7 +251,9 @@ fun buildTimePickerColors(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ExpoDatePickerDialogContent(props: DatePickerDialogProps, onDateSelected: (DatePickerResult) -> Unit, onDismissRequest: () -> Unit) {
+fun ExpoDatePickerDialogContent(props: DatePickerDialogProps) {
+  val onDateSelected = props.onDateSelected
+  val onDismissRequest = { props.onDismissRequest(Unit) }
   val locale = LocalConfiguration.current.locales[0]
   val variant = props.variant.toDisplayMode()
   val selectableDates = rememberSelectableDates(props.selectableDates)
@@ -289,7 +297,9 @@ fun ExpoDatePickerDialogContent(props: DatePickerDialogProps, onDateSelected: (D
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ExpoTimePickerDialogContent(props: TimePickerDialogProps, onDateSelected: (DatePickerResult) -> Unit, onDismissRequest: () -> Unit) {
+fun ExpoTimePickerDialogContent(props: TimePickerDialogProps) {
+  val onDateSelected = props.onDateSelected
+  val onDismissRequest = { props.onDismissRequest(Unit) }
   val initialDate = props.initialDate
 
   val state = remember(initialDate, props.is24Hour) {
@@ -338,15 +348,15 @@ fun ExpoTimePickerDialogContent(props: TimePickerDialogProps, onDateSelected: (D
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun FunctionalComposableScope.DateTimePickerContent(props: DateTimePickerProps, onDateSelected: (DatePickerResult) -> Unit) {
+fun FunctionalComposableScope.DateTimePickerContent(props: DateTimePickerProps) {
   val modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
   if (props.displayedComponents == DisplayedComponents.HOUR_AND_MINUTE) {
     ExpoTimePicker(props = props, modifier = modifier) {
-      onDateSelected(it)
+      props.onDateSelected(it)
     }
   } else {
     ExpoDatePicker(props = props, modifier = modifier) {
-      onDateSelected(it)
+      props.onDateSelected(it)
     }
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/DockedSearchBarView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/DockedSearchBarView.kt
@@ -12,24 +12,25 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.snapshotFlow
 import expo.modules.kotlin.views.ComposableScope
+import expo.modules.kotlin.views.ComposeEventDispatcher
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 
 data class DockedSearchBarProps(
-  val modifiers: ModifierList = emptyList()
+  val modifiers: ModifierList = emptyList(),
+  val onQueryChange: ComposeEventDispatcher<GenericEventPayload1<String>> = ComposeEventDispatcher()
 ) : ComposeProps
 
 @Composable
 fun FunctionalComposableScope.DockedSearchBarContent(
-  props: DockedSearchBarProps,
-  onQueryChange: (GenericEventPayload1<String>) -> Unit
+  props: DockedSearchBarProps
 ) {
   val searchBarState = rememberSearchBarState()
   val textFieldState = rememberTextFieldState()
 
   LaunchedEffect(Unit) {
     snapshotFlow { textFieldState.text.toString() }
-      .collect { onQueryChange(GenericEventPayload1(it)) }
+      .collect { props.onQueryChange(GenericEventPayload1(it)) }
   }
 
   DockedSearchBar(

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ExpoUIModule.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ExpoUIModule.kt
@@ -5,12 +5,9 @@ package expo.modules.ui
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.ToggleButtonDefaults
-import androidx.compose.runtime.remember
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
-import expo.modules.kotlin.viewevent.getValue
 import expo.modules.ui.button.ButtonContent
-import expo.modules.ui.button.ButtonPressedEvent
 import expo.modules.ui.button.ButtonProps
 import expo.modules.ui.button.ElevatedButtonContent
 import expo.modules.ui.button.FilledTonalButtonContent
@@ -27,7 +24,6 @@ import expo.modules.ui.menu.DropdownMenuContent
 import expo.modules.ui.menu.DropdownMenuProps
 import expo.modules.ui.menu.DropdownMenuItemContent
 import expo.modules.ui.menu.DropdownMenuItemProps
-import expo.modules.ui.menu.ItemPressedEvent
 import okhttp3.OkHttpClient
 
 class ExpoUIModule : Module() {
@@ -92,94 +88,55 @@ class ExpoUIModule : Module() {
 
     //region Expo UI views
 
-    ExpoUIView("ModalBottomSheetView", events = {
-      Events("onDismissRequest")
-    }) { props: ModalBottomSheetProps ->
-      val onDismissRequest by remember { EventDispatcher<Unit>() }
-      ModalBottomSheetContent(props) { onDismissRequest(Unit) }
+    ExpoUIView("ModalBottomSheetView") { props: ModalBottomSheetProps ->
+      ModalBottomSheetContent(props)
     }
 
-    // Defines a single view for now – a single choice segmented control
-    ExpoUIView("PickerView", events = {
-      Events("onOptionSelected")
-    }) { props: PickerProps ->
-      val onOptionSelected by remember { EventDispatcher<PickerOptionSelectedEvent>() }
-      PickerContent(props) { onOptionSelected(it) }
+    ExpoUIView("PickerView") { props: PickerProps ->
+      PickerContent(props)
     }
 
-    ExpoUIView("SwitchView", events = {
-      Events("onValueChange")
-    }) { props: SwitchProps ->
-      val onValueChange by remember { EventDispatcher<ValueChangeEvent>() }
-      SwitchContent(props) { onValueChange(it) }
+    ExpoUIView("SwitchView") { props: SwitchProps ->
+      SwitchContent(props)
     }
 
-    ExpoUIView("Button", events = {
-      Events("onButtonPressed")
-    }) { props: ButtonProps ->
-      val onButtonPressed by remember { EventDispatcher<ButtonPressedEvent>() }
-      ButtonContent(props) { onButtonPressed(it) }
+    ExpoUIView("Button") { props: ButtonProps ->
+      ButtonContent(props)
     }
 
-    ExpoUIView("FilledTonalButton", events = {
-      Events("onButtonPressed")
-    }) { props: ButtonProps ->
-      val onButtonPressed by remember { EventDispatcher<ButtonPressedEvent>() }
-      FilledTonalButtonContent(props) { onButtonPressed(it) }
+    ExpoUIView("FilledTonalButton") { props: ButtonProps ->
+      FilledTonalButtonContent(props)
     }
 
-    ExpoUIView("OutlinedButton", events = {
-      Events("onButtonPressed")
-    }) { props: ButtonProps ->
-      val onButtonPressed by remember { EventDispatcher<ButtonPressedEvent>() }
-      OutlinedButtonContent(props) { onButtonPressed(it) }
+    ExpoUIView("OutlinedButton") { props: ButtonProps ->
+      OutlinedButtonContent(props)
     }
 
-    ExpoUIView("ElevatedButton", events = {
-      Events("onButtonPressed")
-    }) { props: ButtonProps ->
-      val onButtonPressed by remember { EventDispatcher<ButtonPressedEvent>() }
-      ElevatedButtonContent(props) { onButtonPressed(it) }
+    ExpoUIView("ElevatedButton") { props: ButtonProps ->
+      ElevatedButtonContent(props)
     }
 
-    ExpoUIView("TextButton", events = {
-      Events("onButtonPressed")
-    }) { props: ButtonProps ->
-      val onButtonPressed by remember { EventDispatcher<ButtonPressedEvent>() }
-      TextButtonContent(props) { onButtonPressed(it) }
+    ExpoUIView("TextButton") { props: ButtonProps ->
+      TextButtonContent(props)
     }
 
-    ExpoUIView("IconButton", events = {
-      Events("onButtonPressed")
-    }) { props: ButtonProps ->
-      val onButtonPressed by remember { EventDispatcher<ButtonPressedEvent>() }
-      IconButtonContent(props) { onButtonPressed(it) }
+    ExpoUIView("IconButton") { props: ButtonProps ->
+      IconButtonContent(props)
     }
 
-    ExpoUIView("FilledIconButton", events = {
-      Events("onButtonPressed")
-    }) { props: ButtonProps ->
-      val onButtonPressed by remember { EventDispatcher<ButtonPressedEvent>() }
-      FilledIconButtonContent(props) { onButtonPressed(it) }
+    ExpoUIView("FilledIconButton") { props: ButtonProps ->
+      FilledIconButtonContent(props)
     }
 
-    ExpoUIView("FilledTonalIconButton", events = {
-      Events("onButtonPressed")
-    }) { props: ButtonProps ->
-      val onButtonPressed by remember { EventDispatcher<ButtonPressedEvent>() }
-      FilledTonalIconButtonContent(props) { onButtonPressed(it) }
+    ExpoUIView("FilledTonalIconButton") { props: ButtonProps ->
+      FilledTonalIconButtonContent(props)
     }
 
-    ExpoUIView("OutlinedIconButton", events = {
-      Events("onButtonPressed")
-    }) { props: ButtonProps ->
-      val onButtonPressed by remember { EventDispatcher<ButtonPressedEvent>() }
-      OutlinedIconButtonContent(props) { onButtonPressed(it) }
+    ExpoUIView("OutlinedIconButton") { props: ButtonProps ->
+      OutlinedIconButtonContent(props)
     }
 
-    ExpoUIView("SliderView", events = {
-      Events("onValueChange", "onValueChangeFinished")
-    }) { props: SliderProps ->
+    ExpoUIView("SliderView") { props: SliderProps ->
       SliderContent(props)
     }
 
@@ -191,41 +148,24 @@ class ExpoUIModule : Module() {
       DividerContent(props)
     }
 
-    ExpoUIView("DateTimePickerView", events = {
-      Events("onDateSelected")
-    }) { props: DateTimePickerProps ->
-      val onDateSelected by remember { EventDispatcher<DatePickerResult>() }
-      DateTimePickerContent(props) { onDateSelected(it) }
+    ExpoUIView("DateTimePickerView") { props: DateTimePickerProps ->
+      DateTimePickerContent(props)
     }
 
-    ExpoUIView("DatePickerDialogView", events = {
-      Events("onDateSelected", "onDismissRequest")
-    }) { props: DatePickerDialogProps ->
-      val onDateSelected by remember { EventDispatcher<DatePickerResult>() }
-      val onDismissRequest by remember { EventDispatcher<Unit>() }
-      ExpoDatePickerDialogContent(props, { onDateSelected(it) }, { onDismissRequest(Unit) })
+    ExpoUIView("DatePickerDialogView") { props: DatePickerDialogProps ->
+      ExpoDatePickerDialogContent(props)
     }
 
-    ExpoUIView("TimePickerDialogView", events = {
-      Events("onDateSelected", "onDismissRequest")
-    }) { props: TimePickerDialogProps ->
-      val onDateSelected by remember { EventDispatcher<DatePickerResult>() }
-      val onDismissRequest by remember { EventDispatcher<Unit>() }
-      ExpoTimePickerDialogContent(props, { onDateSelected(it) }, { onDismissRequest(Unit) })
+    ExpoUIView("TimePickerDialogView") { props: TimePickerDialogProps ->
+      ExpoTimePickerDialogContent(props)
     }
 
-    ExpoUIView("DropdownMenuView", events = {
-      Events("onDismissRequest")
-    }) { props: DropdownMenuProps ->
-      val onDismissRequest by remember { EventDispatcher<Unit>() }
-      DropdownMenuContent(props) { onDismissRequest(Unit) }
+    ExpoUIView("DropdownMenuView") { props: DropdownMenuProps ->
+      DropdownMenuContent(props)
     }
 
-    ExpoUIView("DropdownMenuItemView", events = {
-      Events("onItemPressed")
-    }) { props: DropdownMenuItemProps ->
-      val onItemPressed by remember { EventDispatcher<ItemPressedEvent>() }
-      DropdownMenuItemContent(props) { onItemPressed(it) }
+    ExpoUIView("DropdownMenuItemView") { props: DropdownMenuItemProps ->
+      DropdownMenuItemContent(props)
     }
 
     ExpoUIView("ProgressView") { props: ProgressProps ->
@@ -252,83 +192,48 @@ class ExpoUIModule : Module() {
       TextContent(props)
     }
 
-    ExpoUIView("SearchBarView", events = {
-      Events("onSearch")
-    }) { props: SearchBarProps ->
-      val onSearch by remember { EventDispatcher<GenericEventPayload1<String>>() }
-      SearchBarContent(props) { onSearch(it) }
+    ExpoUIView("SearchBarView") { props: SearchBarProps ->
+      SearchBarContent(props)
     }
 
-    ExpoUIView("DockedSearchBarView", events = {
-      Events("onQueryChange")
-    }) { props: DockedSearchBarProps ->
-      val onQueryChange by remember { EventDispatcher<GenericEventPayload1<String>>() }
-      DockedSearchBarContent(props) { onQueryChange(it) }
+    ExpoUIView("DockedSearchBarView") { props: DockedSearchBarProps ->
+      DockedSearchBarContent(props)
     }
 
     ExpoUIView("HorizontalFloatingToolbarView") { props: HorizontalFloatingToolbarProps ->
       HorizontalFloatingToolbarContent(props)
     }
 
-    ExpoUIView("PullToRefreshBoxView", events = {
-      Events("onRefresh")
-    }) { props: PullToRefreshBoxProps ->
-      val onRefresh by remember { EventDispatcher<Unit>() }
-      PullToRefreshBoxContent(props) { onRefresh(Unit) }
+    ExpoUIView("PullToRefreshBoxView") { props: PullToRefreshBoxProps ->
+      PullToRefreshBoxContent(props)
     }
 
     ExpoUIView("CarouselView") { props: CarouselProps ->
       CarouselContent(props)
     }
 
-    ExpoUIView("AlertDialogView", events = {
-      Events(
-        "onDismissPressed",
-        "onConfirmPressed"
-      )
-    }) { props: AlertDialogProps ->
-      val onDismissPressed by remember { EventDispatcher<AlertDialogButtonPressedEvent>() }
-      val onConfirmPressed by remember { EventDispatcher<AlertDialogButtonPressedEvent>() }
-      AlertDialogContent(
-        props,
-        { onDismissPressed(it) },
-        { onConfirmPressed(it) }
-      )
+    ExpoUIView("AlertDialogView") { props: AlertDialogProps ->
+      AlertDialogContent(props)
     }
 
-    ExpoUIView("AssistChipView", events = {
-      Events("onNativeClick")
-    }) { props: AssistChipProps ->
-      val onNativeClick by remember { EventDispatcher<ChipPressedEvent>() }
-      AssistChipContent(props) { onNativeClick(it) }
+    ExpoUIView("AssistChipView") { props: AssistChipProps ->
+      AssistChipContent(props)
     }
 
-    ExpoUIView("InputChipView", events = {
-      Events("onNativeClick")
-    }) { props: InputChipProps ->
-      val onNativeClick by remember { EventDispatcher<ChipPressedEvent>() }
-      InputChipContent(props) { onNativeClick(it) }
+    ExpoUIView("InputChipView") { props: InputChipProps ->
+      InputChipContent(props)
     }
 
-    ExpoUIView("SuggestionChipView", events = {
-      Events("onNativeClick")
-    }) { props: SuggestionChipProps ->
-      val onNativeClick by remember { EventDispatcher<ChipPressedEvent>() }
-      SuggestionChipContent(props) { onNativeClick(it) }
+    ExpoUIView("SuggestionChipView") { props: SuggestionChipProps ->
+      SuggestionChipContent(props)
     }
 
-    ExpoUIView("FilterChipView", events = {
-      Events("onNativeClick")
-    }) { props: FilterChipProps ->
-      val onNativeClick by remember { EventDispatcher<ChipPressedEvent>() }
-      FilterChipContent(props) { onNativeClick(it) }
+    ExpoUIView("FilterChipView") { props: FilterChipProps ->
+      FilterChipContent(props)
     }
 
-    ExpoUIView("ToggleButtonView", events = {
-      Events("onCheckedChange")
-    }) { props: ToggleButtonProps ->
-      val onCheckedChange by remember { EventDispatcher<ToggleButtonValueChangeEvent>() }
-      ToggleButtonContent(props) { onCheckedChange(it) }
+    ExpoUIView("ToggleButtonView") { props: ToggleButtonProps ->
+      ToggleButtonContent(props)
     }
 
     ExpoUIView("CardView") { props: CardProps ->
@@ -343,11 +248,8 @@ class ExpoUIModule : Module() {
       SpacerContent(props)
     }
 
-    ExpoUIView("BasicAlertDialogView", events = {
-      Events("onDismissRequest")
-    }) { props: BasicAlertDialogProps ->
-      val onDismissRequest by remember { EventDispatcher<Unit>() }
-      BasicAlertDialogContent(props) { onDismissRequest(Unit) }
+    ExpoUIView("BasicAlertDialogView") { props: BasicAlertDialogProps ->
+      BasicAlertDialogContent(props)
     }
 
     ExpoUIView("SurfaceView") { props: SurfaceProps ->
@@ -358,18 +260,12 @@ class ExpoUIModule : Module() {
       AnimatedVisibilityContent(props)
     }
 
-    ExpoUIView("RadioButtonView", events = {
-      Events("onNativeClick")
-    }) { props: RadioButtonProps ->
-      val onNativeClick by remember { EventDispatcher<Unit>() }
-      RadioButtonContent(props) { onNativeClick(Unit) }
+    ExpoUIView("RadioButtonView") { props: RadioButtonProps ->
+      RadioButtonContent(props)
     }
 
-    ExpoUIView("FloatingActionButtonView", events = {
-      Events("onButtonPressed")
-    }) { props: FloatingActionButtonProps ->
-      val onButtonPressed by remember { EventDispatcher<Unit>() }
-      FloatingActionButtonContent(props) { onButtonPressed(Unit) }
+    ExpoUIView("FloatingActionButtonView") { props: FloatingActionButtonProps ->
+      FloatingActionButtonContent(props)
     }
 
     //endregion Expo UI views

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/PickerView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/PickerView.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.views.ComposeEventDispatcher
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 
@@ -67,7 +68,8 @@ data class PickerProps(
   val elementColors: PickerColors = PickerColors(),
   val variant: String = "segmented",
   val buttonModifiers: List<ModifierType> = emptyList(),
-  val modifiers: ModifierList = emptyList()
+  val modifiers: ModifierList = emptyList(),
+  val onOptionSelected: ComposeEventDispatcher<PickerOptionSelectedEvent> = ComposeEventDispatcher()
 ) : ComposeProps
 
 data class PickerOptionSelectedEvent(
@@ -77,9 +79,9 @@ data class PickerOptionSelectedEvent(
 
 @Composable
 fun FunctionalComposableScope.PickerContent(
-  props: PickerProps,
-  onOptionSelected: (PickerOptionSelectedEvent) -> Unit
+  props: PickerProps
 ) {
+  val onOptionSelected = props.onOptionSelected
   val selectedIndex = props.selectedIndex
   val options = props.options
   val colors = props.elementColors

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/PullToRefreshBoxView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/PullToRefreshBoxView.kt
@@ -8,23 +8,25 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import expo.modules.kotlin.views.ComposableScope
+import expo.modules.kotlin.views.ComposeEventDispatcher
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 
 data class PullToRefreshBoxProps(
   val isRefreshing: Boolean = false,
   val modifiers: ModifierList = emptyList(),
-  val loadingIndicatorModifiers: ModifierList = emptyList()
+  val loadingIndicatorModifiers: ModifierList = emptyList(),
+  val onRefresh: ComposeEventDispatcher<Unit> = ComposeEventDispatcher()
 ) : ComposeProps
 
 @Composable
-fun FunctionalComposableScope.PullToRefreshBoxContent(props: PullToRefreshBoxProps, onRefresh: () -> Unit) {
+fun FunctionalComposableScope.PullToRefreshBoxContent(props: PullToRefreshBoxProps) {
   val isRefreshing = props.isRefreshing
   val pullToRefreshState = rememberPullToRefreshState()
 
   PullToRefreshBox(
     isRefreshing = isRefreshing,
-    onRefresh = { onRefresh() },
+    onRefresh = { props.onRefresh(Unit) },
     state = pullToRefreshState,
     indicator = {
       PullToRefreshDefaults.LoadingIndicator(

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/RadioButtonView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/RadioButtonView.kt
@@ -2,24 +2,25 @@ package expo.modules.ui
 
 import androidx.compose.material3.RadioButton
 import androidx.compose.runtime.Composable
+import expo.modules.kotlin.views.ComposeEventDispatcher
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 
 data class RadioButtonProps(
   val selected: Boolean = false,
   val nativeClickable: Boolean = true,
-  val modifiers: ModifierList = emptyList()
+  val modifiers: ModifierList = emptyList(),
+  val onNativeClick: ComposeEventDispatcher<Unit> = ComposeEventDispatcher()
 ) : ComposeProps
 
 @Composable
 fun FunctionalComposableScope.RadioButtonContent(
-  props: RadioButtonProps,
-  onNativeClick: () -> Unit
+  props: RadioButtonProps
 ) {
   RadioButton(
     selected = props.selected,
     onClick = if (props.nativeClickable) {
-      { onNativeClick() }
+      { props.onNativeClick(Unit) }
     } else {
       null
     },

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SearchBarView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SearchBarView.kt
@@ -10,15 +10,17 @@ import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.rememberSearchBarState
 import androidx.compose.runtime.Composable
 import expo.modules.kotlin.views.ComposableScope
+import expo.modules.kotlin.views.ComposeEventDispatcher
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 
 data class SearchBarProps(
-  val modifiers: ModifierList = emptyList()
+  val modifiers: ModifierList = emptyList(),
+  val onSearch: ComposeEventDispatcher<GenericEventPayload1<String>> = ComposeEventDispatcher()
 ) : ComposeProps
 
 @Composable
-fun FunctionalComposableScope.SearchBarContent(props: SearchBarProps, onSearch: (GenericEventPayload1<String>) -> Unit) {
+fun FunctionalComposableScope.SearchBarContent(props: SearchBarProps) {
   val searchBarState = rememberSearchBarState()
   val textFieldState = rememberTextFieldState()
 
@@ -27,7 +29,7 @@ fun FunctionalComposableScope.SearchBarContent(props: SearchBarProps, onSearch: 
       SearchBarDefaults.InputField(
         searchBarState = searchBarState,
         textFieldState = textFieldState,
-        onSearch = { value -> onSearch.invoke(GenericEventPayload1(value)) },
+        onSearch = { value -> props.onSearch(GenericEventPayload1(value)) },
         placeholder = {
           Children(ComposableScope(), filter = { isSlotWithName(it, "placeholder") })
         }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SliderView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SliderView.kt
@@ -6,15 +6,15 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
-import expo.modules.kotlin.viewevent.getValue
 import expo.modules.kotlin.views.ComposableScope
+import expo.modules.kotlin.views.ComposeEventDispatcher
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 
@@ -42,7 +42,9 @@ data class SliderProps(
   val steps: Int = 0,
   val enabled: Boolean = true,
   val colors: SliderColors = SliderColors(),
-  val modifiers: ModifierList = emptyList()
+  val modifiers: ModifierList = emptyList(),
+  val onValueChange: ComposeEventDispatcher<SliderValueChangedEvent> = ComposeEventDispatcher(),
+  val onValueChangeFinished: ComposeEventDispatcher<Unit> = ComposeEventDispatcher()
 ) : ComposeProps
 
 data class SliderValueChangedEvent(
@@ -52,8 +54,6 @@ data class SliderValueChangedEvent(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FunctionalComposableScope.SliderContent(props: SliderProps) {
-  val onValueChange by remember { this@SliderContent.EventDispatcher<SliderValueChangedEvent>() }
-  val onValueChangeFinished by remember { this@SliderContent.EventDispatcher<Unit>() }
   val interactionSource = remember { MutableInteractionSource() }
 
   var localValue by remember { mutableFloatStateOf(props.value.coerceIn(props.min, props.max)) }
@@ -88,11 +88,11 @@ fun FunctionalComposableScope.SliderContent(props: SliderProps) {
     onValueChange = {
       isDragging = true
       localValue = it
-      onValueChange(SliderValueChangedEvent(it))
+      props.onValueChange(SliderValueChangedEvent(it))
     },
     onValueChangeFinished = {
       isDragging = false
-      onValueChangeFinished(Unit)
+      props.onValueChangeFinished(Unit)
     },
     colors = sliderColors,
     thumb = { sliderState ->

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SwitchView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SwitchView.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposableScope
+import expo.modules.kotlin.views.ComposeEventDispatcher
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import java.io.Serializable
@@ -91,7 +92,8 @@ data class SwitchProps(
   val enabled: Boolean = true,
   val variant: String = "switch",
   val elementColors: SwitchColors = SwitchColors(),
-  val modifiers: ModifierList = emptyList()
+  val modifiers: ModifierList = emptyList(),
+  val onValueChange: ComposeEventDispatcher<ValueChangeEvent> = ComposeEventDispatcher()
 ) : ComposeProps
 
 @Composable
@@ -183,15 +185,14 @@ fun ThemedHybridSwitch(
 
 @Composable
 fun FunctionalComposableScope.SwitchContent(
-  props: SwitchProps,
-  onValueChange: (ValueChangeEvent) -> Unit
+  props: SwitchProps
 ) {
   val thumbContentSlotView = findChildSlotView(view, "thumbContent")
 
   ThemedHybridSwitch(
     props.variant,
     props.value,
-    { newChecked -> onValueChange(ValueChangeEvent(newChecked)) },
+    { newChecked -> props.onValueChange(ValueChangeEvent(newChecked)) },
     props.elementColors,
     ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher),
     props.enabled,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ToggleButtonView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ToggleButtonView.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.ToggleButtonDefaults
 import androidx.compose.runtime.Composable
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.views.ComposeEventDispatcher
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 
@@ -23,7 +24,8 @@ data class ToggleButtonProps(
   val variant: String = "default",
   val color: Color? = null,
   val disabled: Boolean = false,
-  val modifiers: ModifierList = emptyList()
+  val modifiers: ModifierList = emptyList(),
+  val onCheckedChange: ComposeEventDispatcher<ToggleButtonValueChangeEvent> = ComposeEventDispatcher()
 ) : ComposeProps
 
 data class ToggleButtonValueChangeEvent(
@@ -32,8 +34,7 @@ data class ToggleButtonValueChangeEvent(
 
 @Composable
 fun FunctionalComposableScope.ToggleButtonContent(
-  props: ToggleButtonProps,
-  onCheckedChange: (ToggleButtonValueChangeEvent) -> Unit
+  props: ToggleButtonProps
 ) {
   val modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
 
@@ -58,7 +59,7 @@ fun FunctionalComposableScope.ToggleButtonContent(
     "icon" -> {
       IconToggleButton(
         checked = props.checked,
-        onCheckedChange = { onCheckedChange(ToggleButtonValueChangeEvent(it)) },
+        onCheckedChange = { props.onCheckedChange(ToggleButtonValueChangeEvent(it)) },
         enabled = !props.disabled,
         modifier = modifier,
         content = content
@@ -67,7 +68,7 @@ fun FunctionalComposableScope.ToggleButtonContent(
     "filledIcon" -> {
       FilledIconToggleButton(
         checked = props.checked,
-        onCheckedChange = { onCheckedChange(ToggleButtonValueChangeEvent(it)) },
+        onCheckedChange = { props.onCheckedChange(ToggleButtonValueChangeEvent(it)) },
         enabled = !props.disabled,
         modifier = modifier,
         content = content
@@ -76,7 +77,7 @@ fun FunctionalComposableScope.ToggleButtonContent(
     "outlinedIcon" -> {
       OutlinedIconToggleButton(
         checked = props.checked,
-        onCheckedChange = { onCheckedChange(ToggleButtonValueChangeEvent(it)) },
+        onCheckedChange = { props.onCheckedChange(ToggleButtonValueChangeEvent(it)) },
         enabled = !props.disabled,
         modifier = modifier,
         content = content
@@ -85,7 +86,7 @@ fun FunctionalComposableScope.ToggleButtonContent(
     else -> {
       ToggleButton(
         checked = props.checked,
-        onCheckedChange = { onCheckedChange(ToggleButtonValueChangeEvent(it)) },
+        onCheckedChange = { props.onCheckedChange(ToggleButtonValueChangeEvent(it)) },
         enabled = !props.disabled,
         modifier = modifier,
         colors = ToggleButtonDefaults.toggleButtonColors(),

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/UIBaseView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/UIBaseView.kt
@@ -2,14 +2,12 @@ package expo.modules.ui
 
 import androidx.compose.runtime.Composable
 import expo.modules.kotlin.views.ComposeProps
-import expo.modules.kotlin.views.ComposeViewFunctionDefinitionBuilder
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.kotlin.views.ModuleDefinitionBuilderWithCompose
 
 inline fun <reified Props : ComposeProps> ModuleDefinitionBuilderWithCompose.ExpoUIView(
   name: String,
-  events: ComposeViewFunctionDefinitionBuilder<Props>.() -> Unit = {},
   noinline viewFunction: @Composable FunctionalComposableScope.(props: Props) -> Unit
 ) {
-  return View(name, events, viewFunction)
+  return View(name, viewFunction)
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/button/Button.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/button/Button.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.unit.dp
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposableScope
+import expo.modules.kotlin.views.ComposeEventDispatcher
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.ui.ModifierList
@@ -50,16 +51,16 @@ data class ButtonProps(
   val enabled: Boolean = true,
   val contentPadding: ContentPaddingRecord? = null,
   val shape: ShapeRecord? = null,
-  val modifiers: ModifierList = emptyList()
+  val modifiers: ModifierList = emptyList(),
+  val onButtonPressed: ComposeEventDispatcher<ButtonPressedEvent> = ComposeEventDispatcher()
 ) : ComposeProps
 
 @Composable
 fun FunctionalComposableScope.ButtonContent(
-  props: ButtonProps,
-  onClick: (ButtonPressedEvent) -> Unit
+  props: ButtonProps
 ) {
   androidx.compose.material3.Button(
-    onClick = { onClick(ButtonPressedEvent()) },
+    onClick = { props.onButtonPressed(ButtonPressedEvent()) },
     enabled = props.enabled,
     contentPadding = props.contentPadding?.toPaddingValues() ?: ButtonDefaults.ContentPadding,
     colors = ButtonDefaults.buttonColors(
@@ -77,11 +78,10 @@ fun FunctionalComposableScope.ButtonContent(
 
 @Composable
 fun FunctionalComposableScope.FilledTonalButtonContent(
-  props: ButtonProps,
-  onClick: (ButtonPressedEvent) -> Unit
+  props: ButtonProps
 ) {
   FilledTonalButton(
-    onClick = { onClick(ButtonPressedEvent()) },
+    onClick = { props.onButtonPressed(ButtonPressedEvent()) },
     enabled = props.enabled,
     contentPadding = props.contentPadding?.toPaddingValues() ?: ButtonDefaults.ContentPadding,
     colors = ButtonDefaults.filledTonalButtonColors(
@@ -99,11 +99,10 @@ fun FunctionalComposableScope.FilledTonalButtonContent(
 
 @Composable
 fun FunctionalComposableScope.OutlinedButtonContent(
-  props: ButtonProps,
-  onClick: (ButtonPressedEvent) -> Unit
+  props: ButtonProps
 ) {
   OutlinedButton(
-    onClick = { onClick(ButtonPressedEvent()) },
+    onClick = { props.onButtonPressed(ButtonPressedEvent()) },
     enabled = props.enabled,
     contentPadding = props.contentPadding?.toPaddingValues() ?: ButtonDefaults.ContentPadding,
     colors = ButtonDefaults.outlinedButtonColors(
@@ -121,11 +120,10 @@ fun FunctionalComposableScope.OutlinedButtonContent(
 
 @Composable
 fun FunctionalComposableScope.ElevatedButtonContent(
-  props: ButtonProps,
-  onClick: (ButtonPressedEvent) -> Unit
+  props: ButtonProps
 ) {
   ElevatedButton(
-    onClick = { onClick(ButtonPressedEvent()) },
+    onClick = { props.onButtonPressed(ButtonPressedEvent()) },
     enabled = props.enabled,
     contentPadding = props.contentPadding?.toPaddingValues() ?: ButtonDefaults.ContentPadding,
     colors = ButtonDefaults.elevatedButtonColors(
@@ -143,11 +141,10 @@ fun FunctionalComposableScope.ElevatedButtonContent(
 
 @Composable
 fun FunctionalComposableScope.TextButtonContent(
-  props: ButtonProps,
-  onClick: (ButtonPressedEvent) -> Unit
+  props: ButtonProps
 ) {
   TextButton(
-    onClick = { onClick(ButtonPressedEvent()) },
+    onClick = { props.onButtonPressed(ButtonPressedEvent()) },
     enabled = props.enabled,
     contentPadding = props.contentPadding?.toPaddingValues() ?: ButtonDefaults.TextButtonContentPadding,
     colors = ButtonDefaults.textButtonColors(

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/button/FloatingActionButton.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/button/FloatingActionButton.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.runtime.Composable
 import expo.modules.kotlin.types.Enumerable
 import expo.modules.kotlin.views.ComposableScope
+import expo.modules.kotlin.views.ComposeEventDispatcher
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.ui.ModifierList
@@ -27,14 +28,15 @@ data class FloatingActionButtonProps(
   val variant: FloatingActionButtonVariant = FloatingActionButtonVariant.MEDIUM,
   val expanded: Boolean = true,
   val containerColor: Color? = null,
-  val modifiers: ModifierList = emptyList()
+  val modifiers: ModifierList = emptyList(),
+  val onButtonPressed: ComposeEventDispatcher<Unit> = ComposeEventDispatcher()
 ) : ComposeProps
 
 @Composable
 fun FunctionalComposableScope.FloatingActionButtonContent(
-  props: FloatingActionButtonProps,
-  onClick: () -> Unit
+  props: FloatingActionButtonProps
 ) {
+  val onClick = { props.onButtonPressed(Unit) }
   val containerColor = props.containerColor?.compose ?: FloatingActionButtonDefaults.containerColor
   val modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
 

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/button/IconButton.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/button/IconButton.kt
@@ -14,12 +14,11 @@ import expo.modules.ui.shapeFromShapeRecord
 
 @Composable
 fun FunctionalComposableScope.IconButtonContent(
-  props: ButtonProps,
-  onButtonPressed: (ButtonPressedEvent) -> Unit
+  props: ButtonProps
 ) {
   val shape = shapeFromShapeRecord(props.shape)
   IconButton(
-    onClick = { onButtonPressed(ButtonPressedEvent()) },
+    onClick = { props.onButtonPressed(ButtonPressedEvent()) },
     enabled = props.enabled,
     colors = IconButtonDefaults.iconButtonColors(
       containerColor = props.colors.containerColor.compose,
@@ -36,12 +35,11 @@ fun FunctionalComposableScope.IconButtonContent(
 
 @Composable
 fun FunctionalComposableScope.FilledIconButtonContent(
-  props: ButtonProps,
-  onButtonPressed: (ButtonPressedEvent) -> Unit
+  props: ButtonProps
 ) {
   val shape = shapeFromShapeRecord(props.shape)
   FilledIconButton(
-    onClick = { onButtonPressed(ButtonPressedEvent()) },
+    onClick = { props.onButtonPressed(ButtonPressedEvent()) },
     enabled = props.enabled,
     colors = IconButtonDefaults.filledIconButtonColors(
       containerColor = props.colors.containerColor.compose,
@@ -58,12 +56,11 @@ fun FunctionalComposableScope.FilledIconButtonContent(
 
 @Composable
 fun FunctionalComposableScope.FilledTonalIconButtonContent(
-  props: ButtonProps,
-  onButtonPressed: (ButtonPressedEvent) -> Unit
+  props: ButtonProps
 ) {
   val shape = shapeFromShapeRecord(props.shape)
   FilledTonalIconButton(
-    onClick = { onButtonPressed(ButtonPressedEvent()) },
+    onClick = { props.onButtonPressed(ButtonPressedEvent()) },
     enabled = props.enabled,
     colors = IconButtonDefaults.filledTonalIconButtonColors(
       containerColor = props.colors.containerColor.compose,
@@ -80,12 +77,11 @@ fun FunctionalComposableScope.FilledTonalIconButtonContent(
 
 @Composable
 fun FunctionalComposableScope.OutlinedIconButtonContent(
-  props: ButtonProps,
-  onButtonPressed: (ButtonPressedEvent) -> Unit
+  props: ButtonProps
 ) {
   val shape = shapeFromShapeRecord(props.shape)
   OutlinedIconButton(
-    onClick = { onButtonPressed(ButtonPressedEvent()) },
+    onClick = { props.onButtonPressed(ButtonPressedEvent()) },
     enabled = props.enabled,
     colors = IconButtonDefaults.outlinedIconButtonColors(
       containerColor = props.colors.containerColor.compose,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/DropdownMenu.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/DropdownMenu.kt
@@ -13,8 +13,7 @@ import expo.modules.ui.isSlotView
 
 @Composable
 fun FunctionalComposableScope.DropdownMenuContent(
-  props: DropdownMenuProps,
-  onDismissRequest: () -> Unit
+  props: DropdownMenuProps
 ) {
   val itemsSlotView = findChildSlotView(view, "items")
 
@@ -25,7 +24,7 @@ fun FunctionalComposableScope.DropdownMenuContent(
     DropdownMenu(
       containerColor = props.color?.composeOrNull ?: MenuDefaults.containerColor,
       expanded = props.expanded,
-      onDismissRequest = onDismissRequest
+      onDismissRequest = { props.onDismissRequest(Unit) }
     ) {
       itemsSlotView?.let {
         with(ComposableScope()) {

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/DropdownMenuItem.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/DropdownMenuItem.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposableScope
+import expo.modules.kotlin.views.ComposeEventDispatcher
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.ui.ModifierList
@@ -30,13 +31,13 @@ class DropdownMenuItemColors : Record {
 data class DropdownMenuItemProps(
   val enabled: Boolean = true,
   val elementColors: DropdownMenuItemColors = DropdownMenuItemColors(),
-  val modifiers: ModifierList = emptyList()
+  val modifiers: ModifierList = emptyList(),
+  val onItemPressed: ComposeEventDispatcher<ItemPressedEvent> = ComposeEventDispatcher()
 ) : ComposeProps
 
 @Composable
 fun FunctionalComposableScope.DropdownMenuItemContent(
-  props: DropdownMenuItemProps,
-  onItemPressed: (ItemPressedEvent) -> Unit
+  props: DropdownMenuItemProps
 ) {
   val textSlotView = findChildSlotView(view, "text")
   val leadingSlotView = findChildSlotView(view, "leadingIcon")
@@ -64,7 +65,7 @@ fun FunctionalComposableScope.DropdownMenuItemContent(
       { with(ComposableScope()) { with(it) { Content() } } }
     },
     onClick = {
-      onItemPressed(ItemPressedEvent())
+      props.onItemPressed(ItemPressedEvent())
     }
   )
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/DropdownMenuRecords.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/DropdownMenuRecords.kt
@@ -2,6 +2,7 @@ package expo.modules.ui.menu
 
 import android.graphics.Color
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.views.ComposeEventDispatcher
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.ui.ModifierList
 
@@ -14,5 +15,6 @@ data class DropdownMenuProps(
   val activationMethod: ActivationMethod = ActivationMethod.SINGLE_PRESS,
   val expanded: Boolean = false,
   val color: Color? = null,
-  val modifiers: ModifierList = emptyList()
+  val modifiers: ModifierList = emptyList(),
+  val onDismissRequest: ComposeEventDispatcher<Unit> = ComposeEventDispatcher()
 ) : ComposeProps


### PR DESCRIPTION
# Why

Currently in compose, the syntax to define Events in ExpoUIView is below.

### Before
```kotlin
ExpoUIView("ModalBottomSheetView", events = {
  Events("onDismissRequest")
}) { props: ModalBottomSheetProps ->
  val onDismissRequest by remember { EventDispatcher<Unit>() }
  ModalBottomSheetContent(props) { onDismissRequest(Unit) }
}
```

### After
```kotlin

// Register event props in props.
data class ModalBottomSheetProps(
  val onDismissRequest: ComposeEventDispatcher<Unit> = ComposeEventDispatcher()
) : ComposeProps


// Simplified definition 
ExpoUIView("ModalBottomSheetView") { props: ModalBottomSheetProps ->
    ModalBottomSheetContent(props)
}

```

The event callbacks `onDismissRequest` can be defined as props, matching the iOS `ExpoUIView` API.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Added a new class `ComposeEventDispatcher` which is initialised on view factory creation that will invoke the `ViewEvent`.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Test all examples in `UIScreen.android.tsx` NCL with events.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
