### PR TITLE
feat(cli): prefetch bundles when using run:[android|ios] command

### DIFF
--- a/packages/@expo/cli/src/run/android/__tests__/runAndroidAsync-test.ts
+++ b/packages/@expo/cli/src/run/android/__tests__/runAndroidAsync-test.ts
@@ -35,6 +35,7 @@ jest.mock('../../startBundler', () => ({
     startAsync: jest.fn(),
     getDefaultDevServer: jest.fn(() => ({
       openCustomRuntimeAsync: jest.fn(),
+      getDevServerUrl: jest.fn(() => null),
     })),
   })),
 }));

--- a/packages/@expo/cli/src/run/android/runAndroidAsync.ts
+++ b/packages/@expo/cli/src/run/android/runAndroidAsync.ts
@@ -15,6 +15,7 @@ import { ensurePortAvailabilityAsync } from '../../utils/port';
 import { getSchemesForAndroidAsync } from '../../utils/scheme';
 import { ensureNativeProjectAsync } from '../ensureNativeProject';
 import { logProjectLogsLocation } from '../hints';
+import { prefetchBundleAsync } from '../prefetchBundle';
 import { startBundlerAsync } from '../startBundler';
 
 const debug = require('debug')('expo:run:android');
@@ -81,6 +82,8 @@ export async function runAndroidAsync(projectRoot: string, { install, ...options
     scheme: (await getSchemesForAndroidAsync(projectRoot))?.[0],
     headless: !props.shouldStartBundler,
   });
+  // prefetch the bundle so it's cached when the app requests it.
+  prefetchBundleAsync(projectRoot, manager, 'android');
 
   if (!options.binary) {
     // Find the APK file path

--- a/packages/@expo/cli/src/run/ios/__tests__/runIosAsync-test.ts
+++ b/packages/@expo/cli/src/run/ios/__tests__/runIosAsync-test.ts
@@ -36,6 +36,9 @@ jest.mock('../../../utils/env', () => ({
 jest.mock('../../startBundler', () => ({
   startBundlerAsync: jest.fn(() => ({
     startAsync: jest.fn(),
+    getDefaultDevServer: jest.fn(() => ({
+      getDevServerUrl: jest.fn(() => null),
+    })),
   })),
 }));
 

--- a/packages/@expo/cli/src/run/ios/runIosAsync.ts
+++ b/packages/@expo/cli/src/run/ios/runIosAsync.ts
@@ -21,6 +21,7 @@ import { profile } from '../../utils/profile';
 import { getSchemesForIosAsync } from '../../utils/scheme';
 import { ensureNativeProjectAsync } from '../ensureNativeProject';
 import { logProjectLogsLocation } from '../hints';
+import { prefetchBundleAsync } from '../prefetchBundle';
 import { startBundlerAsync } from '../startBundler';
 
 const debug = require('debug')('expo:run:ios');
@@ -184,8 +185,7 @@ export async function runIosAsync(projectRoot: string, options: Options) {
     }
   }
 
-  // Start the dev server which creates all of the required info for
-  // launching the app on a simulator.
+  // Use the early-started manager if available, otherwise start Metro now.
   const manager = await startBundlerAsync(projectRoot, {
     port: props.port,
     headless: !props.shouldStartBundler,
@@ -197,6 +197,8 @@ export async function runIosAsync(projectRoot: string, options: Options) {
       : // If a scheme is specified then use that instead of the package name.
         (await getSchemesForIosAsync(projectRoot))?.[0],
   });
+  // prefetch the bundle so it's cached when the app requests it.
+  prefetchBundleAsync(projectRoot, manager, 'ios');
 
   // Install and launch the app binary on a device.
   await launchAppAsync(

--- a/packages/@expo/cli/src/run/prefetchBundle.ts
+++ b/packages/@expo/cli/src/run/prefetchBundle.ts
@@ -1,0 +1,69 @@
+import { getConfig } from '@expo/config';
+
+import { isEnableHermesManaged } from '../export/exportHermes';
+import { DevServerManager } from '../start/server/DevServerManager';
+import { getRouterDirectoryModuleIdWithManifest } from '../start/server/metro/router';
+import { resolveMainModuleName } from '../start/server/middleware/ManifestMiddleware';
+import {
+  createBundleUrlPath,
+  getAsyncRoutesFromExpoConfig,
+  getBaseUrlFromExpoConfig,
+} from '../start/server/middleware/metroOptions';
+import { env } from '../utils/env';
+
+const debug = require('debug')('expo:run:prefetch') as typeof console.log;
+
+/**
+ * Fire-and-forget prefetch of the JS bundle so Metro's graph cache is warm
+ * by the time the app launches on the device/simulator.
+ */
+export function prefetchBundleAsync(
+  projectRoot: string,
+  manager: DevServerManager,
+  platform: string
+): void {
+  const serverUrl = manager.getDefaultDevServer()?.getDevServerUrl();
+  if (!serverUrl) {
+    debug('No dev server URL available, skipping prefetch');
+    return;
+  }
+
+  try {
+    const { exp } = getConfig(projectRoot, {
+      skipSDKVersionRequirement: true,
+      skipPlugins: true,
+    });
+
+    const mainModuleName = resolveMainModuleName(projectRoot, { platform });
+    const engine = isEnableHermesManaged(exp, platform) ? 'hermes' : undefined;
+
+    const bundlePath = createBundleUrlPath({
+      mode: 'development',
+      minify: false,
+      platform,
+      mainModuleName,
+      lazy: !env.EXPO_NO_METRO_LAZY,
+      engine,
+      bytecode: engine === 'hermes',
+      baseUrl: getBaseUrlFromExpoConfig(exp),
+      isExporting: false,
+      asyncRoutes: getAsyncRoutesFromExpoConfig(exp, 'development', platform),
+      routerRoot: getRouterDirectoryModuleIdWithManifest(projectRoot, exp),
+      reactCompiler: !!exp.experiments?.reactCompiler,
+    });
+
+    const url = serverUrl + bundlePath;
+    debug('Prefetching bundle:', url);
+
+    fetch(url).then(
+      (res) => {
+        debug('Prefetch completed with status:', res.status);
+      },
+      (error) => {
+        debug('Prefetch failed (non-fatal):', error?.message);
+      }
+    );
+  } catch (error: any) {
+    debug('Failed to construct prefetch URL (non-fatal):', error?.message);
+  }
+}


### PR DESCRIPTION
# Why

When running npx `expo run:[android|ios]` for debug builds, the first bundle request from the app triggers Metro's full dependency graph traversal, adding ~30s of latency after the app launches. The user stares at a loading screen while Metro processes the entire module graph for the first time.

Since we already know the target platform when Metro starts, we can proactively trigger a bundle build immediately, so Metro's graph cache is warm by the time the app actually requests the bundle.

# How

Added a new `prefetchBundleAsync` utility that constructs the exact same bundle URL the app will request (matching the parameters used by `ManifestMiddleware._getBundleUrl`) and issues a fire-and-forget fetch() to Metro's .bundle endpoint.

This is called right after `startBundlerAsync` in both `runIosAsync` and `runAndroidAsync`. The prefetch kicks off Metro's graph traversal in the background, so by the time the app is installed, launched, and requests its bundle, Metro can serve it from its cached graph revision instead of building from scratch.
 
# Test Plan

`npx expo run:ios`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
