### PR TITLE
[expo-symbols][expo-ui] Support custom SF Symbols from asset catalogs

### DIFF
--- a/packages/expo-symbols/CHANGELOG.md
+++ b/packages/expo-symbols/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Support custom SF Symbols from asset catalogs by trying `UIImage(named:)` before `UIImage(systemName:)`. ([#43946](https://github.com/expo/expo/pull/43946) by [@chrism](https://github.com/chrism))
+
 ### 💡 Others
 
 - Add explicit type re-export and return type annotations ([#43562](https://github.com/expo/expo/pull/43562) by [@kitten](https://github.com/kitten))

--- a/packages/expo-symbols/ios/SymbolView.swift
+++ b/packages/expo-symbols/ios/SymbolView.swift
@@ -24,7 +24,7 @@ class SymbolView: ExpoView {
   }
 
   func reloadSymbol() {
-    guard let image = UIImage(systemName: name) else {
+    guard let image = UIImage(named: name) ?? UIImage(systemName: name) else {
       return
     }
     imageView.image = image

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Support custom SF Symbols from asset catalogs in `Button` by trying `UIImage(named:)` before `UIImage(systemName:)`. ([#43946](https://github.com/expo/expo/pull/43946) by [@chrism](https://github.com/chrism))
 - [iOS] Fix `Slider` thumb snapping back during drag by guarding `.onReceive` with `isEditing` state. ([#43701](https://github.com/expo/expo/issues/43701) by [@fedeciancaglini](https://github.com/fedeciancaglini)) ([#43797](https://github.com/expo/expo/pull/43797) by [@fedeciancaglini](https://github.com/fedeciancaglini))
 - [Android] Fix touch events for RN views inside Compose BottomSheet. ([#43716](https://github.com/expo/expo/pull/43716) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Fix `RNHostView` child parent related crash. ([#43691](https://github.com/expo/expo/pull/43691) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/ios/Button/Button.swift
+++ b/packages/expo-ui/ios/Button/Button.swift
@@ -13,8 +13,14 @@ public struct Button: ExpoSwiftUI.View {
   public var body: some View {
     if let label = props.label {
       if let systemImage = props.systemImage {
-        SwiftUI.Button(label, systemImage: systemImage, role: props.role?.toNativeRole()) {
+        SwiftUI.Button(role: props.role?.toNativeRole(), action: {
           props.onButtonPress()
+        }) {
+          if UIImage(named: systemImage) != nil {
+            Label(label, image: systemImage)
+          } else {
+            Label(label, systemImage: systemImage)
+          }
         }
       } else {
         SwiftUI.Button(label, role: props.role?.toNativeRole()) {


### PR DESCRIPTION
# Why

iOS supports [custom SF Symbols](https://developer.apple.com/documentation/uikit/uiimage/creating_custom_symbol_images_for_your_app) added via asset catalogs. Expo's config plugin system makes it straightforward to add custom symbols (SVG → xcassets symbolset), but both `expo-symbols` and `@expo/ui` only look up symbols via `UIImage(systemName:)`, which doesn't resolve custom symbols from the app's asset catalog.

This forces developers to maintain patches for both packages.

# How

**`expo-symbols` (`SymbolView.swift`)**: Try `UIImage(named:)` first (resolves custom symbols from asset catalogs), then fall back to `UIImage(systemName:)` for system SF Symbols:

```swift
guard let image = UIImage(named: name) ?? UIImage(systemName: name) else {
```

**`@expo/ui` (`Button.swift`)**: When a `systemImage` prop is provided, check if it exists as a custom asset via `UIImage(named:)`. If so, use `Label(_:image:)` instead of `Label(_:systemImage:)`:

```swift
if UIImage(named: systemImage) != nil {
  Label(label, image: systemImage)
} else {
  Label(label, systemImage: systemImage)
}
```

# Test Plan

- Verified custom SF Symbols (added via xcassets symbolset) render correctly in both `SymbolView` and `Button`
- Verified system SF Symbols continue to work as before (fallback to `UIImage(systemName:)`)
- No behavior change for apps without custom symbols