### PR TITLE
fix(expo-modules-autolinking): support commander 12+ import changes

### DIFF
--- a/packages/expo-modules-autolinking/src/commands/autolinkingOptions.ts
+++ b/packages/expo-modules-autolinking/src/commands/autolinkingOptions.ts
@@ -1,4 +1,4 @@
-import commander from 'commander';
+import { Command } from 'commander';
 import fs from 'fs';
 import path from 'path';
 
@@ -134,7 +134,7 @@ export interface AutolinkingCommonArguments {
   platform?: SupportedPlatform | null;
 }
 
-export function registerAutolinkingArguments(command: commander.Command): commander.Command {
+export function registerAutolinkingArguments(command: Command): Command {
   return command
     .option<string[] | null>(
       '-e, --exclude <exclude...>',

--- a/packages/expo-modules-autolinking/src/commands/generateModulesProviderCommand.ts
+++ b/packages/expo-modules-autolinking/src/commands/generateModulesProviderCommand.ts
@@ -1,4 +1,4 @@
-import commander from 'commander';
+import { Command } from 'commander';
 import fs from 'fs';
 
 import {
@@ -23,7 +23,7 @@ type PartialPodfileProperties = {
 };
 
 /** Generates a source file listing all packages to link in the runtime */
-export function generateModulesProviderCommand(cli: commander.CommanderStatic) {
+export function generateModulesProviderCommand(cli: Command) {
   return registerAutolinkingArguments(cli.command('generate-modules-provider [searchPaths...]'))
     .option(
       '-t, --target <path>',

--- a/packages/expo-modules-autolinking/src/commands/mirrorKotlinInlineModulesCommand.ts
+++ b/packages/expo-modules-autolinking/src/commands/mirrorKotlinInlineModulesCommand.ts
@@ -1,4 +1,4 @@
-import commander from 'commander';
+import { Command } from 'commander';
 import fs from 'fs';
 import path from 'path';
 
@@ -25,7 +25,7 @@ interface MirrorKotlinInlineModulesCommandArguments extends AutolinkingCommonArg
  * - mirrors directory structure of watched directories
  * - symlinks the original kotlin files in the new mirror directories.
  */
-export function mirrorKotlinInlineModulesCommand(cli: commander.CommanderStatic) {
+export function mirrorKotlinInlineModulesCommand(cli: Command) {
   return registerAutolinkingArguments(cli.command('mirror-kotlin-inline-modules'))
     .requiredOption(
       '--kotlin-files-mirror-directory <path>',

--- a/packages/expo-modules-autolinking/src/commands/reactNativeConfigCommand.ts
+++ b/packages/expo-modules-autolinking/src/commands/reactNativeConfigCommand.ts
@@ -1,4 +1,4 @@
-import commander from 'commander';
+import { Command } from 'commander';
 
 import {
   AutolinkingCommonArguments,
@@ -13,7 +13,7 @@ interface ReactNativeConfigArguments extends AutolinkingCommonArguments {
 }
 
 /** The react-native-config command (like RN CLI linking) */
-export function reactNativeConfigCommand(cli: commander.CommanderStatic) {
+export function reactNativeConfigCommand(cli: Command) {
   return registerAutolinkingArguments(cli.command('react-native-config [searchPaths...]'))
     .option(
       '-p, --platform [platform]',

--- a/packages/expo-modules-autolinking/src/commands/resolveCommand.ts
+++ b/packages/expo-modules-autolinking/src/commands/resolveCommand.ts
@@ -1,4 +1,4 @@
-import commander from 'commander';
+import { Command } from 'commander';
 
 import {
   AutolinkingCommonArguments,
@@ -29,7 +29,7 @@ interface ResolveArguments extends AutolinkingCommonArguments {
 }
 
 /** Searches for available expo modules and resolves the results for given platform. */
-export function resolveCommand(cli: commander.CommanderStatic) {
+export function resolveCommand(cli: Command) {
   return registerAutolinkingArguments(cli.command('resolve [searchPaths...]'))
     .option('-j, --json', 'Output results in the plain JSON format.', () => true, false)
     .action(async (searchPaths: string[] | null, commandArguments: ResolveArguments) => {

--- a/packages/expo-modules-autolinking/src/commands/searchCommand.ts
+++ b/packages/expo-modules-autolinking/src/commands/searchCommand.ts
@@ -1,4 +1,4 @@
-import commander from 'commander';
+import { Command } from 'commander';
 
 import {
   AutolinkingCommonArguments,
@@ -11,7 +11,7 @@ interface SearchArguments extends AutolinkingCommonArguments {
   json?: boolean | null;
 }
 
-export function searchCommand(cli: commander.CommanderStatic) {
+export function searchCommand(cli: Command) {
   return registerAutolinkingArguments(cli.command('search [searchPaths...]'))
     .option('-j, --json', 'Output results in the plain JSON format.', () => true, false)
     .action(async (searchPaths: string[] | null, commandArguments: SearchArguments) => {

--- a/packages/expo-modules-autolinking/src/commands/verifyCommand.ts
+++ b/packages/expo-modules-autolinking/src/commands/verifyCommand.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import commander from 'commander';
+import { Command } from 'commander';
 import fs from 'fs';
 import path from 'path';
 
@@ -26,7 +26,7 @@ interface VerifyArguments extends AutolinkingCommonArguments {
   json?: boolean | null;
 }
 
-export function verifyCommand(cli: commander.CommanderStatic) {
+export function verifyCommand(cli: Command) {
   return registerAutolinkingArguments(cli.command('verify'))
     .option('-v, --verbose', 'Output all results instead of just warnings.', () => true, false)
     .option('-j, --json', 'Output results in the plain JSON format.', () => true, false)

--- a/packages/expo-modules-autolinking/src/index.ts
+++ b/packages/expo-modules-autolinking/src/index.ts
@@ -1,4 +1,4 @@
-import commander from 'commander';
+import { Command } from 'commander';
 
 import { generateModulesProviderCommand } from './commands/generateModulesProviderCommand';
 import { mirrorKotlinInlineModulesCommand } from './commands/mirrorKotlinInlineModulesCommand';
@@ -9,7 +9,7 @@ import { verifyCommand } from './commands/verifyCommand';
 import { createMemoizer } from './memoize';
 
 async function main(args: string[]) {
-  const cli = commander
+  const cli = new Command()
     .version(require('expo-modules-autolinking/package.json').version)
     .description('CLI command that searches for native modules to autolink them.');
 


### PR DESCRIPTION
## Summary

`expo-modules-autolinking` uses `import commander from 'commander'` (default import) and then calls `commander.version(...)`, `commander.command(...)`, etc., treating the default export as a `Command` instance. This worked in commander 7.x where the default export **is** a global `Command` instance.

However, **commander 12.0 removed the default export of a global Command instance** ([changelog](https://github.com/tj/commander.js/releases/tag/v12.0.0)). When a newer commander version (e.g. 14.x) gets hoisted by package managers like bun, the default import no longer resolves to a Command instance. This causes autolinking to **silently fail** — the CLI just prints help and exits without performing any autolinking, leading to broken builds with no clear error message.

### Changes

Replaced `import commander from 'commander'` with `import { Command } from 'commander'` across all source files in `packages/expo-modules-autolinking/src/`:

- **`index.ts`** — Uses `new Command()` instead of the default import as a Command instance
- **`commands/autolinkingOptions.ts`** — Uses `Command` type directly instead of `commander.Command`
- **`commands/*.ts`** (6 command files) — Uses `Command` type instead of `commander.CommanderStatic` for the `cli` parameter

The named `Command` export has been available since commander 7.x and works through 14.x, so this change is fully backwards-compatible with the declared `^7.2.0` dependency range.

### Why this matters

When using bun (or other package managers with aggressive hoisting), a transitive dependency on commander 14.x can get hoisted above expo-modules-autolinking's own commander 7.x. Since Node module resolution finds the hoisted version first, autolinking silently breaks. The fix ensures the import style works regardless of which commander version gets resolved.

## Test plan

- [ ] Verify autolinking CLI works: `npx expo-modules-autolinking resolve --platform apple --json`
- [ ] Verify `npx expo-modules-autolinking search --platform android --json` returns module results
- [ ] Test with both commander 7.x (pinned) and commander 14.x (hoisted) to confirm compatibility
- [ ] Run existing autolinking tests in the expo monorepo