### PR TITLE
[ios][ui] Fix DatePicker selection prop ignored on mount

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `DatePicker` ignoring `selection` prop on mount, always displaying current time instead of the provided value. ([#43951](https://github.com/expo/expo/pull/43951) by [@samtsai](https://github.com/samtsai))
 - [iOS] Fix `Slider` thumb snapping back during drag by guarding `.onReceive` with `isEditing` state. ([#43701](https://github.com/expo/expo/issues/43701) by [@fedeciancaglini](https://github.com/fedeciancaglini)) ([#43797](https://github.com/expo/expo/pull/43797) by [@fedeciancaglini](https://github.com/fedeciancaglini))
 - [Android] Fix touch events for RN views inside Compose BottomSheet. ([#43716](https://github.com/expo/expo/pull/43716) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Fix `RNHostView` child parent related crash. ([#43691](https://github.com/expo/expo/pull/43691) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/ios/DatePickerView.swift
+++ b/packages/expo-ui/ios/DatePickerView.swift
@@ -18,6 +18,16 @@ internal struct DatePickerView: ExpoSwiftUI.View {
       .onChange(of: date) { newDate in
         props.onDateChange(["date": newDate.timeIntervalSince1970 * 1000])
       }
+      .onAppear {
+        if let selection = props.selection, selection != date {
+          date = selection
+        }
+      }
+      .onChange(of: props.selection) { newSelection in
+        if let newSelection, newSelection != date {
+          date = newSelection
+        }
+      }
       .if(props.title == nil && !hasChildren) { $0.labelsHidden() }
 #endif
   }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes the iOS SwiftUI DatePicker ignoring the selection prop value on mount — it always displays the current time instead of the value passed
  from JS.

SwiftUI's `@State` only respects `initialValue` on first struct initialization. When ExpoModulesCore creates DatePickerView, props are nil during `init` — by the time `props.selection` is delivered from JS, `@State date` has already been initialized to `Date()` (the current time) and ignores subsequent `init` calls with a new `initialValue`.

This was a regression from #42933, which removed the `.onAppear` sync that previously existed and relied solely on the `init`-based `_date = State(initialValue: props.selection ?? Date())` pattern.

NOTE 📝: I found and resolved the issue using Claude Code. I'm not as familiar with Swift UI but after several iterations a patch was the only solution to getting my app to sync time.

# How

<!--
How did you build this feature or fix this bug and why?
-->
- `.onAppear`: syncs `date` from `props.selection` once the view is in the hierarchy and props have been delivered
- `.onChange(of: props.selection)`: keeps `date` in sync when JS updates `selection` after mount

All existing NCL examples use `useState(new Date())` which masked the bug because `Date()` matched the fallback. Any app that passes a non-current date as `selection` (e.g. a persisted time preference) would see the picker display the wrong value.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
- Tested in two production apps I am working on locally with persisted notification time preferences — picker now correctly shows the stored time instead of current time on mount
- Verified NCL DatePicker examples still work (they use new Date() so behavior is unchanged)
- Verified .onChange(of: props.selection) correctly updates picker when JS changes selection after mount

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
