### PR TITLE
fix(modules-core): serialize PersistentFileLog reads on the dispatch queue

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [Android] Fixed Compose view clipping that caused Material ripple effects to be cut off (e.g., Switch thumb ripple). ([#43656](https://github.com/expo/expo/pull/43656) by [@vonovak](https://github.com/vonovak))
 - [iOS] Fix memory leak due to retain cycle in SwiftUI views. ([#43468](https://github.com/expo/expo/pull/43468) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fixed compilation issues due to missing fallthrough case in `EXJavaScriptSerializable`. ([#43634](https://github.com/expo/expo/pull/43634) by [@tjzel](https://github.com/tjzel))
+- [iOS] Fixed `PersistentFileLog.readEntries` race condition by serializing reads on the dispatch queue. ([#43958](https://github.com/expo/expo/pull/43958) by [@ramonclaudio](https://github.com/ramonclaudio))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Core/Logging/PersistentFileLog.swift
+++ b/packages/expo-modules-core/ios/Core/Logging/PersistentFileLog.swift
@@ -43,10 +43,12 @@ public class PersistentFileLog {
    Read entries from log file
    */
   public func readEntries() -> [String] {
-    if getFileSize() == 0 {
-      return []
+    return PersistentFileLog.serialQueue.sync {
+      if getFileSize() == 0 {
+        return []
+      }
+      return (try? self.readFileSync()) ?? []
     }
-    return (try? self.readFileSync()) ?? []
   }
 
   /**


### PR DESCRIPTION
Fix race condition in `PersistentFileLog.readEntries` where reads bypassed the serial dispatch queue that guards all writes. This caused flaky `UpdatesLogReaderTests.PurgeOldLogs` failures in CI (e.g. [#43955](https://github.com/expo/expo/pull/43955)) where `entries1.count` was 1 instead of 2 because the read executed before a queued write was flushed to disk.

- Wrap `readEntries` in `serialQueue.sync` so reads wait for any pending writes
- No deadlock risk: all callers (`UpdatesLogReader`, `PersistentFileLogTests`) are external to the queue

# Test Plan

- `yarn test` in `expo-modules-core`: 168/168 passing
- `yarn test` in `expo-updates`: 15/15 passing
- `yarn lint` in `expo-modules-core`: clean
- `yarn build` in `expo-modules-core`: clean
- `tsc --noEmit`: clean
- Native `PersistentFileLogTests` and `UpdatesLogReaderTests` run in CI