### PR TITLE
[android][updates] Add correct cancellation handling

### DIFF
--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
@@ -18,6 +18,9 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.json.JSONException
 import org.json.JSONObject
@@ -60,7 +63,8 @@ class RemoteLoaderTest {
       mockFileDownloader,
       File("testDirectory"),
       null,
-      mockLoaderFiles
+      mockLoaderFiles,
+      CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
     )
 
     val manifestString = CertificateFixtures.testExpoUpdatesManifestBody

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
@@ -34,6 +34,7 @@ import expo.modules.updates.statemachine.UpdatesStateValue
 import expo.modules.updatesinterface.UpdatesInterface
 import expo.modules.updatesinterface.UpdatesStateChangeListener
 import expo.modules.updatesinterface.UpdatesStateChangeSubscription
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -254,7 +255,7 @@ class EnabledUpdatesController(
   }
 
   override suspend fun fetchUpdate() = suspendCancellableCoroutine { continuation ->
-    val procedure = FetchUpdateProcedure(context, updatesConfiguration, logger, databaseHolder, updatesDirectory, fileDownloader, selectionPolicy, launchedUpdate) {
+    val procedure = FetchUpdateProcedure(context, updatesConfiguration, logger, databaseHolder, updatesDirectory, fileDownloader, selectionPolicy, launchedUpdate, controllerScope) {
       continuation.resume(it)
     }
     stateMachine.queueExecution(procedure)
@@ -278,6 +279,8 @@ class EnabledUpdatesController(
           }
         }
         continuation.resume(resultMap)
+      } catch (e: CancellationException) {
+        throw e
       } catch (e: Exception) {
         continuation.resumeWithException(e.toCodedException())
       }
@@ -286,7 +289,7 @@ class EnabledUpdatesController(
 
   override suspend fun setExtraParam(key: String, value: String?) = suspendCancellableCoroutine { continuation ->
     controllerScope.launch {
-      runCatching {
+      try {
         ManifestMetadata.setExtraParam(
           databaseHolder.database,
           updatesConfiguration,
@@ -294,7 +297,9 @@ class EnabledUpdatesController(
           value
         )
         continuation.resume(Unit)
-      }.onFailure { e ->
+      } catch (e: CancellationException) {
+        throw e
+      } catch (e: Exception) {
         continuation.resumeWithException(e.toCodedException())
       }
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -33,9 +33,11 @@ import expo.modules.updatesinterface.UpdatesDevLauncherInterface
 import expo.modules.updatesinterface.UpdatesInterfaceCallbacks
 import expo.modules.updatesinterface.UpdatesStateChangeListener
 import expo.modules.updatesinterface.UpdatesStateChangeSubscription
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.json.JSONObject
@@ -181,7 +183,8 @@ class UpdatesDevLauncherController(
       databaseHolder.database,
       fileDownloader,
       updatesDirectory,
-      null
+      null,
+      controllerScope
     )
     controllerScope.launch {
       val progressJob = launch {
@@ -213,6 +216,8 @@ class UpdatesDevLauncherController(
           return@launch
         }
         launchUpdate(loaderResult.updateEntity, updatesConfiguration!!, fileDownloader, callback)
+      } catch (e: CancellationException) {
+        throw e
       } catch (e: Exception) {
         // reset controller's configuration to what it was before this request
         updatesConfiguration = previousUpdatesConfiguration
@@ -307,6 +312,8 @@ class UpdatesDevLauncherController(
           get() = launcher.launchAssetFile!!
       })
       runReaper()
+    } catch (e: CancellationException) {
+      throw e
     } catch (e: Exception) {
       // reset controller's configuration to what it was before this request
       updatesConfiguration = previousUpdatesConfiguration
@@ -383,7 +390,7 @@ class UpdatesDevLauncherController(
   }
 
   override fun shutdown() {
-    // no-op
+    controllerScope.cancel()
   }
 
   companion object {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.kt
@@ -9,6 +9,9 @@ import expo.modules.updates.UpdatesUtils
 import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.utils.AndroidResourceAssetUtils
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import java.io.File
 import java.io.FileNotFoundException
 import java.lang.AssertionError
@@ -32,14 +35,16 @@ class EmbeddedLoader internal constructor(
   database: UpdatesDatabase,
   updatesDirectory: File,
   private val loaderFiles: LoaderFiles,
-  private val shouldCopyEmbeddedAssets: Boolean = BuildConfig.EX_UPDATES_COPY_EMBEDDED_ASSETS
+  private val shouldCopyEmbeddedAssets: Boolean = BuildConfig.EX_UPDATES_COPY_EMBEDDED_ASSETS,
+  scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 ) : Loader(
   context,
   configuration,
   logger,
   database,
   updatesDirectory,
-  loaderFiles
+  loaderFiles,
+  scope
 ) {
 
   constructor(
@@ -47,8 +52,9 @@ class EmbeddedLoader internal constructor(
     configuration: UpdatesConfiguration,
     logger: UpdatesLogger,
     database: UpdatesDatabase,
-    updatesDirectory: File
-  ) : this(context, configuration, logger, database, updatesDirectory, LoaderFiles())
+    updatesDirectory: File,
+    scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+  ) : this(context, configuration, logger, database, updatesDirectory, LoaderFiles(), scope = scope)
 
   override suspend fun loadRemoteUpdate(
     database: UpdatesDatabase,

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.SupervisorJob
 import java.io.File
 import java.io.IOException
 import java.util.*
+import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -44,9 +45,9 @@ abstract class Loader protected constructor(
   private var updateResponse: UpdateResponse? = null
   private var updateEntity: UpdateEntity? = null
   private var assetTotal = 0
-  private var erroredAssetList = mutableListOf<AssetEntity>()
-  private var existingAssetList = mutableListOf<AssetEntity>()
-  private var finishedAssetList = mutableListOf<AssetEntity>()
+  private var erroredAssetList: MutableList<AssetEntity> = Collections.synchronizedList(mutableListOf())
+  private var existingAssetList: MutableList<AssetEntity> = Collections.synchronizedList(mutableListOf())
+  private var finishedAssetList: MutableList<AssetEntity> = Collections.synchronizedList(mutableListOf())
   private val _progressFlow = MutableSharedFlow<AssetLoadProgress>()
   private var assetProgressMap: MutableMap<AssetEntity, Double> = ConcurrentHashMap()
 
@@ -115,9 +116,9 @@ abstract class Loader protected constructor(
     updateResponse = null
     updateEntity = null
     assetTotal = 0
-    erroredAssetList = mutableListOf()
-    existingAssetList = mutableListOf()
-    finishedAssetList = mutableListOf()
+    erroredAssetList = Collections.synchronizedList(mutableListOf())
+    existingAssetList = Collections.synchronizedList(mutableListOf())
+    finishedAssetList = Collections.synchronizedList(mutableListOf())
     assetProgressMap = ConcurrentHashMap()
     assetLoadProgressBlock = null
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.kt
@@ -17,6 +17,7 @@ import expo.modules.updates.manifest.EmbeddedManifestUtils
 import expo.modules.updates.manifest.ManifestMetadata
 import expo.modules.updates.manifest.Update
 import expo.modules.updates.selectionpolicy.SelectionPolicy
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.CoroutineScope
 import org.json.JSONObject
@@ -189,6 +190,8 @@ class LoaderTask(
           callback.onFinishedAllLoading()
         }
       }
+    } catch (e: CancellationException) {
+      throw e
     } catch (e: Exception) {
       if (!shouldCheckForUpdate) {
         finish(e)
@@ -209,6 +212,8 @@ class LoaderTask(
       isRunning = false
       runReaper()
       callback.onFinishedAllLoading()
+    } catch (e: CancellationException) {
+      throw e
     } catch (e: Exception) {
       finish(e)
       isRunning = false
@@ -296,10 +301,12 @@ class LoaderTask(
         )
       ) {
         try {
-          val embeddedLoader = EmbeddedLoader(context, configuration, logger, database, directory)
+          val embeddedLoader = EmbeddedLoader(context, configuration, logger, database, directory, scope)
           embeddedLoader.load { _ ->
             Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
           }
+        } catch (e: CancellationException) {
+          throw e
         } catch (e: Exception) {
           logger.error("Unexpected error copying embedded update", e, UpdatesErrorCode.Unknown)
         }
@@ -315,7 +322,7 @@ class LoaderTask(
   private suspend fun launchRemoteUpdateInBackground() {
     val database = databaseHolder.database
     callback.onRemoteCheckForUpdateStarted()
-    val remoteLoader = RemoteLoader(context, configuration, logger, database, fileDownloader, directory, candidateLauncher?.launchedUpdate)
+    val remoteLoader = RemoteLoader(context, configuration, logger, database, fileDownloader, directory, candidateLauncher?.launchedUpdate, scope)
 
     remoteLoader.assetLoadProgressBlock = { progress ->
       callback.onRemoteUpdateProgressChanged(progress)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
@@ -10,6 +10,9 @@ import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.manifest.EmbeddedManifestUtils
 import expo.modules.updates.manifest.ManifestMetadata
 import expo.modules.updates.selectionpolicy.SelectionPolicy
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import java.io.File
 
 data class ProcessSuccessLoaderResult(
@@ -32,8 +35,9 @@ class RemoteLoader internal constructor(
   private val mFileDownloader: FileDownloader,
   updatesDirectory: File,
   private val launchedUpdate: UpdateEntity?,
-  private val loaderFiles: LoaderFiles
-) : Loader(context, configuration, logger, database, updatesDirectory, loaderFiles) {
+  private val loaderFiles: LoaderFiles,
+  scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+) : Loader(context, configuration, logger, database, updatesDirectory, loaderFiles, scope) {
   constructor(
     context: Context,
     configuration: UpdatesConfiguration,
@@ -41,8 +45,9 @@ class RemoteLoader internal constructor(
     database: UpdatesDatabase,
     fileDownloader: FileDownloader,
     updatesDirectory: File,
-    launchedUpdate: UpdateEntity?
-  ) : this(context, configuration, logger, database, fileDownloader, updatesDirectory, launchedUpdate, LoaderFiles())
+    launchedUpdate: UpdateEntity?,
+    scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+  ) : this(context, configuration, logger, database, fileDownloader, updatesDirectory, launchedUpdate, LoaderFiles(), scope)
 
   override suspend fun loadRemoteUpdate(
     database: UpdatesDatabase,

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/CheckForUpdateProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/CheckForUpdateProcedure.kt
@@ -43,6 +43,8 @@ class CheckForUpdateProcedure(
     try {
       val updateResponse = downloadRemoteUpdate(extraHeaders)
       processUpdatesResponse(updateResponse, procedureContext, embeddedUpdate)
+    } catch (e: CancellationException) {
+      throw e
     } catch (e: Exception) {
       procedureContext.processStateEvent(UpdatesStateEvent.CheckError(e.localizedMessageWithCauseLocalizedMessage()))
       callback(IUpdatesController.CheckForUpdateResult.ErrorResult(e))

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/FetchUpdateProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/FetchUpdateProcedure.kt
@@ -14,6 +14,7 @@ import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.selectionpolicy.SelectionPolicy
 import expo.modules.updates.statemachine.UpdatesStateEvent
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import java.io.File
 
 class FetchUpdateProcedure(
@@ -25,6 +26,7 @@ class FetchUpdateProcedure(
   private val fileDownloader: FileDownloader,
   private val selectionPolicy: SelectionPolicy,
   private val launchedUpdate: UpdateEntity?,
+  private val scope: CoroutineScope,
   private val callback: (IUpdatesController.FetchUpdateResult) -> Unit
 ) : StateMachineProcedure() {
   override val loggerTimerLabel = "timer-fetch-update"
@@ -36,6 +38,8 @@ class FetchUpdateProcedure(
     try {
       val loaderResult = startRemoteLoader(database, procedureContext)
       processSuccessLoaderResult(loaderResult, procedureContext)
+    } catch (e: CancellationException) {
+      throw e
     } catch (e: Exception) {
       logger.error("Failed to download new update", e)
       procedureContext.processStateEvent(
@@ -55,7 +59,8 @@ class FetchUpdateProcedure(
       database,
       fileDownloader,
       updatesDirectory,
-      launchedUpdate
+      launchedUpdate,
+      scope
     )
 
     remoteLoader.assetLoadProgressBlock = { progress ->

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RelaunchProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RelaunchProcedure.kt
@@ -14,6 +14,7 @@ import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.reloadscreen.ReloadScreenManager
 import expo.modules.updates.selectionpolicy.SelectionPolicy
 import expo.modules.updates.statemachine.UpdatesStateEvent
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -58,6 +59,8 @@ class RelaunchProcedure(
     )
     try {
       launchWith(newLauncher)
+    } catch (e: CancellationException) {
+      throw e
     } catch (e: Exception) {
       logger.error("Error launching new launcher", e, UpdatesErrorCode.Unknown)
       callback.onFailure(e)
@@ -92,6 +95,8 @@ class RelaunchProcedure(
           getCurrentLauncher().launchedUpdate,
           selectionPolicy
         )
+      } catch (e: CancellationException) {
+        throw e
       } catch (e: Exception) {
         logger.error("Could not run Reaper.", e, UpdatesErrorCode.Unknown)
       }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
@@ -21,6 +21,7 @@ import expo.modules.updates.manifest.Update
 import expo.modules.updates.selectionpolicy.SelectionPolicy
 import expo.modules.updates.statemachine.UpdatesStateEvent
 import expo.modules.updates.statemachine.UpdatesStateValue
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -242,7 +243,7 @@ class StartupProcedure(
           return
         }
         remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.NEW_UPDATE_LOADING
-        val remoteLoader = RemoteLoader(context, updatesConfiguration, logger, databaseHolder.database, fileDownloader, updatesDirectory, launchedUpdate)
+        val remoteLoader = RemoteLoader(context, updatesConfiguration, logger, databaseHolder.database, fileDownloader, updatesDirectory, launchedUpdate, procedureScope)
         procedureScope.launch {
           try {
             val loaderResult = remoteLoader.load { updateResponse ->
@@ -267,6 +268,8 @@ class StartupProcedure(
                 ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
               }
             )
+          } catch (e: CancellationException) {
+            throw e
           } catch (e: Exception) {
             logger.error("UpdatesController loadRemoteUpdate onFailure", e, UpdatesErrorCode.UpdateFailedToLoad, launchedUpdate?.loggingId, null)
             setRemoteLoadStatus(ErrorRecoveryDelegate.RemoteLoadStatus.IDLE)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/reloadscreen/ReloadScreenView.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/reloadscreen/ReloadScreenView.kt
@@ -11,6 +11,7 @@ import android.view.View
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.ProgressBar
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
@@ -135,6 +136,8 @@ class ReloadScreenView @JvmOverloads constructor(
             imageView.setImageBitmap(it)
           } ?: handleImageLoadFailure()
         }
+      } catch (e: CancellationException) {
+        throw e
       } catch (e: Exception) {
         withContext(Dispatchers.Main) {
           handleImageLoadFailure()


### PR DESCRIPTION
# Why
In many cases, we were treating cancellation the same as if an actual system error occurred. This led to wasting resources retrying when unnecessary or misreporting an error.

# How
- Explicitly catch cancellation errors so they are handled appropriately
- synchronized the lists used in the loader as these were modified inside suspend blocks.
- The loader was not using the controllers scope leading it to be orphaned if the controller scope was cancelled. We were already accepting the scope in the parent `Loader` class but we were not using it in the subclasses, now we use it so this work is parented correctly.

# Test Plan
e2e tests pass
Instrumentation and units tests pass
