### PR TITLE
[expo-router][ios]: Fixes xcasset icons to use custom symbols

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix xcasset icon handling in native tabs to return the correct `xcasset` type instead of wrapping as `imageSource` ([#XXXX](https://github.com/expo/expo/pull/XXXX) by [@kaarl77](https://github.com/kaarl77))
+- Fix xcasset icon handling in native tabs to return the correct `xcasset` type instead of wrapping as `imageSource` ([#43976](https://github.com/expo/expo/pull/43976) by [@kaarl77](https://github.com/kaarl77))
 - Fix pinned `react-navigation` dependencies ([#43456](https://github.com/expo/expo/pull/43456) by [@kitten](https://github.com/kitten))
 - Fix zoom transition to prefetched routes ([#43852](https://github.com/expo/expo/pull/43852) by [@Ubax](https://github.com/Ubax))
 - Fix `Stack.Protected` guard not applying to index routes. ([#43769](https://github.com/expo/expo/pull/43769) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix xcasset icon handling in native tabs to return the correct `xcasset` type instead of wrapping as `imageSource` ([#XXXX](https://github.com/expo/expo/pull/XXXX) by [@kaarl77](https://github.com/kaarl77))
 - Fix pinned `react-navigation` dependencies ([#43456](https://github.com/expo/expo/pull/43456) by [@kitten](https://github.com/kitten))
 - Fix zoom transition to prefetched routes ([#43852](https://github.com/expo/expo/pull/43852) by [@Ubax](https://github.com/Ubax))
 - Fix `Stack.Protected` guard not applying to index routes. ([#43769](https://github.com/expo/expo/pull/43769) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-router/src/native-tabs/utils/icon.ts
+++ b/packages/expo-router/src/native-tabs/utils/icon.ts
@@ -84,11 +84,11 @@ export function convertOptionsIconToIOSPropsIcon(
       name: icon.sf,
     };
   }
-  if (icon && (('xcasset' in icon && icon.xcasset) || ('src' in icon && icon.src))) {
-    const imageSource =
-      'xcasset' in icon && icon.xcasset
-        ? { uri: icon.xcasset }
-        : (icon as { src: ImageSourcePropType }).src;
+  if (icon && 'xcasset' in icon && icon.xcasset) {
+    return { type: 'xcasset', name: icon.xcasset };
+  }
+  if (icon && 'src' in icon && icon.src) {
+    const imageSource = (icon as { src: ImageSourcePropType }).src;
     const renderingMode = 'renderingMode' in icon ? icon.renderingMode : undefined;
     const effectiveRenderingMode =
       renderingMode ?? (iconColor !== undefined ? 'template' : 'original');


### PR DESCRIPTION




# Why

The convertOptionsIconToIOSPropsIcon function incorrectly wrapped xcasset icons as { uri: icon.xcasset } and passed them through the imageSource/templateSource rendering logic. However, react-native-screens defines a dedicated PlatformIconIOS variant { type: 'xcasset', name } for xcasset icons.

# How

Split the combined xcasset/src condition into two separate branches so xcasset icons return the correct type directly, while src icons continue through the existing rendering mode logic.

# Test Plan

- Tested with xcasset icons in native tabs — icons now render correctly using the proper xcasset pipeline
- Verified that both custom (xcasset prop) and standard (sf prop) SF Symbols continue to work as expected

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
