### PR TITLE
fix(exponent): handle exps links as https in dev servers

### DIFF
--- a/apps/expo-go/ios/Exponent/Versioned/Core/EXVersionManagerObjC.mm
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/EXVersionManagerObjC.mm
@@ -15,6 +15,7 @@
 #import <React/RCTDevMenu.h>
 #import <React/RCTDevSettings.h>
 #import <React/RCTExceptionsManager.h>
+#import <React/RCTBundleURLProvider.h>
 #import <React/RCTLog.h>
 #import <React/RCTRedBox.h>
 #import <React/RCTPackagerConnection.h>
@@ -117,6 +118,8 @@ RCT_EXTERN void EXRegisterScopedModule(Class, ...);
   if ([self _isDevModeEnabledForHost:bundleURL]) {
     // Set the bundle url for the packager connection manually
     NSString *packagerServerHostPort = [NSString stringWithFormat:@"%@:%@", bundleURL.host, bundleURL.port];
+    RCTBundleURLProvider *settings = [RCTBundleURLProvider sharedSettings];
+    settings.packagerScheme = ([bundleURL.scheme isEqualToString:@"https"] || [bundleURL.scheme isEqualToString:@"exps"]) ? @"https" : @"http";
     
     RCTDevSettings* devSettings = (RCTDevSettings*)[self getModuleInstanceFromClass:[self getModuleClassFromName:"DevSettings"]];
     if (devSettings == nil) {

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [iOS] Fix issue when using `fullScreenModal` with `expo-router`. ([#43520](https://github.com/expo/expo/pull/43520) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix missing navigation bar padding ([#43672](https://github.com/expo/expo/pull/43672) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix orientation change regression. ([#43847](https://github.com/expo/expo/pull/43847) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix hard-coded usage of http with exps URLs ([#43982](https://github.com/expo/expo/pull/43982) by [@muvaf](https://github.com/muvaf))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/Unsafe/RCTPackagerConnection+EXDevLauncherPackagerConnectionInterceptor.m
+++ b/packages/expo-dev-launcher/ios/Unsafe/RCTPackagerConnection+EXDevLauncherPackagerConnectionInterceptor.m
@@ -18,7 +18,8 @@ static RCTReconnectingWebSocket *createSocketForURL(NSURL * url)
 {
   NSURLComponents *const components = [NSURLComponents new];
   components.host = [url host];
-  components.scheme = @"http";
+  NSString *scheme = [url scheme];
+  components.scheme = ([scheme isEqualToString:@"https"] || [scheme isEqualToString:@"exps"]) ? @"https" : @"http";
   components.port =  [url port];
   components.path = @"/message";
   components.queryItems = @[[NSURLQueryItem queryItemWithName:@"role" value:@"ios"]];


### PR DESCRIPTION
# Why

Even when `exps://` URL is used, Expo Go still tries to use `http` as its scheme and because websocket client does not support `301 Moved Permanently`, it fails to establish a WebSocket connection. It fall backs to HTTP polling but it keeps trying for the duration of the app and those connections don't seem to be properly closed that they end up being stale.

I think this can be backported to Expo 54 and 55 as well.

# How

Added logic to choose `https` if the link is `exps`.

# Test Plan

1. Install Expo Go to local iOS simulator.
1. Get the Expo dev server running behing forced HTTPS, such as Replit dev URLs.
1. Get the IP address.
   ```bash
   nslookup some-udid.worf.replit.dev
   ```
1. Watch what's happening on with that IP live
   ``` bash
   sudo tcpdump -i any -n -A -s 0 'host 34.75.151.117' 2>/dev/null | grep -E --line-buffered 'GET |Host:|Upgrade:|HTTP/1\.[01] [0-9]|Location:|\.80:|\.443:'
   ```

Before this change, you'll see repeated `301 Moved Permanently` on port 80 that never stops because it's not able to upgrade WebSocket connection. After this change, you'll see no port 80 connections and the flow settles after a while since it was able to establish WebSocket on 443, though it's not visible as it's behind TLS.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
