### PR TITLE
Add optional codeSignIdentity parameter to setProvisioningProfileForPbxproj

### DIFF
--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Added optional `codeSignIdentity` parameter to `setProvisioningProfileForPbxproj` to allow callers to specify the code signing identity instead of always using `"iPhone Distribution"`. ([#XXXX](https://github.com/expo/expo/pull/XXXX) by [@qwertey6](https://github.com/qwertey6))
+- Added optional `codeSignIdentity` parameter to `setProvisioningProfileForPbxproj` to allow callers to specify the code signing identity instead of always using `"iPhone Distribution"`. ([#43986](https://github.com/expo/expo/pull/43986) by [@qwertey6](https://github.com/qwertey6))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added optional `codeSignIdentity` parameter to `setProvisioningProfileForPbxproj` to allow callers to specify the code signing identity instead of always using `"iPhone Distribution"`. ([#XXXX](https://github.com/expo/expo/pull/XXXX) by [@qwertey6](https://github.com/qwertey6))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/@expo/config-plugins/src/ios/ProvisioningProfile.ts
+++ b/packages/@expo/config-plugins/src/ios/ProvisioningProfile.ts
@@ -16,6 +16,7 @@ type ProvisioningProfileSettings = {
   appleTeamId: string;
   profileName: string;
   buildConfiguration?: string;
+  codeSignIdentity?: string;
 };
 
 export function setProvisioningProfileForPbxproj(
@@ -25,6 +26,7 @@ export function setProvisioningProfileForPbxproj(
     profileName,
     appleTeamId,
     buildConfiguration = 'Release',
+    codeSignIdentity = 'iPhone Distribution',
   }: ProvisioningProfileSettings
 ): void {
   const project = getPbxproj(projectRoot);
@@ -41,7 +43,7 @@ export function setProvisioningProfileForPbxproj(
     .forEach(([, item]: ConfigurationSectionEntry) => {
       item.buildSettings.PROVISIONING_PROFILE_SPECIFIER = `"${profileName}"`;
       item.buildSettings.DEVELOPMENT_TEAM = quotedAppleTeamId;
-      item.buildSettings.CODE_SIGN_IDENTITY = '"iPhone Distribution"';
+      item.buildSettings.CODE_SIGN_IDENTITY = `"${codeSignIdentity}"`;
       item.buildSettings.CODE_SIGN_STYLE = 'Manual';
     });
 

--- a/packages/@expo/config-plugins/src/ios/__tests__/ProvisioningProfile-test.ts
+++ b/packages/@expo/config-plugins/src/ios/__tests__/ProvisioningProfile-test.ts
@@ -84,6 +84,18 @@ describe('ProvisioningProfile module', () => {
         const pbxprojContents = fs.readFileSync(path.join(projectRoot, pbxProjPath), 'utf-8');
         expect(pbxprojContents).toMatch(/DevelopmentTeam = "Something Spaced";/);
       });
+      it('configures the project.pbxproj file with a custom code sign identity', () => {
+        setProvisioningProfileForPbxproj(projectRoot, {
+          profileName: '*[expo] com.swmansion.dominik.abcd.v2 AppStore 2020-07-24T07:56:22.983Z',
+          appleTeamId: 'J5FM626PE2',
+          codeSignIdentity: 'Apple Development: Test User',
+        });
+        const pbxprojContents = fs.readFileSync(path.join(projectRoot, pbxProjPath), 'utf-8');
+        expect(pbxprojContents).toMatch(
+          /CODE_SIGN_IDENTITY = "Apple Development: Test User"/
+        );
+        expect(pbxprojContents).not.toMatch(/CODE_SIGN_IDENTITY = "iPhone Distribution"/);
+      });
       it('throws descriptive error when target name does not exist', () => {
         expect(() =>
           setProvisioningProfileForPbxproj(projectRoot, {


### PR DESCRIPTION
## Why

`setProvisioningProfileForPbxproj` hardcodes `CODE_SIGN_IDENTITY = "iPhone Distribution"`, which is incorrect for iOS Development provisioning profiles. Development certificates can have various signing identities (`"Apple Development"`, `"iPhone Developer"`, `"iOS Development"`, etc.), and there's currently no way for callers to specify the correct identity.

This was identified while working on [expo/eas-cli#3496](https://github.com/expo/eas-cli/pull/3496), where EAS build needs to set the correct code signing identity for Development profiles.

## How

Added an optional `codeSignIdentity` parameter to the `ProvisioningProfileSettings` type. It defaults to `"iPhone Distribution"` so existing callers are unaffected. When provided, the specified identity is used instead of the hardcoded default.

## Test Plan

- Added a new test case that passes a custom `codeSignIdentity` (`"Apple Development: Test User"`) and verifies it appears in the output pbxproj instead of `"iPhone Distribution"`.
- All existing tests continue to pass (default behavior unchanged).

```
PASS @expo/config-plugins src/ios/__tests__/ProvisioningProfile-test.ts
  ProvisioningProfile module
    setProvisioningProfileForPbxproj
      multitarget
        ✓ configures the project.pbxproj file for multitarget projects
        ✓ configures the project.pbxproj file for multitarget projects without existing target attributes
      single target
        ✓ configures the project.pbxproj file with the profile name and apple team id
        ✓ configures the project.pbxproj file with the profile name and apple team id
        ✓ configures the project.pbxproj file with a custom code sign identity
        ✓ throws descriptive error when target name does not exist
```

## Checklist

- [x] I added a `changelog.md` entry and rebuilt package sources (per [CONTRIBUTING.md](https://github.com/expo/expo/blob/main/CONTRIBUTING.md) guide)