### PR TITLE
[widgets] Fix `projectRoot` for widgets bundle

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add support for `React.Fragment`. ([#43833](https://github.com/expo/expo/pull/43833) by [@jakex7](https://github.com/jakex7))
 - Add Button children support. ([#43832](https://github.com/expo/expo/pull/43832) by [@jakex7](https://github.com/jakex7))
 - Remove unused `Compression` related code. ([#43981](https://github.com/expo/expo/pull/43981) by [@jakex7](https://github.com/jakex7))
+- Fix `projectRoot` for widgets bundle. ([#43987](https://github.com/expo/expo/pull/43987) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-widgets/metro.config.js
+++ b/packages/expo-widgets/metro.config.js
@@ -30,6 +30,10 @@ if (rel.startsWith('..') || path.isAbsolute(rel)) {
 const buildConfig = {
   ...config,
   projectRoot: __dirname, // Override root to be expo-widgets
+  config: {
+    ...config.config,
+    projectRoot: __dirname, // Override root to be expo-widgets
+  },
   watchFolders,
   resolver: {
     ...config.resolver,


### PR DESCRIPTION
# Why

When used in the project, widgets `app.json` is ignored as `config.projectRoot` is set to the user project instead of widgets directory. This is a regression https://github.com/expo/expo/pull/43350

# How

Override `projectRoot` to widgets `__dirname`

# Test Plan

Run widgets in the project with react compiler enabled. Generated widgets bundle should not contain compiler-related code.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
