### PR TITLE
[docs] Add Expo Agent intro video to additional resources

### DIFF
--- a/docs/pages/additional-resources/index.mdx
+++ b/docs/pages/additional-resources/index.mdx
@@ -1,5 +1,5 @@
 ---
-modificationDate: March 2, 2026
+modificationDate: March 17, 2026
 title: Additional resources
 description: A reference of resources that are useful to learn about Expo tooling and services.
 ---

--- a/docs/public/static/talks.ts
+++ b/docs/public/static/talks.ts
@@ -438,6 +438,12 @@ export const LIVE_STREAMS = [
 
 export const YOUTUBE_VIDEOS = [
   {
+    title: 'Introducing Expo Agent (beta): build real, production-quality native apps from your browser',
+    event: 'Expo Tutorials',
+    videoId: '3yyy32R0s2k',
+    uploadDate: '2026-03-10',
+  },
+  {
     title: "What's new in Expo SDK 55",
     event: 'Expo Tutorials',
     videoId: 'q72aeXsbF9c',


### PR DESCRIPTION
# Why

The Expo team published a new video, "Introducing Expo Agent (beta)", on the @ExpoDevelopers YouTube channel on March 10, 2026. It is not yet listed on the additional resources page.

# How

- Add the "Introducing Expo Agent (beta)" video entry to the top of the `YOUTUBE_VIDEOS` array in `docs/public/static/talks.ts`.
- Update `modificationDate` in `docs/pages/additional-resources/index.mdx` to reflect the current date.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2776" height="844" alt="CleanShot 2026-03-17 at 15 35 11@2x" src="https://github.com/user-attachments/assets/fb4dc5c5-e8d1-4a32-a85e-9d85cd9a3b0b" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
