### PR TITLE
[docs] Add `next-end.d.ts` to `.gitignore`

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -14,6 +14,7 @@ public/static/constants
 .next
 .swc
 out
+next-env.d.ts
 
 # worker test temp dir
 .worker-test

--- a/docs/next-env.d.ts
+++ b/docs/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.


### PR DESCRIPTION
# Why

`next-env.d.ts` is auto-generated by Next.js every time `next dev` or `next build` runs. The import path inside it changes depending on the Next.js version and mode (for example, `.next/dev/types/routes.d.ts` vs `.next/types/routes.d.ts`), which causes it to repeatedly show up as a dirty file. Since the file's own comment says "this file should not be edited" and Next.js recreates it automatically, there is no reason to track it.

# How

- Add `next-env.d.ts` to `docs/.gitignore`, grouped with the other Next.js entries (`.next`, `.swc`, `out`).
- Remove the file from Git tracking via `git rm --cached`. The local file is preserved and Next.js will continue to regenerate it as needed.

# Test Plan

Run `next dev` in the docs directory and confirm `next-env.d.ts` is regenerated locally but does not appear in `git status`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
