### PR TITLE
[updates] fix e2e for dev-client

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Remove pin on `arg` dependency ([#43456](https://github.com/expo/expo/pull/43456) by [@kitten](https://github.com/kitten))
+- Fixed Updates E2E tests. ([#43995](https://github.com/expo/expo/pull/43995) by [@kudo](https://github.com/kudo))
 
 ## 55.0.11 — 2026-02-25
 

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_runUpdate.yml
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_runUpdate.yml
@@ -25,10 +25,17 @@ onFlowStart:
     when:
       platform: android
     commands:
-      - tapOn: exp://
+      - tapOn:
+          label: Tap on "New development server"
+          text: New development server
+          optional: true
+      - tapOn:
+          label: Tap on "Updates URL" text field
+          text: '.*exp:.*'
 - inputText:
     label: Input local update server URL
     text: "http://localhost:4747/update\n"
+- hideKeyboard
 - tapOn:
     label: Tap on "Connect" button
     text: Connect

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_verifyState.yml
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_verifyState.yml
@@ -20,10 +20,17 @@ onFlowStart:
     when:
       platform: android
     commands:
-      - tapOn: exp://
+      - tapOn:
+          label: Tap on "New development server"
+          text: New development server
+          optional: true
+      - tapOn:
+          label: Tap on "Updates URL" text field
+          text: '.*exp:.*'
 - inputText:
     label: Input local update server URL
     text: "http://localhost:8081\n"
+- hideKeyboard
 - tapOn:
     label: Tap on "Connect" button
     text: Connect


### PR DESCRIPTION
# Why

fix updates e2e error: https://expo.dev/accounts/expo-ci/projects/expo-workflow-testing/workflows/019ce351-89c6-7c69-8b46-9f21c6cfb672#job-019ce351-8d0c-7bd4-a498-7777b53a6f5b

# How

- support two differents ui with "New development server" button or without "New development server" button
- add hideKeyboard to fix emulator small screen that cannot find the "Connect" button

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
