### PR TITLE
chore(minimal-tester): Remove redundant deps and babel config

### DIFF
--- a/apps/minimal-tester/babel.config.js
+++ b/apps/minimal-tester/babel.config.js
@@ -1,6 +1,0 @@
-module.exports = function(api) {
-  api.cache(true);
-  return {
-    presets: ['babel-preset-expo'],
-  };
-};

--- a/apps/minimal-tester/package.json
+++ b/apps/minimal-tester/package.json
@@ -1,5 +1,6 @@
 {
   "name": "minimal-tester",
+  "private": true,
   "version": "1.0.0",
   "scripts": {
     "start": "expo start --dev-client",
@@ -26,14 +27,5 @@
     "react-dom": "19.2.3",
     "react-native": "0.85.0-rc.1",
     "react-native-web": "~0.21.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.25.2"
-  },
-  "private": true,
-  "expo": {
-    "autolinking": {
-      "exclude": []
-    }
   }
 }


### PR DESCRIPTION
Explicit babel config in pnpm isolated deps requires babel-preset-expo, but the config is redundant.

Ref: 27ea1d2cff61907754ecb2d6539fb5db42c88da5

Picked from:
- #41288
- https://github.com/expo/expo/pull/41288/changes/27ea1d2cff61907754ecb2d6539fb5db42c88da5