### PR TITLE
chore(notification-tester): Remove babel dep and invalid resolution

### DIFF
--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -2,6 +2,7 @@
   "name": "notification-tester",
   "main": "index.ts",
   "version": "1.0.0",
+  "private": true
   "scripts": {
     "start": "expo start --dev-client",
     "android": "expo run:android",
@@ -39,13 +40,7 @@
     "react-native-screens": "4.24.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.0",
     "@types/jest": "^29.5.12",
     "@types/react": "~19.2.0"
-  },
-  "resolutions": {
-    "react-test-renderer": "19.2.3"
-  },
-  "expo": {},
-  "private": true
+  }
 }


### PR DESCRIPTION
# Why

Resolutions in individual packages have no effect, and the `@babel/core` dependency is now redundant.

Picked from:
- #41288
- https://github.com/expo/expo/pull/41288/changes/f89ec9fec9b229accdaec7b78ab4a688acf8ae6e

@vonovak: What is the metro config good for? It might've been copied from another app but should be removed, unless it's still serving a purpose. Not sure if it can be removed

# How

- Remove `package.json:resolutions`
- Remove `@babel/core` dependency

# Test Plan

- CI should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
