### PR TITLE
chore(cli,autolinking): Add re-export `package.json:exports` entries to CLI & autolinking

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Drop `expo-router/doctor` install check ([#43461](https://github.com/expo/expo/pull/43461) by [@kitten](https://github.com/kitten))
 - Pass on `tls` options from Metro config to Metro `runServer` fork ([#43186](https://github.com/expo/expo/pull/43186) by [@cortinico](https://github.com/cortinico))
 - Add internal `--skip-server` flag to skip server bundling in `export:embed` ([#43602](https://github.com/expo/expo/pull/43602) by [@kitten](https://github.com/kitten))
+- Add `package.json:exports` with no-op reexport paths ([#44002](https://github.com/expo/expo/pull/44002) by [@kitten](https://github.com/kitten), [@hassankhan](https://github.com/hassankhan))
 
 ## 55.0.12 — 2026-02-25
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -8,6 +8,7 @@
   },
   "exports": {
     "./package.json": "./package.json",
+    "./static/template/*": "./static/template/*",
     ".": "./build/bin/cli",
     "./*": "./*.js",
     "./*.js": "./*.js"

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -6,6 +6,12 @@
   "bin": {
     "expo-internal": "build/bin/cli"
   },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./build/bin/cli",
+    "./*": "./*.js",
+    "./*.js": "./*.js"
+  },
   "files": [
     "add-module.js",
     "internal",

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 💡 Others
 
+- Add `package.json:exports` with no-op reexport paths ([#44002](https://github.com/expo/expo/pull/44002) by [@kitten](https://github.com/kitten), [@hassankhan](https://github.com/hassankhan))
+
 ## 55.0.8 — 2026-02-25
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-modules-autolinking/package.json
+++ b/packages/expo-modules-autolinking/package.json
@@ -4,6 +4,16 @@
   "description": "Scripts that autolink Expo modules.",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./build/index.d.ts",
+      "require": "./build/index.js",
+      "default": "./build/index.js"
+    },
+    "./*": "./*.js",
+    "./*.js": "./*.js"
+  },
   "scripts": {
     "build": "expo-module build",
     "clean": "expo-module clean",

--- a/packages/expo-modules-autolinking/package.json
+++ b/packages/expo-modules-autolinking/package.json
@@ -11,6 +11,11 @@
       "require": "./build/index.js",
       "default": "./build/index.js"
     },
+    "./exports": {
+      "types": "./build/exports.d.ts",
+      "require": "./build/exports.js",
+      "default": "./build/exports.js"
+    },
     "./*": "./*.js",
     "./*.js": "./*.js"
   },


### PR DESCRIPTION
# Why

This was necessary for resolution to work correctly in Node in some cases. I don't quite remember what mode this puts us into but it's unfortunately required.

Picked from:
- https://github.com/expo/expo/pull/41288
- https://github.com/expo/expo/pull/41288/changes/0363a0285dd8a2e3f1a9c1957036467a2d019204

# How

- Add noop `package.json:exports` re-exports to CLI
- Add noop `package.json:exports` re-exports to expo-modules-autolinking

# Test Plan

- CI should still pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
