### PR TITLE
chore(cli/e2e): Fix transient CLI E2E test failures using atomic move

### DIFF
--- a/packages/@expo/cli/e2e/__tests__/utils.ts
+++ b/packages/@expo/cli/e2e/__tests__/utils.ts
@@ -88,7 +88,10 @@ export async function createFromFixtureAsync(
       return projectRoot;
     } else {
       log('Clearing existing fixture project:', projectRoot);
-      await fs.promises.rm(projectRoot, { recursive: true, force: true });
+      // NOTE(@kitten): Rename first to quickly move project out of the way
+      const tempName = getTemporaryPath();
+      await fs.promises.rename(projectRoot, tempName);
+      await fs.promises.rm(tempName, { recursive: true, force: true });
     }
   }
 


### PR DESCRIPTION
# Why

Picked: https://github.com/expo/expo/pull/41288/changes/cb256d910f163d18fe89242dd110c34879d5d493

This fixes re-run and transient failures by atomically moving existing test fixtures out of the way.

# How

- `mv` before `rm` on test fixtures

# Test Plan

- CI should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
