### PR TITLE
test(cli): Update resolve-from mock with explicit error

### DIFF
--- a/packages/@expo/cli/__mocks__/resolve-from.ts
+++ b/packages/@expo/cli/__mocks__/resolve-from.ts
@@ -1,5 +1,3 @@
-const resolveFrom = require(require.resolve('resolve-from'));
-
 const silent = (fromDirectory: string, request: string) => {
   const fs = require('fs');
   const path = require('path');
@@ -32,7 +30,9 @@ const silent = (fromDirectory: string, request: string) => {
 module.exports = jest.fn((fromDirectory, request) => {
   const path = silent(fromDirectory, request);
   if (!path) {
-    return resolveFrom(fromDirectory, request);
+    const err: any = new Error(`Cannot find module '${request}'`);
+    err.code = 'MODULE_NOT_FOUND';
+    throw err;
   }
   return path;
 });

--- a/packages/@expo/cli/__mocks__/resolve-from.ts
+++ b/packages/@expo/cli/__mocks__/resolve-from.ts
@@ -30,9 +30,8 @@ const silent = (fromDirectory: string, request: string) => {
 module.exports = jest.fn((fromDirectory, request) => {
   const path = silent(fromDirectory, request);
   if (!path) {
-    const err: any = new Error(`Cannot find module '${request}'`);
-    err.code = 'MODULE_NOT_FOUND';
-    throw err;
+    const err = new Error(`Cannot find module '${request}'`);
+    throw Object.assign(err, { code: 'MODULE_NOT_FOUND' });
   }
   return path;
 });


### PR DESCRIPTION
# Why

Picked: https://github.com/expo/expo/pull/41288/changes/fb9bdbdd552e0e0c7b6d89b01561fe4ec9dd033c

I believe this is/was masking incorrect test mocks. We should monitor CI to see whether changing this before the pnpm switchover causes any issues.

# How

- Remove incorrect `resolve-from` mock fallback in tests

# Test Plan

- CI should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
