### PR TITLE
test(cli/e2e): Fix `NODE_PATH` pollution for some E2E tests

### DIFF
--- a/packages/@expo/cli/e2e/__tests__/config-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/config-test.ts
@@ -56,7 +56,13 @@ it('runs `npx expo config --json`', async () => {
   // Add an environment variable file to test that it's not included in the config.
   await fs.writeFile(path.join(projectRoot, '.env'), 'FOOBAR=1');
 
-  const results = await executeExpoAsync(projectRoot, ['config', '--json']);
+  const results = await executeExpoAsync(projectRoot, ['config', '--json'], {
+    env: {
+      // TODO(@kitten): remove once hoist=false in pnpm; Prevent node_modules/.pnpm/node_modules hoist path from being passed
+      NODE_PATH: '',
+    },
+  });
+
   // @ts-ignore
   const exp = JSON.parse(results.stdout);
 
@@ -80,7 +86,13 @@ it('runs `npx expo config --json` with a warning', async () => {
     '{ "abc": true, "expo": { "name": "foobar" } }'
   );
 
-  const results = await executeExpoAsync(projectRoot, ['config', '--json']);
+  const results = await executeExpoAsync(projectRoot, ['config', '--json'], {
+    env: {
+      // TODO(@kitten): remove once hoist=false in pnpm; Prevent node_modules/.pnpm/node_modules hoist path from being passed
+      NODE_PATH: '',
+    },
+  });
+
   // @ts-ignore
   const exp = JSON.parse(results.stdout);
 
@@ -90,6 +102,12 @@ it('runs `npx expo config --json` with a warning', async () => {
 
 it('throws on invalid project root', async () => {
   await expect(
-    executeExpoAsync(projectRoot, ['config', 'very---invalid', '--json'], { verbose: false })
+    executeExpoAsync(projectRoot, ['config', 'very---invalid', '--json'], {
+      verbose: false,
+      env: {
+        // TODO(@kitten): remove once hoist=false in pnpm; Prevent node_modules/.pnpm/node_modules hoist path from being passed
+        NODE_PATH: '',
+      },
+    })
   ).rejects.toThrow(/^Invalid project root: .*very---invalid$/m);
 });

--- a/packages/@expo/cli/e2e/__tests__/config-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/config-test.ts
@@ -58,6 +58,7 @@ it('runs `npx expo config --json`', async () => {
 
   const results = await executeExpoAsync(projectRoot, ['config', '--json'], {
     env: {
+      ...process.env,
       // TODO(@kitten): remove once hoist=false in pnpm; Prevent node_modules/.pnpm/node_modules hoist path from being passed
       NODE_PATH: '',
     },
@@ -88,6 +89,7 @@ it('runs `npx expo config --json` with a warning', async () => {
 
   const results = await executeExpoAsync(projectRoot, ['config', '--json'], {
     env: {
+      ...process.env,
       // TODO(@kitten): remove once hoist=false in pnpm; Prevent node_modules/.pnpm/node_modules hoist path from being passed
       NODE_PATH: '',
     },
@@ -105,6 +107,7 @@ it('throws on invalid project root', async () => {
     executeExpoAsync(projectRoot, ['config', 'very---invalid', '--json'], {
       verbose: false,
       env: {
+        ...process.env,
         // TODO(@kitten): remove once hoist=false in pnpm; Prevent node_modules/.pnpm/node_modules hoist path from being passed
         NODE_PATH: '',
       },

--- a/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
@@ -78,7 +78,13 @@ it('runs `npx expo prebuild` asserts when expo is not installed', async () => {
   await fs.writeFile(path.join(projectRoot, 'app.json'), '{ "expo": { "name": "foobar" } }');
 
   await expect(
-    executeExpoAsync(projectRoot, ['prebuild', '--no-install'], { verbose: false })
+    executeExpoAsync(projectRoot, ['prebuild', '--no-install'], {
+      verbose: false,
+      env: {
+        // TODO(@kitten): remove once hoist=false in pnpm; Prevent node_modules/.pnpm/node_modules hoist path from being passed
+        NODE_PATH: '',
+      },
+    })
   ).rejects.toThrow(
     /Cannot determine the project's Expo SDK version because the module `expo` is not installed\. Install it with `npm install expo` and try again./
   );

--- a/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
@@ -81,6 +81,7 @@ it('runs `npx expo prebuild` asserts when expo is not installed', async () => {
     executeExpoAsync(projectRoot, ['prebuild', '--no-install'], {
       verbose: false,
       env: {
+        ...process.env,
         // TODO(@kitten): remove once hoist=false in pnpm; Prevent node_modules/.pnpm/node_modules hoist path from being passed
         NODE_PATH: '',
       },


### PR DESCRIPTION
# Why

`pnpm` likes to inject `NODE_PATH` to make sure that a "semi-isolated" mode can still find some dependencies. This can cause us to find dependencies that should be inaccessible. This interferes with our tests explicitly testing that dependencies are complete.

To prevent this, we should override `NODE_PATH` to empty it out. This should have no effect with Yarn.

# How

- Pick: https://github.com/expo/expo/pull/41288/changes/d45ec5dce7c71a5ae96e486e2bd61cb07fc25a84

# Test Plan

- CI should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
