### PR TITLE
fix/test(create-expo): Remove semver import and replace

### DIFF
--- a/packages/create-expo/e2e/__tests__/index-test.ts
+++ b/packages/create-expo/e2e/__tests__/index-test.ts
@@ -1,7 +1,6 @@
 import spawnAsync from '@expo/spawn-async';
 import fs from 'fs';
 import path from 'path';
-import semver from 'semver';
 
 import {
   createTestPath,
@@ -60,15 +59,10 @@ it('creates a full basic project by default', async () => {
 });
 
 // TODO: drop this test when the oldest supported Node version is >=23
-(semver.major(process.versions.node) >= 23 ? it.skip : it)(
+const [nodeMajor] = process.versions.node.split('.').map(Number);
+(nodeMajor >= 23 ? it.skip : it)(
   'throws when fetch is disabled',
   async () => {
-    const [major] = process.versions.node.split('.').map(Number);
-    if (major >= 23) {
-      expect(true).toBe(true);
-      // `--no-experimental-fetch` is a legacy flag fetch it not experimental in Node.js 23+
-      return;
-    }
     const projectName = 'throws-when-fetch-disabled';
     let result: Awaited<ReturnType<typeof execute>>;
 


### PR DESCRIPTION
# Why

`create-expo` uses `semver` in its tests but has no dependency on it. We actually also don't need `semver` for this trivial check and can just drop it.

# How

- Manually check Node version in test for `create-expo`
- Picks: https://github.com/expo/expo/pull/41288/changes/0d8389c0ea7daf7940c6d685dd0b1aadcf7edd06

# Test Plan

- CI should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
