### PR TITLE
test(cli/e2e): Sanitize RSC payloads

### DIFF
--- a/packages/@expo/cli/e2e/playwright/dev/02-server-actions.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/02-server-actions.test.ts
@@ -3,6 +3,7 @@ import { test, expect } from '@playwright/test';
 import { clearEnv, restoreEnv } from '../../__tests__/export/export-side-effects';
 import { getRouterE2ERoot } from '../../__tests__/utils';
 import { createExpoStart } from '../../utils/expo';
+import { sanitizeRSCPayloadString } from '../../utils/rsc';
 import { pageCollectErrors } from '../page';
 
 test.beforeAll(() => clearEnv());
@@ -101,7 +102,7 @@ test.describe(inputDir, () => {
 
     const rscPayload = new TextDecoder().decode(await response.body());
 
-    expect(rscPayload)
+    expect(sanitizeRSCPayloadString(rscPayload))
       .toBe(`1:I["node_modules/react-native-web/dist/exports/Text/index.js",["/node_modules/react-native-web/dist/exports/Text/index.js.bundle?platform=web&dev=true&hot=false&transform.asyncRoutes=true&transform.routerRoot=__e2e__%2F02-server-actions%2Fapp&modulesOnly=true&runModule=false&resolver.clientboundary=true&xRSC=1"],"",1]
 0:{"_value":[["$","$L1",null,{"style":{"color":"darkcyan"},"testID":"server-action-props","children":"c=0"},null],["$","$L1",null,{"testID":"server-action-platform","children":"web"},null]]}
 `);

--- a/packages/@expo/cli/e2e/playwright/dev/02-server-actions.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/02-server-actions.test.ts
@@ -103,7 +103,7 @@ test.describe(inputDir, () => {
     const rscPayload = new TextDecoder().decode(await response.body());
 
     expect(sanitizeRSCPayloadString(rscPayload))
-      .toBe(`1:I["node_modules/react-native-web/dist/exports/Text/index.js",["/node_modules/react-native-web/dist/exports/Text/index.js.bundle?platform=web&dev=true&hot=false&transform.asyncRoutes=true&transform.routerRoot=__e2e__%2F02-server-actions%2Fapp&modulesOnly=true&runModule=false&resolver.clientboundary=true&xRSC=1"],"",1]
+      .toBe(`1:I["react-native-web/dist/exports/Text/index.js",["/react-native-web/dist/exports/Text/index.js.bundle?platform=web&dev=true&hot=false&transform.asyncRoutes=true&transform.routerRoot=__e2e__%2F02-server-actions%2Fapp&modulesOnly=true&runModule=false&resolver.clientboundary=true&xRSC=1"],"",1]
 0:{"_value":[["$","$L1",null,{"style":{"color":"darkcyan"},"testID":"server-action-props","children":"c=0"},null],["$","$L1",null,{"testID":"server-action-platform","children":"web"},null]]}
 `);
 

--- a/packages/@expo/cli/e2e/playwright/dev/03-server-actions-only.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/03-server-actions-only.test.ts
@@ -3,6 +3,7 @@ import { test, expect } from '@playwright/test';
 import { clearEnv, restoreEnv } from '../../__tests__/export/export-side-effects';
 import { getRouterE2ERoot } from '../../__tests__/utils';
 import { createExpoStart } from '../../utils/expo';
+import { sanitizeRSCPayloadString } from '../../utils/rsc';
 import { pageCollectErrors } from '../page';
 
 test.beforeAll(() => clearEnv());
@@ -83,7 +84,7 @@ test.describe(inputDir, () => {
 
     const rscPayload = new TextDecoder().decode(await response.body());
 
-    expect(rscPayload).toMatch(
+    expect(sanitizeRSCPayloadString(rscPayload)).toMatch(
       '2:I["node_modules/react-native-web/dist/exports/Text/index.js",["/node_modules/react-native-web/dist/exports/Text/index.js.bundle?platform=web&dev=true&hot=false&transform.asyncRoutes=true&transform.routerRoot=__e2e__%2F03-server-actions-only%2Fapp&modulesOnly=true&runModule=false&resolver.clientboundary=true&xRSC=1"]'
     );
 

--- a/packages/@expo/cli/e2e/playwright/dev/03-server-actions-only.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/03-server-actions-only.test.ts
@@ -85,7 +85,7 @@ test.describe(inputDir, () => {
     const rscPayload = new TextDecoder().decode(await response.body());
 
     expect(sanitizeRSCPayloadString(rscPayload)).toMatch(
-      '2:I["node_modules/react-native-web/dist/exports/Text/index.js",["/node_modules/react-native-web/dist/exports/Text/index.js.bundle?platform=web&dev=true&hot=false&transform.asyncRoutes=true&transform.routerRoot=__e2e__%2F03-server-actions-only%2Fapp&modulesOnly=true&runModule=false&resolver.clientboundary=true&xRSC=1"]'
+      '2:I["react-native-web/dist/exports/Text/index.js",["/react-native-web/dist/exports/Text/index.js.bundle?platform=web&dev=true&hot=false&transform.asyncRoutes=true&transform.routerRoot=__e2e__%2F03-server-actions-only%2Fapp&modulesOnly=true&runModule=false&resolver.clientboundary=true&xRSC=1"]'
     );
 
     expect(pageErrors.all).toEqual([]);

--- a/packages/@expo/cli/e2e/playwright/prod/01-rsc.test.ts
+++ b/packages/@expo/cli/e2e/playwright/prod/01-rsc.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { clearEnv, restoreEnv } from '../../__tests__/export/export-side-effects';
 import { findProjectFiles, getRouterE2ERoot } from '../../__tests__/utils';
 import { createExpoServe, executeExpoAsync } from '../../utils/expo';
+import { sanitizeRSCPayloadString } from '../../utils/rsc';
 import { pageCollectErrors } from '../page';
 
 // TODO: We'll split this test up in the future when server/single do different things.
@@ -155,7 +156,7 @@ for (const outputMode of outputModes) {
       const response = await serverResponsePromise;
       const rscPayload = new TextDecoder().decode(await response.body()).trim();
 
-      expect(rscPayload)
+      expect(sanitizeRSCPayloadString(rscPayload))
         .toBe(`1:I["node_modules/react-native-safe-area-context/lib/module/index.js",[],"SafeAreaView",1]
 2:I["packages/expo-router/build/rsc/router/host.js",[],"Children",1]
 3:I["node_modules/react-native-web/dist/exports/View/index.js",[],"",1]

--- a/packages/@expo/cli/e2e/playwright/prod/01-rsc.test.ts
+++ b/packages/@expo/cli/e2e/playwright/prod/01-rsc.test.ts
@@ -157,11 +157,11 @@ for (const outputMode of outputModes) {
       const rscPayload = new TextDecoder().decode(await response.body()).trim();
 
       expect(sanitizeRSCPayloadString(rscPayload))
-        .toBe(`1:I["node_modules/react-native-safe-area-context/lib/module/index.js",[],"SafeAreaView",1]
+        .toBe(`1:I["react-native-safe-area-context/lib/module/index.js",[],"SafeAreaView",1]
 2:I["packages/expo-router/build/rsc/router/host.js",[],"Children",1]
-3:I["node_modules/react-native-web/dist/exports/View/index.js",[],"",1]
+3:I["react-native-web/dist/exports/View/index.js",[],"",1]
 4:I["packages/expo-router/build/rsc/router/client.js",[],"Link",1]
-5:I["node_modules/react-native-web/dist/exports/Text/index.js",[],"",1]
+5:I["react-native-web/dist/exports/Text/index.js",[],"",1]
 0:{"layout":["$","$L1",null,{"style":{"flex":1},"testID":"layout-child-wrapper","children":[["$","$L2",null,{}],["$","$L3",null,{"testID":"layout-global-style","style":[{"width":100,"height":100},{"$$css":true,"_":"custom-global-style"}]}],["$","$L3",null,{"testID":"layout-module-style","style":[{"width":100,"height":100},{"$$css":true,"_":"zvzhJW_container"}]}],["$","$L3",null,{"style":{"flexDirection":"row","padding":12,"justifyContent":"space-around"},"children":[["$","$L4",null,{"href":"/","style":{},"children":"One"}],["$","$L4",null,{"href":"/second","style":{},"children":"Two"}]]}]]}],"colors/blue/page":["$","$L5",null,{"testID":"color","children":["blue","-","static"]}],"/SHOULD_SKIP":[["layout",[]],["colors/layout",[]],["colors/blue/layout",[]],["colors/blue/page",[]]],"/LOCATION":["/colors/blue",""]}`);
 
       await expect(page.locator('[data-testid="color"]')).toHaveText('blue-static');

--- a/packages/@expo/cli/e2e/playwright/prod/02-server-actions.test.ts
+++ b/packages/@expo/cli/e2e/playwright/prod/02-server-actions.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from '@playwright/test';
 import { clearEnv, restoreEnv } from '../../__tests__/export/export-side-effects';
 import { getRouterE2ERoot } from '../../__tests__/utils';
 import { createExpoServe, executeExpoAsync } from '../../utils/expo';
+import { sanitizeRSCPayloadString } from '../../utils/rsc';
 import { pageCollectErrors } from '../page';
 
 test.beforeAll(() => clearEnv());
@@ -137,7 +138,8 @@ test.describe(inputDir, () => {
 
     const rscPayload = new TextDecoder().decode(await response.body());
 
-    expect(rscPayload).toBe(`1:I["node_modules/react-native-web/dist/exports/Text/index.js",[],"",1]
+    expect(sanitizeRSCPayloadString(rscPayload))
+      .toBe(`1:I["node_modules/react-native-web/dist/exports/Text/index.js",[],"",1]
 0:{"_value":[["$","$L1",null,{"style":{"color":"darkcyan"},"testID":"server-action-props","children":"c=0"}],["$","$L1",null,{"testID":"server-action-platform","children":"web"}]]}
 `);
 

--- a/packages/@expo/cli/e2e/playwright/prod/02-server-actions.test.ts
+++ b/packages/@expo/cli/e2e/playwright/prod/02-server-actions.test.ts
@@ -139,7 +139,7 @@ test.describe(inputDir, () => {
     const rscPayload = new TextDecoder().decode(await response.body());
 
     expect(sanitizeRSCPayloadString(rscPayload))
-      .toBe(`1:I["node_modules/react-native-web/dist/exports/Text/index.js",[],"",1]
+      .toBe(`1:I["react-native-web/dist/exports/Text/index.js",[],"",1]
 0:{"_value":[["$","$L1",null,{"style":{"color":"darkcyan"},"testID":"server-action-props","children":"c=0"}],["$","$L1",null,{"testID":"server-action-platform","children":"web"}]]}
 `);
 

--- a/packages/@expo/cli/e2e/utils/rsc.ts
+++ b/packages/@expo/cli/e2e/utils/rsc.ts
@@ -1,0 +1,29 @@
+const stringRe = /"(?:"|[^\r\n]*?[^\\]")/g;
+const complexStringRe = /\\/g;
+
+const maybeParseString = (match: string): string | null => {
+  if (!complexStringRe.test(match)) {
+    return match.slice(1, -1);
+  }
+  try {
+    return JSON.parse(match);
+  } catch {
+    return null;
+  }
+};
+
+const pathReplacePattern = /^(\/)?node_modules\/(\.pnpm\/[\w@+.-]+\/)?/g;
+
+export function sanitizeRSCPayloadString(input: string): string {
+  // TODO(@kitten): We currently don't parse the RSC payloads. We only sanitize the pnpm paths in them for now
+  return input.replace(stringRe, (match) => {
+    let str = maybeParseString(match);
+    if (str) {
+      // Account for optional leading slash
+      str = str.replace(pathReplacePattern, (_match, prefix) => prefix || '');
+      return JSON.stringify(str);
+    } else {
+      return match;
+    }
+  });
+}


### PR DESCRIPTION
# Why

We should be sanitizing the RSC payload to remove pnpm paths from the RSC outputs since they're unstable. There's currently no better way of achieving this unless we make core changes.

> [!NOTE]
> There's a good chance the pick here is incomplete, as in, fixtures/snapshots will need to be updated, but I'll wait for a CI run for simplicity

# How

- Picks: https://github.com/expo/expo/pull/41288/changes/9df88eb6ee9dcbe3d7fbde640e8967f05ac81222

# Test Plan

- CI should still pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
