### PR TITLE
chore(bare-expo): Add missing `@expo/spawn-async` scripts deps

### DIFF
--- a/apps/bare-expo/e2e/image-comparison/package.json
+++ b/apps/bare-expo/e2e/image-comparison/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "main": "src/server.ts",
   "scripts": {
-		"buildInspector": "./inspector/scripts/build.sh",
+    "buildInspector": "./inspector/scripts/build.sh",
     "dev": "bun --watch --no-clear-screen ./src/server.ts",
     "start": "bun run src/server.ts",
     "test": "bun test",
@@ -15,6 +15,7 @@
     "debug-inspector": "bun run inspector/ScreenInspectorIOS.ts"
   },
   "dependencies": {
+    "@expo/spawn-async": "^1.7.2",
     "jimp-compact": "^0.16.1-2",
     "pixelmatch": "^7.1.0",
     "pngjs": "^7.0.0",

--- a/apps/bare-expo/e2e/image-comparison/yarn.lock
+++ b/apps/bare-expo/e2e/image-comparison/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@expo/spawn-async@^1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@expo/spawn-async/-/spawn-async-1.7.2.tgz#fcfe66c3e387245e72154b1a7eae8cada6a47f58"
+  integrity sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==
+  dependencies:
+    cross-spawn "^7.0.3"
+
 "@types/bun@latest":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@types/bun/-/bun-1.3.0.tgz#3d3dfbe0b610163d135c9ac925af808b2448cc18"
@@ -30,10 +37,29 @@ bun-types@1.3.0:
   dependencies:
     "@types/node" "*"
 
+cross-spawn@^7.0.3:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
 jimp-compact@^0.16.1-2:
   version "0.16.1-2"
   resolved "https://registry.yarnpkg.com/jimp-compact/-/jimp-compact-0.16.1-2.tgz#a82ff9a5a81f15a4b61b5e2e50fae6a43305e5a9"
   integrity sha512-b2A3rRT1TITzqmaO70U2/uunCh43BQVq7BfRwGPkD5xj8/WZsR3sPTy9DENt+dNZGsel3zBEm1UtYegUxjZW7A==
+
+path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
 pixelmatch@^7.1.0:
   version "7.1.0"
@@ -47,10 +73,29 @@ pngjs@^7.0.0:
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-7.0.0.tgz#a8b7446020ebbc6ac739db6c5415a65d17090e26"
   integrity sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==
 
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
 undici-types@~7.14.0:
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.14.0.tgz#4c037b32ca4d7d62fae042174604341588bc0840"
   integrity sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==
+
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+  dependencies:
+    isexe "^2.0.0"
 
 zod@^4.1.12:
   version "4.1.12"

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -83,6 +83,7 @@
     "test-suite": "*"
   },
   "devDependencies": {
+    "@expo/spawn-async": "^1.7.2",
     "@babel/core": "^7.20.0",
     "@types/react": "~19.2.0",
     "babel-preset-expo": "~55.0.8",


### PR DESCRIPTION
# Why

Picked from: 
- https://github.com/expo/expo/pull/41288/changes/9ccce6e701a7c699d50c12ffb14067d75782dc8f#diff-715a34e1282e2804dfc732bf880f8335858fe6a1e67a36f74e6ed39606a14fe1
- https://github.com/expo/expo/pull/41288/changes/90db131b6a5b768cb426b0f1226207f3c0d7df6c

# How

- Adds missing `@expo/spawn-async` for `bare-expo`'s scripts

# Test Plan

- CI should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
