### PR TITLE
[image][iOS] Fix `VM region info is not in any region`

### DIFF
--- a/packages/expo-image/ios/ImageLoader.swift
+++ b/packages/expo-image/ios/ImageLoader.swift
@@ -6,7 +6,7 @@ import ExpoModulesCore
 internal final class ImageLoader {
   nonisolated(unsafe) static let shared = ImageLoader()
 
-  lazy var imageManager = SDWebImageManager(
+  let imageManager = SDWebImageManager(
     cache: SDImageCache.shared,
     loader: SDImageLoadersManager.shared
   )


### PR DESCRIPTION
# Why

Fixes:
```
-------------------------------------
Translated Report (Full Report Below)
-------------------------------------
Process:             expoimagecrashrepro [87312]
Path:                /Users/USER/Library/Developer/CoreSimulator/Devices/67F47FEA-D30C-4C19-B8D5-EE342653AC8E/data/Containers/Bundle/Application/9816A963-CC51-480E-8FA7-65BC5797E91B/expoimagecrashrepro.app/expoimagecrashrepro
Identifier:          com.anonymous.expoimagecrashrepro
Version:             1.0.0 (1)
Code Type:           ARM-64 (Native)
Role:                Foreground
Parent Process:      launchd_sim [11248]
Coalition:           com.apple.CoreSimulator.SimDevice [189128]
Responsible Process: SimulatorTrampoline [93176]
User ID:             501

Date/Time:           2026-03-17 12:29:49.2866 +0100
Launch Time:         2026-03-17 12:29:47.9531 +0100
Hardware Model:      Mac16,8
OS Version:          macOS 26.3 (25D125)
Release Type:        User

Time Awake Since Boot: 330000 seconds
Time Since Wake:       12571 seconds

System Integrity Protection: enabled

Triggered by Thread: 2, Dispatch Queue: com.apple.root.user-initiated-qos.cooperative

Exception Type:    EXC_BAD_ACCESS (SIGSEGV)
Exception Subtype: KERN_INVALID_ADDRESS at 0x0000beaddccdecb0
Exception Codes:   0x0000000000000001, 0x0000beaddccdecb0

Termination Reason:  Namespace SIGNAL, Code 11, Segmentation fault: 11
Terminating Process: exc handler [87312]


VM Region Info: 0x3eaddccdecb0 is not in any region.  Bytes after previous region: 68435410021553  Bytes before following region: 36636661519184
      REGION TYPE                    START - END         [ VSIZE] PRT/MAX SHRMOD  REGION DETAIL
      VM_ALLOCATE                7000418000-7000800000   [ 4000K] rw-/rwx SM=ZER  
--->  GAP OF 0x5f8fff800000 BYTES
      MALLOC_NANO              600000000000-600020000000 [512.0M] rw-/rwx SM=PRV  

Thread 0::  Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	       0x1050ccb70 mach_msg2_trap + 8
1   libsystem_kernel.dylib        	       0x1050dd90c mach_msg2_internal + 72
2   libsystem_kernel.dylib        	       0x1050d4c10 mach_msg_overwrite + 480
3   libsystem_kernel.dylib        	       0x1050ccee4 mach_msg + 20
4   CoreFoundation                	       0x180455c04 __CFRunLoopServiceMachPort + 156
5   CoreFoundation                	       0x180454dbc __CFRunLoopRun + 1128
6   CoreFoundation                	       0x18044fcec _CFRunLoopRunSpecificWithOptions + 496
7   GraphicsServices              	       0x192a669bc GSEventRunModal + 116
8   UIKitCore                     	       0x186348574 -[UIApplication _run] + 772
9   UIKitCore                     	       0x18634c79c UIApplicationMain + 124
10  UIKitCore                     	       0x18557f2d0 0x18519e000 + 4068048
11  expoimagecrashrepro.debug.dylib	       0x10791c21c static UIApplicationDelegate.main() + 128
12  expoimagecrashrepro.debug.dylib	       0x10791c18c static AppDelegate.$main() + 44
13  expoimagecrashrepro.debug.dylib	       0x10791cc98 __debug_main_executable_dylib_entry_point + 28
14  ???                           	       0x1050113d0 ???
15  dyld                          	       0x105154d54 start + 7184

Thread 1::  Dispatch queue: com.apple.root.user-initiated-qos.cooperative
0   libsystem_kernel.dylib        	       0x1050d9ac0 __ulock_wait2 + 8
1   libsystem_platform.dylib      	       0x104fdd3dc _os_unfair_lock_lock_slow + 172
2   libswiftCore.dylib            	       0x197660a60 swift::MetadataCacheEntryBase<swift::GenericCacheEntry, void const*>::awaitSatisfyingState(swift::ConcurrencyControl&, swift::MetadataRequest) + 300
3   libswiftCore.dylib            	       0x197661c80 std::__1::pair<swift::GenericCacheEntry*, swift::MetadataResponse> swift::LockingConcurrentMap<swift::GenericCacheEntry, swift::LockingConcurrentMapStorage<swift::GenericCacheEntry, (unsigned short)14>>::getOrInsert<swift::MetadataCacheKey, swift::MetadataRequest&, swift::TargetTypeContextDescriptor<swift::InProcess> const*&, void const* const*&>(swift::MetadataCacheKey, swift::MetadataRequest&, swift::TargetTypeContextDescriptor<swift::InProcess> const*&, void const* const*&) + 188
4   libswiftCore.dylib            	       0x197650ef8 _swift_getGenericMetadata(swift::MetadataRequest, void const* const*, swift::TargetTypeContextDescriptor<swift::InProcess> const*) + 276
5   libswiftCore.dylib            	       0x1979c7c98 __swift_instantiateGenericMetadata + 32
6   libswiftCore.dylib            	       0x19779525c _NativeDictionary.bridged() + 272
7   expoimagecrashrepro.debug.dylib	       0x1079da68c closure #1 in ImageLoader.load(_:options:) + 508
8   libswift_Concurrency.dylib    	       0x2575b2930 closure #1 in withCheckedContinuation<A>(isolation:function:_:) + 92
9   libswift_Concurrency.dylib    	       0x2575b2a18 withCheckedThrowingContinuation<A>(isolation:function:_:) + 92
10  expoimagecrashrepro.debug.dylib	       0x1079daed1 withCheckedThrowingContinuation<A>(isolation:function:_:) + 1
11  expoimagecrashrepro.debug.dylib	       0x1079da1c5 ImageLoader.load(_:options:) + 1 (ImageLoader.swift:25)
12  expoimagecrashrepro.debug.dylib	       0x1079ddc75 closure #1 in implicit closure #1 in ImageLoadTask.load() + 1 (ImageLoadTask.swift:18)
13  expoimagecrashrepro.debug.dylib	       0x1079ddef5 partial apply for closure #1 in implicit closure #1 in ImageLoadTask.load() + 1
14  libswift_Concurrency.dylib    	       0x2575f9d69 completeTaskWithClosure(swift::AsyncContext*, swift::SwiftError*) + 1

Thread 2 Crashed::  Dispatch queue: com.apple.root.user-initiated-qos.cooperative
0   libobjc.A.dylib               	       0x180072c14 objc_msgSend + 20
1   expoimagecrashrepro.debug.dylib	       0x1079da794 closure #1 in ImageLoader.load(_:options:) + 772 (ImageLoader.swift:26)
2   libswift_Concurrency.dylib    	       0x2575b2930 closure #1 in withCheckedContinuation<A>(isolation:function:_:) + 92
3   libswift_Concurrency.dylib    	       0x2575b2a18 withCheckedThrowingContinuation<A>(isolation:function:_:) + 92
4   expoimagecrashrepro.debug.dylib	       0x1079daed1 withCheckedThrowingContinuation<A>(isolation:function:_:) + 1
5   expoimagecrashrepro.debug.dylib	       0x1079da1c5 ImageLoader.load(_:options:) + 1 (ImageLoader.swift:25)
6   expoimagecrashrepro.debug.dylib	       0x1079ddc75 closure #1 in implicit closure #1 in ImageLoadTask.load() + 1 (ImageLoadTask.swift:18)
7   expoimagecrashrepro.debug.dylib	       0x1079ddef5 partial apply for closure #1 in implicit closure #1 in ImageLoadTask.load() + 1
8   libswift_Concurrency.dylib    	       0x2575f9d69 completeTaskWithClosure(swift::AsyncContext*, swift::SwiftError*) + 1
```

# How

The `lazy var` is not thread-safe, which can cause race conditions when loading multiple images simultaneously. The construction of `SDWebImageManager` is cheap, so I've decided to make it eager.  

# Test Plan

- bare-expo ✅ 