### PR TITLE
chore(apps/notification-tester): fix broken `package.json`

### DIFF
--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -2,7 +2,7 @@
   "name": "notification-tester",
   "main": "index.ts",
   "version": "1.0.0",
-  "private": true
+  "private": true,
   "scripts": {
     "start": "expo start --dev-client",
     "android": "expo run:android",


### PR DESCRIPTION
# Why

The changes in https://github.com/expo/expo/issues/44001 missed adding a comma after the newly-added `private` property, causing breakages in CI.

# How

Added missing comma.

# Test Plan

- CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
