### PR TITLE
[calendar][next] Add instance domain

### DIFF
--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/instance/InstanceEntity.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/instance/InstanceEntity.kt
@@ -7,9 +7,22 @@ import expo.modules.calendar.next.domain.model.event.Status
 import expo.modules.calendar.next.domain.wrappers.CalendarId
 import expo.modules.calendar.next.domain.wrappers.EventId
 
+/**
+ * Calendar instance entity mapped from the Android database cursor.
+ *
+ * Mapping Assumptions:
+ * - [id], [eventId], [begin], and [end] are non-nullable fields required by the provider.
+ * - Null booleans ([allDay], guest permission flags) are mapped to `false`.
+ * - [accessLevel] null is not equivalent to [AccessLevel.DEFAULT].
+ *
+ * Design Note:
+ * Default values are intentionally omitted to ensure compile-time safety.
+ * This forces the mapper to explicitly handle every field and prevents
+ * accidental omissions during cursor reading.
+ */
 data class InstanceEntity(
   val accessLevel: AccessLevel?,
-  val allDay: Boolean?,
+  val allDay: Boolean,
   val availability: Availability?,
   val begin: Long,
   val calendarId: CalendarId?,
@@ -20,12 +33,12 @@ data class InstanceEntity(
   val eventLocation: String?,
   val eventTimezone: String?,
   val id: Long,
-  val guestsCanInviteOthers: Boolean?,
-  val guestsCanModify: Boolean?,
-  val guestsCanSeeGuests: Boolean?,
+  val guestsCanInviteOthers: Boolean,
+  val guestsCanModify: Boolean,
+  val guestsCanSeeGuests: Boolean,
   val organizer: String?,
   val originalId: EventId?,
   val rrule: RecurrenceRule?,
-  val status: Status? = null,
+  val status: Status?,
   val title: String?
 )

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/instance/InstanceEntity.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/instance/InstanceEntity.kt
@@ -1,0 +1,31 @@
+package expo.modules.calendar.next.domain.model.instance
+
+import expo.modules.calendar.next.domain.model.event.AccessLevel
+import expo.modules.calendar.next.domain.model.event.Availability
+import expo.modules.calendar.next.domain.model.event.RecurrenceRule
+import expo.modules.calendar.next.domain.model.event.Status
+import expo.modules.calendar.next.domain.wrappers.CalendarId
+import expo.modules.calendar.next.domain.wrappers.EventId
+
+data class InstanceEntity(
+  val accessLevel: AccessLevel?,
+  val allDay: Boolean?,
+  val availability: Availability?,
+  val begin: Long,
+  val calendarId: CalendarId?,
+  val description: String?,
+  val end: Long,
+  val eventEndTimezone: String?,
+  val eventId: EventId,
+  val eventLocation: String?,
+  val eventTimezone: String?,
+  val id: Long,
+  val guestsCanInviteOthers: Boolean?,
+  val guestsCanModify: Boolean?,
+  val guestsCanSeeGuests: Boolean?,
+  val organizer: String?,
+  val originalId: EventId?,
+  val rrule: RecurrenceRule?,
+  val status: Status? = null,
+  val title: String?
+)

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/instance/InstanceCursorExtensions.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/instance/InstanceCursorExtensions.kt
@@ -1,0 +1,56 @@
+package expo.modules.calendar.next.domain.repositories.instance
+
+import android.database.Cursor
+import android.provider.CalendarContract
+import expo.modules.calendar.next.domain.model.event.AccessLevel
+import expo.modules.calendar.next.domain.model.event.Availability
+import expo.modules.calendar.next.domain.model.event.RecurrenceRule
+import expo.modules.calendar.next.domain.model.event.Status
+import expo.modules.calendar.next.domain.model.instance.InstanceEntity
+import expo.modules.calendar.next.domain.repositories.getOptionalInt
+import expo.modules.calendar.next.domain.repositories.getOptionalLong
+import expo.modules.calendar.next.domain.repositories.getOptionalString
+import expo.modules.calendar.next.domain.wrappers.CalendarId
+import expo.modules.calendar.next.domain.wrappers.EventId
+
+fun Cursor.toInstanceEntity(): InstanceEntity {
+  return InstanceEntity(
+    accessLevel = getOptionalInt(CalendarContract.Instances.ACCESS_LEVEL)?.let {
+      AccessLevel.fromAndroidValue(it)
+    },
+    allDay = getOptionalInt(CalendarContract.Instances.ALL_DAY) != 0,
+    availability = getOptionalInt(CalendarContract.Instances.AVAILABILITY)?.let {
+      Availability.fromAndroidValue(it)
+    },
+    begin = getOptionalLong(CalendarContract.Instances.BEGIN)
+      ?: throw IllegalStateException("instance begin must not be null"),
+    calendarId = getOptionalLong(CalendarContract.Instances.CALENDAR_ID)?.let {
+      CalendarId(it)
+    },
+    description = getOptionalString(CalendarContract.Instances.DESCRIPTION),
+    end = getOptionalLong(CalendarContract.Instances.END)
+      ?: throw IllegalStateException("instance end must not be null"),
+    eventEndTimezone = getOptionalString(CalendarContract.Instances.EVENT_END_TIMEZONE),
+    eventId = EventId(
+      getOptionalLong(CalendarContract.Instances.EVENT_ID)
+        ?: throw IllegalStateException("instance eventId must not be null")
+    ),
+    eventLocation = getOptionalString(CalendarContract.Instances.EVENT_LOCATION),
+    eventTimezone = getOptionalString(CalendarContract.Instances.EVENT_TIMEZONE),
+    guestsCanInviteOthers = getOptionalInt(CalendarContract.Instances.GUESTS_CAN_INVITE_OTHERS) != 0,
+    guestsCanModify = getOptionalInt(CalendarContract.Instances.GUESTS_CAN_MODIFY) != 0,
+    guestsCanSeeGuests = getOptionalInt(CalendarContract.Instances.GUESTS_CAN_SEE_GUESTS) != 0,
+    organizer = getOptionalString(CalendarContract.Instances.ORGANIZER),
+    originalId = getOptionalLong(CalendarContract.Instances.ORIGINAL_ID)?.let {
+      EventId(it)
+    },
+    rrule = getOptionalString(CalendarContract.Instances.RRULE)
+      ?.takeIf { it.isNotBlank() }
+      ?.let { RecurrenceRule.fromRuleString(it) },
+    status = getOptionalInt(CalendarContract.Instances.STATUS)
+      ?.let { Status.fromAndroidValue(it) },
+    title = getOptionalString(CalendarContract.Instances.TITLE),
+    id = getOptionalLong(CalendarContract.Instances._ID)
+      ?: throw IllegalStateException("instance ID must not be null")
+  )
+}

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/instance/InstanceCursorExtensions.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/instance/InstanceCursorExtensions.kt
@@ -18,7 +18,7 @@ fun Cursor.toInstanceEntity(): InstanceEntity {
     accessLevel = getOptionalInt(CalendarContract.Instances.ACCESS_LEVEL)?.let {
       AccessLevel.fromAndroidValue(it)
     },
-    allDay = getOptionalInt(CalendarContract.Instances.ALL_DAY) != 0,
+    allDay = getOptionalInt(CalendarContract.Instances.ALL_DAY) == 1,
     availability = getOptionalInt(CalendarContract.Instances.AVAILABILITY)?.let {
       Availability.fromAndroidValue(it)
     },
@@ -37,9 +37,9 @@ fun Cursor.toInstanceEntity(): InstanceEntity {
     ),
     eventLocation = getOptionalString(CalendarContract.Instances.EVENT_LOCATION),
     eventTimezone = getOptionalString(CalendarContract.Instances.EVENT_TIMEZONE),
-    guestsCanInviteOthers = getOptionalInt(CalendarContract.Instances.GUESTS_CAN_INVITE_OTHERS) != 0,
-    guestsCanModify = getOptionalInt(CalendarContract.Instances.GUESTS_CAN_MODIFY) != 0,
-    guestsCanSeeGuests = getOptionalInt(CalendarContract.Instances.GUESTS_CAN_SEE_GUESTS) != 0,
+    guestsCanInviteOthers = getOptionalInt(CalendarContract.Instances.GUESTS_CAN_INVITE_OTHERS) == 1,
+    guestsCanModify = getOptionalInt(CalendarContract.Instances.GUESTS_CAN_MODIFY) == 1,
+    guestsCanSeeGuests = getOptionalInt(CalendarContract.Instances.GUESTS_CAN_SEE_GUESTS) == 1,
     organizer = getOptionalString(CalendarContract.Instances.ORGANIZER),
     originalId = getOptionalLong(CalendarContract.Instances.ORIGINAL_ID)?.let {
       EventId(it)

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/instance/InstanceCursorExtensions.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/instance/InstanceCursorExtensions.kt
@@ -15,12 +15,12 @@ import expo.modules.calendar.next.domain.wrappers.EventId
 
 fun Cursor.toInstanceEntity(): InstanceEntity {
   return InstanceEntity(
-    accessLevel = getOptionalInt(CalendarContract.Instances.ACCESS_LEVEL)?.let {
-      AccessLevel.fromAndroidValue(it)
+    accessLevel = getOptionalInt(CalendarContract.Instances.ACCESS_LEVEL)?.let { value ->
+      AccessLevel.entries.find { it.value == value }
     },
     allDay = getOptionalInt(CalendarContract.Instances.ALL_DAY) == 1,
-    availability = getOptionalInt(CalendarContract.Instances.AVAILABILITY)?.let {
-      Availability.fromAndroidValue(it)
+    availability = getOptionalInt(CalendarContract.Instances.AVAILABILITY)?.let { value ->
+      Availability.entries.find { it.value == value }
     },
     begin = getOptionalLong(CalendarContract.Instances.BEGIN)
       ?: throw IllegalStateException("instance begin must not be null"),
@@ -47,8 +47,9 @@ fun Cursor.toInstanceEntity(): InstanceEntity {
     rrule = getOptionalString(CalendarContract.Instances.RRULE)
       ?.takeIf { it.isNotBlank() }
       ?.let { RecurrenceRule.fromRuleString(it) },
-    status = getOptionalInt(CalendarContract.Instances.STATUS)
-      ?.let { Status.fromAndroidValue(it) },
+    status = getOptionalInt(CalendarContract.Instances.STATUS)?.let { value ->
+      Status.entries.find { it.value == value }
+    },
     title = getOptionalString(CalendarContract.Instances.TITLE),
     id = getOptionalLong(CalendarContract.Instances._ID)
       ?: throw IllegalStateException("instance ID must not be null")

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/instance/InstanceCursorExtensions.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/instance/InstanceCursorExtensions.kt
@@ -15,11 +15,11 @@ import expo.modules.calendar.next.domain.wrappers.EventId
 
 fun Cursor.toInstanceEntity(): InstanceEntity {
   return InstanceEntity(
-    accessLevel = getOptionalInt(CalendarContract.Instances.ACCESS_LEVEL)?.let { value ->
+    accessLevel = getOptionalInt(CalendarContract.Instances.ACCESS_LEVEL).let { value ->
       AccessLevel.entries.find { it.value == value }
     },
     allDay = getOptionalInt(CalendarContract.Instances.ALL_DAY) == 1,
-    availability = getOptionalInt(CalendarContract.Instances.AVAILABILITY)?.let { value ->
+    availability = getOptionalInt(CalendarContract.Instances.AVAILABILITY).let { value ->
       Availability.entries.find { it.value == value }
     },
     begin = getOptionalLong(CalendarContract.Instances.BEGIN)
@@ -47,7 +47,7 @@ fun Cursor.toInstanceEntity(): InstanceEntity {
     rrule = getOptionalString(CalendarContract.Instances.RRULE)
       ?.takeIf { it.isNotBlank() }
       ?.let { RecurrenceRule.fromRuleString(it) },
-    status = getOptionalInt(CalendarContract.Instances.STATUS)?.let { value ->
+    status = getOptionalInt(CalendarContract.Instances.STATUS).let { value ->
       Status.entries.find { it.value == value }
     },
     title = getOptionalString(CalendarContract.Instances.TITLE),

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/instance/InstanceRepository.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/instance/InstanceRepository.kt
@@ -62,7 +62,6 @@ class InstanceRepository(private val contentResolver: ContentResolver) {
     val selectionArgs: Array<String>?
   )
 
-
   companion object {
     val FULL_PROJECTION = arrayOf(
       CalendarContract.Instances._ID,

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/instance/InstanceRepository.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/instance/InstanceRepository.kt
@@ -1,0 +1,90 @@
+package expo.modules.calendar.next.domain.repositories.instance
+
+import android.content.ContentResolver
+import android.content.ContentUris
+import android.provider.CalendarContract
+import expo.modules.calendar.next.domain.model.instance.InstanceEntity
+import expo.modules.calendar.next.domain.repositories.asSequence
+import expo.modules.calendar.next.domain.repositories.safeQuery
+import expo.modules.calendar.next.domain.wrappers.CalendarId
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+// Instances are read-only on Android and generated on-the-fly based on start/end dates.
+// That's why there is no create/update/delete operations. It doesn't contain findById
+// because IDs are ephemeral.
+class InstanceRepository(private val contentResolver: ContentResolver) {
+  suspend fun findAll(
+    startDate: Long,
+    endDate: Long,
+    calendars: List<CalendarId>
+  ): List<InstanceEntity> = withContext(Dispatchers.IO) {
+    val query = buildSelection(calendars)
+
+    contentResolver.safeQuery(
+      uri = CalendarContract.Instances.CONTENT_URI.buildUpon().let { builder ->
+        ContentUris.appendId(builder, startDate)
+        ContentUris.appendId(builder, endDate)
+        builder.build()
+      },
+      projection = FULL_PROJECTION,
+      selection = query.selection,
+      selectionArgs = query.selectionArgs,
+      sortOrder = "${CalendarContract.Instances.BEGIN} ASC"
+    ).use { cursor ->
+      cursor.asSequence()
+        .map { it.toInstanceEntity() }
+        .toList()
+    }
+  }
+
+  private fun buildSelection(calendarIds: List<CalendarId>): SelectionQuery {
+    val visible = "${CalendarContract.Instances.VISIBLE} = 1"
+
+    return if (calendarIds.isNotEmpty()) {
+      val placeholders = calendarIds
+        .map { it.value.toString() }
+        .joinToString(",") { "?" }
+      val calendarFilter = "${CalendarContract.Instances.CALENDAR_ID} IN ($placeholders)"
+      SelectionQuery(
+        selection = "($visible AND $calendarFilter)",
+        selectionArgs = calendarIds
+          .map { it.value.toString() }
+          .toTypedArray()
+      )
+    } else {
+      SelectionQuery(selection = "($visible)", selectionArgs = null)
+    }
+  }
+
+  private class SelectionQuery(
+    val selection: String,
+    val selectionArgs: Array<String>?
+  )
+
+
+  companion object {
+    val FULL_PROJECTION = arrayOf(
+      CalendarContract.Instances._ID,
+      CalendarContract.Instances.ACCESS_LEVEL,
+      CalendarContract.Instances.ALL_DAY,
+      CalendarContract.Instances.AVAILABILITY,
+      CalendarContract.Instances.BEGIN,
+      CalendarContract.Instances.CALENDAR_ID,
+      CalendarContract.Instances.DESCRIPTION,
+      CalendarContract.Instances.END,
+      CalendarContract.Instances.EVENT_END_TIMEZONE,
+      CalendarContract.Instances.EVENT_ID,
+      CalendarContract.Instances.EVENT_LOCATION,
+      CalendarContract.Instances.EVENT_TIMEZONE,
+      CalendarContract.Instances.GUESTS_CAN_INVITE_OTHERS,
+      CalendarContract.Instances.GUESTS_CAN_MODIFY,
+      CalendarContract.Instances.GUESTS_CAN_SEE_GUESTS,
+      CalendarContract.Instances.ORGANIZER,
+      CalendarContract.Instances.ORIGINAL_ID,
+      CalendarContract.Instances.RRULE,
+      CalendarContract.Instances.STATUS,
+      CalendarContract.Instances.TITLE
+    )
+  }
+}

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/instance/InstanceRepositoryTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/instance/InstanceRepositoryTest.kt
@@ -8,7 +8,6 @@ import expo.modules.calendar.next.domain.model.event.AccessLevel
 import expo.modules.calendar.next.domain.model.event.Availability
 import expo.modules.calendar.next.domain.model.event.Status
 import expo.modules.calendar.next.domain.wrappers.CalendarId
-import expo.modules.calendar.next.domain.wrappers.EventId
 import expo.modules.calendar.next.exceptions.CouldNotExecuteQueryException
 import expo.modules.calendar.next.exceptions.PermissionException
 import io.mockk.every
@@ -64,7 +63,7 @@ class InstanceRepositoryTest {
         CalendarContract.Instances.RRULE to null,
         CalendarContract.Instances.GUESTS_CAN_INVITE_OTHERS to 1,
         CalendarContract.Instances.GUESTS_CAN_MODIFY to 0,
-        CalendarContract.Instances.GUESTS_CAN_SEE_GUESTS to 1,
+        CalendarContract.Instances.GUESTS_CAN_SEE_GUESTS to 1
       )
     )
     every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
@@ -131,7 +130,7 @@ class InstanceRepositoryTest {
     val cursor = cursorWithRows(
       minimalRow(id = 1L, eventId = 10L),
       minimalRow(id = 2L, eventId = 20L),
-      minimalRow(id = 3L, eventId = 30L),
+      minimalRow(id = 3L, eventId = 30L)
     )
     every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
 
@@ -261,7 +260,7 @@ class InstanceRepositoryTest {
     begin: Long = 1_000_000L,
     end: Long = 2_000_000L,
     allDay: Int = 0,
-    rrule: String? = null,
+    rrule: String? = null
   ): Map<String, Any?> = mapOf(
     CalendarContract.Instances._ID to id,
     CalendarContract.Instances.EVENT_ID to eventId,
@@ -282,7 +281,7 @@ class InstanceRepositoryTest {
     CalendarContract.Instances.RRULE to rrule,
     CalendarContract.Instances.GUESTS_CAN_INVITE_OTHERS to 0,
     CalendarContract.Instances.GUESTS_CAN_MODIFY to 0,
-    CalendarContract.Instances.GUESTS_CAN_SEE_GUESTS to 0,
+    CalendarContract.Instances.GUESTS_CAN_SEE_GUESTS to 0
   )
 
   // endregion

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/instance/InstanceRepositoryTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/instance/InstanceRepositoryTest.kt
@@ -97,22 +97,32 @@ class InstanceRepositoryTest {
   }
 
   @Test
-  fun `given cursor with allDay flag, when findAll, then maps allDay = 1 to true`() = runTest {
-    // Given
-    val cursor = cursorWithRows(minimalRow(allDay = 1))
-    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
-
-    // When
-    val result = repository.findAll(0L, 1000L, emptyList())
-
-    // Then
-    Assert.assertEquals(true, result.first().allDay)
-  }
-
-  @Test
   fun `given cursor with rrule, when findAll, then parses rrule from cursor`() = runTest {
     // Given
-    val cursor = cursorWithRows(minimalRow(rrule = "FREQ=WEEKLY;INTERVAL=1"))
+    val cursor = cursorWithRows(
+      mapOf(
+        CalendarContract.Instances._ID to 1L,
+        CalendarContract.Instances.EVENT_ID to 10L,
+        CalendarContract.Instances.BEGIN to 1_000_000L,
+        CalendarContract.Instances.END to 2_000_000L,
+        CalendarContract.Instances.ALL_DAY to 0,
+        CalendarContract.Instances.TITLE to null,
+        CalendarContract.Instances.DESCRIPTION to null,
+        CalendarContract.Instances.CALENDAR_ID to null,
+        CalendarContract.Instances.ACCESS_LEVEL to null,
+        CalendarContract.Instances.AVAILABILITY to null,
+        CalendarContract.Instances.STATUS to null,
+        CalendarContract.Instances.EVENT_LOCATION to null,
+        CalendarContract.Instances.EVENT_TIMEZONE to null,
+        CalendarContract.Instances.EVENT_END_TIMEZONE to null,
+        CalendarContract.Instances.ORGANIZER to null,
+        CalendarContract.Instances.ORIGINAL_ID to null,
+        CalendarContract.Instances.RRULE to "FREQ=WEEKLY;INTERVAL=1",
+        CalendarContract.Instances.GUESTS_CAN_INVITE_OTHERS to 0,
+        CalendarContract.Instances.GUESTS_CAN_MODIFY to 0,
+        CalendarContract.Instances.GUESTS_CAN_SEE_GUESTS to 0
+      )
+    )
     every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
 
     // When
@@ -125,12 +135,31 @@ class InstanceRepositoryTest {
   }
 
   @Test
-  fun `given cursor with multiple rows, when findAll, then returns multiple entities`() = runTest {
+  fun `given cursor with missing boolean flags, when findAll, then maps them to false`() = runTest {
     // Given
     val cursor = cursorWithRows(
-      minimalRow(id = 1L, eventId = 10L),
-      minimalRow(id = 2L, eventId = 20L),
-      minimalRow(id = 3L, eventId = 30L)
+      mapOf(
+        CalendarContract.Instances._ID to 1L,
+        CalendarContract.Instances.EVENT_ID to 10L,
+        CalendarContract.Instances.BEGIN to 1_000_000L,
+        CalendarContract.Instances.END to 2_000_000L,
+        CalendarContract.Instances.ALL_DAY to null,
+        CalendarContract.Instances.TITLE to null,
+        CalendarContract.Instances.DESCRIPTION to null,
+        CalendarContract.Instances.CALENDAR_ID to null,
+        CalendarContract.Instances.ACCESS_LEVEL to null,
+        CalendarContract.Instances.AVAILABILITY to null,
+        CalendarContract.Instances.STATUS to null,
+        CalendarContract.Instances.EVENT_LOCATION to null,
+        CalendarContract.Instances.EVENT_TIMEZONE to null,
+        CalendarContract.Instances.EVENT_END_TIMEZONE to null,
+        CalendarContract.Instances.ORGANIZER to null,
+        CalendarContract.Instances.ORIGINAL_ID to null,
+        CalendarContract.Instances.RRULE to null,
+        CalendarContract.Instances.GUESTS_CAN_INVITE_OTHERS to null,
+        CalendarContract.Instances.GUESTS_CAN_MODIFY to null,
+        CalendarContract.Instances.GUESTS_CAN_SEE_GUESTS to null
+      )
     )
     every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
 
@@ -138,10 +167,11 @@ class InstanceRepositoryTest {
     val result = repository.findAll(0L, 1000L, emptyList())
 
     // Then
-    Assert.assertEquals(3, result.size)
-    Assert.assertEquals(1L, result[0].id)
-    Assert.assertEquals(2L, result[1].id)
-    Assert.assertEquals(3L, result[2].id)
+    val entity = result.first()
+    Assert.assertEquals(false, entity.allDay)
+    Assert.assertEquals(false, entity.guestsCanInviteOthers)
+    Assert.assertEquals(false, entity.guestsCanModify)
+    Assert.assertEquals(false, entity.guestsCanSeeGuests)
   }
 
   // endregion
@@ -191,22 +221,6 @@ class InstanceRepositoryTest {
     Assert.assertEquals(listOf("1", "2"), selectionArgsSlot.captured.toList())
   }
 
-  @Test
-  fun `given single calendarId, when findAll, then uses single placeholder`() = runTest {
-    // Given
-    val selectionArgsSlot = slot<Array<String>>()
-    val cursor = emptyCursor()
-    every {
-      contentResolver.query(any(), any(), any(), capture(selectionArgsSlot), any())
-    } returns cursor
-
-    // When
-    repository.findAll(0L, 1000L, listOf(CalendarId(99L)))
-
-    // Then
-    Assert.assertEquals(listOf("99"), selectionArgsSlot.captured.toList())
-  }
-
   // endregion
 
   // region findAll — error handling
@@ -253,36 +267,6 @@ class InstanceRepositoryTest {
 
     return cursor
   }
-
-  private fun minimalRow(
-    id: Long = 1L,
-    eventId: Long = 10L,
-    begin: Long = 1_000_000L,
-    end: Long = 2_000_000L,
-    allDay: Int = 0,
-    rrule: String? = null
-  ): Map<String, Any?> = mapOf(
-    CalendarContract.Instances._ID to id,
-    CalendarContract.Instances.EVENT_ID to eventId,
-    CalendarContract.Instances.BEGIN to begin,
-    CalendarContract.Instances.END to end,
-    CalendarContract.Instances.ALL_DAY to allDay,
-    CalendarContract.Instances.TITLE to null,
-    CalendarContract.Instances.DESCRIPTION to null,
-    CalendarContract.Instances.CALENDAR_ID to null,
-    CalendarContract.Instances.ACCESS_LEVEL to null,
-    CalendarContract.Instances.AVAILABILITY to null,
-    CalendarContract.Instances.STATUS to null,
-    CalendarContract.Instances.EVENT_LOCATION to null,
-    CalendarContract.Instances.EVENT_TIMEZONE to null,
-    CalendarContract.Instances.EVENT_END_TIMEZONE to null,
-    CalendarContract.Instances.ORGANIZER to null,
-    CalendarContract.Instances.ORIGINAL_ID to null,
-    CalendarContract.Instances.RRULE to rrule,
-    CalendarContract.Instances.GUESTS_CAN_INVITE_OTHERS to 0,
-    CalendarContract.Instances.GUESTS_CAN_MODIFY to 0,
-    CalendarContract.Instances.GUESTS_CAN_SEE_GUESTS to 0
-  )
 
   // endregion
 }

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/instance/InstanceRepositoryTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/instance/InstanceRepositoryTest.kt
@@ -174,6 +174,46 @@ class InstanceRepositoryTest {
     Assert.assertEquals(false, entity.guestsCanSeeGuests)
   }
 
+  @Test
+  fun `given cursor with missing guest boolean flags, when findAll, then maps them to false`() = runTest {
+    // Given
+    val cursor = cursorWithRows(
+      mapOf(
+        CalendarContract.Instances._ID to 2L,
+        CalendarContract.Instances.EVENT_ID to 20L,
+        CalendarContract.Instances.BEGIN to 1_000_000L,
+        CalendarContract.Instances.END to 2_000_000L,
+        CalendarContract.Instances.ALL_DAY to 1,
+        CalendarContract.Instances.TITLE to null,
+        CalendarContract.Instances.DESCRIPTION to null,
+        CalendarContract.Instances.CALENDAR_ID to null,
+        CalendarContract.Instances.ACCESS_LEVEL to null,
+        CalendarContract.Instances.AVAILABILITY to null,
+        CalendarContract.Instances.STATUS to null,
+        CalendarContract.Instances.EVENT_LOCATION to null,
+        CalendarContract.Instances.EVENT_TIMEZONE to null,
+        CalendarContract.Instances.EVENT_END_TIMEZONE to null,
+        CalendarContract.Instances.ORGANIZER to null,
+        CalendarContract.Instances.ORIGINAL_ID to null,
+        CalendarContract.Instances.RRULE to null,
+        CalendarContract.Instances.GUESTS_CAN_INVITE_OTHERS to null,
+        CalendarContract.Instances.GUESTS_CAN_MODIFY to null,
+        CalendarContract.Instances.GUESTS_CAN_SEE_GUESTS to null
+      )
+    )
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
+
+    // When
+    val result = repository.findAll(0L, 1000L, emptyList())
+
+    // Then
+    val entity = result.first()
+    Assert.assertEquals(true, entity.allDay)
+    Assert.assertEquals(false, entity.guestsCanInviteOthers)
+    Assert.assertEquals(false, entity.guestsCanModify)
+    Assert.assertEquals(false, entity.guestsCanSeeGuests)
+  }
+
   // endregion
 
   // region findAll — selection / selectionArgs

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/instance/InstanceRepositoryTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/instance/InstanceRepositoryTest.kt
@@ -214,6 +214,45 @@ class InstanceRepositoryTest {
     Assert.assertEquals(false, entity.guestsCanSeeGuests)
   }
 
+  @Test
+  fun `given cursor with unknown enum values, when findAll, then maps them to null`() = runTest {
+    // Given
+    val cursor = cursorWithRows(
+      mapOf(
+        CalendarContract.Instances._ID to 3L,
+        CalendarContract.Instances.EVENT_ID to 30L,
+        CalendarContract.Instances.BEGIN to 1_000_000L,
+        CalendarContract.Instances.END to 2_000_000L,
+        CalendarContract.Instances.ALL_DAY to 0,
+        CalendarContract.Instances.TITLE to null,
+        CalendarContract.Instances.DESCRIPTION to null,
+        CalendarContract.Instances.CALENDAR_ID to null,
+        CalendarContract.Instances.ACCESS_LEVEL to 999,
+        CalendarContract.Instances.AVAILABILITY to 999,
+        CalendarContract.Instances.STATUS to 999,
+        CalendarContract.Instances.EVENT_LOCATION to null,
+        CalendarContract.Instances.EVENT_TIMEZONE to null,
+        CalendarContract.Instances.EVENT_END_TIMEZONE to null,
+        CalendarContract.Instances.ORGANIZER to null,
+        CalendarContract.Instances.ORIGINAL_ID to null,
+        CalendarContract.Instances.RRULE to null,
+        CalendarContract.Instances.GUESTS_CAN_INVITE_OTHERS to 0,
+        CalendarContract.Instances.GUESTS_CAN_MODIFY to 0,
+        CalendarContract.Instances.GUESTS_CAN_SEE_GUESTS to 0
+      )
+    )
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
+
+    // When
+    val result = repository.findAll(0L, 1000L, emptyList())
+
+    // Then
+    val entity = result.first()
+    Assert.assertNull(entity.accessLevel)
+    Assert.assertNull(entity.availability)
+    Assert.assertNull(entity.status)
+  }
+
   // endregion
 
   // region findAll — selection / selectionArgs

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/instance/InstanceRepositoryTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/instance/InstanceRepositoryTest.kt
@@ -1,0 +1,289 @@
+package expo.modules.calendar.next.domain.repositories.instance
+
+import android.content.ContentResolver
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.provider.CalendarContract
+import expo.modules.calendar.next.domain.model.event.AccessLevel
+import expo.modules.calendar.next.domain.model.event.Availability
+import expo.modules.calendar.next.domain.model.event.Status
+import expo.modules.calendar.next.domain.wrappers.CalendarId
+import expo.modules.calendar.next.domain.wrappers.EventId
+import expo.modules.calendar.next.exceptions.CouldNotExecuteQueryException
+import expo.modules.calendar.next.exceptions.PermissionException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class InstanceRepositoryTest {
+  private val contentResolver = mockk<ContentResolver>()
+  private val repository = InstanceRepository(contentResolver)
+
+  // region findAll — empty / multiple rows
+
+  @Test
+  fun `given cursor has no rows, when findAll, then returns empty list`() = runTest {
+    // Given
+    val cursor = emptyCursor()
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
+
+    // When
+    val result = repository.findAll(0L, 1000L, emptyList())
+
+    // Then
+    Assert.assertEquals(emptyList<Any>(), result)
+  }
+
+  @Test
+  fun `given cursor with data, when findAll, then maps a single cursor row to InstanceEntity`() = runTest {
+    // Given
+    val cursor = cursorWithRows(
+      mapOf(
+        CalendarContract.Instances._ID to 42L,
+        CalendarContract.Instances.EVENT_ID to 7L,
+        CalendarContract.Instances.BEGIN to 1_000_000L,
+        CalendarContract.Instances.END to 2_000_000L,
+        CalendarContract.Instances.TITLE to "Meeting",
+        CalendarContract.Instances.DESCRIPTION to "Standup",
+        CalendarContract.Instances.CALENDAR_ID to "3",
+        CalendarContract.Instances.ALL_DAY to 0,
+        CalendarContract.Instances.ACCESS_LEVEL to CalendarContract.Events.ACCESS_PUBLIC,
+        CalendarContract.Instances.AVAILABILITY to CalendarContract.Events.AVAILABILITY_FREE,
+        CalendarContract.Instances.STATUS to CalendarContract.Events.STATUS_CONFIRMED,
+        CalendarContract.Instances.EVENT_LOCATION to "Room 1",
+        CalendarContract.Instances.EVENT_TIMEZONE to "Europe/Warsaw",
+        CalendarContract.Instances.EVENT_END_TIMEZONE to "Europe/Warsaw",
+        CalendarContract.Instances.ORGANIZER to "organizer@example.com",
+        CalendarContract.Instances.ORIGINAL_ID to null,
+        CalendarContract.Instances.RRULE to null,
+        CalendarContract.Instances.GUESTS_CAN_INVITE_OTHERS to 1,
+        CalendarContract.Instances.GUESTS_CAN_MODIFY to 0,
+        CalendarContract.Instances.GUESTS_CAN_SEE_GUESTS to 1,
+      )
+    )
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
+
+    // When
+    val result = repository.findAll(0L, 3_000_000L, emptyList())
+
+    // Then
+    Assert.assertEquals(1, result.size)
+    val entity = result.first()
+    Assert.assertEquals(42L, entity.id)
+    Assert.assertEquals(7L, entity.eventId.value)
+    Assert.assertEquals(1_000_000L, entity.begin)
+    Assert.assertEquals(2_000_000L, entity.end)
+    Assert.assertEquals("Meeting", entity.title)
+    Assert.assertEquals("Standup", entity.description)
+    Assert.assertEquals(3L, entity.calendarId?.value)
+    Assert.assertEquals(false, entity.allDay)
+    Assert.assertEquals(AccessLevel.PUBLIC, entity.accessLevel)
+    Assert.assertEquals(Availability.FREE, entity.availability)
+    Assert.assertEquals(Status.CONFIRMED, entity.status)
+    Assert.assertEquals("Room 1", entity.eventLocation)
+    Assert.assertEquals("Europe/Warsaw", entity.eventTimezone)
+    Assert.assertEquals("Europe/Warsaw", entity.eventEndTimezone)
+    Assert.assertEquals("organizer@example.com", entity.organizer)
+    Assert.assertNull(entity.originalId)
+    Assert.assertNull(entity.rrule)
+    Assert.assertEquals(true, entity.guestsCanInviteOthers)
+    Assert.assertEquals(false, entity.guestsCanModify)
+    Assert.assertEquals(true, entity.guestsCanSeeGuests)
+  }
+
+  @Test
+  fun `given cursor with allDay flag, when findAll, then maps allDay = 1 to true`() = runTest {
+    // Given
+    val cursor = cursorWithRows(minimalRow(allDay = 1))
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
+
+    // When
+    val result = repository.findAll(0L, 1000L, emptyList())
+
+    // Then
+    Assert.assertEquals(true, result.first().allDay)
+  }
+
+  @Test
+  fun `given cursor with rrule, when findAll, then parses rrule from cursor`() = runTest {
+    // Given
+    val cursor = cursorWithRows(minimalRow(rrule = "FREQ=WEEKLY;INTERVAL=1"))
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
+
+    // When
+    val result = repository.findAll(0L, 1000L, emptyList())
+
+    // Then
+    val rrule = result.first().rrule
+    Assert.assertEquals("weekly", rrule?.frequency)
+    Assert.assertEquals(1, rrule?.interval)
+  }
+
+  @Test
+  fun `given cursor with multiple rows, when findAll, then returns multiple entities`() = runTest {
+    // Given
+    val cursor = cursorWithRows(
+      minimalRow(id = 1L, eventId = 10L),
+      minimalRow(id = 2L, eventId = 20L),
+      minimalRow(id = 3L, eventId = 30L),
+    )
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
+
+    // When
+    val result = repository.findAll(0L, 1000L, emptyList())
+
+    // Then
+    Assert.assertEquals(3, result.size)
+    Assert.assertEquals(1L, result[0].id)
+    Assert.assertEquals(2L, result[1].id)
+    Assert.assertEquals(3L, result[2].id)
+  }
+
+  // endregion
+
+  // region findAll — selection / selectionArgs
+
+  @Test
+  fun `given no calendarIds, when findAll, then uses only VISIBLE filter`() = runTest {
+    // Given
+    val selectionSlot = slot<String>()
+    val cursor = emptyCursor()
+    every {
+      contentResolver.query(
+        any(),
+        any(),
+        capture(selectionSlot),
+        isNull(),
+        any()
+      )
+    } returns cursor
+
+    // When
+    repository.findAll(0L, 1000L, emptyList())
+
+    // Then
+    val expectedSelection = "(${CalendarContract.Instances.VISIBLE} = 1)"
+    Assert.assertEquals(expectedSelection, selectionSlot.captured)
+  }
+
+  @Test
+  fun `given multiple calendarIds, when findAll, then adds IN clause to selection`() = runTest {
+    // Given
+    val selectionSlot = slot<String>()
+    val selectionArgsSlot = slot<Array<String>>()
+    val cursor = emptyCursor()
+    every {
+      contentResolver.query(any(), any(), capture(selectionSlot), capture(selectionArgsSlot), any())
+    } returns cursor
+
+    // When
+    repository.findAll(0L, 1000L, listOf(CalendarId(1L), CalendarId(2L)))
+
+    // Then
+    val expectedSelection =
+      "(${CalendarContract.Instances.VISIBLE} = 1 AND ${CalendarContract.Instances.CALENDAR_ID} IN (?,?))"
+    Assert.assertEquals(expectedSelection, selectionSlot.captured)
+    Assert.assertEquals(listOf("1", "2"), selectionArgsSlot.captured.toList())
+  }
+
+  @Test
+  fun `given single calendarId, when findAll, then uses single placeholder`() = runTest {
+    // Given
+    val selectionArgsSlot = slot<Array<String>>()
+    val cursor = emptyCursor()
+    every {
+      contentResolver.query(any(), any(), any(), capture(selectionArgsSlot), any())
+    } returns cursor
+
+    // When
+    repository.findAll(0L, 1000L, listOf(CalendarId(99L)))
+
+    // Then
+    Assert.assertEquals(listOf("99"), selectionArgsSlot.captured.toList())
+  }
+
+  // endregion
+
+  // region findAll — error handling
+
+  @Test(expected = PermissionException::class)
+  fun `given SecurityException, when findAll, then throws PermissionException`() = runTest {
+    // Given
+    every { contentResolver.query(any(), any(), any(), any(), any()) } throws SecurityException()
+
+    // When / Then
+    repository.findAll(0L, 1000L, emptyList())
+  }
+
+  @Test(expected = CouldNotExecuteQueryException::class)
+  fun `given null cursor, when findAll, then throws CouldNotExecuteQueryException`() = runTest {
+    // Given
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns null
+
+    // When / Then
+    repository.findAll(0L, 1000L, emptyList())
+  }
+
+  // endregion
+
+  // region helpers
+
+  private fun emptyCursor(): Cursor {
+    // Empty cursor requires at least one column for MatrixCursor
+    return MatrixCursor(arrayOf(CalendarContract.Instances._ID))
+  }
+
+  private fun cursorWithRows(vararg rows: Map<String, Any?>): Cursor {
+    if (rows.isEmpty()) {
+      return emptyCursor()
+    }
+
+    val columnNames = rows.first().keys.toTypedArray()
+    val cursor = MatrixCursor(columnNames)
+
+    for (row in rows) {
+      val rowValues = columnNames.map { columnName -> row[columnName] }.toTypedArray()
+      cursor.addRow(rowValues)
+    }
+
+    return cursor
+  }
+
+  private fun minimalRow(
+    id: Long = 1L,
+    eventId: Long = 10L,
+    begin: Long = 1_000_000L,
+    end: Long = 2_000_000L,
+    allDay: Int = 0,
+    rrule: String? = null,
+  ): Map<String, Any?> = mapOf(
+    CalendarContract.Instances._ID to id,
+    CalendarContract.Instances.EVENT_ID to eventId,
+    CalendarContract.Instances.BEGIN to begin,
+    CalendarContract.Instances.END to end,
+    CalendarContract.Instances.ALL_DAY to allDay,
+    CalendarContract.Instances.TITLE to null,
+    CalendarContract.Instances.DESCRIPTION to null,
+    CalendarContract.Instances.CALENDAR_ID to null,
+    CalendarContract.Instances.ACCESS_LEVEL to null,
+    CalendarContract.Instances.AVAILABILITY to null,
+    CalendarContract.Instances.STATUS to null,
+    CalendarContract.Instances.EVENT_LOCATION to null,
+    CalendarContract.Instances.EVENT_TIMEZONE to null,
+    CalendarContract.Instances.EVENT_END_TIMEZONE to null,
+    CalendarContract.Instances.ORGANIZER to null,
+    CalendarContract.Instances.ORIGINAL_ID to null,
+    CalendarContract.Instances.RRULE to rrule,
+    CalendarContract.Instances.GUESTS_CAN_INVITE_OTHERS to 0,
+    CalendarContract.Instances.GUESTS_CAN_MODIFY to 0,
+    CalendarContract.Instances.GUESTS_CAN_SEE_GUESTS to 0,
+  )
+
+  // endregion
+}


### PR DESCRIPTION
# Why
[3/n] of the `calendar@next` refactor stacked PR. This PR adds the instance domain, which represents event instances from the Android Calendar API. Unlike the event domain, this table is ephemeral, which means it only contains instances in a given time range. The id is generated on the fly, so we can't add write operations to the repository based on it.

# How
- Adds `InstanceEntity`
- Adds `InstanceRepository`

# Test Plan
- Native unit tests ✅
