### PR TITLE
[calendar][next] Add reminder domain

### DIFF
--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/dto/reminder/ReminderInput.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/dto/reminder/ReminderInput.kt
@@ -1,8 +1,8 @@
 package expo.modules.calendar.next.domain.dto.reminder
 
-import expo.modules.calendar.next.domain.model.reminder.AlarmMethod
+import expo.modules.calendar.next.domain.model.reminder.Method
 
 class ReminderInput(
-  val method: AlarmMethod? = null,
+  val method: Method? = null,
   val minutes: Int
 )

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/dto/reminder/ReminderInput.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/dto/reminder/ReminderInput.kt
@@ -1,17 +1,8 @@
 package expo.modules.calendar.next.domain.dto.reminder
 
-import android.content.ContentValues
-import android.provider.CalendarContract
 import expo.modules.calendar.next.domain.model.reminder.AlarmMethod
-import expo.modules.calendar.next.domain.wrappers.EventId
 
 class ReminderInput(
   val method: AlarmMethod? = null,
   val minutes: Int
-) {
-  fun toContentValues(eventId: EventId) = ContentValues().apply {
-    put(CalendarContract.Reminders.EVENT_ID, eventId.value)
-    put(CalendarContract.Reminders.METHOD, method?.value ?: CalendarContract.Reminders.METHOD_DEFAULT)
-    put(CalendarContract.Reminders.MINUTES, minutes)
-  }
-}
+)

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/dto/reminder/ReminderInput.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/dto/reminder/ReminderInput.kt
@@ -1,0 +1,17 @@
+package expo.modules.calendar.next.domain.dto.reminder
+
+import android.content.ContentValues
+import android.provider.CalendarContract
+import expo.modules.calendar.next.domain.model.reminder.AlarmMethod
+import expo.modules.calendar.next.domain.wrappers.EventId
+
+class ReminderInput(
+  val method: AlarmMethod? = null,
+  val minutes: Int
+) {
+  fun toContentValues(eventId: EventId) = ContentValues().apply {
+    put(CalendarContract.Reminders.EVENT_ID, eventId.value)
+    put(CalendarContract.Reminders.METHOD, method?.value ?: CalendarContract.Reminders.METHOD_DEFAULT)
+    put(CalendarContract.Reminders.MINUTES, minutes)
+  }
+}

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/reminder/AlarmMethod.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/reminder/AlarmMethod.kt
@@ -1,0 +1,11 @@
+package expo.modules.calendar.next.domain.model.reminder
+
+import android.provider.CalendarContract
+
+enum class AlarmMethod(val value: Int) {
+  ALARM(CalendarContract.Reminders.METHOD_ALARM),
+  ALERT(CalendarContract.Reminders.METHOD_ALERT),
+  EMAIL(CalendarContract.Reminders.METHOD_EMAIL),
+  SMS(CalendarContract.Reminders.METHOD_SMS),
+  DEFAULT(CalendarContract.Reminders.METHOD_DEFAULT)
+}

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/reminder/Method.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/reminder/Method.kt
@@ -2,7 +2,7 @@ package expo.modules.calendar.next.domain.model.reminder
 
 import android.provider.CalendarContract
 
-enum class AlarmMethod(val value: Int) {
+enum class Method(val value: Int) {
   ALARM(CalendarContract.Reminders.METHOD_ALARM),
   ALERT(CalendarContract.Reminders.METHOD_ALERT),
   EMAIL(CalendarContract.Reminders.METHOD_EMAIL),

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/reminder/ReminderEntity.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/reminder/ReminderEntity.kt
@@ -3,9 +3,21 @@ package expo.modules.calendar.next.domain.model.reminder
 import expo.modules.calendar.next.domain.wrappers.EventId
 import expo.modules.calendar.next.domain.wrappers.ReminderId
 
+/**
+ * Reminder entity mapped from the Android database cursor.
+ *
+ * Mapping Assumptions:
+ * - [id], [eventId], and [minutes] are non-nullable fields required by the provider.
+ * - [method] remains nullable because the provider may omit it or return an unknown value.
+ *
+ * Design Note:
+ * Default values are intentionally omitted to ensure compile-time safety.
+ * This forces the mapper to explicitly handle every field and prevents
+ * accidental omissions during cursor reading.
+ */
 data class ReminderEntity(
   val id: ReminderId,
   val eventId: EventId,
-  val method: AlarmMethod? = null,
+  val method: AlarmMethod?,
   val minutes: Int
 )

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/reminder/ReminderEntity.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/reminder/ReminderEntity.kt
@@ -1,0 +1,11 @@
+package expo.modules.calendar.next.domain.model.reminder
+
+import expo.modules.calendar.next.domain.wrappers.EventId
+import expo.modules.calendar.next.domain.wrappers.ReminderId
+
+data class ReminderEntity(
+  val id: ReminderId,
+  val eventId: EventId,
+  val method: AlarmMethod? = null,
+  val minutes: Int
+)

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/reminder/ReminderEntity.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/reminder/ReminderEntity.kt
@@ -18,6 +18,6 @@ import expo.modules.calendar.next.domain.wrappers.ReminderId
 data class ReminderEntity(
   val id: ReminderId,
   val eventId: EventId,
-  val method: AlarmMethod?,
+  val method: Method?,
   val minutes: Int
 )

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/reminder/ReminderCursorExtensions.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/reminder/ReminderCursorExtensions.kt
@@ -1,0 +1,23 @@
+package expo.modules.calendar.next.domain.repositories.reminder
+
+import android.database.Cursor
+import android.provider.CalendarContract
+import expo.modules.calendar.next.domain.model.reminder.AlarmMethod
+import expo.modules.calendar.next.domain.model.reminder.ReminderEntity
+import expo.modules.calendar.next.domain.repositories.getOptionalInt
+import expo.modules.calendar.next.domain.repositories.getOptionalLong
+import expo.modules.calendar.next.domain.wrappers.EventId
+import expo.modules.calendar.next.domain.wrappers.ReminderId
+
+fun Cursor.toReminderEntity(eventId: EventId) = ReminderEntity(
+  id = ReminderId(
+    getOptionalLong(CalendarContract.Reminders._ID)
+      ?: throw IllegalStateException("reminder ID must not be null")
+  ),
+  eventId = eventId,
+  method = getOptionalInt(CalendarContract.Reminders.METHOD)?.let { value ->
+    AlarmMethod.entries.find { it.value == value }
+  },
+  minutes = getOptionalInt(CalendarContract.Reminders.MINUTES)
+    ?: throw IllegalStateException("reminder minutes must not be null")
+)

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/reminder/ReminderCursorExtensions.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/reminder/ReminderCursorExtensions.kt
@@ -2,7 +2,7 @@ package expo.modules.calendar.next.domain.repositories.reminder
 
 import android.database.Cursor
 import android.provider.CalendarContract
-import expo.modules.calendar.next.domain.model.reminder.AlarmMethod
+import expo.modules.calendar.next.domain.model.reminder.Method
 import expo.modules.calendar.next.domain.model.reminder.ReminderEntity
 import expo.modules.calendar.next.domain.repositories.getOptionalInt
 import expo.modules.calendar.next.domain.repositories.getOptionalLong
@@ -16,7 +16,7 @@ fun Cursor.toReminderEntity(eventId: EventId) = ReminderEntity(
   ),
   eventId = eventId,
   method = getOptionalInt(CalendarContract.Reminders.METHOD)?.let { value ->
-    AlarmMethod.entries.find { it.value == value }
+    Method.entries.find { it.value == value }
   },
   minutes = getOptionalInt(CalendarContract.Reminders.MINUTES)
     ?: throw IllegalStateException("reminder minutes must not be null")

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/reminder/ReminderCursorExtensions.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/reminder/ReminderCursorExtensions.kt
@@ -15,9 +15,8 @@ fun Cursor.toReminderEntity(eventId: EventId) = ReminderEntity(
       ?: throw IllegalStateException("reminder ID must not be null")
   ),
   eventId = eventId,
-  method = getOptionalInt(CalendarContract.Reminders.METHOD)?.let { value ->
+  method = getOptionalInt(CalendarContract.Reminders.METHOD).let { value ->
     Method.entries.find { it.value == value }
   },
   minutes = getOptionalInt(CalendarContract.Reminders.MINUTES)
-    ?: throw IllegalStateException("reminder minutes must not be null")
 )

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/reminder/ReminderRepository.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/reminder/ReminderRepository.kt
@@ -1,6 +1,7 @@
 package expo.modules.calendar.next.domain.repositories.reminder
 
 import android.content.ContentResolver
+import android.content.ContentValues
 import android.provider.CalendarContract
 import expo.modules.calendar.next.domain.dto.reminder.ReminderInput
 import expo.modules.calendar.next.domain.model.reminder.ReminderEntity
@@ -29,7 +30,14 @@ class ReminderRepository(private val contentResolver: ContentResolver) {
   suspend fun create(eventId: EventId, input: ReminderInput): Long = withContext(Dispatchers.IO) {
     val uri = contentResolver.safeInsert(
       uri = CalendarContract.Reminders.CONTENT_URI,
-      values = input.toContentValues(eventId)
+      values = ContentValues().apply {
+        put(CalendarContract.Reminders.EVENT_ID, eventId.value)
+        put(
+          CalendarContract.Reminders.METHOD,
+          input.method?.value ?: CalendarContract.Reminders.METHOD_DEFAULT
+        )
+        put(CalendarContract.Reminders.MINUTES, input.minutes)
+      }
     )
     uri.lastPathSegment
       ?.toLong()

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/reminder/ReminderRepository.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/reminder/ReminderRepository.kt
@@ -30,14 +30,7 @@ class ReminderRepository(private val contentResolver: ContentResolver) {
   suspend fun create(eventId: EventId, input: ReminderInput): Long = withContext(Dispatchers.IO) {
     val uri = contentResolver.safeInsert(
       uri = CalendarContract.Reminders.CONTENT_URI,
-      values = ContentValues().apply {
-        put(CalendarContract.Reminders.EVENT_ID, eventId.value)
-        put(
-          CalendarContract.Reminders.METHOD,
-          input.method?.value ?: CalendarContract.Reminders.METHOD_DEFAULT
-        )
-        put(CalendarContract.Reminders.MINUTES, input.minutes)
-      }
+      values = input.toContentValues(eventId)
     )
     uri.lastPathSegment
       ?.toLong()
@@ -58,5 +51,14 @@ class ReminderRepository(private val contentResolver: ContentResolver) {
       CalendarContract.Reminders.METHOD,
       CalendarContract.Reminders.MINUTES
     )
+  }
+
+  private fun ReminderInput.toContentValues(eventId: EventId) = ContentValues().apply {
+    put(CalendarContract.Reminders.EVENT_ID, eventId.value)
+    put(
+      CalendarContract.Reminders.METHOD,
+      method?.value ?: CalendarContract.Reminders.METHOD_DEFAULT
+    )
+    put(CalendarContract.Reminders.MINUTES, minutes)
   }
 }

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/reminder/ReminderRepository.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/reminder/ReminderRepository.kt
@@ -1,0 +1,54 @@
+package expo.modules.calendar.next.domain.repositories.reminder
+
+import android.content.ContentResolver
+import android.provider.CalendarContract
+import expo.modules.calendar.next.domain.dto.reminder.ReminderInput
+import expo.modules.calendar.next.domain.model.reminder.ReminderEntity
+import expo.modules.calendar.next.domain.repositories.asSequence
+import expo.modules.calendar.next.domain.repositories.safeDelete
+import expo.modules.calendar.next.domain.repositories.safeInsert
+import expo.modules.calendar.next.domain.repositories.safeQuery
+import expo.modules.calendar.next.domain.wrappers.EventId
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class ReminderRepository(private val contentResolver: ContentResolver) {
+  suspend fun findAllByEventId(eventId: EventId): List<ReminderEntity> = withContext(Dispatchers.IO) {
+    contentResolver.safeQuery(
+      uri = CalendarContract.Reminders.CONTENT_URI,
+      projection = FULL_PROJECTION,
+      selection = "${CalendarContract.Reminders.EVENT_ID} = ?",
+      selectionArgs = arrayOf(eventId.value.toString())
+    ).use { cursor ->
+      cursor.asSequence()
+        .map { it.toReminderEntity(eventId) }
+        .toList()
+    }
+  }
+
+  suspend fun create(eventId: EventId, input: ReminderInput): Long = withContext(Dispatchers.IO) {
+    val uri = contentResolver.safeInsert(
+      uri = CalendarContract.Reminders.CONTENT_URI,
+      values = input.toContentValues(eventId)
+    )
+    uri.lastPathSegment
+      ?.toLong()
+      ?: throw IllegalStateException("Couldn't decode reminder ID from inserted content URI")
+  }
+
+  suspend fun deleteAllByEventId(eventId: EventId) = withContext(Dispatchers.IO) {
+    contentResolver.safeDelete(
+      uri = CalendarContract.Reminders.CONTENT_URI,
+      where = "${CalendarContract.Reminders.EVENT_ID} = ?",
+      selectionArgs = arrayOf(eventId.value.toString())
+    )
+  }
+
+  companion object {
+    val FULL_PROJECTION = arrayOf(
+      CalendarContract.Reminders._ID,
+      CalendarContract.Reminders.METHOD,
+      CalendarContract.Reminders.MINUTES
+    )
+  }
+}

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/wrappers/ReminderId.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/wrappers/ReminderId.kt
@@ -1,0 +1,4 @@
+package expo.modules.calendar.next.domain.wrappers
+
+@JvmInline
+value class ReminderId(val value: Long)

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/reminder/ReminderRepositoryTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/reminder/ReminderRepositoryTest.kt
@@ -1,6 +1,7 @@
 package expo.modules.calendar.next.domain.repositories.reminder
 
 import android.content.ContentResolver
+import android.content.ContentValues
 import android.database.Cursor
 import android.database.MatrixCursor
 import android.net.Uri
@@ -81,39 +82,6 @@ class ReminderRepositoryTest {
     Assert.assertEquals(listOf("77"), selectionArgsSlot.captured.toList())
   }
 
-  @Test
-  fun `given cursor with multiple rows, when findAllByEventId, then returns multiple entities`() = runTest {
-    // Given
-    val cursor = cursorWithRows(
-      minimalRow(id = 1L, minutes = 10),
-      minimalRow(id = 2L, minutes = 30)
-    )
-    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
-
-    // When
-    val result = repository.findAllByEventId(EventId(1L))
-
-    // Then
-    Assert.assertEquals(2, result.size)
-    Assert.assertEquals(ReminderId(1L), result[0].id)
-    Assert.assertEquals(ReminderId(2L), result[1].id)
-    Assert.assertEquals(10, result[0].minutes)
-    Assert.assertEquals(30, result[1].minutes)
-  }
-
-  @Test
-  fun `given cursor with missing method column, when findAllByEventId, then maps method to null in entity`() = runTest {
-    // Given
-    val cursor = cursorWithRows(minimalRow(id = 1L, minutes = 5, includeMethod = false))
-    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
-
-    // When
-    val result = repository.findAllByEventId(EventId(1L))
-
-    // Then
-    Assert.assertNull(result.first().method)
-  }
-
   // endregion
 
   // region create
@@ -130,6 +98,80 @@ class ReminderRepositoryTest {
 
     // Then
     Assert.assertEquals(42L, result)
+  }
+
+  @Test
+  fun `given ReminderInput, when create, then inserts correct values`() = runTest {
+    // Given
+    val valuesSlot = slot<ContentValues>()
+    val mockUri = mockk<Uri>()
+    every { mockUri.lastPathSegment } returns "42"
+    every { contentResolver.insert(any(), capture(valuesSlot)) } returns mockUri
+
+    // When
+    repository.create(
+      EventId(7L),
+      ReminderInput(
+        minutes = 15,
+        method = AlarmMethod.EMAIL
+      )
+    )
+
+    // Then
+    Assert.assertEquals(7L, valuesSlot.captured.getAsLong(CalendarContract.Reminders.EVENT_ID).toLong())
+    Assert.assertEquals(15, valuesSlot.captured.getAsInteger(CalendarContract.Reminders.MINUTES).toInt())
+    Assert.assertEquals(CalendarContract.Reminders.METHOD_EMAIL, valuesSlot.captured.getAsInteger(CalendarContract.Reminders.METHOD).toInt())
+  }
+
+  @Test
+  fun `given ReminderInput without method, when create, then inserts default method`() = runTest {
+    // Given
+    val valuesSlot = slot<ContentValues>()
+    val mockUri = mockk<Uri>()
+    every { mockUri.lastPathSegment } returns "42"
+    every { contentResolver.insert(any(), capture(valuesSlot)) } returns mockUri
+
+    // When
+    repository.create(
+      EventId(7L),
+      ReminderInput(minutes = 15)
+    )
+
+    // Then
+    Assert.assertEquals(7L, valuesSlot.captured.getAsLong(CalendarContract.Reminders.EVENT_ID).toLong())
+    Assert.assertEquals(15, valuesSlot.captured.getAsInteger(CalendarContract.Reminders.MINUTES).toInt())
+    Assert.assertEquals(CalendarContract.Reminders.METHOD_DEFAULT, valuesSlot.captured.getAsInteger(CalendarContract.Reminders.METHOD).toInt())
+  }
+
+  @Test(expected = PermissionException::class)
+  fun `given SecurityException, when create, then throws PermissionException`() = runTest {
+    // Given
+    every { contentResolver.insert(any(), any()) } throws SecurityException()
+
+    // When / Then
+    repository.create(EventId(1L), ReminderInput(minutes = 15))
+  }
+
+  @Test(expected = IllegalStateException::class)
+  fun `given inserted URI without last path segment, when create, then throws IllegalStateException`() = runTest {
+    // Given
+    val mockUri = mockk<Uri>()
+    every { mockUri.lastPathSegment } returns null
+    every { contentResolver.insert(any(), any()) } returns mockUri
+
+    // When / Then
+    repository.create(EventId(1L), ReminderInput(minutes = 15))
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `given inserted URI with non numeric last path segment, when create, then throws IllegalArgumentException`() = runTest {
+    // Given
+    val mockUri = mockk<Uri>()
+    every { mockUri.lastPathSegment } returns "abc"
+    every { contentResolver.insert(any(), any()) } returns mockUri
+
+    // When / Then
+    repository.create(EventId(1L), ReminderInput(minutes = 15))
   }
 
   // endregion
@@ -151,6 +193,15 @@ class ReminderRepositoryTest {
     // Then
     Assert.assertTrue(selectionSlot.captured.contains(CalendarContract.Reminders.EVENT_ID))
     Assert.assertEquals(listOf("55"), selectionArgsSlot.captured.toList())
+  }
+
+  @Test(expected = PermissionException::class)
+  fun `given SecurityException, when deleteAllByEventId, then throws PermissionException`() = runTest {
+    // Given
+    every { contentResolver.delete(any(), any(), any()) } throws SecurityException()
+
+    // When / Then
+    repository.deleteAllByEventId(EventId(55L))
   }
 
   // endregion
@@ -198,17 +249,6 @@ class ReminderRepositoryTest {
     }
 
     return cursor
-  }
-
-  private fun minimalRow(
-    id: Long = 1L,
-    minutes: Int = 10,
-    method: Int = CalendarContract.Reminders.METHOD_DEFAULT,
-    includeMethod: Boolean = true
-  ): Map<String, Any?> = buildMap {
-    put(CalendarContract.Reminders._ID, id)
-    put(CalendarContract.Reminders.MINUTES, minutes)
-    if (includeMethod) put(CalendarContract.Reminders.METHOD, method)
   }
 
   // endregion

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/reminder/ReminderRepositoryTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/reminder/ReminderRepositoryTest.kt
@@ -1,0 +1,215 @@
+package expo.modules.calendar.next.domain.repositories.reminder
+
+import android.content.ContentResolver
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.net.Uri
+import android.provider.CalendarContract
+import expo.modules.calendar.next.domain.dto.reminder.ReminderInput
+import expo.modules.calendar.next.domain.model.reminder.AlarmMethod
+import expo.modules.calendar.next.domain.model.reminder.ReminderEntity
+import expo.modules.calendar.next.domain.wrappers.EventId
+import expo.modules.calendar.next.domain.wrappers.ReminderId
+import expo.modules.calendar.next.exceptions.CouldNotExecuteQueryException
+import expo.modules.calendar.next.exceptions.PermissionException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ReminderRepositoryTest {
+  private val contentResolver = mockk<ContentResolver>()
+  private val repository = ReminderRepository(contentResolver)
+
+  // region findAllByEventId
+
+  @Test
+  fun `given cursor has no rows, when findAllByEventId, then returns empty list`() = runTest {
+    // Given
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns emptyCursor()
+
+    // When
+    val result = repository.findAllByEventId(EventId(1L))
+
+    // Then
+    Assert.assertEquals(emptyList<ReminderEntity>(), result)
+  }
+
+  @Test
+  fun `given cursor with data, when findAllByEventId, then maps cursor row to ReminderEntity`() = runTest {
+    // Given
+    val cursor = cursorWithRows(
+      mapOf(
+        CalendarContract.Reminders._ID to 5L,
+        CalendarContract.Reminders.METHOD to CalendarContract.Reminders.METHOD_EMAIL,
+        CalendarContract.Reminders.MINUTES to 15,
+      )
+    )
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
+
+    // When
+    val result = repository.findAllByEventId(EventId(99L))
+
+    // Then
+    Assert.assertEquals(1, result.size)
+    val entity = result.first()
+    Assert.assertEquals(ReminderId(5L), entity.id)
+    Assert.assertEquals(EventId(99L), entity.eventId)
+    Assert.assertEquals(AlarmMethod.EMAIL, entity.method)
+    Assert.assertEquals(15, entity.minutes)
+  }
+
+  @Test
+  fun `given event id, when findAllByEventId, then uses EVENT_ID in selection`() = runTest {
+    // Given
+    val selectionSlot = slot<String>()
+    val selectionArgsSlot = slot<Array<String>>()
+    every {
+      contentResolver.query(any(), any(), capture(selectionSlot), capture(selectionArgsSlot), any())
+    } returns emptyCursor()
+
+    // When
+    repository.findAllByEventId(EventId(77L))
+
+    // Then
+    Assert.assertTrue(selectionSlot.captured.contains(CalendarContract.Reminders.EVENT_ID))
+    Assert.assertEquals(listOf("77"), selectionArgsSlot.captured.toList())
+  }
+
+  @Test
+  fun `given cursor with multiple rows, when findAllByEventId, then returns multiple entities`() = runTest {
+    // Given
+    val cursor = cursorWithRows(
+      minimalRow(id = 1L, minutes = 10),
+      minimalRow(id = 2L, minutes = 30),
+    )
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
+
+    // When
+    val result = repository.findAllByEventId(EventId(1L))
+
+    // Then
+    Assert.assertEquals(2, result.size)
+    Assert.assertEquals(ReminderId(1L), result[0].id)
+    Assert.assertEquals(ReminderId(2L), result[1].id)
+    Assert.assertEquals(10, result[0].minutes)
+    Assert.assertEquals(30, result[1].minutes)
+  }
+
+  @Test
+  fun `given cursor with missing method column, when findAllByEventId, then maps method to null in entity`() = runTest {
+    // Given
+    val cursor = cursorWithRows(minimalRow(id = 1L, minutes = 5, includeMethod = false))
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
+
+    // When
+    val result = repository.findAllByEventId(EventId(1L))
+
+    // Then
+    Assert.assertNull(result.first().method)
+  }
+
+  // endregion
+
+  // region create
+
+  @Test
+  fun `given inserted URI, when create, then returns reminder id from URI path segment`() = runTest {
+    // Given
+    val mockUri = mockk<Uri>()
+    every { mockUri.lastPathSegment } returns "42"
+    every { contentResolver.insert(any(), any()) } returns mockUri
+
+    // When
+    val result = repository.create(EventId(1L), ReminderInput(minutes = 15))
+
+    // Then
+    Assert.assertEquals(42L, result)
+  }
+
+  // endregion
+
+  // region deleteAllByEventId
+
+  @Test
+  fun `given event id, when deleteAllByEventId, then calls ContentResolver delete with EVENT_ID selection`() = runTest {
+    // Given
+    val selectionSlot = slot<String>()
+    val selectionArgsSlot = slot<Array<String>>()
+    every {
+      contentResolver.delete(any(), capture(selectionSlot), capture(selectionArgsSlot))
+    } returns 3
+
+    // When
+    repository.deleteAllByEventId(EventId(55L))
+
+    // Then
+    Assert.assertTrue(selectionSlot.captured.contains(CalendarContract.Reminders.EVENT_ID))
+    Assert.assertEquals(listOf("55"), selectionArgsSlot.captured.toList())
+  }
+
+  // endregion
+
+  // region exceptions
+
+  @Test(expected = PermissionException::class)
+  fun `given SecurityException, when findAllByEventId, then throws PermissionException`() = runTest {
+    // Given
+    every { contentResolver.query(any(), any(), any(), any(), any()) } throws SecurityException()
+
+    // When / Then
+    repository.findAllByEventId(EventId(1L))
+  }
+
+  @Test(expected = CouldNotExecuteQueryException::class)
+  fun `given null cursor, when findAllByEventId, then throws CouldNotExecuteQueryException`() = runTest {
+    // Given
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns null
+
+    // When / Then
+    repository.findAllByEventId(EventId(1L))
+  }
+
+  // endregion
+
+  // region helpers
+
+  private fun emptyCursor(): Cursor {
+    // Empty cursor requires at least one column for MatrixCursor
+    return MatrixCursor(arrayOf(CalendarContract.Reminders._ID))
+  }
+
+  private fun cursorWithRows(vararg rows: Map<String, Any?>): Cursor {
+    if (rows.isEmpty()) {
+      return emptyCursor()
+    }
+
+    val columnNames = rows.first().keys.toTypedArray()
+    val cursor = MatrixCursor(columnNames)
+
+    for (row in rows) {
+      val rowValues = columnNames.map { columnName -> row[columnName] }.toTypedArray()
+      cursor.addRow(rowValues)
+    }
+
+    return cursor
+  }
+
+  private fun minimalRow(
+    id: Long = 1L,
+    minutes: Int = 10,
+    method: Int = CalendarContract.Reminders.METHOD_DEFAULT,
+    includeMethod: Boolean = true,
+  ): Map<String, Any?> = buildMap {
+    put(CalendarContract.Reminders._ID, id)
+    put(CalendarContract.Reminders.MINUTES, minutes)
+    if (includeMethod) put(CalendarContract.Reminders.METHOD, method)
+  }
+
+  // endregion
+}

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/reminder/ReminderRepositoryTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/reminder/ReminderRepositoryTest.kt
@@ -47,7 +47,7 @@ class ReminderRepositoryTest {
       mapOf(
         CalendarContract.Reminders._ID to 5L,
         CalendarContract.Reminders.METHOD to CalendarContract.Reminders.METHOD_EMAIL,
-        CalendarContract.Reminders.MINUTES to 15,
+        CalendarContract.Reminders.MINUTES to 15
       )
     )
     every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
@@ -86,7 +86,7 @@ class ReminderRepositoryTest {
     // Given
     val cursor = cursorWithRows(
       minimalRow(id = 1L, minutes = 10),
-      minimalRow(id = 2L, minutes = 30),
+      minimalRow(id = 2L, minutes = 30)
     )
     every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
 
@@ -204,7 +204,7 @@ class ReminderRepositoryTest {
     id: Long = 1L,
     minutes: Int = 10,
     method: Int = CalendarContract.Reminders.METHOD_DEFAULT,
-    includeMethod: Boolean = true,
+    includeMethod: Boolean = true
   ): Map<String, Any?> = buildMap {
     put(CalendarContract.Reminders._ID, id)
     put(CalendarContract.Reminders.MINUTES, minutes)

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/reminder/ReminderRepositoryTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/reminder/ReminderRepositoryTest.kt
@@ -7,7 +7,7 @@ import android.database.MatrixCursor
 import android.net.Uri
 import android.provider.CalendarContract
 import expo.modules.calendar.next.domain.dto.reminder.ReminderInput
-import expo.modules.calendar.next.domain.model.reminder.AlarmMethod
+import expo.modules.calendar.next.domain.model.reminder.Method
 import expo.modules.calendar.next.domain.model.reminder.ReminderEntity
 import expo.modules.calendar.next.domain.wrappers.EventId
 import expo.modules.calendar.next.domain.wrappers.ReminderId
@@ -61,7 +61,7 @@ class ReminderRepositoryTest {
     val entity = result.first()
     Assert.assertEquals(ReminderId(5L), entity.id)
     Assert.assertEquals(EventId(99L), entity.eventId)
-    Assert.assertEquals(AlarmMethod.EMAIL, entity.method)
+    Assert.assertEquals(Method.EMAIL, entity.method)
     Assert.assertEquals(15, entity.minutes)
   }
 
@@ -113,7 +113,7 @@ class ReminderRepositoryTest {
       EventId(7L),
       ReminderInput(
         minutes = 15,
-        method = AlarmMethod.EMAIL
+        method = Method.EMAIL
       )
     )
 


### PR DESCRIPTION
# Why

[4/n] of the `calendar@next` refactor stacked PR. This PR adds the reminder domain, which represents event reminders from the Android Calendar API.

# How

- Adds `ReminderInput` for creating reminders
- Adds `ReminderEntity` and `Method` wrapper type for enum values from the reminder contract
- Adds `ReminderRepository`, a data provider for reminder data that operates on DTOs

# Test Plan

- Native unit tests ✅
