### PR TITLE
[calendar][next] Add attendee domain

### DIFF
--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/dto/attendee/AttendeeInput.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/dto/attendee/AttendeeInput.kt
@@ -1,0 +1,15 @@
+package expo.modules.calendar.next.domain.dto.attendee
+
+import expo.modules.calendar.next.domain.model.attendee.AttendeeRole
+import expo.modules.calendar.next.domain.model.attendee.AttendeeStatus
+import expo.modules.calendar.next.domain.model.attendee.AttendeeType
+import expo.modules.calendar.next.domain.wrappers.EventId
+
+data class AttendeeInput(
+  val eventId: EventId,
+  val email: String? = null,
+  val name: String? = null,
+  val role: AttendeeRole? = null,
+  val status: AttendeeStatus? = null,
+  val type: AttendeeType? = null
+)

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/dto/attendee/AttendeeUpdate.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/dto/attendee/AttendeeUpdate.kt
@@ -1,0 +1,16 @@
+package expo.modules.calendar.next.domain.dto.attendee
+
+import expo.modules.calendar.next.domain.model.attendee.AttendeeRole
+import expo.modules.calendar.next.domain.model.attendee.AttendeeStatus
+import expo.modules.calendar.next.domain.model.attendee.AttendeeType
+import expo.modules.calendar.next.domain.wrappers.AttendeeId
+import expo.modules.kotlin.types.ValueOrUndefined
+
+class AttendeeUpdate(
+  val id: AttendeeId,
+  val email: ValueOrUndefined<String?> = ValueOrUndefined.Undefined(),
+  val name: ValueOrUndefined<String?> = ValueOrUndefined.Undefined(),
+  val role: ValueOrUndefined<AttendeeRole?> = ValueOrUndefined.Undefined(),
+  val status: ValueOrUndefined<AttendeeStatus?> = ValueOrUndefined.Undefined(),
+  val type: ValueOrUndefined<AttendeeType?> = ValueOrUndefined.Undefined()
+)

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/attendee/AttendeeEntity.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/attendee/AttendeeEntity.kt
@@ -1,0 +1,12 @@
+package expo.modules.calendar.next.domain.model.attendee
+
+import expo.modules.calendar.next.domain.wrappers.AttendeeId
+
+data class AttendeeEntity(
+  val id: AttendeeId,
+  val email: String? = null,
+  val name: String? = null,
+  val role: AttendeeRole? = null,
+  val status: AttendeeStatus? = null,
+  val type: AttendeeType? = null
+)

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/attendee/AttendeeEntity.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/attendee/AttendeeEntity.kt
@@ -2,11 +2,23 @@ package expo.modules.calendar.next.domain.model.attendee
 
 import expo.modules.calendar.next.domain.wrappers.AttendeeId
 
+/**
+ * Attendee entity mapped from the Android database cursor.
+ *
+ * Mapping Assumptions:
+ * - [id] is a non-nullable primary key.
+ * - Nullable fields represent optional attendee metadata or unknown provider values.
+ *
+ * Design Note:
+ * Default values are intentionally omitted to ensure compile-time safety.
+ * This forces the mapper to explicitly handle every field and prevents
+ * accidental omissions during cursor reading.
+ */
 data class AttendeeEntity(
   val id: AttendeeId,
-  val email: String? = null,
-  val name: String? = null,
-  val role: AttendeeRole? = null,
-  val status: AttendeeStatus? = null,
-  val type: AttendeeType? = null
+  val email: String?,
+  val name: String?,
+  val role: AttendeeRole?,
+  val status: AttendeeStatus?,
+  val type: AttendeeType?
 )

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/attendee/AttendeeRole.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/attendee/AttendeeRole.kt
@@ -1,0 +1,11 @@
+package expo.modules.calendar.next.domain.model.attendee
+
+import android.provider.CalendarContract
+
+enum class AttendeeRole(val value: Int) {
+  ATTENDEE(CalendarContract.Attendees.RELATIONSHIP_ATTENDEE),
+  NONE(CalendarContract.Attendees.RELATIONSHIP_NONE),
+  ORGANIZER(CalendarContract.Attendees.RELATIONSHIP_ORGANIZER),
+  PERFORMER(CalendarContract.Attendees.RELATIONSHIP_PERFORMER),
+  SPEAKER(CalendarContract.Attendees.RELATIONSHIP_SPEAKER)
+}

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/attendee/AttendeeStatus.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/attendee/AttendeeStatus.kt
@@ -1,0 +1,11 @@
+package expo.modules.calendar.next.domain.model.attendee
+
+import android.provider.CalendarContract
+
+enum class AttendeeStatus(val value: Int) {
+  ACCEPTED(CalendarContract.Attendees.ATTENDEE_STATUS_ACCEPTED),
+  DECLINED(CalendarContract.Attendees.ATTENDEE_STATUS_DECLINED),
+  INVITED(CalendarContract.Attendees.ATTENDEE_STATUS_INVITED),
+  NONE(CalendarContract.Attendees.ATTENDEE_STATUS_NONE),
+  TENTATIVE(CalendarContract.Attendees.ATTENDEE_STATUS_TENTATIVE)
+}

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/attendee/AttendeeType.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/attendee/AttendeeType.kt
@@ -1,0 +1,10 @@
+package expo.modules.calendar.next.domain.model.attendee
+
+import android.provider.CalendarContract
+
+enum class AttendeeType(val value: Int) {
+  NONE(CalendarContract.Attendees.TYPE_NONE),
+  OPTIONAL(CalendarContract.Attendees.TYPE_OPTIONAL),
+  REQUIRED(CalendarContract.Attendees.TYPE_REQUIRED),
+  RESOURCE(CalendarContract.Attendees.TYPE_RESOURCE)
+}

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/attendee/AttendeeCursorExtensions.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/attendee/AttendeeCursorExtensions.kt
@@ -1,0 +1,30 @@
+package expo.modules.calendar.next.domain.repositories.attendee
+
+import android.database.Cursor
+import android.provider.CalendarContract
+import expo.modules.calendar.next.domain.model.attendee.AttendeeEntity
+import expo.modules.calendar.next.domain.model.attendee.AttendeeRole
+import expo.modules.calendar.next.domain.model.attendee.AttendeeStatus
+import expo.modules.calendar.next.domain.model.attendee.AttendeeType
+import expo.modules.calendar.next.domain.repositories.getOptionalInt
+import expo.modules.calendar.next.domain.repositories.getOptionalLong
+import expo.modules.calendar.next.domain.repositories.getOptionalString
+import expo.modules.calendar.next.domain.wrappers.AttendeeId
+
+fun Cursor.toAttendeeEntity() = AttendeeEntity(
+  id = AttendeeId(
+    getOptionalLong(CalendarContract.Attendees._ID)
+      ?: throw IllegalStateException("attendee ID must not be null")
+  ),
+  email = getString(getColumnIndexOrThrow(CalendarContract.Attendees.ATTENDEE_EMAIL)),
+  name = getOptionalString(CalendarContract.Attendees.ATTENDEE_NAME),
+  role = getOptionalInt(CalendarContract.Attendees.ATTENDEE_RELATIONSHIP)?.let { value ->
+    AttendeeRole.entries.find { it.value == value }
+  },
+  status = getOptionalInt(CalendarContract.Attendees.ATTENDEE_STATUS)?.let { value ->
+    AttendeeStatus.entries.find { it.value == value }
+  },
+  type = getOptionalInt(CalendarContract.Attendees.ATTENDEE_TYPE)?.let { value ->
+    AttendeeType.entries.find { it.value == value }
+  }
+)

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/attendee/AttendeeCursorExtensions.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/attendee/AttendeeCursorExtensions.kt
@@ -18,13 +18,13 @@ fun Cursor.toAttendeeEntity() = AttendeeEntity(
   ),
   email = getString(getColumnIndexOrThrow(CalendarContract.Attendees.ATTENDEE_EMAIL)),
   name = getOptionalString(CalendarContract.Attendees.ATTENDEE_NAME),
-  role = getOptionalInt(CalendarContract.Attendees.ATTENDEE_RELATIONSHIP)?.let { value ->
+  role = getOptionalInt(CalendarContract.Attendees.ATTENDEE_RELATIONSHIP).let { value ->
     AttendeeRole.entries.find { it.value == value }
   },
-  status = getOptionalInt(CalendarContract.Attendees.ATTENDEE_STATUS)?.let { value ->
+  status = getOptionalInt(CalendarContract.Attendees.ATTENDEE_STATUS).let { value ->
     AttendeeStatus.entries.find { it.value == value }
   },
-  type = getOptionalInt(CalendarContract.Attendees.ATTENDEE_TYPE)?.let { value ->
+  type = getOptionalInt(CalendarContract.Attendees.ATTENDEE_TYPE).let { value ->
     AttendeeType.entries.find { it.value == value }
   }
 )

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/attendee/AttendeeRepository.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/attendee/AttendeeRepository.kt
@@ -1,0 +1,104 @@
+package expo.modules.calendar.next.domain.repositories.attendee
+
+import android.content.ContentResolver
+import android.content.ContentUris
+import android.content.ContentValues
+import android.provider.CalendarContract
+import expo.modules.calendar.next.domain.dto.attendee.AttendeeInput
+import expo.modules.calendar.next.domain.dto.attendee.AttendeeUpdate
+import expo.modules.calendar.next.domain.model.attendee.AttendeeEntity
+import expo.modules.calendar.next.domain.repositories.asSequence
+import expo.modules.calendar.next.domain.repositories.safeDelete
+import expo.modules.calendar.next.domain.repositories.safeInsert
+import expo.modules.calendar.next.domain.repositories.safeQuery
+import expo.modules.calendar.next.domain.repositories.safeUpdate
+import expo.modules.calendar.next.domain.wrappers.AttendeeId
+import expo.modules.calendar.next.domain.wrappers.EventId
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class AttendeeRepository(private val contentResolver: ContentResolver) {
+  suspend fun findAllByEventId(eventId: EventId): List<AttendeeEntity> = withContext(Dispatchers.IO) {
+    contentResolver.safeQuery(
+      uri = CalendarContract.Attendees.CONTENT_URI,
+      projection = FULL_PROJECTION,
+      selection = "${CalendarContract.Attendees.EVENT_ID} = ?",
+      selectionArgs = arrayOf(eventId.value.toString())
+    ).use { cursor ->
+      cursor.asSequence()
+        .map { it.toAttendeeEntity() }
+        .toList()
+    }
+  }
+
+  suspend fun create(attendeeInput: AttendeeInput): AttendeeId = withContext(Dispatchers.IO) {
+    val uri = contentResolver.safeInsert(
+      uri = CalendarContract.Attendees.CONTENT_URI,
+      values = attendeeInput.toContentValues()
+    )
+    val id = uri.lastPathSegment
+      ?: throw IllegalStateException("Couldn't decode attendee ID from inserted content URI")
+    AttendeeId(id.toLong())
+  }
+
+  suspend fun update(attendeeUpdate: AttendeeUpdate): Boolean = withContext(Dispatchers.IO) {
+    contentResolver.safeUpdate(
+      uri = ContentUris.withAppendedId(CalendarContract.Attendees.CONTENT_URI, attendeeUpdate.id.value),
+      values = attendeeUpdate.toContentValues()
+    ) > 0
+  }
+
+  suspend fun findById(id: AttendeeId): AttendeeEntity? = withContext(Dispatchers.IO) {
+    contentResolver.safeQuery(
+      uri = ContentUris.withAppendedId(CalendarContract.Attendees.CONTENT_URI, id.value),
+      projection = FULL_PROJECTION
+    ).use { cursor ->
+      cursor.takeIf { it.moveToFirst() }
+        ?.toAttendeeEntity()
+    }
+  }
+
+  suspend fun delete(id: AttendeeId): Boolean = withContext(Dispatchers.IO) {
+    contentResolver.safeDelete(
+      uri = ContentUris.withAppendedId(CalendarContract.Attendees.CONTENT_URI, id.value)
+    ) > 0
+  }
+
+  private fun AttendeeInput.toContentValues() = ContentValues().apply {
+    put(CalendarContract.Attendees.ATTENDEE_EMAIL, email)
+    put(CalendarContract.Attendees.ATTENDEE_NAME, name)
+    put(CalendarContract.Attendees.ATTENDEE_RELATIONSHIP, role?.value)
+    put(CalendarContract.Attendees.ATTENDEE_STATUS, status?.value)
+    put(CalendarContract.Attendees.ATTENDEE_TYPE, type?.value)
+    put(CalendarContract.Attendees.EVENT_ID, eventId.value)
+  }
+
+  private fun AttendeeUpdate.toContentValues() = ContentValues().apply {
+    if (!email.isUndefined) {
+      put(CalendarContract.Attendees.ATTENDEE_EMAIL, email.optional)
+    }
+    if (!name.isUndefined) {
+      put(CalendarContract.Attendees.ATTENDEE_NAME, name.optional)
+    }
+    if (!role.isUndefined) {
+      put(CalendarContract.Attendees.ATTENDEE_RELATIONSHIP, role.optional?.value)
+    }
+    if (!status.isUndefined) {
+      put(CalendarContract.Attendees.ATTENDEE_STATUS, status.optional?.value)
+    }
+    if (!type.isUndefined) {
+      put(CalendarContract.Attendees.ATTENDEE_TYPE, type.optional?.value)
+    }
+  }
+
+  companion object {
+    val FULL_PROJECTION = arrayOf(
+      CalendarContract.Attendees._ID,
+      CalendarContract.Attendees.ATTENDEE_EMAIL,
+      CalendarContract.Attendees.ATTENDEE_NAME,
+      CalendarContract.Attendees.ATTENDEE_RELATIONSHIP,
+      CalendarContract.Attendees.ATTENDEE_STATUS,
+      CalendarContract.Attendees.ATTENDEE_TYPE
+    )
+  }
+}

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/wrappers/AttendeeId.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/wrappers/AttendeeId.kt
@@ -1,0 +1,4 @@
+package expo.modules.calendar.next.domain.wrappers
+
+@JvmInline
+value class AttendeeId(val value: Long)

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/attendee/AttendeeRepositoryTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/attendee/AttendeeRepositoryTest.kt
@@ -1,11 +1,13 @@
 package expo.modules.calendar.next.domain.repositories.attendee
 
 import android.content.ContentResolver
+import android.content.ContentValues
 import android.database.Cursor
 import android.database.MatrixCursor
 import android.net.Uri
 import android.provider.CalendarContract
 import expo.modules.calendar.next.domain.dto.attendee.AttendeeInput
+import expo.modules.calendar.next.domain.dto.attendee.AttendeeUpdate
 import expo.modules.calendar.next.domain.model.attendee.AttendeeRole
 import expo.modules.calendar.next.domain.model.attendee.AttendeeStatus
 import expo.modules.calendar.next.domain.model.attendee.AttendeeType
@@ -13,6 +15,7 @@ import expo.modules.calendar.next.domain.wrappers.AttendeeId
 import expo.modules.calendar.next.domain.wrappers.EventId
 import expo.modules.calendar.next.exceptions.CouldNotExecuteQueryException
 import expo.modules.calendar.next.exceptions.PermissionException
+import expo.modules.kotlin.types.ValueOrUndefined
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -93,24 +96,6 @@ class AttendeeRepositoryTest {
     Assert.assertEquals(listOf("42"), selectionArgsSlot.captured?.toList())
   }
 
-  @Test
-  fun `given cursor with multiple rows, when findAllByEventId, then returns multiple entities`() = runTest {
-    // Given
-    val cursor = cursorWithRows(
-      minimalRow(id = 1L, email = "a@example.com"),
-      minimalRow(id = 2L, email = "b@example.com")
-    )
-    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
-
-    // When
-    val result = repository.findAllByEventId(EventId(1L))
-
-    // Then
-    Assert.assertEquals(2, result.size)
-    Assert.assertEquals(AttendeeId(1L), result[0].id)
-    Assert.assertEquals(AttendeeId(2L), result[1].id)
-  }
-
   // endregion
 
   // region findById
@@ -118,7 +103,16 @@ class AttendeeRepositoryTest {
   @Test
   fun `given cursor has a row, when findById, then returns entity`() = runTest {
     // Given
-    val cursor = cursorWithRows(minimalRow(id = 7L, email = "bob@example.com"))
+    val cursor = cursorWithRows(
+      mapOf(
+        CalendarContract.Attendees._ID to 7L,
+        CalendarContract.Attendees.ATTENDEE_EMAIL to "bob@example.com",
+        CalendarContract.Attendees.ATTENDEE_NAME to "Bob",
+        CalendarContract.Attendees.ATTENDEE_RELATIONSHIP to CalendarContract.Attendees.RELATIONSHIP_ORGANIZER,
+        CalendarContract.Attendees.ATTENDEE_STATUS to CalendarContract.Attendees.ATTENDEE_STATUS_DECLINED,
+        CalendarContract.Attendees.ATTENDEE_TYPE to CalendarContract.Attendees.TYPE_OPTIONAL
+      )
+    )
     every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
 
     // When
@@ -127,6 +121,10 @@ class AttendeeRepositoryTest {
     // Then
     Assert.assertEquals(AttendeeId(7L), result?.id)
     Assert.assertEquals("bob@example.com", result?.email)
+    Assert.assertEquals("Bob", result?.name)
+    Assert.assertEquals(AttendeeRole.ORGANIZER, result?.role)
+    Assert.assertEquals(AttendeeStatus.DECLINED, result?.status)
+    Assert.assertEquals(AttendeeType.OPTIONAL, result?.type)
   }
 
   @Test
@@ -139,6 +137,24 @@ class AttendeeRepositoryTest {
 
     // Then
     Assert.assertNull(result)
+  }
+
+  @Test(expected = PermissionException::class)
+  fun `given SecurityException, when findById, then throws PermissionException`() = runTest {
+    // Given
+    every { contentResolver.query(any(), any(), any(), any(), any()) } throws SecurityException()
+
+    // When / Then
+    repository.findById(AttendeeId(7L))
+  }
+
+  @Test(expected = CouldNotExecuteQueryException::class)
+  fun `given null cursor, when findById, then throws CouldNotExecuteQueryException`() = runTest {
+    // Given
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns null
+
+    // When / Then
+    repository.findById(AttendeeId(7L))
   }
 
   // endregion
@@ -162,6 +178,155 @@ class AttendeeRepositoryTest {
 
     // Then
     Assert.assertEquals(AttendeeId(88L), result)
+  }
+
+  @Test
+  fun `given AttendeeInput, when create, then inserts correct values`() = runTest {
+    // Given
+    val valuesSlot = slot<ContentValues>()
+    val mockUri = mockk<Uri>()
+    every { mockUri.lastPathSegment } returns "88"
+    every { contentResolver.insert(any(), capture(valuesSlot)) } returns mockUri
+
+    val input = AttendeeInput(
+      eventId = EventId(1L),
+      email = "new@example.com",
+      name = "New User",
+      role = AttendeeRole.ATTENDEE,
+      status = AttendeeStatus.ACCEPTED,
+      type = AttendeeType.REQUIRED
+    )
+
+    // When
+    repository.create(input)
+
+    // Then
+    Assert.assertEquals(1L, valuesSlot.captured.getAsLong(CalendarContract.Attendees.EVENT_ID).toLong())
+    Assert.assertEquals("new@example.com", valuesSlot.captured.getAsString(CalendarContract.Attendees.ATTENDEE_EMAIL))
+    Assert.assertEquals("New User", valuesSlot.captured.getAsString(CalendarContract.Attendees.ATTENDEE_NAME))
+    Assert.assertEquals(CalendarContract.Attendees.RELATIONSHIP_ATTENDEE, valuesSlot.captured.getAsInteger(CalendarContract.Attendees.ATTENDEE_RELATIONSHIP).toInt())
+    Assert.assertEquals(CalendarContract.Attendees.ATTENDEE_STATUS_ACCEPTED, valuesSlot.captured.getAsInteger(CalendarContract.Attendees.ATTENDEE_STATUS).toInt())
+    Assert.assertEquals(CalendarContract.Attendees.TYPE_REQUIRED, valuesSlot.captured.getAsInteger(CalendarContract.Attendees.ATTENDEE_TYPE).toInt())
+  }
+
+  @Test(expected = PermissionException::class)
+  fun `given SecurityException, when create, then throws PermissionException`() = runTest {
+    // Given
+    every { contentResolver.insert(any(), any()) } throws SecurityException()
+
+    // When / Then
+    repository.create(AttendeeInput(eventId = EventId(1L)))
+  }
+
+  @Test(expected = IllegalStateException::class)
+  fun `given inserted URI without last path segment, when create, then throws IllegalStateException`() = runTest {
+    // Given
+    val mockUri = mockk<Uri>()
+    every { mockUri.lastPathSegment } returns null
+    every { contentResolver.insert(any(), any()) } returns mockUri
+
+    // When / Then
+    repository.create(AttendeeInput(eventId = EventId(1L)))
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `given inserted URI with non numeric last path segment, when create, then throws IllegalArgumentException`() = runTest {
+    // Given
+    val mockUri = mockk<Uri>()
+    every { mockUri.lastPathSegment } returns "abc"
+    every { contentResolver.insert(any(), any()) } returns mockUri
+
+    // When / Then
+    repository.create(AttendeeInput(eventId = EventId(1L)))
+  }
+
+  // endregion
+
+  // region update
+
+  @Test
+  fun `given AttendeeUpdate with defined fields, when update, then updates only those fields`() = runTest {
+    // Given
+    val valuesSlot = slot<ContentValues>()
+    every { contentResolver.update(any(), capture(valuesSlot), any(), any()) } returns 1
+
+    val update = AttendeeUpdate(
+      id = AttendeeId(10L),
+      email = ValueOrUndefined.Value("updated@example.com"),
+      name = ValueOrUndefined.Value("Updated User"),
+      role = ValueOrUndefined.Value(AttendeeRole.ORGANIZER),
+      status = ValueOrUndefined.Value(AttendeeStatus.TENTATIVE),
+      type = ValueOrUndefined.Value(AttendeeType.RESOURCE)
+    )
+
+    // When
+    repository.update(update)
+
+    // Then
+    Assert.assertEquals("updated@example.com", valuesSlot.captured.getAsString(CalendarContract.Attendees.ATTENDEE_EMAIL))
+    Assert.assertEquals("Updated User", valuesSlot.captured.getAsString(CalendarContract.Attendees.ATTENDEE_NAME))
+    Assert.assertEquals(CalendarContract.Attendees.RELATIONSHIP_ORGANIZER, valuesSlot.captured.getAsInteger(CalendarContract.Attendees.ATTENDEE_RELATIONSHIP).toInt())
+    Assert.assertEquals(CalendarContract.Attendees.ATTENDEE_STATUS_TENTATIVE, valuesSlot.captured.getAsInteger(CalendarContract.Attendees.ATTENDEE_STATUS).toInt())
+    Assert.assertEquals(CalendarContract.Attendees.TYPE_RESOURCE, valuesSlot.captured.getAsInteger(CalendarContract.Attendees.ATTENDEE_TYPE).toInt())
+  }
+
+  @Test
+  fun `given AttendeeUpdate with null values, when update, then clears supported nullable fields`() = runTest {
+    // Given
+    val valuesSlot = slot<ContentValues>()
+    every { contentResolver.update(any(), capture(valuesSlot), any(), any()) } returns 1
+
+    val update = AttendeeUpdate(
+      id = AttendeeId(10L),
+      email = ValueOrUndefined.Value<String?>(null),
+      name = ValueOrUndefined.Value<String?>(null),
+      role = ValueOrUndefined.Value<AttendeeRole?>(null),
+      status = ValueOrUndefined.Value<AttendeeStatus?>(null),
+      type = ValueOrUndefined.Value<AttendeeType?>(null)
+    )
+
+    // When
+    repository.update(update)
+
+    // Then
+    Assert.assertNull(valuesSlot.captured.get(CalendarContract.Attendees.ATTENDEE_EMAIL))
+    Assert.assertNull(valuesSlot.captured.get(CalendarContract.Attendees.ATTENDEE_NAME))
+    Assert.assertNull(valuesSlot.captured.get(CalendarContract.Attendees.ATTENDEE_RELATIONSHIP))
+    Assert.assertNull(valuesSlot.captured.get(CalendarContract.Attendees.ATTENDEE_STATUS))
+    Assert.assertNull(valuesSlot.captured.get(CalendarContract.Attendees.ATTENDEE_TYPE))
+  }
+
+  @Test
+  fun `given updated rows, when update, then returns true`() = runTest {
+    // Given
+    every { contentResolver.update(any(), any(), any(), any()) } returns 1
+
+    // When
+    val result = repository.update(AttendeeUpdate(id = AttendeeId(10L)))
+
+    // Then
+    Assert.assertTrue(result)
+  }
+
+  @Test
+  fun `given zero updated rows, when update, then returns false`() = runTest {
+    // Given
+    every { contentResolver.update(any(), any(), any(), any()) } returns 0
+
+    // When
+    val result = repository.update(AttendeeUpdate(id = AttendeeId(10L)))
+
+    // Then
+    Assert.assertFalse(result)
+  }
+
+  @Test(expected = PermissionException::class)
+  fun `given SecurityException, when update, then throws PermissionException`() = runTest {
+    // Given
+    every { contentResolver.update(any(), any(), any(), any()) } throws SecurityException()
+
+    // When / Then
+    repository.update(AttendeeUpdate(id = AttendeeId(10L)))
   }
 
   // endregion
@@ -203,6 +368,15 @@ class AttendeeRepositoryTest {
 
     // Then
     Assert.assertEquals("33", uriSlot.captured.lastPathSegment)
+  }
+
+  @Test(expected = PermissionException::class)
+  fun `given SecurityException, when delete, then throws PermissionException`() = runTest {
+    // Given
+    every { contentResolver.delete(any(), any(), any()) } throws SecurityException()
+
+    // When / Then
+    repository.delete(AttendeeId(10L))
   }
 
   // endregion
@@ -251,18 +425,6 @@ class AttendeeRepositoryTest {
 
     return cursor
   }
-
-  private fun minimalRow(
-    id: Long = 1L,
-    email: String? = null
-  ): Map<String, Any?> = mapOf(
-    CalendarContract.Attendees._ID to id,
-    CalendarContract.Attendees.ATTENDEE_EMAIL to email,
-    CalendarContract.Attendees.ATTENDEE_NAME to null,
-    CalendarContract.Attendees.ATTENDEE_RELATIONSHIP to null,
-    CalendarContract.Attendees.ATTENDEE_STATUS to null,
-    CalendarContract.Attendees.ATTENDEE_TYPE to null
-  )
 
   // endregion
 }

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/attendee/AttendeeRepositoryTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/attendee/AttendeeRepositoryTest.kt
@@ -51,7 +51,7 @@ class AttendeeRepositoryTest {
         CalendarContract.Attendees.ATTENDEE_NAME to "Alice",
         CalendarContract.Attendees.ATTENDEE_RELATIONSHIP to CalendarContract.Attendees.RELATIONSHIP_ATTENDEE,
         CalendarContract.Attendees.ATTENDEE_STATUS to CalendarContract.Attendees.ATTENDEE_STATUS_ACCEPTED,
-        CalendarContract.Attendees.ATTENDEE_TYPE to CalendarContract.Attendees.TYPE_REQUIRED,
+        CalendarContract.Attendees.ATTENDEE_TYPE to CalendarContract.Attendees.TYPE_REQUIRED
       )
     )
     every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
@@ -98,7 +98,7 @@ class AttendeeRepositoryTest {
     // Given
     val cursor = cursorWithRows(
       minimalRow(id = 1L, email = "a@example.com"),
-      minimalRow(id = 2L, email = "b@example.com"),
+      minimalRow(id = 2L, email = "b@example.com")
     )
     every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
 
@@ -154,7 +154,7 @@ class AttendeeRepositoryTest {
 
     val input = AttendeeInput(
       eventId = EventId(1L),
-      email = "new@example.com",
+      email = "new@example.com"
     )
 
     // When
@@ -254,14 +254,14 @@ class AttendeeRepositoryTest {
 
   private fun minimalRow(
     id: Long = 1L,
-    email: String? = null,
+    email: String? = null
   ): Map<String, Any?> = mapOf(
     CalendarContract.Attendees._ID to id,
     CalendarContract.Attendees.ATTENDEE_EMAIL to email,
     CalendarContract.Attendees.ATTENDEE_NAME to null,
     CalendarContract.Attendees.ATTENDEE_RELATIONSHIP to null,
     CalendarContract.Attendees.ATTENDEE_STATUS to null,
-    CalendarContract.Attendees.ATTENDEE_TYPE to null,
+    CalendarContract.Attendees.ATTENDEE_TYPE to null
   )
 
   // endregion

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/attendee/AttendeeRepositoryTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/attendee/AttendeeRepositoryTest.kt
@@ -1,0 +1,268 @@
+package expo.modules.calendar.next.domain.repositories.attendee
+
+import android.content.ContentResolver
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.net.Uri
+import android.provider.CalendarContract
+import expo.modules.calendar.next.domain.dto.attendee.AttendeeInput
+import expo.modules.calendar.next.domain.model.attendee.AttendeeRole
+import expo.modules.calendar.next.domain.model.attendee.AttendeeStatus
+import expo.modules.calendar.next.domain.model.attendee.AttendeeType
+import expo.modules.calendar.next.domain.wrappers.AttendeeId
+import expo.modules.calendar.next.domain.wrappers.EventId
+import expo.modules.calendar.next.exceptions.CouldNotExecuteQueryException
+import expo.modules.calendar.next.exceptions.PermissionException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AttendeeRepositoryTest {
+  private val contentResolver = mockk<ContentResolver>()
+  private val repository = AttendeeRepository(contentResolver)
+
+  // region findAllByEventId
+
+  @Test
+  fun `given cursor has no rows, when findAllByEventId, then returns empty list`() = runTest {
+    // Given
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns emptyCursor()
+
+    // When
+    val result = repository.findAllByEventId(EventId(1L))
+
+    // Then
+    Assert.assertEquals(emptyList<Any>(), result)
+  }
+
+  @Test
+  fun `given cursor with data, when findAllByEventId, then maps cursor rows to AttendeeEntity list`() = runTest {
+    // Given
+    val cursor = cursorWithRows(
+      mapOf(
+        CalendarContract.Attendees._ID to 10L,
+        CalendarContract.Attendees.ATTENDEE_EMAIL to "alice@example.com",
+        CalendarContract.Attendees.ATTENDEE_NAME to "Alice",
+        CalendarContract.Attendees.ATTENDEE_RELATIONSHIP to CalendarContract.Attendees.RELATIONSHIP_ATTENDEE,
+        CalendarContract.Attendees.ATTENDEE_STATUS to CalendarContract.Attendees.ATTENDEE_STATUS_ACCEPTED,
+        CalendarContract.Attendees.ATTENDEE_TYPE to CalendarContract.Attendees.TYPE_REQUIRED,
+      )
+    )
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
+
+    // When
+    val result = repository.findAllByEventId(EventId(5L))
+
+    // Then
+    Assert.assertEquals(1, result.size)
+    val entity = result.first()
+    Assert.assertEquals(AttendeeId(10L), entity.id)
+    Assert.assertEquals("alice@example.com", entity.email)
+    Assert.assertEquals("Alice", entity.name)
+    Assert.assertEquals(AttendeeRole.ATTENDEE, entity.role)
+    Assert.assertEquals(AttendeeStatus.ACCEPTED, entity.status)
+    Assert.assertEquals(AttendeeType.REQUIRED, entity.type)
+  }
+
+  @Test
+  fun `given event id, when findAllByEventId, then uses EVENT_ID in selection`() = runTest {
+    // Given
+    val selectionSlot = slot<String>()
+    val selectionArgsSlot = slot<Array<String>>()
+    every {
+      contentResolver.query(
+        any(),
+        any(),
+        capture(selectionSlot),
+        capture(selectionArgsSlot),
+        any()
+      )
+    } returns emptyCursor()
+
+    // When
+    repository.findAllByEventId(EventId(42L))
+
+    // Then
+    Assert.assertTrue(selectionSlot.captured.contains(CalendarContract.Attendees.EVENT_ID))
+    Assert.assertEquals(listOf("42"), selectionArgsSlot.captured?.toList())
+  }
+
+  @Test
+  fun `given cursor with multiple rows, when findAllByEventId, then returns multiple entities`() = runTest {
+    // Given
+    val cursor = cursorWithRows(
+      minimalRow(id = 1L, email = "a@example.com"),
+      minimalRow(id = 2L, email = "b@example.com"),
+    )
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
+
+    // When
+    val result = repository.findAllByEventId(EventId(1L))
+
+    // Then
+    Assert.assertEquals(2, result.size)
+    Assert.assertEquals(AttendeeId(1L), result[0].id)
+    Assert.assertEquals(AttendeeId(2L), result[1].id)
+  }
+
+  // endregion
+
+  // region findById
+
+  @Test
+  fun `given cursor has a row, when findById, then returns entity`() = runTest {
+    // Given
+    val cursor = cursorWithRows(minimalRow(id = 7L, email = "bob@example.com"))
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
+
+    // When
+    val result = repository.findById(AttendeeId(7L))
+
+    // Then
+    Assert.assertEquals(AttendeeId(7L), result?.id)
+    Assert.assertEquals("bob@example.com", result?.email)
+  }
+
+  @Test
+  fun `given cursor has no rows, when findById, then returns null`() = runTest {
+    // Given
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns emptyCursor()
+
+    // When
+    val result = repository.findById(AttendeeId(7L))
+
+    // Then
+    Assert.assertNull(result)
+  }
+
+  // endregion
+
+  // region create
+
+  @Test
+  fun `given inserted URI, when create, then returns AttendeeId from URI path segment`() = runTest {
+    // Given
+    val mockUri = mockk<Uri>()
+    every { mockUri.lastPathSegment } returns "88"
+    every { contentResolver.insert(any(), any()) } returns mockUri
+
+    val input = AttendeeInput(
+      eventId = EventId(1L),
+      email = "new@example.com",
+    )
+
+    // When
+    val result = repository.create(input)
+
+    // Then
+    Assert.assertEquals(AttendeeId(88L), result)
+  }
+
+  // endregion
+
+  // region delete
+
+  @Test
+  fun `given row is deleted successfully, when delete, then returns true`() = runTest {
+    // Given
+    every { contentResolver.delete(any(), any(), any()) } returns 1
+
+    // When
+    val result = repository.delete(AttendeeId(10L))
+
+    // Then
+    Assert.assertTrue(result)
+  }
+
+  @Test
+  fun `given nothing is deleted, when delete, then returns false`() = runTest {
+    // Given
+    every { contentResolver.delete(any(), any(), any()) } returns 0
+
+    // When
+    val result = repository.delete(AttendeeId(10L))
+
+    // Then
+    Assert.assertFalse(result)
+  }
+
+  @Test
+  fun `given attendee id, when delete, then uses attendee-specific URI`() = runTest {
+    // Given
+    val uriSlot = slot<Uri>()
+    every { contentResolver.delete(capture(uriSlot), any(), any()) } returns 1
+
+    // When
+    repository.delete(AttendeeId(33L))
+
+    // Then
+    Assert.assertEquals("33", uriSlot.captured.lastPathSegment)
+  }
+
+  // endregion
+
+  // region exceptions
+
+  @Test(expected = PermissionException::class)
+  fun `given SecurityException, when findAllByEventId, then throws PermissionException`() = runTest {
+    // Given
+    every { contentResolver.query(any(), any(), any(), any(), any()) } throws SecurityException()
+
+    // When / Then
+    repository.findAllByEventId(EventId(1L))
+  }
+
+  @Test(expected = CouldNotExecuteQueryException::class)
+  fun `given null cursor, when findAllByEventId, then throws CouldNotExecuteQueryException`() = runTest {
+    // Given
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns null
+
+    // When / Then
+    repository.findAllByEventId(EventId(1L))
+  }
+
+  // endregion
+
+  // region helpers
+
+  private fun emptyCursor(): Cursor {
+    // Empty MatrixCursor requires at least one column.
+    return MatrixCursor(arrayOf(CalendarContract.Attendees._ID))
+  }
+
+  private fun cursorWithRows(vararg rows: Map<String, Any?>): Cursor {
+    if (rows.isEmpty()) {
+      return emptyCursor()
+    }
+
+    val columnNames = rows.first().keys.toTypedArray()
+    val cursor = MatrixCursor(columnNames)
+
+    for (row in rows) {
+      val rowValues = columnNames.map { columnName -> row[columnName] }.toTypedArray()
+      cursor.addRow(rowValues)
+    }
+
+    return cursor
+  }
+
+  private fun minimalRow(
+    id: Long = 1L,
+    email: String? = null,
+  ): Map<String, Any?> = mapOf(
+    CalendarContract.Attendees._ID to id,
+    CalendarContract.Attendees.ATTENDEE_EMAIL to email,
+    CalendarContract.Attendees.ATTENDEE_NAME to null,
+    CalendarContract.Attendees.ATTENDEE_RELATIONSHIP to null,
+    CalendarContract.Attendees.ATTENDEE_STATUS to null,
+    CalendarContract.Attendees.ATTENDEE_TYPE to null,
+  )
+
+  // endregion
+}


### PR DESCRIPTION
# Why

[5/n] of the `calendar@next` refactor stacked PR. This PR adds the attendee domain, which represents event attendees from the Android Calendar API.

# How

- Adds DTOs: `AttendeeInput` and `AttendeeUpdate` for creating and updating attendees
- Adds `AttendeeEntity` and wrapper types for enum values from the attendee contract
- Adds `AttendeeRepository`, a data provider for attendee data that operates on DTOs

# Test Plan

- Native unit tests ✅
