### PR TITLE
[core][Android] Support rgb()/rgba() strings in ColorTypeConverter

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Added support for CSS `rgb(...)` and `rgba(...)` color strings when converting JS color values to `android.graphics.Color`. ([#44023](https://github.com/expo/expo/pull/44023) by [@dileepapeiris](https://github.com/dileepapeiris))
 - [Android] Fixed Compose view clipping that caused Material ripple effects to be cut off (e.g., Switch thumb ripple). ([#43656](https://github.com/expo/expo/pull/43656) by [@vonovak](https://github.com/vonovak))
 - [iOS] Fix memory leak due to retain cycle in SwiftUI views. ([#43468](https://github.com/expo/expo/pull/43468) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fixed compilation issues due to missing fallthrough case in `EXJavaScriptSerializable`. ([#43634](https://github.com/expo/expo/pull/43634) by [@tjzel](https://github.com/tjzel))

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ColorTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ColorTypeConverter.kt
@@ -14,6 +14,11 @@ import expo.modules.kotlin.jni.SingleType
 import androidx.core.graphics.toColorInt
 import com.facebook.react.bridge.ReadableArray
 
+private val rgbColorRegex = Regex(
+  pattern = """^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*(?:,\s*([0-9]*\.?[0-9]+)\s*)?\)$""",
+  options = setOf(RegexOption.IGNORE_CASE)
+)
+
 /**
  * Color components for named colors following the [CSS3/SVG specification](https://www.w3.org/TR/css-color-3/#svg-color)
  * and additionally the transparent color.
@@ -211,7 +216,8 @@ class ColorTypeConverter : DynamicAwareTypeConverters<Color>() {
   }
 
   private fun colorFromString(value: String): Color {
-    val colorFromString = namedColors[value]
+    val normalizedValue = value.trim().lowercase()
+    val colorFromString = namedColors[normalizedValue]
     if (colorFromString != null) {
       return Color.valueOf(
         colorFromString[0],
@@ -221,7 +227,28 @@ class ColorTypeConverter : DynamicAwareTypeConverters<Color>() {
       )
     }
 
-    return Color.valueOf(value.toColorInt())
+    val rgbMatch = rgbColorRegex.matchEntire(normalizedValue)
+    if (rgbMatch != null) {
+      val red = rgbMatch.groupValues[1].toInt()
+      val green = rgbMatch.groupValues[2].toInt()
+      val blue = rgbMatch.groupValues[3].toInt()
+      require(red in 0..255 && green in 0..255 && blue in 0..255) {
+        "rgb() color component out of range"
+      }
+
+      val alphaGroup = rgbMatch.groupValues.getOrNull(4).orEmpty()
+      val alpha = if (alphaGroup.isNotEmpty()) {
+        val parsed = alphaGroup.toFloat()
+        require(parsed in 0f..1f) { "rgba() alpha out of range" }
+        parsed
+      } else {
+        1f
+      }
+
+      return Color.valueOf(red / 255f, green / 255f, blue / 255f, alpha)
+    }
+
+    return Color.valueOf(normalizedValue.toColorInt())
   }
 
   override fun getCppRequiredTypes(): ExpectedType =

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/ColorTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/ColorTypeConverterTest.kt
@@ -35,6 +35,43 @@ internal class ColorTypeConverterTest {
   }
 
   @Test
+  fun `converts from rgb string`() {
+    val colorString = DynamicFromObject("rgb(0,0,0)")
+
+    val color = convert<Color>(colorString)
+
+    Truth.assertThat(color.alpha()).isEqualTo(1f)
+    Truth.assertThat(color.red()).isEqualTo(0f)
+    Truth.assertThat(color.green()).isEqualTo(0f)
+    Truth.assertThat(color.blue()).isEqualTo(0f)
+  }
+
+  @Test
+  fun `converts from rgba string`() {
+    val colorString = DynamicFromObject("rgba(255, 0, 0, 0.5)")
+
+    val color = convert<Color>(colorString)
+
+    Truth.assertThat(color.alpha()).isEqualTo(0.5f)
+    Truth.assertThat(color.red()).isEqualTo(1f)
+    Truth.assertThat(color.green()).isEqualTo(0f)
+    Truth.assertThat(color.blue()).isEqualTo(0f)
+  }
+
+  @Test
+  fun `converts from rgb string with whitespace`() {
+    val colorString = DynamicFromObject(" rgb( 12 , 34 , 56 ) ")
+
+    val color = convert<Color>(colorString)
+
+    val expectedColor = arrayOf(12f, 34f, 56f).map { it / 255f }
+    Truth.assertThat(color.alpha()).isEqualTo(1f)
+    Truth.assertThat(color.red()).isEqualTo(expectedColor[0])
+    Truth.assertThat(color.green()).isEqualTo(expectedColor[1])
+    Truth.assertThat(color.blue()).isEqualTo(expectedColor[2])
+  }
+
+  @Test
   fun `converts from int`() {
     val colorInt = DynamicFromObject(Color.parseColor("#aabbcc").toDouble())
 


### PR DESCRIPTION
# Why

This fixes an Android crash when passing CSS-style `rgb(...)` / `rgba(...)` strings to props decoded as `android.graphics.Color` (e.g. `@expo/ui` `DateTimePicker` `elementColors.containerColor`). 

The value was previously treated as a plain string and failed to decode into `android.graphics.Color`, throwing `IllegalArgumentException: Unknown color`.

Fixes: #43960

# How

- Extended `expo-modules-core`’s Android `ColorTypeConverter` to recognize and parse `rgb(r,g,b)` and `rgba(r,g,b,a)` strings (including variants with whitespace) into `android.graphics.Color`.
- Added Robolectric unit tests to lock the behavior for `rgb(...)`, `rgba(...)`, and whitespace variants.
- Added a changelog entry under `packages/expo-modules-core/CHANGELOG.md`.

# Test Plan

### Manual repro
Using the reproduction repository: [https://github.com/MariooC14/expo-ui-android-element-colors-bug-repro](https://github.com/MariooC14/expo-ui-android-element-colors-bug-repro)

1. Install a patched `expo-modules-core` containing these changes.
2. Run the application:
   ```bash
   npx expo run:android
   ```
**Expected:** `DateTimePicker` renders correctly and no longer throws “Unknown color” when `containerColor` is provided as an `rgb(...)` string.

### Before / After screenshots
| Before (crash) | After (works) |
|---|---|
| <img width="318" height="668" alt="image" src="https://github.com/user-attachments/assets/43d26069-c31f-446a-9193-71687d4410a8" />| <img width="316" height="681" alt="image" src="https://github.com/user-attachments/assets/5d3ee1a9-eb31-4ce2-aad6-f89d276e7ee6" /> |

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)